### PR TITLE
Compile and link for JavaScript and WebAssembly with Anthology

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -676,7 +676,12 @@ object anthology extends Library:
     override def scalaJs = false // depends on JVM-only `anthology.core`/`zeppelin`
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(`scala`, `java`, core, spectacular.core):
+  object link extends Component(core, eucalyptus.core, guillotine.core):
+    override def scalaJs = false // drives the Scala.js linker (a JVM library) via its API
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+    def mvnDeps = Seq(mvn"io.github.scala-wasm:scalajs-linker_2.13:${settings.scalaJsVersion}")
+  object test extends Tests(`scala`, `java`, core, bundle, link, spectacular.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
 

--- a/lib/anthology/doc/basics.md
+++ b/lib/anthology/doc/basics.md
@@ -1,2 +1,81 @@
-TBC
+### Compiling
 
+A Scala compiler is represented by a `Scalac` value, parameterized by the compiler version and
+the backend it targets, with a list of compiler options whose validity is checked against the
+version at compile time:
+```scala
+val scalac: Scalac[3.8, Backend.Jvm] = Scalac[3.8](List(scalacOptions.experimental))
+```
+
+The single-type-argument form, `Scalac[3.8](options)`, targets the JVM. The same options may be
+retargeted at another backend with `targeting`:
+```scala
+val portable = Scalac[3.8](List(scalacOptions.experimental)).targeting[Backend.Portable]
+```
+
+Four backends exist: `Backend.Jvm`, which produces classfiles, and the three _portable_
+backends—`Backend.Js`, `Backend.Wasm` and `Backend.Wasi`—which additionally produce
+target-neutral `.sjsir` files, deferring the choice of linked representation until link time.
+`Backend.Portable`, the union of the three, is the natural choice when compiling a library whose
+linked form is not yet known; a portable compilation may later be linked as _any_ of the three.
+
+Compiling for a portable backend requires the Scala.js runtime JARs (`scalajs-javalib`,
+`scalajs-library_2.13`, `scalajs-scalalib_2.13` and `scala3-library_sjs1`) on the classpath;
+their absence surfaces as ordinary compiler diagnostics.
+
+### Products
+
+The result of a compilation—an output directory and the classpath it was compiled against—is
+described by a `Compilation`, tagged with its backend:
+```scala
+val compilation: Compilation[Backend.Portable] = Compilation(out, classpath)
+```
+
+Three products can be made from a compilation, and each is only expressible for the backends it
+is valid for:
+ - `Bundler.bundle(compilation, jarfile, main)` produces an executable JAR, and requires a
+   `Compilation[Backend.Jvm]`
+ - `Bundler.library(compilation, jarfile)` produces a library JAR of `.sjsir` files for
+   downstream assembly, and requires a portable compilation
+ - `Linker[target](options, entryPoints).link(compilation, out)` produces a fully-linked
+   artifact for a concrete portable target
+
+### Linking
+
+A `Linker` is parameterized by the concrete backend it links for, with options whose validity is
+checked against that backend at compile time, mirroring `scalacOptions`:
+```scala
+val linker = Linker[Backend.Js]
+  ( List(linkerOptions.moduleKind.esModule, linkerOptions.optimize.fast),
+    List(Linker.EntryPoint(fqcn"com.example.Main")) )
+
+val artifact: Path on Linux = linker.link(compilation, out)
+```
+
+`Backend.Js` produces a `main.js`; `Backend.Wasm` produces a `main.wasm` (with a JavaScript
+loader alongside) for browsers and JavaScript runtimes; `Backend.Wasi` produces a standalone
+WASI component, `main.wasm`, for runtimes such as `wasmtime`.
+
+Options such as `moduleKind.*` apply only to `Backend.Js` (the WebAssembly backends mandate
+their own module kinds), while `checkIr`, `sourceMaps`, `esVersion.*` and `optimize.*` apply to
+every portable backend; a misapplied option is a compile error.
+
+### Linking WASI components
+
+A WASI component link has two prerequisites beyond the linker itself, both expressed as
+contextual values without which `Linker[Backend.Wasi].link` does not compile:
+
+ - a `WasiToolchain`, evidence that the native tools the link shells out to—`wasm-tools` and the
+   scala-wasm fork of `wit-bindgen`—are present; instances exist only via the probing
+   constructor, `WasiToolchain()`, which raises `ToolchainError` if a tool is missing
+ - a `WitWorld`, naming the directory of WIT packages and the world to link against
+
+```scala
+given WasiToolchain = WasiToolchain()
+given WitWorld = WitWorld(witDirectory, t"my-world")
+
+Linker[Backend.Wasi](Nil).link(compilation, out)
+```
+
+`Backend.Js` and `Backend.Wasm` require no native tooling: the linker is an ordinary JVM
+library.

--- a/lib/anthology/doc/features.md
+++ b/lib/anthology/doc/features.md
@@ -8,3 +8,8 @@
 - compiler invocation is typed according to the major compiler version
 - options are typechecked against the compiler version
 - supports compilation with [Scala.js](https://scala-js.org/)
+- compilations are typed by target backend: JVM, JavaScript, WebAssembly or WASI
+- fully-linked `.js` and `.wasm` artifacts, or unlinked `.sjsir` library JARs for
+  downstream assembly
+- linker options are typechecked against the link target
+- a WASI component link will not typecheck until its native tooling is proven present

--- a/lib/anthology/src/bundle/anthology.Bundler.scala
+++ b/lib/anthology/src/bundle/anthology.Bundler.scala
@@ -48,14 +48,13 @@ import turbulence.*
 import vacuous.*
 import zeppelin.*
 
+import filesystemBackends.virtualMachine
 import filesystemOptions.dereferenceSymlinks.enabled
 import filesystemTraversal.preOrderTraversal
 import logging.silentLogging
 import manifestAttributes.*
 import systems.javaSystem
 import workingDirectories.javaWorkingDirectory
-
-import filesystemBackends.virtualMachine
 
 object Bundler:
   def classpath(out: Path on Linux): LocalClasspath =
@@ -71,7 +70,34 @@ object Bundler:
   def bundle(directory: Path on Linux, jarfile0: Optional[Path on Linux], main: Optional[Fqcn])
   :   Path on Linux raises ZipError raises PathError raises IoError raises StreamError =
 
-    val jarfile = jarfile0.or(directory.peer("tmpfile.jar"))
+    assemble(classpath(directory), jarfile0.or(directory.peer("tmpfile.jar")), main)
+
+
+  // Bundles a JVM compilation, together with the classpath it was compiled against, as an
+  // executable JAR file.
+  def bundle
+    ( compilation: Compilation[Backend.Jvm],
+      jarfile0:    Optional[Path on Linux],
+      main:        Optional[Fqcn] )
+  :   Path on Linux raises ZipError raises PathError raises IoError raises StreamError =
+
+    val entries = Classpath.Directory(compilation.out) :: compilation.classpath.entries.to(List)
+    assemble(LocalClasspath(entries*), jarfile0.or(compilation.out.peer("tmpfile.jar")), main)
+
+
+  // Bundles a portable compilation's output—its `.sjsir` files alongside its classfiles—as a
+  // library JAR for downstream assembly: the JAR is a valid classpath entry both for further
+  // compilations and for a later `Linker`.
+  def library(compilation: Compilation[Backend.Portable], jarfile0: Optional[Path on Linux])
+  :   Path on Linux raises ZipError raises PathError raises IoError raises StreamError =
+
+    val entries = List(Classpath.Directory(compilation.out))
+    assemble(LocalClasspath(entries*), jarfile0.or(compilation.out.peer("tmpfile.jar")), Unset)
+
+
+  private def assemble
+    ( classpath: LocalClasspath, jarfile: Path on Linux, main: Optional[Fqcn] )
+  :   Path on Linux raises ZipError raises PathError raises IoError raises StreamError =
 
     val manifest =
       main.let(MainClass(_)).let: main =>
@@ -86,7 +112,7 @@ object Bundler:
     Zipfile.write(jarfile):
       val entries =
         Zip.Entry(%.on[Zip] / "META-INF" / "MANIFEST.MF", manifest) ::
-          classpath(directory).entries.to(List).flatMap:
+          classpath.entries.to(List).flatMap:
           case ClasspathEntry.Directory(directory) =>
             val root = directory.as[Path on Linux]
             root.descendants.to(List).filter: entry => !omissions(entry.name)

--- a/lib/anthology/src/core/anthology.Backend.scala
+++ b/lib/anthology/src/core/anthology.Backend.scala
@@ -30,9 +30,31 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package anthology
 
-export
-  anthology
-  . { Backend, Compilation, CompileEvent, CompileProcess, CompileProgress, Compiler,
-      CompilerError, CompileResult, Importance, Notice }
+import anticipation.*
+import gossamer.*
+
+object Backend:
+  type Jvm = Backend.Jvm.type
+  type Js = Backend.Js.type
+  type Wasm = Backend.Wasm.type
+  type Wasi = Backend.Wasi.type
+
+  // The backends whose compilations emit target-neutral `.sjsir`, deferring the choice of
+  // linked representation (JavaScript, browser Wasm or a WASI component) until link time.
+  type Portable = Js | Wasm | Wasi
+
+  // Determines the additional compiler flags each backend requires; contravariance lets the
+  // single `portable` instance serve every member of the `Portable` union.
+  trait Emission[-backend <: Backend]:
+    def flags: List[Text]
+
+  given jvm: Emission[Jvm]:
+    def flags: List[Text] = Nil
+
+  given portable: Emission[Portable]:
+    def flags: List[Text] = List(t"-scalajs")
+
+enum Backend:
+  case Jvm, Js, Wasm, Wasi

--- a/lib/anthology/src/core/anthology.Compilation.scala
+++ b/lib/anthology/src/core/anthology.Compilation.scala
@@ -30,9 +30,16 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package anthology
 
-export
-  anthology
-  . { Backend, Compilation, CompileEvent, CompileProcess, CompileProgress, Compiler,
-      CompilerError, CompileResult, Importance, Notice }
+import galilei.*
+import hellenism.*
+import prepositional.*
+import serpentine.*
+
+// A token pairing a compilation's output directory with the classpath it was compiled against,
+// tagged with the backend it targeted. Contravariance means a `Compilation[Backend.Portable]`
+// is acceptable wherever a compilation for any single portable backend is required, while a
+// JVM compilation can never be linked and a portable compilation can never be bundled as an
+// executable JAR.
+case class Compilation[-backend <: Backend](out: Path on Linux, classpath: LocalClasspath)

--- a/lib/anthology/src/link/anthology.LinkError.scala
+++ b/lib/anthology/src/link/anthology.LinkError.scala
@@ -1,0 +1,39 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import digression.*
+import fulminate.*
+
+case class LinkError(trace: StackTrace)(using Diagnostics)
+extends Error(779, 1)(m"linking terminated abnormally")

--- a/lib/anthology/src/link/anthology.LinkEvent.scala
+++ b/lib/anthology/src/link/anthology.LinkEvent.scala
@@ -1,0 +1,47 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import anticipation.*
+import fulminate.*
+
+object LinkEvent:
+  given communicable: LinkEvent is Communicable =
+    case Start            => m"starting linking"
+    case Message(message) => m"the linker reported: $message"
+    case Linked(path)     => m"linked output written to $path"
+
+enum LinkEvent:
+  case Start extends LinkEvent, Log.Compiler
+  case Message(message: Text) extends LinkEvent, Log.Compiler
+  case Linked(path: Text) extends LinkEvent, Log.Compiler

--- a/lib/anthology/src/link/anthology.Linkage.scala
+++ b/lib/anthology/src/link/anthology.Linkage.scala
@@ -1,0 +1,77 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import org.scalajs.linker.interface.{ESVersion, ModuleKind, StandardConfig}
+
+import anticipation.*
+import galilei.*
+import prepositional.*
+import serpentine.*
+
+object Linkage:
+  given js: Linkage[Backend.Js]:
+    private[anthology] def configure(config: StandardConfig): StandardConfig =
+      config.withModuleKind(ModuleKind.ESModule)
+
+    private[anthology] def artifact(out: Path on Linux): Path on Linux = out / "main.js"
+
+  given wasm: Linkage[Backend.Wasm]:
+    private[anthology] def configure(config: StandardConfig): StandardConfig =
+      config
+      . withModuleKind(ModuleKind.ESModule)
+      . withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true))
+
+    private[anthology] def artifact(out: Path on Linux): Path on Linux = out / "main.wasm"
+
+
+  given wasi(using toolchain: WasiToolchain, world: WitWorld): Linkage[Backend.Wasi] =
+    new Linkage[Backend.Wasi]:
+      private[anthology] def configure(config: StandardConfig): StandardConfig =
+        config
+        . withModuleKind(ModuleKind.WasmComponent)
+        . withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true))
+        . withWasmFeatures: features =>
+            features
+            . withWitDirectory(Some(world.directory.encode.s))
+            . withWitWorld(Some(world.world.s))
+
+      private[anthology] def artifact(out: Path on Linux): Path on Linux = out / "main.wasm"
+
+// Determines how each portable backend is linked: the linker configuration it mandates and the
+// primary artifact it produces. The `wasi` instance is conditional upon a `WasiToolchain` (the
+// native tools, proven present) and a `WitWorld`, so a WASI component link is only expressible
+// once its runtime prerequisites are satisfied.
+trait Linkage[target <: Backend.Portable]:
+  private[anthology] def configure(config: StandardConfig): StandardConfig
+  private[anthology] def artifact(out: Path on Linux): Path on Linux

