### PR TITLE
Native HTTP/2 server: ALPN-negotiated, multiplexed, with trailers, flow control and per-connection sessions

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2060,7 +2060,7 @@ object savagery extends Library:
       settings.cc(super.scalacOptions())
 
 object scintillate extends Library:
-  object server extends Component(telekinesis.core):
+  object server extends Component(telekinesis.core, telekinesis.http2):
     override def scalaJs = false // HTTP server via `telekinesis`/`coaxial` sockets
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))

--- a/lib/scintillate/src/server/scintillate.Http2Serve.scala
+++ b/lib/scintillate/src/server/scintillate.Http2Serve.scala
@@ -1,0 +1,143 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package scintillate
+
+import java.io as ji
+
+import anticipation.*
+import coaxial.*
+import contingency.*
+import cordillera.*
+import parasite.*
+import prepositional.*
+import proscenium.*
+import rudiments.*
+import telekinesis.*
+import turbulence.*
+import vacuous.*
+import zephyrine.*
+
+// Serves an HTTP/2 connection (already negotiated via ALPN) over a socket's raw
+// streams, driving the same handler contract the HTTP/1.1 backend uses. Each
+// client-initiated stream is handled on its own virtual thread, so requests
+// multiplexed on the one connection run concurrently. Runs until the connection
+// ends (client GOAWAY or socket close). Blocks the calling (accept-loop) daemon
+// for the connection's lifetime, matching `serveConnection`.
+object Http2Serve:
+  def serve
+    ( handler: AnyRef => AnyRef, in: ji.InputStream, out: ji.OutputStream, port: Int )
+    ( using Monitor, (HttpServerEvent is Loggable)^ )
+  :   Unit =
+
+    // A local (pure) Probate rather than one captured from the accept daemon:
+    // capturing the caller's `Probate` capability would make this call — and so
+    // the accept-daemon body — impure.
+    import probates.cancelProbate
+
+    given Tactic[AsyncError] = strategies.throwUnsafely
+    given Tactic[Http2Error] = strategies.throwUnsafely
+    given Tactic[StreamError] = strategies.throwUnsafely
+
+    // The app handler crosses into the per-stream daemons as a neutral rim: a
+    // capability-typed function value re-hides through a fiber boundary (the
+    // cordillera recipe), so it is carried as an `AnyRef` and cast back inside.
+    val handler0: AnyRef = handler.asInstanceOf[AnyRef]
+
+    val connection = Http2ServerConnection(StreamDuplex(in, out))
+    val connectionRef: AnyRef = connection.asInstanceOf[AnyRef]
+    connection.start()
+
+    connection.eachStream: stream =>
+      val streamRef: AnyRef = stream.asInstanceOf[AnyRef]
+
+      daemon:
+        val stream0 = streamRef.asInstanceOf[Http2Stream]
+        val connection0 = connectionRef.asInstanceOf[Http2ServerConnection]
+        val handler1 = handler0.asInstanceOf[AnyRef => AnyRef]
+        val streamId = stream0.id
+
+        safely:
+          val entries = stream0.headers.await()
+
+          // The request body streams the stream's inbound DATA frames, per the
+          // `Spring` re-lending contract.
+          val body: Spring[Data]^ = () =>
+            zephyrine.Stream(stream0.body.stream.records.iterator)
+
+          val request = PseudoHeaders.requestOf(entries, body)
+
+          // The response sink: frame the handler's `Http.Response` as HEADERS
+          // (+ DATA), driving the body block-by-block off its pull endpoint
+          // exactly as the HTTP/1.1 `writeAll` does (never `memoize`, which a
+          // transforming body such as a text encoder does not terminate under).
+          val respond: HttpConnection.Respond^ = new HttpConnection.Respond:
+            def apply(response: Http.Response^)(using Tactic[StreamError]): Unit =
+              val headerEntries = PseudoHeaders.entries(response)
+
+              response.body match
+                case Http.Body.Empty =>
+                  connection0.sendHeaders(streamId, headerEntries, endStream = true)
+
+                case Http.Body.Fixed(data) =>
+                  connection0.sendHeaders(streamId, headerEntries, endStream = data.isEmpty)
+                  if !data.isEmpty then connection0.sendData(streamId, data, endStream = true)
+
+                case Http.Body.Flowing(source) =>
+                  connection0.sendHeaders(streamId, headerEntries, endStream = false)
+
+                  source().sweep: (storage, start, size) =>
+                    val block = storage.asInstanceOf[Array[Byte]]
+                      . slice(start, start + size).immutable(using Unsafe)
+
+                    connection0.sendData(streamId, block, endStream = false)
+
+                  // An empty END_STREAM DATA frame closes the response.
+                  connection0.sendData(streamId, IArray.empty[Byte], endStream = true)
+
+          val connection1 = new HttpConnection(request, true, port, respond)
+          connection1.respond(handler1(connection1.asInstanceOf[AnyRef]).asInstanceOf[Http.Response])
+
+// A `Duplex` over a socket's raw byte streams: reads frame the inbound endpoint,
+// each `send` writes the whole chunk and flushes (the writer serialises one frame
+// per send). Used to drive `Http2ServerConnection` over a scintillate socket.
+class StreamDuplex(in: ji.InputStream, out: ji.OutputStream)(using Tactic[StreamError])
+extends Duplex:
+  def source(using Buffering): (Stream[Data] over Credit)^ = Streamable.inputStream.stream(in)
+
+  def send(consume data: (Stream[Data] over Credit)^): Unit =
+    data.sweep: (storage, start, size) =>
+      out.write(storage.asInstanceOf[Array[Byte]], start, size)
+
+    out.flush()
+
+  def close(): Unit = safely(out.close())

--- a/lib/scintillate/src/server/scintillate.Http2Serve.scala
+++ b/lib/scintillate/src/server/scintillate.Http2Serve.scala
@@ -38,6 +38,7 @@ import anticipation.*
 import coaxial.*
 import contingency.*
 import cordillera.*
+import gossamer.*
 import parasite.*
 import prepositional.*
 import proscenium.*
@@ -102,18 +103,37 @@ object Http2Serve:
           // transforming body such as a text encoder does not terminate under).
           val respond: HttpConnection.Respond^ = new HttpConnection.Respond:
             def apply(response: Http.Response^)(using Tactic[StreamError]): Unit =
-              val headerEntries = PseudoHeaders.entries(response)
+              // A `Trailer` header (RFC 7230 §4.4) names response headers to be
+              // sent as HTTP/2 trailers — a trailing HEADERS block after the body
+              // (e.g. gRPC's `grpc-status`) — rather than in the initial block.
+              val trailerNames: Set[Text] =
+                response.textHeaders
+                  . filter(_.key.lower == t"trailer")
+                  . flatMap(_.value.cut(t",").map(_.trim.lower))
+                  . to(Set)
+
+              val (trailerEntries, headEntries) =
+                PseudoHeaders.entries(response).partition: entry =>
+                  trailerNames.contains(entry.name)
+
+              val trailing: Boolean = !trailerEntries.isEmpty
+
+              def sendTrailers(): Unit =
+                if trailing then connection0.sendTrailers(streamId, trailerEntries)
 
               response.body match
                 case Http.Body.Empty =>
-                  connection0.sendHeaders(streamId, headerEntries, endStream = true)
+                  connection0.sendHeaders(streamId, headEntries, endStream = !trailing)
+                  sendTrailers()
 
                 case Http.Body.Fixed(data) =>
-                  connection0.sendHeaders(streamId, headerEntries, endStream = data.isEmpty)
-                  if !data.isEmpty then connection0.sendData(streamId, data, endStream = true)
+                  val headEnd = data.isEmpty && !trailing
+                  connection0.sendHeaders(streamId, headEntries, endStream = headEnd)
+                  if !data.isEmpty then connection0.sendData(streamId, data, endStream = !trailing)
+                  sendTrailers()
 
                 case Http.Body.Flowing(source) =>
-                  connection0.sendHeaders(streamId, headerEntries, endStream = false)
+                  connection0.sendHeaders(streamId, headEntries, endStream = false)
 
                   source().sweep: (storage, start, size) =>
                     val block = storage.asInstanceOf[Array[Byte]]
@@ -121,8 +141,9 @@ object Http2Serve:
 
                     connection0.sendData(streamId, block, endStream = false)
 
-                  // An empty END_STREAM DATA frame closes the response.
-                  connection0.sendData(streamId, IArray.empty[Byte], endStream = true)
+                  // Trailers close the stream; otherwise an empty END_STREAM DATA.
+                  if trailing then sendTrailers()
+                  else connection0.sendData(streamId, IArray.empty[Byte], endStream = true)
 
           val connection1 = new HttpConnection(request, true, port, respond)
           connection1.respond(handler1(connection1.asInstanceOf[AnyRef]).asInstanceOf[Http.Response])

