### PR TITLE
Build and package installable Android applications with anthology

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -846,7 +846,14 @@ object anthology extends Library:
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
     def mvnDeps = Seq(mvn"com.android.tools:r8:8.13.19")
-  object test extends Tests(`scala`, `java`, core, linker, link, nir, dex, spectacular.core):
+  // Assembles a complete, installable Android application package: binary manifest (`Axml`),
+  // zip-aligned archive (`zeppelin`), and APK v2 signature (`gastronomy` digests + `java.security`
+  // RSA) — reusing `dex` for the code, and needing no Android SDK build tool.
+  object apk extends Component(dex, gastronomy.core):
+    override def scalaJs = false // packages Android applications (`java.security`, `zeppelin`)
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object test extends Tests(`scala`, `java`, core, linker, link, nir, dex, apk, spectacular.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
 
@@ -2873,3 +2880,75 @@ object wasm extends Module:
     os.proc(command).call(stdout = os.Inherit, stderr = os.Inherit)
 
     PathRef(Task.dest / "main.wasm")
+
+// The Android sample (`tests/android`; instructions in tests/android/README.md): builds Google's
+// Dice Roller codelab as a Soundness app — Scala source calling Android and Kotlin APIs through
+// xenophile's Kotlin facades — compiled by anthology's `Scalac` and linked as `Artifact.Dex`.
+// Needs the Android platform stubs (`ANDROID_HOME` with a `platforms/android-NN`, or a direct
+// `ANDROID_JAR`); it is not part of the ordinary build. Mirrors `object wasm`.
+object android extends Module:
+  // The runtime the app compiles against and dexes with (besides the platform stubs): the
+  // Kotlin facade machinery and its transitive closure, including kotlin-stdlib.
+  object runtime extends ScalaModule, Toolchain:
+    def scalaVersion = settings.scalaVersion
+    override def moduleDeps = Seq(xenophile.kotlin, iridescence.core)
+
+  // The build driver, which runs anthology: see tests/android/builder/build.scala.
+  object builder extends ScalaModule, Toolchain:
+    def scalaVersion = settings.scalaVersion
+    def scalacOptions = settings.cc(settings.scalaOptions)
+    def sources = Task.Sources(mill.api.BuildCtx.workspaceRoot / "tests" / "android" / "builder")
+    override def moduleDeps = Seq(anthology.`scala`, anthology.dex, anthology.apk,
+      distillate.core, turbulence.core)
+
+  def appSource = Task.Source(mill.api.BuildCtx.workspaceRoot / "tests" / "android" / "src")
+
+  def dex: T[PathRef] = Task:
+    val androidJar = Task.env.getOrElse("ANDROID_JAR", {
+      val home = Task.env.getOrElse("ANDROID_HOME", throw Exception(
+        "Set ANDROID_HOME (an Android SDK with platforms/android-NN installed) or ANDROID_JAR "
+        + "(a platform android.jar) to build the Android sample"))
+      val platforms = os.list(os.Path(home) / "platforms").filter(p => os.exists(p / "android.jar"))
+      if platforms.isEmpty then throw Exception(s"no platforms/android-NN/android.jar under $home")
+      (platforms.sortBy(_.last).last / "android.jar").toString
+    })
+
+    val classpath = runtime.runClasspath().map(_.path).filter(os.exists)
+    val classpathFile = Task.dest / "classpath"
+    os.write.over(classpathFile, classpath.mkString("\n"))
+
+    val driverClasspath =
+      builder.runClasspath().map(_.path.toString).mkString(java.io.File.pathSeparator)
+
+    os.proc("java", "-cp", driverClasspath, "androidsample.buildDice", androidJar,
+        Task.dest.toString, (appSource().path / "dice.scala").toString, classpathFile.toString)
+    . call(stdout = os.Inherit, stderr = os.Inherit)
+
+    PathRef(Task.dest / "main.dex.jar")
+
+  // The pure-Soundness packaging path: compile, then link `Artifact.Apk` — dexed, binary-
+  // manifested, zip-aligned and v2-signed with no Android SDK build tool. Produces an
+  // installable, signed `app.apk`. Needs `~/.android/debug.keystore` (a PKCS#12 debug keystore,
+  // as Android Studio and `keytool` create).
+  def apk: T[PathRef] = Task:
+    val androidJar = Task.env.getOrElse("ANDROID_JAR", {
+      val home = Task.env.getOrElse("ANDROID_HOME", throw Exception(
+        "Set ANDROID_HOME (an Android SDK with platforms/android-NN installed) or ANDROID_JAR "
+        + "(a platform android.jar) to build the Android sample"))
+      val platforms = os.list(os.Path(home) / "platforms").filter(p => os.exists(p / "android.jar"))
+      if platforms.isEmpty then throw Exception(s"no platforms/android-NN/android.jar under $home")
+      (platforms.sortBy(_.last).last / "android.jar").toString
+    })
+
+    val classpath = runtime.runClasspath().map(_.path).filter(os.exists)
+    val classpathFile = Task.dest / "classpath"
+    os.write.over(classpathFile, classpath.mkString("\n"))
+
+    val driverClasspath =
+      builder.runClasspath().map(_.path.toString).mkString(java.io.File.pathSeparator)
+
+    os.proc("java", "-cp", driverClasspath, "androidsample.buildApk", androidJar,
+        Task.dest.toString, (appSource().path / "dice.scala").toString, classpathFile.toString)
+    . call(stdout = os.Inherit, stderr = os.Inherit)
+
+    PathRef(Task.dest / "app.apk")

--- a/lib/anthology/src/apk/anthology.ApkConfiguration.scala
+++ b/lib/anthology/src/apk/anthology.ApkConfiguration.scala
@@ -32,37 +32,40 @@
                                                                                                   */
 package anthology
 
-import prepositional.*
+import anticipation.*
+import gossamer.*
 
-object Provenance:
-  given jar: (Provenance[Artifact.Jar] from Universe.Classfile):
-    type Origin = Universe.Classfile
+object ApkConfiguration:
+  // The conventional Android debug keystore (shared with Android Studio), a PKCS#12 store with a
+  // well-known alias and password. The defaults produce a debuggable, emulator-installable APK.
+  def default: ApkConfiguration =
+    val home = java.lang.System.getProperty("user.home").nn.tt
 
-  given dex: (Provenance[Artifact.Dex] from Universe.Classfile):
-    type Origin = Universe.Classfile
+    ApkConfiguration
+      ( minApi      = 26,
+        targetApi   = 34,
+        packageName = t"dev.soundness.app",
+        versionCode = 1,
+        versionName = t"1.0",
+        label       = t"Soundness App",
+        permissions = Nil,
+        keystore    = t"$home/.android/debug.keystore",
+        storePass   = t"android",
+        alias       = t"androiddebugkey",
+        keyPass     = t"android" )
 
-  given apk: (Provenance[Artifact.Apk] from Universe.Classfile):
-    type Origin = Universe.Classfile
-
-  given js: [module <: Artifact.Js.Modules]
-  =>  (Provenance[Artifact.Js[module]] from Universe.Sjsir):
-    type Origin = Universe.Sjsir
-
-  given wasm: (Provenance[Artifact.Wasm] from Universe.Sjsir):
-    type Origin = Universe.Sjsir
-
-  given wasi: [version <: Artifact.Wasi.Versions]
-  =>  (Provenance[Artifact.Wasi[version]] from Universe.Sjsir):
-    type Origin = Universe.Sjsir
-
-  given binary: (Provenance[Artifact.Binary] from Universe.Nir):
-    type Origin = Universe.Nir
-
-  given library: [universe <: Universe] => (Provenance[Artifact.Library[universe]] from universe):
-    type Origin = universe
-
-// Witnesses the universe an artifact is produced from—its origin. Unconditional: every artifact
-// has a provenance, whether or not it is currently linkable, so it can drive compilation
-// (`producing`) without demanding the link-time prerequisites that a `Linkage` may impose.
-trait Provenance[artifact <: Artifact]:
-  type Origin <: Universe
+// What an Android application package needs beyond its compiled code: the Android API level it
+// targets, the package name and human label, the requested runtime permissions, and the keystore
+// to sign with. The launcher activity is the compilation's entry point.
+case class ApkConfiguration
+  ( minApi:       Int,
+    targetApi:    Int,
+    packageName:  Text,
+    versionCode:  Int,
+    versionName:  Text,
+    label:        Text,
+    permissions:  List[Text],
+    keystore:     Text,
+    storePass:    Text,
+    alias:        Text,
+    keyPass:      Text )

--- a/lib/anthology/src/apk/anthology.ApkManifest.scala
+++ b/lib/anthology/src/apk/anthology.ApkManifest.scala
@@ -32,37 +32,86 @@
                                                                                                   */
 package anthology
 
-import prepositional.*
+import anticipation.*
+import gossamer.*
+import vacuous.*
 
-object Provenance:
-  given jar: (Provenance[Artifact.Jar] from Universe.Classfile):
-    type Origin = Universe.Classfile
+// Builds the `Axml.Element` tree for an Android manifest. The resource IDs below are the stable,
+// public `android.R.attr.*` constants (verified against `aapt`'s own output); public resource
+// IDs never change across platform versions, so hardcoding the handful a manifest needs avoids
+// depending on the platform `android.jar`'s resource table at all.
+object ApkManifest:
+  private val versionCode:      Int = 0x0101021b
+  private val versionName:      Int = 0x0101021c
+  private val minSdkVersion:    Int = 0x0101020c
+  private val targetSdkVersion: Int = 0x01010270
+  private val nameAttr:         Int = 0x01010003
+  private val labelAttr:        Int = 0x01010001
+  private val exportedAttr:     Int = 0x01010010
 
-  given dex: (Provenance[Artifact.Dex] from Universe.Classfile):
-    type Origin = Universe.Classfile
+  private def android(name: Text, id: Int, value: Axml.Value): Axml.Attribute =
+    Axml.Attribute(Axml.androidUri, name, id, value)
 
-  given apk: (Provenance[Artifact.Apk] from Universe.Classfile):
-    type Origin = Universe.Classfile
+  def apply
+    ( packageName:  Text,
+      versionCode:  Int,
+      versionName:  Text,
+      minSdk:       Int,
+      targetSdk:    Int,
+      label:        Text,
+      activity:     Text,
+      permissions:  List[Text] )
+  :   Axml.Element =
 
-  given js: [module <: Artifact.Js.Modules]
-  =>  (Provenance[Artifact.Js[module]] from Universe.Sjsir):
-    type Origin = Universe.Sjsir
+    // Each requested runtime permission is a `<uses-permission android:name="…"/>` element.
+    val permissionElements = permissions.map: permission =>
+      Axml.Element
+        ( t"uses-permission",
+          List(android(t"name", nameAttr, Axml.Value.Str(permission))),
+          Nil )
 
-  given wasm: (Provenance[Artifact.Wasm] from Universe.Sjsir):
-    type Origin = Universe.Sjsir
+    val launcher =
+      Axml.Element
+        ( t"intent-filter",
+          Nil,
+          List
+            ( Axml.Element
+                ( t"action",
+                  List(android(t"name", nameAttr,
+                      Axml.Value.Str(t"android.intent.action.MAIN"))),
+                  Nil ),
+              Axml.Element
+                ( t"category",
+                  List(android(t"name", nameAttr,
+                      Axml.Value.Str(t"android.intent.category.LAUNCHER"))),
+                  Nil ) ) )
 
-  given wasi: [version <: Artifact.Wasi.Versions]
-  =>  (Provenance[Artifact.Wasi[version]] from Universe.Sjsir):
-    type Origin = Universe.Sjsir
+    val activityElement =
+      Axml.Element
+        ( t"activity",
+          List
+            ( android(t"name", nameAttr, Axml.Value.Str(activity)),
+              android(t"exported", exportedAttr, Axml.Value.Bool(true)) ),
+          List(launcher) )
 
-  given binary: (Provenance[Artifact.Binary] from Universe.Nir):
-    type Origin = Universe.Nir
+    val application =
+      Axml.Element
+        ( t"application",
+          List(android(t"label", labelAttr, Axml.Value.Str(label))),
+          List(activityElement) )
 
-  given library: [universe <: Universe] => (Provenance[Artifact.Library[universe]] from universe):
-    type Origin = universe
+    val usesSdk =
+      Axml.Element
+        ( t"uses-sdk",
+          List
+            ( android(t"minSdkVersion", minSdkVersion, Axml.Value.Num(minSdk)),
+              android(t"targetSdkVersion", targetSdkVersion, Axml.Value.Num(targetSdk)) ),
+          Nil )
 
-// Witnesses the universe an artifact is produced from—its origin. Unconditional: every artifact
-// has a provenance, whether or not it is currently linkable, so it can drive compilation
-// (`producing`) without demanding the link-time prerequisites that a `Linkage` may impose.
-trait Provenance[artifact <: Artifact]:
-  type Origin <: Universe
+    Axml.Element
+      ( t"manifest",
+        List
+          ( Axml.Attribute(Unset, t"package", Unset, Axml.Value.Str(packageName)),
+            android(t"versionCode", ApkManifest.versionCode, Axml.Value.Num(versionCode)),
+            android(t"versionName", ApkManifest.versionName, Axml.Value.Str(versionName)) ),
+        usesSdk :: permissionElements ++ List(application) )

--- a/lib/anthology/src/apk/anthology.ApkSigner.scala
+++ b/lib/anthology/src/apk/anthology.ApkSigner.scala
@@ -1,0 +1,187 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import java.io as ji
+import java.security as js
+import java.security.cert as jsc
+
+import anticipation.*
+import gastronomy.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+import gastronomy.providers.javaStdlibProvider
+
+// APK Signature Scheme v2: signs a finished (aligned, unsigned) ZIP by inserting an "APK Signing
+// Block" between its entries and its central directory. The signature covers a digest of the
+// whole file computed in 1 MiB chunks, so any later byte change invalidates it — which is why
+// signing is the final step. The digests are computed with gastronomy (SHA-256, streaming); the
+// RSA signature, the keystore, and the certificate use `java.security` directly, since
+// enigmatic's RSA is encryption-only and its keystore surfaces no private keys. No Android SDK
+// tool is involved: this replaces `apksigner`.
+object ApkSigner:
+  private val chunkSize:         Int  = 1048576
+  private val signAlgorithm:     Long = 0x0103L        // RSASSA-PKCS1-v1.5 with SHA2-256
+  private val v2BlockId:         Long = 0x7109871aL
+  private val magic:             Text = t"APK Sig Block 42"
+
+  private def u32(value: Long): Data =
+    IArray((value & 0xff).toByte, ((value >> 8) & 0xff).toByte, ((value >> 16) & 0xff).toByte,
+        ((value >> 24) & 0xff).toByte)
+
+  private def u64(value: Long): Data =
+    IArray.range(0, 8).map: i =>
+      ((value >> (i*8)) & 0xff).toByte
+
+  private def concat(parts: Data*): Data =
+    val total = parts.map(_.length).sum
+    val array = new Array[Byte](total)
+    var offset = 0
+
+    parts.foreach: part =>
+      System.arraycopy(part.mutable(using Unsafe), 0, array, offset, part.length)
+      offset += part.length
+
+    array.immutable(using Unsafe)
+
+  private def sha256(data: Data): Data = data.digest[Sha2[256]].data
+
+  // Reads the little-endian u32 at `offset`.
+  private def readU32(data: Data, offset: Int): Long =
+    def byte(index: Int): Long = data(offset + index).toLong & 0xff
+    byte(0) | (byte(1) << 8) | (byte(2) << 16) | (byte(3) << 24)
+
+  // The end-of-central-directory record is the archive's final 22 bytes: the writer emits no
+  // ZIP comment, and the package is far too small for the ZIP64 end record.
+  private def endOfCentralDirectory(data: Data): Int = data.length - 22
+
+  // A length-prefixed (u32) sequence of length-prefixed (u32) elements.
+  private def lengthPrefixedSequence(elements: List[Data]): Data =
+    val body = concat(elements.map { element => concat(u32(element.length.toLong), element) }*)
+    concat(u32(body.length.toLong), body)
+
+  // Splits a byte range into 1 MiB chunks and returns each chunk's content digest, prefixed
+  // per the v2 scheme (0xa5, then the chunk length).
+  private def chunkDigests(data: Data, from: Int, until: Int): List[Data] =
+    val builder = List.newBuilder[Data]
+    var offset = from
+
+    while offset < until do
+      val end = math.min(offset + chunkSize, until)
+      val length = end - offset
+      val chunk = new Array[Byte](length)
+      System.arraycopy(data.mutable(using Unsafe), offset, chunk, 0, length)
+      val prefixed = concat(IArray(0xa5.toByte), u32(length.toLong), chunk.immutable(using Unsafe))
+      builder += sha256(prefixed)
+      offset = end
+
+    builder.result()
+
+  // Signs the finished, unsigned APK bytes with the RSA key and certificate loaded from the
+  // keystore, returning the signed APK.
+  def sign
+    ( unsigned: Data, keystore: Text, storePass: Text, alias: Text, keyPass: Text )
+  :   Data =
+
+    val store = js.KeyStore.getInstance("PKCS12").nn
+
+    val stream = ji.FileInputStream(keystore.s)
+    try store.load(stream, storePass.s.toCharArray) finally stream.close()
+
+    val privateKey = store.getKey(alias.s, keyPass.s.toCharArray).nn.asInstanceOf[js.PrivateKey]
+    val certificate = store.getCertificate(alias.s).nn.asInstanceOf[jsc.X509Certificate]
+    val certificateDer = certificate.getEncoded.nn.immutable(using Unsafe)
+    val publicKeyDer = certificate.getPublicKey.nn.getEncoded.nn.immutable(using Unsafe)
+
+    val eocdOffset = endOfCentralDirectory(unsigned)
+    val cdOffset = readU32(unsigned, eocdOffset + 16).toInt
+
+    // The three digested sections: the ZIP entries, the central directory, and the
+    // end-of-central-directory record. The unsigned EOCD already points at `cdOffset` — which is
+    // exactly where the signing block will begin — so it is digested as-is.
+    val digests =
+      chunkDigests(unsigned, 0, cdOffset) ++
+        chunkDigests(unsigned, cdOffset, eocdOffset) ++
+        chunkDigests(unsigned, eocdOffset, unsigned.length)
+
+    val count = digests.length
+    val topLevel = sha256(concat(IArray(0x5a.toByte), u32(count.toLong), concat(digests*)))
+
+    // signed data: digests, certificates, additional attributes (none).
+    val digestRecord = concat(u32(signAlgorithm), u32(topLevel.length.toLong), topLevel)
+    val digestBlock = lengthPrefixedSequence(List(digestRecord))
+    val certBlock = lengthPrefixedSequence(List(certificateDer))
+    val attributes = concat(u32(0))
+    val signedData = concat(digestBlock, certBlock, attributes)
+
+    val signature = js.Signature.getInstance("SHA256withRSA").nn
+    signature.initSign(privateKey)
+    signature.update(signedData.mutable(using Unsafe))
+    val signatureData = signature.sign.nn.immutable(using Unsafe)
+
+    // signer: signed data, signatures, public key.
+    val signatureRecord =
+      concat(u32(signAlgorithm), u32(signatureData.length.toLong), signatureData)
+
+    val signer =
+      concat
+        ( concat(u32(signedData.length.toLong), signedData),
+          lengthPrefixedSequence(List(signatureRecord)),
+          concat(u32(publicKeyDer.length.toLong), publicKeyDer) )
+
+    val v2Block = lengthPrefixedSequence(List(signer))
+
+    // The ID-value pair, then the signing block framing (size, pair, size again, magic).
+    val pair = concat(u64((4 + v2Block.length).toLong), u32(v2BlockId), v2Block)
+    val blockLength = pair.length + 8 + 16
+    val magicBytes = magic.s.getBytes("US-ASCII").nn.immutable(using Unsafe)
+    val signingBlock = concat(u64(blockLength.toLong), pair, u64(blockLength.toLong), magicBytes)
+
+    // The final file: entries, signing block, central directory, and the EOCD with its
+    // central-directory offset advanced past the inserted block.
+    val section1 = slice(unsigned, 0, cdOffset)
+    val centralDirectory = slice(unsigned, cdOffset, eocdOffset)
+    val eocd = slice(unsigned, eocdOffset, unsigned.length).mutable(using Unsafe)
+    val newCdOffset = cdOffset + signingBlock.length
+    val patch = u32(newCdOffset.toLong)
+    for i <- 0 until 4 do eocd(16 + i) = patch(i)
+
+    concat(section1, signingBlock, centralDirectory, eocd.immutable(using Unsafe))
+
+  private def slice(data: Data, from: Int, until: Int): Data =
+    val length = until - from
+    val array = new Array[Byte](length)
+    System.arraycopy(data.mutable(using Unsafe), from, array, 0, length)
+    array.immutable(using Unsafe)

--- a/lib/anthology/src/apk/anthology.Axml.scala
+++ b/lib/anthology/src/apk/anthology.Axml.scala
@@ -1,0 +1,260 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import scala.collection.mutable as scm
+
+import anticipation.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+// Android binary XML ("AXML"): the compact, chunked encoding Android's framework parses a
+// manifest from — a string pool, an optional resource-map chunk, then a flat stream of
+// start-namespace / start-element / end-element / end-namespace events. It is deliberately not a
+// Xylophone serialization format: its data model is not text-XML's. Attribute values are typed
+// (a boolean, an integer, a string — not all strings), `android:`-namespaced attributes are
+// addressed at parse time by a numeric *resource ID* rather than by name, and namespaces are
+// first-class chunks rather than `xmlns` attributes — none of which the general XML model
+// carries. So AXML has its own small model here, in the Android layer that owns that knowledge.
+object Axml:
+  // The Android resources namespace, and the prefix a manifest conventionally binds it to.
+  val androidUri: Text = t"http://schemas.android.com/apk/res/android"
+  val androidPrefix: Text = t"android"
+
+  // A typed attribute value: Android reads each attribute at a specific `TypedValue` type, so
+  // the encoder must commit to one rather than emit every value as a string.
+  enum Value:
+    case Str(text: Text)
+    case Num(value: Int)
+    case Bool(flag: Boolean)
+
+  // An attribute: its namespace (the android URI, or `Unset` for an unnamespaced attribute such
+  // as `package`), its local name, the public resource ID Android identifies it by (for
+  // `android:` manifest attributes), and its typed value.
+  case class Attribute
+    ( namespace: Optional[Text], name: Text, resourceId: Optional[Int], value: Value )
+
+  case class Element(name: Text, attributes: List[Attribute], children: List[Element])
+
+  // `TypedValue` data-type tags (a subset): a string references the pool; an integer or boolean
+  // is stored inline.
+  private val typeReference: Int = 0x01
+  private val typeString:    Int = 0x03
+  private val typeIntDec:    Int = 0x10
+  private val typeIntBool:   Int = 0x12
+
+  private val noRef: Long = 0xffffffffL
+
+  // The string pool, whose first entries must be exactly the resource-mapped attribute names in
+  // resource-map order: Android pairs the i-th pool string with the i-th resource-map ID, so an
+  // `android:` attribute is recognized only when its name string and its ID share an index.
+  private class Strings:
+    private val indices: scm.LinkedHashMap[Text, Int] = scm.LinkedHashMap()
+    def intern(string: Text): Int = indices.getOrElseUpdate(string, indices.size)
+    def count: Int = indices.size
+    def ordered: List[Text] = indices.toList.sortBy(_(1)).map(_(0))
+
+  // A growable little-endian byte buffer with the back-patching the chunked format needs: chunk
+  // sizes and the total file size are only known after their contents are written.
+  private class Buffer:
+    private val bytes: scm.ArrayBuffer[Byte] = scm.ArrayBuffer()
+    def position: Int = bytes.length
+
+    def u8(value: Int): Unit = bytes += value.toByte
+
+    def u16(value: Int): Unit =
+      u8(value & 0xff); u8((value >> 8) & 0xff)
+
+    def u32(value: Long): Unit =
+      u16((value & 0xffff).toInt); u16(((value >> 16) & 0xffff).toInt)
+
+    def patchU32(at: Int, value: Long): Unit =
+      bytes(at) = (value & 0xff).toByte
+      bytes(at + 1) = ((value >> 8) & 0xff).toByte
+      bytes(at + 2) = ((value >> 16) & 0xff).toByte
+      bytes(at + 3) = ((value >> 24) & 0xff).toByte
+
+    def align4(): Unit = while position%4 != 0 do u8(0)
+    def data: Data = bytes.toArray.immutable(using Unsafe)
+
+  def encode(root: Element): Data =
+    val strings = Strings()
+
+    // Pass 1: the resource-mapped names first (in first-seen order), so they take the low pool
+    // indices the resource map addresses.
+    val resourceMap: scm.LinkedHashMap[Text, Int] = scm.LinkedHashMap()
+
+    def collectResources(element: Element): Unit =
+      for attribute <- element.attributes do attribute.resourceId.let: id =>
+        if !resourceMap.contains(attribute.name) then
+          resourceMap(attribute.name) = id
+          strings.intern(attribute.name)
+
+      for child <- element.children do collectResources(child)
+
+    collectResources(root)
+
+    // Pass 2: every other referenced string (the namespace prefix and URI, element names,
+    // unmapped attribute names, and string values).
+    strings.intern(androidPrefix)
+    strings.intern(androidUri)
+
+    def collectStrings(element: Element): Unit =
+      strings.intern(element.name)
+
+      for attribute <- element.attributes do
+        strings.intern(attribute.name)
+        attribute.value.only { case Value.Str(text) => strings.intern(text) }
+
+      for child <- element.children do collectStrings(child)
+
+    collectStrings(root)
+
+    val out = Buffer()
+
+    // The XML chunk header; its total-size field is patched once the file is complete.
+    out.u16(0x0003)
+    out.u16(0x0008)
+    val totalSizeAt = out.position
+    out.u32(0)
+
+    writeStringPool(out, strings.ordered)
+    writeResourceMap(out, resourceMap.values.to(List))
+
+    val android = strings.intern(androidUri)
+    val prefix = strings.intern(androidPrefix)
+
+    // START_NAMESPACE
+    startChunk(out, 0x0100):
+      out.u32(prefix)
+      out.u32(android)
+
+    writeElement(out, root, strings)
+
+    // END_NAMESPACE
+    startChunk(out, 0x0101):
+      out.u32(prefix)
+      out.u32(android)
+
+    out.patchU32(totalSizeAt, out.position.toLong)
+    out.data
+
+  // A namespace or resource-map-free node chunk with a 16-byte header (type, header size, chunk
+  // size, line number, comment); `body` writes the remainder and the size is patched in.
+  private def startChunk(out: Buffer, chunkType: Int)(body: => Unit): Unit =
+    out.u16(chunkType)
+    out.u16(0x0010)
+    val sizeAt = out.position
+    out.u32(0)
+    out.u32(1)          // line number (unimportant; a manifest carries none)
+    out.u32(noRef)      // comment
+    body
+    out.patchU32(sizeAt, (out.position - sizeAt + 4).toLong)
+
+  private def writeElement(out: Buffer, element: Element, strings: Axml.Strings): Unit =
+    startChunk(out, 0x0102):
+      out.u32(noRef)                       // element namespace (none)
+      out.u32(strings.intern(element.name))
+      out.u16(0x0014)                      // attribute record start
+      out.u16(0x0014)                      // attribute record size
+      out.u16(element.attributes.length)
+      out.u16(0)                           // id attribute index (none)
+      out.u16(0)                           // class attribute index (none)
+      out.u16(0)                           // style attribute index (none)
+
+      element.attributes.each: attribute =>
+        out.u32(attribute.namespace.let(strings.intern(_)).or(noRef.toInt).toLong)
+        out.u32(strings.intern(attribute.name))
+
+        attribute.value match
+          case Value.Str(text) =>
+            val index = strings.intern(text)
+            out.u32(index)                 // raw value (the string itself)
+            out.u16(0x0008); out.u8(0); out.u8(typeString)
+            out.u32(index)
+
+          case Value.Num(value) =>
+            out.u32(noRef)
+            out.u16(0x0008); out.u8(0); out.u8(typeIntDec)
+            out.u32(value & 0xffffffffL)
+
+          case Value.Bool(flag) =>
+            out.u32(noRef)
+            out.u16(0x0008); out.u8(0); out.u8(typeIntBool)
+            out.u32(if flag then noRef else 0L)
+
+    element.children.each(writeElement(out, _, strings))
+
+    // END_ELEMENT
+    startChunk(out, 0x0103):
+      out.u32(noRef)
+      out.u32(strings.intern(element.name))
+
+  private def writeStringPool(out: Buffer, entries: List[Text]): Unit =
+    out.u16(0x0001)
+    out.u16(0x001c)
+    val sizeAt = out.position
+    out.u32(0)
+    out.u32(entries.length)
+    out.u32(0)                             // style count
+    out.u32(0)                             // flags: 0 = UTF-16
+    val stringsStartAt = out.position
+    out.u32(0)
+    out.u32(0)                             // styles start (none)
+
+    // The string data, assembled separately so each entry's offset (from the data start) is
+    // known before the offset table is written.
+    val data = Buffer()
+
+    val offsets = entries.map: entry =>
+      val offset = data.position
+      val chars = entry.s
+      data.u16(chars.length)
+      for index <- 0 until chars.length do data.u16(chars.charAt(index).toInt)
+      data.u16(0)                          // NUL terminator
+      offset
+
+    for offset <- offsets do out.u32(offset.toLong)
+    val stringsStart = out.position - sizeAt + 4
+    out.patchU32(stringsStartAt, stringsStart.toLong)
+    for byte <- data.data do out.u8(byte.toInt)
+    out.align4()
+    out.patchU32(sizeAt, (out.position - sizeAt + 4).toLong)
+
+  private def writeResourceMap(out: Buffer, ids: List[Int]): Unit =
+    if ids.nonEmpty then
+      out.u16(0x0180)
+      out.u16(0x0008)
+      out.u32((8 + 4*ids.length).toLong)
+      for id <- ids do out.u32(id & 0xffffffffL)

--- a/lib/anthology/src/apk/anthology_apk.scala
+++ b/lib/anthology/src/apk/anthology_apk.scala
@@ -1,0 +1,147 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import java.nio.file as jnf
+
+import scala.util.control as suc
+
+import anticipation.*
+import contingency.*
+import digression.*
+import galilei.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import serpentine.*
+import turbulence.*
+import vacuous.*
+import zeppelin.*
+
+import dexLinkages.given
+
+object apkOptions:
+  private def apk(edit: ApkConfiguration => ApkConfiguration): Linker.Option[Artifact.Apk] =
+    Linker.Option(edit)
+
+  def minApi(level: Int): Linker.Option[Artifact.Apk] = apk(_.copy(minApi = level))
+  def targetApi(level: Int): Linker.Option[Artifact.Apk] = apk(_.copy(targetApi = level))
+  def packageName(name: Text): Linker.Option[Artifact.Apk] = apk(_.copy(packageName = name))
+  def label(text: Text): Linker.Option[Artifact.Apk] = apk(_.copy(label = text))
+
+  def version(code: Int, name: Text): Linker.Option[Artifact.Apk] =
+    apk(_.copy(versionCode = code, versionName = name))
+
+  // Adds a requested runtime permission (e.g. `android.permission.VIBRATE`).
+  def permission(name: Text): Linker.Option[Artifact.Apk] =
+    apk: config =>
+      config.copy(permissions = config.permissions :+ name)
+
+  def keystore(path: Text, storePass: Text, alias: Text, keyPass: Text)
+  :   Linker.Option[Artifact.Apk] =
+
+    apk(_.copy(keystore = path, storePass = storePass, alias = alias, keyPass = keyPass))
+
+// The classfile-to-APK link family: dexes the compilation (reusing the `Dex` linkage), encodes a
+// binary manifest (`Axml`), assembles a zip-aligned package (`zeppelin`), and signs it (APK v2,
+// `ApkSigner`) — a complete, installable Android application, produced with no Android SDK build
+// tool. Import it where APK artifacts are linked: `import apkLinkages.given`.
+object apkLinkages:
+  given apk: (Linkage[Artifact.Apk] from Universe.Classfile):
+    type Origin = Universe.Classfile
+    private[anthology] type Form = ApkConfiguration
+    private[anthology] def initial: ApkConfiguration = ApkConfiguration.default
+
+    private[anthology] def link
+      ( form:        ApkConfiguration,
+        compilation: Compilation[Universe.Classfile],
+        entryPoints: List[Linker.EntryPoint],
+        out:         Path on Linux )
+    :   Path on Linux logs LinkEvent raises LinkError =
+
+      val activity: Fqcn = entryPoints match
+        case List(entry) => entry.mainClass
+        case Nil         => abort(LinkError(LinkError.Reason.NoEntryPoint))
+        case _           => abort(LinkError(LinkError.Reason.ManyEntryPoints))
+
+      try
+        jnf.Files.createDirectories(jnf.Paths.get(out.encode.s))
+        val dexDir = out / "dex"
+        jnf.Files.createDirectories(jnf.Paths.get(dexDir.encode.s))
+
+        // Dexing is the `Dex` linkage, reused verbatim: it yields an archive of `classes*.dex`.
+        val dexOptionList = List(dexOptions.minApi(form.minApi), dexOptions.mode.release)
+        val dexArchive = Linker[Artifact.Dex](dexOptionList).link(compilation, dexDir)
+
+        val dexEntries = unsafely(Zipfile.read(dexArchive).entries.to(List)).filter: entry =>
+          entry.ref.encode.ends(t".dex")
+
+        // The binary manifest, built from the configuration and the launcher activity.
+        val manifest =
+          Axml.encode:
+            ApkManifest
+              ( packageName = form.packageName,
+                versionCode = form.versionCode,
+                versionName = form.versionName,
+                minSdk      = form.minApi,
+                targetSdk   = form.targetApi,
+                label       = form.label,
+                activity    = activity.text,
+                permissions = form.permissions )
+
+        // The package: the manifest first, then each dex stored uncompressed and 4-byte aligned
+        // so the runtime can memory-map it. `Zip.Compression.Stored` keeps every entry
+        // uncompressed, and `.aligned(4)` requests the boundary.
+        given Zip.Compression = Zip.Compression.Stored
+
+        val manifestEntry = Zip.Entry(%.on[Zip] / "AndroidManifest.xml", manifest)
+
+        // Reuse each dex entry's own path (`classes.dex`, `classes2.dex`, …), re-storing its
+        // decompressed bytes uncompressed and aligned.
+        val dexZipEntries = dexEntries.map: entry =>
+          Zip.Entry(entry.ref, unsafely(entry.read[Data])).aligned(4)
+
+        val unsignedPath = out / "unsigned.apk"
+        unsafely(Zipfile.write(unsignedPath)(manifestEntry :: dexZipEntries))
+        val unsigned = jnf.Files.readAllBytes(jnf.Paths.get(unsignedPath.encode.s)).nn
+
+        val signed =
+          ApkSigner.sign(unsigned.immutable(using Unsafe), form.keystore, form.storePass,
+              form.alias, form.keyPass)
+
+        val apkPath = out / "app.apk"
+        jnf.Files.write(jnf.Paths.get(apkPath.encode.s), signed.mutable(using Unsafe))
+        apkPath
+
+      catch case suc.NonFatal(error) =>
+        abort(LinkError(LinkError.Reason.Failed(error.stackTrace)))

--- a/lib/anthology/src/apk/soundness_anthology_apk.scala
+++ b/lib/anthology/src/apk/soundness_anthology_apk.scala
@@ -30,39 +30,7 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package anthology
+package soundness
 
-import prepositional.*
-
-object Provenance:
-  given jar: (Provenance[Artifact.Jar] from Universe.Classfile):
-    type Origin = Universe.Classfile
-
-  given dex: (Provenance[Artifact.Dex] from Universe.Classfile):
-    type Origin = Universe.Classfile
-
-  given apk: (Provenance[Artifact.Apk] from Universe.Classfile):
-    type Origin = Universe.Classfile
-
-  given js: [module <: Artifact.Js.Modules]
-  =>  (Provenance[Artifact.Js[module]] from Universe.Sjsir):
-    type Origin = Universe.Sjsir
-
-  given wasm: (Provenance[Artifact.Wasm] from Universe.Sjsir):
-    type Origin = Universe.Sjsir
-
-  given wasi: [version <: Artifact.Wasi.Versions]
-  =>  (Provenance[Artifact.Wasi[version]] from Universe.Sjsir):
-    type Origin = Universe.Sjsir
-
-  given binary: (Provenance[Artifact.Binary] from Universe.Nir):
-    type Origin = Universe.Nir
-
-  given library: [universe <: Universe] => (Provenance[Artifact.Library[universe]] from universe):
-    type Origin = universe
-
-// Witnesses the universe an artifact is produced from—its origin. Unconditional: every artifact
-// has a provenance, whether or not it is currently linkable, so it can drive compilation
-// (`producing`) without demanding the link-time prerequisites that a `Linkage` may impose.
-trait Provenance[artifact <: Artifact]:
-  type Origin <: Universe
+export anthology.{apkLinkages, apkOptions, ApkConfiguration, Axml, ApkManifest,
+    ApkSigner}

--- a/lib/anthology/src/core/anthology.Artifact.scala
+++ b/lib/anthology/src/core/anthology.Artifact.scala
@@ -46,6 +46,11 @@ object Artifact:
   // `import dexLinkages.given`.
   sealed trait Dex extends Artifact
 
+  // Classfile universe: a complete, installable Android application package — the dexed code,
+  // a binary manifest, aligned and signed — bound to the Android runtime. Its linkage lives in
+  // the `apk` module: `import apkLinkages.given`.
+  sealed trait Apk extends Artifact
+
   object Js:
     // How a JavaScript host consumes the artifact: an ECMAScript module, a CommonJS module, or
     // a plain script. The module system is part of the artifact's binding contract, so it is

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -116,6 +116,33 @@ object Tests extends Suite(m"Anthology Tests"):
         Linker[Artifact.Jar](List(dexOptions.minApi(24)))
     . assert(_.nonEmpty)
 
+    test(m"The AXML encoder emits the binary-XML chunk header"):
+      val axml = Axml.encode(Axml.Element(t"manifest", Nil, Nil))
+      List(axml(0), axml(1), axml(2), axml(3)).map(_.toInt & 0xff)
+    . assert(_ == List(0x03, 0x00, 0x08, 0x00))
+
+    test(m"The AXML total-size field equals the encoded length"):
+      val axml = Axml.encode(Axml.Element(t"manifest", Nil, Nil))
+      def u8(index: Int): Int = axml(index).toInt & 0xff
+      val declared = u8(4) | (u8(5) << 8) | (u8(6) << 16) | (u8(7) << 24)
+      declared == axml.length
+    . assert(_ == true)
+
+    test(m"An APK linkage is not available without importing apkLinkages"):
+      demilitarize:
+        summon[Linkage[Artifact.Apk]]
+    . assert(_.nonEmpty)
+
+    test(m"The APK linkage defaults to API level 26"):
+      import apkLinkages.given
+      summon[Linkage[Artifact.Apk]].initial.asInstanceOf[ApkConfiguration].minApi
+    . assert(_ == 26)
+
+    test(m"An APK option is not applicable to a dex linker"):
+      demilitarize:
+        Linker[Artifact.Dex](List(apkOptions.minApi(24)))
+    . assert(_.nonEmpty)
+
     test(m"A WASI linkage is not available without toolchain and WIT world"):
       demilitarize:
         summon[Linkage[Artifact.Wasi[0.2]]]

--- a/lib/xenophile/src/kotlin/xenophile.Facade.scala
+++ b/lib/xenophile/src/kotlin/xenophile.Facade.scala
@@ -42,6 +42,7 @@ import stenography.*
 import vacuous.*
 
 object Facade extends prophesy.Completable:
+
   // Dynamic tab completions, invoked reflectively through `Completable` by a completion
   // engine: the members of the underlying Kotlin class, rendered in Kotlin syntax.
   def completions(using quotes: scala.quoted.Quotes)
@@ -67,7 +68,7 @@ object Facade extends prophesy.Completable:
   // the value travels verbatim and every navigation is a direct call on it.
   def apply[underlying](value: underlying): Facade over underlying =
     val facade = new Facade:
-      def unwrap: Any = value
+      def raw: Any = value
 
     facade.asInstanceOf[Facade over underlying]
 
@@ -79,8 +80,13 @@ object Facade extends prophesy.Completable:
 // class: nullable results become `Optional`, `kotlin.String` becomes `Text`, and Kotlin-typed
 // results are wrapped as further facades.
 trait Facade extends Dynamic, Transportive:
-  // The raw underlying value: the escape hatch back to plain Java-level interop.
-  def unwrap: Any
+  // The underlying value at its erased runtime type; the emission machinery's accessor. User
+  // code should prefer `unwrap`, which recovers the precise static type.
+  def raw: Any
+
+  // The underlying value, at the full Scala type the facade records: the escape hatch back to
+  // plain Java-level interop, typed so no cast is needed at the boundary.
+  transparent inline def unwrap: Any = ${KotlinFacade.unwrapped('this)}
 
   transparent inline def selectDynamic(name: String): Any =
     ${KotlinFacade.select('this, 'name)}

--- a/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
+++ b/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
@@ -209,7 +209,7 @@ object KotlinFacade:
     import quotes.reflect.*
 
     repr.asType.absolve match
-      case '[u] => '{$self.unwrap.asInstanceOf[u]}.asTerm
+      case '[u] => '{$self.raw.asInstanceOf[u]}.asTerm
 
   // Whether an argument can satisfy a JVM parameter type, given Kotlin's view of the boundary:
   // a conforming value always can; `Text` satisfies any parameter that accepts a `String` or
@@ -313,7 +313,7 @@ object KotlinFacade:
     def outward(value: Expr[Any]): Expr[Any] =
       ' {
           $value.absolve match
-            case facade: Facade => facade.unwrap
+            case facade: Facade => facade.raw
             case other          => other
         }
 
@@ -386,7 +386,7 @@ object KotlinFacade:
 
     val unwrapped = sam.or:
       if argument.tpe.widen <:< TypeRepr.of[Facade]
-      then '{${argument.asExprOf[Facade]}.unwrap}.asTerm
+      then '{${argument.asExprOf[Facade]}.raw}.asTerm
       else argument
 
     if unwrapped.tpe <:< parameter then unwrapped
@@ -595,7 +595,7 @@ object KotlinFacade:
         val rest = args.drop(fixed.length).map: argument =>
           val unwrapped =
             if argument.tpe.widen <:< TypeRepr.of[Facade]
-            then '{${argument.asExprOf[Facade]}.unwrap}.asTerm
+            then '{${argument.asExprOf[Facade]}.raw}.asTerm
             else argument
 
           TypeApply(Select.unique(unwrapped, "asInstanceOf"), List(Inferred(target)))
@@ -926,7 +926,7 @@ object KotlinFacade:
     def textual(element: TypeRepr): TypeRepr =
       if solid(element) <:< TypeRepr.of[String] then TypeRepr.of[Text] else solid(element)
 
-    val unwrapped = '{$self.unwrap}
+    val unwrapped = '{$self.raw}
 
     repr.dealias match
       case AppliedType(constructor, List(element)) if repr <:< TypeRepr.of[java.util.List[?]] =>
@@ -959,3 +959,14 @@ object KotlinFacade:
 
       case _ =>
         halt(m"xenophile: ${repr.show} is not a collection type")
+
+  // The underlying value at the facade's full recorded Scala type, so handing it to plain
+  // Java-level code needs no cast.
+  def unwrapped(self: Expr[Facade])(using Quotes): Expr[Any] =
+    import quotes.reflect.*
+
+    val transport = Xenophile.refinements(self.asTerm.tpe.widen).at(t"Transport")
+
+    if transport.absent then '{$self.raw} else
+      transport.vouch.asType.absolve match
+        case '[u] => '{$self.raw.asInstanceOf[u]}

--- a/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
+++ b/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
@@ -229,7 +229,7 @@ object KotlinFacade:
 
     val direct = argument.tpe.widen <:< target || (textual && stringy) || transported
 
-    val functional = samCompatible(argument, target)
+    val functional = samCompatible(argument, target) || proxyCompatible(argument, target)
     val bridged = functional || collectionCompatible(argument.tpe.widen, target)
 
     direct || bridged
@@ -270,6 +270,97 @@ object KotlinFacade:
       TypeApply(Select.unique(view.asTerm, "asInstanceOf"), List(Inferred(solid(target))))
 
   // The arity of a Kotlin function type, when the parameter is one.
+  // A Java functional interface's single abstract method and its arity, when the parameter is
+  // one (`Runnable`, `View.OnClickListener`, `java.util.function.*`, …). Kotlin's `FunctionN`
+  // types are handled separately, since their adaptation implements a known interface directly.
+  private def isJavaFunctionalInterface(using quotes: Quotes)(symbol: quotes.reflect.Symbol)
+  :   Boolean =
+
+    import quotes.reflect.*
+    val java = symbol.flags.is(Flags.Trait) && symbol.flags.is(Flags.JavaDefined)
+    java && !symbol.fullName.startsWith("kotlin.jvm.functions.")
+
+  private def javaSam(using quotes: Quotes)(target: quotes.reflect.TypeRepr)
+  :   Optional[(quotes.reflect.Symbol, Int)] =
+
+    import quotes.reflect.*
+
+    target.classSymbol match
+      case Some(symbol) if isJavaFunctionalInterface(symbol) =>
+        val abstractMethods = symbol.methodMembers.filter: method =>
+          method.flags.is(Flags.Deferred) && !method.flags.is(Flags.Synthetic)
+
+        abstractMethods match
+          case List(method) => (method, method.paramSymss.flatten.length)
+          case _            => Unset
+
+      case _ =>
+        Unset
+
+  // Whether a *typed* Scala lambda can satisfy a Java functional-interface parameter. (An
+  // untyped lambda never reaches the macro: `Dynamic` gives arguments no expected type, so a
+  // lambda's parameter types must be written — `(_: View) => …` — though a `() => …` lambda is
+  // always fully typed.)
+  private def proxyCompatible(using quotes: Quotes)
+    ( argument: quotes.reflect.Term, target: quotes.reflect.TypeRepr )
+  :   Boolean =
+
+    import quotes.reflect.*
+
+    javaSam(target).lay(false): (_, arity) =>
+      arity match
+        case 0 => argument.tpe.widen <:< TypeRepr.of[() => Any]
+        case 1 => argument.tpe.widen <:< TypeRepr.of[Nothing => Any]
+        case 2 => argument.tpe.widen <:< TypeRepr.of[(Nothing, Nothing) => Any]
+        case _ => false
+
+  // Adapts a typed Scala lambda to a Java functional interface through a dynamic proxy: the
+  // proxy answers `equals`/`hashCode`/`toString` itself and forwards the single abstract method
+  // to the lambda, unwrapping any facade result. The `Proxy` machinery costs a reflective
+  // dispatch per invocation — negligible for callbacks like click listeners.
+  private def proxyAdapted(using quotes: Quotes)
+    ( argument: quotes.reflect.Term, target: quotes.reflect.TypeRepr )
+  :   Optional[quotes.reflect.Term] =
+
+    import quotes.reflect.*
+
+    javaSam(target).let: (_, arity) =>
+      val interface = solid(target)
+
+      interface.asType.absolve match
+        case '[i] =>
+          val handler: Expr[(Array[Object | Null] | Null) => Object | Null] = arity match
+            case 0 =>
+              val lambda = argument.asExprOf[() => Any]
+              '{_ => KotlinRuntime.dispatch($lambda())}
+
+            case 1 =>
+              val lambda = '{${argument.asExpr}.asInstanceOf[Any => Any]}
+              '{args => KotlinRuntime.dispatch($lambda(args.nn(0)))}
+
+            case 2 =>
+              val lambda = '{${argument.asExpr}.asInstanceOf[(Any, Any) => Any]}
+              '{args => KotlinRuntime.dispatch($lambda(args.nn(0), args.nn(1)))}
+
+            case _ =>
+              halt(m"xenophile: functional interfaces above arity 2 are not yet supported")
+
+          // `classOf[Interface]` reaches the interface's runtime `Class` from its type, avoiding
+          // any reconstruction of the JVM binary name (a nested interface such as
+          // `View.OnClickListener` mangles to `View$OnClickListener`).
+          val samClass = Literal(ClassOfConstant(interface)).asExprOf[Class[i]]
+
+          val proxy =
+            ' {
+                val loader = $samClass.getClassLoader
+                val invocations = KotlinRuntime.forwarder($handler)
+
+                java.lang.reflect.Proxy.newProxyInstance(loader, Array($samClass), invocations)
+                . asInstanceOf[i]
+              }
+
+          proxy.asTerm
+
   private def samArity(using quotes: Quotes)(target: quotes.reflect.TypeRepr): Optional[Int] =
     target.classSymbol.map(_.fullName).getOrElse("") match
       case "kotlin.jvm.functions.Function0" => 0
@@ -382,7 +473,10 @@ object KotlinFacade:
 
     import quotes.reflect.*
 
-    val sam = samAdapted(argument, solid(parameter)).or(collectionAdapted(argument, parameter))
+    val sam =
+      samAdapted(argument, solid(parameter))
+      . or(proxyAdapted(argument, solid(parameter)))
+      . or(collectionAdapted(argument, parameter))
 
     val unwrapped = sam.or:
       if argument.tpe.widen <:< TypeRepr.of[Facade]

--- a/lib/xenophile/src/kotlin/xenophile.KotlinRuntime.scala
+++ b/lib/xenophile/src/kotlin/xenophile.KotlinRuntime.scala
@@ -44,6 +44,23 @@ object KotlinRuntime:
   private val handles: juc.ConcurrentHashMap[String, jli.MethodHandle] =
     juc.ConcurrentHashMap()
 
+  // Unwraps a facade returned from an adapted lambda, so Kotlin/Java receives the raw value.
+  def dispatch(result: Any | Null): Object | Null = result match
+    case facade: Facade => facade.raw.asInstanceOf[Object | Null]
+    case other          => other.asInstanceOf[Object | Null]
+
+  // The invocation handler behind a functional-interface proxy: `equals`/`hashCode`/`toString`
+  // answer locally; everything else (the single abstract method) forwards to the lambda.
+  def forwarder(handler: (Array[Object | Null] | Null) => Object | Null)
+  :   java.lang.reflect.InvocationHandler^{handler} =
+
+    (proxy, method, arguments) =>
+      method.nn.getName match
+        case "equals"   => java.lang.Boolean.valueOf(proxy.nn eq arguments.nn(0))
+        case "hashCode" => java.lang.Integer.valueOf(java.lang.System.identityHashCode(proxy))
+        case "toString" => s"<function proxy>"
+        case _          => handler(arguments)
+
   def invokeDefault(owner: Class[?], name: String, arguments: Array[Any | Null]): Any | Null =
     val key = s"${owner.getName}#$name#${arguments.length}"
 

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -271,6 +271,20 @@ object Tests extends Suite(m"Xenophile tests"):
         . map(_.message)
       . assert(_.exists(_.contains("value class")))
 
+      test(m"a typed lambda satisfies a Java functional-interface parameter"):
+        val list = Kotlin.make[java.util.ArrayList[Text]](List(t"a", t"bb", t"ccc"))
+        list.removeIf((text: Text) => text.length > 1)
+        val size: Int = list.size()
+        size
+      . assert(_ == 1)
+
+      test(m"a nullary lambda satisfies a Runnable parameter with no ascription"):
+        var ran = false
+        val thread = Kotlin.make[java.lang.Thread](() => ran = true)
+        thread.run()
+        ran
+      . assert(_ == true)
+
     val foo: Foreign of "Foo" from Typescript = Foreign["Foo", Typescript]
 
     suite(m"Foreign type navigation"):

--- a/lib/zeppelin/src/core/zeppelin.Zip.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zip.scala
@@ -169,12 +169,21 @@ object Zip:
      dosTime:          Int               = Zip.epochTime,
      dosDate:          Int               = Zip.epochDate,
      directory:        Boolean           = false,
-     comment:          Optional[Text]    = Unset ):
+     comment:          Optional[Text]    = Unset,
+     alignment:        Int               = 1 ):
 
     // The decompressed content of the entry.
     def contents: LazyList[Data] = method match
       case Method.Stored  => storedBytes()
       case Method.Deflate => LazyList(inflate(gather(storedBytes())))