--- a/lib/anthology/src/link/anthology.Linker.scala
+++ b/lib/anthology/src/link/anthology.Linker.scala
@@ -1,0 +1,120 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import java.nio.file as jnf
+
+import scala.concurrent.*
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.*
+import scala.util.control as suc
+
+import org.scalajs.linker.interface.{ModuleInitializer, StandardConfig}
+import org.scalajs.linker.{PathIRContainer, PathOutputDirectory, StandardImpl}
+import org.scalajs.logging.{Level, Logger}
+
+import anticipation.*
+import contingency.*
+import digression.*
+import galilei.*
+import hellenism.*
+import prepositional.*
+import serpentine.*
+
+object Linker:
+  // An entry point whose `main(args: Array[String])` method runs when the linked module loads.
+  case class EntryPoint(mainClass: Fqcn)
+
+  object Option:
+    private[anthology] def apply[target <: Backend.Portable]
+      ( configure0: StandardConfig => StandardConfig )
+    :   Option[target] =
+
+      new Option[target]:
+        private[anthology] def configure(config: StandardConfig): StandardConfig =
+          configure0(config)
+
+  // Options are constructible only through the `linkerOptions` DSL, keeping the underlying
+  // Scala.js linker types out of the public API; contravariance permits an option declared for
+  // `Backend.Portable` in the options list of any linker.
+  trait Option[-target <: Backend.Portable]:
+    private[anthology] def configure(config: StandardConfig): StandardConfig
+
+case class Linker[target <: Backend.Portable]
+  ( options: List[Linker.Option[target]], entryPoints: List[Linker.EntryPoint] = Nil ):
+
+  def link(compilation: Compilation[target], out: Path on Linux)(using linkage: Linkage[target])
+  :   Path on Linux logs LinkEvent raises LinkError =
+
+    Log.info(LinkEvent.Start)
+
+    val config: StandardConfig =
+      options.foldLeft(linkage.configure(StandardConfig())): (config, option) =>
+        option.configure(config)
+
+    val entries: List[jnf.Path] =
+      jnf.Paths.get(compilation.out.encode.s).nn ::
+        compilation.classpath.entries.to(List).flatMap:
+          case ClasspathEntry.Directory(directory) => List(jnf.Paths.get(directory.s).nn)
+          case ClasspathEntry.Jar(jar)             => List(jnf.Paths.get(jar.s).nn)
+          case _                                   => Nil
+
+    val initializers: List[ModuleInitializer] = entryPoints.map: entry =>
+      ModuleInitializer.mainMethodWithArgs(entry.mainClass.text.s, "main")
+
+    object logger extends Logger:
+      def log(level: Level, message: => String): Unit =
+        if level == Level.Error || level == Level.Warn
+        then Log.warn(LinkEvent.Message(message.tt))
+        else if level == Level.Info then Log.info(LinkEvent.Message(message.tt))
+        else Log.fine(LinkEvent.Message(message.tt))
+
+      def trace(error: => Throwable): Unit = Log.warn(LinkEvent.Message(error.toString.tt))
+
+    try
+      val outPath = jnf.Paths.get(out.encode.s).nn
+      jnf.Files.createDirectories(outPath)
+      val linker = StandardImpl.linker(config)
+      val cache = StandardImpl.irFileCache().newCache
+
+      val (containers, _) =
+        Await.result(PathIRContainer.fromClasspath(entries), 300.seconds)
+
+      val irFiles = Await.result(cache.cached(containers), 300.seconds)
+      val output = PathOutputDirectory(outPath)
+      Await.result(linker.link(irFiles, initializers, output, logger), 1800.seconds)
+      val result = linkage.artifact(out)
+      Log.info(LinkEvent.Linked(result.encode))
+      result
+
+    catch case suc.NonFatal(error) => abort(LinkError(error.stackTrace))