--- a/lib/scintillate/src/server/scintillate.Http2Serve.scala
+++ b/lib/scintillate/src/server/scintillate.Http2Serve.scala
@@ -55,28 +55,20 @@ import zephyrine.*
 // ends (client GOAWAY or socket close). Blocks the calling (accept-loop) daemon
 // for the connection's lifetime, matching `serveConnection`.
 object Http2Serve:
-  def serve
-    ( handler: AnyRef => AnyRef, in: ji.InputStream, out: ji.OutputStream, port: Int )
-    ( using Monitor, (HttpServerEvent is Loggable)^ )
+  // Serve every stream on `connection` with the request handler `handler0` (a
+  // neutral `AnyRef => AnyRef` rim of the context-function handler), each on its
+  // own virtual thread. Blocks until the connection ends. The per-connection
+  // state a session sets up is captured by `handler0` and shared here across
+  // all streams.
+  private def runStreams
+    ( connection: Http2ServerConnection^, handler0: AnyRef, port: Int )
+    ( using Monitor, Probate, (HttpServerEvent is Loggable)^ )
   :   Unit =
 
-    // A local (pure) Probate rather than one captured from the accept daemon:
-    // capturing the caller's `Probate` capability would make this call — and so
-    // the accept-daemon body — impure.
-    import probates.cancelProbate
-
-    given Tactic[AsyncError] = strategies.throwUnsafely
     given Tactic[Http2Error] = strategies.throwUnsafely
     given Tactic[StreamError] = strategies.throwUnsafely
 
-    // The app handler crosses into the per-stream daemons as a neutral rim: a
-    // capability-typed function value re-hides through a fiber boundary (the
-    // cordillera recipe), so it is carried as an `AnyRef` and cast back inside.
-    val handler0: AnyRef = handler.asInstanceOf[AnyRef]
-
-    val connection = Http2ServerConnection(StreamDuplex(in, out))
     val connectionRef: AnyRef = connection.asInstanceOf[AnyRef]
-    connection.start()
 
     connection.eachStream: stream =>
       val streamRef: AnyRef = stream.asInstanceOf[AnyRef]
@@ -147,6 +139,64 @@ object Http2Serve:
 
           val connection1 = new HttpConnection(request, true, port, respond)
           connection1.respond(handler1(connection1.asInstanceOf[AnyRef]).asInstanceOf[Http.Response])
+
+  // Open the HTTP/2 connection over the socket's streams and run its session
+  // scope. `serve` (per-request) is the degenerate session that immediately
+  // handles with no per-connection setup; `serveSession` lends the caller an
+  // `Http2Session` so it can set up per-connection state first.
+  private def open(in: ji.InputStream, out: ji.OutputStream)(using Monitor)
+  :   (Http2ServerConnection^, Probate) =
+
+    // A local (pure) Probate rather than one captured from the accept daemon:
+    // capturing the caller's `Probate` capability would make this call — and so
+    // the accept-daemon body — impure.
+    import probates.cancelProbate
+    given Tactic[AsyncError] = strategies.throwUnsafely
+    given Tactic[StreamError] = strategies.throwUnsafely
+    val connection = Http2ServerConnection(StreamDuplex(in, out))
+    connection.start()
+    (connection, cancelProbate)
+
+  def serve
+    ( handler: AnyRef => AnyRef, in: ji.InputStream, out: ji.OutputStream, port: Int )
+    ( using Monitor, (HttpServerEvent is Loggable)^ )
+  :   Unit =
+
+    val (connection, probate) = open(in, out)
+    runStreams(connection, handler.asInstanceOf[AnyRef], port)(using summon, probate)
+
+  // Serve one HTTP/2 connection as a session: `scope0` — the (rimmed) session
+  // scope — runs once when the connection is established and may set up
+  // per-connection state (auth, a rate limiter, …) before calling
+  // `session.handle` to serve every stream with that state in scope. Capture
+  // checking confines the state to this connection — the server dual of the
+  // client's `Http2.Endpoint.session`. `scope0` crosses the accept daemon as an
+  // `AnyRef => Unit` rim (a session-scope function value re-hides otherwise).
+  def serveSession
+    ( scope0: AnyRef, in: ji.InputStream, out: ji.OutputStream, port: Int )
+    ( using Monitor, (HttpServerEvent is Loggable)^ )
+  :   Unit =
+
+    val (connection, probate) = open(in, out)
+
+    val session: Http2Session^ = new Http2Session:
+      def handle(handler: (connection: HttpConnection) ?=> Http.Response^{connection}): Unit =
+        // Rim the context-function handler to a neutral `AnyRef => AnyRef`, as
+        // the accept loop does for the per-request path.
+        val handler0: AnyRef =
+          ((ref: AnyRef) => handler(using ref.asInstanceOf[HttpConnection])).asInstanceOf[AnyRef]
+
+        runStreams(connection, handler0, port)(using summon, probate)
+
+    scope0.asInstanceOf[AnyRef => Unit](session.asInstanceOf[AnyRef])
+
+// A per-connection serve scope. Runs once when an HTTP/2 connection is
+// established; `handle` registers the per-stream request handler and serves
+// every stream on the connection with it (concurrently), sharing whatever state
+// the enclosing scope set up. That state is confined by capture checking to the
+// connection, so it cannot leak to another client's connection.
+trait Http2Session:
+  def handle(handler: (connection: HttpConnection) ?=> Http.Response^{connection}): Unit
 
 // A `Duplex` over a socket's raw byte streams: reads frame the inbound endpoint,
 // each `send` writes the whole chunk and flushes (the writer serialises one frame

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -282,7 +282,21 @@ extends RequestServable:
         val address = jn.InetAddress.getByName(if local then "localhost" else "0.0.0.0").nn
 
         ssl.lay(jn.ServerSocket(port, 0, address)): context =>
-          context.getServerSocketFactory.nn.createServerSocket(port, 0, address).nn
+          val socket = context.getServerSocketFactory.nn.createServerSocket(port, 0, address).nn
+
+          // Offer `h2` then `http/1.1` by ALPN, so a client that speaks HTTP/2
+          // negotiates it during the TLS handshake; accepted sockets inherit
+          // these parameters. Plaintext servers have no ALPN.
+          socket match
+            case ssl: jns.SSLServerSocket =>
+              val params = ssl.getSSLParameters.nn
+              params.setApplicationProtocols(Array[String | Null]("h2", "http/1.1"))
+              ssl.setSSLParameters(params)
+
+            case _ =>
+              ()
+
+          socket
       catch case error: jn.BindException => abort(ServerError(port))
 
     val serverSocket = startServer()
@@ -316,13 +330,29 @@ extends RequestServable:
               try
                 socket1.setSoTimeout(idleTimeout)
 
-                val h = handler0.asInstanceOf[AnyRef => AnyRef]
+                val in = socket1.getInputStream.nn
+                val out = socket1.getOutputStream.nn
+                given HttpServerEvent is Loggable = loggable0.asInstanceOf[HttpServerEvent is Loggable]
+                val h0 = handler0.asInstanceOf[AnyRef => AnyRef]
 
-                self.asInstanceOf[SocketServer]
-                . serveConnection
-                    (h(summon[HttpConnection].asInstanceOf[AnyRef]).asInstanceOf[Http.Response])
-                    (socket1.getInputStream.nn, socket1.getOutputStream.nn)
-                    (using loggable0.asInstanceOf[HttpServerEvent is Loggable])
+                // A TLS socket may have negotiated `h2` by ALPN; force the
+                // handshake to learn the protocol, then dispatch to the native
+                // HTTP/2 engine. Everything else (plaintext, or ALPN `http/1.1`)
+                // takes the HTTP/1.1 keep-alive path.
+                val protocol: Text = socket1 match
+                  case tls: jns.SSLSocket =>
+                    safely(tls.startHandshake())
+                    Optional(tls.getApplicationProtocol).let(_.tt).or(t"")
+
+                  case _ =>
+                    t""
+
+                if protocol == t"h2" then Http2Serve.serve(h0, in, out, port)
+                else
+                  self.asInstanceOf[SocketServer]
+                  . serveConnection
+                      (h0(summon[HttpConnection].asInstanceOf[AnyRef]).asInstanceOf[Http.Response])
+                      (in, out)
 
               finally safely(socket1.close())
 

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -270,7 +270,22 @@ extends RequestServable:
         var continue = true
         while continue && !cursor.finished do continue = serveRequest(cursor)
 
