### PR TITLE
Route every JAR through Linker, retiring the legacy Bundler

### DIFF
--- a/lib/anthology/doc/basics.md
+++ b/lib/anthology/doc/basics.md
@@ -58,8 +58,16 @@ Every artifact is produced by the same verb:
 from the artifact's origin universe. `Linker[Artifact.Jar]` produces an executable JAR from a
 classfile compilation (with at most one entry point becoming its `Main-Class`, and
 `jarOptions.name` choosing its filename); `Linker[Artifact.Library[universe]]` packages any
-compilation's unlinked output as a library JAR. (`Bundler.bundle` remains for the distinct task
-of bundling the _running application's_ classpath, as staging rigs do.)
+compilation's unlinked output as a library JAR.
+
+A staging rig, which must fold its own running classpath into the JARs it produces, pairs
+`Bundler.applicationClasspath` (the running application's classpath, introspected from the
+thread-context classloader) with its compiled output as the `Compilation` it links:
+
+```scala
+val compilation = Compilation[Universe.Classfile](out, Bundler.applicationClasspath)
+Linker[Artifact.Jar](List(jarOptions.name(t"$uuid.jar")), List(executor)).link(compilation, out)
+```
 
 ### Linking
 

--- a/lib/anthology/src/linker/anthology.Bundler.scala
+++ b/lib/anthology/src/linker/anthology.Bundler.scala
@@ -57,23 +57,18 @@ import systems.javaSystem
 import workingDirectories.javaWorkingDirectory
 
 object Bundler:
-  def classpath(out: Path on Linux): LocalClasspath =
-    val entries = Classpath.Directory(out) :: (classloaders.threadContextClassloader.classpath.match
+  // The classpath of the running application, as introspected from the thread-context
+  // classloader (or the `java.class.path` system property as a fallback). A staging rig pairs
+  // this with its compiled output as a `Compilation` and links it into a self-contained JAR
+  // with `Linker[Artifact.Jar]`, so the JAR carries the rig's own executor and dependencies.
+  def applicationClasspath: LocalClasspath =
+    val entries = classloaders.threadContextClassloader.classpath.match
       case classpath: LocalClasspath => classpath.entries
 
       case _ =>
-        unsafely(System.properties.java.`class`.path().as[LocalClasspath]).entries)
+        unsafely(System.properties.java.`class`.path().as[LocalClasspath]).entries
 
     LocalClasspath(entries*)
-
-
-  // Bundles the running application's classpath, together with the given directory's contents,
-  // as an executable JAR: the self-replication path used by staging rigs. For a compilation's
-  // products, use `Linker[Artifact.Jar]` or `Linker[Artifact.Library[universe]]` instead.
-  def bundle(directory: Path on Linux, jarfile0: Optional[Path on Linux], main: Optional[Fqcn])
-  :   Path on Linux raises ZipError raises PathError raises IoError raises StreamError =
-
-    assemble(classpath(directory), jarfile0.or(directory.peer("tmpfile.jar")), main)
 
 
   private[anthology] def assemble

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -105,12 +105,14 @@ extends Rig:
     val target = unsafely(out / name)
 
     unsafely:
-      val name2 = t"$name.jar"
-      val jarfile = out / name2
       // `Fqcn.apply` rather than the `fqcn""` interpolator: the macro's synthesized tree
       // fails capture-variable unification when expanded in a capture-checked module.
       val executor: Fqcn = safely(Fqcn(t"superlunary.Executor2")).vouch
-      val bundle = Bundler.bundle(out, jarfile, executor)
+      val compilation = Compilation[Universe.Classfile](out, Bundler.applicationClasspath)
+
+      val jarfile =
+        Linker[Artifact.Jar](List(jarOptions.name(t"$name.jar")), List(Linker.EntryPoint(executor)))
+        . link(compilation, out)
 
       val cmd = (buildId: @unchecked) match
         case id: Int => sh"java -Dbuild.id=$id -Dbuild.executable=$target -jar $jarfile '[]'"

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -47,7 +47,6 @@ import gossamer.*
 import hellenism.*
 import inimitable.*
 import jacinta.*
