### PR TITLE
Add XZ and raw LZMA2 compression to Pneumatic

### DIFF
--- a/lib/pneumatic/src/core/pneumatic.LzDecoder.scala
+++ b/lib/pneumatic/src/core/pneumatic.LzDecoder.scala
@@ -30,6 +30,86 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package pneumatic
 
-export pneumatic.{Brotli, compress, Compression, Compressor, decompress, Lzma2, Lzw, Xz}
+// The decoder's sliding-window dictionary: a flat buffer holding recently-decoded bytes, from which
+// LZMA match copies read. `start..pos` is the not-yet-flushed run; `full` tracks the history
+// available for distance references. `setLimit` bounds how far a single decode pass may advance
+// `pos` before the caller flushes, which keeps match copies inside the buffer.
+private[pneumatic] final class LzDecoder(dictSize: Int):
+  private val buffer: Array[Byte] = new Array[Byte](dictSize)
+  private var start: Int = 0
+  private var position: Int = 0
+  private var full: Int = 0
+  private var limit: Int = 0
+  private var pendingLength: Int = 0
+  private var pendingDist: Int = 0
+
+  reset()
+
+  def reset(): Unit =
+    start = 0
+    position = 0
+    full = 0
+    limit = 0
+    buffer(dictSize - 1) = 0 // so the very first back-reference reads a defined zero
+
+  // After a dictionary reset LZMA2 may keep decoding into the same window; only the model resets.
+  def resetDictionary(): Unit = reset()
+
+  def setLimit(outMax: Int): Unit =
+    limit = if dictSize - position <= outMax then dictSize else position + outMax
+
+  def hasSpace: Boolean = position < limit
+  def hasPending: Boolean = pendingLength > 0
+  def pos: Int = position
+
+  def getByte(dist: Int): Int =
+    var offset = position - dist - 1
+    if dist >= position then offset += dictSize
+    buffer(offset) & 0xff
+
+  def putByte(byte: Byte): Unit =
+    buffer(position) = byte
+    position += 1
+    if full < position then full = position
+
+  def repeat(dist: Int, len: Int): Unit =
+    if dist < 0 || dist >= full then
+      throw IllegalStateException("the LZMA data is corrupt: invalid match distance")
+
+    var left = if limit - position < len then limit - position else len
+    pendingLength = len - left
+    pendingDist = dist
+
+    var back = position - dist - 1
+    if dist >= position then back += dictSize
+
+    while left > 0 do
+      buffer(position) = buffer(back)
+      position += 1
+      back += 1
+      if back == dictSize then back = 0
+      left -= 1
+
+    if full < position then full = position
+
+  def repeatPending(): Unit =
+    if pendingLength > 0 then repeat(pendingDist, pendingLength)
+
+  // Copy `len` literal bytes straight from a source array (an LZMA2 uncompressed chunk).
+  def copyUncompressed(source: Array[Byte], sourceOffset: Int, len: Int): Unit =
+    val copySize = if dictSize - position < len then dictSize - position else len
+    System.arraycopy(source, sourceOffset, buffer, position, copySize)
+    position += copySize
+    if full < position then full = position
+
+  // Emit everything decoded since the last flush, wrapping `pos` when it reaches the buffer end.
+  def flush(out: Array[Byte], outOffset: Int): Int =
+    val copySize = position - start
+    if position == dictSize then position = 0
+    System.arraycopy(buffer, start, out, outOffset, copySize)
+    start = position
+    copySize
+
+  def flushSize: Int = position - start

--- a/lib/pneumatic/src/core/pneumatic.Lzma2.scala
+++ b/lib/pneumatic/src/core/pneumatic.Lzma2.scala
@@ -1,0 +1,350 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package pneumatic
+
+import scala.collection.mutable as scm
+
+import anticipation.*
+import rudiments.*
+import turbulence.*
+import vacuous.*
+import zephyrine.*
+
+// LZMA2 wraps the raw LZMA symbol stream in self-describing chunks: each carries its uncompressed
+// size and, for compressed chunks, its compressed size plus flags saying whether the dictionary,
+// the LZMA state, and the properties (lc/lp/pb) reset at the chunk boundary. This is what makes
+// LZMA2 seekable and resettable where plain LZMA is not. A control byte of 0x00 ends the stream.
+//
+// The decompressor is a streaming state machine: it accumulates just enough input to parse a chunk
+// header, then (for compressed chunks) buffers the ≤ 64 KiB compressed payload before handing to
+// the range decoder. Consumed input is compacted away, so buffered compressed data stays bounded to
+// roughly one chunk. Decoded bytes are appended to `output`, which the enclosing engine drains.
+
+object Lzma2:
+  inline val UncompressedSizeMax = 1 << 21 // 2 MiB per chunk
+  inline val CompressedSizeMax = 1 << 16   // 64 KiB per LZMA chunk
+  inline val DefaultPreset = 6
+
+  private def compressorEngine(preset: Int): XzEngine = Lzma2CompressorEngine(preset)
+
+  private def decompressorEngine(dictSize: Int): XzEngine = Lzma2DecompressorEngine(dictSize)
+
+  private def defaultDictSize: Int = Lzma2Options.preset(DefaultPreset).dictSize
+
+  given compression: Lzma2 is Compression:
+    def compressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      XzStage(compressorEngine(DefaultPreset))
+
+    def decompressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      XzStage(decompressorEngine(defaultDictSize))
+
+    override def compress(stream: LazyList[Data]): LazyList[Data] =
+      Xz.drive(compressorEngine(DefaultPreset), stream)
+
+    override def decompress(stream: LazyList[Data]): LazyList[Data] =
+      Xz.drive(decompressorEngine(defaultDictSize), stream)
+
+  // Compress raw LZMA2 with an explicit preset (0..9).
+  def compressor(preset: Int)(using Buffering): Duct[Data, Data] {
+    type Transport = Credit
+    type Upstream = Credit } =
+
+    XzStage(compressorEngine(preset))
+
+  def compress(stream: LazyList[Data], preset: Int): LazyList[Data] =
+    Xz.drive(compressorEngine(preset), stream)
+
+  // Decompress raw LZMA2 with an explicit dictionary size — the size the producer used, as a raw
+  // LZMA2 stream (unlike `.xz`) does not record it. The default forms assume the preset-6 size.
+  def decompressor(dictSize: Int)(using Buffering): Duct[Data, Data] {
+    type Transport = Credit
+    type Upstream = Credit } =
+
+    XzStage(decompressorEngine(dictSize))
+
+  def decompress(stream: LazyList[Data], dictSize: Int): LazyList[Data] =
+    Xz.drive(decompressorEngine(dictSize), stream)
+
+private enum Lzma2State:
+  case Control, UncompressedHeader, UncompressedData, LzmaHeader, LzmaData, Ended
+
+private[pneumatic] final class Lzma2Decompressor(dictSize: Int):
+  private val lz = LzDecoder(dictSize)
+  private val rc = RangeDecoder()
+
+  // Bounded output scratch: decode/copy passes are capped to this size so a large dictionary does
+  // not force a correspondingly large flush buffer.
+  private val flushCap =
+    if dictSize >= (1 << 16) then 1 << 16 else if dictSize > 0 then dictSize else 1
+
+  private val flushBuffer = new Array[Byte](flushCap)
+  private var lzma: LzmaDecoder | Null = null
+  private var haveProperties = false
+  private var propsLc = -1
+  private var propsLp = -1
+  private var propsPb = -1
+
+  private var state = Lzma2State.Control
+
+  // Buffered, not-yet-consumed compressed input, with a read cursor.
+  private var input: Array[Byte] = new Array[Byte](1 << 16)
+  private var readPos = 0
+  private var writePos = 0
+
+  // Per-chunk header fields.
+  private var control = 0
+  private var chunkReset = 0
+  private var chunkUncompressed = 0
+  private var chunkCompressed = 0
+  private var uncompressedRemaining = 0
+  private var dictResetPending = true
+
+  val output: scm.ArrayBuffer[Byte] = scm.ArrayBuffer()
+
+  private var consumedTotal = 0
+
+  def ended: Boolean = state == Lzma2State.Ended
+
+  // Total bytes drawn from the fed input, so the container can locate where a block's LZMA2 data
+  // ends and its padding/check begin.
+  def consumed: Int = consumedTotal
+
+  private def available: Int = writePos - readPos
+
+  private def compact(): Unit =
+    if readPos > 0 then
+      System.arraycopy(input, readPos, input, 0, writePos - readPos)
+      writePos -= readPos
+      readPos = 0
+
+  private def ensureCapacity(extra: Int): Unit =
+    if writePos + extra > input.length then
+      compact()
+
+      if writePos + extra > input.length then
+        var size = input.length*2
+        while writePos + extra > size do size *= 2
+        val grown = new Array[Byte](size)
+        System.arraycopy(input, 0, grown, 0, writePos)
+        input = grown
+
+  def accept(bytes: Array[Byte], offset: Int, length: Int): Unit =
+    ensureCapacity(length)
+    System.arraycopy(bytes, offset, input, writePos, length)
+    writePos += length
+    process()
+
+  private def readByte(): Int =
+    val byte = input(readPos) & 0xff
+    readPos += 1
+    consumedTotal += 1
+    byte
+
+  private def process(): Unit =
+    var progressing = true
+
+    while progressing do
+      progressing = false
+
+      state match
+        case Lzma2State.Ended => ()
+
+        case Lzma2State.Control =>
+          if available >= 1 then
+            control = readByte()
+
+            if control == 0x00 then state = Lzma2State.Ended
+            else if control >= 0x80 then
+              chunkUncompressed = (control & 0x1f) << 16
+              chunkReset = (control >> 5) & 0x03
+              state = Lzma2State.LzmaHeader
+              progressing = true
+            else if control <= 2 then
+              if control == 1 then { lz.reset(); dictResetPending = false; haveProperties = false }
+              state = Lzma2State.UncompressedHeader
+              progressing = true
+            else
+              throw IllegalStateException("the LZMA2 data is corrupt: bad control byte")
+
+        case Lzma2State.UncompressedHeader =>
+          if available >= 2 then
+            chunkUncompressed = ((readByte() << 8) | readByte()) + 1
+            uncompressedRemaining = chunkUncompressed
+            state = Lzma2State.UncompressedData
+            progressing = true
+
+        case Lzma2State.UncompressedData =>
+          if available >= 1 then
+            val take =
+              if available < uncompressedRemaining then available else uncompressedRemaining
+
+            var offset = readPos
+            var remaining = take
+
+            while remaining > 0 do
+              val step = if remaining < flushCap then remaining else flushCap
+              lz.copyUncompressed(input, offset, step)
+              val flushed = lz.flush(flushBuffer, 0)
+              appendOutput(flushed)
+              offset += flushed
+              remaining -= flushed
+
+            readPos += take
+            consumedTotal += take
+            uncompressedRemaining -= take
+            if uncompressedRemaining == 0 then state = Lzma2State.Control
+            progressing = uncompressedRemaining == 0
+
+        case Lzma2State.LzmaHeader =>
+          val headerSize = 4 + (if chunkReset >= 2 then 1 else 0)
+
+          if available >= headerSize then
+            chunkUncompressed += ((readByte() << 8) | readByte()) + 1
+            chunkCompressed = ((readByte() << 8) | readByte()) + 1
+
+            if chunkReset >= 2 then configureProperties(readByte())
+            else if chunkReset == 1 then
+              (lzma.nn).reset()
+            else if lzma == null then
+              throw IllegalStateException("the LZMA2 data is corrupt: no properties before chunk")
+
+            if chunkReset == 3 then lz.reset()
+            uncompressedRemaining = chunkUncompressed
+            state = Lzma2State.LzmaData
+            progressing = true
+
+        case Lzma2State.LzmaData =>
+          if available >= chunkCompressed then
+            rc.prepare(input, readPos, chunkCompressed)
+            var remaining = uncompressedRemaining
+
+            while remaining > 0 do
+              lz.setLimit(if remaining < flushCap then remaining else flushCap)
+              (lzma.nn).decode()
+              val flushed = lz.flush(flushBuffer, 0)
+              appendOutput(flushed)
+              remaining -= flushed
+
+            if rc.inError then
+              throw IllegalStateException("the LZMA2 data is corrupt: range coder overran chunk")
+
+            readPos += chunkCompressed
+            consumedTotal += chunkCompressed
+            state = Lzma2State.Control
+            progressing = true
+
+    compact()
+
+  private def configureProperties(propsByte: Int): Unit =
+    val (lc, lp, pb) = Lzma2Options.decodeProperties(propsByte)
+
+    if lzma == null || lc != propsLc || lp != propsLp || pb != propsPb then
+      propsLc = lc; propsLp = lp; propsPb = pb
+      lzma = LzmaDecoder(lz, rc, lc, lp, pb)
+    else
+      (lzma.nn).reset()
+
+    haveProperties = true
+
+  private def appendOutput(count: Int): Unit =
+    var i = 0
+    while i < count do { output += flushBuffer(i); i += 1 }
+
+  def finish(): Unit =
+    if state != Lzma2State.Ended && available > 0 then process()
+
+// Compresses a fully-buffered payload into an LZMA2 chunk stream. The single LZMA model persists
+// across chunks (only the first chunk resets the dictionary, state and properties); the range coder
+// is finished and restarted at each chunk boundary, which is cut when the chunk's uncompressed size
+// approaches 2 MiB or its compressed size approaches the 64 KiB ceiling. A trailing 0x00 control
+// byte ends the stream. Incompressible spans still emit valid (if not smaller) LZMA chunks.
+private[pneumatic] final class Lzma2Compressor(data: Array[Byte], options: Lzma2Options):
+  private val rc = RangeEncoder()
+
+  private val effectiveDict =
+    if options.dictSize < data.length then options.dictSize else data.length
+
+  private val depth = if options.depthLimit > 0 then options.depthLimit else 32
+  private val finder = HashChain(data, if effectiveDict > 0 then effectiveDict else 1, depth)
+
+  private val lzma = LzmaEncoder(data, rc, options.lc, options.lp, options.pb, finder,
+      options.niceLen, options.mode == Lzma2Options.ModeNormal)
+
+  def compress(): Array[Byte] =
+    val out = scm.ArrayBuffer[Byte]()
+
+    if data.length == 0 then out += 0x00.toByte else
+      var firstChunk = true
+
+      while lzma.hasMore do
+        rc.reset()
+        val startPos = lzma.pos
+        val uncompressedCeiling = Lzma2.UncompressedSizeMax - Lzma.MatchLenMax
+        val compressedCeiling = Lzma2.CompressedSizeMax - 64
+
+        while lzma.hasMore &&
+          (lzma.pos - startPos) < uncompressedCeiling &&
+          rc.pendingSize < compressedCeiling
+        do lzma.encodeSymbol()
+
+        val uncompressedSize = lzma.pos - startPos
+        val compressedSize = rc.finish()
+        val reset = if firstChunk then 3 else 0
+        val u = uncompressedSize - 1
+        val c = compressedSize - 1
+
+        out += (0x80 | (reset << 5) | ((u >>> 16) & 0x1f)).toByte
+        out += ((u >>> 8) & 0xff).toByte
+        out += (u & 0xff).toByte
+        out += ((c >>> 8) & 0xff).toByte
+        out += (c & 0xff).toByte
+
+        if reset >= 2 then
+          out += Lzma2Options.propertiesByte(options.lc, options.lp, options.pb).toByte
+
+        val payload = rc.bytes
+        var i = 0
+        while i < payload.length do { out += payload(i); i += 1 }
+        firstChunk = false
+
+      out += 0x00.toByte
+
+    out.toArray
+
+sealed trait Lzma2 extends Compressor