+  // A per-request server: handle every request (HTTP/1.1) or stream (HTTP/2)
+  // with `handler`. The degenerate session with no per-connection setup.
   def handle(handler: (connection: HttpConnection) ?=> Http.Response^{connection})
+    ( using Monitor, Probate )
+    ( using (HttpServerEvent is Loggable)^, Tactic[ServerError] )
+  :   Service^ =
+
+    handleSession: session ?=>
+      session.handle(handler)
+
+  // A per-connection session server: `scope` runs once when a connection is
+  // established (an HTTP/2 connection, or an HTTP/1.1 keep-alive socket) and may
+  // set up per-connection state before calling `session.handle` to serve that
+  // connection's requests/streams with the state in scope. Capture checking
+  // confines the state to its connection.
+  def handleSession(scope: (session: Http2Session^) ?=> Unit)
     ( using Monitor, Probate )
     ( using (HttpServerEvent is Loggable)^, Tactic[ServerError] )
   :   Service^ =
@@ -311,12 +326,12 @@ extends RequestServable:
         // Daemon bodies must be pure context functions, so the server, the handler and each
         // socket cross into them as `AnyRef` rims (the cordillera recipe).
         val self: AnyRef = this
-        // Eta-wrapped into a capture-neutral `AnyRef => AnyRef` (capability-typed function
+        // Eta-wrapped into a capture-neutral `AnyRef => Unit` (capability-typed function
         // types re-hide when crossed through a rim; the kernel-module-sep finding), since a
         // context-function value applies itself in any non-context-function position.
-        val handler1: AnyRef => AnyRef =
-          connection => handler(using connection.asInstanceOf[HttpConnection])
-        val handler0: AnyRef = handler1.asInstanceOf[AnyRef]
+        val scope1: AnyRef => Unit =
+          session => scope(using session.asInstanceOf[Http2Session^])
+        val scope0: AnyRef = scope1.asInstanceOf[AnyRef]
         // The (capability-typed) Loggable evidence crosses as an `AnyRef` rim too.
         val loggable0: AnyRef = summon[(HttpServerEvent is Loggable)^].asInstanceOf[AnyRef]
 
@@ -333,12 +348,14 @@ extends RequestServable:
                 val in = socket1.getInputStream.nn
                 val out = socket1.getOutputStream.nn
                 given HttpServerEvent is Loggable = loggable0.asInstanceOf[HttpServerEvent is Loggable]
-                val h0 = handler0.asInstanceOf[AnyRef => AnyRef]
+                val scope2 = scope0.asInstanceOf[AnyRef => Unit]
+                val self1 = self.asInstanceOf[SocketServer]
 
                 // A TLS socket may have negotiated `h2` by ALPN; force the
                 // handshake to learn the protocol, then dispatch to the native
                 // HTTP/2 engine. Everything else (plaintext, or ALPN `http/1.1`)
-                // takes the HTTP/1.1 keep-alive path.
+                // takes the HTTP/1.1 keep-alive path. Either way the connection is
+                // one session scope.
                 val protocol: Text = socket1 match
                   case tls: jns.SSLSocket =>
                     safely(tls.startHandshake())
@@ -347,12 +364,16 @@ extends RequestServable:
                   case _ =>
                     t""
 
-                if protocol == t"h2" then Http2Serve.serve(h0, in, out, port)
+                if protocol == t"h2" then Http2Serve.serveSession(scope0, in, out, port)
                 else
-                  self.asInstanceOf[SocketServer]
-                  . serveConnection
-                      (h0(summon[HttpConnection].asInstanceOf[AnyRef]).asInstanceOf[Http.Response])
-                      (in, out)
+                  // An HTTP/1.1 keep-alive connection is also a per-connection
+                  // scope; its session `handle` serves the connection's requests.
+                  val session: Http2Session^ = new Http2Session:
+                    def handle(handler: (connection: HttpConnection) ?=> Http.Response^{connection})
+                    :   Unit =
+                      self1.serveConnection(handler)(in, out)
+
+                  scope2(session.asInstanceOf[AnyRef])
 
               finally safely(socket1.close())
 

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -343,6 +343,38 @@ object Tests extends Suite(m"Scintillate tests"):
 
         . assert(_ == List(t"multiplexed", t"multiplexed", t"multiplexed"))
 
+        test(m"a session shares per-connection state across its streams"):
+          val port = freePort()
+
+          // The scope sets up a per-connection counter, shared by every stream
+          // handled on that connection; capture checking keeps it from leaking
+          // to another connection.
+          val server = SocketServer(port, ssl = serverContext()).handleSession: session ?=>
+            val counter = java.util.concurrent.atomic.AtomicInteger(0)
+
+            session.handle:
+              Http.Response(Http.Ok)(t"${counter.incrementAndGet}")
+
+          val client = java.net.http.HttpClient.newBuilder.nn
+            . sslContext(trustAllContext()).nn
+            . version(java.net.http.HttpClient.Version.HTTP_2).nn
+            . build.nn
+
+          def fetch(): Int =
+            val request = java.net.http.HttpRequest.newBuilder.nn
+              . uri(java.net.URI.create(s"https://localhost:$port/").nn).nn
+              . build.nn
+
+            client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString.nn).nn.body.nn.toInt
+
+          // Three requests reuse the one pooled HTTP/2 connection, so the shared
+          // counter yields three distinct values.
+          val results = List(fetch(), fetch(), fetch())
+          server.cancel()
+          results.sorted
+
+        . assert(_ == List(1, 2, 3))
+
     // Drive the connection loop entirely in memory — no socket, no threads — by
     // feeding request bytes through `serveConnection` and capturing the response.
     def inProcess(handler: HttpConnection ?=> Http.Response, request: Text): Text =

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -261,6 +261,88 @@ object Tests extends Suite(m"Scintillate tests"):
 
         . assert(_.contains(t"secure"))
 
+      suite(m"Native HTTP/2 server"):
+        // A throwaway self-signed certificate, shared by the h2 tests below.
+        def serverContext(): javax.net.ssl.SSLContext =
+          val dir = java.nio.file.Files.createTempDirectory("scintillate-h2").nn
+          val path = dir.resolve("test.p12").nn.toString.nn
+
+          val keytool = java.lang.ProcessBuilder("keytool", "-genkeypair", "-alias", "test",
+              "-keyalg", "RSA", "-keysize", "2048", "-validity", "1", "-storetype", "PKCS12",
+              "-keystore", path, "-storepass", "changeit", "-dname", "CN=localhost")
+
+          keytool.redirectErrorStream(true)
+          keytool.redirectOutput(java.lang.ProcessBuilder.Redirect.DISCARD)
+          keytool.start().nn.waitFor()
+
+          val password = "changeit".toCharArray.nn
+          val keystore = java.security.KeyStore.getInstance("PKCS12").nn
+          keystore.load(java.io.FileInputStream(path), password)
+          val keyManagers = javax.net.ssl.KeyManagerFactory.getInstance("SunX509").nn
+          keyManagers.init(keystore, password)
+          val context = javax.net.ssl.SSLContext.getInstance("TLS").nn
+          context.init(keyManagers.getKeyManagers, null, null)
+          context
+
+        // A client SSL context that trusts any certificate.
+        def trustAllContext(): javax.net.ssl.SSLContext =
+          val trustManager = new javax.net.ssl.X509TrustManager:
+            type Certs = Array[java.security.cert.X509Certificate | Null] | Null
+            def getAcceptedIssuers: Certs = scala.Array.empty[java.security.cert.X509Certificate | Null]
+            def checkClientTrusted(chain: Certs, kind: String | Null): Unit = ()
+            def checkServerTrusted(chain: Certs, kind: String | Null): Unit = ()
+
+          val context = javax.net.ssl.SSLContext.getInstance("TLS").nn
+          context.init(null, scala.Array(trustManager), java.security.SecureRandom())
+          context
+
+        // The JDK HTTP client negotiates ALPN and speaks HTTP/2 automatically
+        // over TLS, so it exercises our server against a reference h2 client.
+        test(m"serves an HTTP/2 request negotiated by ALPN"):
+          val port = freePort()
+
+          val server =
+            SocketServer(port, ssl = serverContext()).handle(Http.Response(Http.Ok)(t"h2-secure"))
+
+          val client = java.net.http.HttpClient.newBuilder.nn
+            . sslContext(trustAllContext()).nn
+            . version(java.net.http.HttpClient.Version.HTTP_2).nn
+            . build.nn
+
+          val request = java.net.http.HttpRequest.newBuilder.nn
+            . uri(java.net.URI.create(s"https://localhost:$port/").nn).nn
+            . build.nn
+
+          val response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString.nn).nn
+          server.cancel()
+          (response.version.nn.toString.nn.tt, response.body.nn.tt)
+
+        . assert(_ == (t"HTTP_2", t"h2-secure"))
+
+        test(m"serves several HTTP/2 requests on one multiplexed connection"):
+          val port = freePort()
+
+          val server = SocketServer(port, ssl = serverContext()).handle:
+            Http.Response(Http.Ok)(t"multiplexed")
+
+          val client = java.net.http.HttpClient.newBuilder.nn
+            . sslContext(trustAllContext()).nn
+            . version(java.net.http.HttpClient.Version.HTTP_2).nn
+            . build.nn
+
+          def fetch(): Text =
+            val request = java.net.http.HttpRequest.newBuilder.nn
+              . uri(java.net.URI.create(s"https://localhost:$port/").nn).nn
+              . build.nn
+
+            client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString.nn).nn.body.nn.tt
+
+          val results = List(fetch(), fetch(), fetch())
+          server.cancel()
+          results
+
+        . assert(_ == List(t"multiplexed", t"multiplexed", t"multiplexed"))
+
     // Drive the connection loop entirely in memory — no socket, no threads — by
     // feeding request bytes through `serveConnection` and capturing the response.
     def inProcess(handler: HttpConnection ?=> Http.Response, request: Text): Text =

