### PR TITLE
Read and write JPEG images natively

### DIFF
--- a/lib/hallucination/src/core/hallucination.JpegBitWriter.scala
+++ b/lib/hallucination/src/core/hallucination.JpegBitWriter.scala
@@ -32,37 +32,37 @@
                                                                                                   */
 package hallucination
 
-import anticipation.*
-import contingency.*
-import fulminate.*
-import vacuous.*
+import java.io as ji
 
-// The pure-Scala backend, selected on Scala.js and WASI. The codecs themselves live in `core`
-// (so they compile, and are differentially tested against `javax.imageio`, on the JVM); this
-// object only dispatches.
-private[hallucination] object RasterBackend:
-  def decode(format: Rasterizable, data: Data): Raster raises RasterError = format.name.s match
-    case "PNG"  => PngCodec.decode(data)
-    case "BMP"  => BmpCodec.decode(data)
-    case "GIF"  => GifCodec.decode(data)
-    case "WEBP" => WebpCodec.decode(data)
-    case "JPEG" => JpegCodec.decode(data)
-    case _      => abort(RasterError(format))
+// An MSB-first bit writer for JPEG entropy-coded data, accumulating into a 64-bit register and
+// flushing whole bytes, with the mandatory `0xFF -> 0xFF 0x00` byte stuffing. Simpler than
+// jpeg-encoder's word-at-a-time writer but produces equivalent output.
+private[hallucination] final class JpegBitWriter(out: ji.ByteArrayOutputStream):
+  private var accumulator: Long = 0L
+  private var count: Int = 0
 
-  // Format-agnostic decoding, recognising the format by its opening magic bytes.
-  def decode(data: Data): Raster raises RasterError =
-    if data.length < 4 then abort(RasterError(Unset, RasterError.Reason.Truncated))
-    else if (data(0)&0xff) == 0x89 && data(1) == 0x50 then PngCodec.decode(data)
-    else if data(0) == 0x47 && data(1) == 0x49 && data(2) == 0x46 then GifCodec.decode(data)
-    else if data(0) == 0x42 && data(1) == 0x4d then BmpCodec.decode(data)
-    else if JpegCodec.isJpeg(data) then JpegCodec.decode(data)
-    else if WebpCodec.isWebp(data) then WebpCodec.decode(data)
-    else abort(RasterError(Unset))
+  def writeBits(value: Int, size: Int): Unit =
+    if size > 0 then
+      accumulator = (accumulator << size) | (value.toLong & ((1L << size) - 1))
+      count += size
 
-  def encode(format: Rasterizable, raster: Raster): Data = format.name.s match
-    case "PNG"  => PngCodec.encode(raster)
-    case "BMP"  => BmpCodec.encode(raster)
-    case "GIF"  => GifCodec.encode(raster)
-    case "WEBP" => WebpCodec.encode(raster)
-    case "JPEG" => JpegEncoder.encode(raster)
-    case _      => panic(m"the ${format.name} format has no native encoder")
+      while count >= 8 do
+        count -= 8
+        val byte = ((accumulator >>> count) & 0xff).toInt
+        out.write(byte)
+        if byte == 0xff then out.write(0)
+
+  // Emits a Huffman-coded symbol.
+  def encode(symbol: Int, table: JpegEncodeTable): Unit =
+    writeBits(table.codeOf(symbol), table.sizeOf(symbol))
+
+  // Emits a Huffman-coded symbol followed by `size` raw magnitude bits.
+  def encodeValue(size: Int, symbol: Int, value: Int, table: JpegEncodeTable): Unit =
+    val combined = (table.codeOf(symbol) << size) | (value & ((1 << size) - 1))
+    writeBits(combined, size + table.sizeOf(symbol))
+
+  // Pads the final partial byte with 1-bits, as the JPEG bitstream requires.
+  def flushBits(): Unit =
+    if count > 0 then
+      val padding = 8 - count
+      writeBits((1 << padding) - 1, padding)