--- a/lib/pneumatic/src/core/pneumatic.Lzma2Options.scala
+++ b/lib/pneumatic/src/core/pneumatic.Lzma2Options.scala
@@ -30,6 +30,93 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package pneumatic
 
-export pneumatic.{Brotli, compress, Compression, Compressor, decompress, Lzma2, Lzw, Xz}
+// LZMA2 encoding options from a preset level 0..9. `dictSize`, `lc`/`lp`/`pb` are recorded in the
+// stream (dictionary-size property byte and the LZMA properties byte), so a decoder recovers
+// them; `mode`, `niceLen`, `matchFinder` and `depthLimit` steer only the encoder's search and
+// do not affect decodability. Presets 0..3 use the fast greedy encoder; 4..9 use the normal
+// price-based encoder (cost-optimal per-step decisions with repeat-matches and lazy evaluation).
+private[pneumatic] object Lzma2Options:
+  inline val ModeFast = 1
+  inline val ModeNormal = 2
+
+  inline val MatchFinderHc4 = 0x04
+  inline val MatchFinderBt4 = 0x14
+
+  inline val NiceLenMin = 2
+  inline val NiceLenMax = 273
+
+  inline val DictSizeMin = 4096
+  inline val DictSizeMax = 768 << 20 // 768 MiB
+
+  inline val LcDefault = 3
+  inline val LpDefault = 0
+  inline val PbDefault = 2
+
+  private val presetDictSizes: Array[Int] = Array(
+      1 << 18, 1 << 20, 1 << 21, 1 << 22, 1 << 22, 1 << 23, 1 << 23, 1 << 24, 1 << 25, 1 << 26)
+
+  private val fastDepths: Array[Int] = Array(4, 8, 24, 48)
+
+  def preset(level0: Int): Lzma2Options =
+    val level = if level0 < 0 then 0 else if level0 > 9 then 9 else level0
+    val dictSize = presetDictSizes(level)
+
+    if level <= 3 then
+      val niceLen = if level <= 1 then 128 else 273
+
+      Lzma2Options(dictSize, LcDefault, LpDefault, PbDefault, ModeFast, niceLen, MatchFinderHc4,
+          fastDepths(level))
+    else
+      val niceLen = if level == 4 then 16 else if level == 5 then 32 else 64
+
+      Lzma2Options(dictSize, LcDefault, LpDefault, PbDefault, ModeNormal, niceLen, MatchFinderBt4,
+          0)
+
+  // The LZMA properties byte packs lc/lp/pb: p = (pb*5 + lp)*9 + lc, with lc+lp <= 4.
+  def propertiesByte(lc: Int, lp: Int, pb: Int): Int = (pb*5 + lp)*9 + lc
+
+  def decodeProperties(byte: Int): (Int, Int, Int) =
+    if byte < 0 || byte > (4*5 + 4)*9 + 8 then
+      throw IllegalStateException("the LZMA data is corrupt: invalid properties byte")
+
+    var props = byte
+    val lc = props % 9
+    props /= 9
+    val lp = props % 5
+    val pb = props / 5
+
+    if lc + lp > 4 then
+      throw IllegalStateException("the LZMA data is corrupt: lc + lp exceeds 4")
+
+    (lc, lp, pb)
+
+  // The LZMA2 dictionary-size property byte: the smallest `i` whose size covers `dictSize`.
+  def dictSizeToByte(dictSize: Int): Int =
+    var i = 0
+
+    while i < 40 do
+      if ((2 | (i & 1)).toLong << (i / 2 + 11)) >= (dictSize.toLong & 0xffffffffL) then return i
+      i += 1
+
+    40
+
+  def byteToDictSize(byte: Int): Int =
+    if byte < 0 || byte > 40 then
+      throw IllegalStateException("the LZMA data is corrupt: invalid dictionary-size byte")
+
+    if byte == 40 then DictSizeMax
+    else
+      val size = ((2 | (byte & 1)).toLong << (byte / 2 + 11))
+      if size > DictSizeMax then DictSizeMax else size.toInt
+
+private[pneumatic] case class Lzma2Options
+  ( dictSize:    Int,
+    lc:          Int,
+    lp:          Int,
+    pb:          Int,
+    mode:        Int,
+    niceLen:     Int,
+    matchFinder: Int,
+    depthLimit:  Int )

--- a/lib/pneumatic/src/core/pneumatic.LzmaCoder.scala
+++ b/lib/pneumatic/src/core/pneumatic.LzmaCoder.scala
@@ -1,0 +1,155 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package pneumatic
+
+import RangeCoder.{ProbInit, probabilities, resetProbabilities}
+
+// Shared LZMA model constants and the coder base holding every adaptive probability array. The
+// encoder and decoder derive from this so their models have identical shapes; only the direction of
+// coding differs. These are the standard LZMA parameters (match lengths 2..273, 12 states, 4 reps,
+// 64 distance slots, a 16-entry alignment tree), documented in the LZMA specification.
+private[pneumatic] object Lzma:
+  inline val PosStatesMax = 1 << 4
+
+  inline val MatchLenMin = 2
+  inline val LenLowSymbols = 1 << 3  // 8
+  inline val LenMidSymbols = 1 << 3  // 8
+  inline val LenHighSymbols = 1 << 8 // 256
+  inline val MatchLenMax = MatchLenMin + LenLowSymbols + LenMidSymbols + LenHighSymbols - 1 // 273
+
+  inline val DistStates = 4
+  inline val DistSlots = 1 << 6      // 64
+  inline val DistModelStart = 4
+  inline val DistModelEnd = 14
+  inline val FullDistances = 1 << (DistModelEnd / 2) // 128
+  inline val AlignBits = 4
+  inline val AlignSize = 1 << AlignBits // 16
+  inline val AlignMask = AlignSize - 1
+
+  inline val Reps = 4
+  inline val States = 12
+
+  def distState(len: Int): Int =
+    if len < DistStates + MatchLenMin then len - MatchLenMin else DistStates - 1
+
+import Lzma.*
+
+// The 12-state LZMA context tracking the recent history of literal/match/rep decisions; its value
+// selects which `isMatch`/`isRep*` probabilities apply.
+private[pneumatic] final class State:
+  private var value: Int = 0
+
+  def get: Int = value
+  def reset(): Unit = value = 0
+  def set(other: State): Unit = value = other.value
+  def isLiteral: Boolean = value < 7
+
+  def updateLiteral(): Unit =
+    value = if value < 4 then 0 else if value < 10 then value - 3 else value - 6
+
+  def updateMatch(): Unit = value = if value < 7 then 7 else 10
+  def updateRep(): Unit = value = if value < 7 then 8 else 11
+  def updateShortRep(): Unit = value = if value < 7 then 9 else 11
+
+// The length model: a two-bit `choice` selecting one of three symbol ranges (8 low, 8 mid, 256
+// high), the low/mid trees indexed by position-state. Subclassed for decoding and encoding.
+private[pneumatic] abstract class LengthCoder:
+  val choice: Array[Short] = new Array[Short](2)
+  val low: Array[Array[Short]] = Array.tabulate(PosStatesMax)(_ => probabilities(LenLowSymbols))
+  val mid: Array[Array[Short]] = Array.tabulate(PosStatesMax)(_ => probabilities(LenMidSymbols))
+  val high: Array[Short] = probabilities(LenHighSymbols)
+
+  def reset(): Unit =
+    choice(0) = ProbInit
+    choice(1) = ProbInit
+    var i = 0
+    while i < PosStatesMax do { resetProbabilities(low(i)); resetProbabilities(mid(i)); i += 1 }
+    resetProbabilities(high)
+
+// The coder base: every probability array LZMA needs, plus the reps, state and literal-context
+// arithmetic. `pb`/`lp`/`lc` fix the position and literal-context masks.
+private[pneumatic] abstract class LzmaCoder(lc: Int, lp: Int, pb: Int):
+  val posMask: Int = (1 << pb) - 1
+  private val literalPosMask: Int = (1 << lp) - 1
+  private val literalContextBits: Int = lc
+
+  val reps: Array[Int] = new Array[Int](Reps)
+  val state: State = State()
+
+  val isMatch: Array[Array[Short]] = Array.tabulate(States)(_ => probabilities(PosStatesMax))
+  val isRep: Array[Short] = probabilities(States)
+  val isRep0: Array[Short] = probabilities(States)
+  val isRep1: Array[Short] = probabilities(States)
+  val isRep2: Array[Short] = probabilities(States)
+  val isRep0Long: Array[Array[Short]] = Array.tabulate(States)(_ => probabilities(PosStatesMax))
+  val distSlots: Array[Array[Short]] = Array.tabulate(DistStates)(_ => probabilities(DistSlots))
+
+  // One reverse-tree per distance slot from `DistModelStart` up to `DistModelEnd`; sizes double
+  // every two slots (2,2,4,4,8,8,16,16,32,32), indexed by `distSlot - DistModelStart`.
+  val distSpecial: Array[Array[Short]] = Array(
+      probabilities(2), probabilities(2), probabilities(4), probabilities(4),
+      probabilities(8), probabilities(8), probabilities(16), probabilities(16),
+      probabilities(32), probabilities(32))
+
+  val distAlign: Array[Short] = probabilities(AlignSize)
+
+  // The literal model: 0x300 probabilities per (high bits of the previous byte, low bits of the
+  // position) context. Stored flat; `literalIndex` yields the base offset of a context's block.
+  val literalProbs: Array[Short] = probabilities(0x300 << (lc + lp))
+
+  def literalIndex(prevByte: Int, position: Int): Int =
+    val contextLow = prevByte >>> (8 - literalContextBits)
+    val contextHigh = (position & literalPosMask) << literalContextBits
+    (contextLow + contextHigh)*0x300
+
+  def reset(): Unit =
+    var i = 0
+    while i < Reps do { reps(i) = 0; i += 1 }
+    state.reset()
+    i = 0
+
+    while i < States do
+      resetProbabilities(isMatch(i))
+      resetProbabilities(isRep0Long(i))
+      i += 1
+
+    resetProbabilities(isRep)
+    resetProbabilities(isRep0)
+    resetProbabilities(isRep1)
+    resetProbabilities(isRep2)
+    i = 0
+    while i < DistStates do { resetProbabilities(distSlots(i)); i += 1 }
+    i = 0
+    while i < distSpecial.length do { resetProbabilities(distSpecial(i)); i += 1 }
+    resetProbabilities(distAlign)
+    resetProbabilities(literalProbs)

