### PR TITLE
Publish every artifact at the release version, not a stale cached one

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -352,11 +352,21 @@ trait BaseScalaModule extends Toolchain:
   override def assemblyRules =
     super.assemblyRules :+ mill.javalib.Assembly.Rule.AppendPattern("META-INF/givens/.*")
 
-  def publishVersion = Task:
-    try
-      val lastTagged = os.proc("git", "rev-list", "--tags", "--max-count", "1").call().out.text().trim
-      os.proc("git", "describe", "--tags", lastTagged).call().out.text().trim
-    catch case error: Exception => "unknown"
+  // A `Task.Input` (not a cached `Task`), because the published version is external state Mill
+  // can't see: a plain cached target reads `git` once and persists the string in `out/`, so a
+  // release that reuses `out/` across a tag bump can re-serve a stale version (this is exactly how
+  // 0.64.0 shipped 0.63.0 plugin jars — the earliest-built, most-stable plugin modules kept a
+  // pre-tag cache). The release drives the authoritative version through `SOUNDNESS_RELEASE_VERSION`
+  // (set by `etc/ci/release.sh`); the git-describe fallback is only for local `publishLocal`.
+  def publishVersion = Task.Input:
+    // `Task.env`, not `sys.env`: the mill daemon is long-lived and freezes `sys.env` at daemon
+    // start, but `release.sh` exports the version to a *later* `./mill` invocation that reuses that
+    // daemon. `Task.env` is the client invocation's forwarded environment, so the export is seen.
+    Task.env.get("SOUNDNESS_RELEASE_VERSION").filter(_.nonEmpty).getOrElse:
+      try
+        val lastTagged = os.proc("git", "rev-list", "--tags", "--max-count", "1").call().out.text().trim
+        os.proc("git", "describe", "--tags", lastTagged).call().out.text().trim
+      catch case error: Exception => "unknown"
 
   override def docJar = Task:
     val jar = Task.dest / "empty.jar"

--- a/etc/ci/release.sh
+++ b/etc/ci/release.sh
@@ -79,6 +79,23 @@ export MILL_PGP_PASSPHRASE=$(read_secret soundness.pgp.passphrase)
 # version.
 git tag -s "$VERSION" -m "Version $VERSION"
 
+# Drive the published version explicitly rather than letting each module re-derive it from git.
+# `publishVersion` reads this (build.mill); it is the single source of truth for the release, so
+# every artifact carries exactly $VERSION regardless of `out/` cache state or git-describe quirks.
+export SOUNDNESS_RELEASE_VERSION="$VERSION"
+
+# Guard: every published module must resolve to exactly $VERSION before anything leaves the machine.
+# Probes both compiler plugins (which shipped a stale 0.63.0 in the 0.64.0 bundle) plus a normal
+# module; the env var makes all modules resolve identically, so a representative few suffice.
+for module in beneficence.plugin decorum.plugin rudiments.core; do
+  resolved=$(./mill show "$module.publishVersion" | tr -d '"')
+  if [[ "$resolved" != "$VERSION" ]]; then
+    echo "release: $module.publishVersion=$resolved, expected $VERSION; aborting" >&2
+    git tag -d "$VERSION" >/dev/null
+    exit 1
+  fi
+done
+
 if ! ./mill mill.javalib.SonatypeCentralPublishModule/publishAll \
        --publishArtifacts __.publishArtifacts \
        --shouldRelease true \


### PR DESCRIPTION
Publishing 0.64.0 to Maven Central shipped the Beneficence and Decorum compiler-plugin JARs under coordinate version 0.63.0 while every other module was correct, which caused the whole bundle to be rejected. The cause was that each module's `publishVersion` was a cached Mill task that shelled out to `git describe` but declared no inputs, so Mill persisted the result and re-served it across builds; the two plugins — built earliest and most stably in the tree — kept a version computed before the 0.64.0 tag existed, while churnier modules recomputed to 0.64.0. The release now drives the version explicitly and verifies it before publishing, so a stale coordinate can no longer leak.

This is an internal release-tooling fix; there are no library API changes.

- `publishVersion` is now re-evaluated on every run (a `Task.Input`) and reads the release version from `SOUNDNESS_RELEASE_VERSION`, falling back to `git describe` only for local `publishLocal`.
- `etc/ci/release.sh` sets that variable to the requested version and asserts a representative set of modules resolve to it before publishing, aborting the release on any mismatch.