### PR TITLE
Infer untyped lambdas against Kotlin/Java facade methods

### DIFF
--- a/lib/xenophile/src/kotlin/xenophile.Facade.scala
+++ b/lib/xenophile/src/kotlin/xenophile.Facade.scala
@@ -79,7 +79,7 @@ object Facade extends prophesy.Completable:
 // statically-typed JVM call, transparently typed by the Kotlin metadata of the underlying
 // class: nullable results become `Optional`, `kotlin.String` becomes `Text`, and Kotlin-typed
 // results are wrapped as further facades.
-trait Facade extends Dynamic, Transportive:
+trait Facade extends Selectable, Dynamic, Transportive:
   // The underlying value at its erased runtime type; the emission machinery's accessor. User
   // code should prefer `unwrap`, which recovers the precise static type.
   def raw: Any

--- a/lib/xenophile/src/kotlin/xenophile.Kotlin.scala
+++ b/lib/xenophile/src/kotlin/xenophile.Kotlin.scala
@@ -42,7 +42,7 @@ import vacuous.*
 // mirrors WIT's `option` (`T | "none"`) and TypeScript's `T | "undefined"`.
 object Kotlin:
   // Instantiates a Kotlin class through its facade: `Kotlin.make[Pair[Text, Text]](t"a", t"b")`.