--- a/lib/hallucination/src/core/hallucination.JpegCodec.scala
+++ b/lib/hallucination/src/core/hallucination.JpegCodec.scala
@@ -1,0 +1,579 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package hallucination
+
+import anticipation.*
+import contingency.*
+import vacuous.*
+
+import RasterError.Reason
+
+// A pure-Scala JPEG decoder, ported from image-rs/jpeg-decoder (MIT/Apache-2.0). It handles
+// baseline and progressive Huffman-coded DCT images with 1, 3 or 4 components (grayscale, YCbCr /
+// RGB, and CMYK / YCCK); arithmetic coding, lossless and hierarchical JPEGs are rejected. Unlike
+// the reference it is single-threaded and always decodes at full resolution, accumulating every
+// scan's coefficients into per-component planes that are dequantized and inverse-transformed once
+// the image ends. The JVM keeps using `javax.imageio`; this codec serves Scala.js and WASI.
+private[hallucination] object JpegCodec:
+  def isJpeg(data: Data): Boolean =
+    data.length >= 3 && (data(0) & 0xff) == 0xff && (data(1) & 0xff) == 0xd8 &&
+      (data(2) & 0xff) == 0xff
+
+  def decode(data: Data): Raster raises RasterError =
+    try JpegDecoder(data).decode()
+    catch case _: (IndexOutOfBoundsException | NegativeArraySizeException) =>
+      abort(RasterError(Jpeg(), Reason.Truncated))
+
+private[hallucination] enum JpegColor:
+  case Grayscale, Rgb, YCbCr, Cmyk, Ycck, Unknown
+
+// ITU-R BT.601 YCbCr-to-RGB, based on libjpeg-turbo's `jdcolext.c` via image-rs/jpeg-decoder.
+private[hallucination] object JpegColorConvert:
+  inline val FixedPointOffset = 20
+  private val Half = (1 << FixedPointOffset)/2
+  private def f2f(x: Double): Int = (x*((1 << FixedPointOffset).toDouble) + 0.5).toInt
+  private val Cr2R = f2f(1.40200)
+  private val Cb2G = f2f(0.34414)
+  private val Cr2G = f2f(0.71414)
+  private val Cb2B = f2f(1.77200)
+
+  private def clamp(value: Int): Int = (value >> FixedPointOffset).min(255).max(0)
+
+  def ycbcrToRgb(y0: Int, cb0: Int, cr0: Int): (Int, Int, Int) =
+    val y = y0*(1 << FixedPointOffset) + Half
+    val cb = cb0 - 128
+    val cr = cr0 - 128
+
+    ( clamp(y + Cr2R*cr),
+      clamp(y - Cb2G*cb - Cr2G*cr),
+      clamp(y + Cb2B*cb) )
+
+private[hallucination] final class JpegDecoder(data: Data)(using Tactic[RasterError]):
+  private val reader = JpegReader(data, 0)
+
+  private var frame: Optional[JpegFrame] = Unset
+  private val dcTables: Array[Optional[JpegHuffmanTable]] = Array(Unset, Unset, Unset, Unset)
+  private val acTables: Array[Optional[JpegHuffmanTable]] = Array(Unset, Unset, Unset, Unset)
+
+  // Quantization tables in natural (un-zigzagged) order, indexed by destination identifier.
+  private val quantTables: Array[Optional[Array[Int]]] = Array(Unset, Unset, Unset, Unset)
+
+  private var restartInterval = 0
+  private var adobeTransform: Optional[Int] = Unset
+  private var isJfif = false
+
+  // One coefficient plane per frame component (`blockWidth*blockHeight*64` entries), accumulated
+  // across all scans.
+  private var coefficients: Array[Array[Int]] = Array()
+
+  // The zig-zag scan order: `Unzigzag(k)` is the natural (row-major) block index of the k-th
+  // coefficient in the bitstream.
+  private val Unzigzag: Array[Int] = Array(
+    0, 1, 8, 16, 9, 2, 3, 10,
+    17, 24, 32, 25, 18, 11, 4, 5,
+    12, 19, 26, 33, 40, 48, 41, 34,
+    27, 20, 13, 6, 7, 14, 21, 28,
+    35, 42, 49, 56, 57, 50, 43, 36,
+    29, 22, 15, 23, 30, 37, 44, 51,
+    58, 59, 52, 45, 38, 31, 39, 46,
+    53, 60, 61, 54, 47, 55, 62, 63)
+
+  private def bad(): Nothing = abort(RasterError(Jpeg(), Reason.Bitstream))
+
+  def decode(): Raster =
+    if reader.u8() != 0xff || reader.u8() != JpegMarker.Soi then bad()
+
+    var previousMarker = JpegMarker.Soi
+    var pendingMarker = -1
+    var running = true
+
+    while running do
+      val marker =
+        if pendingMarker == -1 then readMarker()
+        else
+          val next = pendingMarker
+          pendingMarker = -1
+          next
+
+      if JpegMarker.isSof(marker) then
+        if frame.present then abort(RasterError(Jpeg(), Reason.UnsupportedVariant))
+        val parsed = JpegParser.parseSof(reader, marker)
+        frame = parsed
+
+        coefficients = parsed.components.map: component =>
+          new Array[Int](component.blockWidth*component.blockHeight*64)
+
+      else if marker == JpegMarker.Sos then
+        val current = frame.lay(bad())(identity)
+        val scan = JpegParser.parseSos(reader, current)
+        pendingMarker = decodeScan(current, scan)
+
+      else if marker == JpegMarker.Dqt then
+        loadQuantizationTables()
+
+      else if marker == JpegMarker.Dht then
+        loadHuffmanTables()
+
+      else if marker == JpegMarker.Dri then
+        restartInterval = JpegParser.parseDri(reader)
+
+      else if marker == JpegMarker.Dac then
+        abort(RasterError(Jpeg(), Reason.UnsupportedVariant))
+
+      else if marker == JpegMarker.Com then
+        JpegParser.skipSegment(reader)
+
+      else if JpegMarker.isApp(marker) then
+        JpegParser.parseApp(reader, marker) match
+          case JpegApp.Jfif             => isJfif = true
+          case JpegApp.Avi1             => ()
+          case JpegApp.Adobe(transform) => adobeTransform = transform
+          case JpegApp.None             => ()
+
+      else if JpegMarker.isRst(marker) then
+        if previousMarker != JpegMarker.Sos then bad()
+
+      else if marker == JpegMarker.Eoi then
+        running = false
+
+      else if marker == JpegMarker.Dnl || marker == JpegMarker.Dhp || marker == JpegMarker.Exp then
+        abort(RasterError(Jpeg(), Reason.UnsupportedVariant))
+
+      else
+        bad()
+
+      previousMarker = marker
+
+    render(frame.lay(bad())(identity))
+
+  // Skips extraneous bytes and fill bytes to the next marker, returning its code.
+  private def readMarker(): Int =
+    var marker = 0
+
+    while marker == 0 do
+      while reader.u8() != 0xff do ()
+      var byte = reader.u8()
+      while byte == 0xff do byte = reader.u8()
+      if byte != 0x00 then marker = byte
+
+    marker
+
+  private def loadQuantizationTables(): Unit =
+    val tables = JpegParser.parseDqt(reader)
+    var index = 0
+
+    while index < 4 do
+      tables(index).let: table =>
+        val natural = new Array[Int](64)
+        var j = 0
+        while j < 64 do { natural(Unzigzag(j)) = table(j); j += 1 }
+        quantTables(index) = natural
+
+      index += 1
+
+  private def loadHuffmanTables(): Unit =
+    val baseline = frame.lay(false)(_.isBaseline)
+    val (dc, ac) = JpegParser.parseDht(reader, baseline)
+    var index = 0
+
+    while index < 4 do
+      dc(index).let(dcTables(index) = _)
+      ac(index).let(acTables(index) = _)
+      index += 1
+
+  // Decodes one scan's entropy-coded data into the coefficient planes; returns the marker that
+  // terminated it (or -1).
+  private def decodeScan(frame: JpegFrame, scan: JpegScan): Int =
+    val count = scan.componentIndices.length
+    val components = scan.componentIndices.map(frame.components(_))
+    var check = 0
+
+    while check < count do
+      if quantTables(components(check).quantizationTableIndex).absent then bad()
+      check += 1
+
+    if scan.spectralStart == 0 then
+      var index = 0
+
+      while index < count do
+        if dcTables(scan.dcTableIndices(index)).absent then bad()
+        index += 1
+
+    if scan.spectralEnd > 1 then
+      var index = 0
+
+      while index < count do
+        if acTables(scan.acTableIndices(index)).absent then bad()
+        index += 1
+
+    val isInterleaved = count > 1
+    val huffman = JpegHuffmanDecoder()
+    val dcPredictors = new Array[Int](count)
+    val eobRun = new Array[Int](1)
+    var mcusLeftUntilRestart = restartInterval
+    var expectedRst = 0
+
+    val mcuHoriz = new Array[Int](count)
+    val mcuVert = new Array[Int](count)
+    var index = 0
+
+    while index < count do
+      mcuHoriz(index) = if isInterleaved then components(index).horizontalSamplingFactor else 1
+      mcuVert(index) = if isInterleaved then components(index).verticalSamplingFactor else 1
+      index += 1
+
+    val maxMcuX = if isInterleaved then frame.mcuWidth else components(0).blockWidth
+    val maxMcuY = if isInterleaved then frame.mcuHeight else components(0).blockHeight
+
+    var mcuY = 0
+    var stop = false
+
+    while mcuY < maxMcuY && !stop do
+      if mcuY*8 >= frame.imageHeight then stop = true else
+        var mcuX = 0
+        var rowStop = false
+
+        while mcuX < maxMcuX && !rowStop do
+          if mcuX*8 >= frame.imageWidth then rowStop = true else
+            if restartInterval > 0 && mcusLeftUntilRestart == 0 then
+              val rst = huffman.takeMarker(reader)
+              if rst == -1 || !JpegMarker.isRst(rst) || (rst & 7) != expectedRst then bad()
+              huffman.reset()
+              var reset = 0
+              while reset < count do { dcPredictors(reset) = 0; reset += 1 }
+              eobRun(0) = 0
+              expectedRst = (expectedRst + 1) % 8
+              mcusLeftUntilRestart = restartInterval
+
+            var i = 0
+
+            while i < count do
+              val component = components(i)
+              val globalIndex = scan.componentIndices(i)
+              val plane = coefficients(globalIndex)
+              var vPos = 0
+
+              while vPos < mcuVert(i) do
+                var hPos = 0
+
+                while hPos < mcuHoriz(i) do
+                  val blockY = mcuY*mcuVert(i) + vPos
+                  val blockX = mcuX*mcuHoriz(i) + hPos
+                  val base = (blockY*component.blockWidth + blockX)*64
+
+                  if scan.successiveHigh == 0 then
+                    decodeBlock
+                      ( huffman, plane, base, scan.dcTableIndices(i), scan.acTableIndices(i),
+                        scan.spectralStart, scan.spectralEnd, scan.successiveLow, eobRun,
+                        dcPredictors, i )
+                  else
+                    decodeBlockRefine
+                      ( huffman, plane, base, scan.acTableIndices(i), scan.spectralStart,
+                        scan.spectralEnd, scan.successiveLow, eobRun )
+
+                  hPos += 1
+
+                vPos += 1
+
+              i += 1
+
+            if restartInterval > 0 then mcusLeftUntilRestart -= 1
+
+            mcuX += 1
+
+        mcuY += 1
+
+    var marker = huffman.takeMarker(reader)
+    while JpegMarker.isRst(marker) do marker = readMarker()
+    marker
+
+  // Section F.2.2: decodes the coefficients of one block on the first pass over its spectral band.
+  private def decodeBlock
+    ( huffman:       JpegHuffmanDecoder,
+      coeff:         Array[Int],
+      base:          Int,
+      dcTableIndex:  Int,
+      acTableIndex:  Int,
+      spectralStart: Int,
+      spectralEnd:   Int,
+      successiveLow: Int,
+      eobRun:        Array[Int],
+      dcPredictors:  Array[Int],
+      predIndex:     Int )
+  :   Unit =
+
+    if spectralStart == 0 then
+      val value = huffman.decode(reader, dcTables(dcTableIndex).vouch)
+
+      val diff =
+        if value == 0 then 0
+        else if value <= 11 then huffman.receiveExtend(reader, value)
+        else bad()
+
+      dcPredictors(predIndex) = dcPredictors(predIndex) + diff
+      coeff(base) = dcPredictors(predIndex) << successiveLow
+
+    var index = spectralStart.max(1)
+
+    if index < spectralEnd && eobRun(0) > 0 then eobRun(0) -= 1
+    else if index < spectralEnd then
+      val acTable = acTables(acTableIndex).vouch
+      var continue = true
+
+      while continue && index < spectralEnd do
+        if huffman.decodeFastAc(reader, acTable) then
+          index += huffman.fastAcRun
+
+          if index >= spectralEnd then continue = false else
+            coeff(base + Unzigzag(index)) = huffman.fastAcValue << successiveLow
+            index += 1
+        else
+          val byte = huffman.decode(reader, acTable)
+          val r = byte >> 4
+          val s = byte & 0x0f
+
+          if s == 0 then
+            if r == 15 then index += 16
+            else
+              eobRun(0) = (1 << r) - 1
+              if r > 0 then eobRun(0) += huffman.getBits(reader, r)
+              continue = false
+          else
+            index += r
+
+            if index >= spectralEnd then continue = false else
+              coeff(base + Unzigzag(index)) = huffman.receiveExtend(reader, s) << successiveLow
+              index += 1
+
+  // Section G.1.2: refines coefficients on later (successive-approximation) passes.
+  private def decodeBlockRefine
+    ( huffman:       JpegHuffmanDecoder,
+      coeff:         Array[Int],
+      base:          Int,
+      acTableIndex:  Int,
+      spectralStart: Int,
+      spectralEnd:   Int,
+      successiveLow: Int,
+      eobRun:        Array[Int] )
+  :   Unit =
+
+    val bit = 1 << successiveLow
+
+    if spectralStart == 0 then
+      if huffman.getBits(reader, 1) == 1 then coeff(base) |= bit
+    else
+      val acTable = acTables(acTableIndex).vouch
+
+      if eobRun(0) > 0 then
+        eobRun(0) -= 1
+        refineNonZeroes(huffman, coeff, base, acTable, spectralStart, spectralEnd, 64, bit)
+      else
+        var index = spectralStart
+
+        while index < spectralEnd do
+          val byte = huffman.decode(reader, acTable)
+          val r = byte >> 4
+          val s = byte & 0x0f
+          var zeroRun = r
+          var value = 0
+
+          if s == 0 then
+            if r != 15 then
+              eobRun(0) = (1 << r) - 1
+              if r > 0 then eobRun(0) += huffman.getBits(reader, r)
+              zeroRun = 64
+          else if s == 1 then
+            value = if huffman.getBits(reader, 1) == 1 then bit else -bit
+          else
+            bad()
+
+          index = refineNonZeroes(huffman, coeff, base, acTable, index, spectralEnd, zeroRun, bit)
+          if value != 0 then coeff(base + Unzigzag(index)) = value
+          index += 1
+
+  // Section G.1.2.3: advances through the band, refining already-nonzero coefficients by one bit,
+  // until `zrl` zero coefficients have been skipped; returns the index reached.
+  private def refineNonZeroes
+    ( huffman:     JpegHuffmanDecoder,
+      coeff:       Array[Int],
+      base:        Int,
+      acTable:     JpegHuffmanTable,
+      start:       Int,
+      end:         Int,
+      zrl:         Int,
+      bit:         Int )
+  :   Int =
+
+    var zeroRun = zrl
+    var index = start
+    var result = end - 1
+    var settled = false
+
+    while index < end && !settled do
+      val position = base + Unzigzag(index)
+
+      if coeff(position) == 0 then
+        if zeroRun == 0 then
+          result = index
+          settled = true
+        else
+          zeroRun -= 1
+      else if huffman.getBits(reader, 1) == 1 && (coeff(position) & bit) == 0 then
+        if coeff(position) > 0 then coeff(position) += bit else coeff(position) -= bit
+
+      if !settled then index += 1
+
+    result
+
+  // Dequantizes and inverse-transforms every coefficient plane, then assembles the interleaved,
+  // colour-converted image and wraps it as a `Raster`.
+  private def render(frame: JpegFrame): Raster =
+    val planes = new Array[Array[Byte]](frame.components.length)
+    var index = 0
+
+    while index < frame.components.length do
+      planes(index) = renderPlane(frame.components(index), coefficients(index))
+      index += 1
+
+    val width = frame.imageWidth
+    val height = frame.imageHeight
+
+    if frame.components.length == 1
+    then grayscaleRaster(frame.components(0), planes(0), width, height)
+    else colorRaster(frame, planes, width, height)
+
+  private def renderPlane(component: JpegComponent, coeff: Array[Int]): Array[Byte] =
+    val quant = quantTables(component.quantizationTableIndex).vouch
+    val stride = component.blockWidth*8
+    val plane = new Array[Byte](stride*component.blockHeight*8)
+    var blockY = 0
+
+    while blockY < component.blockHeight do
+      var blockX = 0
+
+      while blockX < component.blockWidth do
+        val base = (blockY*component.blockWidth + blockX)*64
+        JpegIdct.dequantizeAndIdct8x8(coeff, base, quant, plane, blockY*8*stride + blockX*8, stride)
+        blockX += 1
+
+      blockY += 1
+
+    plane
+
+  private def grayscaleRaster(component: JpegComponent, plane: Array[Byte], width: Int, height: Int)
+  :   Raster =
+
+    val stride = component.blockWidth*8
+
+    Raster.build(width, height, Descriptor.rgb): pixel =>
+      val x = pixel%width
+      val y = pixel/width
+      val luma = plane(y*stride + x) & 0xffL
+      (luma << 16) | (luma << 8) | luma
+
+  private def colorRaster
+    ( frame: JpegFrame, planes: Array[Array[Byte]], width: Int, height: Int )
+  :   Raster =
+
+    val transform = determineColorTransform(frame)
+    val upsampler = JpegUpsampler(frame.components, width, height)
+    val convert = chooseColorConvert(frame.components.length, transform)
+    val rgb = new Array[Byte](width*height*3)
+    val row = new Array[Byte](width*3)
+
+    var y = 0
+
+    while y < height do
+      upsampler.upsampleAndInterleaveRow(planes, y, row, convert)
+      System.arraycopy(row, 0, rgb, y*width*3, width*3)
+      y += 1
+
+    Raster.build(width, height, Descriptor.rgb): pixel =>
+      (rgb(pixel*3) & 0xffL) << 16 | (rgb(pixel*3 + 1) & 0xffL) << 8 | (rgb(pixel*3 + 2) & 0xffL)
+
+  private def chooseColorConvert(count: Int, transform: JpegColor)
+  :   (Array[Array[Byte]], Array[Byte]) => Unit =
+
+    (buffers, output) =>
+      val width = output.length/3
+      var x = 0
+
+      while x < width do
+        val a0 = buffers(0)(x) & 0xff
+        val a1 = buffers(1)(x) & 0xff
+        val a2 = buffers(2)(x) & 0xff
+
+        val (r, g, b) = transform match
+          case JpegColor.Rgb   => (a0, a1, a2)
+          case JpegColor.YCbCr => JpegColorConvert.ycbcrToRgb(a0, a1, a2)
+
+          case JpegColor.Cmyk =>
+            val k = buffers(3)(x) & 0xff
+            (a0*k/255, a1*k/255, a2*k/255)
+
+          case JpegColor.Ycck =>
+            val k = buffers(3)(x) & 0xff
+            val (yr, yg, yb) = JpegColorConvert.ycbcrToRgb(a0, a1, a2)
+            (yr*k/255, yg*k/255, yb*k/255)
+
+          case _ =>
+            (a0, a0, a0)
+
+        output(x*3) = r.toByte
+        output(x*3 + 1) = g.toByte
+        output(x*3 + 2) = b.toByte
+        x += 1
+
+  // Section on colour determination, following the reference (and the heuristics described at
+  // entropymine.wordpress.com/2018/10/22/how-is-a-jpeg-images-color-type-determined).
+  private def determineColorTransform(frame: JpegFrame): JpegColor =
+    val count = frame.components.length
+
+    if count == 1 then JpegColor.Grayscale
+    else if count == 3 && matchesIdentifiers(frame, 1, 2, 3) then JpegColor.YCbCr
+    else if count == 3 && matchesIdentifiers(frame, 82, 71, 66) then JpegColor.Rgb
+    else if count == 3 && isJfif then JpegColor.YCbCr
+    else if adobeTransform.present then adobeColor(count)
+    else if count == 4 then JpegColor.Cmyk
+    else if count == 3 then JpegColor.YCbCr
+    else JpegColor.Unknown
+
+  // The colour transform indicated by an Adobe APP14 marker.
+  private def adobeColor(count: Int): JpegColor = adobeTransform.vouch match
+    case 0 => if count == 3 then JpegColor.Rgb else JpegColor.Cmyk
+    case 1 => JpegColor.YCbCr
+    case _ => JpegColor.Ycck
+
+  private def matchesIdentifiers(frame: JpegFrame, a: Int, b: Int, c: Int): Boolean =
+    frame.components(0).identifier == a && frame.components(1).identifier == b &&
+      frame.components(2).identifier == c

