### PR TITLE
Name the classfile universe precisely, type JavaScript modules, and add Dex

### DIFF
--- a/lib/anthology/doc/basics.md
+++ b/lib/anthology/doc/basics.md
@@ -2,17 +2,23 @@
 
 Anthology structures compilation around two tiers. A _universe_ is the intermediate
 representation a compilation emits, and hence the ecosystem of library artifacts it can link
-with: `Universe.Bytecode` (JVM classfiles), `Universe.Sjsir` (Scala.js IR) and `Universe.Nir`
+with: `Universe.Classfile` (JVM classfiles), `Universe.Sjsir` (Scala.js IR) and `Universe.Nir`
 (Scala Native IR). An _artifact_ is a linked end product: `Artifact.Jar` (an executable JAR,
-bound to the JDK), `Artifact.Js` (a JavaScript module or script, bound to a JavaScript host),
-`Artifact.Wasm` (a core WebAssembly module with JavaScript glue), `Artifact.Wasi[version]` (a
-standalone WebAssembly artifact bound to a version of the WASI system interface: `0.1`, `0.2` or
-`0.3`) and `Artifact.Binary` (a machine-code executable).
+bound to the JDK), `Artifact.Dex` (Dalvik bytecode for Android—nameable, though no linkage yet
+exists for it), `Artifact.Js[module]` (JavaScript, bound to a JavaScript host through the
+`"es"`, `"commonjs"` or `"script"` module system), `Artifact.Wasm` (a core WebAssembly module
+with JavaScript glue), `Artifact.Wasi[version]` (a standalone WebAssembly artifact bound to a
+version of the WASI system interface: `0.1`, `0.2` or `0.3`) and `Artifact.Binary` (a
+machine-code executable).
+
+Where a variant changes an artifact's binding contract—the module system a JavaScript host
+imports it through, or the WASI interface version—it is part of the artifact's type; open-ended
+refinements such as native target triples or ECMAScript versions remain link options.
 
 Each artifact is produced from exactly one universe, witnessed by a `Provenance` instance:
-`Jar` from `Bytecode`; `Js`, `Wasm` and `Wasi` from `Sjsir`; `Binary` from `Nir`. The sjsir
-universe defers the choice among its three artifacts until link time, so one compilation may be
-linked as any of them.
+`Jar` and `Dex` from `Classfile`; `Js`, `Wasm` and `Wasi` from `Sjsir`; `Binary` from `Nir`.
+The sjsir universe defers the choice among its artifacts until link time, so one compilation
+may be linked as any of them.
 
 ### Compiling
 
@@ -20,13 +26,13 @@ A Scala compiler is represented by a `Scalac` value, parameterized by the compil
 the universe it compiles into, with options whose validity is checked against the version at
 compile time:
 ```scala
-val scalac: Scalac[3.8, Universe.Bytecode] = Scalac[3.8](List(scalacOptions.experimental))
+val scalac: Scalac[3.8, Universe.Classfile] = Scalac[3.8](List(scalacOptions.experimental))
 ```
 
-The single-type-argument form targets the bytecode universe. `targeting` selects a universe
+The single-type-argument form targets the classfile universe. `targeting` selects a universe
 explicitly, while `producing` selects it via the artifact you ultimately want:
 ```scala
-val forJs = Scalac[3.8](options).producing[Artifact.Js]            // Scalac[3.8, Universe.Sjsir]
+val forJs = Scalac[3.8](options).producing[Artifact.Js["es"]]      // Scalac[3.8, Universe.Sjsir]
 val forNative = Scalac[3.8](options).targeting[Universe.Nir]
 ```
 
@@ -46,7 +52,7 @@ described by a `Compilation`, tagged with its universe:
 val compilation: Compilation[Universe.Sjsir] = Compilation(out, classpath)
 ```
 
- - `Bundler.bundle(compilation, jarfile, main)` produces an executable JAR from a bytecode
+ - `Bundler.bundle(compilation, jarfile, main)` produces an executable JAR from a classfile
    compilation
  - `Bundler.library(compilation, jarfile)` produces a library JAR from a compilation in _any_
    universe—classfiles, `.sjsir` or `.nir`—for downstream assembly
@@ -58,18 +64,18 @@ val compilation: Compilation[Universe.Sjsir] = Compilation(out, classpath)
 A `Linker` is parameterized by the artifact it produces, with options whose validity is checked
 against that artifact at compile time, mirroring `scalacOptions`:
 ```scala