--- a/lib/anthology/src/link/anthology.ToolchainError.scala
+++ b/lib/anthology/src/link/anthology.ToolchainError.scala
@@ -1,0 +1,39 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import anticipation.*
+import fulminate.*
+
+case class ToolchainError(tool: Text)(using Diagnostics)
+extends Error(779, 2)(m"the native tool $tool is not available on the PATH")

--- a/lib/anthology/src/link/anthology.WasiToolchain.scala
+++ b/lib/anthology/src/link/anthology.WasiToolchain.scala
@@ -1,0 +1,56 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import ambience.*
+import anticipation.*
+import contingency.*
+import eucalyptus.*
+import gossamer.*
+import guillotine.*
+import rudiments.*
+
+// Evidence that the native tools a WASI component link shells out to (`wasm-tools` and the
+// scala-wasm fork of `wit-bindgen`) are present. Instances exist only via the probing `apply`,
+// so linking for `Backend.Wasi` cannot discover a missing tool at link time.
+object WasiToolchain:
+  def apply()(using WorkingDirectory): WasiToolchain raises ToolchainError =
+    probe(t"wasm-tools")
+    probe(t"wit-bindgen")
+    new WasiToolchain()
+
+  private def probe(tool: Text)(using WorkingDirectory): Unit raises ToolchainError =
+    if safely(mute[ExecEvent](sh"$tool --version".exec[Exit]())) != Exit.Ok
+    then raise(ToolchainError(tool))
+
+class WasiToolchain private ()

