### PR TITLE
Produce DEX artifacts for Android by driving R8's D8 dexer

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -325,7 +325,9 @@ object nativeToolchain extends mill.javalib.CoursierModule:
 // version-string ceremony.
 trait Toolchain extends ScalaModule:
   override def repositories: T[Seq[String]] = Task:
-    super.repositories() :+ s"file://${toolchain.repo().path}"
+    // Google's repository serves the artifacts absent from Maven Central (R8, for dexing), and
+    // is listed last so it is only consulted for them.
+    super.repositories() :+ s"file://${toolchain.repo().path}" :+ "https://maven.google.com"
 
   override def scalaCompilerClasspath: T[Seq[PathRef]] = Task:
     // The fork-built jars come from the repository view because Zinc locates the standard
@@ -831,7 +833,12 @@ object anthology extends Library:
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
     def mvnDeps = Seq(mvn"org.scala-native:tools_3:0.5.12")
-  object test extends Tests(`scala`, `java`, core, linker, link, nir, spectacular.core):
+  object dex extends Component(linker):
+    override def scalaJs = false // drives R8's D8 dexer (a JVM library) via its API
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+    def mvnDeps = Seq(mvn"com.android.tools:r8:8.13.19")
+  object test extends Tests(`scala`, `java`, core, linker, link, nir, dex, spectacular.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
 

--- a/lib/anthology/src/dex/anthology_dex.scala
+++ b/lib/anthology/src/dex/anthology_dex.scala
@@ -1,0 +1,149 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import java.nio.file as jnf
+
+import scala.jdk.CollectionConverters.*
+import scala.util.control as suc
+
+import com.android.tools.r8.{CompilationMode, D8, D8Command, Diagnostic, DiagnosticsHandler,
+    OutputMode}
+
+import anticipation.*
+import contingency.*
+import digression.*
+import galilei.*
+import hellenism.*
+import prepositional.*
+import serpentine.*
+import vacuous.*
+
+// The dexing configuration `Linkage[Artifact.Dex]` folds options into: the lowest Android API
+// level the output must run on (lower levels oblige D8 to desugar more), D8's compilation mode,
+// and optionally the Android platform stubs (`android.jar`) that ground desugaring decisions in
+// the platform's real API surface.
+private[anthology] case class DexConfiguration
+  ( minApi:   Int,
+    mode:     CompilationMode,
+    platform: Optional[Path on Linux] )
+
+object dexOptions:
+  private def dex(edit: DexConfiguration => DexConfiguration): Linker.Option[Artifact.Dex] =
+    Linker.Option(edit)
+
+  // The lowest Android API level the artifact must run on. Levels below 24 lack native default
+  // interface methods (which Scala 3 emits for trait members), so they additionally demand the
+  // `platform` stubs to desugar against.
+  def minApi(level: Int): Linker.Option[Artifact.Dex] = dex(_.copy(minApi = level))
+
+  // An Android SDK's platform stubs (`platforms/android-<n>/android.jar`), needed only below
+  // API level 24 or when the program references platform types.
+  def platform(jar: Path on Linux): Linker.Option[Artifact.Dex] = dex(_.copy(platform = jar))
+
+  object mode:
+    val debug: Linker.Option[Artifact.Dex] = dex(_.copy(mode = CompilationMode.DEBUG))
+    val release: Linker.Option[Artifact.Dex] = dex(_.copy(mode = CompilationMode.RELEASE))
+
+// The classfile-to-DEX link family: drives R8's D8 dexer (a JVM library) through its API to
+// translate a compilation's classfiles, and its whole classpath with them, into an archive of
+// `classes*.dex` files—the container ART and `DexClassLoader` consume, and the form the dexes
+// of an APK are zipped from. Since this linkage lives outside `Linkage`'s implicit scope,
+// import it where DEX artifacts are linked: `import dexLinkages.given`.
+object dexLinkages:
+  given dex: (Linkage[Artifact.Dex] from Universe.Classfile):
+    type Origin = Universe.Classfile
+    private[anthology] type Form = DexConfiguration
+
+    // API level 26 (Android 8.0) is the earliest with native support for everything Scala 3
+    // bytecode relies on, so dexing needs no platform stubs by default.
+    private[anthology] def initial: DexConfiguration =
+      DexConfiguration(26, CompilationMode.DEBUG, Unset)
+
+    private[anthology] def link
+      ( form:        DexConfiguration,
+        compilation: Compilation[Universe.Classfile],
+        entryPoints: List[Linker.EntryPoint],
+        out:         Path on Linux )
+    :   Path on Linux logs LinkEvent raises LinkError =
+
+      // DEX carries no entry-point metadata: ART is told its main class at invocation, by the
+      // manifest of a hosting APK or the command line of `dalvikvm`, so entry points—like a
+      // library JAR's—do not apply.
+
+      val roots: List[jnf.Path] =
+        jnf.Paths.get(compilation.out.encode.s).nn ::
+          compilation.classpath.entries.to(List).flatMap:
+            case ClasspathEntry.Directory(directory) => List(jnf.Paths.get(directory.s).nn)
+            case ClasspathEntry.Jar(jar)             => List(jnf.Paths.get(jar.s).nn)
+            case _                                   => Nil
+
+      val (archives, directories) = roots.partition(jnf.Files.isRegularFile(_))
+
+      // D8 accepts archives wholesale but not directories, whose classfiles are enumerated
+      // individually; `module-info` classfiles are not program code and are excluded.
+      val classfiles: List[jnf.Path] = directories.flatMap: directory =>
+        val walk = jnf.Files.walk(directory).nn
+
+        try walk.iterator.nn.asScala.to(List).filter: path =>
+          path.toString.endsWith(".class") && !path.toString.endsWith("module-info.class")
+        finally walk.close()
+
+      object handler extends DiagnosticsHandler:
+        override def error(diagnostic: Diagnostic | Null): Unit =
+          Log.warn(LinkEvent.Message(diagnostic.nn.getDiagnosticMessage.nn.tt))
+
+        override def warning(diagnostic: Diagnostic | Null): Unit =
+          Log.warn(LinkEvent.Message(diagnostic.nn.getDiagnosticMessage.nn.tt))
+
+        override def info(diagnostic: Diagnostic | Null): Unit =
+          Log.info(LinkEvent.Message(diagnostic.nn.getDiagnosticMessage.nn.tt))
+
+      try
+        val outPath = jnf.Paths.get(out.encode.s).nn
+        jnf.Files.createDirectories(outPath)
+
+        val builder = D8Command.builder(handler).nn
+        builder.addProgramFiles((archives ++ classfiles).asJava)
+        builder.setMinApiLevel(form.minApi)
+        builder.setMode(form.mode)
+        builder.setOutput(outPath.resolve("main.dex.jar").nn, OutputMode.DexIndexed)
+
+        form.platform.let: platform =>
+          builder.addLibraryFiles(jnf.Paths.get(platform.encode.s))
+
+        D8.run(builder.build().nn)
+        out / "main.dex.jar"
+
+      catch case suc.NonFatal(error) =>
+        abort(LinkError(LinkError.Reason.Failed(error.stackTrace)))

--- a/lib/anthology/src/dex/soundness_anthology_dex.scala
+++ b/lib/anthology/src/dex/soundness_anthology_dex.scala
@@ -30,54 +30,6 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package anthology
+package soundness
 
-object Artifact:
-  // Classfile universe: an executable JAR, bound to the JDK.
-  sealed trait Jar extends Artifact
-
-  // Any universe: a library JAR of the compilation's output—classfiles, and any `.sjsir` or
-  // `.nir` alongside them—for downstream assembly rather than execution. Packaging rather than
-  // closed-world linking, but produced through the same `Linker` verb.
-  sealed trait Library[+universe <: Universe] extends Artifact
-
-  // Classfile universe: Dalvik executable bytecode, bound to the Android runtime, packaged as
-  // an archive of `classes*.dex` files. Its linkage lives in the `dex` module:
-  // `import dexLinkages.given`.
-  sealed trait Dex extends Artifact
-
-  object Js:
-    // How a JavaScript host consumes the artifact: an ECMAScript module, a CommonJS module, or
-    // a plain script. The module system is part of the artifact's binding contract, so it is
-    // part of its type.
-    type Modules = "es" | "commonjs" | "script"
-
-  // Sjsir universe: JavaScript, bound to a JavaScript host (a browser's DOM or a runtime such
-  // as Node) through the given module system.
-  sealed trait Js[+module <: Js.Modules] extends Artifact
-
-  // Sjsir universe: a core WebAssembly module with JavaScript glue, bound to a JavaScript host.
-  sealed trait Wasm extends Artifact
-
-  object Wasi:
-    // WASI interface versions: 0.1 (preview 1) is a flat, libc-style syscall ABI on core
-    // modules; 0.2 is the component model, with imports and exports described by WIT; 0.3 adds
-    // native asynchrony. Versions determine the artifact's ABI, so they are part of its type.
-    type Versions = 0.1 | 0.2 | 0.3
-
-  // A standalone WebAssembly artifact bound to a version of the WASI system interface.
-  sealed trait Wasi[+version <: Wasi.Versions] extends Artifact
-
-  // Nir universe: a machine-code executable, bound to an operating system's C library; the
-  // platform and architecture are selected at link time as a `Triple`.
-  sealed trait Binary extends Artifact
-
-  // The artifacts linked from `.sjsir` by the Scala.js linker, sharing one options family.
-  type Sjs = Js[Js.Modules] | Wasm | Wasi[Wasi.Versions]
-
-  // The JAR-packaged artifacts, sharing one options family.
-  type Packaged = Jar | Library[Universe]
-
-// A linked product of a compilation: the tier users choose from. Each artifact is producible
-// from exactly one universe, witnessed by `Provenance`.
-sealed trait Artifact
+export anthology.{dexLinkages, dexOptions}

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -101,9 +101,19 @@ object Tests extends Suite(m"Anthology Tests"):
         summon[Linkage[Artifact.Js["amd"]]]
     . assert(_.nonEmpty)
 
-    test(m"Dex is nameable but not linkable"):
+    test(m"A dex linkage is not available without importing dexLinkages"):
       demilitarize:
         summon[Linkage[Artifact.Dex]]
+    . assert(_.nonEmpty)
+
+    test(m"The dex linkage defaults to API level 26"):
+      import dexLinkages.given
+      summon[Linkage[Artifact.Dex]].initial.asInstanceOf[DexConfiguration].minApi
+    . assert(_ == 26)
+
+    test(m"A dex option is not applicable to a JAR linker"):
+      demilitarize:
+        Linker[Artifact.Jar](List(dexOptions.minApi(24)))
     . assert(_.nonEmpty)
 
     test(m"A WASI linkage is not available without toolchain and WIT world"):
@@ -242,6 +252,18 @@ object Tests extends Suite(m"Anthology Tests"):
           . pipe: artifact =>
               mute[ExecEvent](sh"java -jar $artifact".exec[Text]()).trim
         . assert(_ == t"hello")
+
+        test(m"Linking as DEX produces an archive containing classes.dex"):
+          import dexLinkages.given
+
+          Linker[Artifact.Dex](Nil)
+          . link(Compilation(out, classpath), linked)
+          . pipe: artifact =>
+              val zipfile = java.util.zip.ZipFile(artifact.encode.s)
+
+              try zipfile.entries.nn.asScala.exists(_.getName == "classes.dex")
+              finally zipfile.close()
+        . assert(_ == true)
 
     // The native counterpart—compile with the Scala Native plugin, link with clang, and run the
     // binary—which runs only when the plugin and runtime JARs are cached and clang is present.


### PR DESCRIPTION
Anthology's artifact tier already named `Artifact.Dex` but no `Linkage` existed for it. This PR adds an `anthology.dex` module which drives the D8 dexer from Google's `r8.jar` (a new, last-resort Google Maven repository supplies it) through its supported Java API, linking a classfile compilation and its whole classpath into an archive of `classes*.dex` files — the container that ART and `DexClassLoader` consume, and the form an APK's dexes are zipped from.

## Dalvik executables for Android

A compilation in the classfile universe can now be linked as Dalvik executable bytecode, ready to run on the Android runtime:

```scala
import dexLinkages.given

val artifact = Linker[Artifact.Dex](List(dexOptions.minApi(26), dexOptions.mode.release))
  .link(compilation, out)  // out/main.dex.jar, containing classes.dex, classes2.dex, …
```

Options control the lowest Android API level the artifact must run on (defaulting to 26; lower levels make D8 desugar more, and levels below 24 need an SDK's platform stubs, supplied with `dexOptions.platform`), the compilation mode (`debug`, the default, or `release`), and the platform stubs. Entry points don't apply: DEX carries no main-class metadata — ART is told the class at invocation, by a hosting APK's manifest or `dalvikvm`'s command line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)