### PR TITLE
xenophile: load native FFI libraries at runtime instead of by static link

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2625,6 +2625,36 @@ object nativelink extends Module:
       hypotenuse.core.native, spectacular.core.native, aviation.core.native, galilei.core.native,
       ambience.core.native, coaxial.core.native, enigmatic.openssl.native, parasite.core.native)
 
+  // The crypto-only regression binary: enigmatic's `OpensslCrypto` with NO coaxial in the graph,
+  // so nothing statically links libcrypto. It links only because xenophile loads libcrypto by path
+  // at run time (`ForeignLibrary.register` → `dlopen`) and resolves symbols from that handle; a
+  // regression to `dlopen(null)`-only lookup would link but crash at run time (see the source).
+  object cryptoApp extends ScalaModule, Toolchain:
+    def scalaVersion = settings.scalaVersion
+    def scalacOptions = Task:
+      (settings.scalaOptions ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+        :+ s"-Xplugin:${nativeToolchain.nscplugin().path}"
+    def sources = Task.Sources(mill.api.BuildCtx.workspaceRoot / "nativelink" / "crypto")
+    def compileMvnDeps = nativeToolchain.runtimeDeps
+    override def mainClass = Some("nativecrypto.Main")
+    override def moduleDeps = Seq(
+      xenophile.scalanative.native, gossamer.core.native, gastronomy.core.native,
+      enigmatic.openssl.native)
+
+  def cryptoBinary: T[PathRef] = Task:
+    val classpath =
+      (cryptoApp.compile().classes.path
+        +: (cryptoApp.compileClasspath() ++ cryptoApp.runClasspath()).toSeq.map(_.path))
+      . distinct.filter(os.exists)
+    val driverClasspath =
+      linker.runClasspath().map(_.path.toString).mkString(java.io.File.pathSeparator)
+
+    os.proc("java", "-cp", driverClasspath, "nativelink.link", Task.dest.toString,
+      "nativecrypto.Main", classpath.map(_.toString).mkString(java.io.File.pathSeparator))
+    . call(stdout = os.Inherit, stderr = os.Inherit)
+
+    PathRef(Task.dest / "soundness-native")
+
   // Real test suites compiled for Native and linked as binaries — each runs `<module>.Tests`
   // natively, the end-state check that `probably` and a green module's entire suite work as a
   // native binary. Only suites free of `demilitarize` blocks qualify (larceny is a JVM compiler
@@ -2672,10 +2702,12 @@ object nativelink extends Module:
 
       PathRef(Task.dest / "soundness-native")
 
-  // Links every enrolled suite and runs each binary; a failing suite (nonzero exit) fails the
-  // task, so `mill nativelink.testSuites` is the one-shot native-test sweep.
+  // Links every enrolled suite plus the crypto-only regression binary and runs each; a failing
+  // one (nonzero exit) fails the task, so `mill nativelink.testSuites` is the one-shot native
+  // sweep.
   def testSuites: T[Unit] = Task:
-    Task.traverse(suite.crossModules.toSeq)(_.binary)().foreach: binary =>
+    val binaries = Task.traverse(suite.crossModules.toSeq)(_.binary)() :+ cryptoBinary()
+    binaries.foreach: binary =>
       os.proc(binary.path.toString).call(stdout = os.Inherit, stderr = os.Inherit)
 
   object linker extends ScalaModule, Toolchain:

--- a/lib/xenophile/src/nativeruntime/xenophile.ForeignLibrary.scala
+++ b/lib/xenophile/src/nativeruntime/xenophile.ForeignLibrary.scala
@@ -32,13 +32,64 @@
                                                                                                   */
 package xenophile
 
-import anticipation.*
+import scala.scalanative.posix.dlfcn.*
+import scala.scalanative.unsafe.*
 
-// The Scala Native twin of the JVM (Panama) `ForeignLibrary` object's registration surface. A
-// native binary resolves every C symbol from the flat namespace of its own statically-linked
-// image (`NativeInvoke` emits `dlopen(null)`), so there is no library to load at runtime —
-// `register` is a no-op, and the library must instead be present at *link* time (a `-l...`
-// linking option, or a reachable `@link` annotation). Sharing the name and signature lets code
-// that registers its libraries cross-compile unchanged.
+import anticipation.*
+import fulminate.*
+import gossamer.*
+
+// The Scala Native twin of the JVM (Panama) `ForeignLibrary`. Both now load libraries by path at
+// *runtime* (`dlopen`) and resolve symbols from the loaded set, so a native FFI binary has no
+// link-time dependency on the foreign library — exactly like the JVM, whose `SymbolLookup` also
+// loads by path. This is what makes the identical FFI source safe on both platforms: a library
+// missing at its declared paths fails loudly at `register` (a clear panic naming the paths tried),
+// not with an undefined symbol at link time or — worse — a NULL-pointer crash on first call, which
+// is what a `dlopen(null)`-only resolution silently risked when nothing else statically linked it.
+//
+// `NativeInvoke` routes every symbol through `resolve`.
 object ForeignLibrary:
-  def register(paths: Text*): Unit = ()
+  // Handles opened by `register`, newest first; searched before the process-default lookup.
+  // Registration happens in a provider's object initializer (before any worker thread that would
+  // call `resolve`), so a plain `var` needs no synchronisation.
+  private var handles: List[CVoidPtr] = Nil
+
+  // The default lookup (`dlopen(null)`): the main image and everything statically linked or already
+  // loaded — where libc/libm symbols (`getpid`, `malloc`, …) resolve without any registration.
+  private lazy val self: CVoidPtr = dlopen(null.asInstanceOf[CString], RTLD_NOW)
+
+  // Loads the first of `paths` that `dlopen` resolves and keeps the handle for the life of the
+  // process (foreign libraries are never unloaded); panics if none load — the native counterpart of
+  // the JVM `SymbolLookup.libraryLookup` failure.
+  def register(paths: Text*): Unit =
+    def attempt(remaining: List[Text]): CVoidPtr = remaining match
+      case path :: rest =>
+        val handle = Zone.acquire: zone =>
+          dlopen(toCString(path.s)(using zone), RTLD_NOW)
+
+        if handle == null then attempt(rest) else handle
+
+      case Nil =>
+        val tried = paths.map(_.s).mkString(", ").tt
+        panic(m"xenophile: no native library could be loaded from $tried")
+
+    handles = attempt(paths.to(List)) :: handles
+
+  // Resolves a C symbol from the registered handles, then the default lookup; panics if unbound —
+  // a symbol whose library was neither `register`ed nor statically linked (the failure that a
+  // `dlopen(null)`-only resolution would have turned into a NULL-pointer call).
+  def resolve(symbol: CString): CVoidPtr =
+    def search(remaining: List[CVoidPtr]): CVoidPtr = remaining match
+      case handle :: rest =>
+        val pointer = dlsym(handle, symbol)
+        if pointer == null then search(rest) else pointer
+
+      case Nil =>
+        val pointer = dlsym(self, symbol)
+
+        if pointer == null then
+          val name = fromCString(symbol).tt
+          panic(m"xenophile: unresolved native symbol $name (is its library registered?)")
+        else pointer
+
+    search(handles)

--- a/lib/xenophile/src/scalanative/xenophile.NativeInvoke.scala
+++ b/lib/xenophile/src/scalanative/xenophile.NativeInvoke.scala
@@ -61,10 +61,12 @@ object NativeInvoke:
 
     // The native runtime entry points, resolved from the downstream `nativelib`/`posixlib` so this
     // module needs no dependency on them (the macro runs on the JVM; the call links downstream).
+    // `dlopen` is retained only for its `CString` parameter type (read off below); symbol
+    // resolution itself goes through `xenophile.ForeignLibrary.resolve` (its native twin), which
+    // searches the libraries loaded at runtime by `register` before the process-default lookup.
     val dlfcn = Symbol.requiredModule("scala.scalanative.posix.dlfcn")
     val dlopen = dlfcn.methodMember("dlopen").head
-    val dlsym = dlfcn.methodMember("dlsym").head
-    val rtldNow = dlfcn.methodMember("RTLD_NOW").head
+    val resolve = Symbol.requiredMethod("xenophile.ForeignLibrary.resolve")
     val cfuncPtr = Symbol.requiredModule("scala.scalanative.unsafe.CFuncPtr")
     val fromPtr = cfuncPtr.methodMember("fromPtr").head
     val cquote = Symbol.requiredClass("scala.scalanative.unsafe.CQuote")
@@ -207,15 +209,11 @@ object NativeInvoke:
     val quoted = Apply(Select(New(TypeTree.ref(cquote)), cquote.primaryConstructor), List(context))
     val symbolName = Apply(Select(quoted, cMethod), Nil)
 
-    // `dlopen(null, RTLD_NOW)` — a handle over the main program and everything already loaded (the
-    // C symbols the linked binary provides), then `dlsym(handle, c"function")`. The null filename
-    // is cast to dlopen's own `CString` parameter type, since Scala Native's pointer type is not
-    // implicitly nullable.
-    val nullFilename =
-      Select.unique(Literal(NullConstant()), "asInstanceOf").appliedToType(cstringType)
-
-    val handle = Apply(Ref(dlopen), List(nullFilename, Ref(rtldNow)))
-    val symbol = Apply(Ref(dlsym), List(handle, symbolName))
+    // `ForeignLibrary.resolve(c"function")` — the symbol pointer from the registered libraries (or
+    // the default lookup), panicking if unbound rather than returning NULL. This replaces a bare
+    // `dlsym(dlopen(null, RTLD_NOW), …)`, whose default-only lookup found a symbol just when some
+    // *other* reachable code had statically linked its library (`@link`), and crashed otherwise.
+    val symbol = Apply(Ref(resolve), List(symbolName))
 
     // `CFuncPtr.fromPtr[CFuncPtr0[result]](symbol)` — summon the required `Tag` implicit (present
     // downstream, where the Native runtime is on the classpath) and pass it explicitly.

--- a/nativelink/crypto/Main.scala
+++ b/nativelink/crypto/Main.scala
@@ -1,0 +1,33 @@
+// A native binary whose ONLY foreign-library user is enigmatic's `OpensslCrypto` — deliberately
+// NOT depending on coaxial, whose hand-written `@extern @link("crypto")` TLS backend would
+// otherwise statically link libcrypto and mask a missing link. This is the regression guard for
+// xenophile's runtime library loading (model A): `OpensslCrypto`'s object initializer
+// `ForeignLibrary.register`s libcrypto by path (a real `dlopen` on native), and every FFI symbol
+// resolves from that handle. If that path regressed to a `dlopen(null)`-only lookup, this binary
+// would still LINK but crash at run time — so its passing run, with no coaxial in the graph, is
+// exactly the proof the smoke binary cannot give.
+package nativecrypto
+
+import soundness.*
+import gastronomy.*
+
+object Main:
+  def main(args: Array[String]): Unit =
+    val out = java.lang.System.out.nn
+    import charEncoders.utf8Encoder
+
+    // HMAC-SHA256 against a known vector — the same assertion the JVM suite makes, here proving
+    // libcrypto was loaded and its symbols resolved at run time with nothing else linking it.
+    val mac = enigmatic.OpensslCrypto.hmac(t"HmacSHA256").mac(t"key".in[Data], t"message".in[Data])
+    val hex = mac.to(List).map(b => String.format("%02x", Int.box(b & 255))).mkString
+    val expected = "6e9ef29b75fffc5b7abae527d58fdadb2fe42e7219011976917343065f58ed4a"
+    out.println("crypto-only: hmac verified = "+(hex == expected))
+
+    // AES-256-CBC round-trip through the EVP cipher API — a second, independent libcrypto surface.
+    val aes = enigmatic.OpensslCrypto.aes
+    val key = aes.generateKey(256)
+    val iv = enigmatic.OpensslCrypto.random.bytes(16)
+    val secret = t"attack at dawn!!".in[Data]
+    val ciphertext = aes.encrypt(t"AES/CBC/PKCS7", key, iv, secret)
+    val plaintext = aes.decrypt(t"AES/CBC/PKCS7", key, 16, ciphertext)
+    out.println("crypto-only: aes round-trip = "+(plaintext.to(List) == secret.to(List)))


### PR DESCRIPTION
On Scala Native, xenophile's `NativeInvoke` resolved every foreign symbol with `dlsym(dlopen(null))` — the process-default lookup. That found a symbol only when some *other* reachable code had statically linked its library (via a `@link` annotation), and returned NULL — a crash on first call — otherwise. So a provider like enigmatic's `OpensslCrypto` linked only by coincidence (coaxial's TLS backend happened to `@link("crypto")`), and a native binary using crypto alone would segfault silently.

This makes native FFI symmetric with the JVM (Panama): libraries load by path at runtime, with no link-time dependency on the foreign library at all. A missing library now fails loudly, at the point of loading, naming the paths it tried.

### Release notes

- **`ForeignLibrary.register(paths*)` on Scala Native** now performs a real `dlopen` (it was previously a no-op), and `NativeInvoke` resolves every symbol through a new `ForeignLibrary.resolve` that searches the registered handles before the process-default lookup (which still serves statically-linked libc/libm symbols like `getpid`/`malloc` with no registration).
- A foreign library missing at its declared paths now **panics at `register`** with the paths it tried, rather than crashing with a NULL-pointer call on first use.
- No source changes are required of FFI providers: `OpensslCrypto` already registered libcrypto's paths, and now links and runs on native with nothing else pulling the library in.
- A `nativelink.cryptoBinary` regression target links `OpensslCrypto` with no coaxial in its graph — so nothing statically links libcrypto — and is part of the `nativelink.testSuites` sweep; it links and runs (HMAC + AES round-trip) purely on runtime library loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