--- a/lib/anthology/src/link/anthology.WitWorld.scala
+++ b/lib/anthology/src/link/anthology.WitWorld.scala
@@ -1,0 +1,42 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import anticipation.*
+import galilei.*
+import prepositional.*
+import serpentine.*
+
+// The WIT definitions a WASI component link resolves its imports and exports against: a
+// directory of `.wit` packages and the name of the world to link.
+case class WitWorld(directory: Path on Linux, world: Text)

--- a/lib/anthology/src/link/anthology_link.scala
+++ b/lib/anthology/src/link/anthology_link.scala
@@ -1,0 +1,66 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import org.scalajs.linker.interface.{ESVersion, ModuleKind}
+
+object linkerOptions:
+  object moduleKind:
+    val esModule: Linker.Option[Backend.Js] =
+      Linker.Option(_.withModuleKind(ModuleKind.ESModule))
+
+    val commonJs: Linker.Option[Backend.Js] =
+      Linker.Option(_.withModuleKind(ModuleKind.CommonJSModule))
+
+    val noModule: Linker.Option[Backend.Js] =
+      Linker.Option(_.withModuleKind(ModuleKind.NoModule))
+
+  val checkIr: Linker.Option[Backend.Portable] = Linker.Option(_.withCheckIR(true))
+  val sourceMaps: Linker.Option[Backend.Portable] = Linker.Option(_.withSourceMap(true))
+
+  object esVersion:
+    private def of(version: ESVersion): Linker.Option[Backend.Portable] =
+      Linker.Option(_.withESFeatures(_.withESVersion(version)))
+
+    val es2015: Linker.Option[Backend.Portable] = of(ESVersion.ES2015)
+    val es2016: Linker.Option[Backend.Portable] = of(ESVersion.ES2016)
+    val es2017: Linker.Option[Backend.Portable] = of(ESVersion.ES2017)
+    val es2018: Linker.Option[Backend.Portable] = of(ESVersion.ES2018)
+    val es2019: Linker.Option[Backend.Portable] = of(ESVersion.ES2019)
+    val es2020: Linker.Option[Backend.Portable] = of(ESVersion.ES2020)
+    val es2021: Linker.Option[Backend.Portable] = of(ESVersion.ES2021)
+    val es2022: Linker.Option[Backend.Portable] = of(ESVersion.ES2022)
+
+  object optimize:
+    val none: Linker.Option[Backend.Portable] = Linker.Option(_.withOptimizer(false))
+    val fast: Linker.Option[Backend.Portable] = Linker.Option(_.withOptimizer(true))

