### PR TITLE
Interpret semantic diagnostics with TASTy-reified types via Stenography

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -581,7 +581,7 @@ object soundness extends Toolchain:
   object tool extends Bundle(anthology.core, decorum.plugin, harlequin.core, hellenism.core,
     hyperbole.core, octogenarian.core, revolution.core, umbrageous.plugin, anthology.java,
     harlequin.md, harlequin.ansi, austronesian.core, anthology.linker, anthology.link, anthology.nir,
-    anthology.`scala`, exegesis.core, hellenism.jvm)
+    anthology.`scala`, exegesis.core, hellenism.jvm, delicious.core, delicious.`scala`)
 
   object web extends Bundle(archimedes.core, cacophony.core, cataclysm.core, coaxial.core, coaxial.jvm, cosmopolite.core, gesticulate.core,
     honeycomb.core, urticose.core, urticose.url, hallucination.core, phoenicia.core,
@@ -1187,6 +1187,21 @@ object decorum extends Library:
     override def scalaJs = false // compiler plugin: uses the JVM-only dotty compiler API
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
   object test extends Tests(plugin):
+    override def scalacOptions = Task:
+      settings.cc(super.scalacOptions())
+
+object delicious extends Library:
+  object core extends Component(gossamer.core, vacuous.core):
+    override def scalacOptions = Task:
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+
+  object `scala` extends Component(core, stenography.core, anthology.core):
+    override def scalaJs = false // wraps the Scala compiler (dotty)
+    override def scalacOptions = Task:
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+    def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
+
+  object test extends Tests(core, `scala`, anthology.`scala`):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
 
@@ -2640,7 +2655,7 @@ val allLibraries: Seq[Library] = Seq(
   burdock,
   cacophony, caduceus, caesura, camouflage, capricious, cardinality, cataclysm,
   charisma, chiaroscuro, coaxial, contextual, contingency, cosmopolite,
-  decorum, dendrology, denominative, digression, dissonance, distillate, diuretic,
+  decorum, delicious, dendrology, denominative, digression, dissonance, distillate, diuretic,
   embarcadero, enigmatic, escapade, escritoire, ethereal, eucalyptus, exegesis,
   exoskeleton, facsimile,
   frontier, fulminate, galilei, gastronomy, geodesy, gesticulate, gigantism,

--- a/build.mill
+++ b/build.mill
@@ -45,7 +45,7 @@ import publish.*
 import os.Path
 
 object settings:
-  // The Scala compiler is the propensive/scala fork: the 3.9.0-RC1 tree merged with the
+  // The Scala compiler is the propensive/scala fork: the 3.9.0-RC4 tree merged with the
   // capture-checking fix branches (the stock compiler mis-boxes pure values, mishandles quote
   // type-holes, alias and context-result capabilities, cast type-arguments, and cycles on JDK 25
   // sealed-classfile parsing — see rep/DECISIONS.md). It is consumed in one of two modes:
@@ -54,7 +54,7 @@ object settings:
   //      https://github.com/propensive/proscala/releases; each release ships a single
   //      `proscala-<tag>.tar.gz` asset whose contents are a `lib` directory (the unversioned core
   //      jars plus the versioned third-party jars). The `toolchain` module below downloads
-  //      `SOUNDNESS_SCALA_RELEASE` (default `3.9.0-RC1-p3`, the latest in the 3.9.0 stream) and
+  //      `SOUNDNESS_SCALA_RELEASE` (default `3.9.0-RC4-p1`, the latest in the 3.9.0 stream) and
   //      extracts it into a shared cache, exposing its jars to every coursier resolution — no
   //      local compiler build and no publishing step needed. Switch streams by setting
   //      `SOUNDNESS_SCALA_RELEASE` (e.g. `3.10.0-dev-p2`).
@@ -68,11 +68,11 @@ object settings:
   // `scalaVersion` is the *coordinate* version the toolchain force-versions every artifact to; it
   // must match the version string the jars were built with (`compiler.properties`), or
   // coursier/zinc caches poison each other across compilers. The release tag
-  // (`SOUNDNESS_SCALA_RELEASE`) is a separate concept: `3.9.0-RC1-p3` ships jars built as
-  // `3.9.0-RC1-propensive`. Override the coordinate with `SOUNDNESS_SCALA_VERSION` (e.g. the
-  // 3.10.0 row is version "3.10.0-propensive").
-  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC1-propensive")
-  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC1-p3")
+  // (`SOUNDNESS_SCALA_RELEASE`) is a separate concept, though from `3.9.0-RC4-p1` on the two
+  // coincide (earlier releases shipped jars built as e.g. `3.9.0-RC1-propensive`). Override the
+  // coordinate with `SOUNDNESS_SCALA_VERSION`.
+  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC4-p6")
+  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC4-p6")
   // Empty by default → download `scalaRelease`. Set to a local `release` directory to use its
   // `release/lib` jars directly (fork-developer mode).
   val scalaHome = sys.env.getOrElse("SOUNDNESS_SCALA_HOME", "")
@@ -83,7 +83,8 @@ object settings:
   // no fork-republished Native artifacts are needed. `scalaNativeScalaVersion` is the *base*
   // version those artifacts are published for (the fork's `-propensive` suffix is dropped).
   val scalaNativeVersion = "0.5.12"
-  val scalaNativeScalaVersion = "3.9.0-RC1"
+  // Nearest published base version (no RC4 Native artifacts yet); TASTy-identical to RC4.
+  val scalaNativeScalaVersion = "3.9.0-RC3"
   val scalaOptions = Seq(
     "-experimental",
     "-new-syntax",

--- a/lib/anthology/src/scala/anthology.Scalac.scala
+++ b/lib/anthology/src/scala/anthology.Scalac.scala
@@ -56,7 +56,7 @@ import prepositional.*
 import rudiments.*
 
 object Scalac:
-  type Versions = 3.0 | 3.1 | 3.2 | 3.3 | 3.4 | 3.5 | 3.6 | 3.7 | 3.8
+  type Versions = 3.0 | 3.1 | 3.2 | 3.3 | 3.4 | 3.5 | 3.6 | 3.7 | 3.8 | 3.9
 
   case class Option[-version <: Versions](flags: Text*)
 

--- a/lib/anthology/src/scala/anthology_scala.scala
+++ b/lib/anthology/src/scala/anthology_scala.scala
@@ -50,6 +50,8 @@ object scalacOptions:
 
   val experimental = Scalac.Option[3.4 | 3.5 | 3.6 | 3.7 | 3.8](t"-experimental")
 
+  val semanticDiagnostics = Scalac.Option[3.9](t"-Xsemantic-diagnostics")
+
   object warnings:
     val feature = Scalac.Option[Scalac.Versions](t"-feature")
     val deprecation = Scalac.Option[Scalac.Versions](t"-deprecation")
@@ -134,6 +136,13 @@ private[anthology] def notice(diagnostic: Diagnostic): Notice =
   val file: Text = diagnostic.position.map(_.nn.source.nn.name.nn.tt).nn.orElse(t"unknown").nn
   val message: Text = diagnostic.message.tt
 
+  // Under `-Xsemantic-diagnostics`, the raw message carries in-band semantic
+  // markers (stripped from the `message` accessor above); preserve it so
+  // consumers can interpret them, e.g. with the `delicious` module.
+  val markup: Optional[Text] =
+    val raw = diagnostic.msg.message
+    if raw.exists(_ == '\uE000') then raw.tt else Unset
+
   diagnostic.position.map: position =>
     position.nn.pipe: position =>
       val span =
@@ -143,8 +152,8 @@ private[anthology] def notice(diagnostic: Diagnostic): Notice =
             position.endLine.nn.z,
             position.endColumn.nn.z )
 
-      Notice(importance, file, message, span)
+      Notice(importance, file, message, span, markup)
 
   . nn
-  . orElse(Notice(importance, file, message, Unset))
+  . orElse(Notice(importance, file, message, Unset, markup))
   . nn

--- a/lib/delicious/src/core/delicious.Markup.scala
+++ b/lib/delicious/src/core/delicious.Markup.scala
@@ -1,0 +1,187 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package delicious
+
+import scala.collection.mutable
+
+import anticipation.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+object Markup:
+  private final val Start    = '\uE000'
+  private final val End      = '\uE001'
+  private final val AttrsSep = '\uE002'
+  private final val TextSep  = '\uE003'
+  private final val AttrSep  = '\u001F'
+
+  def marked(text: Text): Boolean = text.s.exists { char => char >= Start && char <= TextSep }
+
+  private[delicious] def decode(text: Text): Text =
+    if text.s.indexOf('%') < 0 then text else
+      val builder = new StringBuilder
+      var index = 0
+
+      while index < text.s.length do
+        val char = text.s.charAt(index)
+
+        if char == '%' && index + 4 < text.s.length then
+          try
+            builder.append(Integer.parseInt(text.s.substring(index + 1, index + 5), 16).toChar)
+            index += 5
+          catch case _: NumberFormatException =>
+            builder.append(char)
+            index += 1
+        else
+          builder.append(char)
+          index += 1
+
+      builder.toString.tt
+
+  private def typed(kind: Text, attrs: List[(Text, Text)], children: List[Markup]): Markup =
+    def attr(name: Text): Optional[Text] =
+      attrs.find(_(0) == name).optional.let(_(1))
+
+    val style = Style(attr(t"style"))
+
+    kind.s match
+      case "type" =>
+        val placeholders = attrs.filter(_(0) == t"p").flatMap { (_, value) =>
+          Placeholder.decode(value).option
+        }
+
+        Typed(attr(t"tasty"), placeholders, style, children)
+
+      case "sym"  => Symbolic(attr(t"name").or(t""), attr(t"full").or(t""), style, children)
+      case "name" => Named(attr(t"isType").let(_ == t"true").or(false), style, children)
+      case "code" => Code(style, children)
+      case _      => Spanned(kind, style, children)
+
+  /** Parse a marked-up string into a tree, following the compiler's
+   *  `DiagnosticMarkup.parse` semantics exactly: anything that does not form a
+   *  complete marker is dropped and the surrounding content treated as plain
+   *  text; the children of an unterminated marker are spliced into its parent. */
+  def parse(text: Text): List[Markup] =
+    val input: String = text.s
+
+    final class Frame(val kind: Text, val attrs: List[(Text, Text)]):
+      val children = mutable.ListBuffer[Markup]()
+      val text = new StringBuilder
+
+      def flush(): Unit =
+        if text.nonEmpty then
+          children += Textual(text.toString.tt)
+          text.clear()
+
+    val root = Frame(t"", Nil)
+    var stack = List(root)
+    var index = 0
+
+    while index < input.length do
+      val char = input.charAt(index)
+
+      if char == Start then
+        val kindEnd = input.indexOf(AttrsSep, index + 1)
+        val attrsEnd = if kindEnd < 0 then -1 else input.indexOf(TextSep, kindEnd + 1)
+
+        val headerOk = kindEnd > 0 && attrsEnd > 0
+          && !input.substring(index + 1, attrsEnd).nn.exists { char => char == Start || char == End }
+
+        if !headerOk then index += 1 else
+          stack.head.flush()
+
+          val attrs = input.substring(kindEnd + 1, attrsEnd).nn match
+            case ""         => Nil
+            case attributes =>
+              attributes.tt.cut(AttrSep).map: keyValue =>
+                keyValue.cut(t"=", 2) match
+                  case List(key, value) => (key, decode(value))
+                  case _                => (keyValue, t"")
+
+          stack = Frame(input.substring(index + 1, kindEnd).nn.tt, attrs) :: stack
+          index = attrsEnd + 1
+
+      else if char == End then
+        stack match
+          case top :: (rest @ (parent :: _)) =>
+            top.flush()
+            parent.children += typed(top.kind, top.attrs, top.children.to(List))
+            stack = rest
+
+          case _ => // stray End at top level
+
+        index += 1
+
+      else if char == AttrsSep || char == TextSep then index += 1
+
+      else
+        stack.head.text.append(char)
+        index += 1
+
+    // splice the children of any unterminated markers into their parents
+    while stack.tail.nonEmpty do
+      val top :: (parent :: _) = stack: @unchecked
+      top.flush()
+      parent.children ++= top.children
+      stack = stack.tail
+
+    root.flush()
+    root.children.to(List)
+
+  /** The string with all markers removed, keeping only the visible text. */
+  def plain(text: Text): Text =
+    if !marked(text) then text else parse(text).map(_.plain).join
+
+
+enum Markup:
+  case Textual(text: Text)
+
+  case Typed
+        (tasty:        Optional[Text],
+         placeholders: List[Placeholder],
+         style:        Style,
+         children:     List[Markup])
+
+  case Symbolic(name: Text, full: Text, style: Style, children: List[Markup])
+  case Named(isType: Boolean, style: Style, children: List[Markup])
+  case Code(style: Style, children: List[Markup])
+  case Spanned(kind: Text, style: Style, children: List[Markup])
+
+  def plain: Text = this match
+    case Textual(text)               => text
+    case Typed(_, _, _, children)    => children.map(_.plain).join
+    case Symbolic(_, _, _, children) => children.map(_.plain).join
+    case Named(_, _, children)       => children.map(_.plain).join
+    case Code(_, children)           => children.map(_.plain).join
+    case Spanned(_, _, children)     => children.map(_.plain).join

--- a/lib/delicious/src/core/delicious.Placeholder.scala
+++ b/lib/delicious/src/core/delicious.Placeholder.scala
@@ -1,0 +1,84 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package delicious
+
+import anticipation.*
+import gossamer.*
+import vacuous.*
+
+object Placeholder:
+  /** The reserved prefix of placeholder literal types. A genuine string
+   *  literal type starting with this prefix is escaped by the compiler with
+   *  the `esc:` form. */
+  final val Prefix: Text = t"⟨scala-diag:"
+
+  def text(id: Int): Text = t"$Prefix$id⟩"
+
+  /** The placeholder id, if the text is a placeholder reference. */
+  def reference(text: Text): Optional[Int] =
+    if text.s.startsWith(Prefix.s) && text.s.endsWith("⟩") then
+      val body = text.s.substring(Prefix.s.length, text.s.length - 1).nn
+      if body.nonEmpty && body.forall(_.isDigit) then body.toInt else Unset
+    else Unset
+
+  /** The original string literal, if the text is an escaped genuine literal. */
+  def escaped(text: Text): Optional[Text] =
+    val prefix = t"${Prefix}esc:"
+    if text.s.startsWith(prefix.s) && text.s.endsWith("⟩")
+    then text.s.substring(prefix.s.length, text.s.length - 1).nn.tt
+    else Unset
+
+  def decode(text: Text): Optional[Placeholder] =
+    text.cut(t"|") match
+      case List(id, kind, name, arity, definedAt, printed) =>
+        def field(value: Text): Text = Markup.decode(value)
+
+        try
+          Placeholder
+            ( field(id).s.toInt,
+              PlaceholderKind(field(kind)),
+              field(name),
+              field(arity).s.toInt,
+              if definedAt.s.isEmpty then Unset else field(definedAt),
+              field(printed) )
+        catch case _: NumberFormatException => Unset
+
+      case _ => Unset
+
+case class Placeholder
+     (id:        Int,
+      kind:      PlaceholderKind,
+      name:      Text,
+      arity:     Int,
+      definedAt: Optional[Text],
+      printed:   Text)

--- a/lib/delicious/src/core/delicious.PlaceholderKind.scala
+++ b/lib/delicious/src/core/delicious.PlaceholderKind.scala
@@ -1,0 +1,48 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package delicious
+
+import anticipation.*
+
+object PlaceholderKind:
+  def apply(text: Text): PlaceholderKind = text.s match
+    case "local-type" => LocalType
+    case "local-term" => LocalTerm
+    case "error"      => Error
+    case "typevar"    => Typevar
+    case "skolem"     => Skolem
+    case _            => Other(text)
+
+enum PlaceholderKind:
+  case LocalType, LocalTerm, Error, Typevar, Skolem
+  case Other(kind: Text)

--- a/lib/delicious/src/core/delicious.SemanticMessage.scala
+++ b/lib/delicious/src/core/delicious.SemanticMessage.scala
@@ -1,0 +1,56 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package delicious
+
+import anticipation.*
+import gossamer.*
+
+object SemanticMessage:
+  /** Does the text contain semantic-diagnostic markers? */
+  def marked(text: Text): Boolean = Markup.marked(text)
+
+  def parse(text: Text): SemanticMessage = SemanticMessage(Markup.parse(text))
+
+case class SemanticMessage(markup: List[Markup]):
+  def plain: Text = markup.map(_.plain).join
+
+  def types: List[Markup.Typed] =
+    def recur(nodes: List[Markup]): List[Markup.Typed] = nodes.flatMap:
+      case node@Markup.Typed(_, _, _, children) => node :: recur(children)
+      case Markup.Textual(_)                    => Nil
+      case Markup.Symbolic(_, _, _, children)   => recur(children)
+      case Markup.Named(_, _, children)         => recur(children)
+      case Markup.Code(_, children)             => recur(children)
+      case Markup.Spanned(_, _, children)       => recur(children)
+
+    recur(markup)

--- a/lib/delicious/src/core/delicious.Style.scala
+++ b/lib/delicious/src/core/delicious.Style.scala
@@ -1,0 +1,47 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package delicious
+
+import anticipation.*
+import vacuous.*
+
+object Style:
+  def apply(text: Optional[Text]): Style = text.lay(Style.Default): text =>
+    text.s match
+      case "dcl"     => Declaration
+      case "located" => Located
+      case "full"    => Full
+      case _         => Default
+
+enum Style:
+  case Default, Declaration, Located, Full

--- a/lib/delicious/src/core/soundness_delicious_core.scala
+++ b/lib/delicious/src/core/soundness_delicious_core.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export delicious.{Markup, Placeholder, PlaceholderKind, SemanticMessage, Style}

--- a/lib/delicious/src/scala/delicious.Reifier.scala
+++ b/lib/delicious/src/scala/delicious.Reifier.scala
@@ -1,0 +1,154 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package delicious
+
+import scala.collection.immutable.ListMap
+
+import dotty.tools.dotc as dtd
+import dotty.tools.dotc.ast.tpd.TreeOps
+import dotty.tools.dotc.core.Contexts
+import dotty.tools.dotc.core.tasty.DottyUnpickler
+import dotty.tools.dotc.quoted.QuotesCache
+import dotty.tools.dotc.core.tasty.TreeUnpickler.UnpickleMode
+import dotty.tools.dotc.reporting.Reporter
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.io.NoAbstractFile
+
+import java.util as ju
+
+import anticipation.*
+import gossamer.*
+import hellenism.*
+import rudiments.*
+import stenography.*
+import vacuous.*
+
+object Reifier:
+  /** Rewrite the placeholder sentinels — string-literal types the pickler
+   *  substituted for unpicklable subtrees — into renderings of the recorded
+   *  placeholders. Sound because the pickler replaces whole maximal subtrees,
+   *  so a sentinel can only appear as a complete type, never in constructor or
+   *  prefix position. */
+  def substitute(syntax: Syntax, placeholders: List[Placeholder]): Syntax =
+    val byId: Map[Int, Placeholder] = placeholders.map { placeholder => placeholder.id -> placeholder }.to(Map)
+
+    def replace(text: Text): Optional[Syntax] =
+      if text.s.length >= 2 && text.s.startsWith("\"") && text.s.endsWith("\"") then
+        val body = text.s.substring(1, text.s.length - 1).nn.tt
+
+        Placeholder.reference(body).let { id => byId.at(id).let { p => Syntax.Symbolic(p.printed) } }
+        . or(Placeholder.escaped(body).let { literal => Syntax.Primitive(t"\"$literal\"") })
+
+      else Unset
+
+    def entries(map: ListMap[Text, Syntax]): ListMap[Text, Syntax] =
+      map.map { (key, value) => key -> recur(value) }
+
+    def recur(syntax: Syntax): Syntax = syntax match
+      case Syntax.Primitive(text)          => replace(text).or(syntax)
+      case Syntax.Simple(_)                => syntax
+      case Syntax.Symbolic(_)              => syntax
+      case Syntax.Value(_)                 => syntax
+      case Syntax.Projection(base, text)   => Syntax.Projection(recur(base), text)
+      case Syntax.Infix(left, mid, right)  => Syntax.Infix(recur(left), mid, recur(right))
+      case Syntax.Prefix(middle, right)    => Syntax.Prefix(middle, recur(right))
+      case Syntax.Suffix(left, suffix)     => Syntax.Suffix(recur(left), suffix)
+      case Syntax.Selection(left, right)   => Syntax.Selection(recur(left), right)
+      case Syntax.Named(using0, name, s)   => Syntax.Named(using0, name, recur(s))
+      case Syntax.Sequence(style, parts)   => Syntax.Sequence(style, parts.map(recur))
+      case Syntax.Compound(parts)          => Syntax.Compound(parts.map(recur))
+      case Syntax.Match(scrutinee, cases)  => Syntax.Match(recur(scrutinee), cases.map(recur))
+
+      case Syntax.Structural(base, types, terms) =>
+        Syntax.Structural(recur(base), entries(types), entries(terms))
+
+      case Syntax.Application(left, elements, infix) =>
+        Syntax.Application(recur(left), elements.map(recur), infix)
+
+      case Syntax.Declaration(method, syntaxes, result) =>
+        Syntax.Declaration(method, syntaxes.map(recur), recur(result))
+
+    recur(syntax)
+
+/** Turns the TASTy payloads of semantic diagnostics back into stenography
+ *  `Syntax` values, resolving them against the given classpath. The pickler
+ *  guarantees the payload resolves against the classpath alone: anything that
+ *  could not (local symbols, skolems, error types, type variables) was
+ *  replaced by a placeholder before pickling. */
+class Reifier(classpath: LocalClasspath):
+  private lazy val runContext: Contexts.Context =
+    val entries: Text =
+      classpath.entries.flatMap:
+        case ClasspathEntry.Directory(directory) => List(directory)
+        case ClasspathEntry.Jar(jar)             => List(jar)
+        case _                                   => Nil
+
+      . join(java.io.File.pathSeparator.nn.tt)
+
+    object driver extends dtd.Driver:
+      def context: Contexts.Context =
+        // The trailing empty argument stops the driver from treating an
+        // argument list with no source files as a request to print usage.
+        setup(Array("-classpath", entries.s, ""), initCtx.fresh).map(_(1)).get
+
+    val base = driver.context.fresh.setReporter(Reporter.NoReporter)
+    val run = dtd.Compiler().newRun(using base)
+    run.compileSources(List(SourceFile.virtual("<delicious>", "")))
+
+    // Quote unpickling (which stenography's `TypeRepr.of` comparisons trigger)
+    // expects the quote-cache context property that macro-expansion contexts
+    // carry; a standalone context must install it explicitly.
+    QuotesCache.init(run.runContext.fresh)
+
+  /** The stenography rendering of a type marker's TASTy payload, or `Unset`
+   *  if there is no payload or it cannot be unpickled: a diagnostic must never
+   *  become a crash, so callers fall back to the compiler-printed text. */
+  def syntax(typed: Markup.Typed): Optional[Syntax] =
+    typed.tasty.let: tasty =>
+      try
+        given Contexts.Context = runContext
+        val bytes = ju.Base64.getDecoder.nn.decode(tasty.s).nn
+
+        val unpickler =
+          DottyUnpickler(NoAbstractFile, bytes, isBestEffortTasty = false, UnpickleMode.TypeTree)
+
+        unpickler.enter(Set.empty)
+        val tree = unpickler.tree
+        tree.foreachSubTree { _ => () } // force trees and positions
+
+        val quotes = scala.quoted.runtime.impl.QuotesImpl()
+        val repr = tree.tpe.asInstanceOf[quotes.reflect.TypeRepr]
+
+        Reifier.substitute(Syntax(using quotes)(repr), typed.placeholders)
+
+      catch case scala.util.control.NonFatal(_) => Unset

--- a/lib/delicious/src/scala/delicious_scala.scala
+++ b/lib/delicious/src/scala/delicious_scala.scala
@@ -30,15 +30,31 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package anthology
+package delicious
 
 import anticipation.*
-import denominative.*
+import gossamer.*
+import stenography.*
 import vacuous.*
 
-case class Notice
-     (importance: Importance,
-      file:       Text,
-      message:    Text,
-      span:       Optional[Span],
-      markup:     Optional[Text] = Unset)
+extension (notice: anthology.Notice)
+  /** The message's semantic structure, when it was compiled under
+   *  `-Xsemantic-diagnostics`. */
+  def semantic: Optional[SemanticMessage] = notice.markup.let(SemanticMessage.parse(_))
+
+extension (message: SemanticMessage)
+  /** Render the message with every type re-rendered through stenography,
+   *  abbreviated according to the given `Imports`; anything that cannot be
+   *  reified falls back to the compiler-printed text. */
+  def render(reifier: Reifier)(using Imports): Text =
+    def recur(nodes: List[Markup]): Text = nodes.map(node).join
+
+    def node(markup: Markup): Text = markup match
+      case Markup.Textual(text)                     => text
+      case typed@Markup.Typed(_, _, _, children)    => reifier.syntax(typed).let(_.text).or(recur(children))
+      case Markup.Symbolic(_, _, _, children)       => recur(children)
+      case Markup.Named(_, _, children)             => recur(children)
+      case Markup.Code(_, children)                 => recur(children)
+      case Markup.Spanned(_, _, children)           => recur(children)
+
+    recur(message.markup)

--- a/lib/delicious/src/scala/soundness_delicious_scala.scala
+++ b/lib/delicious/src/scala/soundness_delicious_scala.scala
@@ -30,15 +30,6 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package anthology
+package soundness
 
-import anticipation.*
-import denominative.*
-import vacuous.*
-
-case class Notice
-     (importance: Importance,
-      file:       Text,
-      message:    Text,
-      span:       Optional[Span],
-      markup:     Optional[Text] = Unset)
+export delicious.{Reifier, render, semantic}

--- a/lib/delicious/src/test/delicious_test.scala
+++ b/lib/delicious/src/test/delicious_test.scala
@@ -278,7 +278,11 @@ object Tests extends Suite(m"Delicious Tests"):
           test(m"A semantic notice renders its types through stenography"):
             marked.map { notice => notice.semantic.let(_.render(reifier)).or(t"") }
             . join(t"\n")
-          . assert(_.contains(t"List["))
+          . assert { rendered =>
+              // `java.lang.String` (not the compiler-printed `String`) proves the type
+              // came through stenography; `Bad.Local` proves placeholder substitution.
+              rendered.contains(t"java.lang.String") && rendered.contains(t"Bad.Local")
+            }
 
   def proscalaLibrary(): Optional[java.nio.file.Path] =
     val home = java.lang.System.getProperty("user.home").nn

--- a/lib/delicious/src/test/delicious_test.scala
+++ b/lib/delicious/src/test/delicious_test.scala
@@ -32,11 +32,20 @@
                                                                                                   */
 package delicious
 
-import anticipation.*
-import fulminate.*
-import gossamer.*
-import probably.*
-import vacuous.*
+import java.nio.file.{Files, Paths}
+
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+
+import soundness.*
+
+import galilei.Linux.pathOnLinux
+import logging.silentLogging
+import probates.cancelProbate
+import strategies.throwUnsafely
+import systems.javaSystem
+import temporaryDirectories.systemTemporaryDirectory
+import threading.platformThreading
+import workingDirectories.javaWorkingDirectory
 
 object Tests extends Suite(m"Delicious Tests"):
   val Start: Char    = '\uE000'
@@ -169,3 +178,114 @@ object Tests extends Suite(m"Delicious Tests"):
     test(m"A message with markers is marked"):
       SemanticMessage.marked(mark(t"sym", Nil, t"foo"))
     . assert(_ == true)
+
+    test(m"Substitution replaces a placeholder sentinel"):
+      val placeholder =
+        Placeholder(0, PlaceholderKind.LocalType, t"Local", 0, Unset, t"Bad.Local")
+
+      val list = Syntax.Simple(Typename(t"scala.collection.immutable.List"))
+      val syntax =
+        Syntax.Application(list, List(Syntax.Primitive(t"\"⟨scala-diag:0⟩\"")), false)
+
+      Reifier.substitute(syntax, List(placeholder))
+    . assert(_ == Syntax.Application
+        ( Syntax.Simple(Typename(t"scala.collection.immutable.List")),
+          List(Syntax.Symbolic(t"Bad.Local")),
+          false ))
+
+    test(m"Substitution unescapes an escaped genuine literal"):
+      Reifier.substitute(Syntax.Primitive(t"\"⟨scala-diag:esc:x⟩\""), Nil)
+    . assert(_ == Syntax.Primitive(t"\"x\""))
+
+    test(m"Substitution leaves other primitives alone"):
+      Reifier.substitute(Syntax.Primitive(t"42"), Nil)
+    . assert(_ == Syntax.Primitive(t"42"))
+
+    // Payloads captured from a semdiag compiler run over:
+    //   object Bad:
+    //     class Local
+    //     val xs: List[String] = List(1.5)
+    //     def f: Option[Int] = List(new Local)
+    // TASTy is version-locked (28.9-1), so these decode under any 3.9-stream compiler.
+    val stringPayload: Text =
+      t"XKGrH5yJgZpTY2FsYSAzLjkuMC1SQzEtcHJvcGVuc2l2ZQAadmNlJOIHAAAAAAAAAACeAYRBU1RzAYZTdHJpbmcBhGphdmEBhGxhbmcCgoKDgIR1gUCE"
+
+    val placeholderPayload: Text =
+      t"XKGrH5yJgZpTY2FsYSAzLjkuMC1SQzEtcHJvcGVuc2l2ZQDQKNr7HmsuAAAAAAAAAADGAYRBU1RzAYRMaXN0AYVzY2FsYQGKY29sbGVjdGlvbgKCgoMBiWltbXV0YWJsZQKChIUBkuKfqHNjYWxhLWRpYWc6MOKfqYCIoYZ1gUCGSoc="
+
+    proscalaLibrary().let: lib =>
+      val jars = List("scala-library.jar", "scala3-library.jar").map(lib.resolve(_).nn)
+      val classpath = LocalClasspath(jars.map { jar => ClasspathEntry.Jar(jar.toString.tt) }*)
+      val reifier = Reifier(classpath)
+      given Imports = Imports.empty
+
+      test(m"A pickled type payload reifies to a stenography rendering"):
+        reifier.syntax(Markup.Typed(stringPayload, Nil, Style.Default, Nil)).let(_.text)
+      . assert(_ == t"java.lang.String")
+
+      test(m"A placeholder payload reifies with its placeholder substituted"):
+        val placeholder =
+          Placeholder(0, PlaceholderKind.LocalType, t"Local", 0, t"Bad.scala:2", t"Bad.Local")
+
+        reifier.syntax(Markup.Typed(placeholderPayload, List(placeholder), Style.Default, Nil))
+        . let(_.text)
+      . assert(_ == t"scala.collection.immutable.List[Bad.Local]")
+
+      test(m"An unpicklable payload degrades to Unset"):
+        reifier.syntax(Markup.Typed(t"bm90IHRhc3R5", Nil, Style.Default, Nil))
+      . assert(_ == Unset)
+
+      test(m"A marked message renders types through stenography"):
+        val typed = mark(t"type", List(t"tasty" -> stringPayload), t"printed")
+        SemanticMessage.parse(t"Required: $typed").render(reifier)
+      . assert(_ == t"Required: java.lang.String")
+
+      // End-to-end through the embedded compiler. Feature-detecting: a compiler
+      // without semdiag (releases up to p5) produces no markup, and only the
+      // fallback invariants are asserted.
+      supervise:
+        val out: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
+        Files.createDirectories(Paths.get(out.encode.s))
+
+        val source: Text =
+          t"""|object Bad:
+              |  class Local
+              |  val xs: List[String] = List(new Local)
+              |""".s.stripMargin.tt
+
+        val process =
+          Scalac[3.9](List(scalacOptions.semanticDiagnostics))
+            (classpath)(Map(t"bad.scala" -> source), out)
+
+        process.complete()
+        val notices = process.notices.to(List)
+
+        test(m"A failed compilation produces at least one error notice"):
+          notices.count(_.importance == Importance.Error)
+        . assert(_ > 0)
+
+        val marked = notices.filter(_.markup.present)
+
+        if marked.isEmpty then
+          test(m"Without semdiag support, messages are plain and unmarked"):
+            notices.forall { notice => !SemanticMessage.marked(notice.message) }
+          . assert(_ == true)
+        else
+          test(m"Semantic notices strip markers from the plain message"):
+            marked.forall { notice => !SemanticMessage.marked(notice.message) }
+          . assert(_ == true)
+
+          test(m"A semantic notice renders its types through stenography"):
+            marked.map { notice => notice.semantic.let(_.render(reifier)).or(t"") }
+            . join(t"\n")
+          . assert(_.contains(t"List["))
+
+  def proscalaLibrary(): Optional[java.nio.file.Path] =
+    val home = java.lang.System.getProperty("user.home").nn
+    val root = Paths.get(home, ".cache", "soundness", "proscala").nn
+
+    if !Files.isDirectory(root) then Unset else
+      Files.list(root).nn.iterator.nn.asScala.to(List).sortBy(_.toString).reverse
+      . map(_.resolve("lib").nn)
+      . find { lib => Files.isDirectory(lib) && Files.exists(lib.resolve("scala3-library.jar")) }
+      . getOrElse(Unset)

--- a/lib/delicious/src/test/delicious_test.scala
+++ b/lib/delicious/src/test/delicious_test.scala
@@ -1,0 +1,171 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package delicious
+
+import anticipation.*
+import fulminate.*
+import gossamer.*
+import probably.*
+import vacuous.*
+
+object Tests extends Suite(m"Delicious Tests"):
+  val Start: Char    = '\uE000'
+  val End: Char      = '\uE001'
+  val AttrsSep: Char = '\uE002'
+  val TextSep: Char  = '\uE003'
+  val AttrSep: Char  = '\u001F'
+
+  def mark(kind: Text, attrs: List[(Text, Text)], text: Text): Text =
+    val attributes = attrs.map { (key, value) => t"$key=$value" }.join(t"${AttrSep}")
+    t"${Start}$kind${AttrsSep}$attributes${TextSep}$text${End}"
+
+  def run(): Unit =
+    test(m"Unmarked text parses as a single text node"):
+      Markup.parse(t"type mismatch")
+    . assert(_ == List(Markup.Textual(t"type mismatch")))
+
+    test(m"A sym marker parses with its attributes"):
+      Markup.parse(t"method ${mark(t"sym", List(t"name" -> t"foo", t"full" -> t"example.foo"), t"foo")} here")
+    . assert(_ == List
+        ( Markup.Textual(t"method "),
+          Markup.Symbolic(t"foo", t"example.foo", Style.Default, List(Markup.Textual(t"foo"))),
+          Markup.Textual(t" here") ))
+
+    test(m"A name marker records whether it is a type name"):
+      Markup.parse(mark(t"name", List(t"isType" -> t"true"), t"Elem"))
+    . assert(_ == List(Markup.Named(true, Style.Default, List(Markup.Textual(t"Elem")))))
+
+    test(m"An unknown marker kind falls back to a spanned node"):
+      Markup.parse(mark(t"mystery", Nil, t"???"))
+    . assert(_ == List(Markup.Spanned(t"mystery", Style.Default, List(Markup.Textual(t"???")))))
+
+    test(m"Styles decode from their wire names"):
+      Markup.parse(mark(t"sym", List(t"name" -> t"foo", t"style" -> t"dcl"), t"def foo: Int"))
+    . assert(_ == List
+        ( Markup.Symbolic(t"foo", t"", Style.Declaration, List(Markup.Textual(t"def foo: Int"))) ))
+
+    test(m"Markers nest, and children keep their order"):
+      val inner = mark(t"sym", List(t"name" -> t"foo"), t"foo")
+      Markup.parse(mark(t"name", Nil, t"method $inner"))
+    . assert(_ == List
+        ( Markup.Named
+            ( false,
+              Style.Default,
+              List
+                ( Markup.Textual(t"method "),
+                  Markup.Symbolic(t"foo", t"", Style.Default, List(Markup.Textual(t"foo"))) )) ))
+
+    test(m"Percent-encoded attribute values decode"):
+      Markup.parse(mark(t"sym", List(t"name" -> t"%003ainit%003a"), t"constructor"))
+    . assert(_ == List
+        ( Markup.Symbolic(t":init:", t"", Style.Default, List(Markup.Textual(t"constructor"))) ))
+
+    test(m"A stray start marker is dropped"):
+      Markup.parse(t"broken ${Start} text")
+    . assert(_ == List(Markup.Textual(t"broken  text")))
+
+    test(m"A stray end marker is dropped"):
+      Markup.parse(t"broken ${End} text")
+    . assert(_ == List(Markup.Textual(t"broken  text")))
+
+    test(m"An unterminated marker splices its children into the parent"):
+      Markup.parse(t"a ${Start}sym${AttrsSep}name=foo${TextSep}bar")
+    . assert(_ == List(Markup.Textual(t"a "), Markup.Textual(t"bar")))
+
+    test(m"A truncated header is treated as text"):
+      Markup.parse(t"a ${Start}sym no header end")
+    . assert(_ == List(Markup.Textual(t"a sym no header end")))
+
+    test(m"Plain text strips all markers"):
+      val inner = mark(t"sym", List(t"name" -> t"foo"), t"foo")
+      Markup.plain(t"method ${mark(t"name", Nil, t"call of $inner")} failed")
+    . assert(_ == t"method call of foo failed")
+
+    test(m"A type marker carries its TASTy payload and placeholders"):
+      val placeholder = t"0|local-type|Foo|1||Foo[Int]"
+      Markup.parse(mark(t"type", List(t"tasty" -> t"QUJD", t"p" -> placeholder), t"Foo[Int]"))
+    . assert(_ == List
+        ( Markup.Typed
+            ( t"QUJD",
+              List(Placeholder(0, PlaceholderKind.LocalType, t"Foo", 1, Unset, t"Foo[Int]")),
+              Style.Default,
+              List(Markup.Textual(t"Foo[Int]")) ) ))
+
+    test(m"A placeholder decodes its six fields"):
+      Placeholder.decode(t"3|skolem|x|0|Test.scala:5|x.type")
+    . assert(_ == Placeholder(3, PlaceholderKind.Skolem, t"x", 0, t"Test.scala:5", t"x.type"))
+
+    test(m"A placeholder with an escaped pipe decodes"):
+      Placeholder.decode(t"1|error|a%007cb|0||a|b")
+    . assert(_ == Unset)
+
+    test(m"An escaped pipe within a field decodes to a literal pipe"):
+      Placeholder.decode(t"1|error|a%007cb|0||printed")
+    . assert(_ == Placeholder(1, PlaceholderKind.Error, t"a|b", 0, Unset, t"printed"))
+
+    test(m"A non-numeric placeholder id is rejected"):
+      Placeholder.decode(t"x|error|a|0||printed")
+    . assert(_ == Unset)
+
+    test(m"A placeholder with too few fields is rejected"):
+      Placeholder.decode(t"1|error|a|0|")
+    . assert(_ == Unset)
+
+    test(m"An unknown placeholder kind is preserved"):
+      Placeholder.decode(t"1|quantum|a|0||printed")
+    . assert(_ == Placeholder(1, PlaceholderKind.Other(t"quantum"), t"a", 0, Unset, t"printed"))
+
+    test(m"A placeholder reference is recognized"):
+      Placeholder.reference(t"⟨scala-diag:42⟩")
+    . assert(_ == 42)
+
+    test(m"A non-placeholder literal is not a reference"):
+      Placeholder.reference(t"⟨scala-diag:esc:7⟩")
+    . assert(_ == Unset)
+
+    test(m"An escaped literal unescapes"):
+      Placeholder.escaped(t"⟨scala-diag:esc:real text⟩")
+    . assert(_ == t"real text")
+
+    test(m"A semantic message finds nested type markers"):
+      val typed = mark(t"type", List(t"tasty" -> t"QUJD"), t"List[Int]")
+      SemanticMessage.parse(t"Found: ${mark(t"name", Nil, t"value of $typed")}").types.length
+    . assert(_ == 1)
+
+    test(m"A message without markers is not marked"):
+      SemanticMessage.marked(t"ordinary message")
+    . assert(_ == false)
+
+    test(m"A message with markers is marked"):
+      SemanticMessage.marked(mark(t"sym", Nil, t"foo"))
+    . assert(_ == true)


### PR DESCRIPTION
The new `delicious` module interprets the semantic diagnostics that proscala emits under `-Xsemantic-diagnostics`, parsing the in-band markup into a typed tree, unpickling each type's embedded TASTy payload in a standalone compiler context, and rendering the result through Stenography, with unpicklable parts (local symbols, skolems, error types, type variables) substituted from the diagnostic's placeholder table; anthology notices now carry the raw marked-up message alongside the plain one so this structure survives compilation.

Compiling with the new `scalacOptions.semanticDiagnostics` option (Scala 3.9+) makes each `Notice` retain its semantic markup, which `delicious` can interpret and re-render:

```scala
val process = Scalac[3.9](List(scalacOptions.semanticDiagnostics))(classpath)(sources, out)
process.complete()

val reifier = Reifier(classpath)

process.notices.each: notice =>
  notice.semantic.let: message =>
    given Imports = Imports.empty
    Out.println(message.render(reifier))   // types rendered by Stenography
```

A `SemanticMessage` exposes the parsed `Markup` tree — `Typed` nodes carry the pickled type and its `Placeholder`s, `Symbolic`/`Named`/`Code` nodes mark up symbols, names and trees — so tools can also style or hyperlink diagnostics rather than merely render them. Messages from compilers without semantic-diagnostic support (or without the flag) are unaffected, and every reification failure falls back to the compiler-printed text: a diagnostic never becomes a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)