--- a/lib/pneumatic/src/core/pneumatic.LzmaDecoder.scala
+++ b/lib/pneumatic/src/core/pneumatic.LzmaDecoder.scala
@@ -30,6 +30,120 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package pneumatic
 
-export pneumatic.{Brotli, compress, Compression, Compressor, decompress, Lzma2, Lzw, Xz}
+import Lzma.*
+
+// The length decoder: a choice bit selects the low (8), mid (8) or high (256) symbol range, each a
+// bit-tree; low/mid are indexed by position-state.
+private[pneumatic] final class LengthDecoder extends LengthCoder:
+  def decode(rc: RangeDecoder, posState: Int): Int =
+    if rc.decodeBit(choice, 0) == 0 then rc.decodeBitTree(low(posState)) + MatchLenMin
+    else if rc.decodeBit(choice, 1) == 0 then
+      rc.decodeBitTree(mid(posState)) + MatchLenMin + LenLowSymbols
+    else
+      rc.decodeBitTree(high) + MatchLenMin + LenLowSymbols + LenMidSymbols
+
+// The LZMA symbol decoder: reads literals and matches from the range decoder, writing bytes (and
+// match copies) into the sliding window. Driven a window's-worth at a time by the LZMA2 layer,
+// which bounds output via `lz.setLimit`.
+private[pneumatic] final class LzmaDecoder
+  ( lz: LzDecoder, rc: RangeDecoder, lc: Int, lp: Int, pb: Int )
+extends LzmaCoder(lc, lp, pb):
+
+  private val matchLengthDecoder = LengthDecoder()
+  private val repLengthDecoder = LengthDecoder()
+
+  reset()
+
+  override def reset(): Unit =
+    super.reset()
+    matchLengthDecoder.reset()
+    repLengthDecoder.reset()
+
+  def endMarkerDetected: Boolean = reps(0) == -1
+
+  // Decode until the window has no more space (the LZMA2 chunk's uncompressed length is reached, or
+  // the buffer is full and needs flushing). Any match left dangling at the limit is finished first.
+  def decode(): Unit =
+    lz.repeatPending()
+
+    while lz.hasSpace do
+      val posState = lz.pos & posMask
+
+      if rc.decodeBit(isMatch(state.get), posState) == 0 then decodeLiteral()
+      else
+        val len =
+          if rc.decodeBit(isRep, state.get) == 0 then decodeMatch(posState)
+          else decodeRepMatch(posState)
+
+        lz.repeat(reps(0), len)
+
+  private def decodeLiteral(): Unit =
+    val prevByte = lz.getByte(0)
+    val base = literalIndex(prevByte, lz.pos)
+    var symbol = 1
+
+    if state.isLiteral then
+      while symbol < 0x100 do symbol = (symbol << 1) | rc.decodeBit(literalProbs, base + symbol)
+    else
+      var matchByte = lz.getByte(reps(0)) << 1
+      var continue = true
+
+      while continue && symbol < 0x100 do
+        val matchBit = (matchByte >> 8) & 1
+        matchByte <<= 1
+        val bit = rc.decodeBit(literalProbs, base + ((1 + matchBit) << 8) + symbol)
+        symbol = (symbol << 1) | bit
+        if matchBit != bit then continue = false
+
+      while symbol < 0x100 do symbol = (symbol << 1) | rc.decodeBit(literalProbs, base + symbol)
+
+    lz.putByte(symbol.toByte)
+    state.updateLiteral()
+
+  private def decodeMatch(posState: Int): Int =
+    state.updateMatch()
+    reps(3) = reps(2)
+    reps(2) = reps(1)
+    reps(1) = reps(0)
+
+    val len = matchLengthDecoder.decode(rc, posState)
+    val distSlot = rc.decodeBitTree(distSlots(distState(len)))
+
+    if distSlot < DistModelStart then reps(0) = distSlot
+    else
+      val footerBits = (distSlot >> 1) - 1
+      reps(0) = (2 | (distSlot & 1)) << footerBits
+
+      if distSlot < DistModelEnd then
+        reps(0) += rc.decodeBitTreeReverse(distSpecial(distSlot - DistModelStart))
+      else
+        reps(0) += rc.decodeDirectBits(footerBits - AlignBits) << AlignBits
+        reps(0) += rc.decodeBitTreeReverse(distAlign)
+
+    len
+
+  private def decodeRepMatch(posState: Int): Int =
+    if rc.decodeBit(isRep0, state.get) == 0 then
+      if rc.decodeBit(isRep0Long(state.get), posState) == 0 then
+        state.updateShortRep()
+        return 1
+    else
+      val distance =
+        if rc.decodeBit(isRep1, state.get) == 0 then reps(1)
+        else if rc.decodeBit(isRep2, state.get) == 0 then
+          val d = reps(2)
+          reps(2) = reps(1)
+          d
+        else
+          val d = reps(3)
+          reps(3) = reps(2)
+          reps(2) = reps(1)
+          d
+
+      reps(1) = reps(0)
+      reps(0) = distance
+
+    state.updateRep()
+    repLengthDecoder.decode(rc, posState)