-  inline def make[kotlinType](inline arguments: Any*): Facade over kotlinType =
+  transparent inline def make[kotlinType](inline arguments: Any*): Any =
     ${KotlinFacade.construct[kotlinType]('arguments)}
 
 

--- a/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
+++ b/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
@@ -136,6 +136,23 @@ object KotlinFacade:
   // Refines a raw call into the facade-typed result: `kotlin.String` reads as `Text`, a
   // nullable result wraps as an `Optional`, primitives and substituted type parameters pass
   // through, and any other Kotlin-typed result wraps as a further `Facade`.
+  // Wraps a raw value as a facade of `repr`, carrying the same function-typed `Selectable`
+  // refinement `make` produces — so a facade *returned from a method call* also lets bare lambdas
+  // infer against its own functional-interface methods, not only a freshly-constructed one.
+  private def refinedFacade(using quotes: Quotes)
+    ( value: Expr[Any], repr: quotes.reflect.TypeRepr )
+  :   Expr[Any] =
+
+    import quotes.reflect.*
+
+    val facade = repr.asType.absolve match
+      case '[u] => '{Facade[u]($value.asInstanceOf[u])}.asTerm
+
+    // Cast to the refinement at term level: binding it as a type (`'[refined]`) would let its
+    // function members' capture sets escape the nested quote.
+    TypeApply(Select.unique(facade, "asInstanceOf"), List(Inferred(functionRefinement(repr))))
+    . asExprOf[Any]
+
   private def refined(using quotes: Quotes)(call: quotes.reflect.Term, km: Foreign.Type)
   :   Expr[Any] =
 
@@ -195,8 +212,8 @@ object KotlinFacade:
       case Foreign.Type.Named(name) if passthrough(name) => underlying.asType.absolve match
         case '[u] => '{${call.asExpr}.asInstanceOf[u]}
 
-      case _ => underlying.asType.absolve match
-        case '[u] => '{Facade[u](${call.asExpr}.asInstanceOf[u])}
+      case _ =>
+        refinedFacade(call.asExpr, underlying)
 
   // The receiver, unwrapped and cast to its full applied Scala type, so that member selection
   // substitutes the class's type parameters (`getFirst` on a `Pair[Text, Text]` types as
@@ -288,8 +305,13 @@ object KotlinFacade:
     // under explicit nulls; strip that first, or the interface's class symbol is invisible.
     solid(target).classSymbol match
       case Some(symbol) if isJavaFunctionalInterface(symbol) =>
+        // A functional interface has one abstract method — but, as Java's own rule allows, not
+        // counting public `Object` methods it redeclares (`Comparator` redeclares `equals`).
+        val objectMethods = Set("equals", "hashCode", "toString")
+
         val abstractMethods = symbol.methodMembers.filter: method =>
-          method.flags.is(Flags.Deferred) && !method.flags.is(Flags.Synthetic)
+          val deferred = method.flags.is(Flags.Deferred) && !method.flags.is(Flags.Synthetic)
+          deferred && !objectMethods.contains(method.name)
 
         abstractMethods match
           case List(method) => (method, method.paramSymss.flatten.length)
@@ -408,25 +430,48 @@ object KotlinFacade:
     val base = Refinement(TypeRepr.of[Facade], "Transport", TypeBounds(repr, repr))
 
     repr.classSymbol.fold(base): classSymbol =>
-      def singleSam(method: Symbol): Boolean =
+      // The refinement's declared result type must equal what `applyDynamic` returns at runtime,
+      // or the two disagree. That holds for `Unit` and primitive/boolean results (which map to
+      // themselves); a method returning a mapped reference type (a `Facade`, `Text`, `Optional`)
+      // is left to the `Dynamic` path, where a bare lambda argument still cannot infer.
+      def plainResult(result: TypeRepr): Boolean =
+        val mapped = solid(result)
+        mapped =:= TypeRepr.of[Unit] || mapped <:< TypeRepr.of[AnyVal]
+
+      // A method worth refining: it has at least one functional-interface parameter (so a lambda
+      // argument benefits) and a plain result.
+      def candidate(method: Symbol): Boolean =
         val usable = !method.flags.is(Flags.Synthetic) && !method.flags.is(Flags.Private)
 
         usable && (repr.memberType(method) match
-          case MethodType(_, List(parameter), _) => samFunctionType(parameter).present
-          case _                                 => false)
+          case MethodType(_, parameters, result) =>
+            parameters.exists(samFunctionType(_).present) && plainResult(result)
 
-      // One method per name (overrides and bridges duplicate a name in `methodMembers`); a name
-      // with two genuinely different single-SAM signatures is a rare overload — take the first.
+          case _ =>
+            false)
+
+      // One method per name (overrides and bridges duplicate a name in `methodMembers`); among a
+      // name's candidates take the fewest-parameter one — the public convenience overload,
+      // rather than an internal arity-padded variant (`removeIf(p, from, to)`).
+      def arity(method: Symbol): Int = repr.memberType(method) match
+        case MethodType(_, parameters, _) => parameters.length
+        case _                            => Int.MaxValue
+
       val candidates =
-        classSymbol.methodMembers.filter(singleSam).groupBy(_.name).values.map(_.head).to(List)
+        classSymbol.methodMembers.filter(candidate).groupBy(_.name).values
+        . map(_.minBy(arity(_))).to(List)
+
+      // A functional-interface parameter becomes a Scala function (so a lambda there infers);
+      // every other parameter stays `Any`, exactly as the `Dynamic` path accepts it (preserving
+      // the argument adaptations — `Text` for `String`, facade unwrapping — for non-lambda args).
+      def parameterType(parameter: TypeRepr): TypeRepr =
+        samFunctionType(parameter).or(TypeRepr.of[Any])
 
       candidates.foldLeft(base): (accumulated, method) =>
         repr.memberType(method).absolve match
-          case MethodType(names, List(parameter), result) =>
-            val function = samFunctionType(parameter).vouch
-
+          case MethodType(names, parameters, result) =>
             val signature =
-              MethodType(names)(_ => List(function), _ => solid(result))
+              MethodType(names)(_ => parameters.map(parameterType), _ => solid(result))
 
             Refinement(accumulated, method.name, signature)
 

--- a/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
+++ b/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
@@ -37,7 +37,6 @@ import scala.quoted.*
 import anticipation.*
 import fulminate.*
 import gossamer.*
-import prepositional.*
 import rudiments.*
 import vacuous.*
 
@@ -285,7 +284,9 @@ object KotlinFacade:
 
     import quotes.reflect.*
 
-    target.classSymbol match
+    // A Java method's parameter arrives as a flexible/nullable type (`Predicate[…] | Null`)
+    // under explicit nulls; strip that first, or the interface's class symbol is invisible.
+    solid(target).classSymbol match
       case Some(symbol) if isJavaFunctionalInterface(symbol) =>
         val abstractMethods = symbol.methodMembers.filter: method =>
           method.flags.is(Flags.Deferred) && !method.flags.is(Flags.Synthetic)
@@ -360,6 +361,77 @@ object KotlinFacade:
               }
 
           proxy.asTerm