--- a/lib/telekinesis/src/http2/cordillera.FrameReader.scala
+++ b/lib/telekinesis/src/http2/cordillera.FrameReader.scala
@@ -34,6 +34,7 @@ package cordillera
 
 import anticipation.{Data as Bytes, *}
 import contingency.*
+import gossamer.*
 import rudiments.*
 import vacuous.*
 import prepositional.*
@@ -95,6 +96,21 @@ extends caps.ExclusiveCapability, caps.Stateful:
     System.arraycopy(buffer, pos, out, 0, n)
     pos += n
     out.immutable(using Unsafe)
+
+  // Consume and validate the given connection preface (RFC 7540 §3.5) ahead of
+  // the first frame — the server role's first read on a new connection. A
+  // mismatch (or a stream ending mid-preface) is a protocol error.
+  update def expectPreface(preface: Bytes)(using Tactic[Http2Error]): Unit =
+    if !ensure(preface.length)
+    then abort(Http2Error(Reason.Protocol(t"bad connection preface")))
+
+    val read: Bytes = slice(preface.length)
+    var index: Int = 0
+
+    while index < preface.length do
+      if read(index) != preface(index)
+      then abort(Http2Error(Reason.Protocol(t"bad connection preface")))
+      index += 1
 
   // Read the next frame, or `Unset` at clean end of stream. The tactic is a plain
   // using-parameter: a context-function result may not hide `this`.

--- a/lib/telekinesis/src/http2/cordillera.Http2.scala
+++ b/lib/telekinesis/src/http2/cordillera.Http2.scala
@@ -37,6 +37,7 @@ import scala.collection.mutable as scm
 import anticipation.{Data as Bytes, *}
 import coaxial.*
 import contingency.*
+import fulminate.*
 import gossamer.*
 import parasite.*
 import prepositional.*
@@ -164,7 +165,13 @@ object Http2:
       if end > data.length then abort(Http2Error(Reason.Truncated))
       val body: anticipation.Data = data.slice(start, end)
 
-      val frame = FrameType.fromId(typeId).lest(Http2Error(Reason.BadFrameType(typeId))) match
+      // An unrecognised frame type — PRIORITY or PUSH_PROMISE (which this stack
+      // does not model), or an extension frame — must be ignored, not treated as
+      // a connection error (RFC 7540 §4.1, §5.5): clients routinely send
+      // PRIORITY, so aborting here would kill real connections.
+      val frame = (FrameType.fromId(typeId): @unchecked) match
+        case Unset => Frame.Ignored(typeId, streamId)
+
         case FrameType.Data =>
           Frame.Data(streamId, stripPadding(body, flags), Flags.set(flags, Flags.EndStream))
 
@@ -237,6 +244,7 @@ object Http2:
       case _: Frame.Ping         => FrameType.Ping
       case _: Frame.GoAway       => FrameType.GoAway
       case _: Frame.WindowUpdate => FrameType.WindowUpdate
+      case _: Frame.Ignored      => panic(m"an ignored frame cannot be serialized")
 
     private def frameFlags(frame: Frame): Int = frame match
       case Frame.Headers(_, _, endStream, endHeaders) =>
@@ -269,6 +277,7 @@ object Http2:
       case Frame.Data(_, payload, _)       => payload
       case Frame.Ping(opaque, _)           => opaque
       case Frame.RstStream(_, errorCode)   => frameBuilder(writeUint32(_, errorCode))
+      case Frame.Ignored(_, _)             => panic(m"an ignored frame cannot be serialized")
 
       case Frame.WindowUpdate(_, increment) =>
         frameBuilder(writeUint32(_, increment.toLong & 0x7fffffffL))
@@ -317,6 +326,11 @@ object Http2:
     case GoAway(lastStreamId: Int, errorCode: Long, debug: Bytes)
     case WindowUpdate(streamId: Int, increment: Int)
 
+    // An inbound frame of a type this stack does not model — PRIORITY,
+    // PUSH_PROMISE or an extension — decoded only to be discarded (RFC 7540
+    // §4.1, §5.5). Never serialised.
+    case Ignored(typeId: Int, streamId: Int)
+
     // The stream this frame belongs to; connection-level frames (SETTINGS, PING,
     // GOAWAY) use stream 0.
     def stream: Int = this match
@@ -328,6 +342,7 @@ object Http2:
       case Ping(_, _)             => 0
       case GoAway(_, _, _)        => 0
       case WindowUpdate(id, _)    => id
+      case Ignored(_, id)         => id
 
     // Serialise the frame, including its 9-byte header.
     // Delegates to the companion: builder mutation inside an enum-class method

--- a/lib/telekinesis/src/http2/cordillera.Http2ServerConnection.scala
+++ b/lib/telekinesis/src/http2/cordillera.Http2ServerConnection.scala
@@ -32,6 +32,9 @@
                                                                                                   */
 package cordillera
 
+import java.util.concurrent.atomic as juca
+import java.util.concurrent.locks as jucl
+
 import scala.collection.concurrent as scc
 
 import anticipation.{Data as Bytes, *}
@@ -48,7 +51,42 @@ import zephyrine.*
 
 import Http2.*
 
+// A single HTTP/2 flow-control send window (RFC 7540 §6.9): a signed byte
+// budget the peer grants us for sending DATA. `acquire` blocks the sending
+// fiber until at least one byte is available and returns up to `n` (so a large
+// body drains as the window opens); `release` (from an inbound WINDOW_UPDATE)
+// tops it up and wakes waiters. A `ReentrantLock`/`Condition` rather than
+// `synchronized`, so a blocked virtual thread unmounts its carrier.
+class FlowWindow(initial: Int):
+  private val lock: jucl.ReentrantLock = jucl.ReentrantLock()
+  private val replenished: jucl.Condition = lock.newCondition().nn
+
+  // Guarded by `lock`; reached only through this window's own methods.
+  @caps.unsafe.untrackedCaptures
+  private var value: Long = initial.toLong
+
+  def acquire(n: Int): Int =
+    lock.lock()
+    try
+      while value <= 0 do replenished.await()
+      val take: Int = math.min(n.toLong, value).toInt
+      value -= take
+      take
+    finally lock.unlock()
+
+  def release(increment: Int): Unit =
+    lock.lock()
+    try
+      value += increment.toLong
+      replenished.signalAll()
+    finally lock.unlock()
+
 object Http2ServerConnection:
+  // The HTTP/2 default flow-control window (RFC 7540 §6.9.2): the initial send
+  // budget for the connection, and for a stream until the peer's SETTINGS say
+  // otherwise.
+  private val defaultWindow: Int = 65535
+
   // Our advertised SETTINGS: a generous stream window. (`EnablePush` is a
   // client-only setting, so the server sends only the window.)
   private val serverSettings: List[Setting] =
@@ -65,8 +103,14 @@ object Http2ServerConnection:
     ( using Tactic[Http2Error] )
   :   Boolean =
     frame match
-      case Frame.Settings(_, ack) =>
+      case Frame.Settings(settings, ack) =>
         if !ack then
+          // Adopt the peer's advertised initial per-stream send window; applies
+          // to streams opened after this point (existing streams are not
+          // retroactively adjusted — a deliberate simplification).
+          settings.find(_.id == SettingId.InitialWindowSize.id).foreach: setting =>
+            conn.peerInitialWindow.set(setting.value.toInt)
+
           conn.send(Frame.Settings(Nil, ack = true))
           conn.started.offer(())
 