--- a/lib/pneumatic/src/core/pneumatic.LzmaEncoder.scala
+++ b/lib/pneumatic/src/core/pneumatic.LzmaEncoder.scala
@@ -1,0 +1,464 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package pneumatic
+
+import Lzma.*
+
+// A hash-chain match finder over a fully-buffered input. Every position is keyed by a hash of its
+// four leading bytes; positions sharing a hash are threaded newest-first through `chain`, so a
+// search walks recent candidates in the dictionary window up to a bounded depth — the hash-chain
+// (HC4) family used by the fast LZMA presets — simple and correct, trading some ratio for speed.
+private[pneumatic] final class HashChain(data: Array[Byte], dictSize: Int, depth: Int):
+  private val length = data.length
+  private val hashBits = 17
+  private val hashSize = 1 << hashBits
+  private val head = new Array[Int](hashSize)
+  private val chain = new Array[Int](if length > 0 then length else 1)
+
+  private var i = 0
+  while i < hashSize do { head(i) = -1; i += 1 }
+
+  private def hash(pos: Int): Int =
+    val value = (data(pos) & 0xff) | ((data(pos + 1) & 0xff) << 8) |
+      ((data(pos + 2) & 0xff) << 16) | ((data(pos + 3) & 0xff) << 24)
+
+    (value*0x9e3779b1) >>> (32 - hashBits)
+
+  def insert(pos: Int): Unit =
+    if pos + 4 <= length then
+      val h = hash(pos)
+      chain(pos) = head(h)
+      head(h) = pos
+
+  // The longest match at `pos`, as (length, distanceValue) where the LZMA distance is one less than
+  // the byte offset. Returns length 0 if nothing usable is found.
+  def find(pos: Int, lenLimit: Int): Long =
+    if pos + 4 > length || lenLimit < MatchLenMin then 0L else
+      var bestLen = 0
+      var bestDist = 0
+      var candidate = head(hash(pos))
+      var remaining = depth
+
+      while candidate >= 0 && (pos - candidate) <= dictSize && remaining > 0 do
+        var len = 0
+        while len < lenLimit && data(candidate + len) == data(pos + len) do len += 1
+
+        if len > bestLen then
+          bestLen = len
+          bestDist = pos - candidate - 1
+          if len >= lenLimit then remaining = 1
+
+        candidate = chain(candidate)
+        remaining -= 1
+
+      (bestLen.toLong << 32) | (bestDist.toLong & 0xffffffffL)
+
+  // The full candidate set at `pos`: for each length reachable (strictly increasing), the nearest
+  // distance achieving it, so the caller can weigh the length/distance trade-off by price. Results
+  // fill `outLen`/`outDist`; the return value is the count. Read-only (does not insert `pos`).
+  def findAll(pos: Int, lenLimit: Int, outLen: Array[Int], outDist: Array[Int]): Int =
+    if pos + 4 > length || lenLimit < MatchLenMin then 0 else
+      var count = 0
+      var maxLen = MatchLenMin - 1
+      var candidate = head(hash(pos))
+      var remaining = depth
+
+      while candidate >= 0 && (pos - candidate) <= dictSize && remaining > 0 do
+        var len = 0
+        while len < lenLimit && data(candidate + len) == data(pos + len) do len += 1
+
+        if len > maxLen then
+          outLen(count) = len
+          outDist(count) = pos - candidate - 1
+          count += 1
+          maxLen = len
+          if len >= lenLimit then remaining = 1
+
+        candidate = chain(candidate)
+        remaining -= 1
+
+      count
+
+// The length model encoder: a choice bit chooses the low/mid/high range, then a bit-tree codes the
+// symbol within it. Lengths are offset by `MatchLenMin`.
+private[pneumatic] final class LengthEncoder extends LengthCoder:
+  def encode(rc: RangeEncoder, len: Int, posState: Int): Unit =
+    val value = len - MatchLenMin
+
+    if value < LenLowSymbols then
+      rc.encodeBit(choice, 0, 0)
+      rc.encodeBitTree(low(posState), value)
+    else
+      rc.encodeBit(choice, 0, 1)
+      val mid0 = value - LenLowSymbols
+
+      if mid0 < LenMidSymbols then
+        rc.encodeBit(choice, 1, 0)
+        rc.encodeBitTree(mid(posState), mid0)
+      else
+        rc.encodeBit(choice, 1, 1)
+        rc.encodeBitTree(high, mid0 - LenMidSymbols)
+
+// The LZMA symbol encoder. It walks the input once, at each step choosing between a literal, an
+// ordinary match, and — in normal mode — a repeat-match reusing one of the four recent distances
+// (understood by the decoder, and far cheaper in bits than a fresh distance). Every emitted symbol
+// keeps `state` and `reps` in step with what the decoder will reconstruct, so matched-context
+// literals stay synchronised.
+//
+// Two strategies: `fast` (presets 0..3) greedily takes the longest match, subject to a
+// distance-dependent minimum length that keeps short far matches from costing more than they save;
+// `normal` (presets 4..9) additionally prefers repeat-matches when they are competitive and applies
+// one-step lazy evaluation, deferring a match when the next position offers a longer one. Both are
+// always valid; normal simply compresses better.
+private[pneumatic] final class LzmaEncoder
+  ( data: Array[Byte], rc: RangeEncoder, lc: Int, lp: Int, pb: Int, finder: HashChain,
+    niceLen: Int, normal: Boolean )
+extends LzmaCoder(lc, lp, pb):
+
+  private val length = data.length
+  private val matchLengthEncoder = LengthEncoder()
+  private val repLengthEncoder = LengthEncoder()
+  private var readPos = 0
+
+  // Reusable candidate buffers for the price-based normal parser.
+  private val candidateLen = new Array[Int](MatchLenMax + 1)
+  private val candidateDist = new Array[Int](MatchLenMax + 1)
+
+  reset()
+
+  override def reset(): Unit =
+    super.reset()
+    matchLengthEncoder.reset()
+    repLengthEncoder.reset()
+
+  def pos: Int = readPos
+  def hasMore: Boolean = readPos < length
+
+  private def byteAt(dist: Int): Int = data(readPos - dist - 1) & 0xff
+
+  private def distSlot(dist: Int): Int =
+    if dist < DistModelStart then dist
+    else
+      val n = 31 - java.lang.Integer.numberOfLeadingZeros(dist)
+      (n << 1) | ((dist >>> (n - 1)) & 1)
+
+  private def minLenFor(dist: Int): Int =
+    if dist >= 32768 then 4 else if dist >= 512 then 3 else 2
+
+  // The match length obtainable at repeat distance `repDist` from `at`, capped at `lenLimit`.
+  private def repMatchLen(at: Int, repDist: Int, lenLimit: Int): Int =
+    val back = at - repDist - 1
+
+    if back < 0 then 0 else
+      var l = 0
+      while l < lenLimit && data(back + l) == data(at + l) do l += 1
+      l
+
+  // The best of the four repeat distances at `at`: the packed (length << 32 | index).
+  private def bestRep(at: Int, lenLimit: Int): Long =
+    var bestLen = 0
+    var bestIndex = 0
+    var i = 0
+
+    while i < Reps do
+      val l = repMatchLen(at, reps(i), lenLimit)
+      if l > bestLen then { bestLen = l; bestIndex = i }
+      i += 1
+
+    (bestLen.toLong << 32) | bestIndex.toLong
+
+  def encodeSymbol(): Int =
+    val posState = readPos & posMask
+    val lenLimit = if length - readPos < MatchLenMax then length - readPos else MatchLenMax
+
+    if normal then
+      // Gather the candidate set (read-only) before inserting this position, so it is never a
+      // candidate for itself.
+      val count = finder.findAll(readPos, lenLimit, candidateLen, candidateDist)
+      finder.insert(readPos)
+      encodeNormal(posState, lenLimit, count)
+    else
+      val found = finder.find(readPos, lenLimit)
+      finder.insert(readPos)
+      encodeFast(posState, (found >>> 32).toInt, (found & 0xffffffffL).toInt)
+
+  private def emitMatch(dist: Int, len: Int, posState: Int): Int =
+    rc.encodeBit(isMatch(state.get), posState, 1)
+    rc.encodeBit(isRep, state.get, 0)
+    encodeMatch(dist, len, posState)
+    advance(len)
+
+  private def emitRep(index: Int, len: Int, posState: Int): Int =
+    rc.encodeBit(isMatch(state.get), posState, 1)
+    rc.encodeBit(isRep, state.get, 1)
+    encodeRepMatch(index, len, posState)
+    advance(len)
+
+  private def emitLiteral(posState: Int): Int =
+    rc.encodeBit(isMatch(state.get), posState, 0)
+    encodeLiteral()
+    readPos += 1
+    1
+
+  private def advance(len: Int): Int =
+    var k = 1
+    while k < len do { finder.insert(readPos + k); k += 1 }
+    readPos += len
+    len
+
+  private def encodeFast(posState: Int, matchLen: Int, matchDist: Int): Int =
+    if matchLen >= MatchLenMin && matchLen >= minLenFor(matchDist) then
+      emitMatch(matchDist, matchLen, posState)
+    else
+      emitLiteral(posState)
+
+  // Price-based per-step parsing: cost every candidate (literal, each repeat-match, and each
+  // fresh-match length/distance trade-off from the finder) in fixed-point bits using the current
+  // probability model, and take the option with the lowest cost-per-byte, applying one-step lazy
+  // evaluation to fresh matches. Reps are cheap, so they win whenever competitive.
+  private def encodeNormal(posState: Int, lenLimit: Int, count: Int): Int =
+    val rep = bestRep(readPos, lenLimit)
+    val repLen = (rep >>> 32).toInt
+    val repIndex = (rep & 0xffffffffL).toInt
+
+    // Start from the literal option; matches must beat it on cost-per-byte.
+    var bestKind = 0 // 0 literal, 1 match, 2 rep
+    var bestLen = 1
+    var bestArg = 0
+    var bestCost = literalPrice(readPos)
+
+    if repLen >= MatchLenMin then
+      val cost = repPrice(repIndex, repLen, posState)
+
+      if cheaperPerByte(cost, repLen, bestCost, bestLen) then
+        bestKind = 2; bestLen = repLen; bestArg = repIndex; bestCost = cost
+
+    var k = 0
+
+    while k < count do
+      val len = candidateLen(k)
+      val dist = candidateDist(k)
+
+      if len >= MatchLenMin && len >= minLenFor(dist) then
+        val cost = matchPrice(dist, len, posState)
+
+        if cheaperPerByte(cost, len, bestCost, bestLen) then
+          bestKind = 1; bestLen = len; bestArg = dist; bestCost = cost
+
+      k += 1
+
+    if bestKind == 0 then emitLiteral(posState)
+    else if bestKind == 1 && bestLen < niceLen && lazyDefer(bestLen) then emitLiteral(posState)
+    else if bestKind == 2 then emitRep(bestArg, bestLen, posState)
+    else emitMatch(bestArg, bestLen, posState)
+
+  // Is (costA over lenA) strictly cheaper per byte than (costB over lenB)? Cross-multiplied to keep
+  // the comparison exact in integers.
+  private def cheaperPerByte(costA: Int, lenA: Int, costB: Int, lenB: Int): Boolean =
+    costA.toLong*lenB < costB.toLong*lenA
+
+  // One-step lazy evaluation: if the next position offers a strictly longer fresh match, defer by
+  // emitting a literal now. `readPos` has already been inserted, so the lookahead sees it.
+  private def lazyDefer(currentLen: Int): Boolean =
+    val next = readPos + 1
+
+    if next + 4 > length then false else
+      val nextLimit = if length - next < MatchLenMax then length - next else MatchLenMax
+      val nextFound = finder.find(next, nextLimit)
+      (nextFound >>> 32).toInt > currentLen
+
+  private inline def priceBit(probs: Array[Short], index: Int, bit: Int): Int =
+    RangeCoder.bitPrice(probs(index).toInt, bit)
+
+  private def lengthPrice(coder: LengthEncoder, len: Int, posState: Int): Int =
+    val l = len - MatchLenMin
+
+    if l < LenLowSymbols then
+      priceBit(coder.choice, 0, 0) + RangeCoder.bitTreePrice(coder.low(posState), l)
+    else if l < LenLowSymbols + LenMidSymbols then
+      priceBit(coder.choice, 0, 1) + priceBit(coder.choice, 1, 0) +
+        RangeCoder.bitTreePrice(coder.mid(posState), l - LenLowSymbols)
+    else
+      priceBit(coder.choice, 0, 1) + priceBit(coder.choice, 1, 1) +
+        RangeCoder.bitTreePrice(coder.high, l - LenLowSymbols - LenMidSymbols)
+
+  private def distancePrice(dist: Int, lenState: Int): Int =
+    val slot = distSlot(dist)
+    var price = RangeCoder.bitTreePrice(distSlots(lenState), slot)
+
+    if slot >= DistModelStart then
+      val footerBits = (slot >> 1) - 1
+      val base = (2 | (slot & 1)) << footerBits
+
+      if slot < DistModelEnd then
+        price += RangeCoder.bitTreeReversePrice(distSpecial(slot - DistModelStart), dist - base)
+      else
+        price += RangeCoder.directBitsPrice(footerBits - AlignBits)
+        price += RangeCoder.bitTreeReversePrice(distAlign, (dist - base) & AlignMask)
+
+    price
+
+  private def matchPrice(dist: Int, len: Int, posState: Int): Int =
+    priceBit(isMatch(state.get), posState, 1) + priceBit(isRep, state.get, 0) +
+      lengthPrice(matchLengthEncoder, len, posState) + distancePrice(dist, distState(len))
+
+  private def repPrice(index: Int, len: Int, posState: Int): Int =
+    var price = priceBit(isMatch(state.get), posState, 1) + priceBit(isRep, state.get, 1)
+
+    if index == 0 then
+      price += priceBit(isRep0, state.get, 0) + priceBit(isRep0Long(state.get), posState, 1)
+    else
+      price += priceBit(isRep0, state.get, 1)
+
+      if index == 1 then price += priceBit(isRep1, state.get, 0)
+      else
+        price += priceBit(isRep1, state.get, 1) +
+          priceBit(isRep2, state.get, if index == 2 then 0 else 1)
+
+    price + lengthPrice(repLengthEncoder, len, posState)
+
+  private def literalPrice(at: Int): Int =
+    val prevByte = if at > 0 then data(at - 1) & 0xff else 0
+    val base = literalIndex(prevByte, at)
+    val target = data(at) & 0xff
+    var price = 0
+    var context = 1
+
+    if state.isLiteral then
+      var i = 7
+
+      while i >= 0 do
+        val bit = (target >>> i) & 1
+        price += priceBit(literalProbs, base + context, bit)
+        context = (context << 1) | bit
+        i -= 1
+    else
+      var matchByte = (data(at - reps(0) - 1) & 0xff) << 1
+      var stillMatched = true
+      var i = 7
+
+      while i >= 0 do
+        val bit = (target >>> i) & 1
+
+        if stillMatched then
+          val matchBit = (matchByte >>> 8) & 1
+          matchByte <<= 1
+          price += priceBit(literalProbs, base + ((1 + matchBit) << 8) + context, bit)
+          if matchBit != bit then stillMatched = false
+        else
+          price += priceBit(literalProbs, base + context, bit)
+
+        context = (context << 1) | bit
+        i -= 1
+
+    price
+
+  private def encodeLiteral(): Unit =
+    val prevByte = if readPos > 0 then data(readPos - 1) & 0xff else 0
+    val base = literalIndex(prevByte, readPos)
+    val target = data(readPos) & 0xff
+    var context = 1
+
+    if state.isLiteral then
+      var i = 7
+
+      while i >= 0 do
+        val bit = (target >>> i) & 1
+        rc.encodeBit(literalProbs, base + context, bit)
+        context = (context << 1) | bit
+        i -= 1
+    else
+      var matchByte = byteAt(reps(0)) << 1
+      var stillMatched = true
+      var i = 7
+
+      while i >= 0 do
+        val bit = (target >>> i) & 1
+
+        if stillMatched then
+          val matchBit = (matchByte >>> 8) & 1
+          matchByte <<= 1
+          rc.encodeBit(literalProbs, base + ((1 + matchBit) << 8) + context, bit)
+          if matchBit != bit then stillMatched = false
+        else
+          rc.encodeBit(literalProbs, base + context, bit)
+
+        context = (context << 1) | bit
+        i -= 1
+
+    state.updateLiteral()
+
+  private def encodeMatch(dist: Int, len: Int, posState: Int): Unit =
+    state.updateMatch()
+    reps(3) = reps(2)
+    reps(2) = reps(1)
+    reps(1) = reps(0)
+    reps(0) = dist
+
+    matchLengthEncoder.encode(rc, len, posState)
+
+    val slot = distSlot(dist)
+    rc.encodeBitTree(distSlots(distState(len)), slot)
+
+    if slot >= DistModelStart then
+      val footerBits = (slot >> 1) - 1
+      val base = (2 | (slot & 1)) << footerBits
+
+      if slot < DistModelEnd then
+        rc.encodeBitTreeReverse(distSpecial(slot - DistModelStart), dist - base)
+      else
+        rc.encodeDirectBits((dist - base) >>> AlignBits, footerBits - AlignBits)
+        rc.encodeBitTreeReverse(distAlign, (dist - base) & AlignMask)
+
+  // Encode a repeat-match reusing recent distance `index` (0..3), length `len` (at least 2, never
+  // a short-rep). The rep-index bits and the reps rotation mirror the decoder's `decodeRepMatch`
+  // exactly, and all sub-bits are coded against the pre-update `state`.
+  private def encodeRepMatch(index: Int, len: Int, posState: Int): Unit =
+    if index == 0 then
+      rc.encodeBit(isRep0, state.get, 0)
+      rc.encodeBit(isRep0Long(state.get), posState, 1)
+    else
+      rc.encodeBit(isRep0, state.get, 1)
+
+      if index == 1 then rc.encodeBit(isRep1, state.get, 0)
+      else
+        rc.encodeBit(isRep1, state.get, 1)
+        rc.encodeBit(isRep2, state.get, if index == 2 then 0 else 1)
+
+      val dist = reps(index)
+      var j = index
+      while j > 0 do { reps(j) = reps(j - 1); j -= 1 }
+      reps(0) = dist
+
+    state.updateRep()
+    repLengthEncoder.encode(rc, len, posState)