--- a/lib/anthology/src/link/soundness_anthology_link.scala
+++ b/lib/anthology/src/link/soundness_anthology_link.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export
+  anthology
+  . { Linkage, LinkError, LinkEvent, Linker, linkerOptions, ToolchainError, WasiToolchain,
+      WitWorld }

--- a/lib/anthology/src/scala/anthology.Scalac.scala
+++ b/lib/anthology/src/scala/anthology.Scalac.scala
@@ -34,6 +34,7 @@ package anthology
 
 import language.adhocExtensions
 
+import scala.annotation.targetName
 import scala.util.control as suc
 
 import dotty.tools.dotc as dtd
@@ -65,15 +66,24 @@ object Scalac:
   def refresh(): Unit = mutex { Scala3 = new dtd.Compiler() }
   def compiler(): dtd.Compiler = Scala3
 
-case class Scalac[version <: Scalac.Versions](options: List[Scalac.Option[version]]):
+  // Preserves the single-type-argument call form, `Scalac[3.6](options)`, which targets the JVM.
+  @targetName("applyJvm")
+  def apply[version <: Versions](options: List[Option[version]]): Scalac[version, Backend.Jvm] =
+    new Scalac(options)
+
+case class Scalac[version <: Scalac.Versions, backend <: Backend] private
+  ( options: List[Scalac.Option[version]] ):
+
   def commandLineArguments: List[Text] = options.flatMap(_.flags)
+
+  def targeting[backend2 <: Backend]: Scalac[version, backend2] = new Scalac(options)
 
 
   def apply
     ( classpath: LocalClasspath )
     [ path: Abstractable across Paths to Text ]
     ( sources: Map[Text, Text], out: path )
-    ( using System, Monitor, Probate )
+    ( using System, Monitor, Probate, Backend.Emission[backend] )
   :   CompileProcess logs CompileEvent raises CompilerError =
 
     val scalacProcess: CompileProcess = CompileProcess()