--- a/lib/hallucination/src/core/hallucination.JpegEncoder.scala
+++ b/lib/hallucination/src/core/hallucination.JpegEncoder.scala
@@ -1,0 +1,361 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package hallucination
+
+import java.io as ji
+
+import anticipation.*
+import rudiments.*
+import vacuous.*
+
+// A pure-Scala baseline JPEG encoder, ported from the jpeg-encoder crate (Apache-2.0/MIT). It
+// converts an RGB raster to YCbCr, quantizes with the mozjpeg-derived Annex K tables scaled by a
+// quality factor, runs the forward DCT, builds per-image optimized Huffman tables, and writes a
+// baseline sequential JPEG with one non-interleaved scan per component. Chroma is subsampled 2x1x1
+// (4:2:0) below quality 90 and kept full-resolution (4:4:4) at 90 and above.
+private[hallucination] object JpegEncoder:
+  // The zig-zag order: `ZigZag(k)` is the natural block index of the k-th coefficient written.
+  private val ZigZag: Array[Int] = Array(
+    0, 1, 8, 16, 9, 2, 3, 10,
+    17, 24, 32, 25, 18, 11, 4, 5,
+    12, 19, 26, 33, 40, 48, 41, 34,
+    27, 20, 13, 6, 7, 14, 21, 28,
+    35, 42, 49, 56, 57, 50, 43, 36,
+    29, 22, 15, 23, 30, 37, 44, 51,
+    58, 59, 52, 45, 38, 31, 39, 46,
+    53, 60, 61, 54, 47, 55, 62, 63)
+
+  // Annex K luminance and chrominance base quantization tables (natural order).
+  private val LumaQuant: Array[Int] = Array(
+    16, 11, 10, 16, 24, 40, 51, 61,
+    12, 12, 14, 19, 26, 58, 60, 55,
+    14, 13, 16, 24, 40, 57, 69, 56,
+    14, 17, 22, 29, 51, 87, 80, 62,
+    18, 22, 37, 56, 68, 109, 103, 77,
+    24, 35, 55, 64, 81, 104, 113, 92,
+    49, 64, 78, 87, 103, 121, 120, 101,
+    72, 92, 95, 98, 112, 100, 103, 99)
+
+  private val ChromaQuant: Array[Int] = Array(
+    17, 18, 24, 47, 99, 99, 99, 99,
+    18, 21, 26, 66, 99, 99, 99, 99,
+    24, 26, 56, 99, 99, 99, 99, 99,
+    47, 66, 99, 99, 99, 99, 99, 99,
+    99, 99, 99, 99, 99, 99, 99, 99,
+    99, 99, 99, 99, 99, 99, 99, 99,
+    99, 99, 99, 99, 99, 99, 99, 99,
+    99, 99, 99, 99, 99, 99, 99, 99)
+
+  private def clamp(value: Int, low: Int, high: Int): Int = value.max(low).min(high)
+
+  private def ceilDiv(x: Int, y: Int): Int = (x + y - 1)/y
+
+  // The quantization divisors for a quality factor: the base table scaled and clamped to 1..255.
+  private def scaledTable(base: Array[Int], quality: Int): Array[Int] =
+    val q = clamp(quality, 1, 100)
+    val scale = if q < 50 then 5000/q else 200 - q*2
+
+    base.map: value =>
+      clamp((value*scale + 50)/100, 1, 255)
+
+  // ITU-R BT.601 RGB-to-YCbCr, scaled by 2^16 (matching the encoder's fixed-point conversion).
+  private def rgbToYcbcr(r: Int, g: Int, b: Int): (Int, Int, Int) =
+    val y = (19595*r + 38470*g + 7471*b + 0x7fff) >> 16
+    val cb = (-11059*r - 21709*g + 32768*b + (128 << 16) + 0x7fff) >> 16
+    val cr = (32768*r - 27439*g - 5329*b + (128 << 16) + 0x7fff) >> 16
+    (clamp(y, 0, 255), clamp(cb, 0, 255), clamp(cr, 0, 255))
+
+  private def quantizeValue(coefficient: Int, divisor0: Int): Int =
+    val divisor = divisor0 << 3 // premultiplied by 8, since the DCT leaves an overall factor of 8
+    val magnitude = if coefficient < 0 then -coefficient else coefficient
+    val quotient = (magnitude + divisor/2)/divisor
+    if coefficient < 0 then -quotient else quotient
+
+  // Extracts one 8x8 block from a plane at the given stride, level-shifting samples by -128.
+  private def block
+    ( plane: Array[Byte], startX: Int, startY: Int, colStride: Int, rowStride: Int, width: Int )
+  :   Array[Int] =
+
+    val result = new Array[Int](64)
+    var y = 0
+
+    while y < 8 do
+      var x = 0
+
+      while x < 8 do
+        val ix = startX + x*colStride
+        val iy = startY + y*rowStride
+        result(y*8 + x) = (plane(iy*width + ix) & 0xff) - 128
+        x += 1
+
+      y += 1
+
+    result
+
+  // Forward-transforms and quantizes a block, returning coefficients in zig-zag order.
+  private def transform(samples: Array[Int], quant: Array[Int]): Array[Int] =
+    JpegFdct.fdct(samples)
+    val result = new Array[Int](64)
+    var i = 0
+
+    while i < 64 do
+      val z = ZigZag(i)
+      result(i) = quantizeValue(samples(z), quant(z))
+      i += 1
+
+    result
+
+  def encode(raster: Raster): Data = encode(raster, 90)
+
+  def encode(raster: Raster, quality: Int): Data =
+    val width = raster.width
+    val height = raster.height
+    val hMax = if quality < 90 then 2 else 1
+    val vMax = hMax
+
+    // Full-resolution YCbCr planes, padded to whole MCUs and edge-extended.
+    val bufWidth = ceilDiv(width, 8*hMax)*hMax*8
+    val bufHeight = ceilDiv(height, 8*vMax)*vMax*8
+    val planeY = new Array[Byte](bufWidth*bufHeight)
+    val planeCb = new Array[Byte](bufWidth*bufHeight)
+    val planeCr = new Array[Byte](bufWidth*bufHeight)
+
+    var y = 0
+
+    while y < bufHeight do
+      val sy = y.min(height - 1)
+      var x = 0
+
+      while x < bufWidth do
+        val chroma = raster(x.min(width - 1), sy)
+        val (yv, cb, cr) = rgbToYcbcr(chroma.red, chroma.green, chroma.blue)
+        val index = y*bufWidth + x
+        planeY(index) = yv.toByte
+        planeCb(index) = cb.toByte
+        planeCr(index) = cr.toByte
+        x += 1
+
+      y += 1
+
+    val lumaQuant = scaledTable(LumaQuant, quality)
+    val chromaQuant = scaledTable(ChromaQuant, quality)
+    val colsBlocks = ceilDiv(width, 8)
+    val rowsBlocks = ceilDiv(height, 8)
+
+    def blocksFor(plane: Array[Byte], hScale: Int, vScale: Int, quant: Array[Int])
+    :   Array[Array[Int]] =
+
+      val cols = ceilDiv(colsBlocks, hScale)
+      val rows = ceilDiv(rowsBlocks, vScale)
+      val result = new Array[Array[Int]](cols*rows)
+      var blockY = 0
+
+      while blockY < rows do
+        var blockX = 0
+
+        while blockX < cols do
+          val samples =
+            block(plane, blockX*8*hScale, blockY*8*vScale, hScale, vScale, bufWidth)
+
+          result(blockY*cols + blockX) = transform(samples, quant)
+          blockX += 1
+
+        blockY += 1
+
+      result
+
+    val yBlocks = blocksFor(planeY, 1, 1, lumaQuant)
+    val cbBlocks = blocksFor(planeCb, hMax, vMax, chromaQuant)
+    val crBlocks = blocksFor(planeCr, hMax, vMax, chromaQuant)
+
+    val (lumaDc, lumaAc) = optimizeTables(Array(yBlocks))
+    val (chromaDc, chromaAc) = optimizeTables(Array(cbBlocks, crBlocks))
+
+    val out = ji.ByteArrayOutputStream()
+
+    def u8(value: Int): Unit = out.write(value & 0xff)
+    def u16(value: Int): Unit = { u8(value >> 8); u8(value) }
+    def marker(code: Int): Unit = { u8(0xff); u8(code) }
+
+    marker(JpegMarker.Soi)
+
+    // APP0 JFIF header.
+    marker(0xe0)
+    u16(16)
+
+    "JFIF".foreach: char =>
+      u8(char.toInt)
+
+    u8(0)
+    u8(1); u8(2)  // version 1.02
+    u8(0)         // pixel-aspect-ratio units
+    u16(1); u16(1)
+    u8(0); u8(0)  // no thumbnail
+
+    writeQuantization(u8, u16, marker, 0, lumaQuant)
+    writeQuantization(u8, u16, marker, 1, chromaQuant)
+
+    // SOF0: baseline; components Y (subsampled), Cb, Cr.
+    marker(0xc0)
+    u16(8 + 3*3)
+    u8(8)
+    u16(height); u16(width)
+    u8(3)
+    u8(1); u8((hMax << 4) | vMax); u8(0)
+    u8(2); u8(0x11); u8(1)
+    u8(3); u8(0x11); u8(1)
+
+    writeHuffman(u8, u16, marker, 0, 0, lumaDc)
+    writeHuffman(u8, u16, marker, 1, 0, lumaAc)
+    writeHuffman(u8, u16, marker, 0, 1, chromaDc)
+    writeHuffman(u8, u16, marker, 1, 1, chromaAc)
+
+    writeScan(out, u8, u16, marker, 1, 0, 0, yBlocks, lumaDc, lumaAc)
+    writeScan(out, u8, u16, marker, 2, 1, 1, cbBlocks, chromaDc, chromaAc)
+    writeScan(out, u8, u16, marker, 3, 1, 1, crBlocks, chromaDc, chromaAc)
+
+    marker(JpegMarker.Eoi)
+    out.toByteArray.nn.immutable(using Unsafe)
+
+  private def writeQuantization
+    ( u8: Int => Unit, u16: Int => Unit, marker: Int => Unit, dest: Int, quant: Array[Int] )
+  :   Unit =
+
+    marker(JpegMarker.Dqt)
+    u16(2 + 1 + 64)
+    u8(dest)
+    var k = 0
+
+    while k < 64 do
+      u8(quant(ZigZag(k)))
+      k += 1
+
+  private def writeHuffman
+    ( u8: Int => Unit, u16: Int => Unit, marker: Int => Unit, tableClass: Int, dest: Int,
+      table: JpegEncodeTable )
+  :   Unit =
+
+    marker(JpegMarker.Dht)
+    u16(2 + 1 + 16 + table.values.length)
+    u8((tableClass << 4) | dest)
+    table.lengths.foreach(u8)
+    table.values.foreach(u8)
+
+  private def writeScan
+    ( out: ji.ByteArrayOutputStream, u8: Int => Unit, u16: Int => Unit, marker: Int => Unit,
+      id: Int, dcTable: Int, acTable: Int, blocks: Array[Array[Int]], dc: JpegEncodeTable,
+      ac: JpegEncodeTable )
+  :   Unit =
+
+    marker(JpegMarker.Sos)
+    u16(2 + 1 + 2 + 3)
+    u8(1)
+    u8(id)
+    u8((dcTable << 4) | acTable)
+    u8(0); u8(63); u8(0)
+
+    val writer = JpegBitWriter(out)
+    var prevDc = 0
+    var index = 0
+
+    while index < blocks.length do
+      writeBlock(writer, blocks(index), prevDc, dc, ac)
+      prevDc = blocks(index)(0)
+      index += 1
+
+    writer.flushBits()
+
+  private def writeBlock
+    ( writer: JpegBitWriter, block: Array[Int], prevDc: Int, dc: JpegEncodeTable,
+      ac: JpegEncodeTable )
+  :   Unit =
+
+    val (dcSize, dcValue) = JpegHuffmanEncoder.getCode(block(0) - prevDc)
+    writer.encodeValue(dcSize, dcSize, dcValue, dc)
+
+    var zeroRun = 0
+    var i = 1
+
+    while i < 64 do
+      if block(i) == 0 then zeroRun += 1
+      else
+        while zeroRun > 15 do
+          writer.encode(0xf0, ac)
+          zeroRun -= 16
+
+        val (size, value) = JpegHuffmanEncoder.getCode(block(i))
+        writer.encodeValue(size, (zeroRun << 4) | size, value, ac)
+        zeroRun = 0
+
+      i += 1
+
+    if zeroRun > 0 then writer.encode(0x00, ac)
+
+  // Gathers DC and AC symbol frequencies across the components sharing a table, then builds
+  // optimized Huffman tables. The DC predictor resets at the start of each component.
+  private def optimizeTables(components: Array[Array[Array[Int]]])
+  :   (JpegEncodeTable, JpegEncodeTable) =
+
+    val dcFreq = new Array[Int](257)
+    val acFreq = new Array[Int](257)
+    dcFreq(256) = 1
+    acFreq(256) = 1
+
+    components.foreach: blocks =>
+      var prevDc = 0
+      var index = 0
+
+      while index < blocks.length do
+        val block = blocks(index)
+        dcFreq(JpegHuffmanEncoder.numBits(block(0) - prevDc)) += 1
+        prevDc = block(0)
+
+        var zeroRun = 0
+        var i = 1
+
+        while i < 64 do
+          if block(i) == 0 then zeroRun += 1
+          else
+            while zeroRun > 15 do
+              acFreq(0xf0) += 1
+              zeroRun -= 16
+
+            acFreq((zeroRun << 4) | JpegHuffmanEncoder.numBits(block(i))) += 1
+            zeroRun = 0
+
+          i += 1
+
+        if zeroRun > 0 then acFreq(0) += 1
+        index += 1
+
+    (JpegHuffmanEncoder.newOptimized(dcFreq), JpegHuffmanEncoder.newOptimized(acFreq))

