### PR TITLE
Exclude dormant JS/Native crosses from the release publish set

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2630,6 +2630,19 @@ val nativeComponents: Seq[ScalaModule] =
     case component: Component if component.scalaNative     => component.native
     case component: BareComponent if component.scalaNative => component.native
 
+// The platform crosses that must NOT be published: the `.js` cross of a `scalaJs = false` module
+// and the `.native` cross of a `scalaNative = false` module are dormant — never compiled by the
+// `soundness.js`/`soundness.native` aggregates and unable to cross-compile (e.g. a compiler plugin
+// under Scala.js). `release.sh` subtracts these from `__.publishArtifacts`, since mill has no
+// per-module publish skip. Path matching can't identify them (the `xenophile.js`/`.native`
+// *components* are not crosses), so they are derived here from the capability flags.
+def dormantCrosses: T[Seq[String]] = Task:
+  allLibraries.flatMap(_.moduleDirectChildren).flatMap:
+    case component: PlatformCross =>
+      val base = component.moduleSegments.render
+      Option.when(!component.scalaJs)(s"$base.js") ++ Option.when(!component.scalaNative)(s"$base.native")
+    case _ => Nil
+
 // A tiny Scala.js app whose `fastLinkJS` actually LINKS a representative slice of
 // the JS-capable modules, so the linker reports any reachable reference to a
 // `java.*` class Scala.js does not implement (the runtime counterpart to the

--- a/etc/ci/attest.sh
+++ b/etc/ci/attest.sh
@@ -134,6 +134,7 @@ if [[ "${SOUNDNESS_CI_SKIP_BUILD:-0}" != "1" ]]; then
     make runners-build \
       && CLAUDECODE=1 ./mill --no-daemon -j "$JOBS" --ticker false soundness.all.compile \
       && CLAUDECODE=1 ./mill --no-daemon -j "$JOBS" --ticker false soundness.js.compile \
+      && CLAUDECODE=1 ./mill --no-daemon -j "$JOBS" --ticker false soundness.native.compile \
       && CLAUDECODE=1 ./mill --no-daemon -j "$JOBS" --ticker false test.assembly \
       && CLAUDECODE=1 make ci \
       && CLAUDECODE=1 make wasm-e2e
@@ -175,6 +176,7 @@ statement = {
         "commands": [
             "./mill --no-daemon -j 6 --ticker false soundness.all.compile",
             "./mill --no-daemon -j 6 --ticker false soundness.js.compile",
+            "./mill --no-daemon -j 6 --ticker false soundness.native.compile",
             "./mill --no-daemon -j 6 --ticker false test.assembly",
             "make ci",
             "make wasm-e2e",

--- a/etc/ci/release.sh
+++ b/etc/ci/release.sh
@@ -96,8 +96,28 @@ for module in beneficence.plugin decorum.plugin rudiments.core; do
   fi
 done
 
+# Build the publish selector: every PublishModule EXCEPT the dormant platform crosses (the `.js`
+# cross of a `scalaJs = false` module and the `.native` cross of a `scalaNative = false` module).
+# Those can't cross-compile, and mill has no per-module publish skip, so subtract `dormantCrosses`
+# (derived in build.mill from the capability flags) from the `__.publishArtifacts` wildcard.
+dormant_file=$(mktemp)
+./mill show dormantCrosses 2>/dev/null \
+  | python3 -c 'import json,sys; [print(x) for x in json.load(sys.stdin)]' \
+  | sort > "$dormant_file"
+keep=$(./mill resolve '__.publishArtifacts' 2>/dev/null \
+  | grep -E '^[a-zA-Z].*\.publishArtifacts$' \
+  | sed -E 's/\.publishArtifacts$//' \
+  | sort | grep -vxF -f "$dormant_file")
+rm -f "$dormant_file"
+if [[ -z "$keep" ]]; then
+  echo "release: computed an empty publish set; aborting" >&2
+  git tag -d "$VERSION" >/dev/null; exit 1
+fi
+publish_selector="{$(printf '%s\n' "$keep" | paste -sd, -)}.publishArtifacts"
+echo "release: publishing $(printf '%s\n' "$keep" | grep -c .) modules (dormant crosses excluded)"
+
 if ! ./mill mill.javalib.SonatypeCentralPublishModule/publishAll \
-       --publishArtifacts __.publishArtifacts \
+       --publishArtifacts "$publish_selector" \
        --shouldRelease true \
        --bundleName "dev.soundness-soundness:$VERSION"; then
   echo "release: publish failed; removing local tag $VERSION" >&2


### PR DESCRIPTION
Publishing a release failed because making every platform cross a publishable module also made the `.js`/`.native` crosses of JVM-only modules (compiler plugins, staged modules, native materializers) publishable — and the publish step then tried to cross-compile them, which is impossible (e.g. a compiler plugin under Scala.js), aborting the whole bundle. The release now publishes only the platform-capable crosses, and the local attestation build compiles the full native surface so this class of failure is caught before a release rather than during it.

This is an internal release/CI-tooling fix; there are no library API changes.

- A new `dormantCrosses` build task derives, from each module's `scalaJs`/`scalaNative` capability, the crosses that must not be published; `release.sh` subtracts them from the publish set (492 modules published, 163 dormant crosses excluded).
- `make attest` now also runs `soundness.native.compile`, so a green attestation covers everything a release publishes (previously it compiled `soundness.all` + `soundness.js` only).