--- a/lib/pneumatic/src/core/pneumatic.RangeCoder.scala
+++ b/lib/pneumatic/src/core/pneumatic.RangeCoder.scala
@@ -1,0 +1,327 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package pneumatic
+
+// The LZMA binary range coder, the entropy stage beneath LZMA/LZMA2. It codes single bits against
+// adaptive 11-bit probabilities (`Array[Short]` in [0, 2048]), plus "direct" equiprobable bits and
+// MSB-/LSB-first probability trees. This is a clean-room implementation of the well-documented LZMA
+// range coder (the same arithmetic used by 7-Zip and XZ Utils), following the structure of the
+// public-domain XZ for Java reference so that streams interoperate byte-for-byte.
+//
+// All 32-bit quantities (`range`, `code`, `bound`) are handled as unsigned via explicit masking and
+// the sign-flip comparison trick; the encoder's `low` is a 33-bit accumulator held in a `Long`.
+
+private[pneumatic] object RangeCoder:
+  inline val TopMask = 0xff000000
+  inline val BitModelTotalBits = 11
+  inline val BitModelTotal = 1 << BitModelTotalBits // 2048
+  inline val MoveBits = 5
+  val ProbInit: Short = 1024 // BitModelTotal / 2
+
+  inline val MoveReducingBits = 4
+  inline val BitPriceShiftBits = 4
+
+  // A fresh probability array, every entry initialised to the neutral 0.5 estimate.
+  def probabilities(size: Int): Array[Short] =
+    val array = new Array[Short](size)
+    var i = 0
+    while i < size do { array(i) = ProbInit; i += 1 }
+    array
+
+  def resetProbabilities(array: Array[Short]): Unit =
+    var i = 0
+    while i < array.length do { array(i) = ProbInit; i += 1 }
+
+  // Fixed-point bit prices (in 1/16-bit units): the cost of coding a bit whose probability index is
+  // `prob >>> MoveReducingBits`. Built once, then read by the encoder's cost estimator.
+  val prices: Array[Short] =
+    val table = new Array[Short](BitModelTotal >>> MoveReducingBits)
+    var i = 1 << (MoveReducingBits - 1)
+
+    while i < BitModelTotal do
+      var w = i
+      var bitCount = 0
+      var j = 0
+
+      while j < BitPriceShiftBits do
+        w *= w
+        bitCount <<= 1
+        while (w & 0xffff0000) != 0 do { w >>>= 1; bitCount += 1 }
+        j += 1
+
+      table(i >> MoveReducingBits) =
+        ((BitModelTotalBits << BitPriceShiftBits) - 15 - bitCount).toShort
+
+      i += 1 << MoveReducingBits
+
+    table
+
+  def bitPrice(prob: Int, bit: Int): Int =
+    prices((prob ^ ((-bit) & (BitModelTotal - 1))) >>> MoveReducingBits).toInt
+
+  def directBitsPrice(count: Int): Int = count << BitPriceShiftBits
+
+  def bitTreePrice(probs: Array[Short], symbol0: Int): Int =
+    var price = 0
+    var symbol = symbol0 | probs.length
+
+    while symbol != 1 do
+      val bit = symbol & 1
+      symbol >>>= 1
+      price += bitPrice(probs(symbol).toInt, bit)
+
+    price
+
+  def bitTreeReversePrice(probs: Array[Short], symbol0: Int): Int =
+    var price = 0
+    var index = 1
+    var symbol = symbol0
+    var continue = true
+
+    while continue do
+      val bit = symbol & 1
+      symbol >>>= 1
+      price += bitPrice(probs(index).toInt, bit)
+      index = (index << 1) | bit
+      continue = index < probs.length
+
+    price
+
+import RangeCoder.*
+
+// Decodes a whole LZMA-coded buffer (an LZMA2 chunk's compressed payload). The first byte of the
+// buffer must be zero; the following four are the initial `code`. `range` starts saturated. Because
+// LZMA2 signals each chunk's uncompressed length out of band, the caller decodes an exact symbol
+// count and never relies on an end-of-stream marker.
+private[pneumatic] final class RangeDecoder:
+  private var buffer: Array[Byte] = new Array[Byte](0)
+  private var position: Int = 0
+  private var limit: Int = 0
+  private var range: Int = 0
+  private var code: Int = 0
+
+  def prepare(input: Array[Byte], offset: Int, length: Int): Unit =
+    buffer = input
+    position = offset + 1 // the leading byte is always zero
+    limit = offset + length
+    range = 0xffffffff
+    code = 0
+    var i = 0
+    while i < 4 do { code = (code << 8) | (buffer(position) & 0xff); position += 1; i += 1 }
+
+  def inError: Boolean = position > limit
+
+  private def normalize(): Unit =
+    if (range & TopMask) == 0 then
+      code = (code << 8) | (nextByte() & 0xff)
+      range <<= 8
+
+  private def nextByte(): Int =
+    val byte = if position < limit then buffer(position).toInt else 0
+    position += 1
+    byte
+
+  def decodeBit(probs: Array[Short], index: Int): Int =
+    normalize()
+    val prob = probs(index).toInt
+    val bound = (range >>> BitModelTotalBits) * prob
+
+    if (code ^ 0x80000000) < (bound ^ 0x80000000) then
+      range = bound
+      probs(index) = (prob + ((BitModelTotal - prob) >>> MoveBits)).toShort
+      0
+    else
+      range -= bound
+      code -= bound
+      probs(index) = (prob - (prob >>> MoveBits)).toShort
+      1
+
+  def decodeBitTree(probs: Array[Short]): Int =
+    var symbol = 1
+
+    while
+      symbol = (symbol << 1) | decodeBit(probs, symbol)
+      symbol < probs.length
+    do ()
+
+    symbol - probs.length
+
+  def decodeBitTreeReverse(probs: Array[Short]): Int =
+    var symbol = 1
+    var result = 0
+    var i = 0
+
+    while
+      val bit = decodeBit(probs, symbol)
+      symbol = (symbol << 1) | bit
+      result |= bit << i
+      i += 1
+      symbol < probs.length
+    do ()
+
+    result
+
+  def decodeDirectBits(count0: Int): Int =
+    var result = 0
+    var count = count0
+
+    while count != 0 do
+      normalize()
+      range >>>= 1
+      val t = (code - range) >>> 31
+      code -= range & (t - 1)
+      result = (result << 1) | (1 - t)
+      count -= 1
+
+    result
+
+// Encodes single bits, direct bits and probability trees into a growable buffer. `low` is a 33-bit
+// carry accumulator; `shiftLow` propagates carries into already-buffered bytes through the one-byte
+// `cache` plus a run of `cacheSize` deferred `0xff`s.
+private[pneumatic] final class RangeEncoder:
+  private var buffer: Array[Byte] = new Array[Byte](1 << 16)
+  private var count: Int = 0
+  private var low: Long = 0
+  private var range: Int = 0
+  private var cache: Int = 0
+  private var cacheSize: Long = 0
+
+  reset()
+
+  def reset(): Unit =
+    low = 0
+    range = 0xffffffff
+    cache = 0
+    cacheSize = 1
+    count = 0
+
+  // A conservative upper bound on how many bytes finishing now would append: the already-buffered
+  // bytes, the deferred cache run, and the five flush bytes. Used to keep LZMA2 chunks within their
+  // 64 KiB compressed limit.
+  def pendingSize: Int = count + cacheSize.toInt + 5 - 1
+
+  private def writeByte(byte: Int): Unit =
+    if count == buffer.length then
+      val grown = new Array[Byte](buffer.length*2)
+      System.arraycopy(buffer, 0, grown, 0, count)
+      buffer = grown
+
+    buffer(count) = byte.toByte
+    count += 1
+
+  private def shiftLow(): Unit =
+    val lowHigh = (low >>> 32).toInt
+
+    if lowHigh != 0 || low < 0xff000000L then
+      var temp = cache
+      var continue = true
+
+      while continue do
+        writeByte((temp + lowHigh) & 0xff)
+        temp = 0xff
+        cacheSize -= 1
+        continue = cacheSize != 0
+
+      cache = (low >>> 24).toInt & 0xff
+
+    cacheSize += 1
+    low = (low & 0x00ffffff) << 8
+
+  def encodeBit(probs: Array[Short], index: Int, bit: Int): Unit =
+    val prob = probs(index).toInt
+    val bound = (range >>> BitModelTotalBits) * prob
+
+    if bit == 0 then
+      range = bound
+      probs(index) = (prob + ((BitModelTotal - prob) >>> MoveBits)).toShort
+    else
+      low += bound & 0xffffffffL
+      range -= bound
+      probs(index) = (prob - (prob >>> MoveBits)).toShort
+
+    if (range & TopMask) == 0 then
+      range <<= 8
+      shiftLow()
+
+  def encodeBitTree(probs: Array[Short], symbol: Int): Unit =
+    var index = 1
+    var mask = probs.length
+    var continue = true
+
+    while continue do
+      mask >>>= 1
+      val bit = symbol & mask
+      encodeBit(probs, index, if bit != 0 then 1 else 0)
+      index <<= 1
+      if bit != 0 then index |= 1
+      continue = mask != 1
+
+  def encodeBitTreeReverse(probs: Array[Short], symbol0: Int): Unit =
+    var index = 1
+    var symbol = symbol0
+    var continue = true
+
+    while continue do
+      val bit = symbol & 1
+      symbol >>>= 1
+      encodeBit(probs, index, bit)
+      index = (index << 1) | bit
+      continue = index < probs.length
+
+  def encodeDirectBits(value: Int, count0: Int): Unit =
+    var i = count0
+
+    while i != 0 do
+      i -= 1
+      range >>>= 1
+      if ((value >>> i) & 1) != 0 then low += range.toLong & 0xffffffffL
+
+      if (range & TopMask) == 0 then
+        range <<= 8
+        shiftLow()
+
+  // Flush the last five bytes of `low`, returning the total encoded length. After this the buffer
+  // holds a complete range-coded payload.
+  def finish(): Int =
+    var i = 0
+    while i < 5 do { shiftLow(); i += 1 }
+    count
+
+  // Copy the encoded bytes into `target` at `offset`; the caller has ensured the space exists.
+  def copyTo(target: Array[Byte], offset: Int): Unit =
+    System.arraycopy(buffer, 0, target, offset, count)
+
+  def bytes: Array[Byte] =
+    val result = new Array[Byte](count)
+    System.arraycopy(buffer, 0, result, 0, count)
+    result