--- a/lib/hallucination/src/core/hallucination.JpegFdct.scala
+++ b/lib/hallucination/src/core/hallucination.JpegFdct.scala
@@ -1,0 +1,152 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package hallucination
+
+// The forward DCT (slow but accurate integer "islow" variant), ported from jpeg-encoder's
+// `fdct.rs` (Apache-2.0/MIT), itself ported from mozjpeg/libjpeg-turbo (IJG). A 2-D DCT is done as
+// 1-D DCTs on rows then columns. Results are left scaled up by an overall factor of 8, which the
+// quantization step divides out. Operates in place on a 64-element block of level-shifted samples.
+private[hallucination] object JpegFdct:
+  private inline val ConstBits = 13
+  private inline val Pass1Bits = 2
+
+  private inline val Fix0_298631336 = 2446
+  private inline val Fix0_390180644 = 3196
+  private inline val Fix0_541196100 = 4433
+  private inline val Fix0_765366865 = 6270
+  private inline val Fix0_899976223 = 7373
+  private inline val Fix1_175875602 = 9633
+  private inline val Fix1_501321110 = 12299
+  private inline val Fix1_847759065 = 15137
+  private inline val Fix1_961570560 = 16069
+  private inline val Fix2_053119869 = 16819
+  private inline val Fix2_562915447 = 20995
+  private inline val Fix3_072711026 = 25172
+
+  private inline def descale(value: Int, bits: Int): Int = (value + (1 << (bits - 1))) >> bits
+
+  def fdct(data: Array[Int]): Unit =
+    val temp = new Array[Int](64)
+
+    // Pass 1: rows, scaled up by 2**Pass1Bits.
+    var y = 0
+
+    while y < 8 do
+      val offset = y*8
+      val tmp0 = data(offset) + data(offset + 7)
+      val tmp7 = data(offset) - data(offset + 7)
+      val tmp1 = data(offset + 1) + data(offset + 6)
+      val tmp6 = data(offset + 1) - data(offset + 6)
+      val tmp2 = data(offset + 2) + data(offset + 5)
+      val tmp5 = data(offset + 2) - data(offset + 5)
+      val tmp3 = data(offset + 3) + data(offset + 4)
+      val tmp4 = data(offset + 3) - data(offset + 4)
+
+      val tmp10 = tmp0 + tmp3
+      val tmp13 = tmp0 - tmp3
+      val tmp11 = tmp1 + tmp2
+      val tmp12 = tmp1 - tmp2
+
+      temp(offset) = (tmp10 + tmp11) << Pass1Bits
+      temp(offset + 4) = (tmp10 - tmp11) << Pass1Bits
+
+      val z1e = (tmp12 + tmp13)*Fix0_541196100
+      temp(offset + 2) = descale(z1e + tmp13*Fix0_765366865, ConstBits - Pass1Bits)
+      temp(offset + 6) = descale(z1e + tmp12*(-Fix1_847759065), ConstBits - Pass1Bits)
+
+      val a1 = tmp4 + tmp7
+      val a2 = tmp5 + tmp6
+      val a3 = tmp4 + tmp6
+      val a4 = tmp5 + tmp7
+      val a5 = (a3 + a4)*Fix1_175875602
+
+      val o4 = tmp4*Fix0_298631336
+      val o5 = tmp5*Fix2_053119869
+      val o6 = tmp6*Fix3_072711026
+      val o7 = tmp7*Fix1_501321110
+      val b1 = a1*(-Fix0_899976223)
+      val b2 = a2*(-Fix2_562915447)
+      val b3 = a3*(-Fix1_961570560) + a5
+      val b4 = a4*(-Fix0_390180644) + a5
+
+      temp(offset + 7) = descale(o4 + b1 + b3, ConstBits - Pass1Bits)
+      temp(offset + 5) = descale(o5 + b2 + b4, ConstBits - Pass1Bits)
+      temp(offset + 3) = descale(o6 + b2 + b3, ConstBits - Pass1Bits)
+      temp(offset + 1) = descale(o7 + b1 + b4, ConstBits - Pass1Bits)
+      y += 1
+
+    // Pass 2: columns, removing the Pass1Bits scaling and leaving an overall factor of 8.
+    var x = 0
+
+    while x < 8 do
+      val tmp0 = temp(x) + temp(56 + x)
+      val tmp7 = temp(x) - temp(56 + x)
+      val tmp1 = temp(8 + x) + temp(48 + x)
+      val tmp6 = temp(8 + x) - temp(48 + x)
+      val tmp2 = temp(16 + x) + temp(40 + x)
+      val tmp5 = temp(16 + x) - temp(40 + x)
+      val tmp3 = temp(24 + x) + temp(32 + x)
+      val tmp4 = temp(24 + x) - temp(32 + x)
+
+      val tmp10 = tmp0 + tmp3
+      val tmp13 = tmp0 - tmp3
+      val tmp11 = tmp1 + tmp2
+      val tmp12 = tmp1 - tmp2
+
+      data(x) = descale(tmp10 + tmp11, Pass1Bits)
+      data(32 + x) = descale(tmp10 - tmp11, Pass1Bits)
+
+      val z1e = (tmp12 + tmp13)*Fix0_541196100
+      data(16 + x) = descale(z1e + tmp13*Fix0_765366865, ConstBits + Pass1Bits)
+      data(48 + x) = descale(z1e + tmp12*(-Fix1_847759065), ConstBits + Pass1Bits)
+
+      val a1 = tmp4 + tmp7
+      val a2 = tmp5 + tmp6
+      val a3 = tmp4 + tmp6
+      val a4 = tmp5 + tmp7
+      val a5 = (a3 + a4)*Fix1_175875602
+
+      val o4 = tmp4*Fix0_298631336
+      val o5 = tmp5*Fix2_053119869
+      val o6 = tmp6*Fix3_072711026
+      val o7 = tmp7*Fix1_501321110
+      val b1 = a1*(-Fix0_899976223)
+      val b2 = a2*(-Fix2_562915447)
+      val b3 = a3*(-Fix1_961570560) + a5
+      val b4 = a4*(-Fix0_390180644) + a5
+
+      data(56 + x) = descale(o4 + b1 + b3, ConstBits + Pass1Bits)
+      data(40 + x) = descale(o5 + b2 + b4, ConstBits + Pass1Bits)
+      data(24 + x) = descale(o6 + b2 + b3, ConstBits + Pass1Bits)
+      data(8 + x) = descale(o7 + b1 + b4, ConstBits + Pass1Bits)
+      x += 1

--- a/lib/hallucination/src/core/hallucination.JpegHuffman.scala
+++ b/lib/hallucination/src/core/hallucination.JpegHuffman.scala
@@ -1,0 +1,249 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package hallucination
+
+import contingency.*
+
+import RasterError.Reason
+
+// A canonical-Huffman decoder for JPEG entropy-coded data, ported from image-rs/jpeg-decoder
+// (`src/huffman.rs`, MIT/Apache-2.0). Bits are buffered MSB-first in a 64-bit accumulator; an
+// 8-bit primary lookup table resolves short codes in one step, with a linear fallback for longer
+// codes. AC tables additionally carry a combined run/value table for small coefficients.
+private[hallucination] object JpegHuffman:
+  inline val LutBits = 8
+
+  // Section F.2.2.1, Figure F.12: sign-extend a `count`-bit magnitude to a signed value.
+  def extend(value: Int, count: Int): Int =
+    val threshold = 1 << (count - 1)
+    if value < threshold then value + (-1 << count) + 1 else value
+
+private[hallucination] object JpegHuffmanTable:
+  def apply(counts: Array[Int], values: Array[Int], ac: Boolean)
+  :   JpegHuffmanTable raises RasterError =
+
+    val lutBits = JpegHuffman.LutBits
+
+    // Section C.2, Figures C.1 and C.2: derive the canonical code sizes and codes.
+    var totalSize = 0
+    var index = 0
+    while index < 16 do { totalSize += counts(index); index += 1 }
+
+    val huffsize = new Array[Int](totalSize)
+    var position = 0
+    index = 0
+
+    while index < 16 do
+      var repeat = 0
+
+      while repeat < counts(index) do
+        huffsize(position) = index + 1
+        position += 1
+        repeat += 1
+
+      index += 1
+
+    val huffcode = new Array[Int](totalSize)
+    var code = 0
+    var codeSize = if totalSize > 0 then huffsize(0) else 0
+    index = 0
+
+    while index < totalSize do
+      while codeSize < huffsize(index) do { code <<= 1; codeSize += 1 }
+      if code >= (1 << huffsize(index)) then abort(RasterError(Jpeg(), Reason.Huffman))
+      huffcode(index) = code
+      code += 1
+      index += 1
+
+    // Section F.2.2.3, Figure F.15: delta[i] = VALPTR(i) - MINCODE(i); maxcode[i] = MAXCODE(i).
+    val delta = new Array[Int](16)
+    val maxcode = Array.fill(16)(-1)
+    var j = 0
+    index = 0
+
+    while index < 16 do
+      if counts(index) != 0 then
+        delta(index) = j - huffcode(j)
+        j += counts(index)
+        maxcode(index) = huffcode(j - 1)
+
+      index += 1
+
+    // The primary lookup table: every code no longer than `lutBits` maps its prefix to a value.
+    val lutValue = new Array[Int](1 << lutBits)
+    val lutSize = new Array[Int](1 << lutBits)
+    index = 0
+
+    while index < totalSize do
+      val size = huffsize(index)
+
+      if size <= lutBits then
+        val remaining = lutBits - size
+        val start = huffcode(index) << remaining
+        var fill = 0
+
+        while fill < (1 << remaining) do
+          lutValue(start + fill) = values(index)
+          lutSize(start + fill) = size
+          fill += 1
+
+      index += 1
+
+    // For AC tables, a secondary table decoding both the value and its magnitude extension for
+    // small coefficients (Section F.2.2.2).
+    val acValue = if ac then new Array[Int](1 << lutBits) else new Array[Int](0)
+    val acRunSize = if ac then new Array[Int](1 << lutBits) else new Array[Int](0)
+
+    if ac then
+      index = 0
+
+      while index < (1 << lutBits) do
+        val value = lutValue(index)
+        val size = lutSize(index)
+        val runLength = value >> 4
+        val magnitude = value & 0x0f
+
+        if magnitude > 0 && size + magnitude <= lutBits then
+          val unextended = ((index << size) & ((1 << lutBits) - 1)) >> (lutBits - magnitude)
+          acValue(index) = JpegHuffman.extend(unextended, magnitude)
+          acRunSize(index) = (runLength << 4) | (size + magnitude)
+
+        index += 1
+
+    new JpegHuffmanTable(values, delta, maxcode, lutValue, lutSize, acValue, acRunSize)
+
+private[hallucination] final class JpegHuffmanTable
+  ( val values:    Array[Int],
+    val delta:     Array[Int],
+    val maxcode:   Array[Int],
+    val lutValue:  Array[Int],
+    val lutSize:   Array[Int],
+    val acValue:   Array[Int],
+    val acRunSize: Array[Int] ):
+
+  // `acValue` and `acRunSize` are empty for DC tables.
+  def hasAcLut: Boolean = acRunSize.length > 0
+
+private[hallucination] final class JpegHuffmanDecoder:
+  private var bits: Long = 0L
+  private var numBits: Int = 0
+  private var marker: Int = -1
+
+  // Results of the most recent `decodeFastAc`, valid when it returns true.
+  var fastAcValue: Int = 0
+  var fastAcRun: Int = 0
+
+  // Section F.2.2.3, Figure F.16.
+  def decode(reader: JpegReader, table: JpegHuffmanTable): Int raises RasterError =
+    if numBits < 16 then readBits(reader)
+
+    val lookup = peekBits(JpegHuffman.LutBits)
+    val size = table.lutSize(lookup)
+
+    if size > 0 then
+      consumeBits(size)
+      table.lutValue(lookup)
+    else
+      val code0 = peekBits(16)
+      var index = JpegHuffman.LutBits
+      var result = -1
+
+      while result == -1 && index < 16 do
+        val code = code0 >> (15 - index)
+
+        if code <= table.maxcode(index) then
+          consumeBits(index + 1)
+          result = table.values(code + table.delta(index))
+
+        index += 1
+
+      if result == -1 then abort(RasterError(Jpeg(), Reason.Huffman)) else result
+
+  // Decodes a small AC coefficient in one step, if the combined table has an entry; returns true
+  // and sets `fastAcValue`/`fastAcRun` when it does.
+  def decodeFastAc(reader: JpegReader, table: JpegHuffmanTable): Boolean raises RasterError =
+    if !table.hasAcLut then false else
+      if numBits < JpegHuffman.LutBits then readBits(reader)
+      val lookup = peekBits(JpegHuffman.LutBits)
+      val runSize = table.acRunSize(lookup)
+
+      if runSize == 0 then false else
+        fastAcValue = table.acValue(lookup)
+        fastAcRun = runSize >> 4
+        consumeBits(runSize & 0x0f)
+        true
+
+  def getBits(reader: JpegReader, count: Int): Int raises RasterError =
+    if count == 0 then 0 else
+      if numBits < count then readBits(reader)
+      val value = peekBits(count)
+      consumeBits(count)
+      value
+
+  def receiveExtend(reader: JpegReader, count: Int): Int raises RasterError =
+    JpegHuffman.extend(getBits(reader, count), count)
+
+  def reset(): Unit =
+    bits = 0L
+    numBits = 0
+
+  def takeMarker(reader: JpegReader): Int raises RasterError =
+    readBits(reader)
+    val result = marker
+    marker = -1
+    result
+
+  private def peekBits(count: Int): Int =
+    if count == 0 then 0 else ((bits >>> (64 - count)) & ((1L << count) - 1)).toInt
+
+  private def consumeBits(count: Int): Unit =
+    bits <<= count
+    numBits -= count
+
+  private def readBits(reader: JpegReader): Unit raises RasterError =
+    while numBits <= 56 do
+      val byte = if marker != -1 then 0 else reader.u8()
+
+      if byte == 0xff && marker == -1 then
+        var next = reader.u8()
+        if next != 0x00 then
+          // Section B.1.1.2: a marker, optionally preceded by fill bytes, ends the entropy data.
+          while next == 0xff do next = reader.u8()
+          if next == 0x00 then abort(RasterError(Jpeg(), Reason.Bitstream)) else marker = next
+          numBits += 8
+        else
+          bits |= 0xffL << (56 - numBits)
+          numBits += 8
+      else
+        bits |= (byte.toLong & 0xff) << (56 - numBits)
+        numBits += 8

