### PR TITLE
Structure Anthology's targets as Universe and Artifact tiers

### DIFF
--- a/lib/anthology/doc/basics.md
+++ b/lib/anthology/doc/basics.md
@@ -1,29 +1,38 @@
+### Universes and artifacts
+
+Anthology structures compilation around two tiers. A _universe_ is the intermediate
+representation a compilation emits, and hence the ecosystem of library artifacts it can link
+with: `Universe.Bytecode` (JVM classfiles), `Universe.Sjsir` (Scala.js IR) and `Universe.Nir`
+(Scala Native IR). An _artifact_ is a linked end product: `Artifact.Jar` (an executable JAR,
+bound to the JDK), `Artifact.Js` (a JavaScript module or script, bound to a JavaScript host),
+`Artifact.Wasm` (a core WebAssembly module with JavaScript glue), `Artifact.Wasi[version]` (a
+standalone WebAssembly artifact bound to a version of the WASI system interface: `0.1`, `0.2` or
+`0.3`) and `Artifact.Binary` (a machine-code executable).
+
+Each artifact is produced from exactly one universe, witnessed by a `Provenance` instance:
+`Jar` from `Bytecode`; `Js`, `Wasm` and `Wasi` from `Sjsir`; `Binary` from `Nir`. The sjsir
+universe defers the choice among its three artifacts until link time, so one compilation may be
+linked as any of them.
+
 ### Compiling
 
 A Scala compiler is represented by a `Scalac` value, parameterized by the compiler version and
-the backend it targets, with a list of compiler options whose validity is checked against the
-version at compile time:
+the universe it compiles into, with options whose validity is checked against the version at
+compile time:
 ```scala
-val scalac: Scalac[3.8, Backend.Jvm] = Scalac[3.8](List(scalacOptions.experimental))
+val scalac: Scalac[3.8, Universe.Bytecode] = Scalac[3.8](List(scalacOptions.experimental))
 ```
 
-The single-type-argument form, `Scalac[3.8](options)`, targets the JVM. The same options may be
-retargeted at another backend with `targeting`:
+The single-type-argument form targets the bytecode universe. `targeting` selects a universe
+explicitly, while `producing` selects it via the artifact you ultimately want:
 ```scala
-val portable = Scalac[3.8](List(scalacOptions.experimental)).targeting[Backend.Portable]
+val forJs = Scalac[3.8](options).producing[Artifact.Js]            // Scalac[3.8, Universe.Sjsir]
+val forNative = Scalac[3.8](options).targeting[Universe.Nir]
 ```
 
