### PR TITLE
Deliver null strand completions instead of crashing the worker

### DIFF
--- a/lib/parasite/src/core/parasite.Promise.scala
+++ b/lib/parasite/src/core/parasite.Promise.scala
@@ -84,7 +84,7 @@ final class Promise[value]():
   // once `Complete` is installed, `enqueue` adds no further waiters.
   private def completeIncomplete(supplied: value)(current: State[value] | Null): State[value] =
     current.nn match
-      case Incomplete(_) => Complete(supplied.nn)
+      case Incomplete(_) => Complete(supplied)
       case current       => current
 
   def fulfill(supplied: => value): Unit raises AsyncError =

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -144,6 +144,12 @@ object Tests extends Suite(m"Parasite tests"):
           promise.apply()
         . assert(_ == 1)
 
+        test(m"Offer with a null value completes the promise"):
+          val promise = Promise[Text]()
+          promise.offer(null.asInstanceOf[Text])
+          promise.complete
+        . assert(_ == true)
+
         test(m"Offer on cancelled promise leaves it cancelled"):
           val promise = Promise[Int]()
           promise.cancel()
@@ -270,6 +276,10 @@ object Tests extends Suite(m"Parasite tests"):
         test(m"Simple task produces a result"):
           async(42).await()
         . assert(_ == 42)
+
+        test(m"Async strand completing with null delivers null"):
+          async(null.asInstanceOf[Text]).await().asInstanceOf[AnyRef]
+        . assert(_ == null)
 
         test(m"Task with side effect produces effect"):
           val counter = juca.AtomicInteger(0)


### PR DESCRIPTION
A parasite strand whose reference-typed body evaluates to null now completes cleanly, delivering null to any joiner, instead of throwing a NullPointerException on the worker thread and losing the result.

## Bug fix

`Promise` previously asserted its completion value was non-null. A strand that legitimately finished with a `null` reference (e.g. a body returning a nullable `Text`) would kill its worker thread with a `NullPointerException`, discard the result, and leave any joiner awaiting it hung indefinitely.

Promises now carry a null completion as an ordinary result:

```scala
async(null.asInstanceOf[Text]).await()  // returns null, no exception
```

`Unit`-returning strands were always safe (`()` is non-null); this only affected reference-typed results. Closes #1627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)