--- a/lib/hallucination/src/core/hallucination.JpegHuffmanEncoder.scala
+++ b/lib/hallucination/src/core/hallucination.JpegHuffmanEncoder.scala
@@ -1,0 +1,225 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package hallucination
+
+// Huffman encoding tables, ported from jpeg-encoder's `huffman.rs` (Apache-2.0/MIT). A table maps
+// each byte symbol to a (bit-length, code) pair; the code-length list and value list are also
+// retained for writing the DHT segment. Both the standard Annex K tables and per-image optimized
+// tables (Annex K.2) are supported.
+private[hallucination] final class JpegEncodeTable
+  ( val lengths: Array[Int],
+    val values:  Array[Int] ):
+
+  // The per-symbol (size, code) lookup, from the canonical code assignment (Figures C.1–C.3).
+  val sizeOf: Array[Int] = new Array[Int](256)
+  val codeOf: Array[Int] = new Array[Int](256)
+
+  locally:
+    val sizes = new Array[Int](256)
+    var k = 0
+    var i = 0
+
+    while i < 16 do
+      var count = 0
+
+      while count < lengths(i) do
+        sizes(k) = i + 1
+        k += 1
+        count += 1
+
+      i += 1
+
+    val codes = new Array[Int](256)
+    var code = 0
+    var currentSize = if k > 0 then sizes(0) else 0
+    var index = 0
+
+    while index < k do
+      if sizes(index) != currentSize then
+        code <<= (sizes(index) - currentSize)
+        currentSize = sizes(index)
+
+      codes(index) = code
+      code += 1
+      index += 1
+
+    i = 0
+
+    while i < values.length do
+      sizeOf(values(i)) = sizes(i)
+      codeOf(values(i)) = codes(i)
+      i += 1
+
+private[hallucination] object JpegHuffmanEncoder:
+  private val LumaDcLengths = Array(0, 1, 5, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0)
+  private val LumaDcValues = Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+  private val ChromaDcLengths = Array(0, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0)
+  private val ChromaDcValues = Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+
+  private val LumaAcLengths = Array(0, 2, 1, 3, 3, 2, 4, 3, 5, 5, 4, 4, 0, 0, 1, 0x7d)
+
+  private val LumaAcValues = Array(
+    0x01, 0x02, 0x03, 0x00, 0x04, 0x11, 0x05, 0x12, 0x21, 0x31, 0x41, 0x06, 0x13, 0x51, 0x61, 0x07,
+    0x22, 0x71, 0x14, 0x32, 0x81, 0x91, 0xa1, 0x08, 0x23, 0x42, 0xb1, 0xc1, 0x15, 0x52, 0xd1, 0xf0,
+    0x24, 0x33, 0x62, 0x72, 0x82, 0x09, 0x0a, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x25, 0x26, 0x27, 0x28,
+    0x29, 0x2a, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49,
+    0x4a, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69,
+    0x6a, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89,
+    0x8a, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+    0xa8, 0xa9, 0xaa, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xc2, 0xc3, 0xc4, 0xc5,
+    0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xe1, 0xe2,
+    0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8,
+    0xf9, 0xfa)
+
+  private val ChromaAcLengths = Array(0, 2, 1, 2, 4, 4, 3, 4, 7, 5, 4, 4, 0, 1, 2, 0x77)
+
+  private val ChromaAcValues = Array(
+    0x00, 0x01, 0x02, 0x03, 0x11, 0x04, 0x05, 0x21, 0x31, 0x06, 0x12, 0x41, 0x51, 0x07, 0x61, 0x71,
+    0x13, 0x22, 0x32, 0x81, 0x08, 0x14, 0x42, 0x91, 0xa1, 0xb1, 0xc1, 0x09, 0x23, 0x33, 0x52, 0xf0,
+    0x15, 0x62, 0x72, 0xd1, 0x0a, 0x16, 0x24, 0x34, 0xe1, 0x25, 0xf1, 0x17, 0x18, 0x19, 0x1a, 0x26,
+    0x27, 0x28, 0x29, 0x2a, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+    0x49, 0x4a, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+    0x69, 0x6a, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79, 0x7a, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
+    0x88, 0x89, 0x8a, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x9a, 0xa2, 0xa3, 0xa4, 0xa5,
+    0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xc2, 0xc3,
+    0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda,
+    0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8,
+    0xf9, 0xfa)
+
+  def defaultLumaDc: JpegEncodeTable = JpegEncodeTable(LumaDcLengths, LumaDcValues)
+  def defaultLumaAc: JpegEncodeTable = JpegEncodeTable(LumaAcLengths, LumaAcValues)
+  def defaultChromaDc: JpegEncodeTable = JpegEncodeTable(ChromaDcLengths, ChromaDcValues)
+  def defaultChromaAc: JpegEncodeTable = JpegEncodeTable(ChromaAcLengths, ChromaAcValues)
+
+  // The magnitude category and coefficient bits of a value, as used for DC differences and AC
+  // coefficients (Section F.1.2).
+  def getCode(value: Int): (Int, Int) =
+    val magnitude = if value < 0 then -value else value
+    val numBits = if magnitude == 0 then 0 else 32 - Integer.numberOfLeadingZeros(magnitude)
+    val adjusted = value - (if value < 0 then 1 else 0)
+    (numBits, adjusted & ((1 << numBits) - 1))
+
+  // The number of magnitude bits of a value.
+  def numBits(value: Int): Int =
+    val magnitude = if value < 0 then -value else value
+    if magnitude == 0 then 0 else 32 - Integer.numberOfLeadingZeros(magnitude)
+
+  // Builds an image-optimized table from symbol frequencies (Annex K.2, Figures K.1–K.4). `freq`
+  // has 257 entries; index 256 is a reserved sentinel guaranteeing a spare longest code.
+  def newOptimized(freq0: Array[Int]): JpegEncodeTable =
+    val freq = freq0.clone()
+    val others = Array.fill(257)(-1)
+    val codesize = new Array[Int](257)
+    var running = true
+
+    // Figure K.1: combine the two least-frequent symbols repeatedly, tracking merged chains.
+    while running do
+      var v1 = -1
+      var v1min = Int.MaxValue
+      var i = 0
+
+      while i < 257 do
+        if freq(i) > 0 && freq(i) <= v1min then { v1min = freq(i); v1 = i }
+        i += 1
+
+      if v1 == -1 then running = false else
+        var v2 = -1
+        var v2min = Int.MaxValue
+        i = 0
+
+        while i < 257 do
+          if freq(i) > 0 && freq(i) <= v2min && i != v1 then { v2min = freq(i); v2 = i }
+          i += 1
+
+        if v2 == -1 then running = false else
+          freq(v1) += freq(v2)
+          freq(v2) = 0
+          codesize(v1) += 1
+          var w1 = v1
+
+          while others(w1) >= 0 do
+            w1 = others(w1)
+            codesize(w1) += 1
+
+          others(w1) = v2
+          codesize(v2) += 1
+          var w2 = v2
+
+          while others(w2) >= 0 do
+            w2 = others(w2)
+            codesize(w2) += 1
+
+    // Figure K.2: count codes of each length.
+    val bits = new Array[Int](33)
+    var i = 0
+
+    while i < 257 do
+      if codesize(i) > 0 then bits(codesize(i)) += 1
+      i += 1
+
+    // Figure K.3: force all code lengths down to at most 16 bits.
+    var length = 32
+
+    while length > 16 do
+      while bits(length) > 0 do
+        var j = length - 2
+        while bits(j) == 0 do j -= 1
+        bits(length) -= 2
+        bits(length - 1) += 1
+        bits(j + 1) += 2
+        bits(j) -= 1
+
+      length -= 1
+
+    while bits(length) == 0 do length -= 1
+    bits(length) -= 1
+
+    // Figure K.4: sort the symbols by increasing code length.
+    val huffval = new Array[Int](256)
+    var k = 0
+    var size = 1
+
+    while size <= 32 do
+      var symbol = 0
+
+      while symbol <= 255 do
+        if codesize(symbol) == size then { huffval(k) = symbol; k += 1 }
+        symbol += 1
+
+      size += 1
+
+    val lengths = new Array[Int](16)
+    i = 0
+    while i < 16 do { lengths(i) = bits(i + 1); i += 1 }
+
+    JpegEncodeTable(lengths, huffval.slice(0, k))

--- a/lib/hallucination/src/core/hallucination.JpegIdct.scala
+++ b/lib/hallucination/src/core/hallucination.JpegIdct.scala
@@ -1,0 +1,189 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package hallucination
+
+// The 8x8 inverse DCT with dequantization, ported from image-rs/jpeg-decoder (`src/idct.rs`,
+// MIT/Apache-2.0), which is in turn based on stb_image's `stbi__idct_block`. Only the
+// full-resolution transform is ported (Hallucination does not do thumbnail downscaling).
+// Arithmetic is 32-bit and wrapping — malicious inputs can overflow, which is harmless here since
+// Scala's `Int` wraps silently, matching the reference's `Wrapping<i32>`.
+private[hallucination] object JpegIdct:
+  // Fixed-point constants scaled by 4096 (`stbi_f2f`), truncated toward zero as the reference does.
+  private def f2f(x: Double): Int = (x*4096.0 + 0.5).toInt
+
+  private val c0_541 = f2f(0.541196100)
+  private val c1_847 = f2f(-1.847759065)
+  private val c0_765 = f2f(0.765366865)
+  private val c1_175 = f2f(1.175875602)
+  private val c0_298 = f2f(0.298631336)
+  private val c2_053 = f2f(2.053119869)
+  private val c3_072 = f2f(3.072711026)
+  private val c1_501 = f2f(1.501321110)
+  private val cn0_899 = f2f(-0.899976223)
+  private val cn2_562 = f2f(-2.562915447)
+  private val cn1_961 = f2f(-1.961570560)
+  private val cn0_390 = f2f(-0.390180644)
+
+  private def clamp(value: Int): Byte = value.max(0).min(255).toByte
+
+  // Dequantizes the 64 zig-unzagged coefficients at `coeffBase` with `quant`, applies the inverse
+  // DCT, and writes the 8x8 block of samples into `output` at `outputBase`, one row every `stride`
+  // bytes.
+  def dequantizeAndIdct8x8
+    ( coefficients: Array[Int],
+      coeffBase:    Int,
+      quant:        Array[Int],
+      output:       Array[Byte],
+      outputBase:   Int,
+      stride:       Int )
+  :   Unit =
+
+    val temp = new Array[Int](64)
+
+    // Pass 1: the columns.
+    var i = 0
+
+    while i < 8 do
+      if coefficients(coeffBase + i + 8) == 0 && coefficients(coeffBase + i + 16) == 0 &&
+        coefficients(coeffBase + i + 24) == 0 && coefficients(coeffBase + i + 32) == 0 &&
+        coefficients(coeffBase + i + 40) == 0 && coefficients(coeffBase + i + 48) == 0 &&
+        coefficients(coeffBase + i + 56) == 0
+      then
+        val dcterm = (coefficients(coeffBase + i)*quant(i)) << 2
+        temp(i) = dcterm; temp(i + 8) = dcterm; temp(i + 16) = dcterm; temp(i + 24) = dcterm
+        temp(i + 32) = dcterm; temp(i + 40) = dcterm; temp(i + 48) = dcterm; temp(i + 56) = dcterm
+      else
+        val s0 = coefficients(coeffBase + i)*quant(i)
+        val s1 = coefficients(coeffBase + i + 8)*quant(i + 8)
+        val s2 = coefficients(coeffBase + i + 16)*quant(i + 16)
+        val s3 = coefficients(coeffBase + i + 24)*quant(i + 24)
+        val s4 = coefficients(coeffBase + i + 32)*quant(i + 32)
+        val s5 = coefficients(coeffBase + i + 40)*quant(i + 40)
+        val s6 = coefficients(coeffBase + i + 48)*quant(i + 48)
+        val s7 = coefficients(coeffBase + i + 56)*quant(i + 56)
+
+        // The constants scale up by 1<<12; 512 keeps two extra bits of precision for pass 2.
+        val p1e = (s2 + s6)*c0_541
+        val t2 = p1e + s6*c1_847
+        val t3 = p1e + s2*c0_765
+        val t0 = (s0 + s4) << 12
+        val t1 = (s0 - s4) << 12
+        val x0 = t0 + t3 + 512
+        val x3 = t0 - t3 + 512
+        val x1 = t1 + t2 + 512
+        val x2 = t1 - t2 + 512
+
+        var o0 = s7; var o1 = s5; var o2 = s3; var o3 = s1
+        val p3 = o0 + o2
+        val p4 = o1 + o3
+        val p1 = o0 + o3
+        val p2 = o1 + o2
+        val p5 = (p3 + p4)*c1_175
+        o0 *= c0_298; o1 *= c2_053; o2 *= c3_072; o3 *= c1_501
+        val q1 = p5 + p1*cn0_899
+        val q2 = p5 + p2*cn2_562
+        val q3 = p3*cn1_961
+        val q4 = p4*cn0_390
+        o3 += q1 + q4
+        o2 += q2 + q3
+        o1 += q2 + q4
+        o0 += q1 + q3
+
+        temp(i)      = (x0 + o3) >> 10
+        temp(i + 56) = (x0 - o3) >> 10
+        temp(i + 8)  = (x1 + o2) >> 10
+        temp(i + 48) = (x1 - o2) >> 10
+        temp(i + 16) = (x2 + o1) >> 10
+        temp(i + 40) = (x2 - o1) >> 10
+        temp(i + 24) = (x3 + o0) >> 10
+        temp(i + 32) = (x3 - o0) >> 10
+
+      i += 1
+
+    // Pass 2: the rows. 1<<12 from the constants, 1<<2 from pass 1, and 1<<3 from the two sqrt(8)
+    // scalings give 1<<17 to remove; the offset both rounds and re-biases -128..127 to 0..255.
+    val xScale = 65536 + (128 << 17)
+    var row = 0
+
+    while row < 8 do
+      val base = row*8
+      val out = outputBase + row*stride
+      val s0 = temp(base)
+
+      if temp(base + 1) == 0 && temp(base + 2) == 0 && temp(base + 3) == 0 &&
+        temp(base + 4) == 0 && temp(base + 5) == 0 && temp(base + 6) == 0 && temp(base + 7) == 0
+      then
+        val dcterm = clamp(((s0 << 12) + xScale) >> 17)
+        var c = 0
+        while c < 8 do { output(out + c) = dcterm; c += 1 }
+      else
+        val s1 = temp(base + 1); val s2 = temp(base + 2); val s3 = temp(base + 3)
+        val s4 = temp(base + 4); val s5 = temp(base + 5); val s6 = temp(base + 6)
+        val s7 = temp(base + 7)
+
+        val p1e = (s2 + s6)*c0_541
+        val t2 = p1e + s6*c1_847
+        val t3 = p1e + s2*c0_765
+        val t0 = (s0 + s4) << 12
+        val t1 = (s0 - s4) << 12
+        val x0 = t0 + t3 + xScale
+        val x3 = t0 - t3 + xScale
+        val x1 = t1 + t2 + xScale
+        val x2 = t1 - t2 + xScale
+
+        var o0 = s7; var o1 = s5; var o2 = s3; var o3 = s1
+        val p3 = o0 + o2
+        val p4 = o1 + o3
+        val p1 = o0 + o3
+        val p2 = o1 + o2
+        val p5 = (p3 + p4)*c1_175
+        o0 *= c0_298; o1 *= c2_053; o2 *= c3_072; o3 *= c1_501
+        val q1 = p5 + p1*cn0_899
+        val q2 = p5 + p2*cn2_562
+        val q3 = p3*cn1_961
+        val q4 = p4*cn0_390
+        o3 += q1 + q4
+        o2 += q2 + q3
+        o1 += q2 + q4
+        o0 += q1 + q3
+
+        output(out)     = clamp((x0 + o3) >> 17)
+        output(out + 7) = clamp((x0 - o3) >> 17)
+        output(out + 1) = clamp((x1 + o2) >> 17)
+        output(out + 6) = clamp((x1 - o2) >> 17)
+        output(out + 2) = clamp((x2 + o1) >> 17)
+        output(out + 5) = clamp((x2 - o1) >> 17)
+        output(out + 3) = clamp((x3 + o0) >> 17)
+        output(out + 4) = clamp((x3 - o0) >> 17)
+
+      row += 1

