### PR TITLE
Encode unset Optional fields as absent, not empty

### DIFF
--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -422,7 +422,7 @@ trait Tel2 extends Tel3:
   =>  ( encodable: inner is Tel.Encodable )
   =>  value is Tel.Encodable =
     Tel.Encodable(() => Morphology.Opt(encodable.shape())): opt =>
-      opt.let(_.asInstanceOf[inner]).lay(Tel.empty)(_.encode)
+      opt.let(_.asInstanceOf[inner]).lay(emptyDocument)(_.encode)
 
   given optionalDecodable: [inner <: value, value >: Unset.type: Mandatable to inner]
   =>  Tactic[TelError]

--- a/lib/stratiform/src/core/stratiform_core.scala
+++ b/lib/stratiform/src/core/stratiform_core.scala
@@ -54,6 +54,13 @@ extension (inline context: StringContext)
 // referencing a trait member would make the codec/optic lambdas capture `Tel2.this`, which the
 // pure `Encodable`/`Optic` SAMs reject under capture checking.
 
+// The empty document — an `Optional`'s `Unset` encoding. It contributes no compound to a struct
+// body (the same shape an empty collection produces), so the product encoder omits the field and
+// both the text and binary formats decode it back to `Unset` via the field's `absent()` path.
+private[stratiform] def emptyDocument: Tel =
+  Tel(Tel.Document(Unset, Unset, Tel.LineEndings.Lf,
+      IArray(Tel.Block(IArray.empty, Unset, IArray.empty, 0))))
+
 // Encodes a collection by flattening each element's compound(s) into one document's children.
 private[stratiform] def collectionDocument[value]
     (values: Iterable[value])(using encodable: value is Encodable in Tel)

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -256,6 +256,18 @@ object Tests extends Suite(m"Stratiform Tests"):
         Tests.Team(t"Reds", Nil).encode.childCompounds.filter(_.keyword == t"members").length
       . assert(_ == 0)
 
+      test(m"an unset Optional field encodes as no compounds"):
+        Tests.OptField(7, Unset).encode.childCompounds.filter(_.keyword == t"note").length
+      . assert(_ == 0)
+
+      test(m"an unset Optional field round-trips as Unset through the text format"):
+        Tests.OptField(7, Unset).encode.as[Tests.OptField]
+      . assert(_ == Tests.OptField(7, Unset))
+
+      test(m"a present empty Optional field round-trips as empty text"):
+        Tests.OptField(7, t"").encode.as[Tests.OptField]
+      . assert(_ == Tests.OptField(7, t""))
+
       test(m"a sum encodes its variant as a child keyed by the variant name"):
         val shape: Tests.Shape2 = Tests.Shape2.Circle(7)
         shape.encode.childCompounds.head.keyword
@@ -2230,14 +2242,25 @@ object Tests extends Suite(m"Stratiform Tests"):
         Bintel.parse[Tests.OptField](Tests.OptField(7, t"note").bintel)
       . assert(_ == Tests.OptField(7, t"note"))
 
+      test(m"an unset Optional field round-trips as Unset through the encoder"):
+        // The encoder omits an unset `Optional` field entirely (it contributes
+        // no child to the struct body), so both decode paths see it as absent.
+        Bintel.read[Tests.OptField](Tests.OptField(7, Unset).bintel)
+      . assert(_ == Tests.OptField(7, Unset))
+
       test(m"an unset Optional agrees with the AST path"):
-        // The BinTEL *encoder* writes an unset `Optional` as a present,
-        // empty scalar, which the AST path restores as empty text rather
-        // than `Unset` — the direct parser reproduces that behavior
-        // exactly. (The encoder-side round-trip is a separate question.)
+        // Both paths now decode the omitted field as `Unset`.
         val bytes = Tests.OptField(7, Unset).bintel
         Bintel.parse[Tests.OptField](bytes) == Bintel.read[Tests.OptField](bytes)
       . assert(identity)
+
+      test(m"an unset Optional reads Unset on the direct path too"):
+        Bintel.parse[Tests.OptField](Tests.OptField(7, Unset).bintel)
+      . assert(_ == Tests.OptField(7, Unset))
+
+      test(m"a present empty Optional field round-trips as empty text through BinTEL"):
+        Bintel.read[Tests.OptField](Tests.OptField(7, t"").bintel)
+      . assert(_ == Tests.OptField(7, t""))
 
       test(m"a truly absent Optional field reads Unset"):
         // A hand-built body: one child, index 0 ("x"), scalar "7" — the


### PR DESCRIPTION
Encoding a record with an unset Optional field to BinTEL no longer writes a present, empty scalar for that field — the field is now genuinely omitted, so it decodes back to Unset rather than empty text.

## Bug fix

An unset `Optional` field previously encoded to an empty compound, which the binary format's type-assignment collapsed into a present empty scalar. The field's index therefore appeared in the struct body and round-tripped to `t""` instead of `Unset`:

```scala
case class OptField(x: Int, note: Optional[Text])
Bintel.read[OptField](OptField(7, Unset).bintel)  // was OptField(7, t""), now OptField(7, Unset)
```

An unset `Optional` now encodes to an empty document — exactly as an empty collection does — contributing no child to the struct body. A present `Some(t"")` is unaffected and still round-trips to empty text. The text format's output for unset optionals is likewise cleaner (the field is omitted), and it continues to decode to `Unset`. Closes #1577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)