+
+    // The same entry, its data required to begin at a byte offset that is a multiple of
+    // `multiple` in the written archive — achieved by padding the local header's extra field.
+    // Meaningful only for stored (uncompressed) entries, whose bytes a reader may `mmap`
+    // directly: an aligned `classes.dex`, `resources.arsc`, or page-aligned (`4096`) native
+    // library needs no copy to be memory-mapped. This is the transform Android's `zipalign`
+    // performs.
+    def aligned(multiple: Int): Entry = copy(alignment = multiple)
 
   // 00:00:00, 1 January 1980 — the minimum value representable in a DOS timestamp.
   private[zeppelin] val epochTime: Int = 0x0000

--- a/lib/zeppelin/src/core/zeppelin.Zipfile.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zipfile.scala
@@ -315,7 +315,20 @@ object Zipfile:
 
   private def utf8Flag(name: Data): Int = if name.exists(_ < 0) then 0x800 else 0
 
-  private def localHeader(entry: Zip.Entry, name: Data): Data =
+  // The base (non-padding) extra-field length of an entry's local header: the ZIP64 record
+  // when the entry's sizes overflow 32 bits, otherwise nothing.
+  private def baseExtraLength(entry: Zip.Entry): Int =
+    if entry.uncompressedSize > u32Max || entry.compressedSize > u32Max then 20 else 0
+
+  // The number of padding bytes to append to a local header's extra field so that the entry's
+  // data — which begins immediately after the header — starts at a multiple of the entry's
+  // alignment, given the header's own start offset.
+  private def alignmentPadding(entry: Zip.Entry, name: Data, offset: Long): Int =
+    if entry.alignment <= 1 then 0 else
+      val dataStart = offset + 30 + name.length + baseExtraLength(entry)
+      ((entry.alignment - dataStart%entry.alignment)%entry.alignment).toInt
+
+  private def localHeader(entry: Zip.Entry, name: Data, padding: Int = 0): Data =
     val zip64 = entry.uncompressedSize > u32Max || entry.compressedSize > u32Max
 
     val extra: Data =