--- a/lib/hallucination/src/core/hallucination.JpegParser.scala
+++ b/lib/hallucination/src/core/hallucination.JpegParser.scala
@@ -1,0 +1,377 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package hallucination
+
+import contingency.*
+import vacuous.*
+
+import RasterError.Reason
+
+// JPEG marker codes (the byte following an `0xFF`), from Table B.1. Only the subset needed to
+// decode baseline and progressive Huffman-coded images is named here.
+private[hallucination] object JpegMarker:
+  inline val Soi = 0xd8
+  inline val Eoi = 0xd9
+  inline val Sos = 0xda
+  inline val Dqt = 0xdb
+  inline val Dht = 0xc4
+  inline val Dri = 0xdd
+  inline val Dac = 0xcc
+  inline val Dnl = 0xdc
+  inline val Dhp = 0xde
+  inline val Exp = 0xdf
+  inline val Com = 0xfe
+
+  def isSof(code: Int): Boolean =
+    code >= 0xc0 && code <= 0xcf && code != Dht && code != 0xc8 && code != Dac
+
+  def isApp(code: Int): Boolean = code >= 0xe0 && code <= 0xef
+  def isRst(code: Int): Boolean = code >= 0xd0 && code <= 0xd7
+
+  // Whether the marker segment carries a two-byte length; standalone markers (RST, SOI, EOI, TEM)
+  // do not.
+  def hasLength(code: Int): Boolean =
+    !(isRst(code) || code == Soi || code == Eoi || code == 0x01)
+
+// The coding process of a frame. Hierarchical, lossless and arithmetic-coded frames are rejected
+// during parsing, so only these two Huffman-coded DCT processes reach the decoder.
+private[hallucination] enum JpegCoding:
+  case Sequential, Progressive
+
+private[hallucination] final case class JpegDimensions(width: Int, height: Int)
+
+// One colour component (plane) of the frame. Sampling factors and the quantization-table index
+// come from the frame header; the pixel and block dimensions are derived once all components are
+// known.
+private[hallucination] final class JpegComponent
+  ( val identifier:               Int,
+    val horizontalSamplingFactor: Int,
+    val verticalSamplingFactor:   Int,
+    val quantizationTableIndex:   Int ):
+
+  // The full-resolution IDCT is always used (no thumbnail scaling), so the DCT scale is fixed at 8.
+  val dctScale: Int = 8
+  var sizeWidth: Int = 0
+  var sizeHeight: Int = 0
+  var blockWidth: Int = 0
+  var blockHeight: Int = 0
+
+private[hallucination] final class JpegFrame
+  ( val isBaseline:    Boolean,
+    val coding:        JpegCoding,
+    val precision:     Int,
+    val imageWidth:    Int,
+    val imageHeight:   Int,
+    var mcuWidth:      Int,
+    var mcuHeight:     Int,
+    val components:    Array[JpegComponent] )
+
+private[hallucination] final class JpegScan
+  ( val componentIndices:  Array[Int],
+    val dcTableIndices:    Array[Int],
+    val acTableIndices:    Array[Int],
+    val spectralStart:     Int,
+    val spectralEnd:       Int, // exclusive
+    val successiveHigh:    Int,
+    val successiveLow:     Int )
+
+// The result of an APP marker relevant to colour interpretation; other application data (ICC,
+// Exif, XMP) is skipped.
+private[hallucination] enum JpegApp:
+  case None, Jfif, Avi1
+  case Adobe(transform: Int)
+
+private[hallucination] object JpegParser:
+  private def bad(): Nothing raises RasterError =
+    abort(RasterError(Jpeg(), Reason.Bitstream))
+
+  private def unsupported(): Nothing raises RasterError =
+    abort(RasterError(Jpeg(), Reason.UnsupportedVariant))
+
+  private def readLength(reader: JpegReader): Int raises RasterError =
+    val length = reader.u16()
+    if length < 2 then bad() else length - 2
+
+  private def ceilDiv(x: Int, y: Int): Int raises RasterError =
+    if x <= 0 || y <= 0 then bad() else 1 + (x - 1)/y
+
+  // Section B.2.2: the Start Of Frame header.
+  def parseSof(reader: JpegReader, code: Int): JpegFrame raises RasterError =
+    val length = readLength(reader)
+    if length <= 6 then bad()
+
+    val sofNumber = code - 0xc0
+
+    val coding = sofNumber match
+      case 0 | 1 => JpegCoding.Sequential
+      case 2     => JpegCoding.Progressive
+      case _     => unsupported() // lossless, differential, hierarchical or arithmetic coding
+
+    val isBaseline = sofNumber == 0
+    val precision = reader.u8()
+    if precision != 8 then unsupported()
+
+    val height = reader.u16()
+    val width = reader.u16()
+    if height == 0 then unsupported() // DNL-defined height
+    if width == 0 then bad()
+
+    val componentCount = reader.u8()
+    if componentCount == 0 then bad()
+    if coding == JpegCoding.Progressive && componentCount > 4 then bad()
+    if length != 6 + 3*componentCount then bad()
+    if componentCount != 1 && componentCount != 3 && componentCount != 4 then unsupported()
+
+    val components = new Array[JpegComponent](componentCount)
+    var index = 0
+
+    while index < componentCount do
+      val identifier = reader.u8()
+
+      var duplicate = 0
+
+      while duplicate < index do
+        if components(duplicate).identifier == identifier then bad()
+        duplicate += 1
+
+      val sampling = reader.u8()
+      val horizontal = sampling >> 4
+      val vertical = sampling & 0x0f
+      if horizontal == 0 || horizontal > 4 then bad()
+      if vertical == 0 || vertical > 4 then bad()
+
+      val quantizationIndex = reader.u8()
+      if quantizationIndex > 3 then bad()
+
+      components(index) = JpegComponent(identifier, horizontal, vertical, quantizationIndex)
+      index += 1
+
+    val frame =
+      JpegFrame(isBaseline, coding, precision, width, height, 0, 0, components)
+
+    updateComponentSizes(frame)
+    frame
+
+  private def updateComponentSizes(frame: JpegFrame): Unit raises RasterError =
+    var hMax = 0
+    var vMax = 0
+    var index = 0
+
+    while index < frame.components.length do
+      hMax = hMax.max(frame.components(index).horizontalSamplingFactor)
+      vMax = vMax.max(frame.components(index).verticalSamplingFactor)
+      index += 1
+
+    frame.mcuWidth = ceilDiv(frame.imageWidth, hMax*8)
+    frame.mcuHeight = ceilDiv(frame.imageHeight, vMax*8)
+    index = 0
+
+    while index < frame.components.length do
+      val component = frame.components(index)
+
+      component.sizeWidth =
+        ceilDiv(frame.imageWidth*component.horizontalSamplingFactor*component.dctScale, hMax*8)
+
+      component.sizeHeight =
+        ceilDiv(frame.imageHeight*component.verticalSamplingFactor*component.dctScale, vMax*8)
+
+      component.blockWidth = frame.mcuWidth*component.horizontalSamplingFactor
+      component.blockHeight = frame.mcuHeight*component.verticalSamplingFactor
+      index += 1
+
+  // Section B.2.3: the Start Of Scan header.
+  def parseSos(reader: JpegReader, frame: JpegFrame): JpegScan raises RasterError =
+    val length = readLength(reader)
+    if length == 0 then bad()
+
+    val componentCount = reader.u8()
+    if componentCount == 0 || componentCount > 4 then bad()
+    if length != 4 + 2*componentCount then bad()
+
+    val componentIndices = new Array[Int](componentCount)
+    val dcTableIndices = new Array[Int](componentCount)
+    val acTableIndices = new Array[Int](componentCount)
+    var index = 0
+
+    while index < componentCount do
+      val identifier = reader.u8()
+
+      var componentIndex = -1
+      var search = 0
+
+      while search < frame.components.length do
+        if frame.components(search).identifier == identifier then componentIndex = search
+        search += 1
+
+      if componentIndex == -1 then bad()
+
+      var duplicate = 0
+
+      while duplicate < index do
+        if componentIndices(duplicate) == componentIndex then bad()
+        duplicate += 1
+
+      val tables = reader.u8()
+      val dcTableIndex = tables >> 4
+      val acTableIndex = tables & 0x0f
+      if dcTableIndex > 3 || (frame.isBaseline && dcTableIndex > 1) then bad()
+      if acTableIndex > 3 || (frame.isBaseline && acTableIndex > 1) then bad()
+
+      componentIndices(index) = componentIndex
+      dcTableIndices(index) = dcTableIndex
+      acTableIndices(index) = acTableIndex
+      index += 1
+
+    val spectralStart = reader.u8()
+    var spectralEnd = reader.u8()
+    val approximation = reader.u8()
+    val successiveHigh = approximation >> 4
+    val successiveLow = approximation & 0x0f
+
+    if frame.coding == JpegCoding.Progressive then
+      if spectralEnd > 63 || spectralStart > spectralEnd ||
+        (spectralStart == 0 && spectralEnd != 0)
+      then bad()
+
+      if spectralStart != 0 && componentCount != 1 then bad()
+      if successiveHigh > 13 || successiveLow > 13 then bad()
+      if successiveHigh != 0 && successiveHigh != successiveLow + 1 then bad()
+    else
+      if spectralEnd == 0 then spectralEnd = 63
+      if spectralStart != 0 || spectralEnd != 63 then bad()
+      if successiveHigh != 0 || successiveLow != 0 then bad()
+
+    JpegScan
+      ( componentIndices, dcTableIndices, acTableIndices, spectralStart, spectralEnd + 1,
+        successiveHigh, successiveLow )
+
+  // Section B.2.4.1: quantization tables, each returned in the file's zigzag order (unzigzagged by
+  // the decoder). The four slots are indexed by the table's destination identifier.
+  def parseDqt(reader: JpegReader): Array[Optional[Array[Int]]] raises RasterError =
+    var length = readLength(reader)
+    val tables: Array[Optional[Array[Int]]] = Array(Unset, Unset, Unset, Unset)
+
+    while length > 0 do
+      val byte = reader.u8()
+      val precision = byte >> 4
+      val index = byte & 0x0f
+      if precision > 1 then bad()
+      if index > 3 then bad()
+      if length < 65 + 64*precision then bad()
+
+      val table = new Array[Int](64)
+      var item = 0
+
+      while item < 64 do
+        table(item) = if precision == 0 then reader.u8() else reader.u16()
+        if table(item) == 0 then bad()
+        item += 1
+
+      tables(index) = table
+      length -= 65 + 64*precision
+
+    tables
+
+  // Section B.2.4.2: Huffman tables. Returns the DC tables then the AC tables, four slots each.
+  def parseDht(reader: JpegReader, isBaseline: Boolean)
+  :   (Array[Optional[JpegHuffmanTable]], Array[Optional[JpegHuffmanTable]]) raises RasterError =
+
+    var length = readLength(reader)
+    val dcTables: Array[Optional[JpegHuffmanTable]] = Array(Unset, Unset, Unset, Unset)
+    val acTables: Array[Optional[JpegHuffmanTable]] = Array(Unset, Unset, Unset, Unset)
+
+    while length > 17 do
+      val byte = reader.u8()
+      val tableClass = byte >> 4
+      val index = byte & 0x0f
+      if tableClass != 0 && tableClass != 1 then bad()
+      if isBaseline && index > 1 then bad()
+      if index > 3 then bad()
+
+      val counts = new Array[Int](16)
+      var size = 0
+      var count = 0
+
+      while count < 16 do
+        counts(count) = reader.u8()
+        size += counts(count)
+        count += 1
+
+      if size == 0 then bad()
+      if size > 256 then bad()
+      if size > length - 17 then bad()
+
+      val values = new Array[Int](size)
+      var value = 0
+
+      while value < size do
+        values(value) = reader.u8()
+        value += 1
+
+      val table = JpegHuffmanTable(counts, values, tableClass == 1)
+      if tableClass == 0 then dcTables(index) = table else acTables(index) = table
+
+      length -= 17 + size
+
+    if length != 0 then bad()
+    (dcTables, acTables)
+
+  // Skips a length-prefixed segment whose contents are not needed (e.g. a comment).
+  def skipSegment(reader: JpegReader): Unit raises RasterError =
+    reader.skip(readLength(reader))
+
+  // Section B.2.4.4: the restart interval.
+  def parseDri(reader: JpegReader): Int raises RasterError =
+    val length = readLength(reader)
+    if length != 2 then bad()
+    reader.u16()
+
+  // Section B.2.4.6: application data. Only the JFIF, AVI1 and Adobe segments, which influence
+  // colour interpretation, are recognised; the rest are skipped.
+  def parseApp(reader: JpegReader, code: Int): JpegApp raises RasterError =
+    val length = readLength(reader)
+    val buffer = new Array[Byte](length)
+    reader.readExact(buffer)
+
+    def matches(prefix: String): Boolean =
+      prefix.length <= length && (0 until prefix.length).forall: index =>
+        (buffer(index) & 0xff) == prefix.charAt(index).toInt
+
+    if code == 0xe0 && matches("JFIF\u0000") then JpegApp.Jfif
+    else if code == 0xe0 && matches("AVI1\u0000") then JpegApp.Avi1
+    else if code == 0xee && length >= 12 && matches("Adobe\u0000") then
+      val transform = buffer(11) & 0xff
+      if transform > 2 then bad()
+      JpegApp.Adobe(transform)
+    else
+      JpegApp.None