@@ -120,7 +130,8 @@ case class Scalac[version <: Scalac.Versions](options: List[Scalac.Option[versio
         //val jsParams =
 
         val arguments: List[Text] =
-          List(t"-d", out.generic, t"-classpath", classpath()) :::
+          summon[Backend.Emission[backend]].flags :::
+            List(t"-d", out.generic, t"-classpath", classpath()) :::
             commandLineArguments :::
             List(t"")
 

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -32,9 +32,19 @@
                                                                                                   */
 package anthology
 
+import java.nio.file.{Files, Paths}
+
 import org.scalajs.linker.interface.{ModuleKind, StandardConfig}
 
 import soundness.*
+
+import galilei.Linux.pathOnLinux
+import logging.silentLogging
+import probates.cancelProbate
+import strategies.throwUnsafely
+import systems.javaSystem
+import temporaryDirectories.systemTemporaryDirectory
+import threading.platformThreading
 
 // Unexecuted definitions whose successful compilation asserts the variance properties of
 // `Compilation`: a portable compilation may be linked as any concrete portable backend.
@@ -107,3 +117,73 @@ object Tests extends Suite(m"Anthology Tests"):
         val compilation: Compilation[Backend.Jvm] = ???
         Bundler.library(compilation, Unset)
     . assert(_.nonEmpty)
+
+    // An end-to-end exercise of the portable pipeline—compile with `-scalajs`, then link as
+    // JavaScript—which runs only when a cached proscala toolchain (whose distribution includes
+    // the Scala.js runtime JARs) can be found.
+    sjsClasspath().let: classpath =>
+      supervise:
+        val out: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
+        Files.createDirectories(Paths.get(out.encode.s))
+
+        val source: Text =
+          t"""|object Main:
+              |  def main(args: Array[String]): Unit = println("hello")
+              |""".s.stripMargin.tt
+
+        val process =
+          Scalac[3.8](Nil).targeting[Backend.Portable]
+            (classpath)(Map(t"hello.scala" -> source), out)
+
+        test(m"A portable compilation succeeds"):
+          process.complete()
+        . assert(_ == CompileResult.Success)
+
+        test(m"A portable compilation emits sjsir"):
+          Files.list(Paths.get(out.encode.s)).nn.iterator.nn.asScala
+          . exists(_.getFileName.nn.toString.endsWith(".sjsir"))
+        . assert(_ == true)
+
+        val linked: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
+
+        test(m"Linking as JavaScript produces a nonempty main.js"):
+          Linker[Backend.Js]
+            ( List(linkerOptions.moduleKind.esModule),
+              List(Linker.EntryPoint(Fqcn(t"Main"))) )
+          . link(Compilation(out, classpath), linked)
+          . pipe: artifact =>
+              Files.size(Paths.get(artifact.encode.s))
+        . assert(_ > 100L)
+
+  // Locates a cached proscala release whose `lib` directory contains the runtime JARs a
+  // portable compilation needs, yielding them as a classpath.
+  def sjsClasspath(): Optional[LocalClasspath] =
+    val fixed: List[Text] =
+      List
+        ( t"scala-library.jar",
+          t"scala3-library.jar",
+          t"scala3-library_sjs1.jar",
+          t"scalajs-scalalib_2.13.jar" )
+
+    val home = java.lang.System.getProperty("user.home").nn
+    val root = Paths.get(home, ".cache", "soundness", "proscala").nn
+
+    if !Files.isDirectory(root) then Unset else
+      Files.list(root).nn.iterator.nn.asScala.to(List).sortBy(_.toString).reverse
+      . map(_.resolve("lib").nn)
+      . find: lib =>
+          def contents = Files.list(lib).nn.iterator.nn.asScala
+          Files.isDirectory(lib)
+          && fixed.forall { name => Files.exists(lib.resolve(name.s)) }
+          && contents.exists(_.getFileName.nn.toString.startsWith("scalajs-javalib"))
+          && contents.exists(_.getFileName.nn.toString.startsWith("scalajs-library_2.13"))
+
+      . map: lib =>
+          val globbed = Files.list(lib).nn.iterator.nn.asScala.to(List).filter: jar =>
+            val name = jar.getFileName.nn.toString
+            name.startsWith("scalajs-javalib") || name.startsWith("scalajs-library_2.13")
+
+          val jars = fixed.map { name => lib.resolve(name.s).nn } ++ globbed
+          LocalClasspath(jars.map { jar => ClasspathEntry.Jar(jar.toString.tt) }*)
+
+      . getOrElse(Unset)

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -32,7 +32,78 @@
                                                                                                   */
 package anthology
 
+import org.scalajs.linker.interface.{ModuleKind, StandardConfig}
+
 import soundness.*
 
+// Unexecuted definitions whose successful compilation asserts the variance properties of
+// `Compilation`: a portable compilation may be linked as any concrete portable backend.
+def portableLinksAsJs(compilation: Compilation[Backend.Portable]): Compilation[Backend.Js] =
+  compilation
+
+def portableLinksAsWasi(compilation: Compilation[Backend.Portable]): Compilation[Backend.Wasi] =
+  compilation
+
 object Tests extends Suite(m"Anthology Tests"):
-  def run(): Unit = ()
+  def run(): Unit =
+    test(m"A single-type-argument Scalac targets the JVM"):
+      val scalac: Scalac[3.6, Backend.Jvm] = Scalac[3.6](Nil)
+      scalac.commandLineArguments
+    . assert(_ == Nil)
+
+    test(m"Retargeting a Scalac preserves its options"):
+      Scalac[3.8](List(scalacOptions.experimental)).targeting[Backend.Portable]
+      . commandLineArguments
+    . assert(_ == List(t"-experimental"))
+
+    test(m"The JVM backend adds no compiler flags"):
+      summon[Backend.Emission[Backend.Jvm]].flags
+    . assert(_ == Nil)
+
+    test(m"Every portable backend adds the -scalajs flag"):
+      List
+        ( summon[Backend.Emission[Backend.Js]].flags,
+          summon[Backend.Emission[Backend.Wasm]].flags,
+          summon[Backend.Emission[Backend.Wasi]].flags,
+          summon[Backend.Emission[Backend.Portable]].flags )
+    . assert(_.forall(_ == List(t"-scalajs")))
+
+    test(m"Module-kind options configure the linker"):
+      linkerOptions.moduleKind.commonJs.configure(StandardConfig()).moduleKind
+    . assert(_ == ModuleKind.CommonJSModule)
+
+    test(m"The JavaScript linkage produces an ES module"):
+      summon[Linkage[Backend.Js]].configure(StandardConfig()).moduleKind
+    . assert(_ == ModuleKind.ESModule)
+
+    test(m"The browser Wasm linkage enables the WebAssembly backend"):
+      summon[Linkage[Backend.Wasm]].configure(StandardConfig()).esFeatures.useWebAssembly
+    . assert(_ == true)
+
+    test(m"A module-kind option is not applicable to a Wasm linker"):
+      demilitarize:
+        Linker[Backend.Wasm](List(linkerOptions.moduleKind.esModule))
+    . assert(_.nonEmpty)
+
+    test(m"A WASI linkage is not available without toolchain and WIT world"):
+      demilitarize:
+        summon[Linkage[Backend.Wasi]]
+    . assert(_.nonEmpty)
+
+    test(m"A JVM compilation cannot be linked"):
+      demilitarize:
+        val compilation: Compilation[Backend.Jvm] = ???
+        portableLinksAsJs(compilation)
+    . assert(_.nonEmpty)
+
+    test(m"A portable compilation cannot be bundled as an executable JAR"):
+      demilitarize:
+        val compilation: Compilation[Backend.Portable] = ???
+        Bundler.bundle(compilation, Unset, Unset)
+    . assert(_.nonEmpty)
+
+    test(m"A JVM compilation cannot be bundled as an sjsir library"):
+      demilitarize:
+        val compilation: Compilation[Backend.Jvm] = ???
+        Bundler.library(compilation, Unset)
+    . assert(_.nonEmpty)

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -120,7 +120,7 @@ extends Rig:
         case Exit.Ok         => target
         case Exit.Fail(fail) => ???
 
-  protected val scalac: Scalac[3.8] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.8, Backend.Jvm] = Scalac(List(scalacOptions.experimental))
 
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux])

