### PR TITLE
Top-level make, and argument fitting by widening and conversions

### DIFF
--- a/lib/xenophile/src/kotlin/soundness_xenophile_kotlin.scala
+++ b/lib/xenophile/src/kotlin/soundness_xenophile_kotlin.scala
@@ -32,5 +32,5 @@
                                                                                                   */
 package soundness
 
-export xenophile.{companion, entry, singleton, Facade, Kotlin, KotlinDialect, KotlinFacade,
+export xenophile.{companion, entry, make, singleton, Facade, Kotlin, KotlinDialect, KotlinFacade,
     KotlinInvoke, KotlinRuntime, kotlinInvocation}

--- a/lib/xenophile/src/kotlin/xenophile.Kotlin.scala
+++ b/lib/xenophile/src/kotlin/xenophile.Kotlin.scala
@@ -41,10 +41,6 @@ import vacuous.*
 // classpath. A nullable Kotlin type `T?` resolves as `T | "null"`, so `Optional` interop
 // mirrors WIT's `option` (`T | "none"`) and TypeScript's `T | "undefined"`.
 object Kotlin:
-  // Instantiates a Kotlin class through its facade: `Kotlin.make[Pair[Text, Text]](t"a", t"b")`.
-  transparent inline def make[kotlinType](inline arguments: Any*): Any =
-    ${KotlinFacade.construct[kotlinType]('arguments)}
-
 
   given int: (Int is Interoperable in Kotlin of "kotlin.Int") =
     Interoperable[Int, Kotlin, "kotlin.Int"]()

--- a/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
+++ b/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
@@ -248,7 +248,7 @@ object KotlinFacade:
     val functional = samCompatible(argument, target) || proxyCompatible(argument, target)
     val bridged = functional || collectionCompatible(argument.tpe.widen, target)
 
-    direct || bridged
+    direct || bridged || converted(argument, target).present
 
   // Whether a Scala collection argument can satisfy a Java collection parameter through an
   // `asJava` view (constant-time, no copy).
@@ -584,6 +584,51 @@ object KotlinFacade:
 
   // The argument term as passed to the JVM method: facades unwrap, and anything not already
   // conforming (an opaque `Text` against `String`) is cast, which is free at runtime.
+  // An argument fitted to a parameter it does not directly conform to, when the gap is closable:
+  // by primitive numeric widening (`45` to a `Long` parameter), or by an in-scope
+  // `scala.Conversion`. `Unset` when no conversion applies. Used both to judge a candidate
+  // overload and to emit the fitted argument, so the two never disagree.
+  private def converted(using quotes: Quotes)
+    ( argument: quotes.reflect.Term, parameter: quotes.reflect.TypeRepr )
+  :   Optional[quotes.reflect.Term] =
+
+    import quotes.reflect.*
+
+    val from = argument.tpe.widen
+    val to = solid(parameter)
+
+    // The rank of a primitive numeric type in the widening order (`Char` sits with `Short`).
+    def rank(repr: TypeRepr): Optional[Int] =
+      if repr =:= TypeRepr.of[Byte] then 0
+      else if repr =:= TypeRepr.of[Short] then 1
+      else if repr =:= TypeRepr.of[Char] then 1
+      else if repr =:= TypeRepr.of[Int] then 2
+      else if repr =:= TypeRepr.of[Long] then 3
+      else if repr =:= TypeRepr.of[Float] then 4
+      else if repr =:= TypeRepr.of[Double] then 5
+      else Unset
+
+    def conversionMethod(repr: TypeRepr): Optional[Text] =
+      if repr =:= TypeRepr.of[Short] then t"toShort"
+      else if repr =:= TypeRepr.of[Int] then t"toInt"
+      else if repr =:= TypeRepr.of[Long] then t"toLong"
+      else if repr =:= TypeRepr.of[Float] then t"toFloat"
+      else if repr =:= TypeRepr.of[Double] then t"toDouble"
+      else Unset
+
+    val widened: Optional[Term] =
+      rank(from).let: low =>
+        rank(to).let: high =>
+          if low < high then conversionMethod(to).let(m => Select.unique(argument, m.s))
+          else Unset
+
+    // Failing a numeric widening, an in-scope implicit conversion `from => to`.
+    widened.or:
+      (from.asType, to.asType).absolve match
+        case ('[a], '[b]) => Expr.summon[Conversion[a, b]] match
+          case Some(conversion) => '{$conversion(${argument.asExprOf[a]})}.asTerm
+          case None             => Unset
+
   private def adapted(using quotes: Quotes)
     ( argument: quotes.reflect.Term, parameter: quotes.reflect.TypeRepr )
   :   quotes.reflect.Term =
@@ -601,7 +646,8 @@ object KotlinFacade:
       else argument
 
     if unwrapped.tpe <:< parameter then unwrapped
-    else TypeApply(Select.unique(unwrapped, "asInstanceOf"), List(Inferred(solid(parameter))))
+    else converted(unwrapped, parameter).or:
+      TypeApply(Select.unique(unwrapped, "asInstanceOf"), List(Inferred(solid(parameter))))
 
   private def parameterTypes(using quotes: Quotes)
     ( repr: quotes.reflect.TypeRepr, method: quotes.reflect.Symbol )

--- a/lib/xenophile/src/kotlin/xenophile_kotlin.scala
+++ b/lib/xenophile/src/kotlin/xenophile_kotlin.scala
@@ -32,6 +32,10 @@
                                                                                                   */
 package xenophile
 
+// Constructs a Kotlin class through its facade: `make[Pair[Text, Text]](t"a", t"b")`.
+transparent inline def make[kotlinType](inline arguments: Any*): Any =
+  ${KotlinFacade.construct[kotlinType]('arguments)}
+
 // The facade of a Kotlin class's companion object, through which its members are reachable:
 // `companion[Regex].escape(t"a.b")`.
 transparent inline def companion[kotlinType]: Any = ${KotlinFacade.companion[kotlinType]}

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -101,7 +101,7 @@ object Tests extends Suite(m"Xenophile tests"):
       . assert(_.nonEmpty)
 
     suite(m"Kotlin facades"):
-      val pair = Kotlin.make[kotlin.Pair[Text, Text]](t"a", t"b")
+      val pair = make[kotlin.Pair[Text, Text]](t"a", t"b")
 
       test(m"a Kotlin class constructs through its facade"):
         pair.unwrap.toString.tt
@@ -117,7 +117,7 @@ object Tests extends Suite(m"Xenophile tests"):
         second
       . assert(_ == t"b")
 
-      val regex = Kotlin.make[kotlin.text.Regex](t"[0-9]+")
+      val regex = make[kotlin.text.Regex](t"[0-9]+")
 
       test(m"an instance method accepts Text for a CharSequence parameter"):
         val matches: Boolean = regex.matches(t"123")
@@ -144,12 +144,12 @@ object Tests extends Suite(m"Xenophile tests"):
 
       test(m"an unknown property is rejected"):
         demilitarize:
-          Kotlin.make[kotlin.Pair[Text, Text]](t"a", t"b").third
+          make[kotlin.Pair[Text, Text]](t"a", t"b").third
       . assert(_.nonEmpty)
 
       test(m"a wrongly-typed constructor argument is rejected"):
         demilitarize:
-          Kotlin.make[kotlin.text.Regex](42)
+          make[kotlin.text.Regex](42)
       . assert(_.nonEmpty)
 
       test(m"a companion object's members are reachable"):
@@ -159,7 +159,7 @@ object Tests extends Suite(m"Xenophile tests"):
 
       test(m"an unknown member's error suggests near misses in Kotlin syntax"):
         demilitarize:
-          Kotlin.make[kotlin.text.Regex](t"x").matchez(t"y")
+          make[kotlin.text.Regex](t"x").matchez(t"y")
         . map(_.message)
       . assert(_.exists(_.contains("did you mean")))
 
@@ -183,7 +183,7 @@ object Tests extends Suite(m"Xenophile tests"):
       . assert(_ == t"33x44")
 
       test(m"a var property accepts assignment through its setter"):
-        val parameter = Kotlin.make[kotlin.metadata.KmValueParameter](t"x")
+        val parameter = make[kotlin.metadata.KmValueParameter](t"x")
         parameter.name = t"y"
         val name: Text = parameter.name
         name
@@ -191,7 +191,7 @@ object Tests extends Suite(m"Xenophile tests"):
 
       test(m"assignment to a val property is rejected"):
         demilitarize:
-          Kotlin.make[kotlin.Pair[Text, Text]](t"a", t"b").first = t"z"
+          make[kotlin.Pair[Text, Text]](t"a", t"b").first = t"z"
       . assert(_.nonEmpty)
 
       test(m"an object singleton's constant properties are reachable"):
@@ -215,11 +215,11 @@ object Tests extends Suite(m"Xenophile tests"):
       // Note `unwrap.toString`: `toString`/`equals`/`hashCode` are real members of the facade
       // wrapper itself, so `Dynamic` cannot intercept them.
       test(m"a plain Java class resolves through the reflection fallback"):
-        Kotlin.make[java.lang.StringBuilder](t"ab").reverse().unwrap.toString.tt
+        make[java.lang.StringBuilder](t"ab").reverse().unwrap.toString.tt
       . assert(_ == t"ba")
 
       test(m"an enum entry is reachable by name, and usable as an argument"):
-        val relaxed = Kotlin.make[kotlin.text.Regex]
+        val relaxed = make[kotlin.text.Regex]
           ( t"[a-z]+", entry[kotlin.text.RegexOption]("IGNORE_CASE") )
 
         val matches: Boolean = relaxed.matches(t"ABC")
@@ -233,7 +233,7 @@ object Tests extends Suite(m"Xenophile tests"):
       . assert(_.exists(_.contains("IGNORE_CASE")))
 
       test(m"a data class destructures into a typed tuple"):
-        Kotlin.make[kotlin.Pair[Text, Text]](t"a", t"b").tuple
+        make[kotlin.Pair[Text, Text]](t"a", t"b").tuple
       . assert(_ == (t"a", t"b"))
 
       test(m"a Kotlin list result copies out as a Scala List of Text"):
@@ -256,13 +256,13 @@ object Tests extends Suite(m"Xenophile tests"):
       . assert(_.exists(_.contains("input")))
 
       test(m"a Scala List argument satisfies a Java collection parameter"):
-        val wrapped = Kotlin.make[java.util.ArrayList[Text]](List(t"a", t"b"))
+        val wrapped = make[java.util.ArrayList[Text]](List(t"a", t"b"))
         val size: Int = wrapped.size()
         size
       . assert(_ == 2)
 
       test(m"surplus arguments collect into a vararg tail"):
-        Kotlin.make[java.util.Formatter]().format(t"[%s:%s]", t"x", t"y").unwrap.toString.tt
+        make[java.util.Formatter]().format(t"[%s:%s]", t"x", t"y").unwrap.toString.tt
       . assert(_ == t"[x:y]")
 
       test(m"a value-class member is rejected with a clear diagnostic"):
@@ -272,35 +272,50 @@ object Tests extends Suite(m"Xenophile tests"):
       . assert(_.exists(_.contains("value class")))
 
       test(m"a typed lambda satisfies a Java functional-interface parameter"):
-        val list = Kotlin.make[java.util.ArrayList[Text]](List(t"a", t"bb", t"ccc"))
-        list.removeIf((text: Text) => text.length > 1)
+        val list = make[java.util.ArrayList[Text]](List(t"a", t"bb", t"ccc"))
+        val _ = list.removeIf((text: Text) => text.length > 1)
         val size: Int = list.size()
         size
       . assert(_ == 1)
 
       test(m"an UNTYPED lambda infers against a functional-interface method"):
-        val list = Kotlin.make[java.util.ArrayList[Text]](List(t"a", t"bb", t"ccc"))
-        list.removeIf(text => text.length > 1)   // no ascription on `text`
+        val list = make[java.util.ArrayList[Text]](List(t"a", t"bb", t"ccc"))
+        val _ = list.removeIf(text => text.length > 1)   // no ascription on `text`
         val size: Int = list.size()
         size
       . assert(_ == 1)
 
       test(m"an UNTYPED multi-argument lambda infers (an arity-2 interface)"):
-        val list = Kotlin.make[java.util.ArrayList[Text]](List(t"ccc", t"a", t"bb"))
-        list.sort((left, right) => left.length - right.length)   // no ascriptions
+        val list = make[java.util.ArrayList[Text]](List(t"ccc", t"a", t"bb"))
+        val _ = list.sort((left, right) => left.length - right.length)   // no ascriptions
         list.get(0).unwrap.toString.tt
       . assert(_ == t"a")
 
       test(m"an UNTYPED lambda infers on a facade RETURNED from a method"):
-        val list = Kotlin.make[java.util.ArrayList[Text]](List(t"a", t"bb", t"ccc", t"d"))
+        val list = make[java.util.ArrayList[Text]](List(t"a", t"bb", t"ccc", t"d"))
         val sub = list.subList(0, 3)             // a facade returned from a call
-        sub.removeIf(text => text.length > 1)    // untyped lambda on the returned facade
+        val _ = sub.removeIf(text => text.length > 1)    // untyped lambda on the returned facade
         sub.size()
       . assert(_ == 1)
 
+      test(m"an Int argument widens to a Long parameter, no `L` suffix"):
+        // Both the constructor and `addAndGet` take `long`; the arguments are plain `Int`s.
+        val counter = make[java.util.concurrent.atomic.AtomicLong](0)
+        val _ = counter.addAndGet(5)
+        counter.get()
+      . assert(_ == 5L)
+
+      test(m"an in-scope Conversion fits an argument to a parameter"):
+        given Conversion[Int, Text] = _.toString.tt
+        // `ArrayList.add(E)` expects a `Text`; pass an `Int`, fitted by the conversion.
+        val list = make[java.util.ArrayList[Text]](List())
+        val _ = list.add(42)
+        list.get(0).unwrap.toString.tt
+      . assert(_ == t"42")
+
       test(m"a nullary lambda satisfies a Runnable parameter with no ascription"):
         var ran = false
-        val thread = Kotlin.make[java.lang.Thread](() => ran = true)
+        val thread = make[java.lang.Thread](() => ran = true)
         thread.run()
         ran
       . assert(_ == true)

--- a/tests/android/src/dice.scala
+++ b/tests/android/src/dice.scala
@@ -7,6 +7,8 @@ import android.os.{Bundle, Handler, Looper, VibrationEffect, Vibrator}
 import android.view.{Gravity, View}
 import android.widget.{Button, LinearLayout, TextView, Toast}
 
+given Decimalizer(3)
+
 // The Dice Roller from Google's "Android Basics" codelab, grown up a little: two dice, an
 // animated roll, haptics, running statistics and a roll history — built programmatically (no
 // XML layouts). Android's APIs are reached through xenophile's Kotlin facades — every call
@@ -22,7 +24,7 @@ class DiceActivity extends Activity:
     // being compiled, so only `Activity` is resolvable), and then even the final handoff to
     // the platform — `setContentView` — is a facade call, and facades never need unwrapping.
     val activity = Facade(this: Activity)
-    val faces = IArray(t"⚀", t"⚁", t"⚂", t"⚃", t"⚄", t"⚅")
+    val faces = IArray("⚀", "⚁", "⚂", "⚃", "⚄", "⚅")
 
     var rolls = 0
     var total = 0
@@ -30,25 +32,25 @@ class DiceActivity extends Activity:
 
     val random = companion[kotlin.random.Random]
     val vibrator = Facade(getSystemService(classOf[Vibrator]))
-    val handler = Kotlin.make[Handler](Looper.getMainLooper)
+    val handler = make[Handler](Looper.getMainLooper)
 
     def textView(size: Float): Facade over TextView =
-      val view = Kotlin.make[TextView](this)
+      val view = make[TextView](this)
       view.setTextSize(size)
       view.setGravity(Gravity.CENTER_HORIZONTAL)
       view
 
-    val left = textView(110.0f)
-    val right = textView(110.0f)
-    val stats = textView(18.0f)
-    val historyView = textView(24.0f)
+    val left = textView(110.0)
+    val right = textView(110.0)
+    val stats = textView(18.0)
+    val historyView = textView(24.0)
 
     left.setText(faces(0))
     right.setText(faces(0))
-    stats.setText(t"Tap ROLL to begin")
+    stats.setText("Tap ROLL to begin")
 
-    val button = Kotlin.make[Button](this)
-    button.setText(t"Roll")
+    val button = make[Button](this)
+    button.setText("Roll")
 
     // Each roll advances the hue by the golden angle; iridescence converts HSV to sRGB, and
     // the platform packs the channels.
@@ -73,13 +75,13 @@ class DiceActivity extends Activity:
       history = (t"${faces(first)}${faces(second)}" :: history).take(6)
       historyView.setText(history.join(t"  "))
 
-      val mean = ((total.toDouble/rolls*100).toInt/100.0).toString.tt
+      val mean = ((total.toDouble/rolls*100).toInt/100.0).show
       stats.setText(t"Rolls: $rolls   Total: $total   Mean: $mean")
 
       vibrator.vibrate(VibrationEffect.createOneShot(40L, VibrationEffect.DEFAULT_AMPLITUDE))
 
       if first == second then
-        Toast.makeText(this, t"Doubles!".s, Toast.LENGTH_SHORT).show()
+        Toast.makeText(this, "Doubles!", Toast.LENGTH_SHORT).show()
 
     def animate(frames: Int): Unit =
       if frames == 0 then settle() else
@@ -89,19 +91,19 @@ class DiceActivity extends Activity:
         // A lambda satisfies any Java functional-interface parameter, inferring its parameter
         // types with no ascription (`postDelayed` takes a `Runnable`). Its `Boolean` result is
         // discarded.
-        val _ = handler.postDelayed(() => animate(frames - 1), 45L)
+        val _ = handler.postDelayed(() => animate(frames - 1), 45)
 
     // …and a unary lambda infers even its parameter type, from the functional interface,
     // through the facade's generated `Selectable` refinement.
     button.setOnClickListener(view => animate(6))
 
-    val row = Kotlin.make[LinearLayout](this)
+    val row = make[LinearLayout](this)
     row.setOrientation(LinearLayout.HORIZONTAL)
     row.setGravity(Gravity.CENTER)
     row.addView(left)
     row.addView(right)
 
-    val layout = Kotlin.make[LinearLayout](this)
+    val layout = make[LinearLayout](this)
     layout.setOrientation(LinearLayout.VERTICAL)
     layout.setGravity(Gravity.CENTER)
     layout.addView(row)


### PR DESCRIPTION
Two Kotlin-facade ergonomics improvements.

`make` becomes a top-level method (`make[T](…)` rather than `Kotlin.make[T](…)`), alongside the existing top-level `companion`, `singleton` and `entry`.

An argument that does not directly conform to a facade method's parameter is now fitted to it — by primitive numeric widening (`45` reaches a `Long` parameter with no `L` suffix) or by an in-scope `scala.Conversion` — in both overload selection and the emitted call, so the two never disagree. This generalizes the existing `Text`-for-`String` and facade-unwrapping adaptations.

## Fewer ceremony, more inference

```scala
val counter = make[java.util.concurrent.atomic.AtomicLong](0)  // Int widens to Long
counter.addAndGet(5)

given Conversion[Int, Text] = _.toString.tt
make[java.util.ArrayList[Text]](Nil).add(42)                    // Int fitted to Text
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)