--- a/lib/hallucination/src/core/hallucination.JpegReader.scala
+++ b/lib/hallucination/src/core/hallucination.JpegReader.scala
@@ -33,35 +33,30 @@
 package hallucination
 
 import anticipation.*
-import contingency.*
-import fulminate.*
-import vacuous.*
 
-// The pure-Scala backend, selected on Scala.js and WASI. The codecs themselves live in `core`
-// (so they compile, and are differentially tested against `javax.imageio`, on the JVM); this
-// object only dispatches.
-private[hallucination] object RasterBackend:
-  def decode(format: Rasterizable, data: Data): Raster raises RasterError = format.name.s match
-    case "PNG"  => PngCodec.decode(data)
-    case "BMP"  => BmpCodec.decode(data)
-    case "GIF"  => GifCodec.decode(data)
-    case "WEBP" => WebpCodec.decode(data)
-    case "JPEG" => JpegCodec.decode(data)
-    case _      => abort(RasterError(format))
+// A forward byte cursor over the fully-buffered image `data`. JPEG is parsed from a `Read` stream
+// in the reference (image-rs/jpeg-decoder); since Hallucination decodes from a materialised
+// `Data`, a position cursor serves the same role. Reads past the end throw
+// `IndexOutOfBoundsException`, caught by `JpegCodec` and reported as a truncated image.
+private[hallucination] final class JpegReader(data: Data, start: Int):
+  private var pos: Int = start
 
-  // Format-agnostic decoding, recognising the format by its opening magic bytes.
-  def decode(data: Data): Raster raises RasterError =
-    if data.length < 4 then abort(RasterError(Unset, RasterError.Reason.Truncated))
-    else if (data(0)&0xff) == 0x89 && data(1) == 0x50 then PngCodec.decode(data)
-    else if data(0) == 0x47 && data(1) == 0x49 && data(2) == 0x46 then GifCodec.decode(data)
-    else if data(0) == 0x42 && data(1) == 0x4d then BmpCodec.decode(data)
-    else if JpegCodec.isJpeg(data) then JpegCodec.decode(data)
-    else if WebpCodec.isWebp(data) then WebpCodec.decode(data)
-    else abort(RasterError(Unset))
+  def position: Int = pos
 
-  def encode(format: Rasterizable, raster: Raster): Data = format.name.s match
-    case "PNG"  => PngCodec.encode(raster)
-    case "BMP"  => BmpCodec.encode(raster)
-    case "GIF"  => GifCodec.encode(raster)
-    case "WEBP" => WebpCodec.encode(raster)
-    case _      => panic(m"the ${format.name} format has no native encoder")
+  def u8(): Int =
+    val byte = data(pos) & 0xff
+    pos += 1
+    byte
+
+  // A big-endian 16-bit value, as used by all JPEG segment length and dimension fields.
+  def u16(): Int = (u8() << 8) | u8()
+
+  def readExact(buffer: Array[Byte]): Unit =
+    var index = 0
+
+    while index < buffer.length do
+      buffer(index) = data(pos)
+      pos += 1
+      index += 1
+
+  def skip(length: Int): Unit = pos += length

--- a/lib/hallucination/src/core/hallucination.JpegUpsampler.scala
+++ b/lib/hallucination/src/core/hallucination.JpegUpsampler.scala
@@ -1,0 +1,225 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package hallucination
+
+import contingency.*
+
+import RasterError.Reason
+
+// Chroma upsampling and row interleaving, ported from image-rs/jpeg-decoder (`src/upsampler.rs`,
+// MIT/Apache-2.0). Each component plane is upsampled to the full image width with the fancy
+// (triangle) filter for the common 4:2:2 and 4:2:0 ratios, and nearest-neighbour otherwise; the
+// upsampled component rows are then handed to a colour-conversion function to produce interleaved
+// output.
+private[hallucination] object JpegUpsampler:
+  // Upsampler kinds; `Generic` additionally carries integer scaling factors.
+  inline val H1V1 = 0
+  inline val H2V1 = 1
+  inline val H1V2 = 2
+  inline val H2V2 = 3
+  inline val Generic = 4
+
+private[hallucination] final class JpegUpsampler
+  ( components:   Array[JpegComponent],
+    outputWidth:  Int,
+    outputHeight: Int )
+  ( using Tactic[RasterError] ):
+
+  import JpegUpsampler.*
+
+  private val count = components.length
+  private val kinds = new Array[Int](count)
+  private val widths = new Array[Int](count)
+  private val heights = new Array[Int](count)
+  private val rowStrides = new Array[Int](count)
+  private val hScales = new Array[Int](count)
+  private val vScales = new Array[Int](count)
+
+  private var hMax = 0
+  private var vMax = 0
+
+  locally:
+    var index = 0
+
+    while index < count do
+      hMax = hMax.max(components(index).horizontalSamplingFactor)
+      vMax = vMax.max(components(index).verticalSamplingFactor)
+      index += 1
+
+  locally:
+    var index = 0
+
+    while index < count do
+      val component = components(index)
+      val h = component.horizontalSamplingFactor
+      val v = component.verticalSamplingFactor
+      val h1 = h == hMax || outputWidth == 1
+      val v1 = v == vMax || outputHeight == 1
+      val h2 = h*2 == hMax
+      val v2 = v*2 == vMax
+
+      kinds(index) =
+        if h1 && v1 then H1V1
+        else if h2 && v1 then H2V1
+        else if h1 && v2 then H1V2
+        else if h2 && v2 then H2V2
+        else if hMax % h != 0 || vMax % v != 0 then
+          abort(RasterError(Jpeg(), Reason.UnsupportedVariant))
+        else
+          Generic
+
+      hScales(index) = if h == 0 then 1 else hMax/h
+      vScales(index) = if v == 0 then 1 else vMax/v
+      widths(index) = component.sizeWidth
+      heights(index) = component.sizeHeight
+      rowStrides(index) = component.blockWidth*component.dctScale
+      index += 1
+
+  private val lineBufferSize =
+    var maximum = 0
+    var index = 0
+    while index < count do { maximum = maximum.max(widths(index)); index += 1 }
+    maximum*hMax
+
+  private val lineBuffers = Array.fill(count)(new Array[Byte](lineBufferSize))
+
+  // Upsamples row `row` of every component to full width and interleaves via `colorConvert`.
+  def upsampleAndInterleaveRow
+    ( componentData: Array[Array[Byte]],
+      row:           Int,
+      output:        Array[Byte],
+      colorConvert:  (Array[Array[Byte]], Array[Byte]) => Unit )
+  :   Unit =
+
+    var index = 0
+
+    while index < count do
+      upsampleRow
+        ( kinds(index), componentData(index), widths(index), heights(index), rowStrides(index),
+          hScales(index), vScales(index), row, lineBuffers(index) )
+
+      index += 1
+
+    colorConvert(lineBuffers, output)
+
+  private def upsampleRow
+    ( kind:      Int,
+      input:     Array[Byte],
+      width:     Int,
+      height:    Int,
+      rowStride: Int,
+      hScale:    Int,
+      vScale:    Int,
+      row:       Int,
+      output:    Array[Byte] )
+  :   Unit =
+
+    inline def sample(offset: Int): Int = input(offset) & 0xff
+
+    kind match
+      case H1V1 =>
+        val base = row*rowStride
+        var i = 0
+        while i < outputWidth do { output(i) = input(base + i); i += 1 }
+
+      case H2V1 =>
+        val base = row*rowStride
+
+        if width == 1 then
+          output(0) = input(base); output(1) = input(base)
+        else
+          output(0) = input(base)
+          output(1) = ((sample(base)*3 + sample(base + 1) + 2) >> 2).toByte
+          var i = 1
+
+          while i < width - 1 do
+            val s = 3*sample(base + i) + 2
+            output(i*2) = ((s + sample(base + i - 1)) >> 2).toByte
+            output(i*2 + 1) = ((s + sample(base + i + 1)) >> 2).toByte
+            i += 1
+
+          output((width - 1)*2) =
+            ((sample(base + width - 1)*3 + sample(base + width - 2) + 2) >> 2).toByte
+
+          output((width - 1)*2 + 1) = input(base + width - 1)
+
+      case H1V2 =>
+        val rowNear = row/2.0
+        val frac = rowNear - rowNear.toInt
+        val rowFar = (rowNear + frac*3.0 - 0.25).min((height - 1).toDouble)
+        val near = rowNear.toInt*rowStride
+        val far = rowFar.toInt*rowStride
+        var i = 0
+
+        while i < outputWidth do
+          output(i) = ((3*sample(near + i) + sample(far + i) + 2) >> 2).toByte
+          i += 1
+
+      case H2V2 =>
+        val rowNear = row/2.0
+        val frac = rowNear - rowNear.toInt
+        val rowFar = (rowNear + frac*3.0 - 0.25).min((height - 1).toDouble)
+        val near = rowNear.toInt*rowStride
+        val far = rowFar.toInt*rowStride
+
+        if width == 1 then
+          val value = ((3*sample(near) + sample(far) + 2) >> 2).toByte
+          output(0) = value; output(1) = value
+        else
+          var t1 = 3*sample(near) + sample(far)
+          output(0) = ((t1 + 2) >> 2).toByte
+          var i = 1
+
+          while i < width do
+            val t0 = t1
+            t1 = 3*sample(near + i) + sample(far + i)
+            output(i*2 - 1) = ((3*t0 + t1 + 8) >> 4).toByte
+            output(i*2) = ((3*t1 + t0 + 8) >> 4).toByte
+            i += 1
+
+          output(width*2 - 1) = ((t1 + 2) >> 2).toByte
+
+      case _ =>
+        val start = (row/vScale)*rowStride
+        var index = 0
+        var i = 0
+
+        while i < width do
+          var repeat = 0
+
+          while repeat < hScale do
+            output(index) = input(start + i)
+            index += 1
+            repeat += 1
+
+          i += 1

--- a/lib/hallucination/src/test/hallucination_test.scala
+++ b/lib/hallucination/src/test/hallucination_test.scala
@@ -344,6 +344,30 @@ object Tests extends Suite(m"Hallucination Tests"):
       capture[RasterError](JpegCodec.decode(jpg420.slice(0, 200))).reason
     . assert(_ == RasterError.Reason.Truncated)
 
+    // A smooth gradient whose channels stay within 0..255 (no wrap-around discontinuity that
+    // chroma subsampling would otherwise amplify).
+    def gradient32: Raster = Raster(32, 24)((x, y) => Chroma(x*7, y*10, (x + y)*4))
+
+    test(m"the pure JPEG encoder produces a valid JPEG signature"):
+      val encoded = JpegEncoder.encode(gradient32, 90)
+      (encoded(0) & 0xff, encoded(1) & 0xff)
+    . assert(_ == (0xff, 0xd8))
+
+    test(m"a high-quality (4:4:4) JPEG round-trips through the pure codec"):
+      val encoded = JpegEncoder.encode(gradient32, 95)
+      jpegClose(JpegCodec.decode(encoded), gradient32, 4.0, 40)
+    . assert(_ == true)
+
+    test(m"a 4:2:0 JPEG round-trips through the pure codec"):
+      val encoded = JpegEncoder.encode(gradient32, 80)
+      jpegClose(JpegCodec.decode(encoded), gradient32, 6.0, 64)
+    . assert(_ == true)
+
+    test(m"ImageIO reads what the pure JPEG encoder writes"):
+      val encoded = JpegEncoder.encode(gradient32, 90)
+      jpegClose(encoded.read[Raster in Jpeg], gradient32, 6.0, 50)
+    . assert(_ == true)
+
     test(m"a pure-PNG round trip preserves every pixel"):
       same(PngCodec.decode(PngCodec.encode(gradient)), gradient)
     . assert(_ == true)