--- a/lib/harlequin/src/core/harlequin.Highlight.scala
+++ b/lib/harlequin/src/core/harlequin.Highlight.scala
@@ -44,23 +44,23 @@ object Highlight:
 
 trait Highlight:
   def depth: Depth
-  def scalac: Optional[Scalac[?]]
+  def scalac: Optional[Scalac[?, ?]]
   def classpath: Optional[LocalClasspath]
 
 object highlighting:
   given tokenizedScala: Highlight = new Highlight:
     def depth: Depth = Depth.Tokenized
-    def scalac: Optional[Scalac[?]] = Unset
+    def scalac: Optional[Scalac[?, ?]] = Unset
     def classpath: Optional[LocalClasspath] = Unset
 
-  given typecheckedScala(using scalac0: Scalac[?], classpath0: LocalClasspath): Highlight =
+  given typecheckedScala(using scalac0: Scalac[?, ?], classpath0: LocalClasspath): Highlight =
     new Highlight:
       def depth: Depth = Depth.Typechecked
-      def scalac: Optional[Scalac[?]] = scalac0
+      def scalac: Optional[Scalac[?, ?]] = scalac0
       def classpath: Optional[LocalClasspath] = classpath0
 
-  given compiledScala(using scalac0: Scalac[?], classpath0: LocalClasspath): Highlight =
+  given compiledScala(using scalac0: Scalac[?, ?], classpath0: LocalClasspath): Highlight =
     new Highlight:
       def depth: Depth = Depth.Compiled
-      def scalac: Optional[Scalac[?]] = scalac0
+      def scalac: Optional[Scalac[?, ?]] = scalac0
       def classpath: Optional[LocalClasspath] = classpath0

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -79,7 +79,7 @@ object SourceCode:
 
       if highlighting.depth == Depth.Tokenized then Unset else
         (highlighting.scalac, highlighting.classpath) match
-          case (scalac: Scalac[?], classpath: LocalClasspath) =>
+          case (scalac: Scalac[?, ?], classpath: LocalClasspath) =>
             resolveTypes
               ( text, scalac, classpath, highlighting.depth == Depth.Compiled, caret )
 
@@ -335,7 +335,7 @@ object SourceCode:
 
   private def resolveTypes
     ( text:      Text,
-      scalac:    Scalac[?],
+      scalac:    Scalac[?, ?],
       classpath: LocalClasspath,
       full:      Boolean,
       caret:     Optional[Ordinal] )
@@ -364,7 +364,7 @@ object SourceCode:
     (metaMap, diagnostics, completions)
 
   private def frontend
-    ( text: Text, scalac: Scalac[?], cp: Text )
+    ( text: Text, scalac: Scalac[?, ?], cp: Text )
     ( stop: Contexts.FreshContext => Contexts.FreshContext )
   :   (Run, Contexts.Context, List[Diagnostic]) =
 

--- a/lib/harlequin/src/test/harlequin_test.scala
+++ b/lib/harlequin/src/test/harlequin_test.scala
@@ -99,7 +99,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert(_ == (t"term", t"binding"))
 
     test(m"typechecked highlighting resolves the type of a val"):
-      given Scalac[3.8] = Scalac[3.8](Nil)
+      given Scalac[3.8, Backend.Jvm] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 
@@ -107,7 +107,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert { rendered => rendered.contains(t"List") && rendered.contains(t"Int") }
 
     test(m"typechecked highlighting reports diagnostics for ill-typed code"):
-      given Scalac[3.8] = Scalac[3.8](Nil)
+      given Scalac[3.8, Backend.Jvm] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 
@@ -115,7 +115,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert(_ > 0)
 
     test(m"no completions are computed without a caret"):
-      given Scalac[3.8] = Scalac[3.8](Nil)
+      given Scalac[3.8, Backend.Jvm] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 
@@ -123,7 +123,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert(_ == Unset)
 
     test(m"completions at a member selection include the type's methods"):
-      given Scalac[3.8] = Scalac[3.8](Nil)
+      given Scalac[3.8, Backend.Jvm] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 