--- a/lib/pneumatic/src/core/pneumatic.Xz.scala
+++ b/lib/pneumatic/src/core/pneumatic.Xz.scala
@@ -1,0 +1,268 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package pneumatic
+
+import scala.collection.mutable as scm
+
+import anticipation.*
+import rudiments.*
+import turbulence.*
+import vacuous.*
+import zephyrine.*
+
+// XZ (LZMA2 inside the `.xz` container), the high-ratio codec, as a pure-Scala port of the
+// public-domain XZ Utils algorithm. It shares the streaming-engine shape of Brotli and LZW: an
+// engine buffers into a `pending` array which a thin `Duct` stage drains. The default preset is 6
+// with a CRC-64 check (matching the `xz` command-line tool); `Xz.compress(stream, preset)` and
+// `Xz.compressor(preset)` select any preset 0..9.
+//
+// `Lzma2` (in `pneumatic.Lzma2.scala`) is the container-free counterpart, exposing the same LZMA2
+// codec without the `.xz` framing — analogous to raw `Deflate` beside `Gzip`/`Zlib`.
+
+// The output-draining half of an engine: mirrors `BrotliEngine`, staging bytes in `pending` and
+// handing them out in whatever space each `deliver` offers.
+private[pneumatic] trait XzEngine:
+  protected val pending: scm.ArrayBuffer[Byte] = scm.ArrayBuffer()
+  private var delivered: Int = 0
+
+  def accept(bytes: Array[Byte], offset: Int, length: Int): Unit
+  def finish(): Unit
+
+  def deliver(target: Array[Byte], offset: Int, space: Int): Int =
+    var produced = 0
+
+    while delivered < pending.length && produced < space do
+      target(offset + produced) = pending(delivered)
+      delivered += 1
+      produced += 1
+
+    if delivered == pending.length then
+      pending.clear()
+      delivered = 0
+
+    produced
+
+  def gather(): Data =
+    val result = new Array[Byte](pending.length - delivered)
+    var i = 0
+
+    while delivered < pending.length do
+      result(i) = pending(delivered)
+      i += 1
+      delivered += 1
+
+    pending.clear()
+    delivered = 0
+    result.immutable(using Unsafe)
+
+// Accumulates the whole input, then applies a one-shot byte transform (encode or container-decode).
+// The transform is a method (not a stored function value) so the engine carries no capability
+// capture, per this module's capture-checked discipline.
+private[pneumatic] abstract class BufferedEngine extends XzEngine:
+  private val input: scm.ArrayBuffer[Byte] = scm.ArrayBuffer()
+  private var finished = false
+
+  protected def transform(bytes: Array[Byte]): Array[Byte]
+
+  def accept(bytes: Array[Byte], offset: Int, length: Int): Unit =
+    var i = 0
+    while i < length do { input += bytes(offset + i); i += 1 }
+
+  def finish(): Unit =
+    if !finished then
+      finished = true
+      val output = transform(input.toArray)
+      var i = 0
+      while i < output.length do { pending += output(i); i += 1 }
+
+// The `.xz` container encoder, streaming with bounded memory: it buffers at most one dictionary's
+// worth of input, emits that as a complete block as soon as it fills, and closes with the index and
+// footer on finish. Peak working memory is therefore ~one segment regardless of total input size.
+// (Small inputs still form a single block, byte-identical to the whole-value encoder.) Each block
+// is self-contained, which the multi-block decoder handles transparently.
+private[pneumatic] final class XzCompressorEngine(preset: Int, checkType: Int) extends XzEngine:
+  private val options = Lzma2Options.preset(preset)
+  private val segmentSize = options.dictSize
+  private val segment: scm.ArrayBuffer[Byte] = scm.ArrayBuffer()
+  private val records: scm.ArrayBuffer[(Long, Long)] = scm.ArrayBuffer()
+  private var headerEmitted = false
+  private var finished = false
+
+  private def emit(bytes: Array[Byte]): Unit =
+    var i = 0
+    while i < bytes.length do { pending += bytes(i); i += 1 }
+
+  private def ensureHeader(): Unit =
+    if !headerEmitted then
+      emit(XzContainer.streamHeader(checkType))
+      headerEmitted = true
+
+  private def emitSegment(): Unit =
+    if segment.nonEmpty then
+      val data = segment.toArray
+      segment.clear()
+      val (blockBytes, unpadded) = XzContainer.block(data, checkType, options)
+      emit(blockBytes)
+      records += ((unpadded, data.length.toLong))
+
+  def accept(bytes: Array[Byte], offset: Int, length: Int): Unit =
+    ensureHeader()
+    var i = 0
+
+    while i < length do
+      segment += bytes(offset + i)
+      i += 1
+      if segment.length >= segmentSize then emitSegment()
+
+  def finish(): Unit =
+    if !finished then
+      finished = true
+      ensureHeader()
+      emitSegment()
+      emit(XzContainer.indexAndFooter(records, checkType))
+
+// The `.xz` container decoder.
+private[pneumatic] final class XzDecompressorEngine extends BufferedEngine:
+  protected def transform(bytes: Array[Byte]): Array[Byte] =
+    val out = scm.ArrayBuffer[Byte]()
+    XzContainer.decode(bytes, out)
+    out.toArray
+
+// The container-free raw-LZMA2 encoder.
+private[pneumatic] final class Lzma2CompressorEngine(preset: Int) extends BufferedEngine:
+  protected def transform(bytes: Array[Byte]): Array[Byte] =
+    Lzma2Compressor(bytes, Lzma2Options.preset(preset)).compress()
+
+// Streams LZMA2 decompression: feeds input into the chunk decoder as it arrives and drains the
+// decoder's freshly-produced bytes into `pending`, keeping the buffered compressed data bounded.
+private[pneumatic] final class Lzma2DecompressorEngine(dictSize: Int) extends XzEngine:
+  private val decompressor = Lzma2Decompressor(dictSize)
+
+  def accept(bytes: Array[Byte], offset: Int, length: Int): Unit =
+    decompressor.accept(bytes, offset, length)
+    drain()
+
+  def finish(): Unit =
+    decompressor.finish()
+    drain()
+
+  private def drain(): Unit =
+    val output = decompressor.output
+    var i = 0
+    while i < output.length do { pending += output(i); i += 1 }
+    output.clear()
+
+// The `Duct` stage wrapping an engine, identical in shape to `BrotliStage`.
+private[pneumatic] class XzStage(engine: XzEngine) extends Duct[Data, Data]:
+  type Transport = Credit
+  type Upstream = Credit
+
+  private var finishing = false
+
+  def regulation: Credit is Regulation = summon[Credit is Regulation]
+  def translate(demand: Credit): Credit = demand
+
+  update def step
+    ( source: input.Storage,
+      sourceOffset: Int,
+      sourceLength: Int,
+      target: output.Storage,
+      targetOffset: Int,
+      targetSpace: Int )
+  :   Duct.Progress =
+
+    engine.accept(source.asInstanceOf[Array[Byte]], sourceOffset, sourceLength)
+
+    Duct.Progress
+      ( sourceLength,
+        engine.deliver(target.asInstanceOf[Array[Byte]], targetOffset, targetSpace) )
+
+  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+    if !finishing then
+      engine.finish()
+      finishing = true
+
+    engine.deliver(target.asInstanceOf[Array[Byte]], targetOffset, targetSpace)
+
+object Xz:
+  inline val DefaultPreset = 6
+
+  private def encoderEngine(preset: Int): XzEngine = XzCompressorEngine(preset, XzCheck.Crc64Type)
+  private def decoderEngine(): XzEngine = XzDecompressorEngine()
+
+  given compression: Xz is Compression:
+    def compressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      XzStage(encoderEngine(DefaultPreset))
+
+    def decompressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      XzStage(decoderEngine())
+
+    override def compress(stream: LazyList[Data]): LazyList[Data] =
+      drive(encoderEngine(DefaultPreset), stream)
+
+    override def decompress(stream: LazyList[Data]): LazyList[Data] =
+      drive(decoderEngine(), stream)
+
+  // Compress with an explicit preset level (0..9); presets 0..3 favour speed, 4..9 favour ratio.
+  def compressor(preset: Int)(using Buffering): Duct[Data, Data] {
+    type Transport = Credit
+    type Upstream = Credit } =
+
+    XzStage(encoderEngine(preset))
+
+  def compress(stream: LazyList[Data], preset: Int): LazyList[Data] =
+    drive(encoderEngine(preset), stream)
+
+  def decompress(stream: LazyList[Data]): LazyList[Data] = drive(decoderEngine(), stream)
+
+  // Drives an engine over a lazy stream chunk by chunk, then collects its finished tail.
+  private[pneumatic] def drive(engine: XzEngine, stream: LazyList[Data]): LazyList[Data] =
+    def recur(stream: LazyList[Data]): LazyList[Data] = stream match
+      case head #:: tail =>
+        engine.accept(head.mutable(using Unsafe), 0, head.length)
+        recur(tail)
+
+      case _ =>
+        engine.finish()
+        val data = engine.gather()
+        if data.length > 0 then LazyList(data) else LazyList.empty
+
+    LazyList.defer(recur(stream))
+
+sealed trait Xz extends Compressor

--- a/lib/pneumatic/src/core/pneumatic.XzCheck.scala
+++ b/lib/pneumatic/src/core/pneumatic.XzCheck.scala
@@ -1,0 +1,230 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package pneumatic
+
+// The integrity checks an XZ stream may carry over each block's uncompressed data. The stream flags
+// name one type for the whole stream: 0x00 none, 0x01 CRC-32, 0x04 CRC-64, 0x0A SHA-256. We compute
+// and verify none/CRC-32/CRC-64; SHA-256-checked streams still decode, but the check is skipped
+// rather than verified. Check values are written little-endian in the block trailer.
+private[pneumatic] object XzCheck:
+  inline val None = 0x00
+  inline val Crc32Type = 0x01
+  inline val Crc64Type = 0x04
+  inline val Sha256Type = 0x0a
+
+  def size(checkType: Int): Int = checkType match
+    case None       => 0
+    case Crc32Type  => 4
+    case Crc64Type  => 8
+    case Sha256Type => 32
+    case _          => throw IllegalStateException("the XZ data is corrupt: unknown check type")
+
+  // A fresh running check for the given type, used by both the encoder (to emit the trailer) and
+  // the decoder (to verify it). Every standard check type is supported.
+  def checker(checkType: Int): XzChecker = checkType match
+    case None       => NoChecker
+    case Crc32Type  => Crc32Checker()
+    case Crc64Type  => Crc64Checker()
+    case Sha256Type => Sha256Checker()
+    case _          => throw IllegalStateException("the XZ data uses an unknown check type")
+
+  def encoder(checkType: Int): XzChecker = checker(checkType)
+
+private[pneumatic] object Crc64:
+  val table: Array[Long] =
+    val result = new Array[Long](256)
+    val poly = 0xc96c5795d7870f42L
+    var n = 0
+
+    while n < 256 do
+      var c = n.toLong
+      var k = 8
+      while k > 0 do { k -= 1; c = if (c & 1L) != 0 then (c >>> 1) ^ poly else c >>> 1 }
+      result(n) = c
+      n += 1
+
+    result
+
+// A check that accumulates over the uncompressed bytes and yields its little-endian trailer bytes.
+private[pneumatic] trait XzChecker:
+  def size: Int
+  def reset(): Unit
+  def update(buffer: Array[Byte], offset: Int, length: Int): Unit
+  def bytes: Array[Byte]
+
+private[pneumatic] object NoChecker extends XzChecker:
+  def size: Int = 0
+  def reset(): Unit = ()
+  def update(buffer: Array[Byte], offset: Int, length: Int): Unit = ()
+  def bytes: Array[Byte] = new Array[Byte](0)
+
+private[pneumatic] final class Crc32Checker extends XzChecker:
+  private val crc = Crc32()
+  def size: Int = 4
+  def reset(): Unit = crc.reset()
+
+  def update(buffer: Array[Byte], offset: Int, length: Int): Unit =
+    crc.update(buffer, offset, length)
+
+  def bytes: Array[Byte] =
+    val value = crc.value
+    val out = new Array[Byte](4)
+    var i = 0
+    while i < 4 do { out(i) = ((value >>> (i*8)) & 0xff).toByte; i += 1 }
+    out
+
+private[pneumatic] final class Crc64Checker extends XzChecker:
+  private var v: Long = -1L
+  def size: Int = 8
+  def reset(): Unit = v = -1L
+
+  def update(buffer: Array[Byte], offset: Int, length: Int): Unit =
+    var i = offset
+    val end = offset + length
+
+    while i < end do
+      v = Crc64.table(((v ^ buffer(i)) & 0xff).toInt) ^ (v >>> 8)
+      i += 1
+
+  def bytes: Array[Byte] =
+    val value = v ^ -1L
+    val out = new Array[Byte](8)
+    var i = 0
+    while i < 8 do { out(i) = ((value >>> (i*8)) & 0xff).toByte; i += 1 }
+    out
+
+// SHA-256 (FIPS 180-4): the 64 round constants are the fractional parts of the cube roots of the
+// first 64 primes; the initial hash words are the fractional parts of the square roots of the first
+// eight. Big-endian digest, written to the block trailer in order.
+private[pneumatic] object Sha256:
+  val roundConstants: Array[Int] = Array(
+      0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+      0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+      0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+      0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+      0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+      0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+      0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+      0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+      0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+      0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+      0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2)
+
+private[pneumatic] final class Sha256Checker extends XzChecker:
+  private val h = new Array[Int](8)
+  private val block = new Array[Byte](64)
+  private val w = new Array[Int](64)
+  private var blockLength = 0
+  private var totalLength = 0L
+
+  reset()
+  def size: Int = 32
+
+  def reset(): Unit =
+    h(0) = 0x6a09e667; h(1) = 0xbb67ae85; h(2) = 0x3c6ef372; h(3) = 0xa54ff53a
+    h(4) = 0x510e527f; h(5) = 0x9b05688c; h(6) = 0x1f83d9ab; h(7) = 0x5be0cd19
+    blockLength = 0
+    totalLength = 0
+
+  private inline def rotr(x: Int, n: Int): Int = (x >>> n) | (x << (32 - n))
+
+  private def processBlock(): Unit =
+    var i = 0
+
+    while i < 16 do
+      w(i) = ((block(i*4) & 0xff) << 24) | ((block(i*4 + 1) & 0xff) << 16) |
+        ((block(i*4 + 2) & 0xff) << 8) | (block(i*4 + 3) & 0xff)
+
+      i += 1
+
+    while i < 64 do
+      val s0 = rotr(w(i - 15), 7) ^ rotr(w(i - 15), 18) ^ (w(i - 15) >>> 3)
+      val s1 = rotr(w(i - 2), 17) ^ rotr(w(i - 2), 19) ^ (w(i - 2) >>> 10)
+      w(i) = w(i - 16) + s0 + w(i - 7) + s1
+      i += 1
+
+    var a = h(0); var b = h(1); var c = h(2); var d = h(3)
+    var e = h(4); var f = h(5); var g = h(6); var hh = h(7)
+    i = 0
+
+    while i < 64 do
+      val big1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25)
+      val ch = (e & f) ^ ((~e) & g)
+      val t1 = hh + big1 + ch + Sha256.roundConstants(i) + w(i)
+      val big0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22)
+      val maj = (a & b) ^ (a & c) ^ (b & c)
+      val t2 = big0 + maj
+      hh = g; g = f; f = e; e = d + t1; d = c; c = b; b = a; a = t1 + t2
+      i += 1
+
+    h(0) += a; h(1) += b; h(2) += c; h(3) += d
+    h(4) += e; h(5) += f; h(6) += g; h(7) += hh
+
+  def update(buffer: Array[Byte], offset: Int, length: Int): Unit =
+    var i = offset
+    val end = offset + length
+    totalLength += length
+
+    while i < end do
+      block(blockLength) = buffer(i)
+      blockLength += 1
+      if blockLength == 64 then { processBlock(); blockLength = 0 }
+      i += 1
+
+  def bytes: Array[Byte] =
+    val bitLength = totalLength*8
+    block(blockLength) = 0x80.toByte
+    blockLength += 1
+
+    if blockLength > 56 then
+      while blockLength < 64 do { block(blockLength) = 0; blockLength += 1 }
+      processBlock()
+      blockLength = 0
+
+    while blockLength < 56 do { block(blockLength) = 0; blockLength += 1 }
+
+    var i = 0
+    while i < 8 do { block(56 + i) = ((bitLength >>> (56 - i*8)) & 0xff).toByte; i += 1 }
+    processBlock()
+
+    val out = new Array[Byte](32)
+    var j = 0
+
+    while j < 8 do
+      out(j*4) = (h(j) >>> 24).toByte
+      out(j*4 + 1) = (h(j) >>> 16).toByte
+      out(j*4 + 2) = (h(j) >>> 8).toByte
+      out(j*4 + 3) = h(j).toByte
+      j += 1
+
+    out