-Five backends exist: `Backend.Jvm`, which produces classfiles; the three _portable_
-backends—`Backend.Js`, `Backend.Wasm` and `Backend.Wasi`—which additionally produce
-target-neutral `.sjsir` files, deferring the choice of linked representation until link time;
-and `Backend.Native`, which produces `.nir` files for Scala Native. `Backend.Portable`, the
-union of the three sjsir backends, is the natural choice when compiling a library whose linked
-form is not yet known; a portable compilation may later be linked as _any_ of the three.
-`Backend.Linked` is the union of every backend whose output is linkable.
-
-Compiling for a portable backend requires the Scala.js runtime JARs (`scalajs-javalib`,
+Compiling into `Universe.Sjsir` requires the Scala.js runtime JARs (`scalajs-javalib`,
 `scalajs-library_2.13`, `scalajs-scalalib_2.13` and `scala3-library_sjs1`) on the classpath;
-their absence surfaces as ordinary compiler diagnostics. Compiling for `Backend.Native`
+their absence surfaces as ordinary compiler diagnostics. Compiling into `Universe.Nir`
 additionally requires a `NirPlugin` in scope—evidence of the location of the Scala Native
 compiler plugin, since NIR is emitted by a plugin rather than a backend built into the
 compiler—plus the Scala Native runtime JARs (`scalalib`, `scala3lib`, `javalib`, `auxlib`,
@@ -32,44 +41,41 @@ compiler—plus the Scala Native runtime JARs (`scalalib`, `scala3lib`, `javalib
 ### Products
 
 The result of a compilation—an output directory and the classpath it was compiled against—is
-described by a `Compilation`, tagged with its backend:
+described by a `Compilation`, tagged with its universe:
 ```scala
-val compilation: Compilation[Backend.Portable] = Compilation(out, classpath)
+val compilation: Compilation[Universe.Sjsir] = Compilation(out, classpath)
 ```
 
-Three products can be made from a compilation, and each is only expressible for the backends it
-is valid for:
- - `Bundler.bundle(compilation, jarfile, main)` produces an executable JAR, and requires a
-   `Compilation[Backend.Jvm]`
- - `Bundler.library(compilation, jarfile)` produces a library JAR of `.sjsir` or `.nir` files
-   for downstream assembly, and requires a linkable compilation
- - `Linker[target](options, entryPoints).link(compilation, out)` produces a fully-linked
-   artifact for a concrete linkable target
+ - `Bundler.bundle(compilation, jarfile, main)` produces an executable JAR from a bytecode
+   compilation
+ - `Bundler.library(compilation, jarfile)` produces a library JAR from a compilation in _any_
+   universe—classfiles, `.sjsir` or `.nir`—for downstream assembly
+ - `Linker[artifact](options, entryPoints).link(compilation, out)` produces a fully-linked
+   artifact, and requires a compilation from that artifact's origin universe
 
 ### Linking
 
-A `Linker` is parameterized by the concrete backend it links for, with options whose validity is
-checked against that backend at compile time, mirroring `scalacOptions`:
+A `Linker` is parameterized by the artifact it produces, with options whose validity is checked
+against that artifact at compile time, mirroring `scalacOptions`:
 ```scala
-val linker = Linker[Backend.Js]
+val linker = Linker[Artifact.Js]
   ( List(linkerOptions.moduleKind.esModule, linkerOptions.optimize.fast),
     List(Linker.EntryPoint(fqcn"com.example.Main")) )
 
-val artifact: Path on Linux = linker.link(compilation, out)
+val mainJs: Path on Linux = linker.link(compilation, out)
 ```
 
-`Backend.Js` produces a `main.js`; `Backend.Wasm` produces a `main.wasm` (with a JavaScript
-loader alongside) for browsers and JavaScript runtimes; `Backend.Wasi` produces a standalone
-WASI component, `main.wasm`, for runtimes such as `wasmtime`.
+The universe is inferred: linking `Artifact.Js` demands a `Compilation[Universe.Sjsir]`, and
+supplying a compilation from any other universe is a compile error. Options such as
+`moduleKind.*` apply only to `Artifact.Js` (the WebAssembly artifacts mandate their own module
+kinds), while `checkIr`, `sourceMaps`, `esVersion.*` and `optimize.*` apply to every sjsir
+artifact; a misapplied option is a compile error.
 
-Options such as `moduleKind.*` apply only to `Backend.Js` (the WebAssembly backends mandate
-their own module kinds), while `checkIr`, `sourceMaps`, `esVersion.*` and `optimize.*` apply to
-every portable backend; a misapplied option is a compile error.
+### Linking WASI artifacts
 
-### Linking WASI components
-
-A WASI component link has two prerequisites beyond the linker itself, both expressed as
-contextual values without which `Linker[Backend.Wasi].link` does not compile:
+A WASI link produces an `Artifact.Wasi[0.2]`—a component-model `.wasm` whose imports and
+exports are described by WIT. It has two prerequisites beyond the linker itself, both expressed
+as contextual values without which the link does not compile:
 
  - a `WasiToolchain`, evidence that the native tools the link shells out to—`wasm-tools` and the
    scala-wasm fork of `wit-bindgen`—are present; instances exist only via the probing
@@ -80,10 +86,15 @@ contextual values without which `Linker[Backend.Wasi].link` does not compile:
 given WasiToolchain = WasiToolchain()
 given WitWorld = WitWorld(witDirectory, t"my-world")
 
-Linker[Backend.Wasi](Nil).link(compilation, out)
+Linker[Artifact.Wasi[0.2]](Nil).link(compilation, out)
 ```
 
-`Backend.Js` and `Backend.Wasm` require no native tooling: the linker is an ordinary JVM
+WASI versions are part of the artifact's type because they determine its ABI: `0.1` (preview 1)
+is a flat, libc-style syscall interface on core modules; `0.2` is the component model; `0.3`
+adds native asynchrony. Only `0.2` is currently linkable—requesting `Artifact.Wasi[0.3]` is a
+compile error until a `Linkage` for it exists.
+
+`Artifact.Js` and `Artifact.Wasm` require no native tooling: the linker is an ordinary JVM
 library.
 
 ### Linking native binaries
@@ -92,9 +103,9 @@ A Scala Native link shells out to `clang` and `clang++`, so its `Linkage` exists
 probing constructor `NativeLinkage()`, which verifies the C toolchain is present (raising
 `ToolchainError` otherwise):
 ```scala
-given Linkage[Backend.Native] = NativeLinkage()
+given NativeLinkage = NativeLinkage()
 
-Linker[Backend.Native]
+Linker[Artifact.Binary]
   ( List(nativeOptions.mode.releaseFast, nativeOptions.gc.commix),
     List(Linker.EntryPoint(fqcn"com.example.Main")) )
 . link(compilation, out)

--- a/lib/anthology/doc/features.md
+++ b/lib/anthology/doc/features.md
@@ -8,7 +8,10 @@
 - compiler invocation is typed according to the major compiler version
 - options are typechecked against the compiler version
 - supports compilation with [Scala.js](https://scala-js.org/)
-- compilations are typed by target backend: JVM, JavaScript, WebAssembly, WASI or Scala Native
+- compilations are typed by the universe they inhabit (JVM bytecode, sjsir or NIR), and links
+  by the artifact they produce (executable JAR, JavaScript, WebAssembly, WASI component or
+  native binary), with each artifact's origin universe inferred
+- WASI versions (0.1, 0.2, 0.3) are part of the artifact's type, since they determine its ABI
 - fully-linked `.js` and `.wasm` artifacts and native binaries, or unlinked `.sjsir`/`.nir`
   library JARs for downstream assembly
 - native links may select a target platform (e.g. arm64/macOS) as a typed LLVM triple

--- a/lib/anthology/src/bundle/anthology.Bundler.scala
+++ b/lib/anthology/src/bundle/anthology.Bundler.scala
@@ -73,10 +73,10 @@ object Bundler:
     assemble(classpath(directory), jarfile0.or(directory.peer("tmpfile.jar")), main)
 
 
-  // Bundles a JVM compilation, together with the classpath it was compiled against, as an
+  // Bundles a bytecode compilation, together with the classpath it was compiled against, as an
   // executable JAR file.
   def bundle
-    ( compilation: Compilation[Backend.Jvm],
+    ( compilation: Compilation[Universe.Bytecode],
       jarfile0:    Optional[Path on Linux],
       main:        Optional[Fqcn] )
   :   Path on Linux raises ZipError raises PathError raises IoError raises StreamError =
@@ -85,10 +85,11 @@ object Bundler:
     assemble(LocalClasspath(entries*), jarfile0.or(compilation.out.peer("tmpfile.jar")), main)
 
 
-  // Bundles a linkable compilation's output—its `.sjsir` or `.nir` files alongside its
-  // classfiles—as a library JAR for downstream assembly: the JAR is a valid classpath entry both
-  // for further compilations and for a later `Linker`.
-  def library(compilation: Compilation[Backend.Linked], jarfile0: Optional[Path on Linux])
+  // Bundles a compilation's output—classfiles, and any `.sjsir` or `.nir` alongside them—as a
+  // library JAR for downstream assembly: the JAR is a valid classpath entry for further
+  // compilations in the same universe, and for a later `Linker`.
+  def library[universe <: Universe]
+    ( compilation: Compilation[universe], jarfile0: Optional[Path on Linux] )
   :   Path on Linux raises ZipError raises PathError raises IoError raises StreamError =
 
     val entries = List(Classpath.Directory(compilation.out))

--- a/lib/anthology/src/core/anthology.Artifact.scala
+++ b/lib/anthology/src/core/anthology.Artifact.scala
@@ -32,90 +32,33 @@
                                                                                                   */
 package anthology
 
-import java.nio.file as jnf
+object Artifact:
+  // Bytecode universe: an executable JAR, bound to the JDK.
+  sealed trait Jar extends Artifact
 
-import scala.concurrent.*
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.*
-import scala.scalanative.build.{Build, Config, GC, LTO, Mode, NativeConfig}
-import scala.scalanative.util.Scope
-import scala.util.control as suc
+  // Sjsir universe: a JavaScript module or script, bound to a JavaScript host (a browser's DOM
+  // or a runtime such as Node).
+  sealed trait Js extends Artifact
 
-import ambience.*
-import anticipation.*
-import contingency.*
-import digression.*
-import distillate.*
-import eucalyptus.*
-import galilei.*
-import gossamer.*
-import guillotine.*
-import hellenism.*
-import prepositional.*
-import serpentine.*
-import vacuous.*
+  // Sjsir universe: a core WebAssembly module with JavaScript glue, bound to a JavaScript host.
+  sealed trait Wasm extends Artifact
 
-// The Scala Native link family. An instance exists only via the probing `apply`, which verifies
-// that the C toolchain (`clang` and `clang++`) the link shells out to is present—so, as with
-// WASI components, a native link whose native tooling is absent is not expressible. Put one in
-// scope with `given NativeLinkage = NativeLinkage()`.
-object NativeLinkage:
-  def apply()(using WorkingDirectory)
-  :   (Linkage[Artifact.Binary] from Universe.Nir) raises ToolchainError =
+  object Wasi:
+    // WASI interface versions: 0.1 (preview 1) is a flat, libc-style syscall ABI on core
+    // modules; 0.2 is the component model, with imports and exports described by WIT; 0.3 adds
+    // native asynchrony. Versions determine the artifact's ABI, so they are part of its type.
+    type Versions = 0.1 | 0.2 | 0.3
 
-    new NativeLinkage(probe(t"clang"), probe(t"clang++"))
+  // A standalone WebAssembly artifact bound to a version of the WASI system interface.
+  sealed trait Wasi[+version <: Wasi.Versions] extends Artifact
 
-  private def probe(tool: Text)(using WorkingDirectory): Text raises ToolchainError =
-    safely(mute[ExecEvent](sh"which $tool".exec[Text]())).let(_.trim)
-    . or(abort(ToolchainError(tool)))
+  // Nir universe: a machine-code executable, bound to an operating system's C library; the
+  // platform and architecture are selected at link time as a `Triple`.
+  sealed trait Binary extends Artifact
 
-class NativeLinkage private (clang: Text, clangpp: Text)
-extends Linkage[Artifact.Binary]:
-  type Origin = Universe.Nir
-  private[anthology] type Form = NativeConfig
+  // The artifacts linked from `.sjsir` by the Scala.js linker, sharing one options family.
+  type Sjs = Js | Wasm | Wasi[Wasi.Versions]
 
-  private[anthology] def initial: NativeConfig =
-    NativeConfig.empty
-    . withClang(jnf.Paths.get(clang.s).nn)
-    . withClangPP(jnf.Paths.get(clangpp.s).nn)
-    . withGC(GC.immix)
-    . withMode(Mode.debug)
-    . withLTO(LTO.none)
-    . withBaseName("main")
-
-  private[anthology] def link
-    ( form:        NativeConfig,
-      compilation: Compilation[Universe.Nir],
-      entryPoints: List[Linker.EntryPoint],
-      out:         Path on Linux )
-  :   Path on Linux logs LinkEvent raises LinkError =
-
-    val main = entryPoints match
-      case List(entry) => entry.mainClass.text
-      case _           => abort(LinkError(LinkError.Reason.NoEntryPoint))
-
-    val entries: List[jnf.Path] =
-      jnf.Paths.get(compilation.out.encode.s).nn ::
-        compilation.classpath.entries.to(List).flatMap:
-          case ClasspathEntry.Directory(directory) => List(jnf.Paths.get(directory.s).nn)
-          case ClasspathEntry.Jar(jar)             => List(jnf.Paths.get(jar.s).nn)
-          case _                                   => Nil
-
-    try
-      val outPath = jnf.Paths.get(out.encode.s).nn
-      jnf.Files.createDirectories(outPath)
-      given Scope = Scope.forever
-
-      val config =
-        Config.empty
-        . withBaseDir(outPath.toAbsolutePath.nn)
-        . withMainClass(Some(main.s))
-        . withClassPath(entries)
-        . withModuleName("main")
-        . withCompilerConfig(form)
-
-      val artifact = Await.result(Build.build(config), 1800.seconds)
-      unsafely(artifact.toString.tt.as[Path on Linux])
-
-    catch case suc.NonFatal(error) =>
-      abort(LinkError(LinkError.Reason.Failed(error.stackTrace)))
+// A linked product of a compilation: the tier users choose from. Each artifact is producible
+// from exactly one universe, witnessed by `Provenance`.
+sealed trait Artifact

--- a/lib/anthology/src/core/anthology.Compilation.scala
+++ b/lib/anthology/src/core/anthology.Compilation.scala
@@ -38,8 +38,8 @@ import prepositional.*
 import serpentine.*
 
 // A token pairing a compilation's output directory with the classpath it was compiled against,
-// tagged with the backend it targeted. Contravariance means a `Compilation[Backend.Portable]`
-// is acceptable wherever a compilation for any single portable backend is required, while a
-// JVM compilation can never be linked and a portable compilation can never be bundled as an
+// tagged with the universe it inhabits. A `Compilation[Universe.Sjsir]` may be linked as any
+// sjsir artifact (JavaScript, browser Wasm or a WASI component), a `Compilation[Universe.Nir]`
+// as a native binary for any target, and a `Compilation[Universe.Bytecode]` bundled as an
 // executable JAR.
-case class Compilation[-backend <: Backend](out: Path on Linux, classpath: LocalClasspath)
+case class Compilation[universe <: Universe](out: Path on Linux, classpath: LocalClasspath)

--- a/lib/anthology/src/core/anthology.Provenance.scala
+++ b/lib/anthology/src/core/anthology.Provenance.scala
@@ -32,41 +32,27 @@
                                                                                                   */
 package anthology
 
-import anticipation.*
-import gossamer.*
-import serpentine.*
+import prepositional.*
 
-object Backend:
-  type Jvm = Backend.Jvm.type
-  type Js = Backend.Js.type
-  type Wasm = Backend.Wasm.type
-  type Wasi = Backend.Wasi.type
-  type Native = Backend.Native.type
+object Provenance:
+  given jar: (Provenance[Artifact.Jar] from Universe.Bytecode):
+    type Origin = Universe.Bytecode
 
-  // The backends whose compilations emit target-neutral `.sjsir`, deferring the choice of
-  // linked representation (JavaScript, browser Wasm or a WASI component) until link time.
-  type Portable = Js | Wasm | Wasi
+  given js: (Provenance[Artifact.Js] from Universe.Sjsir):
+    type Origin = Universe.Sjsir
 
-  // Every backend whose compilations emit a linkable intermediate representation—`.sjsir` for
-  // the portable backends, `.nir` for Scala Native—and whose products are made by a `Linker`.
-  type Linked = Portable | Native
+  given wasm: (Provenance[Artifact.Wasm] from Universe.Sjsir):
+    type Origin = Universe.Sjsir
 
-  // Determines the additional compiler flags each backend requires; contravariance lets the
-  // single `portable` instance serve every member of the `Portable` union.
-  trait Emission[-backend <: Backend]:
-    def flags: List[Text]
+  given wasi: [version <: Artifact.Wasi.Versions]
+  =>  (Provenance[Artifact.Wasi[version]] from Universe.Sjsir):
+    type Origin = Universe.Sjsir
 
-  given jvm: Emission[Jvm]:
-    def flags: List[Text] = Nil
+  given binary: (Provenance[Artifact.Binary] from Universe.Nir):
+    type Origin = Universe.Nir
 
-  given portable: Emission[Portable]:
-    def flags: List[Text] = List(t"-scalajs")
-
-  // NIR is emitted by the Scala Native compiler plugin rather than by a backend built into the
-  // compiler, so compiling for `Backend.Native` requires evidence of the plugin's location.
-  given native(using plugin: NirPlugin): Emission[Native] =
-    new Emission[Native]:
-      def flags: List[Text] = List(t"-Xplugin:${plugin.jar.encode}")
-
-enum Backend:
-  case Jvm, Js, Wasm, Wasi, Native
+// Witnesses the universe an artifact is produced from—its origin. Unconditional: every artifact
+// has a provenance, whether or not it is currently linkable, so it can drive compilation
+// (`producing`) without demanding the link-time prerequisites that a `Linkage` may impose.
+trait Provenance[artifact <: Artifact]:
+  type Origin <: Universe

--- a/lib/anthology/src/core/anthology.Universe.scala
+++ b/lib/anthology/src/core/anthology.Universe.scala
@@ -32,90 +32,34 @@
                                                                                                   */
 package anthology
 
-import java.nio.file as jnf
-
-import scala.concurrent.*
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.*
-import scala.scalanative.build.{Build, Config, GC, LTO, Mode, NativeConfig}
-import scala.scalanative.util.Scope
-import scala.util.control as suc
-
-import ambience.*
 import anticipation.*
-import contingency.*
-import digression.*
-import distillate.*
-import eucalyptus.*
-import galilei.*
 import gossamer.*
-import guillotine.*
-import hellenism.*
-import prepositional.*
 import serpentine.*
-import vacuous.*
 
-// The Scala Native link family. An instance exists only via the probing `apply`, which verifies
-// that the C toolchain (`clang` and `clang++`) the link shells out to is present—so, as with
-// WASI components, a native link whose native tooling is absent is not expressible. Put one in
-// scope with `given NativeLinkage = NativeLinkage()`.
-object NativeLinkage:
-  def apply()(using WorkingDirectory)
-  :   (Linkage[Artifact.Binary] from Universe.Nir) raises ToolchainError =
+object Universe:
+  type Bytecode = Universe.Bytecode.type
+  type Sjsir = Universe.Sjsir.type
+  type Nir = Universe.Nir.type
 
-    new NativeLinkage(probe(t"clang"), probe(t"clang++"))
+  // Determines the additional compiler flags each universe's emission requires.
+  trait Emission[universe <: Universe]:
+    def flags: List[Text]
 
-  private def probe(tool: Text)(using WorkingDirectory): Text raises ToolchainError =
-    safely(mute[ExecEvent](sh"which $tool".exec[Text]())).let(_.trim)
-    . or(abort(ToolchainError(tool)))
+  given bytecode: Emission[Bytecode]:
+    def flags: List[Text] = Nil
 
-class NativeLinkage private (clang: Text, clangpp: Text)
-extends Linkage[Artifact.Binary]:
-  type Origin = Universe.Nir
-  private[anthology] type Form = NativeConfig
+  given sjsir: Emission[Sjsir]:
+    def flags: List[Text] = List(t"-scalajs")
 
-  private[anthology] def initial: NativeConfig =
-    NativeConfig.empty
-    . withClang(jnf.Paths.get(clang.s).nn)
-    . withClangPP(jnf.Paths.get(clangpp.s).nn)
-    . withGC(GC.immix)
-    . withMode(Mode.debug)
-    . withLTO(LTO.none)
-    . withBaseName("main")
+  // NIR is emitted by the Scala Native compiler plugin rather than by a backend built into the
+  // compiler, so compiling into the NIR universe requires evidence of the plugin's location.
+  given nir(using plugin: NirPlugin): Emission[Nir] =
+    new Emission[Nir]:
+      def flags: List[Text] = List(t"-Xplugin:${plugin.jar.encode}")
 
-  private[anthology] def link
-    ( form:        NativeConfig,
-      compilation: Compilation[Universe.Nir],
-      entryPoints: List[Linker.EntryPoint],
-      out:         Path on Linux )
-  :   Path on Linux logs LinkEvent raises LinkError =
-
-    val main = entryPoints match
-      case List(entry) => entry.mainClass.text
-      case _           => abort(LinkError(LinkError.Reason.NoEntryPoint))
-
-    val entries: List[jnf.Path] =
-      jnf.Paths.get(compilation.out.encode.s).nn ::
-        compilation.classpath.entries.to(List).flatMap:
-          case ClasspathEntry.Directory(directory) => List(jnf.Paths.get(directory.s).nn)
-          case ClasspathEntry.Jar(jar)             => List(jnf.Paths.get(jar.s).nn)
-          case _                                   => Nil
-
-    try
-      val outPath = jnf.Paths.get(out.encode.s).nn
-      jnf.Files.createDirectories(outPath)
-      given Scope = Scope.forever
-
-      val config =
-        Config.empty
-        . withBaseDir(outPath.toAbsolutePath.nn)
-        . withMainClass(Some(main.s))
-        . withClassPath(entries)
-        . withModuleName("main")
-        . withCompilerConfig(form)
-
-      val artifact = Await.result(Build.build(config), 1800.seconds)
-      unsafely(artifact.toString.tt.as[Path on Linux])
-
-    catch case suc.NonFatal(error) =>
-      abort(LinkError(LinkError.Reason.Failed(error.stackTrace)))
+// The universe a compilation inhabits: the intermediate representation it emits, and hence the
+// ecosystem of library artifacts it can link with. `Bytecode` is JVM classfiles; `Sjsir` is
+// Scala.js IR, whose linked representation (JavaScript, browser Wasm or a WASI component) is
+// chosen at link time; `Nir` is Scala Native IR, linked to machine code through LLVM.
+enum Universe:
+  case Bytecode, Sjsir, Nir

--- a/lib/anthology/src/core/soundness_anthology_core.scala
+++ b/lib/anthology/src/core/soundness_anthology_core.scala
@@ -34,5 +34,5 @@ package soundness
 
 export
   anthology
-  . { Backend, Compilation, CompileEvent, CompileProcess, CompileProgress, Compiler,
-      CompilerError, CompileResult, Importance, NirPlugin, Notice }
+  . { Artifact, Compilation, CompileEvent, CompileProcess, CompileProgress, Compiler,
+      CompilerError, CompileResult, Importance, NirPlugin, Notice, Provenance, Universe }

--- a/lib/anthology/src/link/anthology.Linkage.scala
+++ b/lib/anthology/src/link/anthology.Linkage.scala
@@ -52,17 +52,19 @@ import prepositional.*
 import serpentine.*
 
 object Linkage:
-  // The `.sjsir` link family: the three portable backends share the Scala.js linker pipeline,
-  // differing only in the configuration they mandate and the artifact they produce.
-  private class Sjs[target <: Backend.Portable]
+  // The sjsir link family: JavaScript, browser Wasm and WASI components share the Scala.js
+  // linker pipeline, differing only in the configuration they mandate and the artifact they
+  // produce.
+  private class Sjs[artifact <: Artifact.Sjs]
     ( base: StandardConfig => StandardConfig, artifact: (Path on Linux) => (Path on Linux) )
-  extends Linkage[target]:
+  extends Linkage[artifact]:
+    type Origin = Universe.Sjsir
     private[anthology] type Form = StandardConfig
     private[anthology] def initial: StandardConfig = base(StandardConfig())
 
     private[anthology] def link
       ( form:        StandardConfig,
-        compilation: Compilation[target],
+        compilation: Compilation[Universe.Sjsir],
         entryPoints: List[Linker.EntryPoint],
         out:         Path on Linux )
     :   Path on Linux logs LinkEvent raises LinkError =
@@ -103,16 +105,17 @@ object Linkage:
       catch case suc.NonFatal(error) =>
         abort(LinkError(LinkError.Reason.Failed(error.stackTrace)))
 
-  given js: Linkage[Backend.Js] =
+  given js: (Linkage[Artifact.Js] from Universe.Sjsir) =
     Sjs(_.withModuleKind(ModuleKind.ESModule), _ / "main.js")
 
-  given wasm: Linkage[Backend.Wasm] =
+  given wasm: (Linkage[Artifact.Wasm] from Universe.Sjsir) =
     Sjs
       ( _.withModuleKind(ModuleKind.ESModule)
         . withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true)),
         _ / "main.wasm" )
 
-  given wasi(using toolchain: WasiToolchain, world: WitWorld): Linkage[Backend.Wasi] =
+  given wasi(using toolchain: WasiToolchain, world: WitWorld)
+  :   (Linkage[Artifact.Wasi[0.2]] from Universe.Sjsir) =
     Sjs
       ( _.withModuleKind(ModuleKind.WasmComponent)
         . withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true))
@@ -122,18 +125,20 @@ object Linkage:
             . withWitWorld(Some(world.world.s)),
         _ / "main.wasm" )
 
-// Determines how each linked backend's compilations become artifacts: the underlying linker
-// configuration type (`Form`), the configuration the backend mandates, and the link pipeline
-// itself. Instances whose runtime prerequisites can be absent are conditional upon evidence of
-// them: `wasi` upon a `WasiToolchain` and a `WitWorld`, and the Scala Native instance (in the
-// `nir` module) upon probing the C toolchain.
-trait Linkage[target <: Backend.Linked]:
+// Determines how an artifact is linked from a compilation in its source universe: the
+// underlying linker-configuration type (`Form`), the configuration the artifact mandates, and
+// the link pipeline itself. Instances exist only for artifacts that are currently producible,
+// and those whose runtime prerequisites can be absent are conditional upon evidence of them:
+// `wasi` (version 0.2, the one WASI version the linker supports) upon a `WasiToolchain` and a
+// `WitWorld`, and the native-binary instance (in the `nir` module) upon probing the C
+// toolchain.
+trait Linkage[artifact <: Artifact] extends Provenance[artifact]:
   private[anthology] type Form
   private[anthology] def initial: Form
 
   private[anthology] def link
     ( form:        Form,
-      compilation: Compilation[target],
+      compilation: Compilation[Origin],
       entryPoints: List[Linker.EntryPoint],
       out:         Path on Linux )
   :   Path on Linux logs LinkEvent raises LinkError

--- a/lib/anthology/src/link/anthology.Linker.scala
+++ b/lib/anthology/src/link/anthology.Linker.scala
@@ -47,22 +47,23 @@ object Linker:
     // Sound by construction: options are only creatable through the per-family DSLs, each of
     // which types its options at a subset of exactly one link family, and every `Linkage` of
     // that family fixes `Form` to the type the DSL edits; no option is typed across families.
-    private[anthology] def apply[target <: Backend.Linked, form](edit0: form => form)
-    :   Option[target] =
+    private[anthology] def apply[artifact <: Artifact, form](edit0: form => form)
+    :   Option[artifact] =
 
-      new Option[target]:
+      new Option[artifact]:
         private[anthology] def edit(form0: Any): Any = edit0(form0.asInstanceOf[form])
 
   // Options are constructible only through the per-family DSLs, keeping the underlying linker
   // configuration types out of the public API; contravariance permits an option declared for a
-  // union of backends in the options list of any of that union's linkers.
-  trait Option[-target <: Backend.Linked]:
+  // union of artifacts in the options list of any of that union's linkers.
+  trait Option[-artifact <: Artifact]:
     private[anthology] def edit(form0: Any): Any
 
-case class Linker[target <: Backend.Linked]
-  ( options: List[Linker.Option[target]], entryPoints: List[Linker.EntryPoint] = Nil ):
+case class Linker[artifact <: Artifact]
+  ( options: List[Linker.Option[artifact]], entryPoints: List[Linker.EntryPoint] = Nil ):
 
-  def link(compilation: Compilation[target], out: Path on Linux)(using linkage: Linkage[target])
+  def link(using linkage: Linkage[artifact])
+    ( compilation: Compilation[linkage.Origin], out: Path on Linux )
   :   Path on Linux logs LinkEvent raises LinkError =
 
     Log.info(LinkEvent.Start)

--- a/lib/anthology/src/link/anthology_link.scala
+++ b/lib/anthology/src/link/anthology_link.scala
@@ -35,37 +35,37 @@ package anthology
 import org.scalajs.linker.interface.{ESVersion, ModuleKind, StandardConfig}
 
 object linkerOptions:
-  private def sjs[target <: Backend.Portable](edit: StandardConfig => StandardConfig)
-  :   Linker.Option[target] =
+  private def sjs[artifact <: Artifact.Sjs](edit: StandardConfig => StandardConfig)
+  :   Linker.Option[artifact] =
 
     Linker.Option(edit)
 
   object moduleKind:
-    val esModule: Linker.Option[Backend.Js] =
+    val esModule: Linker.Option[Artifact.Js] =
       sjs(_.withModuleKind(ModuleKind.ESModule))
 
-    val commonJs: Linker.Option[Backend.Js] =
+    val commonJs: Linker.Option[Artifact.Js] =
       sjs(_.withModuleKind(ModuleKind.CommonJSModule))
 
-    val noModule: Linker.Option[Backend.Js] =
+    val noModule: Linker.Option[Artifact.Js] =
       sjs(_.withModuleKind(ModuleKind.NoModule))
 
-  val checkIr: Linker.Option[Backend.Portable] = sjs(_.withCheckIR(true))
-  val sourceMaps: Linker.Option[Backend.Portable] = sjs(_.withSourceMap(true))
+  val checkIr: Linker.Option[Artifact.Sjs] = sjs(_.withCheckIR(true))
+  val sourceMaps: Linker.Option[Artifact.Sjs] = sjs(_.withSourceMap(true))
 
   object esVersion:
-    private def of(version: ESVersion): Linker.Option[Backend.Portable] =
+    private def of(version: ESVersion): Linker.Option[Artifact.Sjs] =
       sjs(_.withESFeatures(_.withESVersion(version)))
 
-    val es2015: Linker.Option[Backend.Portable] = of(ESVersion.ES2015)
-    val es2016: Linker.Option[Backend.Portable] = of(ESVersion.ES2016)
-    val es2017: Linker.Option[Backend.Portable] = of(ESVersion.ES2017)
-    val es2018: Linker.Option[Backend.Portable] = of(ESVersion.ES2018)
-    val es2019: Linker.Option[Backend.Portable] = of(ESVersion.ES2019)
-    val es2020: Linker.Option[Backend.Portable] = of(ESVersion.ES2020)
-    val es2021: Linker.Option[Backend.Portable] = of(ESVersion.ES2021)
-    val es2022: Linker.Option[Backend.Portable] = of(ESVersion.ES2022)
+    val es2015: Linker.Option[Artifact.Sjs] = of(ESVersion.ES2015)
+    val es2016: Linker.Option[Artifact.Sjs] = of(ESVersion.ES2016)
+    val es2017: Linker.Option[Artifact.Sjs] = of(ESVersion.ES2017)
+    val es2018: Linker.Option[Artifact.Sjs] = of(ESVersion.ES2018)
+    val es2019: Linker.Option[Artifact.Sjs] = of(ESVersion.ES2019)
+    val es2020: Linker.Option[Artifact.Sjs] = of(ESVersion.ES2020)
+    val es2021: Linker.Option[Artifact.Sjs] = of(ESVersion.ES2021)
+    val es2022: Linker.Option[Artifact.Sjs] = of(ESVersion.ES2022)
 
   object optimize:
-    val none: Linker.Option[Backend.Portable] = sjs(_.withOptimizer(false))
-    val fast: Linker.Option[Backend.Portable] = sjs(_.withOptimizer(true))
+    val none: Linker.Option[Artifact.Sjs] = sjs(_.withOptimizer(false))
+    val fast: Linker.Option[Artifact.Sjs] = sjs(_.withOptimizer(true))

--- a/lib/anthology/src/nir/anthology_nir.scala
+++ b/lib/anthology/src/nir/anthology_nir.scala
@@ -35,24 +35,24 @@ package anthology
 import scala.scalanative.build.{GC, LTO, Mode, NativeConfig}
 
 object nativeOptions:
-  private def native(edit: NativeConfig => NativeConfig): Linker.Option[Backend.Native] =
+  private def native(edit: NativeConfig => NativeConfig): Linker.Option[Artifact.Binary] =
     Linker.Option(edit)
 
-  def target(triple: Triple): Linker.Option[Backend.Native] =
+  def target(triple: Triple): Linker.Option[Artifact.Binary] =
     native(_.withTargetTriple(Some(triple.text.s)))
 
   object gc:
-    val immix: Linker.Option[Backend.Native] = native(_.withGC(GC.immix))
-    val commix: Linker.Option[Backend.Native] = native(_.withGC(GC.commix))
-    val boehm: Linker.Option[Backend.Native] = native(_.withGC(GC.boehm))
-    val none: Linker.Option[Backend.Native] = native(_.withGC(GC.none))
+    val immix: Linker.Option[Artifact.Binary] = native(_.withGC(GC.immix))
+    val commix: Linker.Option[Artifact.Binary] = native(_.withGC(GC.commix))
+    val boehm: Linker.Option[Artifact.Binary] = native(_.withGC(GC.boehm))
+    val none: Linker.Option[Artifact.Binary] = native(_.withGC(GC.none))
 
   object mode:
-    val debug: Linker.Option[Backend.Native] = native(_.withMode(Mode.debug))
-    val releaseFast: Linker.Option[Backend.Native] = native(_.withMode(Mode.releaseFast))
-    val releaseFull: Linker.Option[Backend.Native] = native(_.withMode(Mode.releaseFull))
+    val debug: Linker.Option[Artifact.Binary] = native(_.withMode(Mode.debug))
+    val releaseFast: Linker.Option[Artifact.Binary] = native(_.withMode(Mode.releaseFast))
+    val releaseFull: Linker.Option[Artifact.Binary] = native(_.withMode(Mode.releaseFull))
 
   object lto:
-    val none: Linker.Option[Backend.Native] = native(_.withLTO(LTO.none))
-    val thin: Linker.Option[Backend.Native] = native(_.withLTO(LTO.thin))
-    val full: Linker.Option[Backend.Native] = native(_.withLTO(LTO.full))
+    val none: Linker.Option[Artifact.Binary] = native(_.withLTO(LTO.none))
+    val thin: Linker.Option[Artifact.Binary] = native(_.withLTO(LTO.thin))
+    val full: Linker.Option[Artifact.Binary] = native(_.withLTO(LTO.full))

--- a/lib/anthology/src/scala/anthology.Scalac.scala
+++ b/lib/anthology/src/scala/anthology.Scalac.scala
@@ -66,24 +66,34 @@ object Scalac:
   def refresh(): Unit = mutex { Scala3 = new dtd.Compiler() }
   def compiler(): dtd.Compiler = Scala3
 
-  // Preserves the single-type-argument call form, `Scalac[3.6](options)`, which targets the JVM.
-  @targetName("applyJvm")
-  def apply[version <: Versions](options: List[Option[version]]): Scalac[version, Backend.Jvm] =
+  // Preserves the single-type-argument call form, `Scalac[3.6](options)`, which targets the
+  // JVM bytecode universe.
+  @targetName("applyBytecode")
+  def apply[version <: Versions](options: List[Option[version]])
+  :   Scalac[version, Universe.Bytecode] =
+
     new Scalac(options)
 
-case class Scalac[version <: Scalac.Versions, backend <: Backend] private
+case class Scalac[version <: Scalac.Versions, universe <: Universe] private
   ( options: List[Scalac.Option[version]] ):
 
   def commandLineArguments: List[Text] = options.flatMap(_.flags)
 
-  def targeting[backend2 <: Backend]: Scalac[version, backend2] = new Scalac(options)
+  def targeting[universe2 <: Universe]: Scalac[version, universe2] = new Scalac(options)
+
+  // Retargets this configuration at the universe from which the given artifact is produced,
+  // for callers who think in terms of the end product rather than its intermediate form.
+  def producing[artifact <: Artifact](using provenance: Provenance[artifact])
+  :   Scalac[version, provenance.Origin] =
+
+    new Scalac(options)
 
 
   def apply
     ( classpath: LocalClasspath )
     [ path: Abstractable across Paths to Text ]
     ( sources: Map[Text, Text], out: path )
-    ( using System, Monitor, Probate, Backend.Emission[backend] )
+    ( using System, Monitor, Probate, Universe.Emission[universe] )
   :   CompileProcess logs CompileEvent raises CompilerError =
 
     val scalacProcess: CompileProcess = CompileProcess()
@@ -130,7 +140,7 @@ case class Scalac[version <: Scalac.Versions, backend <: Backend] private
         //val jsParams =
 
         val arguments: List[Text] =
-          summon[Backend.Emission[backend]].flags :::
+          summon[Universe.Emission[universe]].flags :::
             List(t"-d", out.generic, t"-classpath", classpath()) :::
             commandLineArguments :::
             List(t"")

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -49,37 +49,33 @@ import workingDirectories.javaWorkingDirectory
 
 private type JnfPath = java.nio.file.Path
 
-// Unexecuted definitions whose successful compilation asserts the variance properties of
-// `Compilation`: a portable compilation may be linked as any concrete portable backend.
-def portableLinksAsJs(compilation: Compilation[Backend.Portable]): Compilation[Backend.Js] =
-  compilation
+// Unexecuted definitions whose successful compilation assert `Provenance`'s tier structure:
+// choosing an artifact determines the universe a compilation must inhabit.
+def producingWasi(scalac: Scalac[3.8, Universe.Bytecode]): Scalac[3.8, Universe.Sjsir] =
+  scalac.targeting[Universe.Bytecode].producing[Artifact.Wasi[0.2]]
 
-def portableLinksAsWasi(compilation: Compilation[Backend.Portable]): Compilation[Backend.Wasi] =
-  compilation
+def producingBinary(scalac: Scalac[3.8, Universe.Bytecode]): Scalac[3.8, Universe.Nir] =
+  scalac.producing[Artifact.Binary]
 
 object Tests extends Suite(m"Anthology Tests"):
   def run(): Unit =
-    test(m"A single-type-argument Scalac targets the JVM"):
-      val scalac: Scalac[3.6, Backend.Jvm] = Scalac[3.6](Nil)
+    test(m"A single-type-argument Scalac targets the bytecode universe"):
+      val scalac: Scalac[3.6, Universe.Bytecode] = Scalac[3.6](Nil)
       scalac.commandLineArguments
     . assert(_ == Nil)
 
     test(m"Retargeting a Scalac preserves its options"):
-      Scalac[3.8](List(scalacOptions.experimental)).targeting[Backend.Portable]
+      Scalac[3.8](List(scalacOptions.experimental)).targeting[Universe.Sjsir]
       . commandLineArguments
     . assert(_ == List(t"-experimental"))
 
-    test(m"The JVM backend adds no compiler flags"):
-      summon[Backend.Emission[Backend.Jvm]].flags
+    test(m"The bytecode universe adds no compiler flags"):
+      summon[Universe.Emission[Universe.Bytecode]].flags
     . assert(_ == Nil)
 
-    test(m"Every portable backend adds the -scalajs flag"):
-      List
-        ( summon[Backend.Emission[Backend.Js]].flags,
-          summon[Backend.Emission[Backend.Wasm]].flags,
-          summon[Backend.Emission[Backend.Wasi]].flags,
-          summon[Backend.Emission[Backend.Portable]].flags )
-    . assert(_.forall(_ == List(t"-scalajs")))
+    test(m"The sjsir universe adds the -scalajs flag"):
+      summon[Universe.Emission[Universe.Sjsir]].flags
+    . assert(_ == List(t"-scalajs"))
 
     test(m"Module-kind options configure the linker"):
       linkerOptions.moduleKind.commonJs.edit(StandardConfig()).asInstanceOf[StandardConfig]
@@ -87,71 +83,80 @@ object Tests extends Suite(m"Anthology Tests"):
     . assert(_ == ModuleKind.CommonJSModule)
 
     test(m"The JavaScript linkage produces an ES module"):
-      summon[Linkage[Backend.Js]].initial.asInstanceOf[StandardConfig].moduleKind
+      summon[Linkage[Artifact.Js]].initial.asInstanceOf[StandardConfig].moduleKind
     . assert(_ == ModuleKind.ESModule)
 
     test(m"The browser Wasm linkage enables the WebAssembly backend"):
-      summon[Linkage[Backend.Wasm]].initial.asInstanceOf[StandardConfig]
+      summon[Linkage[Artifact.Wasm]].initial.asInstanceOf[StandardConfig]
       . esFeatures.useWebAssembly
     . assert(_ == true)
 
     test(m"A module-kind option is not applicable to a Wasm linker"):
       demilitarize:
-        Linker[Backend.Wasm](List(linkerOptions.moduleKind.esModule))
+        Linker[Artifact.Wasm](List(linkerOptions.moduleKind.esModule))
     . assert(_.nonEmpty)
 
     test(m"A WASI linkage is not available without toolchain and WIT world"):
       demilitarize:
-        summon[Linkage[Backend.Wasi]]
+        summon[Linkage[Artifact.Wasi[0.2]]]
     . assert(_.nonEmpty)
 
-    test(m"A JVM compilation cannot be linked"):
+    test(m"WASI 0.3 is not linkable even with the 0.2 prerequisites"):
       demilitarize:
-        val compilation: Compilation[Backend.Jvm] = ???
-        portableLinksAsJs(compilation)
+        given WasiToolchain = ???
+        given WitWorld = ???
+        summon[Linkage[Artifact.Wasi[0.3]]]
     . assert(_.nonEmpty)
 
-    test(m"A portable compilation is not a native compilation"):
+    test(m"A bytecode compilation cannot be linked as JavaScript"):
       demilitarize:
-        val compilation: Compilation[Backend.Portable] = ???
-        val native: Compilation[Backend.Native] = compilation
+        val compilation: Compilation[Universe.Bytecode] = ???
+        Linker[Artifact.Js](Nil).link(compilation, ???)
+    . assert(_.nonEmpty)
+
+    test(m"An sjsir compilation is not a native compilation"):
+      demilitarize:
+        val compilation: Compilation[Universe.Sjsir] = ???
+        val native: Compilation[Universe.Nir] = compilation
     . assert(_.nonEmpty)
 
     test(m"A native option is not applicable to a JavaScript linker"):
       demilitarize:
-        Linker[Backend.Js](List(nativeOptions.gc.immix))
+        Linker[Artifact.Js](List(nativeOptions.gc.immix))
     . assert(_.nonEmpty)
 
     test(m"An sjsir option is not applicable to a native linker"):
       demilitarize:
-        Linker[Backend.Native](List(linkerOptions.optimize.fast))
+        Linker[Artifact.Binary](List(linkerOptions.optimize.fast))
     . assert(_.nonEmpty)
 
     test(m"A native linkage is not available without probing the C toolchain"):
       demilitarize:
-        summon[Linkage[Backend.Native]]
+        summon[Linkage[Artifact.Binary]]
     . assert(_.nonEmpty)
 
-    test(m"Compiling for the native backend requires plugin evidence"):
+    test(m"Compiling into the nir universe requires plugin evidence"):
       demilitarize:
-        summon[Backend.Emission[Backend.Native]]
+        summon[Universe.Emission[Universe.Nir]]
     . assert(_.nonEmpty)
 
     test(m"Triples render as LLVM target triples"):
       Triple.Arm64MacOs.text
     . assert(_ == t"arm64-apple-darwin")
 
-    test(m"A portable compilation cannot be bundled as an executable JAR"):
+    test(m"An sjsir compilation cannot be bundled as an executable JAR"):
       demilitarize:
-        val compilation: Compilation[Backend.Portable] = ???
+        val compilation: Compilation[Universe.Sjsir] = ???
         Bundler.bundle(compilation, Unset, Unset)
     . assert(_.nonEmpty)
 
-    test(m"A JVM compilation cannot be bundled as an sjsir library"):
+    test(m"Any universe's compilation can be bundled as a library JAR"):
       demilitarize:
-        val compilation: Compilation[Backend.Jvm] = ???
-        Bundler.library(compilation, Unset)
-    . assert(_.nonEmpty)
+        def bytecode(compilation: Compilation[Universe.Bytecode]) =
+          Bundler.library(compilation, Unset)
+        def nir(compilation: Compilation[Universe.Nir]) =
+          Bundler.library(compilation, Unset)
+    . assert(_.isEmpty)
 
     // An end-to-end exercise of the portable pipeline—compile with `-scalajs`, then link as
     // JavaScript—which runs only when a cached proscala toolchain (whose distribution includes
@@ -167,7 +172,7 @@ object Tests extends Suite(m"Anthology Tests"):
         Files.createDirectories(Paths.get(out.encode.s))
 
         val process =
-          Scalac[3.8](Nil).targeting[Backend.Portable]
+          Scalac[3.8](Nil).producing[Artifact.Js]
             (classpath)(Map(t"hello.scala" -> source), out)
 
         test(m"A portable compilation succeeds"):
@@ -182,7 +187,7 @@ object Tests extends Suite(m"Anthology Tests"):
         val linked: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
 
         test(m"Linking as JavaScript produces a nonempty main.js"):
-          Linker[Backend.Js]
+          Linker[Artifact.Js]
             ( List(linkerOptions.moduleKind.esModule),
               List(Linker.EntryPoint(Fqcn(t"Main"))) )
           . link(Compilation(out, classpath), linked)
@@ -199,7 +204,7 @@ object Tests extends Suite(m"Anthology Tests"):
         Files.createDirectories(Paths.get(out.encode.s))
 
         val process =
-          Scalac[3.8](Nil).targeting[Backend.Native]
+          Scalac[3.8](Nil).targeting[Universe.Nir]
             (classpath)(Map(t"hello.scala" -> source), out)
 
         test(m"A native compilation succeeds"):
@@ -211,12 +216,12 @@ object Tests extends Suite(m"Anthology Tests"):
           . exists(_.getFileName.nn.toString.endsWith(".nir"))
         . assert(_ == true)
 
-        safely(NativeLinkage()).let: linkage =>
-          given Linkage[Backend.Native] = linkage
+        safely(NativeLinkage()).let: nativeLinkage =>
+          given (Linkage[Artifact.Binary] from Universe.Nir) = nativeLinkage
           val linked: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
 
           test(m"Linking natively produces a runnable binary"):
-            Linker[Backend.Native](Nil, List(Linker.EntryPoint(Fqcn(t"Main"))))
+            Linker[Artifact.Binary](Nil, List(Linker.EntryPoint(Fqcn(t"Main"))))
             . link(Compilation(out, classpath), linked)
             . pipe: artifact =>
                 mute[ExecEvent](sh"$artifact".exec[Text]()).trim

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -120,7 +120,7 @@ extends Rig:
         case Exit.Ok         => target
         case Exit.Fail(fail) => ???
 
-  protected val scalac: Scalac[3.8, Backend.Jvm] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.8, Universe.Bytecode] = Scalac(List(scalacOptions.experimental))
 
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux])

--- a/lib/harlequin/src/test/harlequin_test.scala
+++ b/lib/harlequin/src/test/harlequin_test.scala
@@ -99,7 +99,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert(_ == (t"term", t"binding"))
 
     test(m"typechecked highlighting resolves the type of a val"):
-      given Scalac[3.8, Backend.Jvm] = Scalac[3.8](Nil)
+      given Scalac[3.8, Universe.Bytecode] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 
@@ -107,7 +107,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert { rendered => rendered.contains(t"List") && rendered.contains(t"Int") }
 
     test(m"typechecked highlighting reports diagnostics for ill-typed code"):
-      given Scalac[3.8, Backend.Jvm] = Scalac[3.8](Nil)
+      given Scalac[3.8, Universe.Bytecode] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 
@@ -115,7 +115,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert(_ > 0)
 
     test(m"no completions are computed without a caret"):
-      given Scalac[3.8, Backend.Jvm] = Scalac[3.8](Nil)
+      given Scalac[3.8, Universe.Bytecode] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 
@@ -123,7 +123,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert(_ == Unset)
 
     test(m"completions at a member selection include the type's methods"):
-      given Scalac[3.8, Backend.Jvm] = Scalac[3.8](Nil)
+      given Scalac[3.8, Universe.Bytecode] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 

--- a/lib/mandible/src/core/mandible_core.scala
+++ b/lib/mandible/src/core/mandible_core.scala
@@ -64,7 +64,7 @@ def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using T
 
   val uuid = Uuid()
   val out: Path on Linux = unsafely(temporaryDirectory/uuid)
-  val scalac: Scalac[3.6, Backend.Jvm] = Scalac[3.6](List(scalacOptions.experimental))
+  val scalac: Scalac[3.6, Universe.Bytecode] = Scalac[3.6](List(scalacOptions.experimental))
 
   val settings: staging.Compiler.Settings =
     staging.Compiler.Settings.make(Some(out.encode.s), scalac.commandLineArguments.map(_.s))

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -198,7 +198,7 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
     device.deploy(jarfile, uuid)
     jarfile
 
-  protected val scalac: Scalac[3.7, Backend.Jvm] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.7, Universe.Bytecode] = Scalac(List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
     stage.remote: input =>

--- a/lib/sedentary/src/core/sedentary.Profile.scala
+++ b/lib/sedentary/src/core/sedentary.Profile.scala
@@ -194,7 +194,7 @@ extends Rig:
     device.deploy(jarfile, uuid)
     jarfile
 
-  protected val scalac: Scalac[3.7, Backend.Jvm] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.7, Universe.Bytecode] = Scalac(List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
     stage.remote: input =>

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -451,7 +451,7 @@ extends Rig:
     device.deploy(jarfile, uuid)
     jarfile
 
-  protected val scalac: Scalac[3.7, Backend.Jvm] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.7, Universe.Bytecode] = Scalac(List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
     stage.remote: input =>

--- a/lib/superlunary/src/jvm/superlunary.Isolation.scala
+++ b/lib/superlunary/src/jvm/superlunary.Isolation.scala
@@ -52,7 +52,7 @@ object Isolation extends Rig:
 
   def stage(out: Path on Linux): Classloader = classpath(out).classloader()
 
-  val scalac: Scalac[3.6, Backend.Jvm] = Scalac[3.6](List(scalacOptions.experimental))
+  val scalac: Scalac[3.6, Universe.Bytecode] = Scalac[3.6](List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Form, Target]): output =
     stage.remote: input =>

--- a/lib/superlunary/src/jvm/superlunary.Jvm.scala
+++ b/lib/superlunary/src/jvm/superlunary.Jvm.scala
@@ -55,7 +55,7 @@ object Jvm extends Rig:
 
   def stage(out: Path on Linux): LocalClasspath = classpath(out)
 
-  val scalac: Scalac[3.6, Backend.Jvm] = Scalac[3.6](List(scalacOptions.experimental))
+  val scalac: Scalac[3.6, Universe.Bytecode] = Scalac[3.6](List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Form, Target]): output =
     import workingDirectories.systemWorkingDirectory


### PR DESCRIPTION
Anthology's compilation targets are now organized into two explicit tiers: a `Universe` — the intermediate representation a compilation emits, and hence the library ecosystem it can link with — and an `Artifact` — the linked end product a user asks for. Each artifact knows the universe it is produced from, so the type system infers the rest, and WASI interface versions become part of the artifact's type.

## Universes

`Scalac` and `Compilation` are typed by `Universe.Bytecode` (JVM classfiles), `Universe.Sjsir` (Scala.js IR) or `Universe.Nir` (Scala Native IR). The former `Backend.Portable` union and `Compilation`'s contravariance are gone: they existed only because the old `Backend` enum conflated the two tiers, and a plain `Compilation[Universe.Sjsir]` is now directly linkable as any sjsir artifact.

## Artifacts

`Linker` is typed by the product: `Artifact.Jar`, `Artifact.Js`, `Artifact.Wasm`, `Artifact.Wasi[version]` or `Artifact.Binary`. A `Provenance` typeclass witnesses each artifact's origin universe — using prepositional's `from` refinement, instances read `Linkage[Artifact.Js] from Universe.Sjsir` — so linking demands the right universe by inference, and a new `producing` method compiles straight toward a chosen artifact:

```scala
val scalac = Scalac[3.8](options).producing[Artifact.Wasi[0.2]]   // Scalac[3.8, Universe.Sjsir]
```

## WASI versions in the type

WASI's interface versions determine the artifact's ABI, so they are Double literal types on the artifact: `0.1` (preview 1, the flat syscall interface), `0.2` (the component model) and `0.3` (native asynchrony). Only `Artifact.Wasi[0.2]` currently has a `Linkage`, so requesting any other version is a compile error — the same unmet-prerequisite principle that already governs missing native toolchains:

```scala
given WasiToolchain = WasiToolchain()
given WitWorld = WitWorld(witDirectory, t"my-world")
Linker[Artifact.Wasi[0.2]](Nil, List(main)).link(compilation, out)
```

`Bundler.bundle` requires a bytecode compilation, while `Bundler.library` now accepts a compilation from any universe, packaging classfiles, `.sjsir` or `.nir` as a library JAR for downstream assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
