### PR TITLE
Syntax-highlight code samples in semantic diagnostics with Harlequin

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -582,7 +582,8 @@ object soundness extends Toolchain:
   object tool extends Bundle(anthology.core, decorum.plugin, harlequin.core, hellenism.core,
     hyperbole.core, octogenarian.core, revolution.core, umbrageous.plugin, anthology.java,
     harlequin.md, harlequin.ansi, austronesian.core, anthology.linker, anthology.link, anthology.nir,
-    anthology.`scala`, exegesis.core, hellenism.jvm, delicious.core, delicious.`scala`)
+    anthology.`scala`, exegesis.core, hellenism.jvm, delicious.core, delicious.`scala`,
+    delicious.ansi)
 
   object web extends Bundle(archimedes.core, cacophony.core, cataclysm.core, coaxial.core, coaxial.jvm, cosmopolite.core, gesticulate.core,
     honeycomb.core, urticose.core, urticose.url, hallucination.core, phoenicia.core,
@@ -1202,7 +1203,12 @@ object delicious extends Library:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
 
-  object test extends Tests(core, `scala`, anthology.`scala`):
+  object ansi extends Component(`scala`, harlequin.ansi):
+    override def scalaJs = false // depends on JVM-only `harlequin.ansi`
+    override def scalacOptions = Task:
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+
+  object test extends Tests(core, `scala`, ansi, anthology.`scala`):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
 

--- a/lib/delicious/src/ansi/delicious_ansi.scala
+++ b/lib/delicious/src/ansi/delicious_ansi.scala
@@ -1,0 +1,71 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package delicious
+
+import anticipation.*
+import escapade.*
+import gossamer.*
+import harlequin.*
+import stenography.*
+import vacuous.*
+
+import syntaxHighlighting.unnumberedTeletypeable
+
+extension (message: SemanticMessage)
+  /** Render the message as styled terminal text: embedded code samples are
+   *  syntax-highlighted by harlequin, and types are re-rendered through
+   *  stenography (abbreviated according to the given `Imports`) and then
+   *  highlighted in type position. Anything that cannot be reified falls back
+   *  to the compiler-printed text. */
+  def teletype(reifier: Reifier)(using Imports, ScalaSyntaxPalette, Highlight): Teletype =
+    // The compiler may have styled the shown text with ANSI escapes; harlequin
+    // re-highlights from scratch, so they must not survive into the tokens.
+    def ansiFree(text: Text): Text = text.s.replaceAll("\\u001B\\[[;\\d]*m", "").nn.tt
+
+    def highlight(text: Text, context: Scala.Context): Teletype =
+      unnumberedTeletypeable.teletype(Scala.highlight(ansiFree(text), context))
+
+    def recur(nodes: List[Markup]): Teletype = nodes.map(node).join
+
+    def node(markup: Markup): Teletype = markup match
+      case Markup.Textual(text)  => e"${ansiFree(text)}"
+      case Markup.Code(_, _)     => highlight(markup.plain, Scala.Context.Term)
+
+      case typed@Markup.Typed(_, _, _, _) =>
+        highlight(reifier.syntax(typed).let(_.text).or(typed.plain), Scala.Context.Type)
+
+      case Markup.Symbolic(_, _, _, children) => recur(children)
+      case Markup.Named(_, _, children)       => recur(children)
+      case Markup.Spanned(_, _, children)     => recur(children)
+
+    recur(message.markup)

--- a/lib/delicious/src/ansi/soundness_delicious_ansi.scala
+++ b/lib/delicious/src/ansi/soundness_delicious_ansi.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export delicious.teletype

--- a/lib/delicious/src/test/delicious_test.scala
+++ b/lib/delicious/src/test/delicious_test.scala
@@ -48,6 +48,25 @@ import threading.platformThreading
 import workingDirectories.javaWorkingDirectory
 
 object Tests extends Suite(m"Delicious Tests"):
+  given palette: ScalaSyntaxPalette = new Palette:
+    type Form = Srgb
+    def background: Color in Srgb       = WebColors.Black
+    def foreground: Color in Srgb       = WebColors.White
+    def scalaError: Color in Srgb       = WebColors.Red
+    def scalaNumber: Color in Srgb      = WebColors.Gold
+    def scalaString: Color in Srgb      = WebColors.LimeGreen
+    def scalaTerm: Color in Srgb        = WebColors.Silver
+    def scalaType: Color in Srgb        = WebColors.Turquoise
+    def scalaKeyword: Color in Srgb     = WebColors.Orange
+    def scalaSymbol: Color in Srgb      = WebColors.Gray
+    def scalaParenthesis: Color in Srgb = WebColors.Gray
+    def scalaModifier: Color in Srgb    = WebColors.Orchid
+    def scalaComment: Color in Srgb     = WebColors.DimGray
+    def subdued: Color in Srgb          = WebColors.DimGray
+    def accented: Color in Srgb         = WebColors.White
+    def margin: Color in Srgb           = WebColors.DimGray
+
+  val Esc: Char      = '\u001B'
   val Start: Char    = '\uE000'
   val End: Char      = '\uE001'
   val AttrsSep: Char = '\uE002'
@@ -239,6 +258,22 @@ object Tests extends Suite(m"Delicious Tests"):
         val typed = mark(t"type", List(t"tasty" -> stringPayload), t"printed")
         SemanticMessage.parse(t"Required: $typed").render(reifier)
       . assert(_ == t"Required: java.lang.String")
+
+      test(m"A styled rendering preserves the visible text"):
+        val code = mark(t"code", Nil, t"List(1.5)")
+        val typed = mark(t"type", List(t"tasty" -> stringPayload), t"printed")
+        SemanticMessage.parse(t"Tree: $code has type $typed").teletype(reifier).plain
+      . assert(_ == t"Tree: List(1.5) has type java.lang.String")
+
+      test(m"A code sample is syntax-highlighted, not plain"):
+        val code = mark(t"code", Nil, t"val x = 42")
+        SemanticMessage.parse(t"code: $code").teletype(reifier)
+      . assert(_ != e"code: val x = 42")
+
+      test(m"Compiler styling is stripped before highlighting"):
+        val code = mark(t"code", Nil, t"${Esc}[33m1.5d${Esc}[0m")
+        SemanticMessage.parse(t"Tree: $code").teletype(reifier).plain
+      . assert(_ == t"Tree: 1.5d")
 
       // End-to-end through the embedded compiler. Feature-detecting: a compiler
       // without semdiag (releases up to p5) produces no markup, and only the


### PR DESCRIPTION
The new `delicious.ansi` component renders a `SemanticMessage` as styled terminal text: code samples that the compiler marks up in its semantic diagnostics are syntax-highlighted by Harlequin's tokenizer (needing no classpath), and types — re-rendered through Stenography — are highlighted in type position, giving fully-coloured compiler errors on the terminal.

With a `ScalaSyntaxPalette` in scope, a semantic diagnostic can now be rendered as `Teletype`:

```scala
process.notices.each: notice =>
  notice.semantic.let: message =>
    given Imports = Imports.empty
    Out.println(message.teletype(reifier))
```

Code samples (for example the `Tree:` sections of explanations) are tokenized and coloured by the ambient palette's `scala*` colours; types are highlighted as type expressions, so `List[Bad.Local]` renders with its type constructor, brackets and placeholder each in their proper accent. Any ANSI styling the compiler itself applied to the message text is stripped before re-highlighting, and everything falls back to plain text when reification is impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)