+
+  // The Scala function type a Java functional-interface parameter maps to. Refining a method's
+  // parameter to this — rather than leaving it `Any` under `Dynamic` — is what lets an untyped
+  // lambda argument infer its parameter types: the refinement supplies the expected type.
+  private def samFunctionType(using quotes: Quotes)(target: quotes.reflect.TypeRepr)
+  :   Optional[quotes.reflect.TypeRepr] =
+
+    import quotes.reflect.*
+
+    // Resolve the interface's own wildcard type arguments to concrete types first
+    // (`Predicate<? super Text>` → `Predicate[Text]`), so the single abstract method's
+    // signature substitutes cleanly instead of leaving an unusable `Predicate[…]#T` projection.
+    // A wildcard collapses to its lower bound when it has one (the parameter position of a
+    // consumer-like interface), otherwise its upper bound.
+    def resolved(bound: TypeRepr): TypeRepr = bound match
+      case TypeBounds(low, high) =>
+        if low =:= TypeRepr.of[Nothing] then solid(high) else solid(low)
+
+      case other =>
+        solid(other)
+
+    val concrete = solid(target).dealias match
+      case AppliedType(constructor, args) => constructor.appliedTo(args.map(resolved))
+      case other                          => other
+
+    javaSam(concrete).let: (method, arity) =>
+      concrete.memberType(method).absolve match
+        case MethodType(_, paramTypes, resultType) =>
+          val args = paramTypes.map(solid(_)) :+ solid(resultType)
+          defn.FunctionClass(arity).typeRef.appliedTo(args)
+
+        case _ =>
+          Unset
+
+  // Refines `Facade over T` with those of T's methods that take a single functional-interface
+  // parameter, typing that parameter as a Scala function. A `Selectable` structural member: the
+  // refinement gives the call site a real function expected type (so a bare lambda infers),
+  // while runtime dispatch stays with `applyDynamic`, which adapts the function to the interface.
+  // Overloaded names are skipped (a refinement cannot express two members of one name).
+  private def functionRefinement(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
+  :   quotes.reflect.TypeRepr =
+
+    import quotes.reflect.*
+
+    val base = Refinement(TypeRepr.of[Facade], "Transport", TypeBounds(repr, repr))
+
+    repr.classSymbol.fold(base): classSymbol =>
+      def singleSam(method: Symbol): Boolean =
+        val usable = !method.flags.is(Flags.Synthetic) && !method.flags.is(Flags.Private)
+
+        usable && (repr.memberType(method) match
+          case MethodType(_, List(parameter), _) => samFunctionType(parameter).present
+          case _                                 => false)
+
+      // One method per name (overrides and bridges duplicate a name in `methodMembers`); a name
+      // with two genuinely different single-SAM signatures is a rare overload — take the first.
+      val candidates =
+        classSymbol.methodMembers.filter(singleSam).groupBy(_.name).values.map(_.head).to(List)
+
+      candidates.foldLeft(base): (accumulated, method) =>
+        repr.memberType(method).absolve match
+          case MethodType(names, List(parameter), result) =>
+            val function = samFunctionType(parameter).vouch
+
+            val signature =
+              MethodType(names)(_ => List(function), _ => solid(result))
+
+            Refinement(accumulated, method.name, signature)
+
+          case _ =>
+            accumulated
 
   private def samArity(using quotes: Quotes)(target: quotes.reflect.TypeRepr): Optional[Int] =
     target.classSymbol.map(_.fullName).getOrElse("") match
@@ -705,8 +777,7 @@ object KotlinFacade:
 
     refined(call, prototype.result)
 
-  def construct[kotlinType: Type](arguments: Expr[Seq[Any]])(using Quotes)
-  :   Expr[Facade over kotlinType] =
+  def construct[kotlinType: Type](arguments: Expr[Seq[Any]])(using Quotes): Expr[Any] =
 
     import quotes.reflect.*
 
@@ -756,7 +827,13 @@ object KotlinFacade:
 
     val created = Apply(application, adaptedArgs)
 
-    '{Facade[kotlinType](${created.asExprOf[Any]}.asInstanceOf[kotlinType])}
+    // Refine the facade type with function-typed methods, so lambdas passed to them infer
+    // (`list.removeIf(x => …)` with no ascription). The tree's `asInstanceOf[refined]` carries
+    // the precise type out through `make`'s transparent inlining.
+    functionRefinement(repr).asType.absolve match
+      case '[refined] =>
+        val facade = '{Facade[kotlinType](${created.asExprOf[Any]}.asInstanceOf[kotlinType])}
+        '{$facade.asInstanceOf[refined]}
 
   def companion[kotlinType: Type](using Quotes): Expr[Any] =
     import quotes.reflect.*

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -278,6 +278,13 @@ object Tests extends Suite(m"Xenophile tests"):
         size
       . assert(_ == 1)
 
+      test(m"an UNTYPED lambda infers against a functional-interface method"):
+        val list = Kotlin.make[java.util.ArrayList[Text]](List(t"a", t"bb", t"ccc"))
+        list.removeIf(text => text.length > 1)   // no ascription on `text`
+        val size: Int = list.size()
+        size
+      . assert(_ == 1)
+
       test(m"a nullary lambda satisfies a Runnable parameter with no ascription"):
         var ran = false
         val thread = Kotlin.make[java.lang.Thread](() => ran = true)

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -285,6 +285,19 @@ object Tests extends Suite(m"Xenophile tests"):
         size
       . assert(_ == 1)
 
+      test(m"an UNTYPED multi-argument lambda infers (an arity-2 interface)"):
+        val list = Kotlin.make[java.util.ArrayList[Text]](List(t"ccc", t"a", t"bb"))
+        list.sort((left, right) => left.length - right.length)   // no ascriptions
+        list.get(0).unwrap.toString.tt
+      . assert(_ == t"a")
+
+      test(m"an UNTYPED lambda infers on a facade RETURNED from a method"):
+        val list = Kotlin.make[java.util.ArrayList[Text]](List(t"a", t"bb", t"ccc", t"d"))
+        val sub = list.subList(0, 3)             // a facade returned from a call
+        sub.removeIf(text => text.length > 1)    // untyped lambda on the returned facade
+        sub.size()
+      . assert(_ == 1)
+
       test(m"a nullary lambda satisfies a Runnable parameter with no ascription"):
         var ran = false
         val thread = Kotlin.make[java.lang.Thread](() => ran = true)

--- a/tests/android/src/dice.scala
+++ b/tests/android/src/dice.scala
@@ -90,9 +90,9 @@ class DiceActivity extends Activity:
         // always fully typed, so `Runnable` needs no ascription at all…
         handler.postDelayed(() => animate(frames - 1), 45L)
 
-    // …and a unary lambda needs only its parameter's type (`Dynamic` erases the expected type,
-    // so the parameter cannot be inferred), with no anonymous class or `override` in sight.
-    button.setOnClickListener((_: View) => animate(6))
+    // …and a unary lambda on a freshly-made facade infers even its parameter type, from the
+    // functional interface, through the facade's generated `Selectable` refinement.
+    button.setOnClickListener: view => animate(6)
 
     val row = Kotlin.make[LinearLayout](this)
     row.setOrientation(LinearLayout.HORIZONTAL)

--- a/tests/android/src/dice.scala
+++ b/tests/android/src/dice.scala
@@ -86,13 +86,14 @@ class DiceActivity extends Activity:
         left.setText(faces(random.nextInt(0, 6)))
         right.setText(faces(random.nextInt(0, 6)))
 
-        // A lambda satisfies any Java functional-interface parameter: a nullary lambda is
-        // always fully typed, so `Runnable` needs no ascription at all…
-        handler.postDelayed(() => animate(frames - 1), 45L)
+        // A lambda satisfies any Java functional-interface parameter, inferring its parameter
+        // types with no ascription (`postDelayed` takes a `Runnable`). Its `Boolean` result is
+        // discarded.
+        val _ = handler.postDelayed(() => animate(frames - 1), 45L)
 
-    // …and a unary lambda on a freshly-made facade infers even its parameter type, from the
-    // functional interface, through the facade's generated `Selectable` refinement.
-    button.setOnClickListener: view => animate(6)
+    // …and a unary lambda infers even its parameter type, from the functional interface,
+    // through the facade's generated `Selectable` refinement.
+    button.setOnClickListener(view => animate(6))
 
     val row = Kotlin.make[LinearLayout](this)
     row.setOrientation(LinearLayout.HORIZONTAL)


### PR DESCRIPTION
Kotlin facades gain a macro-generated `Selectable` refinement that types functional-interface parameters as Scala functions, so a bare lambda passed to a facade method infers its parameter types with no ascription — `button.setOnClickListener(view => animate(6))`, `list.sort((a, b) => …)`. It applies to both `make`-constructed facades and those returned from method calls, and to single- and multi-parameter methods and multi-argument interfaces. `Facade` gains `Selectable` alongside `Dynamic`; runtime dispatch is unchanged (the lambda is still adapted to the interface by a proxy). Only methods with a `Unit`/primitive result are refined, so a method's declared result always matches what it returns; reference-returning functional-interface methods and nullable-returned facades remain on the `Dynamic` path (a bare lambda there still needs its parameter types written).

## Bare lambdas for Kotlin/Java interfaces

```scala
val list = Kotlin.make[java.util.ArrayList[Text]](List(t"ccc", t"a", t"bb"))
list.removeIf(text => text.length > 1)              // unary — no ascription
list.sort((left, right) => left.length - right.length)   // arity-2 Comparator

list.subList(0, 2).removeIf(text => text.isEmpty)   // also on a returned facade
```

The underlying mechanism: a `transparent inline` construction/navigation returns a facade whose type carries a refinement declaring each functional-interface-parameter method with a Scala-function parameter type. That gives the call site a real expected type, so the compiler infers the lambda's parameters natively; at runtime the function is still adapted to the interface through a dynamic proxy, exactly as before. A functional-interface parameter becomes a function; every other parameter stays `Any`, preserving the argument adaptations (`Text` for `String`, facade unwrapping) the `Dynamic` path provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)