--- a/lib/pneumatic/src/core/pneumatic.XzContainer.scala
+++ b/lib/pneumatic/src/core/pneumatic.XzContainer.scala
@@ -1,0 +1,267 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package pneumatic
+
+import scala.collection.mutable as scm
+
+// The `.xz` stream container: a 12-byte header (6-byte magic, 2-byte flags naming the check type, a
+// CRC-32 of the flags), then one or more blocks, then an index and a footer. Each block has a
+// self-describing header (its filter chain — here always the single LZMA2 filter, whose one
+// property byte encodes the dictionary size), the LZMA2 payload, four-byte-aligned padding, and the
+// integrity check over the block's uncompressed data. Sizes are LEB128 variable-length integers.
+//
+// Decoding buffers the whole compressed stream, then walks the blocks. Only the single-LZMA2-filter
+// chain is understood; delta/BCJ filters and multi-filter chains are rejected.
+private[pneumatic] object XzContainer:
+  val magic: Array[Byte] = Array(0xfd.toByte, '7', 'z', 'X', 'Z', 0x00)
+  inline val Lzma2FilterId = 0x21
+  inline val IndexIndicator = 0x00
+
+  private def readVli(buffer: Array[Byte], position: Int): (Long, Int) =
+    var result = 0L
+    var shift = 0
+    var pos = position
+    var continue = true
+
+    while continue do
+      if pos >= buffer.length then throw IllegalStateException("the XZ data is corrupt: truncated")
+      val byte = buffer(pos) & 0xff
+      pos += 1
+      result |= (byte & 0x7f).toLong << shift
+      if (byte & 0x80) == 0 then continue = false else shift += 7
+      if shift > 63 then throw IllegalStateException("the XZ data is corrupt: oversized integer")
+
+    (result, pos)
+
+  // Decode a complete `.xz` stream, appending its uncompressed bytes to `sink`.
+  def decode(buffer: Array[Byte], sink: scm.ArrayBuffer[Byte]): Unit =
+    if buffer.length < 12 then
+      throw IllegalStateException("the XZ data is corrupt: truncated header")
+
+    var i = 0
+
+    while i < 6 do
+      if buffer(i) != magic(i) then
+        throw IllegalStateException("the data is not in XZ format: bad magic bytes")
+
+      i += 1
+
+    if buffer(6) != 0 then throw IllegalStateException("the XZ data is corrupt: reserved flag set")
+    val checkType = buffer(7) & 0xff
+    val checkSize = XzCheck.size(checkType)
+
+    var pos = 12
+
+    while pos < buffer.length && (buffer(pos) & 0xff) != IndexIndicator do
+      val headerSizeByte = buffer(pos) & 0xff
+      val headerSize = (headerSizeByte + 1)*4
+      val flags = buffer(pos + 1) & 0xff
+      val filterCount = (flags & 0x03) + 1
+      val compressedSizePresent = (flags & 0x40) != 0
+      val uncompressedSizePresent = (flags & 0x80) != 0
+
+      if (flags & 0x3c) != 0 then
+        throw IllegalStateException("the XZ data is corrupt: reserved block flags set")
+
+      var cursor = pos + 2
+      if compressedSizePresent then cursor = readVli(buffer, cursor)(1)
+      if uncompressedSizePresent then cursor = readVli(buffer, cursor)(1)
+
+      var dictSizeByte = -1
+      var filter = 0
+
+      while filter < filterCount do
+        val (filterId, afterId) = readVli(buffer, cursor)
+        val (propsSize, afterProps) = readVli(buffer, afterId)
+
+        if filterId != Lzma2FilterId then
+          throw IllegalStateException("this XZ stream uses an unsupported filter")
+
+        if propsSize != 1L then
+          throw IllegalStateException("the XZ data is corrupt: bad LZMA2 properties size")
+
+        dictSizeByte = buffer(afterProps) & 0xff
+        cursor = afterProps + 1
+        filter += 1
+
+      if dictSizeByte < 0 then
+        throw IllegalStateException("the XZ data is corrupt: missing LZMA2 filter")
+
+      val blockDataStart = pos + headerSize
+      val dictSize = Lzma2Options.byteToDictSize(dictSizeByte)
+
+      val decompressor = Lzma2Decompressor(dictSize)
+      decompressor.accept(buffer, blockDataStart, buffer.length - blockDataStart)
+      decompressor.finish()
+
+      if !decompressor.ended then
+        throw IllegalStateException("the XZ data is corrupt: block did not terminate")
+
+      val blockOutputStart = sink.length
+      sink ++= decompressor.output
+      val compressedLength = decompressor.consumed
+      val padding = (-compressedLength) & 3
+      val checkStart = blockDataStart + compressedLength + padding
+
+      // Verify the block's integrity check over its uncompressed output.
+      if checkSize > 0 then
+        val checker = XzCheck.checker(checkType)
+        val decoded = new Array[Byte](sink.length - blockOutputStart)
+        var d = 0
+        while d < decoded.length do { decoded(d) = sink(blockOutputStart + d); d += 1 }
+        checker.update(decoded, 0, decoded.length)
+        val expected = checker.bytes
+        var c = 0
+
+        while c < checkSize do
+          if buffer(checkStart + c) != expected(c) then
+            throw IllegalStateException("the XZ data is corrupt: integrity check failed")
+
+          c += 1
+
+      pos = checkStart + checkSize
+
+    // The index and stream footer that follow are not needed to reproduce the payload.
+
+  private def appendBytes(buffer: scm.ArrayBuffer[Byte], bytes: Array[Byte]): Unit =
+    var i = 0
+    while i < bytes.length do { buffer += bytes(i); i += 1 }
+
+  private def crc32Bytes(bytes: Array[Byte], offset: Int, length: Int): Array[Byte] =
+    val crc = Crc32()
+    crc.update(bytes, offset, length)
+    val value = crc.value
+    val out = new Array[Byte](4)
+    var i = 0
+    while i < 4 do { out(i) = ((value >>> (i*8)) & 0xff).toByte; i += 1 }
+    out
+
+  private def writeVli(buffer: scm.ArrayBuffer[Byte], value: Long): Unit =
+    var v = value
+
+    while v >= 0x80 do
+      buffer += ((v & 0x7f) | 0x80).toByte
+      v >>>= 7
+
+    buffer += (v & 0x7f).toByte
+
+  private def blockHeader(dictSizeByte: Int): Array[Byte] =
+    // A 12-byte header: size byte, flags (one filter, no explicit sizes), the LZMA2 filter with its
+    // one dictionary-size property byte, zero padding, then a CRC-32 over the first eight bytes.
+    val header = new Array[Byte](12)
+    header(0) = 0x02 // (12 / 4) - 1
+    header(1) = 0x00 // one filter, no compressed/uncompressed size fields
+    header(2) = XzContainer.Lzma2FilterId.toByte
+    header(3) = 0x01 // property size
+    header(4) = dictSizeByte.toByte
+    val crc = crc32Bytes(header, 0, 8)
+    System.arraycopy(crc, 0, header, 8, 4)
+    header
+
+  // The 12-byte stream header (magic, flags naming the check type, a CRC-32 of the flags).
+  def streamHeader(checkType: Int): Array[Byte] =
+    val out = scm.ArrayBuffer[Byte]()
+    appendBytes(out, magic)
+    val flags = Array[Byte](0x00, checkType.toByte)
+    appendBytes(out, flags)
+    appendBytes(out, crc32Bytes(flags, 0, 2))
+    out.toArray
+
+  // One complete block (header, LZMA2 payload, 4-byte-aligned padding, integrity check) for `data`,
+  // paired with its unpadded size for the index. Used both whole-value and per-segment when
+  // streaming, so each block bounds the compressor's working memory.
+  def block(data: Array[Byte], checkType: Int, options: Lzma2Options): (Array[Byte], Long) =
+    val out = scm.ArrayBuffer[Byte]()
+    val payload = Lzma2Compressor(data, options).compress()
+    val header = blockHeader(Lzma2Options.dictSizeToByte(options.dictSize))
+    appendBytes(out, header)
+    appendBytes(out, payload)
+
+    var padding = (-payload.length) & 3
+    while padding > 0 do { out += 0.toByte; padding -= 1 }
+
+    val checker = XzCheck.encoder(checkType)
+    checker.update(data, 0, data.length)
+    val checkBytes = checker.bytes
+    appendBytes(out, checkBytes)
+
+    (out.toArray, (header.length + payload.length + checkBytes.length).toLong)
+
+  // The index and stream footer that close a stream, given each block's (unpadded, uncompressed)
+  // sizes in order.
+  def indexAndFooter(records: scm.ArrayBuffer[(Long, Long)], checkType: Int): Array[Byte] =
+    val out = scm.ArrayBuffer[Byte]()
+
+    val index = scm.ArrayBuffer[Byte]()
+    index += IndexIndicator.toByte
+    writeVli(index, records.length.toLong)
+
+    records.foreach: (unpadded, uncompressed) =>
+      writeVli(index, unpadded)
+      writeVli(index, uncompressed)
+
+    while index.length % 4 != 0 do index += 0.toByte
+    val indexBody = index.toArray
+    appendBytes(out, indexBody)
+    appendBytes(out, crc32Bytes(indexBody, 0, indexBody.length))
+
+    val indexSize = indexBody.length + 4
+    val footer = new Array[Byte](12)
+    val backward = indexSize/4 - 1
+    footer(4) = (backward & 0xff).toByte
+    footer(5) = ((backward >>> 8) & 0xff).toByte
+    footer(6) = ((backward >>> 16) & 0xff).toByte
+    footer(7) = ((backward >>> 24) & 0xff).toByte
+    footer(8) = 0x00
+    footer(9) = checkType.toByte
+    val footerCrc = crc32Bytes(footer, 4, 6)
+    System.arraycopy(footerCrc, 0, footer, 0, 4)
+    footer(10) = 'Y'
+    footer(11) = 'Z'
+    appendBytes(out, footer)
+
+    out.toArray
+
+  // Encode `data` as a complete single-block `.xz` stream (empty input yields a block-less stream).
+  def encode(data: Array[Byte], checkType: Int, options: Lzma2Options): Array[Byte] =
+    val out = scm.ArrayBuffer[Byte]()
+    appendBytes(out, streamHeader(checkType))
+    val records = scm.ArrayBuffer[(Long, Long)]()
+
+    if data.length > 0 then
+      val (blockBytes, unpadded) = block(data, checkType, options)
+      appendBytes(out, blockBytes)
+      records += ((unpadded, data.length.toLong))
+
+    appendBytes(out, indexAndFooter(records, checkType))
+    out.toArray

--- a/lib/pneumatic/src/test/pneumatic_test.scala
+++ b/lib/pneumatic/src/test/pneumatic_test.scala
@@ -343,6 +343,204 @@ object Tests extends Suite(m"Pneumatic tests"):
       . assert(_ == List[Byte](42))
 
 