-import nomenclature.*
 import prepositional.*
 import probably.*
 import rudiments.*
@@ -192,9 +191,15 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
 
   def stage(out: Path on Linux): Path on Linux = unsafely:
     val uuid = Uuid()
-    val name = t"$uuid.jar"
-    val jarfile = out.peer(name)
-    Bundler.bundle(out, jarfile, fqcn"superlunary.Executor")
+    val compilation = Compilation[Universe.Classfile](out, Bundler.applicationClasspath)
+
+    val jarfile =
+      Linker[Artifact.Jar]
+        ( List(jarOptions.name(t"$uuid.jar")),
+          List(Linker.EntryPoint(fqcn"superlunary.Executor")) )
+
+      . link(compilation, out)
+
     device.deploy(jarfile, uuid)
     jarfile
 

--- a/lib/sedentary/src/core/sedentary.Profile.scala
+++ b/lib/sedentary/src/core/sedentary.Profile.scala
@@ -47,7 +47,6 @@ import gossamer.*
 import hellenism.*
 import inimitable.*
 import jacinta.*
-import nomenclature.*
 import prepositional.*
 import probably.*
 import serpentine.*
@@ -188,9 +187,15 @@ extends Rig:
 
   def stage(out: Path on Linux): Path on Linux = unsafely:
     val uuid = Uuid()
-    val name = t"$uuid.jar"
-    val jarfile = out.peer(name)
-    Bundler.bundle(out, jarfile, fqcn"superlunary.Executor")
+    val compilation = Compilation[Universe.Classfile](out, Bundler.applicationClasspath)
+
+    val jarfile =
+      Linker[Artifact.Jar]
+        ( List(jarOptions.name(t"$uuid.jar")),
+          List(Linker.EntryPoint(fqcn"superlunary.Executor")) )
+
+      . link(compilation, out)
+
     device.deploy(jarfile, uuid)
     jarfile
 

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -47,7 +47,6 @@ import gossamer.*
 import hellenism.*
 import inimitable.*
 import jacinta.*
-import nomenclature.*
 import parasite.*
 import prepositional.*
 import probably.*
@@ -445,9 +444,15 @@ extends Rig:
 
   def stage(out: Path on Linux): Path on Linux = unsafely:
     val uuid = Uuid()
-    val name = t"$uuid.jar"
-    val jarfile = out.peer(name)
-    Bundler.bundle(out, jarfile, fqcn"superlunary.Executor")
+    val compilation = Compilation[Universe.Classfile](out, Bundler.applicationClasspath)
+
+    val jarfile =
+      Linker[Artifact.Jar]
+        ( List(jarOptions.name(t"$uuid.jar")),
+          List(Linker.EntryPoint(fqcn"superlunary.Executor")) )
+
+      . link(compilation, out)
+
     device.deploy(jarfile, uuid)
     jarfile
 


### PR DESCRIPTION
With `Bundler.bundle` gone, every JAR Anthology produces — executable, library, or a staging rig's self-replicating bundle — is built by the single `Linker[artifact]` verb, completing the consolidation begun when `Bundler` folded into the artifact scheme.

## The staging rigs

The superlunary staging rigs (in `sedentary` and `exoskeleton`) were the last callers of the classloader-based `Bundler.bundle`. They now assemble their self-contained JARs through `Linker[Artifact.Jar]`, pairing their compiled output with the running application's classpath:

```scala
val compilation = Compilation[Universe.Classfile](out, Bundler.applicationClasspath)
Linker[Artifact.Jar](List(jarOptions.name(t"$uuid.jar")), List(executor)).link(compilation, out)
```

## What remains of Bundler

`Bundler.classpath(out)` is renamed to `Bundler.applicationClasspath`: it returns just the running application's classpath (introspected from the thread-context classloader, or the `java.class.path` system property as a fallback), no longer prepending an output directory — the `Artifact.Jar` linkage adds that itself. Beyond this one classpath-introspection helper, `Bundler` retains only the internal `assemble` routine shared by the JAR and library linkages.

The exoskeleton suite exercises the migrated path end to end — staging a CLI tool, bundling it with the ambient classpath, and running the produced JAR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