@@ -118,9 +162,18 @@ object Http2ServerConnection:
           stream.end()
           conn.streams.remove(id)
 
+        conn.streamWindows.remove(id)
         true
 
-      case Frame.WindowUpdate(_, _) | Frame.Continuation(_, _, _) | Frame.Ignored(_, _) =>
+      // An inbound WINDOW_UPDATE grants send credit: on stream 0 it tops up the
+      // connection window, otherwise the named stream's window (RFC 7540 §6.9).
+      case Frame.WindowUpdate(id, increment) =>
+        if id == 0 then conn.connWindow.release(increment)
+        else conn.streamWindows.get(id).foreach(_.release(increment))
+
+        true
+
+      case Frame.Continuation(_, _, _) | Frame.Ignored(_, _) =>
         true
 
 // The server role of a multiplexed HTTP/2 connection over a persistent `Duplex`.
@@ -143,6 +196,13 @@ class Http2ServerConnection(duplex: Duplex^)(using Monitor, Probate):
   private[cordillera] val streams: scc.TrieMap[Int, Http2Stream] = scc.TrieMap()
   private val outbound: Relay[Frame] = Relay()
   private[cordillera] val started: Promise[Unit] = Promise()
+
+  // Send-side flow control (RFC 7540 §6.9): the connection window, a per-stream
+  // window created lazily at the peer's advertised initial size, and that
+  // advertised size (updated by the peer's SETTINGS).
+  private[cordillera] val connWindow: FlowWindow = FlowWindow(defaultWindow)
+  private[cordillera] val streamWindows: scc.TrieMap[Int, FlowWindow] = scc.TrieMap()
+  private[cordillera] val peerInitialWindow: juca.AtomicInteger = juca.AtomicInteger(defaultWindow)
 
   // Streams opened by the client, in arrival order; the serve loop takes each
   // and runs its handler. Stopped when the connection ends.
@@ -223,9 +283,29 @@ class Http2ServerConnection(duplex: Duplex^)(using Monitor, Probate):
     val encoder = Hpack()
     send(Frame.Headers(streamId, encoder.encode(entries), endStream, endHeaders = true))
 
-  // Send one DATA frame on `streamId`; `endStream` closes the response.
+  // Send `payload` as DATA on `streamId`, honouring the peer's flow-control
+  // windows (RFC 7540 §6.9): the payload drains in chunks bounded by the
+  // connection and stream send windows, blocking the calling (per-stream) fiber
+  // when a window is exhausted until an inbound WINDOW_UPDATE tops it up. An
+  // empty payload carries no data and is sent immediately (its only role is
+  // `endStream`). `endStream` rides the final chunk.
   def sendData(streamId: Int, payload: Bytes, endStream: Boolean): Unit =
-    send(Frame.Data(streamId, payload, endStream))
+    if payload.length == 0 then send(Frame.Data(streamId, payload, endStream)) else
+      val streamWindow = streamWindows.getOrElseUpdate(streamId, FlowWindow(peerInitialWindow.get))
+      var offset = 0
+
+      while offset < payload.length do
+        val remaining = payload.length - offset
+        // Acquire connection credit first, then stream credit up to that, and
+        // return any connection surplus the stream could not match.
+        val connChunk = connWindow.acquire(remaining)
+        val streamChunk = streamWindow.acquire(connChunk)
+        if streamChunk < connChunk then connWindow.release(connChunk - streamChunk)
+
+        val chunk: Bytes = payload.slice(offset, offset + streamChunk)
+        val last: Boolean = endStream && offset + streamChunk == payload.length
+        send(Frame.Data(streamId, chunk, last))
+        offset += streamChunk
 
   // Send a trailing HEADERS block (always end-stream) on `streamId` — the
   // response trailers, e.g. gRPC's `grpc-status`. A response with trailers must

--- a/lib/telekinesis/src/http2/cordillera.Http2ServerConnection.scala
+++ b/lib/telekinesis/src/http2/cordillera.Http2ServerConnection.scala
@@ -32,40 +32,36 @@
                                                                                                   */
 package cordillera
 
-import java.util.concurrent.atomic as juca
-
 import scala.collection.concurrent as scc
 
 import anticipation.{Data as Bytes, *}
 import coaxial.*
 import contingency.*
 import gossamer.*
-import hieroglyph.*, charEncoders.asciiEncoder
 import parasite.*
+import prepositional.*
 import proscenium.*
 import rudiments.*
-import telekinesis.*
 import turbulence.*
 import vacuous.*
 import zephyrine.*
 
 import Http2.*
 
-object Http2Connection:
-  // The client connection preface (RFC 7540 §3.5): a fixed octet sequence that
-  // precedes the first SETTINGS frame in prior-knowledge h2c.
-  private[cordillera] val connectionPreface: Bytes = t"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".in[Bytes]
+object Http2ServerConnection:
+  // Our advertised SETTINGS: a generous stream window. (`EnablePush` is a
+  // client-only setting, so the server sends only the window.)
+  private val serverSettings: List[Setting] =
+    List(Setting(SettingId.InitialWindowSize.id, 0x7fffffff))
 
-  // Our advertised SETTINGS: disable server push; a generous stream window.
-  private[cordillera] val initialSettings: List[Setting] =
-    List
-      ( Setting(SettingId.EnablePush.id, 0),
-        Setting(SettingId.InitialWindowSize.id, 0x7fffffff) )
-
-  // Dispatch one decoded frame. Lives on the companion — taking the connection as a
-  // plain parameter — so the reader daemon's body stays free of `this` captures.
-  // The tactic is a plain using-parameter: a context-function result may not hide it.
-  private def dispatch(conn: Http2Connection, frame: Frame, decoder: Hpack)
+  // Dispatch one decoded frame, in the server role: the peer is a client, so a
+  // HEADERS frame for an unknown (client-initiated, odd) stream id CREATES the
+  // stream — its header block is the request head — and announces it on the
+  // `accepted` relay for the serve loop to handle; a second HEADERS block on a
+  // known stream carries request trailers. Lives on the companion — taking the
+  // connection as a plain parameter — so the reader daemon's body stays free of
+  // `this` captures. Returns false to stop the reader.
+  private def dispatch(conn: Http2ServerConnection, frame: Frame, decoder: Hpack)
     ( using Tactic[Http2Error] )
   :   Boolean =
     frame match
@@ -85,12 +81,21 @@ object Http2Connection:
         false
 
       case Frame.Headers(id, block, endStream, _) =>
-        conn.streams.get(id).foreach: stream =>
-          stream.acceptHeaders(decoder.decode(block))
+        conn.streams.get(id) match
+          case Some(stream) =>
+            // A second HEADERS block on a live stream: request trailers.
+            stream.acceptHeaders(decoder.decode(block))
 
-          if endStream then
-            stream.end()
-            conn.streams.remove(id)
+            if endStream then
+              stream.end()
+              conn.streams.remove(id)
+
+          case None =>
+            val stream = Http2Stream(id)
+            conn.streams(id) = stream
+            stream.acceptHeaders(decoder.decode(block))
+            if endStream then stream.end() else ()
+            conn.accepted.put(stream)
 
         true
 
@@ -118,69 +123,39 @@ object Http2Connection:
       case Frame.WindowUpdate(_, _) | Frame.Continuation(_, _, _) | Frame.Ignored(_, _) =>
         true
 
+// The server role of a multiplexed HTTP/2 connection over a persistent `Duplex`.
+// The reader daemon first validates the 24-byte client connection preface, then
+// parses inbound frames, creating a stream per client-initiated HEADERS block
+// and announcing it on `accepted`; the writer daemon drains the outbound spool.
+// The caller consumes `accepted` (one handler per stream, on its own virtual
+// thread) and writes responses back with `sendHeaders`/`sendData`, which may be
+// called concurrently for different streams — frames interleave by design, and
+// each header block is encoded with a fresh (always-literal) HPACK encoder, so
+// no encoder state is shared. Must be created within a `supervise`-provided
+// `Monitor`.
+class Http2ServerConnection(duplex: Duplex)(using Monitor, Probate):
+  import Http2ServerConnection.*
 