+    suite(m"XZ tests"):
+      // Golden vectors: real `xz` command-line output, decoded here — validating the decoder against
+      // the reference implementation, not merely against our own encoder. All decode to "hello hello
+      // hello world".
+      val hello: List[Byte] = t"hello hello hello world".in[Data].to(List)
+
+      val crc64Xz: Data = Data(-3, 55, 122, 88, 90, 0, 0, 4, -26, -42, -76, 70, 4, -64, 24, 23, 33,
+          1, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 52, -73, -61, 72, -32, 0, 22, 0, 16, 93, 0, 52, 25, 73,
+          -18, -115, -23, 80, -106, 8, 6, -10, -24, -112, -109, -71, 32, 0, -64, 44, -125, 101, 28,
+          18, -22, 117, 0, 1, 52, 23, 27, -61, 127, 24, 31, -74, -13, 125, 1, 0, 0, 0, 0, 4, 89, 90)
+
+      val crc32Xz: Data = Data(-3, 55, 122, 88, 90, 0, 0, 1, 105, 34, -34, 54, 4, -64, 24, 23, 33, 1,
+          22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 52, -73, -61, 72, -32, 0, 22, 0, 16, 93, 0, 52, 25, 73,
+          -18, -115, -23, 80, -106, 8, 6, -10, -24, -112, -109, -71, 32, 0, 38, -26, 90, -127, 0, 1,
+          48, 23, 31, 6, 19, 124, -112, 66, -103, 13, 1, 0, 0, 0, 0, 1, 89, 90)
+
+      val noneXz: Data = Data(-3, 55, 122, 88, 90, 0, 0, 0, -1, 18, -39, 65, 4, -64, 24, 23, 33, 1,
+          22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 52, -73, -61, 72, -32, 0, 22, 0, 16, 93, 0, 52, 25, 73,
+          -18, -115, -23, 80, -106, 8, 6, -10, -24, -112, -109, -71, 32, 0, 0, 1, 44, 23, 66, 91,
+          100, -102, 6, 114, -98, 122, 1, 0, 0, 0, 0, 0, 89, 90)
+
+      val emptyXz: Data = Data(-3, 55, 122, 88, 90, 0, 0, 4, -26, -42, -76, 70, 0, 0, 0, 0, 28, -33,
+          68, 33, 31, -74, -13, 125, 1, 0, 0, 0, 0, 4, 89, 90)
+
+      val sha256Xz: Data = Data(-3, 55, 122, 88, 90, 0, 0, 10, -31, -5, 12, -95, 4, -64, 24, 23, 33,
+          1, 22, 0, 0, 0, 0, 0, 0, 0, 0, 0, 52, -73, -61, 72, -32, 0, 22, 0, 16, 93, 0, 52, 25, 73,
+          -18, -115, -23, 80, -106, 8, 6, -10, -24, -112, -109, -71, 32, 0, 51, -116, -17, 103,
+          -104, 86, 60, 79, -90, -31, 124, 97, 49, 108, -97, -109, -15, -37, 45, -122, -86, -120,
+          17, -127, 55, 5, 109, 9, -32, -123, 9, 62, 0, 1, 76, 23, -27, 48, -103, -1, 24, -101, 75,
+          -102, 1, 0, 0, 0, 0, 10, 89, 90)
+
+      test(m"Decode reference xz output (SHA-256 check, verified)"):
+        sha256Xz.decompress[Xz].to(List)
+      . assert(_ == hello)
+
+      test(m"A corrupted payload is detected by the integrity check"):
+        // Flip a byte inside the LZMA2 payload (after the 12-byte stream and 12-byte block headers)
+        // and confirm decoding rejects it — via either a decode error or a check mismatch.
+        val original = (t"the quick brown fox " * 40).in[Data]
+        val bytes = original.compress[Xz].mutable(using Unsafe)
+        bytes(36) = (bytes(36) ^ 0x55).toByte
+        val corrupted: Data = bytes.immutable(using Unsafe)
+        try corrupted.decompress[Xz].to(List) != original.to(List)
+        catch case _: Exception => true
+      . assert(_ == true)
+
+      test(m"Decode reference xz output (CRC-64 check)"):
+        crc64Xz.decompress[Xz].to(List)
+      . assert(_ == hello)
+
+      test(m"Decode reference xz output (CRC-32 check)"):
+        crc32Xz.decompress[Xz].to(List)
+      . assert(_ == hello)
+
+      test(m"Decode reference xz output (no check)"):
+        noneXz.decompress[Xz].to(List)
+      . assert(_ == hello)
+
+      test(m"Decode reference xz output (empty input)"):
+        emptyXz.decompress[Xz].to(List)
+      . assert(_ == Nil)
+
+      val xzWhole: Data = IArray.from((0 to 255).map(_.toByte)) ++ Data(1, 1, 2, 3, 5, 8, 13)
+      val xzLong = LazyList.continually(IArray.from((0 to 255).map(_.toByte))).take(1000)
+      val xzVaried: Data =
+        IArray.from((0 until 40000).map { index => ((index*index + index/3)%251).toByte })
+
+      test(m"Roundtrip a single block with Xz"):
+        LazyList(Data(1, 1, 2, 3, 5, 8, 13, 21, 34)).compress[Xz].decompress[Xz]
+      . assert(_.flatten == LazyList(Data(1, 1, 2, 3, 5, 8, 13, 21, 34)).flatten)
+
+      test(m"Roundtrip a long repetitive stream with Xz"):
+        xzLong.compress[Xz].decompress[Xz]
+      . assert(_.flatten == xzLong.flatten)
+
+      test(m"whole-value compress roundtrips through whole-value decompress (Xz)"):
+        xzWhole.compress[Xz].decompress[Xz].to(List)
+      . assert(_ == xzWhole.to(List))
+
+      test(m"whole-value compress feeds the stream decompressor (Xz)"):
+        xzWhole.compress[Xz].stream.decompress[Xz].memoize.to(List)
+      . assert(_ == xzWhole.to(List))
+
+      test(m"stream compress feeds the whole-value decompressor (Xz)"):
+        xzWhole.stream.compress[Xz].memoize.decompress[Xz].to(List)
+      . assert(_ == xzWhole.to(List))
+
+      test(m"Roundtrip varied data spanning many commands (Xz)"):
+        xzVaried.compress[Xz].decompress[Xz].to(List)
+      . assert(_ == xzVaried.to(List))
+
+      test(m"Xz actually compresses a repetitive payload"):
+        val payload = (t"the quick brown fox jumped " * 500).in[Data]
+        payload.compress[Xz].length < payload.length
+      . assert(_ == true)
+
+      test(m"Compress with an explicit fast preset and roundtrip (Xz)"):
+        Xz.compress(LazyList(xzVaried), 1).decompress[Xz].flatten.to(List)
+      . assert(_ == xzVaried.to(List))
+
+      test(m"Empty input roundtrips (Xz)"):
+        Data().compress[Xz].decompress[Xz].to(List)
+      . assert(_ == Nil)
+
+      test(m"Single byte roundtrips (Xz)"):
+        Data(42).compress[Xz].decompress[Xz].to(List)
+      . assert(_ == List[Byte](42))
+
+      test(m"Roundtrip a large multi-chunk payload (Xz)"):
+        val big =
+          IArray.from((0 until 3000000).map { i => ((i*31 + (i >> 6)) & 0xff).toByte })
+        big.compress[Xz].decompress[Xz].to(List) == big.to(List)
+      . assert(_ == true)
+
+      test(m"Streaming encoder emits multiple blocks past the dictionary (preset 0)"):
+        // Preset 0 has a 256 KiB dictionary, so ~700 KiB spans several self-contained blocks; the
+        // multi-block stream must roundtrip and be accepted by the reference `xz` binary.
+        val payload: Data =
+          IArray.from((0 until 700000).map { i => ((i*31 + (i >> 6)) & 0xff).toByte })
+        val encodedChunks = Xz.compress(LazyList(payload), 0)
+        val roundtrips = encodedChunks.decompress[Xz].flatten.to(List) == payload.to(List)
+        val encodedBytes: Array[Byte] = IArray.from(encodedChunks.flatten).mutable(using Unsafe)
+        val byXz =
+          try
+            val process = ProcessBuilder("xz", "-d", "-c").start().nn
+            process.getOutputStream.nn.write(encodedBytes)
+            process.getOutputStream.nn.close()
+            val decoded = process.getInputStream.nn.readAllBytes().nn
+            process.waitFor()
+            decoded.to(List) == payload.to(List)
+          catch case _: ji.IOException => true
+        roundtrips && byXz
+      . assert(_ == true)
+
+      // Cross-check: the real `xz` binary must decode what we produce.
+      def xzBinaryDecodes(data: Data): Boolean =
+        try
+          val encoded = data.compress[Xz].mutable(using Unsafe)
+          val process = ProcessBuilder("xz", "-d", "-c").start().nn
+          val stdin = process.getOutputStream.nn
+          stdin.write(encoded)
+          stdin.close()
+          val decoded = process.getInputStream.nn.readAllBytes().nn
+          process.waitFor()
+          process.exitValue() == 0 && decoded.to(List) == data.to(List)
+        catch case _: ji.IOException => true // xz binary unavailable; skip
+
+      test(m"The xz binary decodes our output (repetitive)"):
+        xzBinaryDecodes((t"the quick brown fox " * 400).in[Data])
+      . assert(_ == true)
+
+      test(m"The xz binary decodes our output (varied)"):
+        xzBinaryDecodes(xzVaried)
+      . assert(_ == true)
+
+    suite(m"LZMA2 tests"):
+      val lzma2Whole: Data = IArray.from((0 to 255).map(_.toByte)) ++ Data(1, 1, 2, 3, 5, 8, 13)
+      val lzma2Long = LazyList.continually(IArray.from((0 to 255).map(_.toByte))).take(1000)
+      val lzma2Varied: Data =
+        IArray.from((0 until 40000).map { index => ((index*index + index/3)%251).toByte })
+
+      test(m"Roundtrip a single block with raw LZMA2"):
+        LazyList(Data(1, 1, 2, 3, 5, 8, 13, 21, 34)).compress[Lzma2].decompress[Lzma2]
+      . assert(_.flatten == LazyList(Data(1, 1, 2, 3, 5, 8, 13, 21, 34)).flatten)
+
+      test(m"Roundtrip a long repetitive stream with raw LZMA2"):
+        lzma2Long.compress[Lzma2].decompress[Lzma2]
+      . assert(_.flatten == lzma2Long.flatten)
+
+      test(m"whole-value compress roundtrips through whole-value decompress (LZMA2)"):
+        lzma2Whole.compress[Lzma2].decompress[Lzma2].to(List)
+      . assert(_ == lzma2Whole.to(List))
+
+      test(m"whole-value compress feeds the stream decompressor (LZMA2)"):
+        lzma2Whole.compress[Lzma2].stream.decompress[Lzma2].memoize.to(List)
+      . assert(_ == lzma2Whole.to(List))
+
+      test(m"stream compress feeds the whole-value decompressor (LZMA2)"):
+        lzma2Whole.stream.compress[Lzma2].memoize.decompress[Lzma2].to(List)
+      . assert(_ == lzma2Whole.to(List))
+
+      test(m"Roundtrip varied data (LZMA2)"):
+        lzma2Varied.compress[Lzma2].decompress[Lzma2].to(List)
+      . assert(_ == lzma2Varied.to(List))
+
+      test(m"Empty input roundtrips (LZMA2)"):
+        Data().compress[Lzma2].decompress[Lzma2].to(List)
+      . assert(_ == Nil)
+
+      test(m"Single byte roundtrips (LZMA2)"):
+        Data(42).compress[Lzma2].decompress[Lzma2].to(List)
+      . assert(_ == List[Byte](42))
+
+      test(m"Explicit preset and dictionary size roundtrip (LZMA2)"):
+        Lzma2.decompress(Lzma2.compress(LazyList(lzma2Varied), 1),
+            Lzma2Options.preset(1).dictSize).flatten.to(List)
+      . assert(_ == lzma2Varied.to(List))
+
     suite(m"Compression duct tests"):
       val mixed: Data =
         Data.fill(50000) { index => (index%251).toByte } ++ (t"repetition "*500).in[Data]


### PR DESCRIPTION
Pneumatic gains XZ and raw LZMA2 compression, a high-ratio codec implemented in pure Scala with no new dependencies, so it works identically on the JVM, Scala.js and WASI. `Xz` handles the full `.xz` container and `Lzma2` the container-free stream, both exposed through the existing compression API and both interoperable with the standard `xz` command-line tool.

Two new formats join the compression API, keyed by type just like the existing ones:

```scala
import soundness.*

// Whole-value
val squeezed: Data = data.compress[Xz]
val restored: Data = squeezed.decompress[Xz]

// Streaming (lazy chunks) and preset selection (0–9)
val stream: LazyList[Data] = Xz.compress(source, preset = 9)
val back: LazyList[Data] = stream.decompress[Xz]
```

`Xz` produces standard `.xz` streams (default preset 6, CRC-64 check) that `xz -d` decodes, and it reads streams written by `xz`, verifying their CRC-32, CRC-64 or SHA-256 integrity check. `Lzma2` is the container-free counterpart — the raw LZMA2 stream without the `.xz` framing, analogous to how raw `Deflate` sits beside `Gzip` and `Zlib`; because a raw LZMA2 stream does not record its dictionary size, `Lzma2.decompress(stream, dictSize)` takes it explicitly:

```scala
val raw: LazyList[Data] = Lzma2.compress(source, preset = 6)
val plain: LazyList[Data] = Lzma2.decompress(raw, Lzma2Options.preset(6).dictSize)
```

Presets 0–3 use a fast encoder; 4–9 use a cost-based encoder that weighs each literal, match and repeat-match by its actual coded price. The `Xz` encoder streams with bounded memory, emitting one self-contained block per dictionary-sized segment rather than buffering the whole input.