@@ -325,7 +338,12 @@ object Zipfile:
         Zip.putU64(array, 4, entry.uncompressedSize)
         Zip.putU64(array, 12, entry.compressedSize)
 
-    Data.build(30 + name.length + extra.length): array =>
+    // Alignment padding follows any ZIP64 record as trailing zero bytes (the same padding
+    // classic `zipalign` emits): a reader takes the extra field's total length from offset 28
+    // and skips it, so the padding is inert, and the entry's data lands on its boundary.
+    val extraLength = extra.length + padding
+
+    Data.build(30 + name.length + extraLength): array =>
       Zip.putU32(array, 0, Zip.localHeaderSig.toLong & 0xffffffffL)
       Zip.putU16(array, 4, if zip64 then 45 else 20)
       Zip.putU16(array, 6, utf8Flag(name))
@@ -336,7 +354,7 @@ object Zipfile:
       Zip.putU32(array, 18, if zip64 then u32Max else entry.compressedSize)
       Zip.putU32(array, 22, if zip64 then u32Max else entry.uncompressedSize)
       Zip.putU16(array, 26, name.length)
-      Zip.putU16(array, 28, extra.length)
+      Zip.putU16(array, 28, extraLength)
       array.place(name, 30.z)
       if extra.length > 0 then array.place(extra, (30 + name.length).z)
 
