### PR TITLE
Idiomatic Kotlin/Java facade properties: bean getters, setters and inferred setter-assignment

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2937,7 +2937,7 @@ object android extends Module:
       builder.runClasspath().map(_.path.toString).mkString(java.io.File.pathSeparator)
 
     os.proc("java", "-cp", driverClasspath, "androidsample.buildDice", androidJar,
-        Task.dest.toString, (appSource().path / "dice.scala").toString, classpathFile.toString)
+        Task.dest.toString, appSource().path.toString, classpathFile.toString)
     . call(stdout = os.Inherit, stderr = os.Inherit)
 
     PathRef(Task.dest / "main.dex.jar")
@@ -2964,7 +2964,30 @@ object android extends Module:
       builder.runClasspath().map(_.path.toString).mkString(java.io.File.pathSeparator)
 
     os.proc("java", "-cp", driverClasspath, "androidsample.buildApk", androidJar,
-        Task.dest.toString, (appSource().path / "dice.scala").toString, classpathFile.toString)
+        Task.dest.toString, appSource().path.toString, classpathFile.toString)
+    . call(stdout = os.Inherit, stderr = os.Inherit)
+
+    PathRef(Task.dest / "app.apk")
+
+  // The richer showcase APK (`sketch.SketchActivity`), same pure pipeline as `apk`.
+  def sketch: T[PathRef] = Task:
+    val androidJar = Task.env.getOrElse("ANDROID_JAR", {
+      val home = Task.env.getOrElse("ANDROID_HOME", throw Exception(
+        "Set ANDROID_HOME or ANDROID_JAR to build the Android sample"))
+      val platforms = os.list(os.Path(home) / "platforms").filter(p => os.exists(p / "android.jar"))
+      if platforms.isEmpty then throw Exception(s"no platforms/android-NN/android.jar under $home")
+      (platforms.sortBy(_.last).last / "android.jar").toString
+    })
+
+    val classpath = runtime.runClasspath().map(_.path).filter(os.exists)
+    val classpathFile = Task.dest / "classpath"
+    os.write.over(classpathFile, classpath.mkString("\n"))
+
+    val driverClasspath =
+      builder.runClasspath().map(_.path.toString).mkString(java.io.File.pathSeparator)
+
+    os.proc("java", "-cp", driverClasspath, "androidsample.buildSketch", androidJar,
+        Task.dest.toString, appSource().path.toString, classpathFile.toString)
     . call(stdout = os.Inherit, stderr = os.Inherit)
 
     PathRef(Task.dest / "app.apk")

--- a/lib/xenophile/src/kotlin/xenophile.Facade.scala
+++ b/lib/xenophile/src/kotlin/xenophile.Facade.scala
@@ -84,9 +84,9 @@ trait Facade extends Selectable, Dynamic, Transportive:
   // code should prefer `unwrap`, which recovers the precise static type.
   def raw: Any
 