-// One outbound request stream's receive side: a promise for its response header
-// block (resolved on the first HEADERS frame), a spool feeding the response body
-// (fed by DATA frames), and a promise for trailers (resolved on a second, end-stream
-// HEADERS frame — gRPC's status). The reader daemon populates these; the caller
-// awaits `headers` and consumes `body.stream`.
-class Http2Stream(val id: Int):
-  val headers: Promise[List[HpackEntry]] = Promise()
-  val trailers: Promise[List[HpackEntry]] = Promise()
-  val body: Relay[Bytes] = Relay()
-  // Untracked: written only by the connection's single reader daemon.
-  @caps.unsafe.untrackedCaptures
-  private var headersSeen: Boolean = false
-
-  // Record an incoming HEADERS block: the first becomes the response headers, a
-  // subsequent one (always end-stream) becomes the trailers.
-  def acceptHeaders(block: List[HpackEntry]): Unit =
-    if !headersSeen then
-      headersSeen = true
-      headers.offer(block)
-    else
-      trailers.offer(block)
-
-  def acceptData(data: Bytes): Unit = body.put(data)
-
-  // Close the receive side; resolve any unfulfilled promises so awaiters don't hang.
-  def end(): Unit =
-    if !headers.ready then headers.offer(Nil)
-    if !trailers.ready then trailers.offer(Nil)
-    body.stop()
-
-// A multiplexed HTTP/2 connection over a persistent `Duplex` (cleartext h2c, with
-// prior knowledge — no upgrade, no TLS). A single writer daemon drains an outbound
-// `Spool[Frame]` to the socket, serialising all writes (so no lock is needed); a
-// reader daemon parses inbound frames and dispatches them by stream id. Must be
-// created within a `supervise`-provided `Monitor`.
-class Http2Connection(duplex: Duplex)(using Monitor, Probate):
-  import Http2Connection.*
-
-  private val streams: scc.TrieMap[Int, Http2Stream] = scc.TrieMap()
-  private val nextId: juca.AtomicInteger = juca.AtomicInteger(1)
+  private[cordillera] val streams: scc.TrieMap[Int, Http2Stream] = scc.TrieMap()
   private val outbound: Relay[Frame] = Relay()
-  private val started: Promise[Unit] = Promise()
+  private[cordillera] val started: Promise[Unit] = Promise()
 
-  private def send(frame: Frame): Unit = outbound.put(frame)
+  // Streams opened by the client, in arrival order; the serve loop takes each
+  // and runs its handler. Stopped when the connection ends.
+  private[cordillera] val accepted: Relay[Http2Stream] = Relay()
 
+  private[cordillera] def send(frame: Frame): Unit = outbound.put(frame)
 
-  // Tear the connection down after an unrecoverable reader/writer failure: unblock a
-  // pending handshake, end every open stream so awaiters of its headers/body/trailers
-  // don't hang on a connection that can no longer make progress, and stop the outbound
-  // spool so the writer exits.
+  // Tear the connection down after an unrecoverable reader/writer failure or a
+  // bad preface: unblock a pending handshake, end every open stream, and stop
+  // the spools so the writer and the serve loop exit.
   private def tearDown(): Unit =
     started.cancel()
     streams.values.foreach(_.end())
     outbound.stop()
+    accepted.stop()
 
-  // The writer drains the outbound spool to the socket, serialising all writes (so no
-  // lock is needed); the reader decodes inbound frames and dispatches them until the
-  // socket ends, a GOAWAY arrives, or a protocol error occurs. Both run under a `trap`
-  // that tears the connection down on failure, so a write, parse or HPACK error is
-  // isolated to this connection — it neither escalates nor leaves a request awaiter
-  // hanging — rather than being swallowed or escaping the daemon.
-  private val (writer, reader): (Daemon, Daemon) =
+  private val (writer, reader) =
     contain:
       case _ => tearDown(); Remedy.Accept
 
@@ -193,76 +168,55 @@ class Http2Connection(duplex: Duplex)(using Monitor, Probate):
         val self: AnyRef = this.asInstanceOf[AnyRef]
 
         val writer = daemon:
-          duplex0.send(zephyrine.Stream(connectionPreface))
-
           outbound0.stream.records.each: frame =>
             duplex0.send(zephyrine.Stream(frame.serialize))
 
         val frameReaderRef: AnyRef = FrameReader(duplex0.source).asInstanceOf[AnyRef]
 
         val reader = daemon:
-          // A protocol error tears down just this connection; throw it to the enclosing
-          // `contain`, which runs `tearDown()` and stops the reader.
+          // A protocol error tears down just this connection; throw it to the
+          // enclosing `contain`, which runs `tearDown()` and stops the reader.
           given Tactic[Http2Error] = AsyncTactic()
 
           val frameReader = frameReaderRef.asInstanceOf[FrameReader^]
+
+          // The server's first read: consume and validate the client
+          // connection preface before frame-parsing.
+          frameReader.expectPreface(Http2Connection.connectionPreface)
+
           val decoder = Hpack()
           var continue = true
 
           while continue do (frameReader.next(): @unchecked) match
             case Unset        => continue = false
             case frame: Frame =>
-              continue = dispatch(self.asInstanceOf[Http2Connection], frame, decoder)
+              continue = dispatch(self.asInstanceOf[Http2ServerConnection], frame, decoder)
+
+          self.asInstanceOf[Http2ServerConnection].accepted.stop()
 
         (writer, reader)
 
-  // Perform the connection handshake: emit our SETTINGS and await the peer's.
-  // Plain using-parameters, de-sugared from `raises`: a context-function result may
-  // not hide `this`.
+  // Perform the server side of the connection handshake: emit our SETTINGS and
+  // await the client's (which the dispatch acks). Plain using-parameters,
+  // de-sugared from `raises`: a context-function result may not hide `this`.
   def start()(using Tactic[AsyncError]): Unit =
-    send(Frame.Settings(initialSettings, ack = false))
+    send(Frame.Settings(serverSettings, ack = false))
     started.await()
 
-  // Open a new client stream, send its header block (and optional body), and return
-  // the stream handle whose promises/spool the reader will populate.
-  def request(headerBlock: List[HpackEntry], body: Optional[Bytes]): Http2Stream =
-    val id = nextId.getAndAdd(2)
-    val stream = Http2Stream(id)
-    streams(id) = stream
+  // Send a response header block on `streamId`, encoded with a fresh
+  // (always-literal) HPACK encoder. `endStream` marks a bodiless response.
+  def sendHeaders(streamId: Int, entries: List[HpackEntry], endStream: Boolean): Unit =
     val encoder = Hpack()
-    val noBody = body.absent
+    send(Frame.Headers(streamId, encoder.encode(entries), endStream, endHeaders = true))
 
-    send(Frame.Headers(id, encoder.encode(headerBlock), endStream = noBody, endHeaders = true))
-
-    body.let: payload =>
-      send(Frame.Data(id, payload, endStream = true))
-
-    stream
-
-  // Issue a telekinesis `Http.Request` over this connection and return the
-  // `Http.Response`, blocking only until the response HEADERS arrive; the body
-  // streams lazily from the stream's spool. `scheme`/`authority` supply the
-  // pseudo-headers the request type doesn't carry. Trailers (e.g. gRPC status) are
-  // available afterwards via `stream.trailers`.
-  def fetch(request: Http.Request, scheme: Text, authority: Text)
-    ( using Tactic[Http2Error], Tactic[AsyncError] )
-  :   (Http2Stream, Http.Response) =
-
-    Log.fine(Http2Event.RequestSent(authority))
-    val headerBlock = PseudoHeaders.request(request, scheme, authority)
-    val data = request.body().memoize
-
-    val payload: Optional[Bytes] = if data.isEmpty then Unset else data
-
-    val stream = this.request(headerBlock, payload)
-    val responseHeaders = stream.headers.await()
-
-    (stream, PseudoHeaders.response(responseHeaders, LazyList.from(stream.body.stream.records)))
+  // Send one DATA frame on `streamId`; `endStream` closes the response.
+  def sendData(streamId: Int, payload: Bytes, endStream: Boolean): Unit =
+    send(Frame.Data(streamId, payload, endStream))
 
   def close(): Unit =
     send(Frame.GoAway(0, ErrorCode.NoError.code, IArray.empty[Byte]))
     outbound.stop()
+    accepted.stop()
     reader.cancel()
     writer.cancel()
     duplex.close()
-

--- a/lib/telekinesis/src/http2/cordillera.Http2ServerConnection.scala
+++ b/lib/telekinesis/src/http2/cordillera.Http2ServerConnection.scala
@@ -227,6 +227,14 @@ class Http2ServerConnection(duplex: Duplex^)(using Monitor, Probate):
   def sendData(streamId: Int, payload: Bytes, endStream: Boolean): Unit =
     send(Frame.Data(streamId, payload, endStream))
 
+  // Send a trailing HEADERS block (always end-stream) on `streamId` — the
+  // response trailers, e.g. gRPC's `grpc-status`. A response with trailers must
+  // leave `endStream` unset on its HEADERS and DATA, so this block closes the
+  // stream. Encoded with a fresh (always-literal) HPACK encoder.
+  def sendTrailers(streamId: Int, entries: List[HpackEntry]): Unit =
+    val encoder = Hpack()
+    send(Frame.Headers(streamId, encoder.encode(entries), endStream = true, endHeaders = true))
+
   def close(): Unit =
     send(Frame.GoAway(0, ErrorCode.NoError.code, IArray.empty[Byte]))
     outbound.stop()

