### PR TITLE
Add an ASN.1 value model and canonical DER codec to Enigmatic

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -563,8 +563,8 @@ object soundness extends Toolchain:
     surveillance.core, punctuation.ansi, hallucination.ansi, ziggurat.core, ziggurat.packager,
     ultimatum.core, xenophile.native, exoskeleton.args, exoskeleton.core)
 
-  object data extends Bundle(caesura.core, dissonance.core, enigmatic.core, facsimile.core,
-    gastronomy.core, chiaroscuro.core, jacinta.core, monotonous.core,
+  object data extends Bundle(caesura.core, dissonance.core, enigmatic.asn1, enigmatic.core,
+    facsimile.core, gastronomy.core, chiaroscuro.core, jacinta.core, monotonous.core,
     panopticon.core, camouflage.core, ulysses.core, polyvinyl.core, polaris.core, zeppelin.core,
     xylophone.core, anamnesis.core, jacinta.time, jacinta.schema, gnossienne.core, jacinta.records,
     stratiform.core, stratiform.time, vexillology.core, enigmatic.cose, enigmatic.openssl,
@@ -1273,11 +1273,18 @@ object embarcadero extends Library:
       settings.cc(settings.maxInlines(super.scalacOptions(), "64"))
 
 object enigmatic extends Library:
+  // The ASN.1 value model and canonical DER codec: pure byte manipulation with no crypto provider
+  // and no platform APIs, so — unlike every other component here — it cross-compiles to Scala.js
+  // and Scala Native as well as the JVM. `core` depends on it so `Pem` can bridge to `Der`.
+  object asn1 extends Component(distillate.core, gossamer.core, monotonous.core, turbulence.core,
+    zephyrine.core):
+    override def scalacOptions = Task:
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   // The platform split mirrors gastronomy's: the cipher/key/PEM model is platform-neutral, while
   // the `JavaStdlibCrypto` provider and PKCS#12 keystores compile against `javax.crypto`/
   // `java.security` on the JVM (`core-jvm`) and against panicking stubs on native (`core-native`,
   // where the OpenSSL provider is the real implementation).
-  object core extends Component(aperture.core, gastronomy.core):
+  object core extends Component(aperture.core, gastronomy.core, asn1):
     override def scalaJs = false // `javax.crypto` has no JS analogue (and no OpenSSL either)
     override def scalaNative = true // but native has the OpenSSL provider
     // `core-jvm` also holds the off-heap/encrypting cloaks (`java.lang.foreign`).

--- a/doc/errors/523.md
+++ b/doc/errors/523.md
@@ -1,0 +1,209 @@
+# `SN-523` — `Asn1Error`
+
+Raised when Enigmatic cannot read a DER-encoded ASN.1 value.
+
+## Cause
+
+DER (the Distinguished Encoding Rules) is the canonical subset of BER:
+every value has exactly one valid encoding. Enigmatic's decoder is
+strict, so anything BER permits but DER does not — indefinite lengths,
+overlong lengths and tag numbers, non-minimal integers, constructed
+strings, unordered sets — is an error rather than something to be
+tolerated. That strictness is what lets a value that was read back be
+re-encoded to the bytes it came from, which is what verifying a
+signature over a certificate's `TBSCertificate` depends on. The message
+is `could not process the ASN.1 value because $reason`, and every reason
+carries the byte offset at which the problem was found.
+
+## Variants
+
+### `SN-523.1` — `Truncated`
+
+The input ended before the current value did.
+
+**Example.** `[↯SN-523.1] could not process the ASN.1 value because the input was truncated at byte 42`
+
+**Resolution.** Confirm the input is complete; a PEM body that was cut
+short, or a length prefix read from the wrong offset, are the usual
+causes.
+
+### `SN-523.2` — `IndefiniteLength`
+
+A value used BER's indefinite-length form, which DER forbids.
+
+**Example.** `[↯SN-523.2] could not process the ASN.1 value because an indefinite length was found at byte 1`
+
+**Resolution.** Re-encode the input as DER; `openssl asn1parse` will
+show where the indefinite lengths are.
+
+### `SN-523.3` — `NonMinimalLength`
+
+A length was not written in the fewest possible bytes: either the
+long form was used for a length below 128, or its leading byte was
+zero.
+
+**Example.** `[↯SN-523.3] could not process the ASN.1 value because an overlong length was found at byte 1`
+
+**Resolution.** Re-encode the input as DER.
+
+### `SN-523.4` — `NonMinimalTag`
+
+A tag number below 31 was written in the high-tag-number form, or a
+high tag number had a leading zero group.
+
+**Example.** `[↯SN-523.4] could not process the ASN.1 value because an overlong tag number was found at byte 1`
+
+**Resolution.** Re-encode the input as DER.
+
+### `SN-523.5` — `NonMinimalInteger`
+
+An integer carried a redundant leading `0x00` or `0xFF` byte. DER
+requires the shortest two's-complement representation.
+
+**Example.** `[↯SN-523.5] could not process the ASN.1 value because an overlong integer was found at byte 0`
+
+**Resolution.** Re-encode the input as DER.
+
+### `SN-523.6` — `EmptyInteger`
+
+An integer had no content octets; ASN.1 requires at least one.
+
+**Example.** `[↯SN-523.6] could not process the ASN.1 value because an integer with no content was found at byte 0`
+
+**Resolution.** Check the producer of the input: a zero must be
+encoded as the single byte `0x00`.
+
+### `SN-523.7` — `Overflow`
+
+A length or tag number was too large to represent: a length needing
+more than four bytes, a length above `Int.MaxValue`, or a tag number
+above `Int.MaxValue`.
+
+**Example.** `[↯SN-523.7] could not process the ASN.1 value because an unrepresentable length was found at byte 1`
+
+**Resolution.** Values this large are almost always a sign that the
+input is not DER at all, or that parsing began at the wrong offset.
+
+### `SN-523.8` — `Trailing`
+
+A complete value was read, but bytes remained after it. A DER document
+holds exactly one value.
+
+**Example.** `[↯SN-523.8] could not process the ASN.1 value because unexpected trailing bytes were found from byte 2`
+
+**Resolution.** If the input holds several concatenated values — a
+certificate chain, for instance — split it before decoding.
+
+### `SN-523.9` — `InvalidUtf8`
+
+A string's content octets were not valid UTF-8.
+
+**Example.** `[↯SN-523.9] could not process the ASN.1 value because invalid UTF-8 was found at byte 12`
+
+**Resolution.** Check the encoding of the source text; ASN.1 string
+types other than `UTF8String` may carry a different character set.
+
+### `SN-523.10` — `ReservedTag`
+
+Universal tag number 0 was found; it is reserved by X.690.
+
+**Example.** `[↯SN-523.10] could not process the ASN.1 value because the reserved tag number 0 was found at byte 0`
+
+**Resolution.** The input is not valid ASN.1; check that decoding began
+at the start of a value.
+
+### `SN-523.11` — `BadOid`
+
+An object identifier was malformed: it had no content, or its final
+subidentifier's continuation bit was set, or a subidentifier began with
+the padding byte `0x80`.
+
+**Example.** `[↯SN-523.11] could not process the ASN.1 value because a malformed object identifier was found at byte 3`
+
+**Resolution.** Re-encode the input as DER.
+
+### `SN-523.12` — `OidArcOverflow`
+
+An object identifier arc was too large for an `Int`. Arcs this large
+occur under the UUID arc `2.25`, which Enigmatic's `Asn1.ObjectId` does
+not yet model.
+
+**Example.** `[↯SN-523.12] could not process the ASN.1 value because an arc too large for Int was found at byte 3`
+
+**Resolution.** Read the value as raw bytes for now; wider arcs are a
+planned extension.
+
+### `SN-523.13` — `UnsortedSet`
+
+The members of a `SET` were not in ascending order of their encodings,
+as X.690 §11.6 requires.
+
+**Example.** `[↯SN-523.13] could not process the ASN.1 value because the set at byte 5 was not in ascending order`
+
+**Resolution.** Re-encode the input as DER; encoders that emit BER
+often leave `SET` members in their declaration order.
+
+### `SN-523.14` — `BadTime`
+
+A `UTCTime` or `GeneralizedTime` was not in DER's single permitted
+form — `YYMMDDHHMMSSZ` and `YYYYMMDDHHMMSSZ` respectively — or named a
+date that does not exist.
+
+**Example.** `[↯SN-523.14] could not process the ASN.1 value because a malformed time value was found at byte 0`
+
+**Resolution.** Re-encode the input as DER: fractional seconds, offsets
+from UTC and omitted seconds are all forbidden.
+
+### `SN-523.15` — `BadBoolean`
+
+A boolean's content octet was neither `0x00` nor `0xFF`. BER allows any
+non-zero byte to mean `true`; DER does not.
+
+**Example.** `[↯SN-523.15] could not process the ASN.1 value because a boolean with the content byte 1 was found at byte 0`
+
+**Resolution.** Re-encode the input as DER.
+
+### `SN-523.16` — `BadLength`
+
+A value's length was not one its type permits: a `NULL` with content, a
+boolean whose length was not 1, or a `BIT STRING` with no content.
+
+**Example.** `[↯SN-523.16] could not process the ASN.1 value because the tag 5 had the invalid length 1 at byte 0`
+
+**Resolution.** Check the producer of the input.
+
+### `SN-523.17` — `BadUnusedBits`
+
+A `BIT STRING`'s leading octet declared more than seven unused bits,
+declared unused bits for an empty string, or the bits it declared
+unused were not zero.
+
+**Example.** `[↯SN-523.17] could not process the ASN.1 value because a bit string declaring 8 unused bits was found at byte 0`
+
+**Resolution.** Re-encode the input as DER.
+
+### `SN-523.18` — `NotPrimitive`
+
+A type that DER requires to be primitive — the string types, integers,
+`BIT STRING`, `OCTET STRING`, `NULL`, object identifiers and the two
+time types — was encoded in constructed form.
+
+**Example.** `[↯SN-523.18] could not process the ASN.1 value because the tag 4 was encoded in constructed form at byte 0`
+
+**Resolution.** Re-encode the input as DER; segmented (constructed)
+strings are a BER feature.
+
+### `SN-523.19` — `NotConstructed`
+
+A `SEQUENCE` or `SET` was encoded in primitive form.
+
+**Example.** `[↯SN-523.19] could not process the ASN.1 value because the tag 16 was encoded in primitive form at byte 0`
+
+**Resolution.** The input is not valid ASN.1; check that decoding began
+at the start of a value.
+
+## See also
+
+- Source: `lib/enigmatic/src/asn1/enigmatic.Asn1Error.scala`
+- `SN-389` — `PemError`, raised when the PEM armor around DER content
+  cannot be parsed

--- a/lib/enigmatic/doc/basics.md
+++ b/lib/enigmatic/doc/basics.md
@@ -17,10 +17,18 @@ valid DER:
 ```scala
 val value: Asn1 = bytes.read[Der].as[Asn1]
 ```
-DER content usually arrives armored as PEM, and `Pem` converts in both directions:
+DER content usually arrives armored as PEM. Reading a `Pem` and decoding its payload can be
+done in one step, from any source a `Text` can be read from:
 ```scala
-val certificate: Asn1 = Pem.parse(text).der.as[Asn1]
+val certificate: Asn1 = text.read[Asn1 in Pem]
+val payload: Der = text.read[Der in Pem]
+
 val armored: Pem = Pem(PemLabel.Certificate, certificate.in[Der])
+```
+or in stages, if the label matters:
+```scala
+val pem: Pem = text.read[Pem]
+val certificate: Asn1 = pem.as[Der].as[Asn1]
 ```
 
 #### Canonicity
@@ -36,8 +44,8 @@ The point of that strictness is that decoding and re-encoding reproduces the ori
 exactly — the property that verifying a signature over a certificate's `TBSCertificate`
 depends on:
 ```scala
-val pem = Pem.parse(certificate)
-pem.der.as[Asn1].in[Der] == pem.der   // true
+val pem = text.read[Pem]
+pem.as[Der].as[Asn1].in[Der] == pem.as[Der]   // true
 ```
 
 #### Tagged and unknown values

--- a/lib/enigmatic/doc/basics.md
+++ b/lib/enigmatic/doc/basics.md
@@ -1,1 +1,55 @@
-TBC
+### ASN.1 and DER
+
+Most of public-key cryptography's file formats — X.509 certificates, PKCS#10 certificate
+requests, PKCS#8 keys, CMS messages — are ASN.1 structures serialized with the
+_Distinguished Encoding Rules_. Enigmatic models an ASN.1 value with the `Asn1` enumeration,
+and DER with the `Der` type:
+```scala
+val name = Asn1.Sequence
+             (List
+               (Asn1.ObjectId(List(2, 5, 4, 3)),
+                Asn1.Utf8String(t"example.com")))
+
+val bytes: Data = name.in[Der].data
+```
+Reading goes the other way, and needs a `Tactic[Asn1Error]` since the input may not be
+valid DER:
+```scala
+val value: Asn1 = bytes.read[Der].as[Asn1]
+```
+DER content usually arrives armored as PEM, and `Pem` converts in both directions:
+```scala
+val certificate: Asn1 = Pem.parse(text).der.as[Asn1]
+val armored: Pem = Pem(PemLabel.Certificate, certificate.in[Der])
+```
+
+#### Canonicity
+
+DER gives every value exactly one valid encoding, and Enigmatic holds to that in both
+directions. The encoder writes integers in the fewest possible bytes, `true` as `0xFF`,
+definite lengths in their shortest form, and the members of a `SET` in ascending order of
+their encodings. The decoder rejects everything BER permits but DER does not: indefinite
+lengths, overlong lengths and tag numbers, non-minimal integers, constructed strings and
+unordered sets each raise an `Asn1Error` naming the byte at which the problem was found.
+
+The point of that strictness is that decoding and re-encoding reproduces the original bytes
+exactly — the property that verifying a signature over a certificate's `TBSCertificate`
+depends on:
+```scala
+val pem = Pem.parse(certificate)
+pem.der.as[Asn1].in[Der] == pem.der   // true
+```
+
+#### Tagged and unknown values
+
+An _explicit_ context tag, `[0] EXPLICIT`, wraps a complete inner value, so it reads and
+writes as `Asn1.Tagged(0, true, inner)`. An _implicit_ context tag, `[0] IMPLICIT`, merely
+replaces the inner value's tag, which makes `[0] IMPLICIT INTEGER` and `[0] IMPLICIT OCTET
+STRING` byte-identical; recovering the inner type needs the ASN.1 module's schema, which
+this layer does not have. `Asn1.Tagged(0, false, inner)` is therefore write-only: the
+decoder yields `Asn1.Unknown` for an implicit tag instead.
+
+`Asn1.Unknown` carries content octets verbatim, and is also what the decoder produces for
+universal types outside the PKIX subset modelled here, such as `T61String` and
+`BMPString`. It is what makes decoding total, and what makes the round-trip above hold for
+certificates in the wild.

--- a/lib/enigmatic/doc/features.md
+++ b/lib/enigmatic/doc/features.md
@@ -3,3 +3,5 @@
 - signing with DSA
 - AES, RSA and DSA key generation
 - calculation of HMACs for SHA-256, SHA-1 and MD5
+- an ASN.1 value model with a canonical DER encoder and a strict DER decoder
+- byte-exact round-tripping of X.509 certificates, PKCS#10 requests and other DER content

--- a/lib/enigmatic/src/asn1/enigmatic.Asn1.scala
+++ b/lib/enigmatic/src/asn1/enigmatic.Asn1.scala
@@ -1,0 +1,670 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+
+import java.nio.charset as jnc
+
+import scala.collection.mutable as scm
+
+import anticipation.*
+import contingency.*
+import distillate.*
+import prepositional.*
+import rudiments.*
+import turbulence.*
+import vacuous.*
+import zephyrine.*
+
+import Asn1Error.Reason
+
+// An ASN.1 value, in the subset of the universal types that PKIX uses, plus two escape hatches for
+// everything else.
+//
+// `Tagged` and `Unknown` deserve explanation. An explicit context tag (`[0] EXPLICIT`) wraps a
+// complete inner value, so it can be both written and read; an *implicit* context tag (`[0]
+// IMPLICIT`) merely replaces the inner value's tag, which makes `[0] IMPLICIT INTEGER` and `[0]
+// IMPLICIT OCTET STRING` byte-identical. Recovering the inner type needs the ASN.1 module's schema,
+// which this layer does not have, so `Tagged(_, explicit = false, _)` is *write-only*: the decoder
+// never produces it, and yields `Unknown` instead.
+//
+// `Unknown` carries the content octets verbatim, which is what makes decoding total (real
+// certificates hold `T61String`, `BMPString` and `ENUMERATED` values that are not modelled here)
+// and what makes `decode` followed by `encode` reproduce the original bytes exactly — the property
+// that verifying a signature over a certificate's `TBSCertificate` depends on.
+object Asn1:
+  // Tag classes, in the two high bits of the identifier octet.
+  val Universal: Int = 0
+  val Application: Int = 1
+  val Context: Int = 2
+  val Private: Int = 3
+
+  // Universal tag numbers.
+  private val BooleanTag: Int = 0x01
+  private val IntegerTag: Int = 0x02
+  private val BitStringTag: Int = 0x03
+  private val OctetStringTag: Int = 0x04
+  private val NullTag: Int = 0x05
+  private val ObjectIdTag: Int = 0x06
+  private val Utf8StringTag: Int = 0x0c
+  private val SequenceTag: Int = 0x10
+  private val SetTag: Int = 0x11
+  private val PrintableStringTag: Int = 0x13
+  private val Ia5StringTag: Int = 0x16
+  private val UtcTimeTag: Int = 0x17
+  private val GeneralizedTimeTag: Int = 0x18
+
+  private val SecondsPerDay: Long = 86400L
+
+  given encodable: Asn1 is Encodable in Der = value => Der(render(value))
+
+  given decodable: (tactic: Tactic[Asn1Error]^) => ((Asn1 is Decodable in Der)^{tactic, caps.any}) =
+    der => Parser.parse(der.data)
+
+  given aggregable: (tactic: Tactic[Asn1Error]^)
+  =>  ( ((Asn1 in Der) is Aggregable by Data)^{tactic, caps.any} ) =
+    bytes => Parser.parse(bytes.read[Data]).asInstanceOf[Asn1 in Der]
+
+  // The DER encoding of a single value. Each node renders its own content into its own producer,
+  // because a definite-length prefix must be written before the content it measures, and because
+  // DER orders the elements of a `SET` by their *encodings* — both need the children's bytes in
+  // hand first. That costs one copy per level of nesting, which is immaterial for the kilobyte-
+  // scale structures (certificates, keys, requests) this exists to serve.
+  private def render(value: Asn1): Data = Producer.collect[Data]()(write(_, value))
+
+  private def write(out: (Producer.Bytes)^, value: Asn1): Unit =
+    val content = contentOf(value)
+    identifier(out, tagClassOf(value), constructedForm(value), tagOf(value))
+    length(out, content.length)
+    out.put(content)
+
+  private def tagClassOf(value: Asn1): Int = value match
+    case Asn1.Tagged(_, _, _)            => Context
+    case Asn1.Unknown(tagClass, _, _, _) => tagClass
+    case _                               => Universal
+
+  private def tagOf(value: Asn1): Int = value match
+    case Asn1.Boolean(_)            => BooleanTag
+    case Asn1.Integer(_)            => IntegerTag
+    case Asn1.BitString(_, _)       => BitStringTag
+    case Asn1.OctetString(_)        => OctetStringTag
+    case Asn1.Null                  => NullTag
+    case Asn1.ObjectId(_)           => ObjectIdTag
+    case Asn1.Utf8String(_)         => Utf8StringTag
+    case Asn1.PrintableString(_)    => PrintableStringTag
+    case Asn1.Ia5String(_)          => Ia5StringTag
+    case Asn1.UtcTime(_)            => UtcTimeTag
+    case Asn1.GeneralizedTime(_)    => GeneralizedTimeTag
+    case Asn1.Sequence(_)           => SequenceTag
+    case Asn1.Set(_)                => SetTag
+    case Asn1.Tagged(tag, _, _)     => tag
+    case Asn1.Unknown(_, tag, _, _) => tag
+
+  private def constructedForm(value: Asn1): scala.Boolean = value match
+    case Asn1.Sequence(_)                   => true
+    case Asn1.Set(_)                        => true
+    case Asn1.Tagged(_, true, _)            => true
+    case Asn1.Tagged(_, false, inner)       => constructedForm(inner)
+    case Asn1.Unknown(_, _, constructed, _) => constructed
+    case _                                  => false
+
+  // The content octets of a value: everything after its identifier and length.
+  private def contentOf(value: Asn1): Data = value match
+    case Asn1.Boolean(boolean)      => IArray[Byte](if boolean then 0xff.toByte else 0.toByte)
+    case Asn1.Integer(integer)      => integer.toByteArray.immutable(using Unsafe)
+    case Asn1.OctetString(bytes)    => bytes
+    case Asn1.Null                  => IArray[Byte]()
+    case Asn1.Utf8String(text)      => utf8(text)
+    case Asn1.PrintableString(text) => utf8(text)
+    case Asn1.Ia5String(text)       => utf8(text)
+
+    case Asn1.BitString(bytes, unusedBits) =>
+      Producer.collect[Data](): out =>
+        out.push(unusedBits.toByte)
+        out.put(bytes)
+
+    case Asn1.ObjectId(arcs) => Producer.collect[Data]()(objectId(_, arcs))
+
+    case Asn1.UtcTime(timestamp) =>
+      Producer.collect[Data]()(time(_, timestamp, false))
+
+    case Asn1.GeneralizedTime(timestamp) =>
+      Producer.collect[Data]()(time(_, timestamp, true))
+
+    case Asn1.Sequence(elements) =>
+      Producer.collect[Data](): out =>
+        elements.foreach: element =>
+          out.put(render(element))
+
+    case Asn1.Set(elements) =>
+      // DER orders the members of a `SET` by their encodings, shorter-first when one is a prefix
+      // of the other (X.690 §11.6, treating the shorter as zero-padded).
+      val rendered = elements.map(render(_)).sortWith(precedes(_, _))
+
+      Producer.collect[Data](): out =>
+        rendered.foreach: element =>
+          out.put(element)
+
+    case Asn1.Tagged(_, true, inner)    => render(inner)
+    case Asn1.Tagged(_, false, inner)   => contentOf(inner)
+    case Asn1.Unknown(_, _, _, content) => content
+
+  private def precedes(left: Data, right: Data): scala.Boolean =
+    var index = 0
+    var difference = 0
+
+    while difference == 0 && index < left.length && index < right.length do
+      difference = (left(index) & 0xff) - (right(index) & 0xff)
+      index += 1
+
+    if difference != 0 then difference < 0 else left.length <= right.length
+
+  private def utf8(text: Text): Data =
+    text.s.getBytes(jnc.StandardCharsets.UTF_8).nn.immutable(using Unsafe)
+
+  private def identifier
+    ( out: (Producer.Bytes)^, tagClass: Int, constructed: scala.Boolean, tag: Int )
+  :   Unit =
+
+    val bits = (tagClass << 6) | (if constructed then 0x20 else 0)
+
+    if tag < 0x1f then out.push((bits | tag).toByte) else
+      out.push((bits | 0x1f).toByte)
+      base128(out, tag)
+
+  private def length(out: (Producer.Bytes)^, size: Int): Unit =
+    if size < 0x80 then out.push(size.toByte) else
+      var count = 0
+      var remaining = size
+
+      while remaining > 0 do
+        count += 1
+        remaining >>>= 8
+
+      out.push((0x80 | count).toByte)
+      var index = count - 1
+
+      while index >= 0 do
+        out.push(((size >>> (index*8)) & 0xff).toByte)
+        index -= 1
+
+  // A base-128 subidentifier: seven bits per octet, most significant first, with the high bit set
+  // on every octet but the last, and no leading zero group.
+  private def base128(out: (Producer.Bytes)^, value: Int): Unit =
+    var shift = 0
+    var remaining = value >>> 7
+
+    while remaining != 0 do
+      shift += 7
+      remaining >>>= 7
+
+    while shift > 0 do
+      out.push((0x80 | ((value >>> shift) & 0x7f)).toByte)
+      shift -= 7
+
+    out.push((value & 0x7f).toByte)
+
+  // The first two arcs of an object identifier share one subidentifier, as `40*first + second`.
+  // An identifier with fewer than two arcs is not well-formed; its arcs are emitted as they are.
+  private def objectId(out: (Producer.Bytes)^, arcs: List[Int]): Unit = arcs match
+    case first :: second :: rest =>
+      base128(out, first*40 + second)
+
+      rest.foreach: arc =>
+        base128(out, arc)
+
+    case rest =>
+      rest.foreach: arc =>
+        base128(out, arc)
+
+  private def time(out: (Producer.Bytes)^, timestamp: Long, generalized: scala.Boolean): Unit =
+    val days = Math.floorDiv(timestamp, SecondsPerDay)
+    val seconds = Math.floorMod(timestamp, SecondsPerDay).toInt
+    val (year, month, day) = civil(days)
+
+    if generalized then digits(out, year, 4) else digits(out, ((year%100) + 100)%100, 2)
+
+    digits(out, month, 2)
+    digits(out, day, 2)
+    digits(out, seconds/3600, 2)
+    digits(out, (seconds/60)%60, 2)
+    digits(out, seconds%60, 2)
+    out.push('Z'.toByte)
+
+  private def digits(out: (Producer.Bytes)^, value: Int, count: Int): Unit =
+    var scale = 1
+    var index = 1
+
+    while index < count do
+      scale *= 10
+      index += 1
+
+    var remaining = value
+
+    while scale > 0 do
+      out.push((remaining/scale + '0').toByte)
+      remaining = remaining%scale
+      scale /= 10
+
+  // Howard Hinnant's `civil_from_days`: the proleptic Gregorian date of a day number counted from
+  // 1970-01-01. Rolling our own keeps this component free of `java.time` (absent from some
+  // platforms) and of a dependency on aviation, which is not yet capture-checked; a later stage
+  // can hand aviation the `Long`.
+  private def civil(days: Long): (Int, Int, Int) =
+    val shifted = days + 719468
+    val era = (if shifted >= 0 then shifted else shifted - 146096)/146097
+    val dayOfEra = shifted - era*146097
+    val yearOfEra = (dayOfEra - dayOfEra/1460 + dayOfEra/36524 - dayOfEra/146096)/365
+    val yearZero = yearOfEra + era*400
+    val dayOfYear = dayOfEra - (365*yearOfEra + yearOfEra/4 - yearOfEra/100)
+    val monthZero = (5*dayOfYear + 2)/153
+    val day = (dayOfYear - (153*monthZero + 2)/5 + 1).toInt
+    val month = (if monthZero < 10 then monthZero + 3 else monthZero - 9).toInt
+
+    ((if month <= 2 then yearZero + 1 else yearZero).toInt, month, day)
+
+  // Hinnant's `days_from_civil`, the inverse of `civil`.
+  private def epochDay(year: Int, month: Int, day: Int): Long =
+    val shifted: Long = year - (if month <= 2 then 1 else 0)
+    val era = (if shifted >= 0 then shifted else shifted - 399)/400
+    val yearOfEra = shifted - era*400
+    val dayOfYear = (153*(month + (if month > 2 then -3 else 9)) + 2)/5 + day - 1
+    val dayOfEra = yearOfEra*365 + yearOfEra/4 - yearOfEra/100 + dayOfYear
+
+    era*146097 + dayOfEra - 719468
+
+  private def monthLength(year: Int, month: Int): Int =
+    val leap = (year%4 == 0 && year%100 != 0) || year%400 == 0
+
+    month match
+      case 1 | 3 | 5 | 7 | 8 | 10 | 12 => 31
+      case 4 | 6 | 9 | 11              => 30
+      case _                           => if leap then 29 else 28
+
+  private[enigmatic] object Parser:
+    def parse(source: Data): Asn1 raises Asn1Error =
+      val parser = new Parser(source)
+      val result = parser.value(parser.data.length)
+
+      if parser.offset < parser.data.length
+      then abort(Asn1Error(Reason.Trailing(parser.offset.toLong)))
+
+      result
+
+  // A strict DER reader: every construct that BER allows but DER forbids — indefinite lengths,
+  // overlong lengths and tags, non-minimal integers, constructed strings, unordered sets — is an
+  // error, so that whatever this accepts re-encodes to the bytes it was read from.
+  final class Parser private[enigmatic] (input: Data):
+    private[enigmatic] val data: Array[Byte] = input.asInstanceOf[Array[Byte]]
+
+    // Exposed to the `parse` entry point only, so that it can detect trailing bytes.
+    var offset: Int = 0
+
+    private inline def need(count: Int, limit: Int): Unit raises Asn1Error =
+      if limit - offset < count then abort(Asn1Error(Reason.Truncated(offset.toLong)))
+
+    private inline def readByte(): Int = (data(offset) & 0xff).also(offset += 1)
+
+    private def readBytes(end: Int): Data =
+      val result = new Array[Byte](end - offset)
+      System.arraycopy(data, offset, result, 0, end - offset)
+      offset = end
+
+      result.immutable(using Unsafe)
+
+    def value(limit: Int): Asn1 raises Asn1Error =
+      val start = offset
+      need(1, limit)
+      val head = readByte()
+      val tagClass = (head >>> 6) & 0x03
+      val constructed = (head & 0x20) != 0
+      val tag = if (head & 0x1f) == 0x1f then readTag(limit) else head & 0x1f
+      val size = readLength(limit)
+      need(size, limit)
+      val end = offset + size
+
+      if tagClass == Universal then universal(start, end, tag, constructed, size)
+      else if !constructed then Asn1.Unknown(tagClass, tag, false, readBytes(end))
+      else if scan(offset, end) == end then Asn1.Tagged(tag, true, value(end))
+      else Asn1.Unknown(tagClass, tag, true, readBytes(end))
+
+    private def universal
+      ( start: Int, end: Int, tag: Int, constructed: scala.Boolean, size: Int )
+    :   Asn1 raises Asn1Error =
+
+      inline def primitive(): Unit =
+        if constructed then abort(Asn1Error(Reason.NotPrimitive(start.toLong, tag)))
+
+      inline def aggregate(): Unit =
+        if !constructed then abort(Asn1Error(Reason.NotConstructed(start.toLong, tag)))
+
+      tag match
+        case 0 => abort(Asn1Error(Reason.ReservedTag(start.toLong)))
+
+        case BooleanTag =>
+          primitive()
+          if size != 1 then abort(Asn1Error(Reason.BadLength(start.toLong, tag, size)))
+          val byte = readByte()
+
+          if byte == 0x00 then Asn1.Boolean(false)
+          else if byte == 0xff then Asn1.Boolean(true)
+          else abort(Asn1Error(Reason.BadBoolean(start.toLong, byte)))
+
+        case IntegerTag =>
+          primitive()
+          if size == 0 then abort(Asn1Error(Reason.EmptyInteger(start.toLong)))
+
+          if size > 1 then
+            val first = data(offset) & 0xff
+            val second = data(offset + 1) & 0xff
+
+            if (first == 0x00 && (second & 0x80) == 0) || (first == 0xff && (second & 0x80) != 0)
+            then abort(Asn1Error(Reason.NonMinimalInteger(start.toLong)))
+
+          Asn1.Integer(BigInt(readBytes(end).mutable(using Unsafe)))
+
+        case BitStringTag =>
+          primitive()
+          if size == 0 then abort(Asn1Error(Reason.BadLength(start.toLong, tag, size)))
+          val unusedBits = readByte()
+
+          if unusedBits > 7 || (size == 1 && unusedBits != 0)
+          then abort(Asn1Error(Reason.BadUnusedBits(start.toLong, unusedBits)))
+
+          if unusedBits > 0 && (data(end - 1) & ((1 << unusedBits) - 1)) != 0
+          then abort(Asn1Error(Reason.BadUnusedBits(start.toLong, unusedBits)))
+
+          Asn1.BitString(readBytes(end), unusedBits)
+
+        case OctetStringTag =>
+          primitive()
+          Asn1.OctetString(readBytes(end))
+
+        case NullTag =>
+          primitive()
+          if size != 0 then abort(Asn1Error(Reason.BadLength(start.toLong, tag, size)))
+          Asn1.Null
+
+        case ObjectIdTag =>
+          primitive()
+          Asn1.ObjectId(objectId(start, end))
+
+        case Utf8StringTag =>
+          primitive()
+          Asn1.Utf8String(text(end))
+
+        case PrintableStringTag =>
+          primitive()
+          Asn1.PrintableString(text(end))
+
+        case Ia5StringTag =>
+          primitive()
+          Asn1.Ia5String(text(end))
+
+        case UtcTimeTag =>
+          primitive()
+          Asn1.UtcTime(timestamp(start, end, false))
+
+        case GeneralizedTimeTag =>
+          primitive()
+          Asn1.GeneralizedTime(timestamp(start, end, true))
+
+        case SequenceTag =>
+          aggregate()
+          Asn1.Sequence(elements(end))
+
+        case SetTag =>
+          aggregate()
+          Asn1.Set(members(end))
+
+        case _ => Asn1.Unknown(Universal, tag, constructed, readBytes(end))
+
+    private def elements(end: Int): List[Asn1] raises Asn1Error =
+      val builder = scm.ListBuffer[Asn1]()
+      while offset < end do builder += value(end)
+
+      builder.to(List)
+
+    private def members(end: Int): List[Asn1] raises Asn1Error =
+      val builder = scm.ListBuffer[Asn1]()
+      var previous = -1
+      var previousEnd = -1
+
+      while offset < end do
+        val start = offset
+        builder += value(end)
+
+        if previous >= 0 && !ordered(previous, previousEnd, start, offset)
+        then abort(Asn1Error(Reason.UnsortedSet(start.toLong)))
+
+        previous = start
+        previousEnd = offset
+
+      builder.to(List)
+
+    private def ordered(from: Int, until: Int, from2: Int, until2: Int): scala.Boolean =
+      val leftSize = until - from
+      val rightSize = until2 - from2
+      var index = 0
+      var difference = 0
+
+      while difference == 0 && index < leftSize && index < rightSize do
+        difference = (data(from + index) & 0xff) - (data(from2 + index) & 0xff)
+        index += 1
+
+      if difference != 0 then difference < 0 else leftSize <= rightSize
+
+    private def text(end: Int): Text =
+      val size = end - offset
+      val result = new String(data, offset, size, jnc.StandardCharsets.UTF_8)
+      offset = end
+
+      result.tt
+
+    private def readTag(limit: Int): Int raises Asn1Error =
+      val start = offset
+      need(1, limit)
+      if (data(offset) & 0xff) == 0x80 then abort(Asn1Error(Reason.NonMinimalTag(start.toLong)))
+      var result = 0
+      var reading = true
+
+      while reading do
+        need(1, limit)
+        val byte = readByte()
+
+        if (result >>> 24) != 0 then abort(Asn1Error(Reason.Overflow(start.toLong)))
+        result = (result << 7) | (byte & 0x7f)
+        if (byte & 0x80) == 0 then reading = false
+
+      if result < 0x1f then abort(Asn1Error(Reason.NonMinimalTag(start.toLong)))
+
+      result
+
+    private def readLength(limit: Int): Int raises Asn1Error =
+      val start = offset
+      need(1, limit)
+      val first = readByte()
+
+      if first < 0x80 then first
+      else if first == 0x80 then abort(Asn1Error(Reason.IndefiniteLength(start.toLong)))
+      else
+        val count = first & 0x7f
+        if count == 0x7f then abort(Asn1Error(Reason.NonMinimalLength(start.toLong)))
+        if count > 4 then abort(Asn1Error(Reason.Overflow(start.toLong)))
+        need(count, limit)
+        var result = 0L
+        var index = 0
+
+        while index < count do
+          val byte = readByte()
+          if index == 0 && byte == 0 then abort(Asn1Error(Reason.NonMinimalLength(start.toLong)))
+          result = (result << 8) | byte
+          index += 1
+
+        if result < 0x80 then abort(Asn1Error(Reason.NonMinimalLength(start.toLong)))
+        if result > Int.MaxValue then abort(Asn1Error(Reason.Overflow(start.toLong)))
+
+        result.toInt
+
+    private def objectId(start: Int, end: Int): List[Int] raises Asn1Error =
+      if offset >= end then abort(Asn1Error(Reason.BadOid(start.toLong)))
+      val builder = scm.ListBuffer[Int]()
+      var first = true
+
+      while offset < end do
+        val subidentifier = offset
+        if (data(offset) & 0xff) == 0x80 then abort(Asn1Error(Reason.BadOid(subidentifier.toLong)))
+        var accumulated = 0
+        var reading = true
+
+        while reading do
+          if offset >= end then abort(Asn1Error(Reason.BadOid(subidentifier.toLong)))
+          val byte = readByte()
+
+          if (accumulated >>> 24) != 0
+          then abort(Asn1Error(Reason.OidArcOverflow(subidentifier.toLong)))
+
+          accumulated = (accumulated << 7) | (byte & 0x7f)
+          if (byte & 0x80) == 0 then reading = false
+
+        if !first then builder += accumulated else
+          first = false
+
+          if accumulated < 40 then
+            builder += 0
+            builder += accumulated
+          else if accumulated < 80 then
+            builder += 1
+            builder += accumulated - 40
+          else
+            builder += 2
+            builder += accumulated - 80
+
+      builder.to(List)
+
+    // DER admits exactly one form for each of the two time types: `YYMMDDHHMMSSZ` and
+    // `YYYYMMDDHHMMSSZ`, with no fractional seconds and no offset from UTC. `UTCTime`'s two-digit
+    // year runs from 1950 to 2049 (RFC 5280 §4.1.2.5.1).
+    private def timestamp(start: Int, end: Int, generalized: scala.Boolean)
+    :   Long raises Asn1Error =
+
+      val size = end - offset
+      val expected = if generalized then 15 else 13
+      if size != expected then abort(Asn1Error(Reason.BadTime(start.toLong)))
+
+      def digit(index: Int): Int =
+        val byte = data(offset + index) & 0xff
+        if byte < '0' || byte > '9' then abort(Asn1Error(Reason.BadTime(start.toLong)))
+
+        byte - '0'
+
+      def number(index: Int, count: Int): Int =
+        var result = 0
+        var position = 0
+
+        while position < count do
+          result = result*10 + digit(index + position)
+          position += 1
+
+        result
+
+      if (data(end - 1) & 0xff) != 'Z' then abort(Asn1Error(Reason.BadTime(start.toLong)))
+
+      val year =
+        if generalized then number(0, 4)
+        else
+          val short = number(0, 2)
+          if short < 50 then 2000 + short else 1900 + short
+
+      val base = if generalized then 4 else 2
+      val month = number(base, 2)
+      val day = number(base + 2, 2)
+      val hour = number(base + 4, 2)
+      val minute = number(base + 6, 2)
+      val second = number(base + 8, 2)
+
+      if month < 1 || month > 12 || day < 1 || day > monthLength(year, month) || hour > 23 ||
+        minute > 59 || second > 59
+      then abort(Asn1Error(Reason.BadTime(start.toLong)))
+
+      offset = end
+
+      epochDay(year, month, day)*SecondsPerDay + hour*3600 + minute*60 + second
+
+    // The end offset of the single well-formed value starting at `from`, or `-1` if the bytes up to
+    // `limit` do not hold one. Used to decide whether a constructed context tag is an explicit
+    // wrapper (exactly one value) or opaque content; it inspects structure only, and never raises,
+    // because failing this test is an ordinary outcome rather than an error.
+    private def scan(from: Int, limit: Int): Int = boundary:
+      var position = from
+
+      def next(): Int =
+        if position >= limit then break(-1)
+        val byte = data(position) & 0xff
+        position += 1
+
+        byte
+
+      val head = next()
+      if (head & 0x1f) == 0x1f then while (next() & 0x80) != 0 do ()
+      val first = next()
+
+      if first < 0x80 then (if limit - position < first then -1 else position + first)
+      else if first == 0x80 then -1
+      else
+        val count = first & 0x7f
+        if count > 4 then break(-1)
+        var size = 0L
+        var index = 0
+
+        while index < count do
+          size = (size << 8) | next()
+          index += 1
+
+        if size > limit - position then -1 else position + size.toInt
+
+enum Asn1 derives CanEqual:
+  case Boolean(value: scala.Boolean)
+  case Integer(value: BigInt)
+  case BitString(bytes: Data, unusedBits: Int)
+  case OctetString(bytes: Data)
+  case Null
+  case ObjectId(arcs: List[Int])
+  case Utf8String(text: Text)
+  case PrintableString(text: Text)
+  case Ia5String(text: Text)
+  case UtcTime(timestamp: Long)
+  case GeneralizedTime(timestamp: Long)
+  case Sequence(elements: List[Asn1])
+  case Set(elements: List[Asn1])
+  case Tagged(tag: Int, explicit: scala.Boolean, value: Asn1)
+  case Unknown(tagClass: Int, tag: Int, constructed: scala.Boolean, content: Data)

--- a/lib/enigmatic/src/asn1/enigmatic.Asn1Error.scala
+++ b/lib/enigmatic/src/asn1/enigmatic.Asn1Error.scala
@@ -1,0 +1,92 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+
+import fulminate.*
+
+object Asn1Error:
+  object Reason:
+    given communicable: Reason is Communicable =
+      case Truncated(offset)         => m"the input was truncated at byte $offset"
+      case IndefiniteLength(offset)  => m"an indefinite length was found at byte $offset"
+      case NonMinimalLength(offset)  => m"an overlong length was found at byte $offset"
+      case NonMinimalTag(offset)     => m"an overlong tag number was found at byte $offset"
+      case NonMinimalInteger(offset) => m"an overlong integer was found at byte $offset"
+      case EmptyInteger(offset)      => m"an integer with no content was found at byte $offset"
+      case Overflow(offset)          => m"an unrepresentable length was found at byte $offset"
+      case Trailing(offset)          => m"unexpected trailing bytes were found from byte $offset"
+      case InvalidUtf8(offset)       => m"invalid UTF-8 was found at byte $offset"
+      case ReservedTag(offset)       => m"the reserved tag number 0 was found at byte $offset"
+      case BadOid(offset)            => m"a malformed object identifier was found at byte $offset"
+      case OidArcOverflow(offset)    => m"an arc too large for Int was found at byte $offset"
+      case UnsortedSet(offset)       => m"the set at byte $offset was not in ascending order"
+      case BadTime(offset)           => m"a malformed time value was found at byte $offset"
+
+      case BadBoolean(offset, byte) =>
+        m"a boolean with the content byte ${byte.toString} was found at byte $offset"
+
+      case BadLength(offset, tag, length) =>
+        m"the tag ${tag.toString} had the invalid length ${length.toString} at byte $offset"
+
+      case BadUnusedBits(offset, count) =>
+        m"a bit string declaring ${count.toString} unused bits was found at byte $offset"
+
+      case NotPrimitive(offset, tag) =>
+        m"the tag ${tag.toString} was encoded in constructed form at byte $offset"
+
+      case NotConstructed(offset, tag) =>
+        m"the tag ${tag.toString} was encoded in primitive form at byte $offset"
+
+  enum Reason(val number: Int) extends Clarification:
+    case Truncated(offset: Long) extends Reason(1)
+    case IndefiniteLength(offset: Long) extends Reason(2)
+    case NonMinimalLength(offset: Long) extends Reason(3)
+    case NonMinimalTag(offset: Long) extends Reason(4)
+    case NonMinimalInteger(offset: Long) extends Reason(5)
+    case EmptyInteger(offset: Long) extends Reason(6)
+    case Overflow(offset: Long) extends Reason(7)
+    case Trailing(offset: Long) extends Reason(8)
+    case InvalidUtf8(offset: Long) extends Reason(9)
+    case ReservedTag(offset: Long) extends Reason(10)
+    case BadOid(offset: Long) extends Reason(11)
+    case OidArcOverflow(offset: Long) extends Reason(12)
+    case UnsortedSet(offset: Long) extends Reason(13)
+    case BadTime(offset: Long) extends Reason(14)
+    case BadBoolean(offset: Long, byte: Int) extends Reason(15)
+    case BadLength(offset: Long, tag: Int, length: Int) extends Reason(16)
+    case BadUnusedBits(offset: Long, count: Int) extends Reason(17)
+    case NotPrimitive(offset: Long, tag: Int) extends Reason(18)
+    case NotConstructed(offset: Long, tag: Int) extends Reason(19)
+
+case class Asn1Error(reason: Asn1Error.Reason)(using Diagnostics)
+extends Error(523, reason.number)(m"could not process the ASN.1 value because $reason")

--- a/lib/enigmatic/src/asn1/enigmatic.Der.scala
+++ b/lib/enigmatic/src/asn1/enigmatic.Der.scala
@@ -1,0 +1,66 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+
+import java.util as ju
+
+import scala.compiletime.*
+
+import anticipation.*
+import monotonous.*
+import prepositional.*
+import rudiments.*
+import spectacular.*
+import turbulence.*
+import vacuous.*
+import zephyrine.*
+
+// A DER document: the canonical Distinguished Encoding Rules serialization of a single ASN.1
+// value. It is the `Form` of the ASN.1 codec (`Asn1 is Encodable in Der` and `Asn1 is Decodable
+// in Der`), which makes `asn1.in[Der]` and `der.as[Asn1]` the two directions of the codec, exactly
+// as `Cbor` is the form of breviloquence's CBOR codec.
+//
+// A distinct type, rather than an alias for `Data`, so that `value.in[Der]` and `bytes.read[Der]`
+// are unambiguous, and so that DER documents compare by their bytes rather than by identity.
+object Der:
+  given encodable: Der is Encodable in Data = _.data
+  given streamable: Der is Streamable by Data over Credit = der => Stream(der.data)
+  given aggregable: Der is Aggregable by Data = Aggregable.bytesData.map(Der(_))
+  given showable: Alphabet[Hex] => Der is Showable = _.data.serialize[Hex]
+
+final class Der(val data: Data):
+  override def equals(that: Any): Boolean = that.asMatchable match
+    case der: Der => data.sameElements(der.data)
+    case _        => false
+
+  override def hashCode: Int = ju.Arrays.hashCode(data.mutable(using Unsafe): Array[Byte])

--- a/lib/enigmatic/src/asn1/soundness_enigmatic_asn1.scala
+++ b/lib/enigmatic/src/asn1/soundness_enigmatic_asn1.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export enigmatic.{Asn1, Asn1Error, Der}

--- a/lib/enigmatic/src/core/enigmatic.Pem.scala
+++ b/lib/enigmatic/src/core/enigmatic.Pem.scala
@@ -47,6 +47,10 @@ import vacuous.*
 import zephyrine.*
 
 object Pem:
+  // Armor a DER document, e.g. `Pem(PemLabel.Certificate, certificate.in[Der])`. The label is
+  // always given explicitly: it is a fact about the value, not a mode of the encoding.
+  def apply(label: PemLabel, der: Der): Pem = Pem(label, der.data)
+
   // Streaming, cursor-based parsing: the input is consumed line by line, and
   // the base64 body accumulates in a single builder — nothing else of the
   // input is retained, so a PEM document parses from any source in bounded
@@ -160,6 +164,11 @@ object Pem:
     Stream((t"-----BEGIN ${pem.label}-----\n" #:: LazyList.defer(groups(0))).iterator)
 
 case class Pem(label: PemLabel, data: Data):
+  // The armored payload read as a DER document, so that `pem.der.as[Asn1]` parses a certificate,
+  // key or request without an intermediate `Data` step. Labels are not checked against content:
+  // every PEM label this module knows armors DER.
+  def der: Der = Der(data)
+
   def serialize: Text =
     Seq
       ( Seq(t"-----BEGIN $label-----"),

--- a/lib/enigmatic/src/core/enigmatic.Pem.scala
+++ b/lib/enigmatic/src/core/enigmatic.Pem.scala
@@ -36,6 +36,7 @@ import java.lang as jl
 
 import anticipation.*
 import contingency.*
+import distillate.*
 import fulminate.*
 import gossamer.*
 import kaleidoscope.*
@@ -51,11 +52,43 @@ object Pem:
   // always given explicitly: it is a fact about the value, not a mode of the encoding.
   def apply(label: PemLabel, der: Der): Pem = Pem(label, der.data)
 
+  // The DER payload of a PEM block, so that `pem.as[Der]` reaches the armored bytes as a document
+  // rather than as anonymous `Data`. The label is not checked against the content: every PEM label
+  // this module knows armors DER.
+  given derDecodable: Der is Decodable in Pem = pem => Der(pem.data)
+
+  // `text.read[Asn1 in Pem]` — and, through distillate's identity decodable, `text.read[Der in
+  // Pem]` — reading the armor and decoding its DER payload in one step. Sealed per the codec-thunk
+  // pattern (see rep/DECISIONS.md), like the `Pem` aggregables below.
+  given aggregableIn: [value]
+  =>  ( decodable: (value is Decodable in Der)^ )
+  =>  ( Diagnostics, Tactic[PemError] )
+  =>  ( (value in Pem) is Aggregable by Text ) =
+
+    caps.unsafe.unsafeAssumePure:
+      new Aggregable:
+        type Self = value in Pem
+        type Operand = Text
+
+        def aggregate(stream: LazyList[Text]): value in Pem =
+          decode(parse(Cursor(stream.iterator)))
+
+        override def accept(stream: (Stream[Text] over Credit)^): value in Pem =
+          // See `aggregable` below.
+          val neutral: AnyRef = stream.asInstanceOf[AnyRef]
+          decode(parse(Cursor(neutral.asInstanceOf[(Stream[Text] over Credit)^])))
+
+        private def decode(pem: Pem): value in Pem =
+          decodable.decoded(Der(pem.data)).asInstanceOf[value in Pem]
+
   // Streaming, cursor-based parsing: the input is consumed line by line, and
   // the base64 body accumulates in a single builder — nothing else of the
   // input is retained, so a PEM document parses from any source in bounded
   // memory (modulo its payload).
-  def parse(text: Text)(using Diagnostics): Pem raises PemError = parse(Cursor(text))
+  //
+  // Not public: `text.read[Pem]` (through `aggregable`, below) is the entry point.
+  private[enigmatic] def parse(text: Text)(using Diagnostics): Pem raises PemError =
+    parse(Cursor(text))
 
   // The first PEM block of the input: leading whitespace is skipped (the
   // legacy parser trimmed the whole document), then the first line must be a
@@ -164,11 +197,6 @@ object Pem:
     Stream((t"-----BEGIN ${pem.label}-----\n" #:: LazyList.defer(groups(0))).iterator)
 
 case class Pem(label: PemLabel, data: Data):
-  // The armored payload read as a DER document, so that `pem.der.as[Asn1]` parses a certificate,
-  // key or request without an intermediate `Data` step. Labels are not checked against content:
-  // every PEM label this module knows armors DER.
-  def der: Der = Der(data)
-
   def serialize: Text =
     Seq
       ( Seq(t"-----BEGIN $label-----"),

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -129,16 +129,16 @@ object Tests extends Suite(m"Gastronomy tests"):
         |-----END EXAMPLE-----
         """.s.stripMargin.show
 
-      Pem.parse(example).label
+      example.read[Pem].label
     . assert(_ == PemLabel.Proprietary(t"EXAMPLE"))
 
     test(m"Decode PEM certificate"):
       import alphabets.base64Standard
-      Pem.parse(request).data.digest[Md5].serialize[Base64]
+      request.read[Pem].data.digest[Md5].serialize[Base64]
     . assert(_ == t"iMwRdyDFStqq08vqjPbzYw==")
 
     test(m"PEM roundtrip"):
-      Pem.parse(request).serialize
+      request.read[Pem].serialize
     . assert(_ == request.trim)
 
     test(m"PEM parses from a stream through accept"):
@@ -164,7 +164,7 @@ object Tests extends Suite(m"Gastronomy tests"):
     . assert(_ == List())
 
     test(m"PEM streams its armored form"):
-      Pem.parse(request).read[Text].trim
+      request.read[Pem].read[Text].trim
     . assert(_ == request.trim)
 
     test(m"RSA roundtrip"):
@@ -777,18 +777,18 @@ object Tests extends Suite(m"Gastronomy tests"):
       . assert(_ == Asn1Error.Reason.ReservedTag(0))
 
       test(m"A real X.509 certificate round-trips byte-exactly"):
-        val pem = Pem.parse(certificate)
-        pem.der.as[Asn1].in[Der] == pem.der
+        val value: Asn1 = certificate.read[Asn1 in Pem]
+        value.in[Der] == certificate.read[Der in Pem]
       . assert(identity)
 
       test(m"A real PKCS#10 request round-trips byte-exactly"):
-        val pem = Pem.parse(request)
-        pem.der.as[Asn1].in[Der] == pem.der
+        val pem = request.read[Pem]
+        pem.as[Der].as[Asn1].in[Der] == pem.as[Der]
       . assert(identity)
 
       test(m"A DER document re-armors as PEM"):
-        val pem = Pem.parse(certificate)
-        Pem(PemLabel.Certificate, pem.der.as[Asn1].in[Der]).serialize
+        val value: Asn1 = certificate.read[Asn1 in Pem]
+        Pem(PemLabel.Certificate, value.in[Der]).serialize
       . assert(_ == certificate.trim)
 
     CaptureTests()

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -62,6 +62,34 @@ object Tests extends Suite(m"Gastronomy tests"):
     |-----END CERTIFICATE REQUEST-----
     """.s.stripMargin.show
 
+  // A self-signed certificate, produced by `openssl req -x509 -newkey rsa:2048`. It is here for its
+  // shape rather than its content: v3 extensions behind a `[3] EXPLICIT` tag, a `[0] EXPLICIT`
+  // version, RDNs in `SET`s, object identifiers, `UTCTime`s and a `BIT STRING` signature.
+  val certificate: Text = t"""
+    |-----BEGIN CERTIFICATE-----
+    |MIIDtTCCAp2gAwIBAgIUfOcoc0ZbdhisC8NxLHW9Nj+CvPEwDQYJKoZIhvcNAQEL
+    |BQAwajELMAkGA1UEBhMCR0IxFzAVBgNVBAgMDkNhbWJyaWRnZXNoaXJlMRIwEAYD
+    |VQQHDAlDYW1icmlkZ2UxEzARBgNVBAoMClByb3BlbnNpdmUxGTAXBgNVBAMMEGFz
+    |bjEuZXhhbXBsZS5jb20wHhcNMjYwNzI4MTEwNzIyWhcNMzYwNzI1MTEwNzIyWjBq
+    |MQswCQYDVQQGEwJHQjEXMBUGA1UECAwOQ2FtYnJpZGdlc2hpcmUxEjAQBgNVBAcM
+    |CUNhbWJyaWRnZTETMBEGA1UECgwKUHJvcGVuc2l2ZTEZMBcGA1UEAwwQYXNuMS5l
+    |eGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAN6Yqkcv
+    |lMJP+20lvvwabQXqHLM6eqAOcH1eeP74qe8lkGL4MFooAfUU2hifXdPPXvrE21dK
+    |kifgk9tOd8SkX+EDY4fGn6MEN5hm5l4nOXsZnqhm1lu1EbWgcDdw22Rd+6kPFC35
+    |7JeLL76/6L8XMi1MLNiyuIgozisiGf9TGLPF1tuexPvJZaf/4XrAA7fDdBfz7F5M
+    |PjOAJyT468qcSS1kMZ4weL0yH3kQ8mlwgNmyz5ibPF2KNUVpt194Y8GsXOeqQU+C
+    |joR/LZ/wMh5Iaq8mWjx/TcL/Yac7hhuIttEO71SMZ5+N0g8BGI+ZagVkkJ4FUziW
+    |sluLqCKEiRMrhvECAwEAAaNTMFEwHQYDVR0OBBYEFLMi3Mw9tUXd2rkjBuA96mQk
+    |Dk+TMB8GA1UdIwQYMBaAFLMi3Mw9tUXd2rkjBuA96mQkDk+TMA8GA1UdEwEB/wQF
+    |MAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJspyiAbb9RMGDAKruzVj7nnbmVSv7Kj
+    |shPGW6PWd2uYJvVcpTcGNTepZ61PoEt8zjUUgGXNRSc9SoeY/17I/K9pq79aHkl4
+    |TeBwly0NdkyP788FmpOTbICmBADyM3slCr48GCnH0P5fgBQXv8cXm/fYYWUB4c9p
+    |h+wOiEQOTAJ1m/9kW7/kF7AkFahywqRXOkRUOAAvWDxVrn+FZFHyH1e0PXQssbq9
+    |eeoVq8kR6euQcL4Vyrg9XpOolSlBpJSOnG/S8CP4/JOQxfoXIr1ERuJrLTF+Kniw
+    |VWAjJOn3se6f9d+2rhKmV9Z7W21pdb87yuXgWXl/F6c/wVmOallb/Fw=
+    |-----END CERTIFICATE-----
+    """.s.stripMargin.show
+
   val pangram: Text = t"The quick brown fox jumps over the lazy dog"
 
   def run(): Unit =
@@ -592,5 +620,175 @@ object Tests extends Suite(m"Gastronomy tests"):
         val second = key.data(Divulgence)
         first.serialize[Hex] == second.serialize[Hex]
       . assert(_ == true)
+
+    suite(m"ASN.1 and DER"):
+      // DER is canonical, so `encode` is the equality of record: the byte-carrying cases of `Asn1`
+      // are case classes over `IArray[Byte]`, whose synthesized `equals` compares arrays by
+      // identity. Every assertion below therefore compares hexadecimal encodings.
+      def der(value: Asn1): Text = value.in[Der].data.serialize[Hex]
+      def decode(hex: Text): Asn1 = Der(hex.deserialize[Hex]).as[Asn1]
+      def roundtrip(hex: Text): Text = hex.deserialize[Hex].read[Der].as[Asn1].in[Der].data.serialize[Hex]
+      def reason(hex: Text): Asn1Error.Reason = capture[Asn1Error](decode(hex)).reason
+
+      // Every vector below was generated with `openssl asn1parse -genstr`/`-genconf`, except the
+      // `BIT STRING`, which is X.690 §8.6.4.2's worked example.
+      val vectors: List[Text] =
+        List
+         (t"0500", t"0101FF", t"010100", t"020100", t"02017F", t"02020080", t"0201FF", t"020180",
+          t"0202FF7F", t"02020100", t"04050102030405", t"0304066E5DC0", t"030100",
+          t"06092A864886F70D01010B", t"0603550403", t"06022A03", t"0603813403",
+          t"0C0668C3A96C6C6F", t"130454657374", t"16076140622E636F6D",
+          t"170D3730303130313030303030305A", t"180F31393730303130313030303030305A",
+          t"30050201010500", t"3000", t"3106040101040102", t"310702010102020100", t"A003020102",
+          t"8001AB", t"BF1F020500", t"A30405000500")
+
+      test(m"Null, booleans and empty sequences encode as their tag and length"):
+        List(der(Asn1.Null), der(Asn1.Boolean(true)), der(Asn1.Boolean(false)),
+            der(Asn1.Sequence(Nil)))
+      . assert(_ == List(t"0500", t"0101FF", t"010100", t"3000"))
+
+      test(m"Integers encode minimally, with sign extension"):
+        List(0, 127, 128, -1, -128, -129, 256).map(value => der(Asn1.Integer(BigInt(value))))
+      . assert(_ == List(t"020100", t"02017F", t"02020080", t"0201FF", t"020180", t"0202FF7F",
+          t"02020100"))
+
+      test(m"Octet strings and bit strings encode their content"):
+        List(der(Asn1.OctetString(IArray[Byte](1, 2, 3, 4, 5))),
+            der(Asn1.BitString(IArray[Byte](0x6e, 0x5d, 0xc0.toByte), 6)),
+            der(Asn1.BitString(IArray[Byte](), 0)))
+      . assert(_ == List(t"04050102030405", t"0304066E5DC0", t"030100"))
+
+      test(m"Object identifiers combine their first two arcs"):
+        List(List(1, 2, 840, 113549, 1, 1, 11), List(2, 5, 4, 3), List(1, 2, 3), List(2, 100, 3))
+        . map(arcs => der(Asn1.ObjectId(arcs)))
+      . assert(_ == List(t"06092A864886F70D01010B", t"0603550403", t"06022A03", t"0603813403"))
+
+      test(m"Strings encode as UTF-8"):
+        List(der(Asn1.Utf8String(t"héllo")), der(Asn1.PrintableString(t"Test")),
+            der(Asn1.Ia5String(t"a@b.com")))
+      . assert(_ == List(t"0C0668C3A96C6C6F", t"130454657374", t"16076140622E636F6D"))
+
+      test(m"Times encode in DER's single permitted form"):
+        List(der(Asn1.UtcTime(0)), der(Asn1.GeneralizedTime(0)))
+      . assert(_ == List(t"170D3730303130313030303030305A",
+          t"180F31393730303130313030303030305A"))
+
+      test(m"A set's members are sorted by their encodings"):
+        val two = Asn1.OctetString(IArray[Byte](2.toByte))
+        val one = Asn1.OctetString(IArray[Byte](1.toByte))
+
+        List(der(Asn1.Set(List(two, one))),
+            der(Asn1.Set(List(Asn1.Integer(BigInt(256)), Asn1.Integer(BigInt(1))))))
+      . assert(_ == List(t"3106040101040102", t"310702010102020100"))
+
+      test(m"Context tags encode explicitly, implicitly and in high-tag form"):
+        List(der(Asn1.Tagged(0, true, Asn1.Integer(BigInt(2)))),
+            der(Asn1.Tagged(0, false, Asn1.OctetString(IArray[Byte](0xab.toByte)))),
+            der(Asn1.Tagged(31, true, Asn1.Null)))
+      . assert(_ == List(t"A003020102", t"8001AB", t"BF1F020500"))
+
+      test(m"A long-form length uses the fewest possible bytes"):
+        val short = der(Asn1.OctetString(Data.fill(200)(_ => 0)))
+        val long = der(Asn1.OctetString(Data.fill(300)(_ => 0)))
+        List(short.s.take(6).tt, long.s.take(8).tt)
+      . assert(_ == List(t"0481C8", t"0482012C"))
+
+      test(m"Every known-answer vector round-trips byte-exactly"):
+        vectors.map(roundtrip(_))
+      . assert(_ == vectors)
+
+      test(m"A value reads directly from bytes tagged with its form"):
+        t"A003020102".deserialize[Hex].read[Asn1 in Der]
+      . assert(_ == Asn1.Tagged(0, true, Asn1.Integer(BigInt(2))))
+
+      test(m"A constructed context tag holding one value is an explicit tag"):
+        decode(t"A003020102")
+      . assert(_ == Asn1.Tagged(0, true, Asn1.Integer(BigInt(2))))
+
+      test(m"A constructed context tag holding two values is opaque"):
+        decode(t"A30405000500") match
+          case Asn1.Unknown(2, 3, true, _) => true
+          case _                           => false
+      . assert(identity)
+
+      test(m"A primitive context tag is opaque"):
+        decode(t"8001AB") match
+          case Asn1.Unknown(2, 0, false, _) => true
+          case _                            => false
+      . assert(identity)
+
+      test(m"An unmodelled universal tag is preserved verbatim"):
+        roundtrip(t"1E0400480049")
+      . assert(_ == t"1E0400480049")
+
+      test(m"Indefinite lengths are rejected"):
+        reason(t"0480")
+      . assert(_ == Asn1Error.Reason.IndefiniteLength(1))
+
+      test(m"Overlong lengths and tags are rejected"):
+        List(reason(t"018101FF"), reason(t"1F1E00"))
+      . assert(_ == List(Asn1Error.Reason.NonMinimalLength(1), Asn1Error.Reason.NonMinimalTag(1)))
+
+      test(m"A length needing more than four bytes is rejected"):
+        reason(t"048501010101010101")
+      . assert(_ == Asn1Error.Reason.Overflow(1))
+
+      test(m"Non-minimal and empty integers are rejected"):
+        List(reason(t"02020001"), reason(t"0200"))
+      . assert(_ == List(Asn1Error.Reason.NonMinimalInteger(0),
+          Asn1Error.Reason.EmptyInteger(0)))
+
+      test(m"A boolean other than 0x00 or 0xFF is rejected"):
+        reason(t"010101")
+      . assert(_ == Asn1Error.Reason.BadBoolean(0, 1))
+
+      test(m"A null with content is rejected"):
+        reason(t"050100")
+      . assert(_ == Asn1Error.Reason.BadLength(0, 5, 1))
+
+      test(m"Invalid bit-string padding is rejected"):
+        List(reason(t"03020801"), reason(t"03020103"))
+      . assert(_ == List(Asn1Error.Reason.BadUnusedBits(0, 8),
+          Asn1Error.Reason.BadUnusedBits(0, 1)))
+
+      test(m"Constructed strings and primitive sequences are rejected"):
+        List(reason(t"240404020102"), reason(t"1003020101"))
+      . assert(_ == List(Asn1Error.Reason.NotPrimitive(0, 4),
+          Asn1Error.Reason.NotConstructed(0, 16)))
+
+      test(m"Malformed object identifiers are rejected"):
+        List(reason(t"06022A80"), reason(t"06062A8FFFFFFF7F"))
+      . assert(_ == List(Asn1Error.Reason.BadOid(3), Asn1Error.Reason.OidArcOverflow(3)))
+
+      test(m"An unsorted set is rejected"):
+        reason(t"3106040102040101")
+      . assert(_ == Asn1Error.Reason.UnsortedSet(5))
+
+      test(m"An impossible date is rejected"):
+        reason(t"170D3730303233303030303030305A")
+      . assert(_ == Asn1Error.Reason.BadTime(0))
+
+      test(m"Truncated input and trailing bytes are rejected"):
+        List(reason(t"0101"), reason(t"05000500"))
+      . assert(_ == List(Asn1Error.Reason.Truncated(2), Asn1Error.Reason.Trailing(2)))
+
+      test(m"The reserved tag number zero is rejected"):
+        reason(t"0000")
+      . assert(_ == Asn1Error.Reason.ReservedTag(0))
+
+      test(m"A real X.509 certificate round-trips byte-exactly"):
+        val pem = Pem.parse(certificate)
+        pem.der.as[Asn1].in[Der] == pem.der
+      . assert(identity)
+
+      test(m"A real PKCS#10 request round-trips byte-exactly"):
+        val pem = Pem.parse(request)
+        pem.der.as[Asn1].in[Der] == pem.der
+      . assert(identity)
+
+      test(m"A DER document re-armors as PEM"):
+        val pem = Pem.parse(certificate)
+        Pem(PemLabel.Certificate, pem.der.as[Asn1].in[Der]).serialize
+      . assert(_ == certificate.trim)
 
     CaptureTests()

--- a/lib/octogenarian/src/core/octogenarian.GitRepo.scala
+++ b/lib/octogenarian/src/core/octogenarian.GitRepo.scala
@@ -46,6 +46,7 @@ import nomenclature.*
 import prepositional.*
 import rudiments.*
 import serpentine.*
+import turbulence.*
 import urticose.*
 import vacuous.*
 
@@ -182,7 +183,7 @@ case class GitRepo(gitDir: Path on Linux):
       case failure => abort(GitError(RemoteFailed))
 
 
-  private def parsePem(text: Text): Optional[Pem] = safely(Pem.parse(text))
+  private def parsePem(text: Text): Optional[Pem] = safely(text.read[Pem])
 
   def log()(using GitCommand, WorkingDirectory, Tactic[ExecError]): List[Commit] logs GitEvent =
     val lines =


### PR DESCRIPTION
Enigmatic can now read and write ASN.1 values in DER, the encoding that underpins X.509 certificates, PKCS#10 requests, PKCS#8 keys and CMS messages. The codec is canonical in both directions — the encoder emits DER's single valid form, and the decoder rejects everything BER additionally permits — so a certificate that is decoded and re-encoded reproduces its original bytes exactly. Being pure byte manipulation, the new `enigmatic.asn1` component cross-compiles to Scala.js and Scala Native as well as the JVM.

### ASN.1 and DER

An ASN.1 value is an `Asn1`, and DER is its `Form`:

```scala
val name = Asn1.Sequence
             (List
               (Asn1.ObjectId(List(2, 5, 4, 3)),
                Asn1.Utf8String(t"example.com")))

val bytes: Data = name.in[Der].data
val value: Asn1 = bytes.read[Der].as[Asn1]
```

DER usually arrives armored as PEM, and reading the armor and decoding its payload is a single step from any source a `Text` can be read from:

```scala
val certificate: Asn1 = text.read[Asn1 in Pem]
val payload: Der = text.read[Der in Pem]

val armored: Pem = Pem(PemLabel.Certificate, certificate.in[Der])
```

or in stages, where the label matters:

```scala
val pem: Pem = text.read[Pem]
val certificate: Asn1 = pem.as[Der].as[Asn1]
```

`Pem.parse` is no longer public; `text.read[Pem]` replaces it, putting PEM on the same footing as every other codec in soundness.

### Canonicity

The encoder writes integers in the fewest possible bytes, `true` as `0xFF`, definite lengths in their shortest form, and the members of a `SET` in ascending order of their encodings. The decoder raises an `Asn1Error` — naming the byte at which the problem was found — for indefinite lengths, overlong lengths and tag numbers, non-minimal integers, constructed strings, unordered sets and the rest. That strictness is what makes this hold for real certificates:

```scala
val pem = text.read[Pem]
pem.as[Der].as[Asn1].in[Der] == pem.as[Der]   // true
```

### Tagged and unknown values

`Asn1.Tagged(n, true, inner)` is an explicit context tag and round-trips. An *implicit* tag replaces the inner value's tag, making `[0] IMPLICIT INTEGER` and `[0] IMPLICIT OCTET STRING` byte-identical, so `Asn1.Tagged(n, false, inner)` is write-only; the decoder yields `Asn1.Unknown` instead. `Asn1.Unknown` also carries universal types outside the modelled PKIX subset, such as `T61String` and `BMPString`, which is what keeps decoding total.

This is stage 1 of #1653. The RSA/ECDSA signing schemes and `Certificate.selfSigned` that it exists to serve remain open there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