@@ -449,7 +467,8 @@ case class Zipfile
 
     entryList.foreach: entry =>
       val name = Zipfile.nameBytes(entry)
-      val header = Zipfile.localHeader(entry, name)
+      val padding = Zipfile.alignmentPadding(entry, name, offset)
+      val header = Zipfile.localHeader(entry, name, padding)
       builder += ((entry, name, header, offset))
       offset += header.length + entry.compressedSize
 

--- a/lib/zeppelin/src/test/zeppelin_test.scala
+++ b/lib/zeppelin/src/test/zeppelin_test.scala
@@ -155,6 +155,26 @@ object Tests extends Suite(m"Zeppelin tests"):
         Zip.Entry(zipRef(t"a.txt"), (t"abcd"*64).in[Data]).method
       . assert(_ == Zip.Method.Stored)
 
+      test(m"an aligned entry's data begins on its byte boundary"):
+        given Zip.Compression = Zip.Compression.Stored
+        // "hello.txt" is 9 bytes, so unaligned data would begin at 30+9 = 39; alignment to 4
+        // pads the extra field so 30 + nameLength + extraLength is a multiple of 4.
+        val stored = Zip.Entry(zipRef(t"hello.txt"), t"Hello world".in[Data]).aligned(4)
+        val bytes = bytesOf(writeZip(t"aligned.zip", stored))
+
+        def u16(offset: Int): Int =
+          (bytes(offset).toInt & 0xff) | ((bytes(offset + 1).toInt & 0xff) << 8)
+
+        (30 + u16(26) + u16(28))%4
+      . assert(_ == 0)
+
+      test(m"an aligned entry still reads back through the JDK"):
+        given Zip.Compression = Zip.Compression.Stored
+        val stored = Zip.Entry(zipRef(t"hello.txt"), t"Hello world".in[Data]).aligned(4)
+        val path = writeZip(t"aligned2.zip", stored)
+        jdkContent(path, t"hello.txt").to(List)
+      . assert(_ == t"Hello world".in[Data].to(List))
+
     suite(m"Writing ZIP archives"):
       test(m"single-entry archive begins with the ZIP local-header magic"):
         bytesOf(writeZip(t"one.zip", entry(t"hello.txt", t"Hello world")))