-val linker = Linker[Artifact.Js]
-  ( List(linkerOptions.moduleKind.esModule, linkerOptions.optimize.fast),
+val linker = Linker[Artifact.Js["es"]]
+  ( List(linkerOptions.optimize.fast),
     List(Linker.EntryPoint(fqcn"com.example.Main")) )
 
 val mainJs: Path on Linux = linker.link(compilation, out)
 ```
 
-The universe is inferred: linking `Artifact.Js` demands a `Compilation[Universe.Sjsir]`, and
-supplying a compilation from any other universe is a compile error. Options such as
-`moduleKind.*` apply only to `Artifact.Js` (the WebAssembly artifacts mandate their own module
-kinds), while `checkIr`, `sourceMaps`, `esVersion.*` and `optimize.*` apply to every sjsir
-artifact; a misapplied option is a compile error.
+The universe is inferred: linking `Artifact.Js[module]` demands a
+`Compilation[Universe.Sjsir]`, and supplying a compilation from any other universe is a compile
+error. The module system is part of the artifact's type rather than an option, since it changes
+how a host consumes the artifact. Options such as `checkIr`, `sourceMaps`, `esVersion.*` and
+`optimize.*` apply to every sjsir artifact; a misapplied option is a compile error.
 
 ### Linking WASI artifacts
 
@@ -94,7 +100,7 @@ is a flat, libc-style syscall interface on core modules; `0.2` is the component 
 adds native asynchrony. Only `0.2` is currently linkable—requesting `Artifact.Wasi[0.3]` is a
 compile error until a `Linkage` for it exists.
 
-`Artifact.Js` and `Artifact.Wasm` require no native tooling: the linker is an ordinary JVM
+`Artifact.Js[module]` and `Artifact.Wasm` require no native tooling: the linker is an ordinary JVM
 library.
 
 ### Linking native binaries

--- a/lib/anthology/doc/features.md
+++ b/lib/anthology/doc/features.md
@@ -8,10 +8,11 @@
 - compiler invocation is typed according to the major compiler version
 - options are typechecked against the compiler version
 - supports compilation with [Scala.js](https://scala-js.org/)
-- compilations are typed by the universe they inhabit (JVM bytecode, sjsir or NIR), and links
-  by the artifact they produce (executable JAR, JavaScript, WebAssembly, WASI component or
-  native binary), with each artifact's origin universe inferred
-- WASI versions (0.1, 0.2, 0.3) are part of the artifact's type, since they determine its ABI
+- compilations are typed by the universe they inhabit (classfiles, sjsir or NIR), and links by
+  the artifact they produce (executable JAR, JavaScript, WebAssembly, WASI component or native
+  binary), with each artifact's origin universe inferred
+- variants that change an artifact's binding contract are part of its type: WASI versions
+  (0.1, 0.2, 0.3) and JavaScript module systems (es, commonjs, script)
 - fully-linked `.js` and `.wasm` artifacts and native binaries, or unlinked `.sjsir`/`.nir`
   library JARs for downstream assembly
 - native links may select a target platform (e.g. arm64/macOS) as a typed LLVM triple

--- a/lib/anthology/src/bundle/anthology.Bundler.scala
+++ b/lib/anthology/src/bundle/anthology.Bundler.scala
@@ -73,10 +73,10 @@ object Bundler:
     assemble(classpath(directory), jarfile0.or(directory.peer("tmpfile.jar")), main)
 
 
-  // Bundles a bytecode compilation, together with the classpath it was compiled against, as an
+  // Bundles a classfile compilation, together with the classpath it was compiled against, as an
   // executable JAR file.
   def bundle
-    ( compilation: Compilation[Universe.Bytecode],
+    ( compilation: Compilation[Universe.Classfile],
       jarfile0:    Optional[Path on Linux],
       main:        Optional[Fqcn] )
   :   Path on Linux raises ZipError raises PathError raises IoError raises StreamError =

--- a/lib/anthology/src/core/anthology.Artifact.scala
+++ b/lib/anthology/src/core/anthology.Artifact.scala
@@ -27,18 +27,27 @@
 ┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
 ┃    either express or implied. See the License for the specific language governing permissions    ┃
 ┃    and limitations under the License.                                                            ┃
-┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
 package anthology
 
 object Artifact:
-  // Bytecode universe: an executable JAR, bound to the JDK.
+  // Classfile universe: an executable JAR, bound to the JDK.
   sealed trait Jar extends Artifact
 
-  // Sjsir universe: a JavaScript module or script, bound to a JavaScript host (a browser's DOM
-  // or a runtime such as Node).
-  sealed trait Js extends Artifact
+  // Classfile universe: Dalvik executable bytecode, bound to the Android runtime. Nameable but
+  // not yet producible: no `Linkage` exists for it.
+  sealed trait Dex extends Artifact
+
+  object Js:
+    // How a JavaScript host consumes the artifact: an ECMAScript module, a CommonJS module, or
+    // a plain script. The module system is part of the artifact's binding contract, so it is
+    // part of its type.
+    type Modules = "es" | "commonjs" | "script"
+
+  // Sjsir universe: JavaScript, bound to a JavaScript host (a browser's DOM or a runtime such
+  // as Node) through the given module system.
+  sealed trait Js[+module <: Js.Modules] extends Artifact
 
   // Sjsir universe: a core WebAssembly module with JavaScript glue, bound to a JavaScript host.
   sealed trait Wasm extends Artifact
@@ -57,7 +66,7 @@ object Artifact:
   sealed trait Binary extends Artifact
 
   // The artifacts linked from `.sjsir` by the Scala.js linker, sharing one options family.
-  type Sjs = Js | Wasm | Wasi[Wasi.Versions]
+  type Sjs = Js[Js.Modules] | Wasm | Wasi[Wasi.Versions]
 
 // A linked product of a compilation: the tier users choose from. Each artifact is producible
 // from exactly one universe, witnessed by `Provenance`.

--- a/lib/anthology/src/core/anthology.Compilation.scala
+++ b/lib/anthology/src/core/anthology.Compilation.scala
@@ -40,6 +40,6 @@ import serpentine.*
 // A token pairing a compilation's output directory with the classpath it was compiled against,
 // tagged with the universe it inhabits. A `Compilation[Universe.Sjsir]` may be linked as any
 // sjsir artifact (JavaScript, browser Wasm or a WASI component), a `Compilation[Universe.Nir]`
-// as a native binary for any target, and a `Compilation[Universe.Bytecode]` bundled as an
+// as a native binary for any target, and a `Compilation[Universe.Classfile]` bundled as an
 // executable JAR.
 case class Compilation[universe <: Universe](out: Path on Linux, classpath: LocalClasspath)

--- a/lib/anthology/src/core/anthology.Provenance.scala
+++ b/lib/anthology/src/core/anthology.Provenance.scala
@@ -35,10 +35,14 @@ package anthology
 import prepositional.*
 
 object Provenance:
-  given jar: (Provenance[Artifact.Jar] from Universe.Bytecode):
-    type Origin = Universe.Bytecode
+  given jar: (Provenance[Artifact.Jar] from Universe.Classfile):
+    type Origin = Universe.Classfile
 
-  given js: (Provenance[Artifact.Js] from Universe.Sjsir):
+  given dex: (Provenance[Artifact.Dex] from Universe.Classfile):
+    type Origin = Universe.Classfile
+
+  given js: [module <: Artifact.Js.Modules]
+  =>  (Provenance[Artifact.Js[module]] from Universe.Sjsir):
     type Origin = Universe.Sjsir
 
   given wasm: (Provenance[Artifact.Wasm] from Universe.Sjsir):

--- a/lib/anthology/src/core/anthology.Universe.scala
+++ b/lib/anthology/src/core/anthology.Universe.scala
@@ -37,7 +37,7 @@ import gossamer.*
 import serpentine.*
 
 object Universe:
-  type Bytecode = Universe.Bytecode.type
+  type Classfile = Universe.Classfile.type
   type Sjsir = Universe.Sjsir.type
   type Nir = Universe.Nir.type
 
@@ -45,7 +45,7 @@ object Universe:
   trait Emission[universe <: Universe]:
     def flags: List[Text]
 
-  given bytecode: Emission[Bytecode]:
+  given classfile: Emission[Classfile]:
     def flags: List[Text] = Nil
 
   given sjsir: Emission[Sjsir]:
@@ -58,8 +58,8 @@ object Universe:
       def flags: List[Text] = List(t"-Xplugin:${plugin.jar.encode}")
 
 // The universe a compilation inhabits: the intermediate representation it emits, and hence the
-// ecosystem of library artifacts it can link with. `Bytecode` is JVM classfiles; `Sjsir` is
+// ecosystem of library artifacts it can link with. `Classfile` is JVM classfiles; `Sjsir` is
 // Scala.js IR, whose linked representation (JavaScript, browser Wasm or a WASI component) is
 // chosen at link time; `Nir` is Scala Native IR, linked to machine code through LLVM.
 enum Universe:
-  case Bytecode, Sjsir, Nir
+  case Classfile, Sjsir, Nir

--- a/lib/anthology/src/link/anthology.Linkage.scala
+++ b/lib/anthology/src/link/anthology.Linkage.scala
@@ -105,8 +105,14 @@ object Linkage:
       catch case suc.NonFatal(error) =>
         abort(LinkError(LinkError.Reason.Failed(error.stackTrace)))
 
-  given js: (Linkage[Artifact.Js] from Universe.Sjsir) =
+  given jsEs: (Linkage[Artifact.Js["es"]] from Universe.Sjsir) =
     Sjs(_.withModuleKind(ModuleKind.ESModule), _ / "main.js")
+
+  given jsCommonJs: (Linkage[Artifact.Js["commonjs"]] from Universe.Sjsir) =
+    Sjs(_.withModuleKind(ModuleKind.CommonJSModule), _ / "main.js")
+
+  given jsScript: (Linkage[Artifact.Js["script"]] from Universe.Sjsir) =
+    Sjs(_.withModuleKind(ModuleKind.NoModule), _ / "main.js")
 
   given wasm: (Linkage[Artifact.Wasm] from Universe.Sjsir) =
     Sjs

--- a/lib/anthology/src/link/anthology_link.scala
+++ b/lib/anthology/src/link/anthology_link.scala
@@ -32,23 +32,13 @@
                                                                                                   */
 package anthology
 
-import org.scalajs.linker.interface.{ESVersion, ModuleKind, StandardConfig}
+import org.scalajs.linker.interface.{ESVersion, StandardConfig}
 
 object linkerOptions:
   private def sjs[artifact <: Artifact.Sjs](edit: StandardConfig => StandardConfig)
   :   Linker.Option[artifact] =
 
     Linker.Option(edit)
-
-  object moduleKind:
-    val esModule: Linker.Option[Artifact.Js] =
-      sjs(_.withModuleKind(ModuleKind.ESModule))
-
-    val commonJs: Linker.Option[Artifact.Js] =
-      sjs(_.withModuleKind(ModuleKind.CommonJSModule))
-
-    val noModule: Linker.Option[Artifact.Js] =
-      sjs(_.withModuleKind(ModuleKind.NoModule))
 
   val checkIr: Linker.Option[Artifact.Sjs] = sjs(_.withCheckIR(true))
   val sourceMaps: Linker.Option[Artifact.Sjs] = sjs(_.withSourceMap(true))

--- a/lib/anthology/src/scala/anthology.Scalac.scala
+++ b/lib/anthology/src/scala/anthology.Scalac.scala
@@ -67,10 +67,10 @@ object Scalac:
   def compiler(): dtd.Compiler = Scala3
 
   // Preserves the single-type-argument call form, `Scalac[3.6](options)`, which targets the
-  // JVM bytecode universe.
-  @targetName("applyBytecode")
+  // classfile universe.
+  @targetName("applyClassfile")
   def apply[version <: Versions](options: List[Option[version]])
-  :   Scalac[version, Universe.Bytecode] =
+  :   Scalac[version, Universe.Classfile] =
 
     new Scalac(options)
 

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -51,16 +51,19 @@ private type JnfPath = java.nio.file.Path
 
 // Unexecuted definitions whose successful compilation assert `Provenance`'s tier structure:
 // choosing an artifact determines the universe a compilation must inhabit.
-def producingWasi(scalac: Scalac[3.8, Universe.Bytecode]): Scalac[3.8, Universe.Sjsir] =
-  scalac.targeting[Universe.Bytecode].producing[Artifact.Wasi[0.2]]
+def producingWasi(scalac: Scalac[3.8, Universe.Classfile]): Scalac[3.8, Universe.Sjsir] =
+  scalac.targeting[Universe.Classfile].producing[Artifact.Wasi[0.2]]
 
-def producingBinary(scalac: Scalac[3.8, Universe.Bytecode]): Scalac[3.8, Universe.Nir] =
+def producingBinary(scalac: Scalac[3.8, Universe.Classfile]): Scalac[3.8, Universe.Nir] =
   scalac.producing[Artifact.Binary]
+
+def producingDex(scalac: Scalac[3.8, Universe.Sjsir]): Scalac[3.8, Universe.Classfile] =
+  scalac.producing[Artifact.Dex]
 
 object Tests extends Suite(m"Anthology Tests"):
   def run(): Unit =
-    test(m"A single-type-argument Scalac targets the bytecode universe"):
-      val scalac: Scalac[3.6, Universe.Bytecode] = Scalac[3.6](Nil)
+    test(m"A single-type-argument Scalac targets the classfile universe"):
+      val scalac: Scalac[3.6, Universe.Classfile] = Scalac[3.6](Nil)
       scalac.commandLineArguments
     . assert(_ == Nil)
 
@@ -69,21 +72,21 @@ object Tests extends Suite(m"Anthology Tests"):
       . commandLineArguments
     . assert(_ == List(t"-experimental"))
 
-    test(m"The bytecode universe adds no compiler flags"):
-      summon[Universe.Emission[Universe.Bytecode]].flags
+    test(m"The classfile universe adds no compiler flags"):
+      summon[Universe.Emission[Universe.Classfile]].flags
     . assert(_ == Nil)
 
     test(m"The sjsir universe adds the -scalajs flag"):
       summon[Universe.Emission[Universe.Sjsir]].flags
     . assert(_ == List(t"-scalajs"))
 
-    test(m"Module-kind options configure the linker"):
-      linkerOptions.moduleKind.commonJs.edit(StandardConfig()).asInstanceOf[StandardConfig]
+    test(m"The module system is part of the JavaScript artifact's type"):
+      summon[Linkage[Artifact.Js["commonjs"]]].initial.asInstanceOf[StandardConfig]
       . moduleKind
     . assert(_ == ModuleKind.CommonJSModule)
 
     test(m"The JavaScript linkage produces an ES module"):
-      summon[Linkage[Artifact.Js]].initial.asInstanceOf[StandardConfig].moduleKind
+      summon[Linkage[Artifact.Js["es"]]].initial.asInstanceOf[StandardConfig].moduleKind
     . assert(_ == ModuleKind.ESModule)
 
     test(m"The browser Wasm linkage enables the WebAssembly backend"):
@@ -91,9 +94,14 @@ object Tests extends Suite(m"Anthology Tests"):
       . esFeatures.useWebAssembly
     . assert(_ == true)
 
-    test(m"A module-kind option is not applicable to a Wasm linker"):
+    test(m"An unknown module system is not a JavaScript artifact"):
       demilitarize:
-        Linker[Artifact.Wasm](List(linkerOptions.moduleKind.esModule))
+        summon[Linkage[Artifact.Js["amd"]]]
+    . assert(_.nonEmpty)
+
+    test(m"Dex is nameable but not linkable"):
+      demilitarize:
+        summon[Linkage[Artifact.Dex]]
     . assert(_.nonEmpty)
 
     test(m"A WASI linkage is not available without toolchain and WIT world"):
@@ -108,10 +116,10 @@ object Tests extends Suite(m"Anthology Tests"):
         summon[Linkage[Artifact.Wasi[0.3]]]
     . assert(_.nonEmpty)
 
-    test(m"A bytecode compilation cannot be linked as JavaScript"):
+    test(m"A classfile compilation cannot be linked as JavaScript"):
       demilitarize:
-        val compilation: Compilation[Universe.Bytecode] = ???
-        Linker[Artifact.Js](Nil).link(compilation, ???)
+        val compilation: Compilation[Universe.Classfile] = ???
+        Linker[Artifact.Js["es"]](Nil).link(compilation, ???)
     . assert(_.nonEmpty)
 
     test(m"An sjsir compilation is not a native compilation"):
@@ -122,7 +130,7 @@ object Tests extends Suite(m"Anthology Tests"):
 
     test(m"A native option is not applicable to a JavaScript linker"):
       demilitarize:
-        Linker[Artifact.Js](List(nativeOptions.gc.immix))
+        Linker[Artifact.Js["es"]](List(nativeOptions.gc.immix))
     . assert(_.nonEmpty)
 
     test(m"An sjsir option is not applicable to a native linker"):
@@ -152,7 +160,7 @@ object Tests extends Suite(m"Anthology Tests"):
 
     test(m"Any universe's compilation can be bundled as a library JAR"):
       demilitarize:
-        def bytecode(compilation: Compilation[Universe.Bytecode]) =
+        def classfile(compilation: Compilation[Universe.Classfile]) =
           Bundler.library(compilation, Unset)
         def nir(compilation: Compilation[Universe.Nir]) =
           Bundler.library(compilation, Unset)
@@ -172,7 +180,7 @@ object Tests extends Suite(m"Anthology Tests"):
         Files.createDirectories(Paths.get(out.encode.s))
 
         val process =
-          Scalac[3.8](Nil).producing[Artifact.Js]
+          Scalac[3.8](Nil).producing[Artifact.Js["es"]]
             (classpath)(Map(t"hello.scala" -> source), out)
 
         test(m"A portable compilation succeeds"):
@@ -187,9 +195,7 @@ object Tests extends Suite(m"Anthology Tests"):
         val linked: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
 
         test(m"Linking as JavaScript produces a nonempty main.js"):
-          Linker[Artifact.Js]
-            ( List(linkerOptions.moduleKind.esModule),
-              List(Linker.EntryPoint(Fqcn(t"Main"))) )
+          Linker[Artifact.Js["es"]](Nil, List(Linker.EntryPoint(Fqcn(t"Main"))))
           . link(Compilation(out, classpath), linked)
           . pipe: artifact =>
               Files.size(Paths.get(artifact.encode.s))

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -120,7 +120,7 @@ extends Rig:
         case Exit.Ok         => target
         case Exit.Fail(fail) => ???
 
-  protected val scalac: Scalac[3.8, Universe.Bytecode] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.8, Universe.Classfile] = Scalac(List(scalacOptions.experimental))
 
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux])

--- a/lib/harlequin/src/test/harlequin_test.scala
+++ b/lib/harlequin/src/test/harlequin_test.scala
@@ -99,7 +99,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert(_ == (t"term", t"binding"))
 
     test(m"typechecked highlighting resolves the type of a val"):
-      given Scalac[3.8, Universe.Bytecode] = Scalac[3.8](Nil)
+      given Scalac[3.8, Universe.Classfile] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 
@@ -107,7 +107,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert { rendered => rendered.contains(t"List") && rendered.contains(t"Int") }
 
     test(m"typechecked highlighting reports diagnostics for ill-typed code"):
-      given Scalac[3.8, Universe.Bytecode] = Scalac[3.8](Nil)
+      given Scalac[3.8, Universe.Classfile] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 
@@ -115,7 +115,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert(_ > 0)
 
     test(m"no completions are computed without a caret"):
-      given Scalac[3.8, Universe.Bytecode] = Scalac[3.8](Nil)
+      given Scalac[3.8, Universe.Classfile] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 
@@ -123,7 +123,7 @@ object Tests extends Suite(m"Harlequin Tests"):
     .assert(_ == Unset)
 
     test(m"completions at a member selection include the type's methods"):
-      given Scalac[3.8, Universe.Bytecode] = Scalac[3.8](Nil)
+      given Scalac[3.8, Universe.Classfile] = Scalac[3.8](Nil)
       given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       import highlighting.typecheckedScala
 

--- a/lib/mandible/src/core/mandible_core.scala
+++ b/lib/mandible/src/core/mandible_core.scala
@@ -64,7 +64,7 @@ def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using T
 
   val uuid = Uuid()
   val out: Path on Linux = unsafely(temporaryDirectory/uuid)
-  val scalac: Scalac[3.6, Universe.Bytecode] = Scalac[3.6](List(scalacOptions.experimental))
+  val scalac: Scalac[3.6, Universe.Classfile] = Scalac[3.6](List(scalacOptions.experimental))
 
   val settings: staging.Compiler.Settings =
     staging.Compiler.Settings.make(Some(out.encode.s), scalac.commandLineArguments.map(_.s))

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -198,7 +198,7 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
     device.deploy(jarfile, uuid)
     jarfile
 
-  protected val scalac: Scalac[3.7, Universe.Bytecode] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.7, Universe.Classfile] = Scalac(List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
     stage.remote: input =>

--- a/lib/sedentary/src/core/sedentary.Profile.scala
+++ b/lib/sedentary/src/core/sedentary.Profile.scala
@@ -194,7 +194,7 @@ extends Rig:
     device.deploy(jarfile, uuid)
     jarfile
 
-  protected val scalac: Scalac[3.7, Universe.Bytecode] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.7, Universe.Classfile] = Scalac(List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
     stage.remote: input =>

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -451,7 +451,7 @@ extends Rig:
     device.deploy(jarfile, uuid)
     jarfile
 
-  protected val scalac: Scalac[3.7, Universe.Bytecode] = Scalac(List(scalacOptions.experimental))
+  protected val scalac: Scalac[3.7, Universe.Classfile] = Scalac(List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
     stage.remote: input =>

--- a/lib/superlunary/src/jvm/superlunary.Isolation.scala
+++ b/lib/superlunary/src/jvm/superlunary.Isolation.scala
@@ -52,7 +52,7 @@ object Isolation extends Rig:
 
   def stage(out: Path on Linux): Classloader = classpath(out).classloader()
 
-  val scalac: Scalac[3.6, Universe.Bytecode] = Scalac[3.6](List(scalacOptions.experimental))
+  val scalac: Scalac[3.6, Universe.Classfile] = Scalac[3.6](List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Form, Target]): output =
     stage.remote: input =>

--- a/lib/superlunary/src/jvm/superlunary.Jvm.scala
+++ b/lib/superlunary/src/jvm/superlunary.Jvm.scala
@@ -55,7 +55,7 @@ object Jvm extends Rig:
 
   def stage(out: Path on Linux): LocalClasspath = classpath(out)
 
-  val scalac: Scalac[3.6, Universe.Bytecode] = Scalac[3.6](List(scalacOptions.experimental))
+  val scalac: Scalac[3.6, Universe.Classfile] = Scalac[3.6](List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Form, Target]): output =
     import workingDirectories.systemWorkingDirectory


### PR DESCRIPTION
The JVM universe is now `Universe.Classfile`, named after its intermediate representation as `Sjsir` and `Nir` are — "bytecode" was under-specific, since dex and WebAssembly are bytecodes too. JavaScript artifacts gain a module-system parameter, and Dalvik bytecode joins the artifact taxonomy ahead of support for producing it.

## Typed module systems

How a JavaScript host consumes an artifact — as an ECMAScript module, a CommonJS module, or a plain script — is part of its binding contract, so like a WASI version it now lives in the artifact's type rather than in the options list:

```scala
Linker[Artifact.Js["commonjs"]](Nil, List(main)).link(compilation, out)
```

The `linkerOptions.moduleKind` options are gone, and an unknown module system such as `Artifact.Js["amd"]` does not compile. The general rule the API now follows: variants that change an artifact's binding contract (WASI versions, module systems) are type parameters; open-ended refinements (native target triples, ECMAScript versions) remain link options.

## Dex

`Artifact.Dex` — Dalvik executable bytecode for the Android runtime — is now nameable. Its `Provenance` places it in the classfile universe, so `Scalac[3.8](options).producing[Artifact.Dex]` compiles for `Universe.Classfile`, but no `Linkage` exists yet, so attempting to link it is a compile error until support arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