--- a/lib/telekinesis/src/http2/cordillera.Http2ServerConnection.scala
+++ b/lib/telekinesis/src/http2/cordillera.Http2ServerConnection.scala
@@ -133,8 +133,12 @@ object Http2ServerConnection:
 // each header block is encoded with a fresh (always-literal) HPACK encoder, so
 // no encoder state is shared. Must be created within a `supervise`-provided
 // `Monitor`.
-class Http2ServerConnection(duplex: Duplex)(using Monitor, Probate):
+class Http2ServerConnection(duplex: Duplex^)(using Monitor, Probate):
   import Http2ServerConnection.*
+
+  // A socket-backed `Duplex` captures its I/O capabilities, so it crosses into
+  // the reader/writer daemons (and reaches `close`) as a neutral `AnyRef` rim.
+  private val duplexRef: AnyRef = duplex.asInstanceOf[AnyRef]
 
   private[cordillera] val streams: scc.TrieMap[Int, Http2Stream] = scc.TrieMap()
   private val outbound: Relay[Frame] = Relay()
@@ -163,15 +167,18 @@ class Http2ServerConnection(duplex: Duplex)(using Monitor, Probate):
         // Everything the fibers touch is bound to locals (or neutral carriers)
         // before they spawn: a daemon body may not capture the instance under
         // construction, and its context function must stay pure.
-        val duplex0: Duplex = duplex
+        val duplex0Ref: AnyRef = duplexRef
         val outbound0: Relay[Frame] = outbound
         val self: AnyRef = this.asInstanceOf[AnyRef]
 
         val writer = daemon:
+          val duplex0 = duplex0Ref.asInstanceOf[Duplex^]
+
           outbound0.stream.records.each: frame =>
             duplex0.send(zephyrine.Stream(frame.serialize))
 
-        val frameReaderRef: AnyRef = FrameReader(duplex0.source).asInstanceOf[AnyRef]
+        val frameReaderRef: AnyRef =
+          FrameReader(duplexRef.asInstanceOf[Duplex^].source).asInstanceOf[AnyRef]
 
         val reader = daemon:
           // A protocol error tears down just this connection; throw it to the
@@ -203,6 +210,13 @@ class Http2ServerConnection(duplex: Duplex)(using Monitor, Probate):
     send(Frame.Settings(serverSettings, ack = false))
     started.await()
 
+  // Run `handler` for each client-initiated stream as it arrives, on the
+  // reader-driven serve loop; returns when the connection ends. The handler
+  // typically spawns a per-stream fiber so requests multiplexed on the one
+  // connection are served concurrently.
+  def eachStream(handler: Http2Stream => Unit): Unit =
+    accepted.stream.records.each(handler)
+
   // Send a response header block on `streamId`, encoded with a fresh
   // (always-literal) HPACK encoder. `endStream` marks a bodiless response.
   def sendHeaders(streamId: Int, entries: List[HpackEntry], endStream: Boolean): Unit =
@@ -219,4 +233,4 @@ class Http2ServerConnection(duplex: Duplex)(using Monitor, Probate):
     accepted.stop()
     reader.cancel()
     writer.cancel()
-    duplex.close()
+    duplexRef.asInstanceOf[Duplex^].close()

--- a/lib/telekinesis/src/http2/cordillera.PseudoHeaders.scala
+++ b/lib/telekinesis/src/http2/cordillera.PseudoHeaders.scala
@@ -36,11 +36,14 @@ import scala.collection.mutable as scm
 
 import anticipation.*
 import contingency.*
+import distillate.*
 import gossamer.*
 import rudiments.*
 import spectacular.*
 import telekinesis.*
+import urticose.*
 import vacuous.*
+import zephyrine.*
 
 import Http2Error.Reason
 
@@ -83,3 +86,53 @@ object PseudoHeaders:
       Http.Status.unapply(code).optional.lest(Http2Error(Reason.Protocol(t"missing :status")))
 
     status(headers.to(List), Http.Body.Flowing(() => zephyrine.Stream(body.iterator)))
+
+  // Reconstruct an `Http.Request` from a decoded request HEADERS block and the
+  // body spring: `:method`/`:path` select the method and target, `:authority`
+  // the host (any port stripped, as for an HTTP/1.1 `Host` header); other
+  // pseudo-headers are dropped and the remaining fields become request headers.
+  // The inverse of `request`, used by the server role.
+  // Plain using-parameter, de-sugared from `raises`: a context-function result
+  // may not hide the capturing request.
+  def requestOf(headerBlock: List[HpackEntry], consume body: Spring[Data]^)
+    ( using Tactic[Http2Error] )
+  :   Http.Request^ =
+
+    var methodText: Optional[Text] = Unset
+    var pathText: Optional[Text] = Unset
+    var authorityText: Optional[Text] = Unset
+    val headers = scm.ListBuffer[Http.Header]()
+
+    headerBlock.each: entry =>
+      if entry.name == t":method" then methodText = entry.value
+      else if entry.name == t":path" then pathText = entry.value
+      else if entry.name == t":authority" then authorityText = entry.value
+      else if !entry.name.starts(t":") then headers += Http.Header(entry.name, entry.value)
+
+    val authority: Text =
+      authorityText.lest(Http2Error(Reason.Protocol(t"missing :authority")))
+
+    val host: Host =
+      safely(authority.as[Host]).or:
+        safely(authority.cut(t":").prim.or(authority).as[Host]).or:
+          abort(Http2Error(Reason.Protocol(t"bad :authority")))
+
+    val target: Text = pathText.lest(Http2Error(Reason.Protocol(t"missing :path")))
+    val method: Http.Method = methodText.lest(Http2Error(Reason.Protocol(t"missing :method"))).as
+
+    Http.Request(method, 2.0, host, target, headers.to(List), body)
+
+  // Build the HPACK header list for a response: `:status` first, then the
+  // regular headers lowercased, with connection-specific headers stripped
+  // (RFC 7540 §8.1.2.2). The inverse of `response`, used by the server role.
+  def entries(response: Http.Response^): List[HpackEntry] =
+    val forbidden: List[Text] =
+      List(t"connection", t"keep-alive", t"transfer-encoding", t"upgrade", t"proxy-connection")
+
+    val regular = response.textHeaders.map: header =>
+      HpackEntry(header.key.lower, header.value)
+
+    . filter: entry =>
+        !forbidden.contains(entry.name)
+
+    HpackEntry(t":status", response.status.code.show) :: regular

--- a/lib/telekinesis/src/http2/soundness_cordillera_core.scala
+++ b/lib/telekinesis/src/http2/soundness_cordillera_core.scala
@@ -32,5 +32,5 @@
                                                                                                   */
 package soundness
 
-export cordillera.{Http2, Hpack, HpackEntry, HpackTable, Huffman, Http2Connection, Http2Stream,
-    Http2Error, Http2Event, FrameReader, PseudoHeaders}
+export cordillera.{Http2, Hpack, HpackEntry, HpackTable, Huffman, Http2Connection,
+    Http2ServerConnection, Http2Stream, Http2Error, Http2Event, FrameReader, PseudoHeaders}

--- a/lib/telekinesis/src/test/cordillera_test.scala
+++ b/lib/telekinesis/src/test/cordillera_test.scala
@@ -357,6 +357,43 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
 
       . assert(_ == t"echo:GET:/hello")
 
+      test(m"the server role emits response trailers the client reads"):
+        supervise:
+          val (clientSide, serverSide) = pair()
+          val server = Http2ServerConnection(serverSide)
+          val serverRef: AnyRef = server.asInstanceOf[AnyRef]
+
+          daemon:
+            safely:
+              val server0 = serverRef.asInstanceOf[Http2ServerConnection]
+
+              server0.accepted.stream.records.each: stream =>
+                unsafely:
+                  stream.headers.await()
+                  // HEADERS + DATA left open, then a trailing HEADERS block
+                  // (gRPC status) closes the stream.
+                  val head = List(HpackEntry(t":status", t"200"))
+                  server0.sendHeaders(stream.id, head, endStream = false)
+                  server0.sendData(stream.id, ascii(t"body"), endStream = false)
+                  server0.sendTrailers(stream.id, List(HpackEntry(t"grpc-status", t"0")))
+
+          val client = Http2Connection(clientSide)
+          val serverStarted = async(server.start())
+          client.start()
+          serverStarted.await()
+
+          val request = Http.Request(Http.Post, 2.0, unsafely(t"unix".as[Host]), t"/call", Nil,
+              () => Stream(ascii(t"ping")))
+
+          val (stream, response) = client.fetch(request, t"http", t"unix")
+          val body = response.body.stream.memoize.utf8
+          val grpcStatus = stream.trailers.await().find(_.name == t"grpc-status").map(_.value)
+          client.close()
+          server.close()
+          (body, grpcStatus.getOrElse(t"?"))
+
+      . assert(_ == (t"body", t"0"))
+
       test(m"a session lends one connection to several multiplexed requests"):
         supervise:
           val (clientSide, serverSide) = pair()

