### PR TITLE
Resolve stack-trace frames to their source definitions using TASTy

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1709,7 +1709,16 @@ object hyperbole extends Library:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
     def mvnDeps = Seq(mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}")
 
-  object test extends Tests(core, quantitative.units, mandible.core):
+  // Resolves the frames of a runtime stack trace against the TASTy written beside the classfiles,
+  // naming the source definitions the compiled names were derived from. Split from `core` because
+  // it reads TASTy files rather than introspecting trees during macro expansion, but it shares
+  // `core`'s dependency on the compiler, which supplies the header and name-table readers.
+  object stacks extends Component(core, galilei.jvm, hellenism.jvm):
+    override def scalaJs = false // depends on JVM-only `hyperbole.core` and the filesystem
+    override def scalacOptions = Task:
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+
+  object test extends Tests(core, stacks, quantitative.units, mandible.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
 

--- a/lib/digression/src/core/digression.StackTrace.scala
+++ b/lib/digression/src/core/digression.StackTrace.scala
@@ -47,7 +47,62 @@ object StackTrace:
     lazy val cls: Text = if pivot >= 0 then className.s.substring(pivot + 1).nn.tt else className.s
     lazy val prefix: Text = if pivot >= 0 then className.s.substring(0, pivot).nn.tt else "".tt
 
-  case class Frame(method: Method, file: Text, line: Optional[Int], native: Boolean)
+  object Frame:
+    // What a frame turned out to be, once resolved against the definitions the compiler recorded.
+    // Everything from `Bridge` onwards is plumbing the compiler synthesized, which renderers may
+    // reasonably dim or drop.
+    enum Kind:
+      case Method, Lambda, Value, Class, Constructor, Extension, Default
+      case Bridge, Forwarder, Initializer, Specialized, Synthetic
+
+      def plumbing: Boolean = this match
+        case Bridge | Forwarder | Initializer | Specialized | Synthetic => true
+        case _                                                          => false
+
+    // The source-level definition a frame was compiled from. `owner` is the chain of enclosing
+    // definitions and `name` the definition's own source name, so that renderers which show the
+    // class and the method in separate columns can keep doing so. `path` is the full source path,
+    // of which a stack trace records only the last segment.
+    case class Source
+      ( path: Text, owner: Text, name: Text, kind: Kind, code: Optional[Text] = Unset ):
+
+      def definition: Text = if owner.s.isEmpty then name else (owner.s+"."+name.s).tt
+
+  case class Frame
+    ( method:    Method,
+      file:      Text,
+      line:      Optional[Int],
+      native:    Boolean,
+      jvmClass:  Text = "".tt,
+      jvmMethod: Text = "".tt,
+      source:    Optional[Frame.Source] = Unset ):
+
+    // What to show for the frame's owner: the chain of source definitions it sits inside, when
+    // that is known, and otherwise the demangled class name.
+    def displayClass: Text = source.lay(method.className)(_.owner)
+
+    // What to show for the frame itself: its source name, when that is known, and otherwise the
+    // demangled method name.
+    def displayMethod: Text = source.lay(method.method)(_.name)
+
+    private def pivot: Int = displayClass.s.lastIndexOf(".")
+
+    // `displayClass` without its last segment.
+    def displayPrefix: Text =
+      if pivot >= 0 then displayClass.s.substring(0, pivot).nn.tt else "".tt
+
+    // The last segment of `displayClass`.
+    def displaySegment: Text =
+      if pivot >= 0 then displayClass.s.substring(pivot + 1).nn.tt else displayClass
+
+  object Resolver:
+    given none: Resolver = frame => frame
+
+  // Recovers the source-level definition behind each frame's compiled name. Resolution needs
+  // capabilities — at minimum a classpath — which this module deliberately does not have, so the
+  // default does nothing, and an implementation is supplied from elsewhere by importing it.
+  trait Resolver:
+    def resolve(frame: Frame): Frame
 
   trait Palette extends iridescence.Palette:
     type Form = Srgb
@@ -312,17 +367,20 @@ object StackTrace:
     else
       rewritten
 
-  def apply(exception: Throwable): StackTrace =
+  def apply(exception: Throwable)(using resolver: Resolver): StackTrace =
     val frames = List(exception.getStackTrace.nn.map(_.nn)*).map: frame =>
-      StackTrace.Frame(
-        StackTrace.Method(
-          rewrite(frame.getClassName.nn),
-          rewrite(frame.getMethodName.nn, method = true)
-        ),
-        Text(Option(frame.getFileName).map(_.nn).getOrElse("———")),
-        if frame.getLineNumber < 0 then Unset else frame.getLineNumber,
-        frame.isNativeMethod
-      )
+      val jvmClass = frame.getClassName.nn
+      val jvmMethod = frame.getMethodName.nn
+
+      resolver.resolve:
+        StackTrace.Frame(
+          StackTrace.Method(rewrite(jvmClass), rewrite(jvmMethod, method = true)),
+          Text(Option(frame.getFileName).map(_.nn).getOrElse("———")),
+          if frame.getLineNumber < 0 then Unset else frame.getLineNumber,
+          frame.isNativeMethod,
+          jvmClass.tt,
+          jvmMethod.tt
+        )
 
     val cause = Option(exception.getCause)
     val fullClassName: Text = rewrite(exception.getClass.nn.getName.nn)
@@ -340,8 +398,8 @@ object StackTrace:
     StackTrace(component, className, message, frames, cause.map(_.nn).map(StackTrace(_)).optional)
 
   given communicable: StackTrace is Communicable = stack =>
-    val methodWidth = stack.frames.map(_.method.method.s.length).maxOption.getOrElse(0)
-    val classWidth = stack.frames.map(_.method.className.s.length).maxOption.getOrElse(0)
+    val methodWidth = stack.frames.map(_.displayMethod.s.length).maxOption.getOrElse(0)
+    val classWidth = stack.frames.map(_.displayClass.s.length).maxOption.getOrElse(0)
     val fileWidth = stack.frames.map(_.file.s.length).maxOption.getOrElse(0)
     val fullClass = s"${stack.component}.${stack.className}".tt
     val init = s"$fullClass: ${stack.message}".tt
@@ -349,12 +407,12 @@ object StackTrace:
 
     val root = stack.frames.fuse(init):
       val obj = next.method.className.s.endsWith("#")
-      val drop = if obj then 1 else 0
+      val drop = if next.source.absent && obj then 1 else 0
       val file = (nbsp*(fileWidth - next.file.s.length))+next.file
-      val dot = if obj then ".".tt else "#".tt
-      val className = next.method.className.s.dropRight(drop)
+      val dot = if next.source.present || obj then ".".tt else "#".tt
+      val className = next.displayClass.s.dropRight(drop)
       val classPad = (nbsp*(classWidth - className.length))
-      val method = next.method.method
+      val method = next.displayMethod
       val methodPad = (nbsp*(methodWidth - method.s.length))
 
       val line = next.line match

--- a/lib/digression/src/core/digression_core.scala
+++ b/lib/digression/src/core/digression_core.scala
@@ -33,7 +33,11 @@
 package digression
 
 
-extension (error: Throwable) def stackTrace: StackTrace = StackTrace(error)
+// The resolver is taken here, rather than summoned inside `StackTrace`, so that it is the
+// caller's scope which decides whether frames are resolved; summoning it any deeper would find
+// only the default, and silently do nothing.
+extension (error: Throwable)
+  def stackTrace(using StackTrace.Resolver): StackTrace = StackTrace(error)
 
 extension (inline context: StringContext)
   inline def fqcn(): Fqcn = ${digression.internal.fqcn('context)}

--- a/lib/digression/src/test/digression_test.scala
+++ b/lib/digression/src/test/digression_test.scala
@@ -34,9 +34,98 @@ package digression
 
 import soundness.*
 
+import StackTrace.Frame.Kind
+
 case class Person(name: Text, age: Int)
 
 object Tests extends Suite(m"Digression Tests"):
   def run(): Unit =
-    suite(m"Exception tests"):
-      ()
+    suite(m"Demangling compiled names"):
+      test(m"An operator name is decoded"):
+        StackTrace.rewrite("$plus$plus", method = true)
+
+      . assert(_ == t"++()")
+
+      test(m"An anonymous function is marked as a lambda"):
+        StackTrace.rewrite("Foo$$anonfun$3", method = true)
+
+      . assert(_ == t"Foo.λ₃()")
+
+      test(m"A default getter is marked as a default"):
+        StackTrace.rewrite("defaulted$default$1")
+
+      . assert(_ == t"defaultedδ₁")
+
+      test(m"A constructor is marked as an initializer"):
+        StackTrace.rewrite("<init>", method = true)
+
+      . assert(_ == t"ⲛ()")
+
+      test(m"A module class keeps its marker"):
+        StackTrace.rewrite("pkg.Foo$")
+
+      . assert(_ == t"pkg.ΞFoo")
+
+      test(m"A name with no `.` to split on is left alone"):
+        StackTrace.rewrite("Foo$")
+
+      . assert(_ == t"Foo#")
+
+    suite(m"Capturing a stack trace"):
+      test(m"A captured frame keeps the compiled names it was built from"):
+        Exception("boom").stackTrace.frames.prim.let(_.jvmClass)
+
+      . assert(_.let(_.starts(t"digression.Tests")) == true)
+
+      test(m"Frames are unresolved unless a resolver is imported"):
+        Exception("boom").stackTrace.frames.map(_.source).to(Set)
+
+      . assert(_ == Set(Unset))
+
+      test(m"An unresolved frame displays its demangled names"):
+        Exception("boom").stackTrace.frames.prim.let: frame =>
+          (frame.displayClass, frame.displayMethod)
+
+      . assert: value =>
+          value.let((cls, method) => cls.starts(t"digression.ΞTests") && method.ends(t"()"))
+          == true
+
+    suite(m"Resolved frames"):
+      val source = StackTrace.Frame.Source(t"/src/Foo.scala", t"pkg.Foo.bar", t"λ", Kind.Lambda)
+
+      val frame =
+        StackTrace.Frame
+         ( StackTrace.Method(t"pkg.ΞFoo", t"bar.λ₁()"), t"Foo.scala", 12, false,
+           t"pkg.Foo$$", t"bar$$anonfun$$1", source )
+
+      test(m"A resolved frame displays the source definition"):
+        (frame.displayClass, frame.displayMethod)
+
+      . assert(_ == (t"pkg.Foo.bar", t"λ"))
+
+      test(m"The displayed owner splits at its last segment"):
+        (frame.displayPrefix, frame.displaySegment)
+
+      . assert(_ == (t"pkg.Foo", t"bar"))
+
+      test(m"A definition joins its owner and name"):
+        source.definition
+
+      . assert(_ == t"pkg.Foo.bar.λ")
+
+      test(m"A definition with no owner is just its name"):
+        source.copy(owner = t"").definition
+
+      . assert(_ == t"λ")
+
+      test(m"Compiler-generated frames are marked as plumbing"):
+        List(Kind.Bridge, Kind.Forwarder, Kind.Initializer, Kind.Specialized, Kind.Synthetic)
+        . map(_.plumbing)
+
+      . assert(_.all(identity))
+
+      test(m"Frames from source are not marked as plumbing"):
+        List(Kind.Method, Kind.Lambda, Kind.Value, Kind.Class, Kind.Constructor, Kind.Extension)
+        . map(_.plumbing)
+
+      . assert(_.all(!_))

--- a/lib/escapade/src/core/escapade.Teletypeable.scala
+++ b/lib/escapade/src/core/escapade.Teletypeable.scala
@@ -66,8 +66,8 @@ object Teletypeable:
 
   given showable: [value: Showable] => value is Teletypeable = value => Teletype(value.show)
 
-  given exception: (Text is Measurable) => Exception is Teletypeable = exception =>
-    summon[StackTrace is Teletypeable].teletype(StackTrace(exception))
+  given exception: (Text is Measurable, StackTrace.Resolver) => Exception is Teletypeable =
+    exception => summon[StackTrace is Teletypeable].teletype(StackTrace(exception))
 
   given error: Error is Teletypeable = _.message.teletype
 

--- a/lib/escapade/src/core/escapade.Teletypeable.scala
+++ b/lib/escapade/src/core/escapade.Teletypeable.scala
@@ -120,29 +120,40 @@ object Teletypeable:
     val rows: List[Row] =
       stack.frames.foldLeft((List.empty[Row], t"", t"")):
         case ((acc, lastClass, lastFile), frame) =>
-          val sameClass = frame.method.className == lastClass
+          val sameClass = frame.displayClass == lastClass
           val sameFile = frame.file == lastFile
-          (Row(frame, sameClass, sameFile) :: acc, frame.method.className, frame.file)
+          (Row(frame, sameClass, sameFile) :: acc, frame.displayClass, frame.file)
 
       . _1.reverse
 
+    // A frame the compiler generated—a bridge, a forwarder, an initializer—is rarely what the
+    // reader is looking for, so it stays legible but recedes.
+    def plumbing(row: Row): Boolean = row.frame.source.lay(false)(_.kind.plumbing)
+
     def classCell(row: Row): Teletype =
       val frame = row.frame
-      val obj = frame.method.cls.starts(t"Ξ")
-      val methodCls = if obj then frame.method.cls.skip(1) else frame.method.cls
+      val obj = frame.displaySegment.starts(t"Ξ")
+      val methodCls = if obj then frame.displaySegment.skip(1) else frame.displaySegment
       val color = packages(frame.method.prefix)
 
-      if row.sameClass
-      then e"${palette.subdue(color, 0.85)}(${frame.method.prefix}.$methodCls)"
+      if row.sameClass || plumbing(row)
+      then e"${palette.subdue(color, 0.85)}(${frame.displayPrefix}.$methodCls)"
       else
-        e"${palette.subdue(color, 0.5)}(${frame.method.prefix}.$Bold($color($methodCls)))"
+        e"${palette.subdue(color, 0.5)}(${frame.displayPrefix}.$Bold($color($methodCls)))"
 
     def dotCell(row: Row): Teletype =
-      val ch = if row.frame.method.cls.starts(t"Ξ") then t"." else t"⌗"
+      // A resolved frame names a chain of source definitions, which is joined with dots however
+      // the chain happens to have been compiled.
+      val resolved = row.frame.source.present
+      val ch = if resolved || row.frame.displaySegment.starts(t"Ξ") then t"." else t"⌗"
       e"${palette.separator}($ch)"
 
     def methodCell(row: Row): Teletype =
-      e"${palette.method}(${row.frame.method.method})"
+      val color = if plumbing(row) then palette.subdue(palette.method, 0.85) else palette.method
+      e"$color(${row.frame.displayMethod})"
+
+    def codeCell(row: Row): Teletype =
+      e"${palette.subdue(palette.file, 0.7)}(${row.frame.source.let(_.code).or(t"")})"
 
     def fileCell(row: Row): Teletype =
       val color = if row.sameFile then palette.subdue(palette.file, 0.85) else palette.file
@@ -159,7 +170,10 @@ object Teletypeable:
           Column(e"")(methodCell),
           Column(e"", textAlign = TextAlignment.Right)(fileCell),
           Column(e"")(_ => e"${palette.separator}(:)"),
-          Column(e"", textAlign = TextAlignment.Right)(lineCell) )
+          Column(e"", textAlign = TextAlignment.Right)(lineCell),
+          // The quoted source is the first thing to go when the terminal is too narrow for it:
+          // everything else in the row is needed to identify the frame at all.
+          Column(e"", sizing = columnar.Collapsible(0.5))(codeCell) )
 
     given style: TableStyle =
       TableStyle

--- a/lib/honeycomb/src/core/honeycomb.Renderable.scala
+++ b/lib/honeycomb/src/core/honeycomb.Renderable.scala
@@ -54,17 +54,18 @@ object Renderable:
         Fragment(elements*)
 
   given stackTrace: StackTrace is Renderable in Flow = stackTrace =>
-    given attribution: (Attribution of "at" | "class" | "stack" | "method" | "file" | "line") =
-      Attribution.classes()
+    type Topic = "at" | "class" | "stack" | "method" | "file" | "line" | "code"
+    given attribution: (Attribution of Topic) = Attribution.classes()
 
     val rows = stackTrace.frames.map: frame =>
       Tr
         ( Td.at(Code(t"at")),
-          Td.`class`(Code(frame.method.className)),
-          Td.method(Code(frame.method.method)),
+          Td.`class`(Code(frame.displayClass)),
+          Td.method(Code(frame.displayMethod)),
           Td.file(Code(frame.file)),
           Td(Code(t":")),
-          Td.line(Code(frame.line.let(_.show).or(t""))) )
+          Td.line(Code(frame.line.let(_.show).or(t""))),
+          Td.code(Code(frame.source.let(_.code).or(t""))) )
 
     Div.stack
       ( H2(stackTrace.component),

--- a/lib/hyperbole/src/stacks/hyperbole.StackResolver.scala
+++ b/lib/hyperbole/src/stacks/hyperbole.StackResolver.scala
@@ -1,0 +1,155 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package hyperbole
+
+import scala.collection.mutable
+
+import anticipation.*
+import contingency.*
+import digression.*
+import distillate.*
+import galilei.*, galilei.Platform.pathReadable
+import gossamer.*
+import hellenism.*
+import hieroglyph.*
+import prepositional.*
+import rudiments.*
+import serpentine.*
+import turbulence.*
+import vacuous.*
+
+import StackTrace.Frame.Kind
+import charDecoders.utf8Decoder
+import textSanitizers.skipSanitizer
+
+object StackResolver:
+  // The compiled name cannot say which definition a frame came from, but it can say what kind of
+  // thing it is: each of these markers is minted after TASTy is written, by a phase which erases,
+  // specializes, lifts or bridges, and each is a reliable sign of that phase's work. A name with
+  // no marker says nothing, and the definition the frame resolves to speaks for itself.
+  def hint(method: Text): Optional[Kind] =
+    val name = method.s
+
+    if name == "<init>" then Kind.Constructor
+    else if name == "<clinit>" || name == "$init$" then Kind.Initializer
+    else if name.contains("$anonfun$adapted") then Kind.Bridge
+    else if name.contains("$anonfun") then Kind.Lambda
+    else if name.endsWith("$extension") then Kind.Extension
+    else if name.contains("$default$") then Kind.Default
+    else if name.contains("$adapted") then Kind.Bridge
+    else if name.contains("lzyINIT") || name.contains("$lzy") then Kind.Initializer
+    else if name.contains("$mc") && name.endsWith("$sp") then Kind.Specialized
+    else Unset
+
+  // Which of the definitions on a line the frame belongs to. Position alone cannot tell a
+  // constructor from the first member declared beside it, or a lambda from its enclosing method,
+  // but what the compiled name says about the frame's kind settles both; failing that, a name
+  // which survived compilation unchanged identifies its definition outright.
+  def matches(method: Text, hint: Optional[Kind], definition: TastyDefinition): Boolean =
+    hint match
+      case Kind.Constructor => definition.name == t"<init>"
+      case Kind.Lambda      => definition.kind == Kind.Lambda
+      case _                => definition.name == method
+
+  // Most TASTy names are source names and need no decoding. The exceptions are the ones the
+  // compiler derived before pickling—anonymous functions, default getters, package files—and
+  // those are exactly what `rewrite` already renders, so a resolved frame reads in the same
+  // vocabulary as an unresolved one. A module class's trailing `$` is dropped first: it says
+  // nothing the frame does not say already, and it is not a derivation `rewrite` knows.
+  def display(name: Text): Text =
+    val stripped = if name.s.endsWith("$") then name.s.dropRight(1).nn else name.s
+
+    if stripped == "<init>" then t"ⲛ"
+    else if stripped.contains("$") then StackTrace.rewrite(stripped)
+    else stripped.tt
+
+// Recovers the source definition behind each frame of a stack trace by reading the TASTy the
+// compiler wrote beside the classfile. TASTy records source names, not compiled ones, so the two
+// cannot be matched up by name; but it also records the extent of every definition, and a line
+// table for the source file, so the line the frame already carries is enough to find it.
+class StackResolver(using classloader: Classloader) extends StackTrace.Resolver:
+  private val tastyFiles: mutable.HashMap[Text, Optional[TastyFile]] = mutable.HashMap()
+  private val sourceFiles: mutable.HashMap[Text, Optional[List[Text]]] = mutable.HashMap()
+
+  def resolve(frame: StackTrace.Frame): StackTrace.Frame =
+    tastyFile(frame.jvmClass).lay(frame): tasty =>
+      tasty.path.lay(frame): path =>
+        val hint = StackResolver.hint(frame.jvmMethod)
+        val candidates = frame.line.lay(List[TastyDefinition]())(tasty.covering(_))
+
+        val definition =
+          candidates.find(StackResolver.matches(frame.jvmMethod, hint, _)).optional
+          . or(candidates.prim)
+
+        val kind = hint.or(definition.let(_.kind)).or(Kind.Synthetic)
+        val code = frame.line.let(sourceLine(path, _))
+
+        val (owner, name) =
+          definition.lay((frame.method.className, frame.method.method)): definition =>
+            val chain = definition.owners.reverse.map(StackResolver.display)
+
+            // Landing on a class means the line belongs to it but to none of the definitions it
+            // records—typically a member the compiler generated whole. The class still names the
+            // frame's owner, but only the compiled name can name the frame itself.
+            if definition.kind == Kind.Class then
+              val name = StackResolver.display(definition.name)
+              ((chain :+ name).join(t"."), frame.method.method)
+            else (chain.join(t"."), StackResolver.display(definition.name))
+
+        frame.copy(source = StackTrace.Frame.Source(path, owner, name, kind, code))
+
+  private def tastyFile(name: Text): Optional[TastyFile] =
+    if name.s.isEmpty then Unset
+    else tastyFiles.synchronized(tastyFiles.getOrElseUpdate(name, load(name.s)))
+
+  // TASTy is written once per top-level class, so a frame in a nested, anonymous or module class
+  // resolves through the outermost class enclosing it, which is what stripping `$`-separated
+  // segments from the right arrives at. Top-level definitions live in a `<name>$package` class,
+  // whose TASTy is found before any segment is stripped.
+  private def load(name: String): Optional[TastyFile] =
+    val resource = (name.replace('.', '/').nn+".tasty").tt
+    val loaded: Optional[TastyFile] = classloader(resource).lay(Unset)(TastyFile(_))
+
+    loaded.or:
+      name.lastIndexOf('$') match
+        case -1 | 0 => Unset
+        case index  => load(name.substring(0, index).nn)
+
+  private def sourceLine(path: Text, line: Int): Optional[Text] =
+    lines(path).let(_.lift(line - 1).optional.let(_.trim))
+
+  // The path TASTy records is the path the file was compiled from, which need not exist where the
+  // code now runs; when it does not, the frame simply keeps everything but its line of source.
+  private def lines(path: Text): Optional[List[Text]] =
+    sourceFiles.synchronized:
+      sourceFiles.getOrElseUpdate(path, safely(path.as[Path on Linux].read[Text].cut(t"\n")))

--- a/lib/hyperbole/src/stacks/hyperbole.TastyDefinition.scala
+++ b/lib/hyperbole/src/stacks/hyperbole.TastyDefinition.scala
@@ -32,48 +32,22 @@
                                                                                                   */
 package hyperbole
 
-import scala.annotation.*
+import anticipation.*
+import digression.*
 
-import soundness.*
+import StackTrace.Frame.Kind
 
-object Tests extends Suite(m"Hyperbole Tests"):
-  def run(): Unit =
-    StackTests()
+// One definition the compiler recorded in a TASTy file, reduced to what resolving a stack frame
+// needs: what the definition is called, what encloses it, and which part of the source it covers.
+// `owners` runs innermost-first, and includes the package.
+case class TastyDefinition
+  ( name:      Text,
+    owners:    List[Text],
+    kind:      Kind,
+    start:     Int,
+    end:       Int,
+    firstLine: Int,
+    lastLine:  Int ):
 
-    test(m"Produce hello-world tree"):
-      Introspect.syntax(true):
-        println("hello world")
-
-    . assert: result =>
-        result
-        ==
-        TastyTree
-          ( ' ',
-            "Unit",
-            "Apply",
-            "scala.Predef.println(\"hello world\")",
-            "println(\"hello world\")",
-            List
-              ( TastyTree
-                  ( ' ',
-                    "",
-                    "Ident",
-                    "scala.Predef.println",
-                    "println",
-                    Nil,
-                    "println",
-                    true,
-                    false ),
-                TastyTree
-                  ( 'a',
-                    "\"hello world\"",
-                    "Literal",
-                    "\"hello world\"",
-                    "        \"hello world\"",
-                    Nil,
-                    "\"hello world\"",
-                    true,
-                    false ) ),
-            Unset,
-            true,
-            false )
+  def span: Int = end - start
+  def covers(line: Int): Boolean = firstLine <= line && line <= lastLine

--- a/lib/hyperbole/src/stacks/hyperbole.TastyFile.scala
+++ b/lib/hyperbole/src/stacks/hyperbole.TastyFile.scala
@@ -32,48 +32,42 @@
                                                                                                   */
 package hyperbole
 
-import scala.annotation.*
+import dotty.tools.dotc.core.tasty.TastyUnpickler
 
-import soundness.*
+import anticipation.*
+import rudiments.*
+import vacuous.*
 
-object Tests extends Suite(m"Hyperbole Tests"):
-  def run(): Unit =
-    StackTests()
+object TastyFile:
+  // A TASTy file is only ever a source of extra detail, so anything unexpected about it—a version
+  // this reader does not understand, a truncated file, a section that is absent—means falling
+  // back to what the stack trace already said, never failing.
+  def apply(data: Data): Optional[TastyFile] =
+    try
+      val unpickler = TastyUnpickler(data.mutable(using Unsafe))
+      val positions = unpickler.unpickle(stacksInternal.PositionSection())
 
-    test(m"Produce hello-world tree"):
-      Introspect.syntax(true):
-        println("hello world")
+      positions.map: positions =>
+        val definitions =
+          unpickler.unpickle(stacksInternal.DefinitionSection(positions)).getOrElse(Nil)
 
-    . assert: result =>
-        result
-        ==
-        TastyTree
-          ( ' ',
-            "Unit",
-            "Apply",
-            "scala.Predef.println(\"hello world\")",
-            "println(\"hello world\")",
-            List
-              ( TastyTree
-                  ( ' ',
-                    "",
-                    "Ident",
-                    "scala.Predef.println",
-                    "println",
-                    Nil,
-                    "println",
-                    true,
-                    false ),
-                TastyTree
-                  ( 'a',
-                    "\"hello world\"",
-                    "Literal",
-                    "\"hello world\"",
-                    "        \"hello world\"",
-                    Nil,
-                    "\"hello world\"",
-                    true,
-                    false ) ),
-            Unset,
-            true,
-            false )
+        val path = unpickler.unpickle(stacksInternal.AttributeSection()).getOrElse(Unset)
+
+        TastyFile(path, definitions)
+
+      . getOrElse(Unset)
+
+    catch case error: Throwable => Unset
+
+// The definitions the compiler recorded for one top-level class, and the source file they came
+// from. `path` is the full path the file was compiled from, of which a stack trace keeps only the
+// last segment.
+case class TastyFile(path: Optional[Text], definitions: List[TastyDefinition]):
+  // Every definition covering `line`, innermost first, where nesting is measured by how much
+  // source a definition covers—so an anonymous function comes before the method containing it.
+  // Definitions the compiler synthesized, such as a constructor an `object` never declared, are
+  // pickled with an empty extent at whatever position was to hand, and so cannot be innermost
+  // anything; they sort last, to be reached only when a frame really is one of them.
+  def covering(line: Int): List[TastyDefinition] =
+    definitions.filter(_.covers(line)).sortBy: definition =>
+      (if definition.span == 0 then 1 else 0, definition.span)

--- a/lib/hyperbole/src/stacks/hyperbole.stacksInternal.scala
+++ b/lib/hyperbole/src/stacks/hyperbole.stacksInternal.scala
@@ -1,0 +1,271 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package hyperbole
+
+import scala.collection.mutable
+
+import dotty.tools.dotc.core.tasty.TastyUnpickler
+import dotty.tools.tasty.{TastyBuffer, TastyFormat, TastyReader}
+
+import anticipation.*
+import digression.*
+import gossamer.*
+import vacuous.*
+
+import StackTrace.Frame.Kind
+
+// Readers for the three TASTy sections a stack frame needs. `TastyUnpickler` does the fiddly work
+// of checking the header and decoding the name table (whose entries may be qualified, signed or
+// otherwise derived), and hands out a plain reader positioned at each section's payload; from
+// there the grammar in `TastyFormat`'s documentation is short enough to read directly, and doing
+// so avoids the full tree unpickler, which would need a compiler `Context` and a classpath.
+private[hyperbole] object stacksInternal:
+  import TastyFormat.*
+
+  // The line table pickled at the head of the positions section: the length of every line of the
+  // source file. It is what makes the character offsets in that section resolvable to line
+  // numbers without the source file itself being available.
+  class Lines(sizes: Array[Int]):
+    private val starts: Array[Int] =
+      val array = new Array[Int](sizes.length + 1)
+      var index = 0
+
+      while index < sizes.length do
+        // The `+ 1` accounts for the line terminator, which the pickled size excludes.
+        array(index + 1) = array(index) + 0.max(sizes(index)) + 1
+        index += 1
+
+      array
+
+    def count: Int = sizes.length
+
+    // The one-based line containing `offset`, which is what a stack trace reports.
+    def line(offset: Int): Int =
+      var min = 0
+      var max = sizes.length - 1
+
+      while min < max do
+        val mid = (min + max + 1)/2
+        if starts(mid) <= offset then min = mid else max = mid - 1
+
+      min + 1
+
+  case class Positions(lines: Lines, spans: Map[Int, (Int, Int)])
+
+  class PositionSection extends TastyUnpickler.SectionUnpickler[Positions](PositionsSection):
+    def unpickle(reader: TastyReader, nameAtRef: TastyUnpickler.NameTable): Positions =
+      import reader.*
+      val count = readNat()
+      val sizes = new Array[Int](count)
+      var index = 0
+
+      while index < count do
+        // Compilers before 3.3 could write `-1` here for a line of unknown length; treating it as
+        // empty keeps every later line's offset monotonic, which is all the search below needs.
+        val size = readLongNat()
+        sizes(index) = if size == 0xFFFFFFFFL then 0 else size.toInt
+        index += 1
+
+      val spans = mutable.HashMap[Int, (Int, Int)]()
+      var address = 0
+      var start = 0
+      var end = 0
+
+      while !isAtEnd do
+        val header = readInt()
+
+        if header == SOURCE then readNameRef() else
+          // Each field is a delta against the previously recorded node, and a node whose span
+          // matches its parent's is omitted entirely.
+          address += header >> 3
+          if (header & 4) != 0 then start += readInt()
+          if (header & 2) != 0 then end += readInt()
+          if (header & 1) != 0 then readInt()
+          spans(address) = (start, end)
+
+      Positions(Lines(sizes), spans.to(Map))
+
+  class AttributeSection extends TastyUnpickler.SectionUnpickler[Optional[Text]](AttributesSection):
+    def unpickle(reader: TastyReader, nameAtRef: TastyUnpickler.NameTable): Optional[Text] =
+      import reader.*
+      var path: Optional[Text] = Unset
+
+      while !isAtEnd do
+        val tag = readByte()
+
+        if isStringAttrTag(tag) then
+          val name = nameAtRef(readNameRef()).toString.tt
+          if tag == SOURCEFILEattr then path = name
+
+      path
+
+  // Walks the tree section without building trees. Every tag falls into one of five categories
+  // which fix what follows it, so the walk can step over any node it does not care about, and
+  // needs to understand only the handful that introduce a name or a nesting level. This mirrors
+  // the traversal in the compiler's own `TastyPrinter`.
+  class DefinitionSection(positions: Positions)
+  extends TastyUnpickler.SectionUnpickler[List[TastyDefinition]](ASTsSection):
+
+    def unpickle(reader: TastyReader, nameAtRef: TastyUnpickler.NameTable)
+    :   List[TastyDefinition] =
+
+      import reader.*
+      val definitions = mutable.ListBuffer[TastyDefinition]()
+
+      def label(): Text = nameAtRef(readNameRef()).toString.tt
+
+      // Steps over a number without caring what it means. The widest reader is the right one:
+      // every variable-length integer in TASTy occupies bytes up to the first with its high bit
+      // set, so this consumes exactly as much as a narrower reader would, but it also accepts the
+      // 64-bit payloads of `LONGconst` and `DOUBLEconst`, which a `Nat` reader rejects outright.
+      def number(): Unit =
+        val _ = readLongInt()
+
+      def record(address: Int, tag: Int, name: Text, owners: List[Text], extension: Boolean)
+      :   Unit =
+
+        positions.spans.get(address).foreach: (start, end) =>
+          val kind = tag match
+            case TYPEDEF                   => Kind.Class
+            case VALDEF                    => Kind.Value
+            case _ if extension            => Kind.Extension
+            case _ if name == t"$$anonfun" => Kind.Lambda
+            case _                         => Kind.Method
+
+          val first = positions.lines.line(start)
+          val last = positions.lines.line(end)
+          definitions += TastyDefinition(name, owners, kind, start, end, first, last)
+
+      def walk(owners: List[Text]): Unit =
+        val address = currentAddr.index
+        val tag = readByte()
+
+        def children(end: TastyBuffer.Addr, owners: List[Text]): Unit =
+          while currentAddr.index < end.index do walk(owners)
+
+        if tag >= firstLengthTreeTag then
+          // The length counts from after itself, so the address has to be taken once it has been
+          // read, not while reading it.
+          val length = readNat()
+          val end = currentAddr + length
+
+          tag match
+            case VALDEF | DEFDEF | TYPEDEF =>
+              val name = label()
+              val inner = name :: owners
+              var extension = false
+
+              // A top-level extension method keeps its own name when compiled, so nothing in a
+              // stack frame marks it as one; the modifier the compiler recorded here does. The
+              // modifiers follow the definition's other children, so this waits for them.
+              while currentAddr.index < end.index do
+                if nextByte == EXTENSION then extension = true
+                walk(inner)
+
+              record(address, tag, name, owners, extension)
+
+            case PACKAGE =>
+              // Qualifying definitions by their package costs nothing here: the package path is
+              // the first child. Nested package nodes each name themselves in full, so the
+              // innermost one is the whole path and replaces, rather than extends, what is known
+              // so far; and packages only ever enclose, never nest inside a definition, so there
+              // is nothing else in `owners` to lose.
+              val inner =
+                if currentAddr.index < end.index && nextByte == TERMREFpkg
+                then
+                  readByte()
+                  val name = label()
+                  if name == t"<empty>" then Nil else List(name)
+                else
+                  owners
+
+              children(end, inner)
+
+            case TYPEPARAM | PARAM | NAMEDARG | BIND =>
+              readNameRef()
+              children(end, owners)
+
+            case REFINEDtype | TERMREFin | TYPEREFin | SELECTin =>
+              readNameRef()
+              walk(owners)
+              children(end, owners)
+
+            case RENAMED =>
+              readNameRef()
+              readNameRef()
+
+            case RETURN | HOLE =>
+              readNat()
+              children(end, owners)
+
+            case METHODtype | POLYtype | TYPELAMBDAtype =>
+              walk(owners)
+
+              while currentAddr.index < end.index && !isModifierTag(nextByte) do
+                walk(owners)
+                readNameRef()
+
+              children(end, owners)
+
+            case PARAMtype =>
+              readNat()
+              readNat()
+
+            case _ =>
+              children(end, owners)
+
+          // A tag this walk mis-reads would derail everything after it; resynchronizing on the
+          // recorded length confines the damage to the node itself.
+          if currentAddr.index != end.index then goto(end)
+
+        else if tag >= firstNatASTTreeTag then
+          tag match
+            case IDENT | IDENTtpt | SELECT | SELECTtpt | TERMREF | TYPEREF | SELFDEF =>
+              readNameRef()
+
+            case _ =>
+              number()
+
+          walk(owners)
+
+        else if tag >= firstASTTreeTag then
+          walk(owners)
+
+        else if tag >= firstNatTreeTag then
+          tag match
+            case TERMREFpkg | TYPEREFpkg | STRINGconst | IMPORTED => readNameRef()
+            case _                                                => number()
+
+      while !isAtEnd do walk(Nil)
+
+      definitions.to(List)

--- a/lib/hyperbole/src/stacks/hyperbole_stacks.scala
+++ b/lib/hyperbole/src/stacks/hyperbole_stacks.scala
@@ -32,48 +32,28 @@
                                                                                                   */
 package hyperbole
 
-import scala.annotation.*
+import digression.*
+import hellenism.*
+import vacuous.*
 
-import soundness.*
+package stackResolutions:
+  // Importing this makes every `StackTrace` captured in the enclosing scope name the source
+  // definitions its frames were compiled from, at the cost of reading one TASTy file per
+  // top-level class named in the trace.
+  given tastyStackResolution: Classloader => StackTrace.Resolver = StackResolver()
 
-object Tests extends Suite(m"Hyperbole Tests"):
-  def run(): Unit =
-    StackTests()
+extension (stackTrace: StackTrace)
+  // Resolves an existing trace, for callers which hold a `Classloader` and would rather ask
+  // explicitly than import a resolver into scope.
+  def resolved(using Classloader): StackTrace =
+    val resolver = StackResolver()
 
-    test(m"Produce hello-world tree"):
-      Introspect.syntax(true):
-        println("hello world")
+    def recur(stackTrace: StackTrace): StackTrace =
+      StackTrace
+        ( stackTrace.component,
+          stackTrace.className,
+          stackTrace.message,
+          stackTrace.frames.map(resolver.resolve),
+          stackTrace.cause.let(recur) )
 
-    . assert: result =>
-        result
-        ==
-        TastyTree
-          ( ' ',
-            "Unit",
-            "Apply",
-            "scala.Predef.println(\"hello world\")",
-            "println(\"hello world\")",
-            List
-              ( TastyTree
-                  ( ' ',
-                    "",
-                    "Ident",
-                    "scala.Predef.println",
-                    "println",
-                    Nil,
-                    "println",
-                    true,
-                    false ),
-                TastyTree
-                  ( 'a',
-                    "\"hello world\"",
-                    "Literal",
-                    "\"hello world\"",
-                    "        \"hello world\"",
-                    Nil,
-                    "\"hello world\"",
-                    true,
-                    false ) ),
-            Unset,
-            true,
-            false )
+    recur(stackTrace)

--- a/lib/hyperbole/src/stacks/soundness_hyperbole_stacks.scala
+++ b/lib/hyperbole/src/stacks/soundness_hyperbole_stacks.scala
@@ -30,50 +30,6 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package hyperbole
+package soundness
 
-import scala.annotation.*
-
-import soundness.*
-
-object Tests extends Suite(m"Hyperbole Tests"):
-  def run(): Unit =
-    StackTests()
-
-    test(m"Produce hello-world tree"):
-      Introspect.syntax(true):
-        println("hello world")
-
-    . assert: result =>
-        result
-        ==
-        TastyTree
-          ( ' ',
-            "Unit",
-            "Apply",
-            "scala.Predef.println(\"hello world\")",
-            "println(\"hello world\")",
-            List
-              ( TastyTree
-                  ( ' ',
-                    "",
-                    "Ident",
-                    "scala.Predef.println",
-                    "println",
-                    Nil,
-                    "println",
-                    true,
-                    false ),
-                TastyTree
-                  ( 'a',
-                    "\"hello world\"",
-                    "Literal",
-                    "\"hello world\"",
-                    "        \"hello world\"",
-                    Nil,
-                    "\"hello world\"",
-                    true,
-                    false ) ),
-            Unset,
-            true,
-            false )
+export hyperbole.{resolved, StackResolver, TastyDefinition, TastyFile}

--- a/lib/hyperbole/src/stacks/soundness_hyperbole_stacks.scala
+++ b/lib/hyperbole/src/stacks/soundness_hyperbole_stacks.scala
@@ -33,3 +33,6 @@
 package soundness
 
 export hyperbole.{resolved, StackResolver, TastyDefinition, TastyFile}
+
+package stackResolutions:
+  export hyperbole.stackResolutions.tastyStackResolution

--- a/lib/hyperbole/src/test/hyperbole.StackTests.scala
+++ b/lib/hyperbole/src/test/hyperbole.StackTests.scala
@@ -32,48 +32,104 @@
                                                                                                   */
 package hyperbole
 
-import scala.annotation.*
-
 import soundness.*
 
-object Tests extends Suite(m"Hyperbole Tests"):
+import classloaders.threadContextClassloader
+import unsafeExceptions.canThrowAny
+
+import StackTrace.Frame.Kind
+
+object StackFixture:
+  def method(): Unit = throw Exception("method")
+
+  def lambda(): Unit = List(1).foreach: value =>
+    throw Exception("lambda")
+
+  def defaulted(value: Int = throw Exception("default")): Int = value
+
+  lazy val lazily: Int = throw Exception("lazily")
+
+extension (value: Int) def extended: Int = throw Exception("extension")
+
+object StackTests extends Suite(m"Stack-trace resolution tests"):
   def run(): Unit =
-    StackTests()
+    def capture(block: => Unit): StackTrace =
+      try
+        block
+        panic(m"the fixture did not throw")
+      catch case error: Throwable => error.stackTrace.resolved
 
-    test(m"Produce hello-world tree"):
-      Introspect.syntax(true):
-        println("hello world")
+    // The frames below the fixture belong to the test framework and the JDK, so every test looks
+    // at the topmost frame in the fixture's own file.
+    def frame(stackTrace: StackTrace): StackTrace.Frame =
+      stackTrace.frames.find(_.jvmClass.starts(t"hyperbole.")).optional.vouch
 
-    . assert: result =>
-        result
-        ==
-        TastyTree
-          ( ' ',
-            "Unit",
-            "Apply",
-            "scala.Predef.println(\"hello world\")",
-            "println(\"hello world\")",
-            List
-              ( TastyTree
-                  ( ' ',
-                    "",
-                    "Ident",
-                    "scala.Predef.println",
-                    "println",
-                    Nil,
-                    "println",
-                    true,
-                    false ),
-                TastyTree
-                  ( 'a',
-                    "\"hello world\"",
-                    "Literal",
-                    "\"hello world\"",
-                    "        \"hello world\"",
-                    Nil,
-                    "\"hello world\"",
-                    true,
-                    false ) ),
-            Unset,
-            true,
-            false )
+    suite(m"Locating the TASTy for a class"):
+      test(m"A module class resolves through its top-level class"):
+        frame(capture(StackFixture.method())).source.let(_.path)
+
+      . assert(_.let(_.ends(t"hyperbole.StackTests.scala")) == true)
+
+      test(m"An unresolvable class leaves the frame untouched"):
+        val frame = StackTrace.Frame(StackTrace.Method(t"java.lang.Thread", t"run()"), t"", 1, false)
+        StackResolver().resolve(frame).source
+
+      . assert(_ == Unset)
+
+    suite(m"Naming the definition a frame was compiled from"):
+      test(m"A method frame names the method"):
+        frame(capture(StackFixture.method())).source.let(_.definition)
+
+      . assert(_ == t"hyperbole.StackFixture.method")
+
+      test(m"A lambda frame names the method containing it"):
+        frame(capture(StackFixture.lambda())).source.let(_.definition)
+
+      . assert(_ == t"hyperbole.StackFixture.lambda.λ")
+
+      test(m"An extension method frame names the extension"):
+        frame(capture(1.extended)).source.let(_.definition)
+
+      . assert(_ == t"hyperbole.hyperbole.StackTests⁆.extended")
+
+      test(m"A default getter is named as `rewrite` would name it"):
+        frame(capture(StackFixture.defaulted())).source.let(_.definition)
+
+      . assert(_ == t"hyperbole.StackFixture.defaultedδ₁")
+
+      test(m"A lazy value's initializer names the value"):
+        frame(capture(StackFixture.lazily)).source.let(_.definition)
+
+      . assert(_ == t"hyperbole.StackFixture.lazily")
+
+    suite(m"Classifying frames"):
+      test(m"A lambda is classified as a lambda"):
+        frame(capture(StackFixture.lambda())).source.let(_.kind)
+
+      . assert(_ == Kind.Lambda)
+
+      test(m"An extension method is classified as an extension"):
+        frame(capture(1.extended)).source.let(_.kind)
+
+      . assert(_ == Kind.Extension)
+
+      test(m"A default argument is classified as a default"):
+        frame(capture(StackFixture.defaulted())).source.let(_.kind)
+
+      . assert(_ == Kind.Default)
+
+      test(m"A lazy value's initializer is classified as an initializer"):
+        frame(capture(StackFixture.lazily)).source.let(_.kind)
+
+      . assert(_ == Kind.Initializer)
+
+    suite(m"Quoting the source"):
+      test(m"A frame carries the line of source it was compiled from"):
+        frame(capture(StackFixture.method())).source.let(_.code)
+
+      . assert(_ == t"""def method(): Unit = throw Exception("method")""")
+
+      test(m"The line quoted for a lambda is the line inside it"):
+        frame(capture(StackFixture.lambda())).source.let(_.code)
+
+      . assert(_ == t"""throw Exception("lambda")""")

--- a/lib/hyperbole/src/test/hyperbole.StackTests.scala
+++ b/lib/hyperbole/src/test/hyperbole.StackTests.scala
@@ -59,10 +59,40 @@ object StackTests extends Suite(m"Stack-trace resolution tests"):
         panic(m"the fixture did not throw")
       catch case error: Throwable => error.stackTrace.resolved
 
+    // Captures a trace with no resolver in scope at all, which is what every caller gets by
+    // default, and what every platform without a classpath gets always.
+    def capture0(block: => Unit): StackTrace =
+      try
+        block
+        panic(m"the fixture did not throw")
+      catch case error: Throwable => error.stackTrace
+
+    // Captures a trace which resolves as it is built, rather than afterwards, by importing the
+    // resolver into scope; and does so through the `soundness` re-export, since a given whose
+    // type is a context function is delicate to re-export.
+    def captured(block: => Unit): StackTrace =
+      import stackResolutions.tastyStackResolution
+
+      try
+        block
+        panic(m"the fixture did not throw")
+      catch case error: Throwable => error.stackTrace
+
     // The frames below the fixture belong to the test framework and the JDK, so every test looks
     // at the topmost frame in the fixture's own file.
     def frame(stackTrace: StackTrace): StackTrace.Frame =
       stackTrace.frames.find(_.jvmClass.starts(t"hyperbole.")).optional.vouch
+
+    suite(m"Resolving as a trace is captured"):
+      test(m"An imported resolver resolves frames at capture time"):
+        frame(captured(StackFixture.lambda())).source.let(_.definition)
+
+      . assert(_ == t"hyperbole.StackFixture.lambda.λ")
+
+      test(m"Without an imported resolver, frames are left alone"):
+        frame(capture0(StackFixture.lambda())).source
+
+      . assert(_ == Unset)
 
     suite(m"Locating the TASTy for a class"):
       test(m"A module class resolves through its top-level class"):

--- a/lib/probably/src/core/probably.TerseRenderer.scala
+++ b/lib/probably/src/core/probably.TerseRenderer.scala
@@ -160,7 +160,7 @@ private[probably] object TerseRenderer:
 
   private def formatFrame(frame: StackTrace.Frame): Text =
     val ln = frame.line.let(_.toString.tt).or(t"?")
-    t"  at ${frame.method.cls}.${frame.method.method} (${frame.file}:$ln)"
+    t"  at ${frame.displaySegment}.${frame.displayMethod} (${frame.file}:$ln)"
 
   private def renderFailures(document: Document, columns: Int)(using Stdio): Unit =
     val failureStatuses: Set[Status] =

--- a/lib/spectacular/src/core/spectacular.Showable.scala
+++ b/lib/spectacular/src/core/spectacular.Showable.scala
@@ -83,8 +83,8 @@ object Showable:
     stenography.internal.name[meta](using _)
 
   given stackTrace: StackTrace is Showable = stack =>
-    val methodWidth = stack.frames.map(_.method.method.s.length).maxOption.getOrElse(0)
-    val classWidth = stack.frames.map(_.method.className.s.length).maxOption.getOrElse(0)
+    val methodWidth = stack.frames.map(_.displayMethod.s.length).maxOption.getOrElse(0)
+    val classWidth = stack.frames.map(_.displayClass.s.length).maxOption.getOrElse(0)
     val fileWidth = stack.frames.map(_.file.s.length).maxOption.getOrElse(0)
     val fullClass = s"${stack.component}.${stack.className}".tt
     val init = s"$fullClass: ${stack.message}".tt
@@ -92,16 +92,17 @@ object Showable:
     val root = stack.frames.foldLeft(init):
       case (msg, frame) =>
         val obj = frame.method.className.s.endsWith("#")
-        val drop = if obj then 1 else 0
+        val drop = if frame.source.absent && obj then 1 else 0
         val file = (" "*(fileWidth - frame.file.s.length))+frame.file
-        val dot = if obj then ".".tt else "#".tt
-        val className = frame.method.className.s.dropRight(drop)
+        val dot = if frame.source.present || obj then ".".tt else "#".tt
+        val className = frame.displayClass.s.dropRight(drop)
         val classPad = (" "*(classWidth - className.length)).tt
-        val method = frame.method.method
+        val method = frame.displayMethod
         val methodPad = (" "*(methodWidth - method.s.length)).tt
         val line = frame.line.let(_.show).or("?".tt)
+        val code = frame.source.let(_.code).lay("".tt)(code => s"\n       $code".tt)
 
-        s"$msg\n  at $classPad$className$dot$method$methodPad $file:$line".tt
+        s"$msg\n  at $classPad$className$dot$method$methodPad $file:$line$code".tt
 
     stack.cause.lay(root): cause =>
       s"$root\ncaused by:\n$cause".tt


### PR DESCRIPTION
Stack traces have always been rendered from the names the compiler left in the bytecode, which `digression` could tidy but never explain: a frame reading `Foo#λ₃` tells you a lambda ran, but not which one. Soundness can now read the TASTy files sitting beside the classfiles and resolve each frame to the definition it was compiled from, so that frame instead reads `pkg.Foo.bar.λ`, alongside the full path of its source file and the line of code it stopped on. Resolution is opt-in and costs nothing until it is imported, and `digression` itself gains no dependencies, so stack traces on Scala.js, Native and WASI are exactly as they were.

Stack-trace frames can now name the source definition they were compiled from, instead of the mangled name the JVM reports. Importing a resolver switches this on for every stack trace captured in scope:

```scala
import classloaders.threadContextClassloader
import stackResolutions.tastyStackResolution
```

A frame which previously rendered as,
```
  at   Foo#λ₃()   Foo.scala:88
```
now renders as,
```
  at   pkg.Foo.bar.λ   Foo.scala:88
       xs.map { x => total/x }
```

An existing trace can also be resolved explicitly, for callers which already hold a `Classloader`:

```scala
val trace = error.stackTrace.resolved
```

Each resolved frame carries a `StackTrace.Frame.Source`, giving the full source `path` (of which a stack trace records only the last segment), the `owner` chain and `name` of the definition, its `kind` — `Lambda`, `Extension`, `Default`, `Bridge` and so on, where `kind.plumbing` marks the frames the compiler generated, which renderers dim — and the `code` it was compiled from, when the source file can still be found on disk.

This works by position rather than by name. TASTy records the extent of every definition and a table of line lengths for the source file, so the line a frame already carries is enough to locate the definition. That matters because the names which most need explaining — `$anonfun$3`, `$init$`, bridges, specialisations, lazy initialisers — are minted after TASTy is written and appear nowhere in it, so no amount of name-matching could recover them.

Resolution needs the `.tasty` files on the runtime classpath, which is where the compiler puts them. Frames from Java, from Scala 2 libraries and from the JDK have no TASTy, and render exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