--- a/lib/mandible/src/core/mandible_core.scala
+++ b/lib/mandible/src/core/mandible_core.scala
@@ -64,7 +64,7 @@ def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using T
 
   val uuid = Uuid()
   val out: Path on Linux = unsafely(temporaryDirectory/uuid)
-  val scalac: Scalac[3.6] = Scalac[3.6](List(scalacOptions.experimental))
+  val scalac: Scalac[3.6, Backend.Jvm] = Scalac[3.6](List(scalacOptions.experimental))
 
   val settings: staging.Compiler.Settings =
     staging.Compiler.Settings.make(Some(out.encode.s), scalac.commandLineArguments.map(_.s))

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -198,7 +198,7 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
     device.deploy(jarfile, uuid)
     jarfile
 
-  protected val scalac: Scalac[3.7] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.7, Backend.Jvm] = Scalac(List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
     stage.remote: input =>

--- a/lib/sedentary/src/core/sedentary.Profile.scala
+++ b/lib/sedentary/src/core/sedentary.Profile.scala
@@ -194,7 +194,7 @@ extends Rig:
     device.deploy(jarfile, uuid)
     jarfile
 
-  protected val scalac: Scalac[3.7] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.7, Backend.Jvm] = Scalac(List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
     stage.remote: input =>

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -451,7 +451,7 @@ extends Rig:
     device.deploy(jarfile, uuid)
     jarfile
 
-  protected val scalac: Scalac[3.7] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.7, Backend.Jvm] = Scalac(List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
     stage.remote: input =>

--- a/lib/superlunary/src/core/superlunary.Rig.scala
+++ b/lib/superlunary/src/core/superlunary.Rig.scala
@@ -57,7 +57,7 @@ trait Rig(using classloader0: Classloader) extends Targetable, Formal, Transport
   type Result[output]
   type Transport <: Object
 
-  protected val scalac: Scalac[?]
+  protected val scalac: Scalac[?, ?]
 
   protected def invoke[output](stage: Stage[output, Form, Target]): Result[output]
 

--- a/lib/superlunary/src/jvm/superlunary.Isolation.scala
+++ b/lib/superlunary/src/jvm/superlunary.Isolation.scala
@@ -52,7 +52,7 @@ object Isolation extends Rig:
 
   def stage(out: Path on Linux): Classloader = classpath(out).classloader()
 
-  val scalac: Scalac[3.6] = Scalac[3.6](List(scalacOptions.experimental))
+  val scalac: Scalac[3.6, Backend.Jvm] = Scalac[3.6](List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Form, Target]): output =
     stage.remote: input =>

--- a/lib/superlunary/src/jvm/superlunary.Jvm.scala
+++ b/lib/superlunary/src/jvm/superlunary.Jvm.scala
@@ -55,7 +55,7 @@ object Jvm extends Rig:
 
   def stage(out: Path on Linux): LocalClasspath = classpath(out)
 
-  val scalac: Scalac[3.6] = Scalac[3.6](List(scalacOptions.experimental))
+  val scalac: Scalac[3.6, Backend.Jvm] = Scalac[3.6](List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Form, Target]): output =
     import workingDirectories.systemWorkingDirectory


### PR DESCRIPTION
Anthology can now produce fully-linked JavaScript and WebAssembly output, not just JVM classfiles. Compilations are typed by a new `Backend` (JVM, JS, browser Wasm or WASI component), portable compilations emit target-neutral sjsir whose linked form is chosen later, and a new `anthology.link` module drives the Scala.js linker through a typesafe API in which backend-inapplicable options, products and unmet WASI prerequisites are compile errors.

## Backend-typed compilation

`Scalac` gains a second type parameter for the backend it targets. The familiar form is unchanged and targets the JVM, while `targeting` selects another backend:

```scala
val jvm = Scalac[3.8](List(scalacOptions.experimental))
val portable = jvm.targeting[Backend.Portable]
```

The three portable backends — `Backend.Js`, `Backend.Wasm` and `Backend.Wasi` — compile with `-scalajs` (added automatically) and emit target-neutral `.sjsir`, so a compilation for the `Backend.Portable` union may later be linked as _any_ of the three.

## Typed products

A `Compilation[backend]` pairs an output directory with its classpath, and each product is only expressible for the backends it is valid for: `Bundler.bundle` produces an executable JAR from a JVM compilation; `Bundler.library` packages a portable compilation's sjsir as a library JAR for downstream assembly; and `Linker[target].link` produces a fully-linked artifact:

```scala
val linker = Linker[Backend.Js]
  ( List(linkerOptions.moduleKind.esModule, linkerOptions.optimize.fast),
    List(Linker.EntryPoint(fqcn"com.example.Main")) )

val mainJs = linker.link(compilation, out)
```

Linker options are typechecked against the link target, exactly as compiler options are typechecked against the compiler version.

## WASI components

Linking a WASI component requires two contextual values without which the link does not compile: a `WasiToolchain`, obtainable only from a probing constructor that verifies the native `wasm-tools` and `wit-bindgen` tools are present, and a `WitWorld` naming the WIT packages and world to link against. `Backend.Js` and `Backend.Wasm` need no native tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