--- a/lib/telekinesis/src/test/cordillera_test.scala
+++ b/lib/telekinesis/src/test/cordillera_test.scala
@@ -394,6 +394,63 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
 
       . assert(_ == (t"body", t"0"))
 
+      test(m"a flow window drains in bounded chunks and blocks until replenished"):
+        supervise:
+          val window = FlowWindow(10)
+          val a = window.acquire(4)    // all requested: 4
+          val b = window.acquire(100)  // capped at the remaining 6
+
+          // The window is now empty; this acquire blocks until `release` tops it
+          // up. The result is 3 whichever way `release` and the blocked `acquire`
+          // interleave, so the test needs no timing.
+          val blocked: Promise[Int] = Promise()
+          async(blocked.offer(window.acquire(5)))
+          window.release(3)
+          val c = blocked.await()
+
+          (a, b, c)
+
+      . assert(_ == (4, 6, 3))
+
+      test(m"a response larger than the connection window streams intact"):
+        supervise:
+          val (clientSide, serverSide) = pair()
+          val server = Http2ServerConnection(serverSide)
+          val serverRef: AnyRef = server.asInstanceOf[AnyRef]
+
+          // A body well over the 65535-byte connection window, so the server
+          // must split DATA frames and wait for the client's WINDOW_UPDATEs.
+          val size = 200000
+          val payload: Data = IArray.tabulate(size)(i => (i%256).toByte)
+          val payloadRef: AnyRef = payload.asInstanceOf[AnyRef]
+
+          daemon:
+            safely:
+              val server0 = serverRef.asInstanceOf[Http2ServerConnection]
+              val body = payloadRef.asInstanceOf[Data]
+
+              server0.accepted.stream.records.each: stream =>
+                unsafely:
+                  stream.headers.await()
+                  server0.sendHeaders(stream.id, List(HpackEntry(t":status", t"200")), false)
+                  server0.sendData(stream.id, body, endStream = true)
+
+          val client = Http2Connection(clientSide)
+          val serverStarted = async(server.start())
+          client.start()
+          serverStarted.await()
+
+          val request = Http.Request(Http.Get, 2.0, unsafely(t"unix".as[Host]), t"/big", Nil,
+              () => Http.emptyBody())
+
+          val (_, response) = client.fetch(request, t"http", t"unix")
+          val received = response.body.stream.memoize
+          client.close()
+          server.close()
+          (received.length, received.to(List) == payload.to(List))
+
+      . assert(_ == (200000, true))
+
       test(m"a session lends one connection to several multiplexed requests"):
         supervise:
           val (clientSide, serverSide) = pair()

--- a/lib/telekinesis/src/test/cordillera_test.scala
+++ b/lib/telekinesis/src/test/cordillera_test.scala
@@ -311,6 +311,52 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
           client.request(request, endpoint).status.code
       . assert(_ == 200)
 
+      test(m"the server role serves the client role over an in-memory pair"):
+        supervise:
+          val (clientSide, serverSide) = pair()
+          val server = Http2ServerConnection(serverSide)
+
+          // The serve loop: one handler per accepted stream, echoing the
+          // decoded request's method and target through a real `Http.Response`.
+          // The connection crosses into the daemon as a neutral carrier: a
+          // daemon body may not capture a capability.
+          val serverRef: AnyRef = server.asInstanceOf[AnyRef]
+
+          daemon:
+            safely:
+              val server0 = serverRef.asInstanceOf[Http2ServerConnection]
+
+              server0.accepted.stream.records.each: stream =>
+                unsafely:
+                  val entries = stream.headers.await()
+                  val request = PseudoHeaders.requestOf(entries, () => Http.emptyBody())
+
+                  // A `Data` (byte) body selects the `Fixed` servable, so the
+                  // response body is a plain fixed stream.
+                  val payload: Data = ascii(t"echo:${request.method.show}:${request.target}")
+                  val response = Http.Response(Http.Ok)(payload)
+
+                  server0.sendHeaders(stream.id, PseudoHeaders.entries(response), false)
+                  server0.sendData(stream.id, response.body.stream.memoize, true)
+
+          val client = Http2Connection(clientSide)
+          val serverStarted = async(server.start())
+          client.start()
+          serverStarted.await()
+
+          val request = Http.Request(Http.Get, 2.0, unsafely(t"unix".as[Host]), t"/hello", Nil,
+              () => Http.emptyBody())
+
+          val (_, response) = client.fetch(request, t"http", t"unix")
+          val body = response.body.stream.memoize.utf8
+          client.close()
+          // Stop the server's reader/writer and the serve loop (via
+          // `accepted.stop()`), so the enclosing `supervise` can return.
+          server.close()
+          body
+
+      . assert(_ == t"echo:GET:/hello")
+
       test(m"a session lends one connection to several multiplexed requests"):
         supervise:
           val (clientSide, serverSide) = pair()


### PR DESCRIPTION
Telekinesis and Scintillate now provide a fully native HTTP/2 server: a Scintillate server that is given a TLS context offers `h2` and `http/1.1` by ALPN, and a connection that negotiates `h2` is served by a native HTTP/2 engine (`cordillera.Http2ServerConnection`, in the `telekinesis.http2` module) behind the same handler contract the HTTP/1.1 backend uses, so existing Scintillate applications serve HTTP/2 with no code change. The engine multiplexes concurrent request streams over one connection, emits response trailers, honours the peer's flow-control windows, and supports per-connection session scopes for sharing capture-checked state across a connection's streams.

## Serving HTTP/2

Any Scintillate `SocketServer` given a `javax.net.ssl.SSLContext` now negotiates HTTP/2 automatically — no new server type, no handler change:

```scala
val server = SocketServer(port, ssl = sslContext).handle:
  Http.Response(Http.Ok)(t"served over h2 or h1, whichever the client negotiated")
```

A connection that negotiates `h2` is driven by the native engine; plaintext and ALPN `http/1.1` connections keep the existing HTTP/1.1 keep-alive path. Requests multiplexed on one HTTP/2 connection are each handled on their own virtual thread, so they run concurrently. Response bodies stream block-by-block off their pull endpoint, framed as DATA.

## Response trailers

A handler names trailing headers with a `Trailer` header (RFC 7230 §4.4); the server sends them as a trailing HEADERS block after the body — the mechanism gRPC uses for `grpc-status`:

```scala
Http.Response(Http.Ok, headers = List(Http.Header(t"trailer", t"grpc-status")))(body)
  + Http.Header(t"grpc-status", t"0")
```

At the engine level, `Http2ServerConnection.sendTrailers` sends the trailing block directly.

## Flow control

The engine honours the peer's flow-control windows (RFC 7540 §6.9): a response body drains in chunks bounded by the connection and per-stream send windows, blocking the sending fiber when a window is exhausted and resuming on an inbound `WINDOW_UPDATE`. The peer's advertised `SETTINGS_INITIAL_WINDOW_SIZE` sets new streams' initial window. Unrecognised frame types (`PRIORITY`, `PUSH_PROMISE`, extensions) are ignored rather than treated as connection errors (RFC 7540 §4.1).

## Per-connection sessions

`SocketServer.handleSession` runs a scope once per connection, so a handler can set up per-connection state before serving that connection's streams — the server dual of the client's `Http2.Endpoint.session`. Capture checking confines the state to its connection:

```scala
SocketServer(port, ssl = sslContext).handleSession: session ?=>
  val principal = authenticate(session)   // once per connection
  session.handle: request ?=>             // once per stream, concurrently
    respond(principal)
```

Over HTTP/2 the streams sharing the state run concurrently on one connection; over HTTP/1.1 they are the keep-alive connection's sequential requests. `handle` is the degenerate session with no per-connection setup, so both share one accept loop.

## Notes

The native HTTP/2 stack (client and server) lives in the `telekinesis.http2` component (package `cordillera`). Server push is not implemented (deprecated in the ecosystem). The engine round-trip is verified against both the native client and the JDK `HttpClient` forced to HTTP/2 (ALPN interop, multiplexing, a 200 KB flow-controlled body, and shared per-connection state), and all existing HTTP/1.1 socket and TLS tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