-  // The underlying value, at the full Scala type the facade records: the escape hatch back to
-  // plain Java-level interop, typed so no cast is needed at the boundary.
-  transparent inline def unwrap: Any = ${KotlinFacade.unwrapped('this)}
+  // The underlying value (`k` for "Kotlin"), at the full Scala type the facade records: the
+  // escape hatch back to plain Java-level interop, typed so no cast is needed at the boundary.
+  transparent inline def k: Any = ${KotlinFacade.unwrapped('this)}
 
   transparent inline def selectDynamic(name: String): Any =
     ${KotlinFacade.select('this, 'name)}

--- a/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
+++ b/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
@@ -246,7 +246,10 @@ object KotlinFacade:
     val direct = argument.tpe.widen <:< target || (textual && stringy) || transported
 
     val functional = samCompatible(argument, target) || proxyCompatible(argument, target)
-    val bridged = functional || collectionCompatible(argument.tpe.widen, target)
+
+    val collection = collectionCompatible(argument.tpe.widen, target)
+    val array = arrayCompatible(argument.tpe.widen, target)
+    val bridged = functional || collection || array
 
     direct || bridged || converted(argument, target).present
 
@@ -619,8 +622,8 @@ object KotlinFacade:
     val widened: Optional[Term] =
       rank(from).let: low =>
         rank(to).let: high =>
-          if low < high then conversionMethod(to).let(m => Select.unique(argument, m.s))
-          else Unset
+          if low >= high then Unset else conversionMethod(to).let: method =>
+            Select.unique(argument, method.s)
 
     // Failing a numeric widening, an in-scope implicit conversion `from => to`.
     widened.or:
@@ -628,6 +631,52 @@ object KotlinFacade:
         case ('[a], '[b]) => Expr.summon[Conversion[a, b]] match
           case Some(conversion) => '{$conversion(${argument.asExprOf[a]})}.asTerm
           case None             => Unset
+
+  // The first letter uppercased (`color` -> `Color`), for bean getter/setter synthesis.
+  private def capitalize(text: Text): Text =
+    if text.s.isEmpty then text
+    else t"${text.s.substring(0, 1).nn.toUpperCase.nn}${text.s.substring(1).nn}"
+
+  // The element type of a JVM array type (`Array[E]`), when the type is one.
+  private def arrayElement(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
+  :   Optional[quotes.reflect.TypeRepr] =
+
+    import quotes.reflect.*
+
+    repr.dealias match
+      case AppliedType(constructor, List(element)) if constructor.typeSymbol == defn.ArrayClass =>
+        element
+
+      case _ =>
+        Unset
+
+  // Whether a Scala array argument can satisfy a Java array parameter. Scala arrays are
+  // invariant, so `Array[Text]` does not conform to `CharSequence[]` statically — but each is a
+  // JVM `String[]`/`CharSequence[]`, covariantly assignable, so an element-compatible array is
+  // accepted and cast.
+  private def arrayCompatible(using quotes: Quotes)
+    ( argument: quotes.reflect.TypeRepr, target: quotes.reflect.TypeRepr )
+  :   Boolean =
+
+    import quotes.reflect.*
+
+    (arrayElement(argument), arrayElement(solid(target))).absolve match
+      case (element: TypeRepr @unchecked, wanted: TypeRepr @unchecked) =>
+        val textual = element <:< TypeRepr.of[Text]
+        val stringy = TypeRepr.of[String] <:< wanted || wanted =:= TypeRepr.of[CharSequence]
+        element <:< wanted || (textual && stringy)
+
+      case _ =>
+        false
+
+  private def arrayAdapted(using quotes: Quotes)
+    ( argument: quotes.reflect.Term, parameter: quotes.reflect.TypeRepr )
+  :   Optional[quotes.reflect.Term] =
+
+    import quotes.reflect.*
+
+    if !arrayCompatible(argument.tpe.widen, parameter) then Unset
+    else TypeApply(Select.unique(argument, "asInstanceOf"), List(Inferred(solid(parameter))))
 
   private def adapted(using quotes: Quotes)
     ( argument: quotes.reflect.Term, parameter: quotes.reflect.TypeRepr )
@@ -639,6 +688,7 @@ object KotlinFacade:
       samAdapted(argument, solid(parameter))
       . or(proxyAdapted(argument, solid(parameter)))
       . or(collectionAdapted(argument, parameter))
+      . or(arrayAdapted(argument, parameter))
 
     val unwrapped = sam.or:
       if argument.tpe.widen <:< TypeRepr.of[Facade]
@@ -659,46 +709,79 @@ object KotlinFacade:
       case MethodType(_, types, _) => types
       case _                       => Unset
 
+  // A zero-argument method reached as a short property name: a Java bean getter (`x` reads
+  // `getX()` or `isX()`), so accessing platform state reads the natural Scala way.
+  private def beanGetter(using quotes: Quotes)
+    ( self:        Expr[Facade],
+      repr:        quotes.reflect.TypeRepr,
+      className:   Text,
+      classSymbol: quotes.reflect.Symbol,
+      field:       Text )
+  :   Optional[Expr[Any]] =
+
+    import quotes.reflect.*
+
+    val capital = capitalize(field)
+
+    def getter(name: Text): Optional[Expr[Any]] =
+      val members = KotlinDialect.members(className, name).filter: member =>
+        !member.property && member.arity == 0
+
+      (members, KotlinDialect.memberPrototype(className, name)).absolve match
+        case (member :: _, prototype: Prototype) =>
+          classSymbol.methodMember(member.jvmName.s)
+          . filter(parameterTypes(repr, _) == Optional(Nil)) match
+            case method :: _ =>
+              refined(Apply(Select(receiver(self, repr), method), Nil), prototype.result)
+
+            case Nil =>
+              Unset
+
+        case _ =>
+          Unset
+
+    getter(t"get$capital").or(getter(t"is$capital"))
+
   def select(self: Expr[Facade], name: Expr[String])(using Quotes): Expr[Any] =
     import quotes.reflect.*
 
     val field = name.valueOrAbort.tt
     val repr = transport(self)
     val className = classNameOf(repr)
-
-    val member = KotlinDialect.members(className, field).filter(_.property) match
-      case member :: _ => member
-      case Nil         => missing(className, field)
-
-    val prototype = KotlinDialect.memberPrototype(className, field).or:
-      missing(className, field)
-
     val classSymbol = repr.classSymbol.getOrElse(halt(m"xenophile: not a class type"))
 
-    // A `const`/`@JvmField` property is a bare field — static on the companion module for an
-    // `object`'s members, or an instance field otherwise — read directly.
-    if member.field then
-      val static = classSymbol.companionModule.fieldMember(member.jvmName.s)
+    KotlinDialect.members(className, field).filter(_.property) match
+      case Nil =>
+        beanGetter(self, repr, className, classSymbol, field).or(missing(className, field))
 
-      val term =
-        if static.exists then Select(Ref(classSymbol.companionModule), static) else
-          val instance = classSymbol.fieldMember(member.jvmName.s)
+      case member :: _ =>
+        val prototype =
+          KotlinDialect.memberPrototype(className, field).or(missing(className, field))
 
-          if instance.exists then Select(receiver(self, repr), instance)
-          else halt(m"xenophile: no JVM field ${member.jvmName} on $className")
+        // A `const`/`@JvmField` property is a bare field — static on the companion module for an
+        // `object`'s members, or an instance field otherwise — read directly.
+        if member.field then
+          val static = classSymbol.companionModule.fieldMember(member.jvmName.s)
 
-      refined(term, prototype.result)
+          val term =
+            if static.exists then Select(Ref(classSymbol.companionModule), static) else
+              val instance = classSymbol.fieldMember(member.jvmName.s)
 
-    else
-      mangled(className, member)
+              if instance.exists then Select(receiver(self, repr), instance)
+              else halt(m"xenophile: no JVM field ${member.jvmName} on $className")
 
-      val method =
-        classSymbol.methodMember(member.jvmName.s)
-        . filter(parameterTypes(repr, _) == Optional(Nil)) match
-          case method :: _ => method
-          case Nil         => halt(m"xenophile: no JVM getter ${member.jvmName} on $className")
+          refined(term, prototype.result)
 
-      refined(Apply(Select(receiver(self, repr), method), Nil), prototype.result)
+        else
+          mangled(className, member)
+
+          val method =
+            classSymbol.methodMember(member.jvmName.s)
+            . filter(parameterTypes(repr, _) == Optional(Nil)) match
+              case method :: _ => method
+              case Nil         => halt(m"xenophile: no getter ${member.jvmName} on $className")
+
+          refined(Apply(Select(receiver(self, repr), method), Nil), prototype.result)
 
   def applied(self: Expr[Facade], name: Expr[String], arguments: Expr[Seq[Any]])(using Quotes)
   :   Expr[Any] =
@@ -1025,19 +1108,38 @@ object KotlinFacade:
     val repr = transport(self)
     val className = classNameOf(repr)
 
-    val setter = KotlinDialect.setter(className, field).or:
-      halt(m"xenophile: $className has no mutable property $field")
-
     val classSymbol = repr.classSymbol.getOrElse(halt(m"xenophile: not a class type"))
 
-    val method = classSymbol.methodMember(setter.jvmName.s) match
-      case method :: _ => method
-      case Nil         => halt(m"xenophile: no JVM setter ${setter.jvmName} on $className")
+    // A Kotlin `var` setter, or — synthesized — a Java bean setter (`x = v` writes `setX(v)`).
+    val jvmName: Text = KotlinDialect.setter(className, field).let(_.jvmName).or:
+      val capital = capitalize(field)
 
-    val parameter = parameterTypes(repr, method).or(Nil) match
-      case parameter :: _ => parameter
-      case Nil            => halt(m"xenophile: ${setter.jvmName} is not a setter")
+      val setter = KotlinDialect.members(className, t"set$capital").find: member =>
+        !member.property && member.arity == 1
 
+      setter.map(_.jvmName.s.tt).getOrElse:
+        halt(m"xenophile: $className has no mutable property $field")
+
+    // A setter may be overloaded (`Paint.setColor(int)` and `setColor(long)`); choose the one
+    // whose parameter the assigned value fits, preferring an exact match over one reached by a
+    // conversion, so an `Int` colour is not silently widened into a wide-gamut `long`.
+    def parameterOf(method: Symbol): Optional[TypeRepr] =
+      parameterTypes(repr, method).or(Nil) match
+        case parameter :: Nil => parameter
+        case _                => Unset
+
+    val candidates = classSymbol.methodMember(jvmName.s).filter(parameterOf(_).present)
+    val valueType = value.asTerm.tpe.widen
+
+    def fits(predicate: (TypeRepr) => Boolean)(method: Symbol): Boolean =
+      parameterOf(method).lay(false)(predicate(_))
+
+    val chosen =
+      candidates.find(fits(valueType <:< _))
+      . orElse(candidates.find(fits(satisfies(value.asTerm, _))))
+
+    val method = chosen.getOrElse(halt(m"xenophile: no JVM setter $jvmName on $className"))
+    val parameter = parameterOf(method).or(halt(m"xenophile: $jvmName is not a setter"))
     val call = Apply(Select(receiver(self, repr), method), List(adapted(value.asTerm, parameter)))
 
     '{${call.asExpr}; ()}

--- a/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
+++ b/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
@@ -441,12 +441,19 @@ object KotlinFacade:
         val mapped = solid(result)
         mapped =:= TypeRepr.of[Unit] || mapped <:< TypeRepr.of[AnyVal]
 
+      // Only members a caller could actually invoke are worth refining. A non-empty `privateWithin`
+      // marks a package-private or protected-scoped Java member (e.g. JDK 25's internal
+      // `Thread.uncaughtExceptionHandler(handler)`, scoped to `java.lang`); refining it both
+      // exposes an inaccessible method and, worse, shadows the public `setX`-derived property of the
+      // same name — so the `x = …` setter would silently never be generated.
+      def accessible(method: Symbol): Boolean =
+        !method.flags.is(Flags.Synthetic) && !method.flags.is(Flags.Private)
+          && !method.flags.is(Flags.Protected) && method.privateWithin.isEmpty
+
       // A method worth refining: it has at least one functional-interface parameter (so a lambda
       // argument benefits) and a plain result.
       def candidate(method: Symbol): Boolean =
-        val usable = !method.flags.is(Flags.Synthetic) && !method.flags.is(Flags.Private)
-
-        usable && (repr.memberType(method) match
+        accessible(method) && (repr.memberType(method) match
           case MethodType(_, parameters, result) =>
             parameters.exists(samFunctionType(_).present) && plainResult(result)
 
@@ -470,13 +477,46 @@ object KotlinFacade:
       def parameterType(parameter: TypeRepr): TypeRepr =
         samFunctionType(parameter).or(TypeRepr.of[Any])
 
-      candidates.foldLeft(base): (accumulated, method) =>
+      val withMethods = candidates.foldLeft(base): (accumulated, method) =>
         repr.memberType(method).absolve match
           case MethodType(names, parameters, result) =>
             val signature =
               MethodType(names)(_ => parameters.map(parameterType), _ => solid(result))
 
             Refinement(accumulated, method.name, signature)
+
+          case _ =>
+            accumulated
+
+      // A `setX(SAM): void` method also becomes a `var`-like getter/setter pair (`x` and `x_=`)
+      // typed with the interface's function, so a lambda *assigned* with `x = …` infers its
+      // parameter types too (`button.onClickListener = view => …`), not only one passed to the
+      // method. Runtime dispatch of the `_=` returns to `setX` in `applied`.
+      val propertyNames = candidates.map(_.name).to(Set)
+
+      val setters = classSymbol.methodMembers.filter: method =>
+        val named = method.name.length > 3 && method.name.startsWith("set")
+
+        accessible(method) && named && (repr.memberType(method) match
+          case MethodType(_, List(parameter), result) =>
+            samFunctionType(parameter).present && solid(result) =:= TypeRepr.of[Unit]
+
+          case _ =>
+            false)
+
+      . groupBy(_.name).values.map(_.head).to(List)
+
+      setters.foldLeft(withMethods): (accumulated, method) =>
+        repr.memberType(method).absolve match
+          case MethodType(_, List(parameter), _) =>
+            val property = decapitalize(method.name.substring(3).nn.tt)
+
+            // Skip a property whose name a refined method already occupies.
+            if propertyNames.contains(property.s) then accumulated else
+              val function = samFunctionType(parameter).vouch
+              val getter = Refinement(accumulated, property.s, function)
+              val signature = MethodType(List("value"))(_ => List(function), _ => TypeRepr.of[Unit])
+              Refinement(getter, s"${property.s}_=", signature)
 
           case _ =>
             accumulated
@@ -637,6 +677,11 @@ object KotlinFacade:
     if text.s.isEmpty then text
     else t"${text.s.substring(0, 1).nn.toUpperCase.nn}${text.s.substring(1).nn}"
 
+  // The first letter lowercased (`OnClickListener` -> `onClickListener`).
+  private def decapitalize(text: Text): Text =
+    if text.s.isEmpty then text
+    else t"${text.s.substring(0, 1).nn.toLowerCase.nn}${text.s.substring(1).nn}"
+
   // The element type of a JVM array type (`Array[E]`), when the type is one.
   private def arrayElement(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
   :   Optional[quotes.reflect.TypeRepr] =
@@ -783,12 +828,50 @@ object KotlinFacade:
 
           refined(Apply(Select(receiver(self, repr), method), Nil), prototype.result)
 
+  // A `setX(SAM)`-derived property assigned with `x = value` reaches this as `applyDynamic` of
+  // the synthesized setter name (`x_$eq`), routing to `setX` — where the value, typed by the
+  // refinement, is adapted (a lambda proxied to the interface).
+  private def setterCall(using quotes: Quotes)
+    ( self: Expr[Facade], field: Text, arguments: Expr[Seq[Any]] )
+  :   Expr[Any] =
+
+    import quotes.reflect.*
+
+    val suffix = if field.s.endsWith("_$eq") then 4 else 2
+    val property = field.s.substring(0, field.s.length - suffix).nn.tt
+    val setterName = t"set${capitalize(property)}"
+    val repr = transport(self)
+    val className = classNameOf(repr)
+    val classSymbol = repr.classSymbol.getOrElse(halt(m"xenophile: not a class type"))
+
+    val value = arguments match
+      case Varargs(Seq(single)) => single.asTerm
+      case _                    => halt(m"xenophile: an assignment takes a single value")
+
+    def parameterOf(method: Symbol): Optional[TypeRepr] = parameterTypes(repr, method).or(Nil) match
+      case parameter :: Nil => parameter
+      case _                => Unset
+
+    val candidates = classSymbol.methodMember(setterName.s).filter(parameterOf(_).present)
+
+    val method = candidates.find { m => parameterOf(m).lay(false)(satisfies(value, _)) }.getOrElse:
+      halt(m"xenophile: $className has no mutable property $property")
+
+    val parameter = parameterOf(method).vouch
+    val call = Apply(Select(receiver(self, repr), method), List(adapted(value, parameter)))
+
+    '{${call.asExpr}; ()}
+
   def applied(self: Expr[Facade], name: Expr[String], arguments: Expr[Seq[Any]])(using Quotes)
   :   Expr[Any] =
 
     import quotes.reflect.*
 
     val field = name.valueOrAbort.tt
+
+    if field.s.endsWith("_$eq") || field.s.endsWith("_=")
+    then return setterCall(self, field, arguments)
+
     val repr = transport(self)
     val className = classNameOf(repr)
 

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -104,7 +104,7 @@ object Tests extends Suite(m"Xenophile tests"):
       val pair = make[kotlin.Pair[Text, Text]](t"a", t"b")
 
       test(m"a Kotlin class constructs through its facade"):
-        pair.unwrap.toString.tt
+        pair.k.toString.tt
       . assert(_ == t"(a, b)")
 
       test(m"a property substitutes the facade's type arguments"):
@@ -215,7 +215,7 @@ object Tests extends Suite(m"Xenophile tests"):
       // Note `unwrap.toString`: `toString`/`equals`/`hashCode` are real members of the facade
       // wrapper itself, so `Dynamic` cannot intercept them.
       test(m"a plain Java class resolves through the reflection fallback"):
-        make[java.lang.StringBuilder](t"ab").reverse().unwrap.toString.tt
+        make[java.lang.StringBuilder](t"ab").reverse().k.toString.tt
       . assert(_ == t"ba")
 
       test(m"an enum entry is reachable by name, and usable as an argument"):
@@ -262,7 +262,7 @@ object Tests extends Suite(m"Xenophile tests"):
       . assert(_ == 2)
 
       test(m"surplus arguments collect into a vararg tail"):
-        make[java.util.Formatter]().format(t"[%s:%s]", t"x", t"y").unwrap.toString.tt
+        make[java.util.Formatter]().format(t"[%s:%s]", t"x", t"y").k.toString.tt
       . assert(_ == t"[x:y]")
 
       test(m"a value-class member is rejected with a clear diagnostic"):
@@ -288,7 +288,7 @@ object Tests extends Suite(m"Xenophile tests"):
       test(m"an UNTYPED multi-argument lambda infers (an arity-2 interface)"):
         val list = make[java.util.ArrayList[Text]](List(t"ccc", t"a", t"bb"))
         val _ = list.sort((left, right) => left.length - right.length)   // no ascriptions
-        list.get(0).unwrap.toString.tt
+        list.get(0).k.toString.tt
       . assert(_ == t"a")
 
       test(m"an UNTYPED lambda infers on a facade RETURNED from a method"):
@@ -310,8 +310,27 @@ object Tests extends Suite(m"Xenophile tests"):
         // `ArrayList.add(E)` expects a `Text`; pass an `Int`, fitted by the conversion.
         val list = make[java.util.ArrayList[Text]](List())
         val _ = list.add(42)
-        list.get(0).unwrap.toString.tt
+        list.get(0).k.toString.tt
       . assert(_ == t"42")
+
+      test(m"a Java bean getter reads as a short property name"):
+        val entry: Text = make[java.util.zip.ZipEntry](t"file.txt").name   // getName() -> .name
+        entry
+      . assert(_ == t"file.txt")
+
+      test(m"a Java bean setter writes via assignment"):
+        val entry = make[java.util.zip.ZipEntry](t"e")
+        entry.comment = t"hello"            // setComment(String) via `.comment = …`
+        val comment: Text = entry.comment   // getComment() -> .comment
+        comment
+      . assert(_ == t"hello")
+
+      test(m"a Scala array bridges to a Java array parameter (element conversion)"):
+        // The `E[]` constructor wants `CharSequence[]`; a Scala `Array[Text]` bridges to it.
+        val strings: Array[Text] = Array(t"a", t"bb")
+        val list = make[java.util.concurrent.CopyOnWriteArrayList[CharSequence]](strings)
+        list.size()
+      . assert(_ == 2)
 
       test(m"a nullary lambda satisfies a Runnable parameter with no ascription"):
         var ran = false

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -332,6 +332,25 @@ object Tests extends Suite(m"Xenophile tests"):
         list.size()
       . assert(_ == 2)
 
+      test(m"a setX(interface) property is assignable, inferring the lambda"):
+        val handler = make[java.util.logging.StreamHandler]()
+        // `setFilter(Filter)` reached as a `var`; `record` is inferred (a `LogRecord`).
+        handler.filter = (record => record.getLevel() != null)
+        handler.getFilter().k != null
+      . assert(_ == true)
+
+      test(m"a setX(interface) property with a two-argument SAM is assignable"):
+        var caught = false
+        val thread = make[java.lang.Thread](() => ())
+        // `setUncaughtExceptionHandler(UncaughtExceptionHandler)` reached as a `var`; the lambda's
+        // `who`/`error` parameters are inferred. A package-private `uncaughtExceptionHandler(handler)`
+        // method of the same name (JDK-internal) no longer shadows the generated setter.
+        thread.uncaughtExceptionHandler = ((who, error) => caught = true)
+        val installed = thread.getUncaughtExceptionHandler().k
+        installed.uncaughtException(thread.k, RuntimeException("boom"))
+        caught
+      . assert(_ == true)
+
       test(m"a nullary lambda satisfies a Runnable parameter with no ascription"):
         var ran = false
         val thread = make[java.lang.Thread](() => ran = true)

--- a/tests/android/builder/build.scala
+++ b/tests/android/builder/build.scala
@@ -60,13 +60,21 @@ object build:
         if entry.endsWith(".jar") then ClasspathEntry.Jar(entry.tt)
         else ClasspathEntry.Directory(entry.tt)
 
-  // Compiles the app and returns the compilation to link. The platform stubs join the compile
-  // classpath but must not be dexed: on the device, the operating system provides the platform.
+  // Compiles every `.scala` source in `sourceDir` and returns the compilation to link. The
+  // platform stubs join the compile classpath but must not be dexed: on the device, the
+  // operating system provides the platform.
   def compilation
-    ( androidJar: String, outDir: String, sourceFile: String, classpathFile: String )
+    ( androidJar: String, outDir: String, sourceDir: String, classpathFile: String )
   :   Compilation[Universe.Classfile] =
 
-    val source: Text = Files.readString(Paths.get(sourceFile)).nn.tt
+    val sources: Map[Text, Text] =
+      Files.list(Paths.get(sourceDir)).nn.toArray.nn.to(List).map(_.toString)
+      . filter(_.endsWith(".scala")).map: path =>
+          val name = Paths.get(path).nn.getFileName.nn.toString.tt
+          name -> Files.readString(Paths.get(path)).nn.tt
+
+      . to(Map)
+
     val entries = runtime(classpathFile)
     val platform: ClasspathEntry.Jar = ClasspathEntry.Jar(androidJar.tt)
     val compileClasspath = LocalClasspath((platform :: entries)*)
@@ -77,13 +85,11 @@ object build:
 
     supervise:
       val process =
-        Scalac[3.8](List(scalacOptions.experimental))
-          (compileClasspath)
-          (Map(t"dice.scala" -> source), classesPath)
+        Scalac[3.8](List(scalacOptions.experimental))(compileClasspath)(sources, classesPath)
 
       process.complete() match
         case CompileResult.Success =>
-          Out.println(t"compiled $sourceFile")
+          Out.println(t"compiled ${sources.size} sources")
 
         case other =>
           process.notices.each { notice => Out.println(notice.message) }
@@ -94,11 +100,11 @@ object build:
 
 // Links the compilation as a bare DEX archive, packaged into an APK afterwards by the SDK tools.
 @main
-def buildDice(androidJar: String, outDir: String, sourceFile: String, classpathFile: String)
+def buildDice(androidJar: String, outDir: String, sourceDir: String, classpathFile: String)
 :   Unit =
 
   import dexLinkages.given
-  val compiled = build.compilation(androidJar, outDir, sourceFile, classpathFile)
+  val compiled = build.compilation(androidJar, outDir, sourceDir, classpathFile)
   val out: Path on Linux = unsafely(outDir.tt.as[Path on Linux])
 
   val artifact =
@@ -109,11 +115,11 @@ def buildDice(androidJar: String, outDir: String, sourceFile: String, classpathF
 // Links the compilation as a complete, signed APK — dexed, binary-manifested, zip-aligned and
 // v2-signed entirely by Soundness, with no `aapt2`, `zipalign` or `apksigner`.
 @main
-def buildApk(androidJar: String, outDir: String, sourceFile: String, classpathFile: String)
+def buildApk(androidJar: String, outDir: String, sourceDir: String, classpathFile: String)
 :   Unit =
 
   import apkLinkages.given
-  val compiled = build.compilation(androidJar, outDir, sourceFile, classpathFile)
+  val compiled = build.compilation(androidJar, outDir, sourceDir, classpathFile)
   val out: Path on Linux = unsafely(outDir.tt.as[Path on Linux])
 
   val artifact =
@@ -126,6 +132,29 @@ def buildApk(androidJar: String, outDir: String, sourceFile: String, classpathFi
             apkOptions.version(1, t"1.0"),
             apkOptions.permission(t"android.permission.VIBRATE") ),
         List(Linker.EntryPoint(Fqcn(t"dice.DiceActivity"))) )
+    . link(compiled, out)
+
+  Out.println(t"linked $artifact")
+
+// A richer showcase app (`sketch.SketchActivity`) linked as a signed APK, exercising more of the
+// Android API surface through the facades.
+@main
+def buildSketch(androidJar: String, outDir: String, sourceDir: String, classpathFile: String)
+:   Unit =
+
+  import apkLinkages.given
+  val compiled = build.compilation(androidJar, outDir, sourceDir, classpathFile)
+  val out: Path on Linux = unsafely(outDir.tt.as[Path on Linux])
+
+  val artifact =
+    Linker[Artifact.Apk]
+      ( List
+          ( apkOptions.minApi(26),
+            apkOptions.targetApi(36),
+            apkOptions.packageName(t"dev.soundness.sketch"),
+            apkOptions.label(t"Sketch"),
+            apkOptions.version(1, t"1.0") ),
+        List(Linker.EntryPoint(Fqcn(t"sketch.SketchActivity"))) )
     . link(compiled, out)
 
   Out.println(t"linked $artifact")

--- a/tests/android/src/dice.scala
+++ b/tests/android/src/dice.scala
@@ -67,16 +67,16 @@ class DiceActivity extends Activity:
       total += first + second + 2
 
       val color = dieColor(rolls)
-      left.setText(faces(first))
-      right.setText(faces(second))
-      left.setTextColor(color)
-      right.setTextColor(color)
+      left.text = faces(first)
+      right.text = faces(second)
+      left.textColor = color
+      right.textColor = color
 
       history = (t"${faces(first)}${faces(second)}" :: history).take(6)
-      historyView.setText(history.join(t"  "))
+      historyView.text = history.join(t"  ")
 
       val mean = ((total.toDouble/rolls*100).toInt/100.0).show
-      stats.setText(t"Rolls: $rolls   Total: $total   Mean: $mean")
+      stats.text = t"Rolls: $rolls   Total: $total   Mean: $mean"
 
       vibrator.vibrate(VibrationEffect.createOneShot(40L, VibrationEffect.DEFAULT_AMPLITUDE))
 
@@ -85,8 +85,8 @@ class DiceActivity extends Activity:
 
     def animate(frames: Int): Unit =
       if frames == 0 then settle() else
-        left.setText(faces(random.nextInt(0, 6)))
-        right.setText(faces(random.nextInt(0, 6)))
+        left.text = faces(random.nextInt(0, 6))
+        right.text = faces(random.nextInt(0, 6))
 
         // A lambda satisfies any Java functional-interface parameter, inferring its parameter
         // types with no ascription (`postDelayed` takes a `Runnable`). Its `Boolean` result is
@@ -98,17 +98,17 @@ class DiceActivity extends Activity:
     button.setOnClickListener(view => animate(6))
 
     val row = make[LinearLayout](this)
-    row.setOrientation(LinearLayout.HORIZONTAL)
-    row.setGravity(Gravity.CENTER)
+    row.orientation = LinearLayout.HORIZONTAL
+    row.gravity = Gravity.CENTER
     row.addView(left)
     row.addView(right)
 
     val layout = make[LinearLayout](this)
-    layout.setOrientation(LinearLayout.VERTICAL)
-    layout.setGravity(Gravity.CENTER)
+    layout.orientation = LinearLayout.VERTICAL
+    layout.gravity = Gravity.CENTER
     layout.addView(row)
     layout.addView(stats)
     layout.addView(historyView)
     layout.addView(button)
 
-    activity.setContentView(layout)
+    activity.contentView = layout

--- a/tests/android/src/sketch.scala
+++ b/tests/android/src/sketch.scala
@@ -63,7 +63,7 @@ class SketchActivity extends Activity:
 
     val clear = make[Button](this)
     clear.setText(t"Clear")
-    clear.setOnClickListener(view => canvas.clear())
+    clear.onClickListener = (view => canvas.clear())
 
     val color = make[Button](this)
     color.setText(t"Colour")

--- a/tests/android/src/sketch.scala
+++ b/tests/android/src/sketch.scala
@@ -1,0 +1,136 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package sketch
+
+import soundness.*
+
+import android.app.{Activity, AlertDialog}
+import android.content.{Context, SharedPreferences}
+import android.graphics.{Canvas, Color, Paint, Path}
+import android.view.{Gravity, MotionEvent, View, ViewGroup}
+import android.widget.{Button, LinearLayout, TextView, Toast}
+
+// A finger-painting app, exercising a broad slice of the Android API through xenophile's
+// facades: a custom `View` subclass drawing a `Path` with a `Paint` onto the `Canvas` the
+// framework hands it, touch handling from `MotionEvent`, an `AlertDialog` colour picker (whose
+// item listener is an arity-2 functional interface), `SharedPreferences` persistence of the
+// chosen colour, and a scattering of static methods and constants. Nothing here is written
+// against a raw Java signature — every Android call goes through the facade layer.
+class SketchActivity extends Activity:
+  private val palette: List[(Text, Int)] =
+    List(t"Black" -> Color.BLACK, t"Red" -> Color.RED, t"Green" -> Color.GREEN,
+        t"Blue" -> Color.BLUE, t"Magenta" -> Color.MAGENTA)
+
+  override def onCreate(saved: android.os.Bundle): Unit =
+    super.onCreate(saved)
+    val activity = Facade(this: Activity)
+
+    val prefs = Facade(getSharedPreferences(t"sketch".s, Context.MODE_PRIVATE))
+    val savedColor: Int = prefs.getInt(t"color", Color.BLACK)
+
+    val canvas = SketchView(this)
+    canvas.color(savedColor)
+
+    val clear = make[Button](this)
+    clear.setText(t"Clear")
+    clear.setOnClickListener(view => canvas.clear())
+
+    val color = make[Button](this)
+    color.setText(t"Colour")
+
+    color.setOnClickListener: view =>
+      // A Scala `Array[Text]` now bridges to the `CharSequence[]` parameter.
+      val names: Array[Text] = palette.map(_(0)).toArray
+      make[AlertDialog.Builder](this)
+      . setTitle(t"Choose a colour")
+      . setItems(names, (dialog: android.content.DialogInterface, which: Int) => {
+          val chosen = palette(which)(1)
+          canvas.color(chosen)
+          // `Editor.apply()` collides with the facade's index-access operator (`facade(args)`
+          // desugars to `facade.apply(args)`), so it is reached on the unwrapped value.
+          Facade(prefs.k.edit()).putInt(t"color", chosen).k.apply()
+          Toast.makeText(this, t"Colour set".s, Toast.LENGTH_SHORT).show()
+        })
+      . show()
+
+      ()
+
+    val buttons = make[LinearLayout](this)
+    buttons.setOrientation(LinearLayout.HORIZONTAL)
+    buttons.addView(clear)
+    buttons.addView(color)
+
+    val layout = make[LinearLayout](this)
+    layout.setOrientation(LinearLayout.VERTICAL)
+
+    // A weighted layout parameter so the canvas fills the space above the buttons.
+    val fill = make[LinearLayout.LayoutParams](ViewGroup.LayoutParams.MATCH_PARENT, 0, 1.0f)
+    layout.addView(canvas, fill.k)
+    layout.addView(buttons)
+
+    activity.setContentView(layout)
+
+// The drawing surface: accumulates finger strokes into a `Path` and repaints.
+class SketchView(context: Context) extends View(context):
+  private val path = make[Path]()
+  private val brush = make[Paint]()
+
+  brush.setStyle(Paint.Style.STROKE)
+  brush.setStrokeWidth(12)               // an Int, widened to the `float` parameter
+  brush.setStrokeCap(Paint.Cap.ROUND)
+  brush.setStrokeJoin(Paint.Join.ROUND)
+  brush.setAntiAlias(true)
+
+  def color(value: Int): Unit = brush.color = value
+
+  def clear(): Unit =
+    path.reset()
+    invalidate()
+
+  override def onDraw(surface: Canvas): Unit =
+    val facade = Facade(surface)
+    facade.drawColor(Color.WHITE)
+    facade.drawPath(path.k, brush.k)
+
+  override def onTouchEvent(event: MotionEvent): Boolean =
+    val touch = Facade(event)
+    val x: Float = touch.x
+    val y: Float = touch.y
+
+    touch.action match
+      case MotionEvent.ACTION_DOWN => path.moveTo(x, y)
+      case MotionEvent.ACTION_MOVE => path.lineTo(x, y)
+      case _                       => ()
+
+    invalidate()
+    true


### PR DESCRIPTION
The Kotlin/Java facade layer now presents Java bean accessors as Scala-idiomatic properties. A `getX()`/`isX()` reads as `.x`, a `setX(v)` writes as `.x = v` (picking the overload the value fits), and Scala `Array[T]` arguments bridge to Java array parameters. When a setter takes a functional interface, the property's right-hand side infers the lambda's parameters — for interfaces of any arity — so `button.onClickListener = view => …` works with no ascription. The runtime accessor that recovers a facade's underlying value is renamed from `unwrap` to `k`. A new Sketch sample app exercises the surface (custom `View`, `Canvas`/`Paint`, dialogs, preferences) end-to-end on an Android emulator.

Java facades now expose bean accessors as properties:

```scala
val entry = make[java.util.zip.ZipEntry](t"data.txt")
entry.comment = t"generated"        // setComment(String)
val note: Text = entry.comment      // getComment()
```

A setter that takes a functional interface becomes an assignable property whose lambda infers, including two-parameter interfaces:

```scala
button.onClickListener = view => animate()               // View.OnClickListener
thread.uncaughtExceptionHandler = (who, error) => log(error)  // 2-arg interface
```

Only publicly accessible members are surfaced — package-private and protected Java methods (such as JDK-internal namesakes of a public property) are excluded, so they can no longer shadow a generated setter. The facade's underlying value is now reached with `.k` (was `.unwrap`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)