--- a/tests/android/AndroidManifest.xml
+++ b/tests/android/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="dev.soundness.dice"
+    android:versionCode="1"
+    android:versionName="1.0">
+  <uses-sdk android:minSdkVersion="26" android:targetSdkVersion="36"/>
+  <uses-permission android:name="android.permission.VIBRATE"/>
+  <application android:label="Dice Roller"
+      android:theme="@android:style/Theme.Material.Light">
+    <activity android:name="dice.DiceActivity" android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/tests/android/README.md
+++ b/tests/android/README.md
@@ -1,0 +1,76 @@
+# The Android sample: Dice Roller
+
+A Soundness build of [Google's *Dice Roller*
+codelab](https://developer.android.com/codelabs/basic-android-kotlin-compose-build-a-dice-roller-app)
+(the classic first-steps Android app: a die face and a *Roll* button): a single activity,
+written in Scala (`src/dice.scala`), which reaches Android's widgets and Kotlin's
+`kotlin.random.Random` through xenophile's Kotlin facades, compiled with anthology's `Scalac`
+and linked as `Artifact.Dex` (`builder/build.scala` drives both).
+
+The UI is built programmatically, so the app needs no XML layouts and no resource compilation
+beyond its manifest.
+
+## Prerequisites
+
+- A JDK (for the build, and `keytool`).
+- The Android SDK command-line tools, with:
+
+  ```sh
+  sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0" "emulator" \
+      "system-images;android-34;google_apis;arm64-v8a"    # x86_64 on Intel machines
+  ```
+
+  and `ANDROID_HOME` pointing at the SDK root.
+
+## Build the DEX
+
+```sh
+ANDROID_HOME=~/Library/Android/sdk ./mill android.dex
+```
+
+This compiles `src/dice.scala` against the newest installed platform's `android.jar` plus the
+facade runtime, then links the classfiles *and their whole runtime classpath* (the Scala and
+Kotlin standard libraries included) into `out/android/dex.dest/main.dex.jar` — an archive of
+`classes*.dex` files (multidex; API level 26+). The platform itself is never dexed: on the
+device, the operating system provides it. To build without a full SDK, point `ANDROID_JAR` at
+any platform `android.jar` (Robolectric's `android-all` jar from Maven Central also works).
+
+## Package the APK
+
+There are two ways to turn the dexed code into an installable APK.
+
+### With the Android SDK build tools
+
+```sh
+ANDROID_HOME=~/Library/Android/sdk tests/android/package.sh out/android/dex.dest
+```
+
+This uses `aapt` (binary manifest), `zipalign` (alignment) and `apksigner` (v2 signature) to
+produce `out/android/dex.dest/dice.apk`.
+
+### Purely, with no SDK build tool
+
+```sh
+ANDROID_HOME=~/Library/Android/sdk ./mill android.apk
+```
+
+This links `Artifact.Apk` directly: anthology dexes the code, encodes the binary manifest itself
+(`Axml` — no `aapt2`), assembles the archive with 4-byte-aligned dex entries (zeppelin's
+alignment — no `zipalign`), and applies an APK Signature Scheme v2 signature (gastronomy SHA-256
+digests + `java.security` RSA — no `apksigner`). The only external requirement is a JDK and the
+debug keystore at `~/.android/debug.keystore` (a PKCS#12 store, as `keytool` and Android Studio
+create). The result is `out/android/apk.dest/app.apk` — an installable, signed application built
+without a single Android SDK tool. The platform `android.jar` (from `ANDROID_HOME`, or `ANDROID_JAR`)
+is needed only to *compile* against, never to package.
+
+## Run it in the emulator
+
+```sh
+avdmanager create avd --name soundness --package "system-images;android-34;google_apis;arm64-v8a"
+emulator -avd soundness &
+adb wait-for-device
+adb install -r out/android/dex.dest/dice.apk        # or out/android/apk.dest/app.apk
+adb shell am start -n dev.soundness.dice/dice.DiceActivity
+```
+
+Tap *Roll*.

--- a/tests/android/builder/build.scala
+++ b/tests/android/builder/build.scala
@@ -1,0 +1,131 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package androidsample
+
+import soundness.*
+
+import ambience.systems.javaSystem
+import logging.silentLogging
+import stdios.virtualMachineStdio
+import termcapDefinitions.basicTermcap
+import probates.cancelProbate
+import strategies.throwUnsafely
+import threading.platformThreading
+
+import java.nio.file.{Files, Paths}
+
+// The build driver for the Android sample: it compiles `dice.scala` against the Android platform
+// stubs and the facade runtime with anthology's `Scalac`, then links the compilation either as a
+// bare `Artifact.Dex` (for the SDK-tool packaging path) or — with no Android SDK tool whatsoever
+// — as a complete, signed `Artifact.Apk`.
+//
+// Arguments: <android.jar> <output directory> <app source file> <classpath file (one entry per
+// line: the app's compile-and-dex runtime, excluding the platform)>.
+object build:
+  // The runtime classpath (facade machinery + Scala/Kotlin standard libraries) the app both
+  // compiles against and is dexed with; the platform stubs are added for compilation only.
+  def runtime(classpathFile: String): List[ClasspathEntry.Directory | ClasspathEntry.Jar] =
+    Files.readAllLines(Paths.get(classpathFile)).nn.toArray.nn.to(List).map(_.toString).map:
+      entry =>
+        if entry.endsWith(".jar") then ClasspathEntry.Jar(entry.tt)
+        else ClasspathEntry.Directory(entry.tt)
+
+  // Compiles the app and returns the compilation to link. The platform stubs join the compile
+  // classpath but must not be dexed: on the device, the operating system provides the platform.
+  def compilation
+    ( androidJar: String, outDir: String, sourceFile: String, classpathFile: String )
+  :   Compilation[Universe.Classfile] =
+
+    val source: Text = Files.readString(Paths.get(sourceFile)).nn.tt
+    val entries = runtime(classpathFile)
+    val platform: ClasspathEntry.Jar = ClasspathEntry.Jar(androidJar.tt)
+    val compileClasspath = LocalClasspath((platform :: entries)*)
+
+    val classes = Paths.get(outDir, "classes").nn
+    Files.createDirectories(classes)
+    val classesPath: Path on Linux = unsafely(classes.toString.tt.as[Path on Linux])
+
+    supervise:
+      val process =
+        Scalac[3.8](List(scalacOptions.experimental))
+          (compileClasspath)
+          (Map(t"dice.scala" -> source), classesPath)
+
+      process.complete() match
+        case CompileResult.Success =>
+          Out.println(t"compiled $sourceFile")
+
+        case other =>
+          process.notices.each { notice => Out.println(notice.message) }
+          Out.println(t"compilation failed: $other")
+          sys.exit(1)
+
+    Compilation(classesPath, LocalClasspath(entries*))
+
+// Links the compilation as a bare DEX archive, packaged into an APK afterwards by the SDK tools.
+@main
+def buildDice(androidJar: String, outDir: String, sourceFile: String, classpathFile: String)
+:   Unit =
+
+  import dexLinkages.given
+  val compiled = build.compilation(androidJar, outDir, sourceFile, classpathFile)
+  val out: Path on Linux = unsafely(outDir.tt.as[Path on Linux])
+
+  val artifact =
+    Linker[Artifact.Dex](List(dexOptions.minApi(26), dexOptions.mode.release)).link(compiled, out)
+
+  Out.println(t"linked $artifact")
+
+// Links the compilation as a complete, signed APK — dexed, binary-manifested, zip-aligned and
+// v2-signed entirely by Soundness, with no `aapt2`, `zipalign` or `apksigner`.
+@main
+def buildApk(androidJar: String, outDir: String, sourceFile: String, classpathFile: String)
+:   Unit =
+
+  import apkLinkages.given
+  val compiled = build.compilation(androidJar, outDir, sourceFile, classpathFile)
+  val out: Path on Linux = unsafely(outDir.tt.as[Path on Linux])
+
+  val artifact =
+    Linker[Artifact.Apk]
+      ( List
+          ( apkOptions.minApi(26),
+            apkOptions.targetApi(36),
+            apkOptions.packageName(t"dev.soundness.dice"),
+            apkOptions.label(t"Dice Roller"),
+            apkOptions.version(1, t"1.0"),
+            apkOptions.permission(t"android.permission.VIBRATE") ),
+        List(Linker.EntryPoint(Fqcn(t"dice.DiceActivity"))) )
+    . link(compiled, out)
+
+  Out.println(t"linked $artifact")

--- a/tests/android/package.sh
+++ b/tests/android/package.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Packages the linked DEX archive into a signed, installable APK.
+# Usage: tests/android/package.sh <directory containing main.dex.jar>
+# Requires ANDROID_HOME with `build-tools` and `platforms` installed, and `keytool` (JDK).
+set -euo pipefail
+
+DEX_DIR="$(cd "$1" && pwd)"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+BUILD_TOOLS="$(ls -d "$ANDROID_HOME"/build-tools/* | sort -V | tail -1)"
+PLATFORM="$(ls -d "$ANDROID_HOME"/platforms/android-* | sort -V | tail -1)"
+WORK="$(mktemp -d)"
+
+unzip -o -q "$DEX_DIR/main.dex.jar" -d "$WORK"
+
+"$BUILD_TOOLS/aapt" package -f -M "$HERE/AndroidManifest.xml" -I "$PLATFORM/android.jar" \
+    -F "$WORK/app.unsigned.apk"
+
+(cd "$WORK" && "$BUILD_TOOLS/aapt" add app.unsigned.apk classes*.dex >/dev/null)
+
+"$BUILD_TOOLS/zipalign" -f 4 "$WORK/app.unsigned.apk" "$WORK/app.aligned.apk"
+
+# The standard persistent debug keystore (shared with Android Studio), created on first use:
+# reusing one key keeps successive builds mutually updatable on the device.
+KEYSTORE="$HOME/.android/debug.keystore"
+if [ ! -f "$KEYSTORE" ]; then
+  mkdir -p "$HOME/.android"
+  keytool -genkeypair -keystore "$KEYSTORE" -storepass android -keypass android \
+      -alias androiddebugkey -dname "CN=Android Debug,O=Android,C=US" \
+      -keyalg RSA -keysize 2048 -validity 10000 2>/dev/null
+fi
+
+"$BUILD_TOOLS/apksigner" sign --ks "$KEYSTORE" --ks-pass pass:android \
+    --key-pass pass:android --out "$DEX_DIR/dice.apk" "$WORK/app.aligned.apk"
+
+echo "APK: $DEX_DIR/dice.apk"

--- a/tests/android/src/dice.scala
+++ b/tests/android/src/dice.scala
@@ -86,11 +86,13 @@ class DiceActivity extends Activity:
         left.setText(faces(random.nextInt(0, 6)))
         right.setText(faces(random.nextInt(0, 6)))
 
-        handler.postDelayed(new Runnable { def run(): Unit = animate(frames - 1) }, 45L)
+        // A lambda satisfies any Java functional-interface parameter: a nullary lambda is
+        // always fully typed, so `Runnable` needs no ascription at all…
+        handler.postDelayed(() => animate(frames - 1), 45L)
 
-    button.setOnClickListener:
-      new View.OnClickListener:
-        def onClick(view: View): Unit = animate(6)
+    // …and a unary lambda needs only its parameter's type (`Dynamic` erases the expected type,
+    // so the parameter cannot be inferred), with no anonymous class or `override` in sight.
+    button.setOnClickListener((_: View) => animate(6))
 
     val row = Kotlin.make[LinearLayout](this)
     row.setOrientation(LinearLayout.HORIZONTAL)

--- a/tests/android/src/dice.scala
+++ b/tests/android/src/dice.scala
@@ -1,0 +1,109 @@
+package dice
+
+import soundness.*
+
+import android.app.Activity
+import android.os.{Bundle, Handler, Looper, VibrationEffect, Vibrator}
+import android.view.{Gravity, View}
+import android.widget.{Button, LinearLayout, TextView, Toast}
+
+// The Dice Roller from Google's "Android Basics" codelab, grown up a little: two dice, an
+// animated roll, haptics, running statistics and a roll history — built programmatically (no
+// XML layouts). Android's APIs are reached through xenophile's Kotlin facades — every call
+// materializes as a direct JVM call, typechecked at compile time against the platform — while
+// the rolls come from Kotlin's own `kotlin.random.Random` companion, the die colors are
+// computed by iridescence (a golden-angle walk around the HSV hue circle), and the history
+// line is joined by gossamer: Soundness libraries running on ART, straight out of the dexer.
+class DiceActivity extends Activity:
+  override def onCreate(saved: Bundle): Unit =
+    super.onCreate(saved)
+
+    // The activity itself joins facade-land (at its platform type: `DiceActivity` is still
+    // being compiled, so only `Activity` is resolvable), and then even the final handoff to
+    // the platform — `setContentView` — is a facade call, and facades never need unwrapping.
+    val activity = Facade(this: Activity)
+    val faces = IArray(t"⚀", t"⚁", t"⚂", t"⚃", t"⚄", t"⚅")
+
+    var rolls = 0
+    var total = 0
+    var history: List[Text] = Nil
+
+    val random = companion[kotlin.random.Random]
+    val vibrator = Facade(getSystemService(classOf[Vibrator]))
+    val handler = Kotlin.make[Handler](Looper.getMainLooper)
+
+    def textView(size: Float): Facade over TextView =
+      val view = Kotlin.make[TextView](this)
+      view.setTextSize(size)
+      view.setGravity(Gravity.CENTER_HORIZONTAL)
+      view
+
+    val left = textView(110.0f)
+    val right = textView(110.0f)
+    val stats = textView(18.0f)
+    val historyView = textView(24.0f)
+
+    left.setText(faces(0))
+    right.setText(faces(0))
+    stats.setText(t"Tap ROLL to begin")
+
+    val button = Kotlin.make[Button](this)
+    button.setText(t"Roll")
+
+    // Each roll advances the hue by the golden angle; iridescence converts HSV to sRGB, and
+    // the platform packs the channels.
+    def dieColor(roll: Int): Int =
+      val srgb = Hsv((roll*0.381966) % 1.0, 0.65, 0.75).to[Srgb]
+
+      android.graphics.Color.rgb
+        ((srgb.red*255).toInt, (srgb.green*255).toInt, (srgb.blue*255).toInt)
+
+    def settle(): Unit =
+      val first = random.nextInt(0, 6)
+      val second = random.nextInt(0, 6)
+      rolls += 1
+      total += first + second + 2
+
+      val color = dieColor(rolls)
+      left.setText(faces(first))
+      right.setText(faces(second))
+      left.setTextColor(color)
+      right.setTextColor(color)
+
+      history = (t"${faces(first)}${faces(second)}" :: history).take(6)
+      historyView.setText(history.join(t"  "))
+
+      val mean = ((total.toDouble/rolls*100).toInt/100.0).toString.tt
+      stats.setText(t"Rolls: $rolls   Total: $total   Mean: $mean")
+
+      vibrator.vibrate(VibrationEffect.createOneShot(40L, VibrationEffect.DEFAULT_AMPLITUDE))
+
+      if first == second then
+        Toast.makeText(this, t"Doubles!".s, Toast.LENGTH_SHORT).show()
+
+    def animate(frames: Int): Unit =
+      if frames == 0 then settle() else
+        left.setText(faces(random.nextInt(0, 6)))
+        right.setText(faces(random.nextInt(0, 6)))
+
+        handler.postDelayed(new Runnable { def run(): Unit = animate(frames - 1) }, 45L)
+
+    button.setOnClickListener:
+      new View.OnClickListener:
+        def onClick(view: View): Unit = animate(6)
+
+    val row = Kotlin.make[LinearLayout](this)
+    row.setOrientation(LinearLayout.HORIZONTAL)
+    row.setGravity(Gravity.CENTER)
+    row.addView(left)
+    row.addView(right)
+
+    val layout = Kotlin.make[LinearLayout](this)
+    layout.setOrientation(LinearLayout.VERTICAL)
+    layout.setGravity(Gravity.CENTER)
+    layout.addView(row)
+    layout.addView(stats)
+    layout.addView(historyView)
+    layout.addView(button)
+
+    activity.setContentView(layout)


### PR DESCRIPTION
Completes anthology's Android support: a compilation can now be linked all the way to a signed, installable `Artifact.Apk` with no Android SDK build tool involved.

Five pieces build on the existing DEX (#1646) and Kotlin-facade (#1650) work:

- **zeppelin alignment** — `Zip.Entry.aligned(n)` places a stored entry's data on an n-byte boundary (what `zipalign` does).
- **`Facade#unwrap`** is now transparently typed by the facade's underlying type, so handing a Kotlin/Java value back to a plain API needs no cast.
- **Java-SAM lambda adaptation** — a typed Scala lambda passed where a facade expects a Java functional interface (`Runnable`, `View.OnClickListener`, `java.util.function.*`) is adapted through a dynamic proxy, so a click listener is `button.setOnClickListener((_: View) => animate(6))` — no anonymous class, no `override`.
- **`anthology.apk`** — links `Artifact.Apk`: it dexes the code, encodes the binary manifest itself (`Axml`), zip-aligns the archive, and applies an APK Signature Scheme v2 signature (gastronomy digests + `java.security` RSA), replacing `aapt2`, `zipalign` and `apksigner`.
- **An Android sample** (`tests/android`) — Google's Dice Roller, written in Scala against Android and Kotlin APIs through xenophile's facades, buildable as `./mill android.dex` (SDK-packaged) or `./mill android.apk` (pure). Verified running on a Pixel emulator.

## Android applications, end to end in Soundness

```scala
Linker[Artifact.Apk]
  ( List(apkOptions.minApi(26), apkOptions.label(t"Dice Roller"),
      apkOptions.permission(t"android.permission.VIBRATE")),
    List(Linker.EntryPoint(Fqcn(t"dice.DiceActivity"))) )
. link(compilation, out)   // out/app.apk — dexed, binary-manifested, aligned, v2-signed
```

Binary XML deliberately gets its own small typed model in the Android layer rather than becoming a Xylophone serialization format: AXML's namespaces-as-chunks, typed values and resource IDs are Android semantics, and Xylophone's AST has no namespace model. Certificate generation still reuses a debug keystore (a pure X.509 generator would be a follow-up, as would a Play `Artifact.Aab`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)