--- a/lib/hallucination/src/test/hallucination_test.scala
+++ b/lib/hallucination/src/test/hallucination_test.scala
@@ -55,6 +55,91 @@ object Tests extends Suite(m"Hallucination Tests"):
 
   val broken = hex"00001080200000907753de0000000173524742"
 
+  // A 23x17 photo-like gradient (odd dimensions exercise block padding), encoded by libjpeg via
+  // Pillow: a baseline 4:2:0 image, the same image as a progressive scan, and a grayscale image.
+  val jpg420 = hex"""ffd8ffe000104a46494600010100000100010000ffdb00430003020202020203020202030303
+                     0304060404040404080606050609080a0a090809090a0c0f0c0a0b0e0b09090d110d0e0f1010
+                     11100a0c12131210130f101010ffdb00430103030304030408040408100b090b101010101010
+                     1010101010101010101010101010101010101010101010101010101010101010101010101010
+                     101010101010ffc00011080011001703012200021101031101ffc4001f000001050101010101
+                     0100000000000000000102030405060708090a0bffc400b51000020103030204030505040400
+                     00017d01020300041105122131410613516107227114328191a1082342b1c11552d1f0243362
+                     7282090a161718191a25262728292a3435363738393a434445464748494a535455565758595a
+                     636465666768696a737475767778797a838485868788898a92939495969798999aa2a3a4a5a6
+                     a7a8a9aab2b3b4b5b6b7b8b9bac2c3c4c5c6c7c8c9cad2d3d4d5d6d7d8d9dae1e2e3e4e5e6e7
+                     e8e9eaf1f2f3f4f5f6f7f8f9faffc4001f010003010101010101010101000000000000010203
+                     0405060708090a0bffc400b51100020102040403040705040400010277000102031104052131
+                     061241510761711322328108144291a1b1c109233352f0156272d10a162434e125f11718191a
+                     262728292a35363738393a434445464748494a535455565758595a636465666768696a737475
+                     767778797a82838485868788898a92939495969798999aa2a3a4a5a6a7a8a9aab2b3b4b5b6b7
+                     b8b9bac2c3c4c5c6c7c8c9cad2d3d4d5d6d7d8d9dae2e3e4e5e6e7e8e9eaf2f3f4f5f6f7f8f9
+                     faffda000c03010002110311003f00f93be1f7c1ff00f55fe8be9fc35f4cfc3ef83ffeabfd17
+                     d3f86bbcf02fc36d32d8299a484142032820b039c63039af59d760d23c1fe14ff42f35eff51c
+                     db5b7949b5a3c8f9e4e59586d5ce197386299eb59712ff00abf83adf57c56329426fa39c79b5
+                     76bf2a7ccd2d6f65a59f667a5937174323cb6ae6989bfb3a51727e76d92f36ec979b47cdde20
+                     f0a47e2dd752decadf3a7e96b2410b7cac25727e79548fe16daa072785078c91457a84fe37f8
+                     5df0b4411f8d356b5d3dee154c56ec5a5b96560d87f2224770998dc6fc6dc8c67240a2b2a39b
+                     f0b5382a7839ce708e89c70f88945d9ead4a349a777d53699f864aa717f1a559e7b3c1d5aaeb
+                     3bf3461271b68924d2b5a2928af248e8fe1f758bf0aecfe24f5f0d7fdbd7fed1a28afe3ec3ff
+                     00c8d29ffdbdff00a4b3eb38effe484c67fdc2ff00d3d4cfc9ef01ff00aa5ff77fa514515fdc
+                     d8afe2b3fac72dff007689ffd9
+                     """
+
+  val jpgProg = hex"""ffd8ffe000104a46494600010100000100010000ffdb00430003020202020203020202030303
+                     0304060404040404080606050609080a0a090809090a0c0f0c0a0b0e0b09090d110d0e0f1010
+                     11100a0c12131210130f101010ffdb00430103030304030408040408100b090b101010101010
+                     1010101010101010101010101010101010101010101010101010101010101010101010101010
+                     101010101010ffc20011080011001703012200021101031101ffc40018000100030100000000
+                     00000000000000000005060708ffc40018010002030000000000000000000000000002070405
+                     06ffda000c03010002100310000001c9b4d9eb6049cdd680e1646684f5b727079b67ffc4001a
+                     100003010101010000000000000000000000040503010231ffda00080101000105029f1c9f1c
+                     615e37ba3373f26fcc9357aecb964f29087cffc4002311000104010109000000000000000000
+                     000100020405031112313233354182b2f0ffda0008010301013f01876e20c674ac9c2d1aa2eb
+                     7ba719c70b9db7dc03a7c372bde859bc7ddaa372c2ffc400251100020102020b000000000000
+                     000000000103020005049111121315313234517181b1ffda0008010201013f01b96ef4cf66d7
+                     441f234e5c6a18bb5c46aa4920765b08cc4697d547dfca6f357fffc400251000010204040700
+                     0000000000000000000100020311122204103161212341718291c1ffda0008010100063f0216
+                     a16aa58de5c2981beeb890ac9d712d6cba6e80c6c56c3ab46eaef43b20b0de5f32ffc4001f10
+                     00020202010500000000000000000000011100312141f11051617191ffda0008010100013f21
+                     e06703023002f05b61e0a1f22aab6372da5411eeb0381b1b51ecc018c80bca895966ba8747a9
+                     ffda000c030100020003000000109818feffc4001a1101010100030100000000000000000000
+                     01116100102131ffda0008010301013f10b4b52d9f035606a712f6ad28f00109000c0ef45fff
+                     c4001c11010003000203000000000000000000000100112131415161f0ffda0008010201013f
+                     10d81fa798d5d1b06dd194f860dc3c2829d448dbd8a33e0f69cb3fffc4001e10010003000202
+                     0300000000000000000001001121314151a16181f0ffda0008010100013f10f551eaa2d75810
+                     7771e00d7039690740580221baaa3677dff3e0ee0695652bf30e60860c52bfb8e7455da139fd
+                     67393f27c4ffd9
+                     """
+
+  val jpgGray = hex"""ffd8ffe000104a46494600010100000100010000ffdb00430003020202020203020202030303
+                     0304060404040404080606050609080a0a090809090a0c0f0c0a0b0e0b09090d110d0e0f1010
+                     11100a0c12131210130f101010ffc0000b080011001701011100ffc4001f0000010501010101
+                     010100000000000000000102030405060708090a0bffc400b510000201030302040305050404
+                     0000017d01020300041105122131410613516107227114328191a1082342b1c11552d1f02433
+                     627282090a161718191a25262728292a3435363738393a434445464748494a53545556575859
+                     5a636465666768696a737475767778797a838485868788898a92939495969798999aa2a3a4a5
+                     a6a7a8a9aab2b3b4b5b6b7b8b9bac2c3c4c5c6c7c8c9cad2d3d4d5d6d7d8d9dae1e2e3e4e5e6
+                     e7e8e9eaf1f2f3f4f5f6f7f8f9faffda0008010100003f00f8b3e16f847fd4feebd3b57d81f0
+                     b7c23fea7f75e9dabebdf867e11fdcafeebf87d3dabf3b7e16f847fd4feebd3b57d81f0b7c23
+                     fea7f75e9dabd4be38fc6fd07f64af8293fc55d5f40fedbbb7beb5d2b4ad23ed0f6df6fba949
+                     668fcf58a5116d823b8972cbb4f95b321996be29f85bff002c7f0afb03e16ffcb1fc2be67ff8
+                     2c27fa9f821feef897f969b5ffd9
+                     """
+
+  // libjpeg's own decode of `jpgGray`: one luma byte per pixel, row-major.
+  val grayRef = hex"""0009121a242c363f47515a626c747e878f99a1abb4bcc6050e172029323b444d565f68717a83
+                      8c959fa6b0b9c2cb0a131c252e374049525b646d767f88919aa4abb5bec7d00e182129333b45
+                      4e566069717b838d969ea8b0bac3cbd5141d262f38414a535c656e778089929ba4aeb5bfc9d1
+                      da19222b343d464f58616a737c858e97a0a8b3bac4cdd6df1e273039424b545d666f78818a93
+                      9ca5aeb8bfc9d2dbe4232c353e475059626b747d868f98a1aab3bdc4ced8e0e928313a424c54
+                      5e677079828a949ca6afb5c3cbd1d9e4f02d363f48515a636c757e879099a2abb4bec0cfd6e8
+                      e7f2323b444d565f68717a838c959ea7b0b9c2cfd4dde1f5f2374049515b636d767f889199a3
+                      abb5bec4d3d4e1edf4fe3c454f576169727b848d979fa9b1bac3cfd5dde8f3fb00414a535c65
+                      6e778089929ba4adb6bfc8ced6e7eef2fc0d464f58616a737c858e97a0a9b2bbc4cdd6e7e0f1
+                      fe030b4b545e667078818a939ca6aeb8c0c9d2dce0eef7fe070f5059626b747d868f98a1aab3
+                      bcc5ced7e0e9f2fb050c17
+                      """
+
   def run(): Unit =
     test(m"Read a JPEG's width"):
       val raster = jpeg.read[Raster in Jpeg]
@@ -202,6 +287,62 @@ object Tests extends Suite(m"Hallucination Tests"):
     def translucent: Raster =
       Raster[Rgba](8, 8): (x, y) =>
         Pixel.make[Rgba](x.toLong*30 << 24 | y.toLong*30 << 16 | 128L << 8 | (x*9 + y*9))
+
+    // Mean and maximum absolute per-channel difference between two same-sized rasters, for
+    // comparing the pure (lossy) JPEG decoder against `javax.imageio` — they agree closely but not
+    // bit-for-bit, since each uses a different inverse-DCT implementation.
+    def jpegClose(left: Raster, right: Raster, meanTolerance: Double, maxTolerance: Int): Boolean =
+      left.width == right.width && left.height == right.height && {
+        var sum = 0L
+        var maximum = 0
+        var count = 0
+
+        for index <- 0 until left.width*left.height do
+          val a = left.descriptor.chroma(left.word(index))
+          val b = right.descriptor.chroma(right.word(index))
+
+          for (p, q) <- List((a.red, b.red), (a.green, b.green), (a.blue, b.blue)) do
+            val d = math.abs(p - q)
+            sum += d
+            maximum = maximum.max(d)
+            count += 1
+
+        sum.toDouble/count <= meanTolerance && maximum <= maxTolerance
+      }
+
+    test(m"the pure JPEG decoder reads a baseline image's dimensions"):
+      val raster = JpegCodec.decode(jpg420)
+      (raster.width, raster.height)
+    . assert(_ == (23, 17))
+
+    test(m"the pure and ImageIO decoders agree on a baseline 4:2:0 JPEG"):
+      jpegClose(JpegCodec.decode(jpg420), jpg420.read[Raster in Jpeg], 2.0, 16)
+    . assert(_ == true)
+
+    test(m"the pure and ImageIO decoders agree on a progressive JPEG"):
+      jpegClose(JpegCodec.decode(jpgProg), jpgProg.read[Raster in Jpeg], 2.0, 16)
+    . assert(_ == true)
+
+    // ImageIO decodes grayscale JPEGs through a linear color space and gamma-shifts the samples in
+    // `getRGB`, so it is not a fair reference; instead the decode is pinned to libjpeg's own output
+    // (`grayRef`, one luma byte per pixel, row-major).
+    test(m"the pure JPEG decoder matches libjpeg on a grayscale image"):
+      val raster = JpegCodec.decode(jpgGray)
+      var sum = 0L
+      for index <- 0 until 23*17 do
+        sum += math.abs(raster(index%23, index/23).red - (grayRef(index) & 0xff))
+
+      sum.toDouble/(23*17)
+    . assert(_ < 2.0)
+
+    test(m"the pure JPEG decoder reads what ImageIO writes"):
+      val encoded = gradient.to[Jpeg].read[Data]
+      jpegClose(JpegCodec.decode(encoded), encoded.read[Raster in Jpeg], 2.5, 20)
+    . assert(_ == true)
+
+    test(m"a truncated JPEG fails cleanly"):
+      capture[RasterError](JpegCodec.decode(jpg420.slice(0, 200))).reason
+    . assert(_ == RasterError.Reason.Truncated)
 
     test(m"a pure-PNG round trip preserves every pixel"):
       same(PngCodec.decode(PngCodec.encode(gradient)), gradient)


### PR DESCRIPTION
Hallucination can now decode and encode JPEG images in pure Scala, so JPEG works on every platform — including Scala.js and WASI, where `javax.imageio` has no JPEG codec. The decoder handles baseline and progressive Huffman-coded images with grayscale, YCbCr/RGB and CMYK/YCCK colour; the encoder writes baseline JPEGs with per-image optimized Huffman tables and quality-controlled chroma subsampling.

JPEG images now decode and encode without `javax.imageio`, so they work on Scala.js and WASI as well as the JVM (which continues to use its native codec).

Decoding covers baseline and progressive Huffman-coded JPEGs:

```scala
val raster = jpegBytes.read[Raster in Jpeg]
```

Encoding produces a baseline JPEG with per-image optimized Huffman tables. Chroma is subsampled 4:2:0 below quality 90 and kept full-resolution (4:4:4) at 90 and above:

```scala
val jpeg: Data = raster.to[Jpeg].read[Data]
```

The codecs are ported from [image-rs/jpeg-decoder](https://github.com/image-rs/jpeg-decoder) (decoding) and the [jpeg-encoder](https://github.com/vstroebel/jpeg-encoder) crate (encoding), both under Apache-2.0/MIT, and are differentially tested on the JVM against libjpeg and `javax.imageio`.
