### PR TITLE
Refresh and expand the feature-tutorial documentation

### DIFF
--- a/doc/compatibility.tsv
+++ b/doc/compatibility.tsv
@@ -1,141 +1,150 @@
 # Soundness module compatibility by platform target. One row per top-level module.
-# Generated from build.mill (per-core `scalaJs` flag) and per-module platform backends (src/{jvm,wasi,wasm}).
+# Generated from build.mill (per-core `scalaJs`/`scalaNative` flags) and per-module platform
+# backends (src/{jvm,native,wasi,wasm} components and src/*-jvm, src/*-native source sets).
 #
-# jvm : yes  = runs on the JVM (every module).
-# js  : yes  = cross-compiles to Scala.js.
-#       core = shared `core` cross-compiles, but the module's platform functionality has a
-#              JVM-and/or-WASI-only backend (no Scala.js backend) — e.g. galilei's filesystem.
-#       no   = JVM-only (its `core` sets `scalaJs = false`); see notes for why.
-# wasm: wasi = has a native WebAssembly/WASI backend submodule (src/wasi or src/wasm).
-#       js   = no native backend, but compiles to WebAssembly via the Scala.js -> scala-wasm pipeline (pure code).
-#       core = `core` cross-compiles but the backend is JVM-only (no WASM backend).
-#       no   = JVM-only.
-# notes: platform backends present, JVM-only reason, or JVM-only submodules of an otherwise-JS-capable module.
-module	jvm	js	wasm	notes
-abacist	yes	yes	js	
-acyclicity	yes	yes	js	
-adversaria	yes	yes	js	
-ambience	yes	yes	wasi	backends: core+wasi
-anamnesis	yes	yes	js	
-anthology	yes	no	no	Scala compiler / classpath tooling (dotty, `hellenism`)
-anticipation	yes	yes	js	
-apoplexy	yes	no	no	transitively JVM-only (networking/crypto/fs/process)
-archimedes	yes	yes	js	
-austronesian	yes	yes	js	
-aviation	yes	yes	wasi	backends: core+wasi
-baroque	yes	yes	js	
-beneficence	yes	yes	js	JVM-only submodule(s): plugin
-bitumen	yes	no	no	depends on `galilei` (filesystem) and `turbulence.jvm`
-breviloquence	yes	yes	js	
-burdock	yes	no	no	packaging; depends on JVM-only `zeppelin`/`telekinesis`
-cacophony	yes	no	no	audio (`javax.sound.sampled`)
-caduceus	yes	yes	js	JVM-only submodule(s): resend
-caesura	yes	yes	js	
-camouflage	yes	yes	js	
-capricious	yes	yes	wasi	backends: core+wasi
-cardinality	yes	yes	js	
-cataclysm	yes	yes	js	
-charisma	yes	yes	js	
-chiaroscuro	yes	yes	js	
-coaxial	yes	no	no	TCP sockets (`java.nio.channels`)
-contextual	yes	yes	js	
-contingency	yes	yes	js	
-cordillera	yes	yes	js	
-cosmopolite	yes	yes	js	
-decorum	yes	no	no	compiler plugin: uses the JVM-only dotty compiler API
-dendrology	yes	yes	js	
-denominative	yes	yes	js	
-digression	yes	yes	js	
-dissonance	yes	yes	js	
-distillate	yes	yes	js	
-diuretic	yes	no	no	`java.*` type interop (io.File, nio.Path, net.URL, time, util.Date)
-embarcadero	yes	no	no	container runtime; depends on JVM-only `obligatory.grpc`
-enigmatic	yes	no	no	crypto via `gastronomy` (`java.security`/`javax.crypto`)
-escapade	yes	yes	js	
-escritoire	yes	yes	js	
-ethereal	yes	no	no	transitively JVM-only (networking/crypto/fs/process)
-eucalyptus	yes	yes	js	JVM-only submodule(s): syslog
-exegesis	yes	no	no	LSP server; depends on JVM-only `ethereal`/`exoskeleton`
-exoskeleton	yes	no	no	transitively JVM-only (networking/crypto/fs/process)
-frontier	yes	yes	js	
-fulminate	yes	yes	js	
-galilei	yes	core	wasi	backends: core+jvm+wasi; JVM-only submodule(s): jvm
-gastronomy	yes	no	no	hashing (`java.security` MessageDigest)
-geodesy	yes	yes	js	
-gesticulate	yes	yes	js	
-gigantism	yes	yes	js	
-gnossienne	yes	yes	js	
-gossamer	yes	yes	js	
-graffiti	yes	yes	js	
-guillotine	yes	no	no	transitively JVM-only (networking/crypto/fs/process)
-hallucination	yes	no	no	uses `java.awt`/`javax.imageio` (no Scala.js implementation)
-harlequin	yes	no	no	syntax highlighting via `anthology.scala` (the compiler)
-hellenism	yes	core	core	backends: core+jvm; JVM-only submodule(s): jvm
-hieroglyph	yes	yes	js	
-honeycomb	yes	yes	js	
-hyperbole	yes	no	no	depends on JVM-only `harlequin.ansi`
-hypotenuse	yes	yes	js	
-imperial	yes	no	no	transitively JVM-only (networking/crypto/fs/process)
-inimitable	yes	yes	js	
-iridescence	yes	yes	js	
-jacinta	yes	yes	js	JVM-only submodule(s): http, schema
-kaleidoscope	yes	yes	js	
-larceny	yes	no	no	compiler plugin: uses the JVM-only dotty compiler API
-legerdemain	yes	yes	js	
-locomotion	yes	yes	js	
-mandible	yes	no	no	depends on JVM-only `hyperbole`
-mercator	yes	yes	js	
-metamorphose	yes	yes	js	
-monotonous	yes	yes	js	
-mosquito	yes	yes	js	
-nomenclature	yes	yes	js	
-obligatory	yes	yes	js	JVM-only submodule(s): grpc, json
-octogenarian	yes	no	no	transitively JVM-only (networking/crypto/fs/process)
-orthodoxy	yes	no	no	transitively JVM-only (networking/crypto/fs/process)
-panopticon	yes	yes	js	
-parasite	yes	core	core	backends: core+jvm; JVM-only submodule(s): jvm
-perihelion	yes	no	no	transitively JVM-only (networking/crypto/fs/process)
-phoenicia	yes	yes	js	
-plutocrat	yes	yes	js	
-polaris	yes	yes	js	
-polysyllabic	yes	yes	js	
-polyvinyl	yes	yes	js	
-prepositional	yes	yes	js	
-probably	yes	yes	js	
-profanity	yes	yes	js	
-proscenium	yes	yes	js	
-punctuation	yes	yes	js	JVM-only submodule(s): ansi
-quantitative	yes	yes	js	
-querencia	yes	yes	js	
-revolution	yes	no	no	JAR manifests (`java.util.jar`)
-rudiments	yes	yes	js	
-savagery	yes	yes	js	
-scintillate	yes	no	no	HTTP server via `telekinesis`/`coaxial` sockets
-sedentary	yes	no	no	benchmarking via JVM-only `superlunary`/`anthology`
-serpentine	yes	yes	js	
-spectacular	yes	yes	js	
-stenography	yes	yes	js	
-stratiform	yes	yes	js	JVM-only submodule(s): binary, http
-superlunary	yes	no	no	backends: core+jvm; JVM runtime staging backend
-surveillance	yes	no	no	file watching (`java.nio.file` WatchService)
-symbolism	yes	yes	js	
-synesthesia	yes	no	no	transitively JVM-only (networking/crypto/fs/process)
-tarantula	yes	no	no	browser automation; depends on JVM-only `hallucination`
-telekinesis	yes	core	wasi	backends: core+jvm+wasi; JVM-only submodule(s): jvm
-turbulence	yes	core	wasi	backends: core+jvm+wasi; JVM-only submodule(s): jvm
-typonym	yes	yes	js	
-ultimatum	yes	yes	js	
-ulysses	yes	no	no	transitively JVM-only (networking/crypto/fs/process)
-umbrageous	yes	no	no	compiler plugin: uses the JVM-only dotty compiler API
-urticose	yes	yes	js	
-vacuous	yes	yes	js	
-vexillology	yes	yes	js	
-vicarious	yes	yes	js	
-wisteria	yes	yes	js	
-xenophile	yes	yes	wasi	backends: core+wasm; JVM-only submodule(s): native
-xylophone	yes	yes	js	
-yossarian	yes	yes	js	
-ypsiloid	yes	yes	js	
-zephyrine	yes	yes	js	
-zeppelin	yes	no	no	zip archives (`java.util.zip`, `galilei`)
-ziggurat	yes	yes	js	
+# jvm   : yes  = runs on the JVM (every module).
+# js    : yes  = cross-compiles to Scala.js.
+#         core = shared `core` cross-compiles, but the module's platform functionality has a
+#                JVM-and/or-WASI-only backend (no Scala.js backend) — e.g. galilei's filesystem.
+#         no   = JVM-only (its `core` sets `scalaJs = false`); see notes for why.
+# native: cross-compilation to Scala Native, read the same way as `js`. `scalaNative` defaults to
+#         `scalaJs`, so this differs only where a module overrides it — typically because it
+#         reads tables from classpath resources, which Scala Native has no analogue for.
+# wasm  : wasi = has a native WebAssembly/WASI backend submodule (src/wasi or src/wasm).
+#         js   = no native backend, but compiles to WebAssembly via the Scala.js -> scala-wasm pipeline (pure code).
+#         core = `core` cross-compiles but the backend is JVM-only (no WASM backend).
+#         no   = JVM-only.
+# notes : platform backends present, JVM-only reason, or JVM-only submodules of an otherwise-JS-capable module.
+module	jvm	js	native	wasm	notes
+abacist	yes	yes	yes	js	
+acyclicity	yes	yes	yes	js	
+adversaria	yes	yes	yes	js	
+ambience	yes	yes	yes	wasi	backends: core+wasi
+anamnesis	yes	yes	yes	js	
+anthology	yes	no	no	no	Scala/Java/Kotlin compilers and the JS, Native, DEX and APK linkers (dotty, `hellenism`)
+anticipation	yes	yes	yes	js	
+aperture	yes	yes	yes	js	
+apoplexy	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
+archimedes	yes	yes	no	js	
+austronesian	yes	yes	yes	js	
+aviation	yes	yes	yes	wasi	backends: core+wasi
+baroque	yes	yes	yes	js	
+beneficence	yes	yes	yes	js	JVM-only submodule(s): plugin
+bitumen	yes	core	core	core	backends: core+jvm; JVM-only submodule(s): jvm
+breviloquence	yes	yes	yes	js	JVM-only submodule(s): staged
+burdock	yes	no	no	no	packaging; depends on JVM-only `zeppelin`/`telekinesis`
+cacophony	yes	no	no	no	audio (`javax.sound.sampled`)
+caduceus	yes	yes	no	js	JVM-only submodule(s): resend
+caesura	yes	yes	yes	js	
+camouflage	yes	yes	yes	js	
+capricious	yes	yes	yes	wasi	backends: core+wasi
+cardinality	yes	yes	yes	js	
+cataclysm	yes	yes	no	js	
+charisma	yes	yes	yes	js	
+chiaroscuro	yes	yes	yes	js	
+coaxial	yes	core	core	wasi	backends: core+jvm+wasi; JVM-only submodule(s): jvm
+contextual	yes	yes	yes	js	
+contingency	yes	yes	yes	js	
+cosmopolite	yes	yes	yes	js	
+decorum	yes	no	no	no	compiler plugin: uses the JVM-only dotty compiler API
+delicious	yes	yes	yes	js	JVM-only submodule(s): ansi, scala
+dendrology	yes	yes	yes	js	
+denominative	yes	yes	yes	js	
+digression	yes	yes	yes	js	
+dissonance	yes	yes	yes	js	
+distillate	yes	yes	yes	js	
+diuretic	yes	no	no	no	`java.*` type interop (io.File, nio.Path, net.URL, time, util.Date)
+embarcadero	yes	core	core	core	backends: oci+oci-jvm; JVM-only submodule(s): containerd
+enigmatic	yes	no	yes	no	`javax.crypto` has no JS analogue; the Native build uses the OpenSSL provider; `asn1` cross-compiles everywhere
+escapade	yes	yes	yes	js	
+escritoire	yes	yes	yes	js	
+ethereal	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
+eucalyptus	yes	yes	yes	js	JVM-only submodule(s): syslog
+exegesis	yes	no	no	no	LSP server; depends on JVM-only `ethereal`/`exoskeleton`
+exoskeleton	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
+facsimile	yes	no	no	no	memory-mapped random-access reads (`galilei.jvm` `Ram`), JCE
+frontier	yes	yes	yes	js	
+fulminate	yes	yes	yes	js	
+galilei	yes	core	core	wasi	backends: core+jvm+wasi; JVM-only submodule(s): jvm
+gastronomy	yes	yes	yes	js	backends: core-jvm+core-native
+geodesy	yes	yes	yes	js	
+gesticulate	yes	yes	yes	js	
+gigantism	yes	yes	yes	js	
+gnossienne	yes	yes	yes	js	
+gossamer	yes	yes	yes	js	
+graffiti	yes	yes	no	js	
+guillotine	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
+hallucination	yes	yes	yes	js	backends: core-jvm+core-native
+harlequin	yes	no	no	no	syntax highlighting via `anthology.scala` (the compiler)
+hellenism	yes	core	no	core	backends: core+jvm; JVM-only submodule(s): jvm
+hieroglyph	yes	yes	yes	js	backends: core-jvm+core-native
+honeycomb	yes	yes	no	js	
+hyperbole	yes	no	no	no	depends on JVM-only `harlequin.ansi`
+hypotenuse	yes	yes	yes	js	
+imperial	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
+inimitable	yes	yes	yes	js	
+iridescence	yes	yes	yes	js	
+jacinta	yes	yes	yes	js	JVM-only submodule(s): http, schema, staged
+kaleidoscope	yes	yes	yes	js	
+larceny	yes	no	no	no	compiler plugin: uses the JVM-only dotty compiler API
+legerdemain	yes	yes	no	js	
+locomotion	yes	yes	yes	js	JVM-only submodule(s): staged
+mandible	yes	no	no	no	depends on JVM-only `hyperbole`
+mercator	yes	yes	yes	js	
+metamorphose	yes	yes	yes	js	
+monotonous	yes	yes	yes	js	
+mosquito	yes	yes	yes	js	
+nomenclature	yes	yes	yes	js	
+obligatory	yes	yes	yes	js	JVM-only submodule(s): grpc, json
+octogenarian	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
+orthodoxy	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
+panopticon	yes	yes	yes	js	
+parasite	yes	core	core	core	backends: core-jvm+core-native; JVM-only submodule(s): jvm
+perihelion	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
+phoenicia	yes	yes	yes	js	
+plutocrat	yes	yes	yes	js	
+pneumatic	yes	yes	yes	js	backends: flate-jvm+flate-native
+polaris	yes	yes	yes	js	
+polysyllabic	yes	yes	yes	js	
+polyvinyl	yes	yes	yes	js	
+prepositional	yes	yes	yes	js	
+prescience	yes	no	no	no	expansion-time instance evaluation via the macro classloader
+probably	yes	yes	yes	js	backends: coverage-jvm+coverage-native
+profanity	yes	yes	yes	js	
+prophesy	yes	yes	yes	js	
+proscenium	yes	yes	yes	js	
+punctuation	yes	yes	no	js	JVM-only submodule(s): ansi
+quantitative	yes	yes	yes	js	
+querencia	yes	yes	no	js	
+revolution	yes	no	no	no	JAR manifests (`java.util.jar`)
+rudiments	yes	yes	yes	js	
+savagery	yes	yes	no	js	
+scintillate	yes	no	no	no	HTTP server via `telekinesis`/`coaxial` sockets
+sedentary	yes	no	no	no	benchmarking via JVM-only `superlunary`/`anthology`
+serpentine	yes	yes	yes	js	
+spectacular	yes	yes	yes	js	
+stenography	yes	yes	yes	js	
+stratiform	yes	yes	yes	js	JVM-only submodule(s): binary, binaryStaged, http, staged
+superlunary	yes	no	no	no	backends: core+jvm; JVM runtime staging backend
+surveillance	yes	no	no	no	file watching (`java.nio.file` WatchService)
+symbolism	yes	yes	yes	js	
+synesthesia	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
+tarantula	yes	no	no	no	browser automation; depends on JVM-only `guillotine`/`telekinesis.jvm`
+telekinesis	yes	core	no	wasi	backends: core+jvm+wasi; JVM-only submodule(s): jvm
+turbulence	yes	yes	yes	wasi	backends: core+wasi
+typonym	yes	yes	yes	js	
+ultimatum	yes	yes	yes	js	
+ulysses	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
+umbrageous	yes	no	no	no	compiler plugin: uses the JVM-only dotty compiler API
+urticose	yes	yes	yes	js	
+vacuous	yes	yes	yes	js	
+vexillology	yes	yes	yes	js	
+vicarious	yes	yes	yes	js	
+wisteria	yes	yes	yes	js	
+xenophile	yes	yes	yes	wasi	backends: core+wasm; JVM-only submodule(s): cffi, kotlin, native, scalanative
+xylophone	yes	yes	yes	js	JVM-only submodule(s): staged
+yossarian	yes	yes	yes	js	
+ypsiloid	yes	yes	yes	js	
+zephyrine	yes	yes	yes	js	
+zeppelin	yes	no	no	no	zip archives (`java.util.zip`, `galilei`)
+ziggurat	yes	yes	yes	js	

--- a/doc/compatibility.tsv
+++ b/doc/compatibility.tsv
@@ -79,7 +79,7 @@ harlequin	yes	no	no	no	syntax highlighting via `anthology.scala` (the compiler)
 hellenism	yes	core	no	core	backends: core+jvm; JVM-only submodule(s): jvm
 hieroglyph	yes	yes	yes	js	backends: core-jvm+core-native
 honeycomb	yes	yes	no	js	
-hyperbole	yes	no	no	no	depends on JVM-only `harlequin.ansi`
+hyperbole	yes	no	no	no	depends on JVM-only `harlequin.ansi`; JVM-only submodule(s): stacks
 hypotenuse	yes	yes	yes	js	
 imperial	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
 inimitable	yes	yes	yes	js	

--- a/doc/modules/annotations.md
+++ b/doc/modules/annotations.md
@@ -82,3 +82,25 @@ case class Record(@name[Json](t"first_name") firstName: Text, @name(t"yob") year
 A format's derivation reads these through the same typeclass — the per-format rename overriding the
 bare default — which is why one annotation serves [JSON](json.md), [XML](xml.md),
 [YAML](yaml.md) and the rest identically.
+
+### Reaching fields by name
+
+Alongside annotations, a case class's fields can be reached by name at runtime, with the mapping
+generated as the code compiles rather than by reflection. A `Dereferenceable` gives the field
+names, one field's value by name, and the whole record as a map:
+
+```scala
+val fields = summon[Employee is Dereferenceable to Any]
+
+fields.names(employee)          // the field names, in declaration order
+fields.select(employee, t"code")
+fields.members(employee)        // name to value
+```
+
+The instance is parameterized by the type the fields yield, so a record whose fields are all
+`Text` dereferences to `Text` rather than to `Any` — which is what makes a generic renderer or a
+template engine able to read a value's fields without casting.
+
+Because the mapping is a compiled table of accessors, reaching a field costs a method call, and a
+name the type does not have is discovered where the table is built rather than by a reflective
+lookup failing at runtime.

--- a/doc/modules/archives.md
+++ b/doc/modules/archives.md
@@ -4,9 +4,10 @@
 
 The two archive formats of everyday computing — [ZIP](https://en.wikipedia.org/wiki/ZIP_(file_format))
 and [tar](https://en.wikipedia.org/wiki/Tar_(computing)) — read and write as typed values. A
-`Zipfile` or a `Tarfile` is a lazy sequence of entries, each with a validated archive-relative path
+`Zipfile` or a `Tarfile` is a stream of entries, each with a validated archive-relative path
 and streamed content, so an archive of any size is read entry by entry and written without
-assembling it in memory. Tar entries carry the Unix metadata the format exists to preserve — modes,
+assembling it in memory: a ZIP entry inflates as it is read, and a tar entry parses straight off
+the underlying source. Tar entries carry the Unix metadata the format exists to preserve — modes,
 owners, modification times — as typed values.
 
 ### On archives
@@ -29,14 +30,14 @@ import charEncoders.utf8Encoder
 
 ### ZIP
 
-A ZIP archive reads from a path or from bytes, its entries a lazy list; an entry is looked up by
+A ZIP archive reads from a path or from bytes, its entries a stream; an entry is looked up by
 its path, and its content reads as any type:
 
 ```scala
 val zipfile = Zipfile.read(path)
-zipfile.entries.map(_.ref.encode)   // the entry names
+zipfile.entries.to(List).map(_.ref.encode)   // the entry names
 
-zipfile.entry(t"readme.txt".decode[Path on Zip]).read[Text]
+zipfile.entry(t"readme.txt".as[Path on Zip]).read[Text]
 ```
 
 Writing takes entries — each a path and a content source — and either writes to a path or
@@ -44,8 +45,26 @@ serializes as a byte stream. Compression is a policy in scope, deflating by defa
 where deflation would not help:
 
 ```scala
-val entry = Zip.Entry(t"hello.txt".decode[Path on Zip], t"Hello world".data)
+val entry = Zip.Entry(t"hello.txt".as[Path on Zip], t"Hello world".in[Data])
 Zipfile.write(path)(List(entry))
+```
+
+An archive can also be *opened*, which makes its entries available for the duration of a scope
+and closes the underlying source at the end of it, in the same way as a
+[file](filesystem.md#reading-and-writing):
+
+```scala
+archive.open[Zip]():
+  zip.entries.length
+```
+
+A JAR is a ZIP with a manifest, so opening one as `Jar` gives the same handle refined with the
+main attributes parsed from `META-INF/MANIFEST.MF`, continuation lines rejoined as the
+specification requires. An archive without a manifest simply has no attributes:
+
+```scala
+jarfile.open[Jar]():
+  zip.manifest   // Map(t"Manifest-Version" -> t"1.0", t"Main-Class" -> …)
 ```
 
 ### Tar
@@ -55,25 +74,45 @@ Unix metadata spelled out:
 
 ```scala
 val script = Tar.Entry.File
-  ( path  = t"bin/run".decode[Relative on Tar],
+  ( path  = t"bin/run".as[Relative on Tar],
     mode  = UnixMode(ownerExec = true, groupExec = true, otherExec = true),
     user  = UnixUser(1000, t"alice"),
     group = UnixGroup(1000, t"alice"),
     mtime = timestamp,
-    data  = Stream(scriptText.data) )
+    data  = TarBody(scriptText.in[Data]) )
 ```
 
 A `Tarfile` of entries streams as tar blocks, or as the compressed forms the format usually
 travels in:
 
 ```scala
-val tarball = Tarfile(Stream(script))
-tarball.gzip    // a .tar.gz byte stream
+val tarball = Tarfile(List(script))
+tarball.gzip      // a .tar.gz byte stream
+tarball.zlib
+tarball.deflate
 ```
 
-Reading runs the other way — `Tarfile.read` for raw blocks, `Tarfile.fromGzip` for compressed —
-and a whole directory tree archives with `Tarfile.from(directory)` and unpacks with
-`extractTo`, connecting archives to the [filesystem](filesystem.md):
+Reading runs the other way. `Tarfile.read` parses entries lazily straight off a byte stream —
+one consumed entry advances the source past it, so an archive is never materialized — and a
+compressed archive is simply a decompressed stream read the same way:
+
+```scala
+Tarfile.read(source)
+Tarfile.read(source.decompress[Gzip])
+```
+
+Reading an archive this way is single-pass and single-owner: consume the entries in order, on
+one thread. An entry passed over remains readable, because its body memoizes when the iterator
+advances, but the sequence itself is not replayable. Opening the archive as `Tar` scopes the
+underlying source in the same way as a ZIP archive, and takes the compression as a flag:
+
+```scala
+archive.open[Tar](TarFlag.Gzip): tar ?=>
+  tar.entries.map(_.entryName).to(List)
+```
+
+A whole directory tree archives with `Tarfile.from(directory)` and unpacks with `extractTo`,
+connecting archives to the [filesystem](filesystem.md):
 
 ```scala
 Tarfile.from(sourceDirectory).gzip

--- a/doc/modules/audio.md
+++ b/doc/modules/audio.md
@@ -116,3 +116,21 @@ playback.await()
 
 Playing to an outlet that is unavailable or cannot accept the audio's configuration raises
 an `OutletError`.
+
+### Scoped lines
+
+`record` and `play` suit open-ended use, where the device is held for as long as the program
+wants it. Where the device should be held for exactly one block, a line is *opened* instead, as
+[a file is](filesystem.md): the audio line lasts precisely as long as the scope, and the layout
+and configuration are given as the form and its flags.
+
+```scala
+feed.open[Pcm across Stereo](Read, PcmFlag.Rate(48000), PcmFlag.Chunk(1024)): input ?=>
+  input.stream.head
+
+outlet.open[Pcm](Write): out ?=>
+  out.play(audio)
+```
+
+Playing requires the `Write` grant, so a line opened for capture cannot be played to, and the
+compiler — not the audio driver — says so.

--- a/doc/modules/base-encoding.md
+++ b/doc/modules/base-encoding.md
@@ -34,7 +34,7 @@ in scope:
 ```scala
 import alphabets.base64Standard
 
-val bytes = t"Hello".data
+val bytes = t"Hello".in[Data]
 bytes.serialize[Base64]   // t"SGVsbG8="
 ```
 

--- a/doc/modules/base-encoding.md
+++ b/doc/modules/base-encoding.md
@@ -77,3 +77,18 @@ import alphabets.hexLowerCase
 
 bytes.serialize[Hex]   // t"48656c6c6f"
 ```
+
+### Encoding a stream
+
+An alphabet is also a [stream](streams.md) stage, so bytes are encoded as they flow rather than
+gathered first — which is what a base-encoded body written to a socket, or a large file armoured
+for transport, requires:
+
+```scala
+payload.stream.via(summon[Alphabet[Hex]])
+```
+
+The streaming and whole-value forms agree byte for byte, including at the boundaries where a
+base-64 group of three bytes or a base-32 group of five straddles two chunks. Decoding runs the
+same way, so a stream may be encoded on one side and decoded on the other with neither side
+holding the whole of it.

--- a/doc/modules/binary-data.md
+++ b/doc/modules/binary-data.md
@@ -60,6 +60,36 @@ data.buffer:
 
 `Debufferable` is the reading side — the sixteen sized numeric types have instances, and a case
 class derives its own from its fields — and `Bufferable` is the writing side, with the same
-derivation. A format whose fields need more than fixed-width reads — a length-prefixed string, say —
-defines its own instance, stating its width and its interpretation, and composes into derived
-records like any primitive.
+derivation. `Unpackable` sits above both, and is what `unpack` resolves: it covers a single
+`Debufferable` value and, separately, an `IArray` of them, which is how a count-prefixed section
+reads as one call rather than a loop.
+
+An instance states two things: `width`, the number of bytes the value occupies, and how to read
+those bytes from — or write them to — a `Buffer`. Both are visible to derivation, so a record's
+total width is the sum of its fields' and every offset within it is computed at compiletime.
+
+```scala
+trait Debufferable:
+  def width: Int
+  def debuffer(buffer: Buffer): Self
+```
+
+A format whose fields need more than fixed-width reads — a length-prefixed string, say — defines
+its own instance, and composes into derived records like any primitive. The sized types also fix
+the *interpretation*, not merely the width: `B32` is four raw bytes, `U32` reads them as an
+unsigned integer, `S32` as a signed one, and the plain Scala `Int`, `Short`, `Long` and `Byte`
+have instances too, for layouts that are easier to state in them.
+
+`Bufferable` is the symmetric writing-side typeclass, deriving over products in the same way, so a
+layout is declared once and serves both directions.
+
+### The buffer is a capability
+
+A `Buffer` carries a mutable read position, which makes unpacking an effect rather than a pure
+read, and the position is what makes successive `unpack` calls advance. It is therefore introduced
+by the `buffer { … }` block that scopes it, and is an *exclusive* capability: two readers sharing
+one position would each consume bytes the other expected, so the compiler prevents a buffer from
+being aliased or from escaping its block.
+
+`offset` reports the current position, for a format that must state where a section begins, and
+`advance` skips past padding or a field this reader does not need.

--- a/doc/modules/bloom-filters.md
+++ b/doc/modules/bloom-filters.md
@@ -57,3 +57,32 @@ fuller.hits(t"goodbye")   // false, almost certainly
 
 The asymmetry is the contract: a Bloom filter suits exactly those places where a false *yes* costs
 a redundant check, and a false *no* would be a bug.
+
+### Choosing the parameters
+
+The two numbers given at construction are the expected number of elements and the tolerable
+false-positive rate, and from them the bit-array size and the number of hash functions follow by
+the standard formulae. Stating the intent rather than the parameters means the two cannot
+disagree — a filter sized for a hundred elements at one in a thousand is exactly that.
+
+The consequence of getting the *expected size* wrong is worth knowing: a filter given far more
+elements than it was built for degrades gracefully in the sense that it keeps working, but its
+false-positive rate rises above the one requested. It is a promise about a filter used as
+intended, not a guarantee that holds however it is filled.
+
+### Where the bits come from
+
+The hash algorithm is part of the filter's type, and the bit positions are derived from a single
+digest, extended by rehashing where more bits are needed than one digest provides. That means the
+algorithm in scope decides the filter's behaviour, and two filters over the same elements agree
+only if they agree on the algorithm.
+
+Because elements enter through the ordinary [hashing](hashing.md) machinery, a case class is
+usable as an element with no preparation, and a filter over a structured key needs no
+serialization step written for it.
+
+### Immutability
+
+`+` and `++` return new filters rather than mutating in place, so a filter is safe to share across
+threads and to hold in a data structure. Building one from a large collection with `++` is a
+single pass, rather than the sequence of copies that repeated `+` would suggest.

--- a/doc/modules/caching.md
+++ b/doc/modules/caching.md
@@ -39,6 +39,18 @@ cache(1)(expensiveLookup(1))   // returns the stored value; no computation
 Using an entry — reading or writing — marks it as recent, so the entries that survive are the ones
 the program keeps coming back to.
 
+`contains` asks whether a key is held without computing anything and without marking it recent,
+and `remove` drops an entry — which is what an invalidation needs when the underlying data has
+changed and the cached value is known to be stale:
+
+```scala
+cache.contains(1)   // is it cached?
+cache.remove(1)     // forget it
+```
+
+The computation is passed by name, so nothing is evaluated on a hit. That is the whole point of
+the shape: a cache whose value must be computed before it can be offered saves nothing.
+
 ### An expiring value
 
 A `Cache` memoizes one value, with a lifetime after which it is recomputed. `establish` returns the

--- a/doc/modules/cbor.md
+++ b/doc/modules/cbor.md
@@ -56,10 +56,15 @@ A type with a `Cbor.Parsable` instance is read straight from the bytes, with no 
 built. The instance is derived at compiletime, composing a parser for that exact shape:
 
 ```scala
+import breviloquence.Inlinable
+
 given (Person is Cbor.Parsable) = Inlinable.parsable[Person]
 
 data.read[Person in Cbor]
 ```
+
+The derivation composes the parser at expansion time, so it lives in a separate module from the
+runtime codecs and is imported by name.
 
 Reading also works over a [stream](streams.md) whose chunk boundaries fall anywhere: a value split
 across two chunks reads exactly as one that arrives whole, so a message need not be assembled

--- a/doc/modules/cbor.md
+++ b/doc/modules/cbor.md
@@ -27,13 +27,13 @@ import strategies.throwUnsafely
 
 ### Encoding and decoding
 
-A value encodes with `cbor`, and CBOR data decodes to a type with `as` — or in one step, reading
+A value encodes with `in[Cbor]`, and CBOR data decodes to a type with `as` — or in one step, reading
 bytes straight to the type:
 
 ```scala
 case class Person(name: Text, age: Int)
 
-val encoded = Person(t"Ada", 36).cbor       // a Cbor value
+val encoded = Person(t"Ada", 36).in[Cbor]       // a Cbor value
 encoded.as[Person]                          // Person(t"Ada", 36)
 
 stream.read[Person in Cbor]                 // bytes to Person directly
@@ -54,7 +54,7 @@ including removal, by assigning `Unset` — produce new values:
 ```scala
 import dynamicCborAccess.enabled
 
-val person = Person(t"Ada", 36).cbor
+val person = Person(t"Ada", 36).in[Cbor]
 person.name.as[Text]                 // t"Ada"
 (person.age = 40).as[Person]         // Person(t"Ada", 40)
 ```
@@ -67,7 +67,7 @@ as for the textual formats.
 A CBOR map is assembled from named arguments where no case class fits:
 
 ```scala
-Cbor.make(name = t"Anna".cbor, age = 30.cbor)
+Cbor.make(name = t"Anna".in[Cbor], age = 30.in[Cbor])
 ```
 
 ### Errors

--- a/doc/modules/cbor.md
+++ b/doc/modules/cbor.md
@@ -46,6 +46,49 @@ discriminator declared once:
 given (Status is Discriminable in Cbor) = Cbor.discriminatedUnion(t"kind")
 ```
 
+An `Optional` field is omitted from the map when it is unset and supplied as `Unset` when the map
+lacks it, and a field with a default takes that default — so a message may gain fields without
+breaking readers that predate them.
+
+### Parsing directly, and from a stream
+
+A type with a `Cbor.Parsable` instance is read straight from the bytes, with no intermediate tree
+built. The instance is derived at compiletime, composing a parser for that exact shape:
+
+```scala
+given (Person is Cbor.Parsable) = Inlinable.parsable[Person]
+
+data.read[Person in Cbor]
+```
+
+Reading also works over a [stream](streams.md) whose chunk boundaries fall anywhere: a value split
+across two chunks reads exactly as one that arrives whole, so a message need not be assembled
+before it is decoded.
+
+### Tags
+
+CBOR's tags annotate a value with its meaning — tag 1 is an epoch time, tag 2 a big integer, and
+the registry runs to hundreds. A tagged value keeps both its tag and the value inside it, so a
+document carrying tags round-trips without losing them:
+
+```scala
+val ast = Cbor.unseal(document)
+ast.isTag && ast.tag.tag == 1L
+```
+
+### Diagnostic notation
+
+RFC 8949 defines a human-readable rendering for CBOR — the format's counterpart of a hex dump that
+can actually be read — and `show` produces it. Byte strings render as `h'…'`, arrays and maps as
+their JSON-like equivalents:
+
+```scala
+Cbor.Ast.parse(bytes).show   // t"[1, 2, 3]", or t"h'01020304'"
+```
+
+This is what to reach for when a message is not what it should be: the notation says what the
+bytes mean, in the format's own vocabulary.
+
 ### Navigating and updating
 
 With dynamic access enabled, a map's fields read as members, an array indexes, and updates —
@@ -75,3 +118,21 @@ Cbor.make(name = t"Anna".in[Cbor], age = 30.in[Cbor])
 A malformed document or a failed conversion raises a `CborError` whose reason is specific —
 truncated input, an integer overflow, a wrong type, an absent field — so a protocol failure is
 diagnosed from the error rather than from a hex dump.
+
+Parse failures carry the byte offset at which they occurred, which for a binary format is the
+whole of the diagnosis: input that stops mid-value names the offset of the byte that should have
+followed, trailing bytes name where the surplus begins, and a reserved head byte names both its
+offset and its value.
+
+```scala
+capture[CborError](Cbor.Ast.parse(data)).reason match
+  case CborError.Reason.Truncated(offset) => offset
+  case CborError.Reason.Trailing(offset)  => offset
+  case _                                  => -1L
+```
+
+### CBOR over HTTP
+
+A `Cbor` value serves as a request or response body with the `application/cbor` media type, and a
+body parses back on arrival, so a binary API is consumed and offered with the same code as a JSON
+one — only the format's type differs.

--- a/doc/modules/characters.md
+++ b/doc/modules/characters.md
@@ -40,7 +40,7 @@ import charEncoders.utf8Encoder
 import charDecoders.utf8Decoder
 import textSanitizers.strictSanitizer
 
-val bytes = t"café".data   // UTF-8 bytes
+val bytes = t"café".in[Data]   // UTF-8 bytes
 bytes.utf8                 // t"café"
 ```
 

--- a/doc/modules/characters.md
+++ b/doc/modules/characters.md
@@ -82,6 +82,39 @@ Which behaviour is right depends on the data: strictness for input that should b
 absolutely, tolerance for text recovered from a lossy source. The choice is visible at the
 import.
 
+A fourth choice keeps both: `accrueSanitizer` carries on decoding, as the skipping one does, but
+records each fault so that the whole of a damaged input is recovered *and* every bad sequence is
+reported, each with the position at which it occurred:
+
+```scala
+validate[CharDecoder.Focus](DecodeIssues()):
+  case error: CharDecodeError => accrual + (prior.let(_.position).or(0), error)
+. protect:
+    import textSanitizers.accrueSanitizer
+    charDecoders.utf8Decoder.decoded(data)
+```
+
+This is what a tool importing a file of uncertain provenance wants: the text, plus a list of
+where it was wrong, rather than a choice between the two.
+
+### Encodings
+
+`charEncoders` and `charDecoders` provide the encodings a program is likely to need — `utf8`,
+`utf16` with its explicit little- and big-endian forms, `ascii` and `iso88591` — each as a named
+given, so the encoding a piece of code uses is stated at its import rather than defaulted from the
+platform. An encoding named at runtime is looked up with the `enc"…"` interpolator, which checks
+the name as the code compiles:
+
+```scala
+import charEncoders.utf8Encoder
+
+enc"UTF-8".encoder
+```
+
+Encoding to bytes and decoding back also work as [stream](streams.md) stages, and a multi-byte
+character split across two chunks is carried over the boundary rather than corrupted — including
+a surrogate pair split between chunks, which is where naive implementations lose a character.
+
 ### Character widths
 
 A character's width in a monospaced display is not always one column. The `metrics` extension

--- a/doc/modules/chemistry.md
+++ b/doc/modules/chemistry.md
@@ -69,4 +69,28 @@ An equation knows whether its two sides contain the same atoms:
 ```
 
 Since each side is a typed multiset of atoms rather than text, balance is a real check, computed
-from the structure.
+from the structure. `atoms` gives that multiset for either side, so a formula reports its own
+composition — the element counts across every molecule and coefficient it contains — which is what
+computing a molar mass or checking a proposed reaction needs.
+
+### The reaction arrows
+
+Five arrows are available, and they mean different things rather than being stylistic variants:
+`-->` for a net forward reaction, `<->` for a reversible one, `<=>` for a reaction proceeding in
+both directions, `<~>` for one at equilibrium, and `===` for a statement of equality between two
+formulas. Which arrow a chemist writes carries information, and the equation keeps it.
+
+### Charge and state
+
+An ion carries its charge as part of the molecule, so a charged species is a distinct value from
+its neutral counterpart and the two cannot be confused when balancing. Physical state is
+annotation rather than identity — it affects how a species renders, not what it is — so
+`H₂O(aq)` and `H₂O(l)` describe the same substance in different conditions.
+
+### Building blocks
+
+`Molecular` and `Formulable` are the two typeclasses the operators are defined over: anything
+molecular can be bonded with `*` and multiplied by a coefficient, and anything formulable can be
+added with `+` and joined into an equation. An element is molecular, a molecule is molecular, and
+both are formulable, which is why an element, a molecule and a full formula can all appear on
+either side of an equation without conversion.

--- a/doc/modules/classpath.md
+++ b/doc/modules/classpath.md
@@ -49,7 +49,7 @@ handle passed by hand; the `given Classloader` supplies the context. A resource 
 equally be built from text at runtime by decoding it:
 
 ```scala
-t"/scala/Option.class".decode[Path on Classpath]
+t"/scala/Option.class".as[Path on Classpath]
 ```
 
 A classpath path is _substantiable_, meaning its existence can be tested before it is read,
@@ -71,7 +71,7 @@ A `LocalClasspath` is the classpath as a list of entries. The running program's 
 the value of the `java.class.path` property, which decodes to one:
 
 ```scala
-val classpath = System.properties.java.`class`.path().decode[LocalClasspath]
+val classpath = System.properties.java.`class`.path().as[LocalClasspath]
 ```
 
 Its `entries` are typed: a `ClasspathEntry` is a `Directory`, a `Jar`, a `Url`, or the

--- a/doc/modules/colors.md
+++ b/doc/modules/colors.md
@@ -58,8 +58,8 @@ value in any of them is a `Color`.
 The `in` method converts a color to another model:
 
 ```scala
-val lab = red.in[Cielab]
-val back = lab.in[Srgb]      // the original red, within rounding
+val lab = red.to[Cielab]
+val back = lab.to[Srgb]      // the original red, within rounding
 ```
 
 Conversions compose, so a color reaches any model from any other, passing through the
@@ -85,7 +85,7 @@ Two colors mix into one, by default halfway between them, or in any ratio:
 
 ```scala
 Srgb(0.2, 0.4, 0.6).mix(Srgb(0.8, 0.6, 0.4))        // Srgb(0.5, 0.5, 0.5)
-WebColors.Ivory.in[Cielab].mix(WebColors.DeepPink.in[Cielab])
+WebColors.Ivory.to[Cielab].mix(WebColors.DeepPink.to[Cielab])
 ```
 
 Mixing in sRGB blends the screen values; mixing in CIELAB blends what the eye perceives,
@@ -97,11 +97,11 @@ Hue, saturation and lightness are what a person reaches for to adjust a color, s
 operations live on `Hsl` and `Hsv`. Convert into one, adjust, and convert back:
 
 ```scala
-val tomato = WebColors.Tomato.in[Hsl]
+val tomato = WebColors.Tomato.to[Hsl]
 
-tomato.rotate(180).in[Srgb]     // the complementary color
-tomato.lighten(0.2).in[Srgb]    // a fifth of the way toward white
-tomato.desaturate.in[Srgb]      // the same lightness, no color
+tomato.rotate(180).to[Srgb]     // the complementary color
+tomato.lighten(0.2).to[Srgb]    // a fifth of the way toward white
+tomato.desaturate.to[Srgb]      // the same lightness, no color
 ```
 
 `rotate` turns the hue by a number of degrees, `complement` turns it halfway round,
@@ -115,7 +115,7 @@ CIELAB exists so that the distance between two colors matches how different they
 `delta` gives that distance:
 
 ```scala
-WebColors.DeepPink.in[Cielab].delta(WebColors.Tomato.in[Cielab])
+WebColors.DeepPink.to[Cielab].delta(WebColors.Tomato.to[Cielab])
 ```
 
 A small delta means two colors are hard to tell apart; a large one means they contrast.
@@ -146,5 +146,5 @@ conversion within its scope uses it, and none has to name it:
 ```scala
 given Colorimetry = colorimetry.incandescentTungsten
 
-WebColors.Ivory.in[Cielab]   // computed for tungsten light
+WebColors.Ivory.to[Cielab]   // computed for tungsten light
 ```

--- a/doc/modules/colors.md
+++ b/doc/modules/colors.md
@@ -148,3 +148,27 @@ given Colorimetry = colorimetry.incandescentTungsten
 
 WebColors.Ivory.to[Cielab]   // computed for tungsten light
 ```
+
+### Pixel layouts
+
+A colour on screen is not usually a triple of doubles but a packed integer, and how it is packed
+varies: eight bits per channel with or without alpha, five-six-five for a 16-bit display, ten bits
+per channel for high dynamic range, a single channel for greyscale. A *layout* states that packing
+as a tuple of channel types, most significant first, and the compiler works out the rest:
+
+```scala
+type Rgb565 = (Red[5], Green[6], Blue[5])
+
+compiletime.constValue[Channel.TotalBits[Rgb]]      // 24
+summon[Channel.Storage[Rgb565] =:= Short]           // the narrowest type that fits
+summon[Channel.Storage[Tuple1[Grey[8]]] =:= Byte]
+```
+
+Each channel's shift and mask follow from its position in the tuple, computed as the code
+compiles, so reading a channel from a packed pixel is a single shift-and-mask instruction with no
+runtime dispatch. A `Pixel[layout]` is an unboxed integer carrying the packed value, and converts
+to and from `Chroma`, `Srgb` and `Cmyk` exactly where its layout supports it — a layout with no
+alpha channel has no alpha to read.
+
+This is what [images](images.md) use to give a raster typed pixel access, and it is where a
+colour computed in one of the perceptual spaces above ends up when it reaches a screen.

--- a/doc/modules/compiler.md
+++ b/doc/modules/compiler.md
@@ -115,6 +115,8 @@ import dexLinkages.given
 
 ### Other languages
 
-`Javac` compiles Java sources through the same shape of API, and `Kotlinc` does the same for
-Kotlin — so a tool that orchestrates compilation does not change idiom per language, and a mixed
-Scala/Kotlin/Java application links into one artifact.
+`Javac` compiles Java sources through the same shape of API, so a tool that orchestrates
+compilation does not change idiom per language, and a mixed Scala and Java application links into
+one artifact. Calling *into* a compiled Kotlin library needs no compilation at all: its
+declarations are read from its classfiles, as [foreign interoperability](foreign-interop.md)
+describes.

--- a/doc/modules/compiler.md
+++ b/doc/modules/compiler.md
@@ -9,6 +9,11 @@ output. This is the machinery beneath Soundness's own [staged execution](staging
 compiletime [benchmarks](../standards/benchmarking.md), and it serves any tool that compiles Scala
 on a user's behalf.
 
+Compilation is only half the job. The output is then *linked* into an artifact — an executable
+JAR, JavaScript, a WebAssembly component, a native binary, an Android package — and both the
+intermediate representation a compilation emits and the artifact a linker produces are types, so
+a mismatch between them is a compile error in the tool rather than a failure at link time.
+
 ### On driving the compiler
 
 The compiler's command line is stringly typed twice over: options are strings whose validity
@@ -57,7 +62,59 @@ Each `Notice` carries its importance — info, warning or error — its file and
 can underline the offending code rather than echo compiler output. A crash arrives as a value too,
 with its [stack trace](stack-traces.md), and the process can be aborted mid-compilation.
 
+### Semantic diagnostics
+
+A compiler error message is usually a sentence with types spliced into it, and by the time it
+reaches a tool those types are just words. Asked for semantic diagnostics, the compiler instead
+marks each interpolated argument in band, carrying pickled TASTy for the types among them, and a
+`Notice` keeps that marked-up form alongside the plain one.
+
+The markup parses into a `SemanticMessage`: a typed tree of styled spans, placeholders and types.
+Each type is unpickled from its TASTy and re-rendered through the same type-rendering machinery
+used elsewhere, so a type reads the way it would in the code, abbreviated against what is
+imported. A "found `A`, required `B`" message
+therefore arrives as two types to render, link and compare, rather than as a string to
+re-parse.
+
+### Universes
+
+A compilation emits one intermediate representation, and that choice decides which library
+artifacts it can link against. `Universe.Classfile` is JVM classfiles, `Universe.Sjsir` is
+Scala.js IR, and `Universe.Nir` is Scala Native IR. The universe is a type parameter of the
+`Compilation`, so a Scala.js compilation is not interchangeable with a native one, and the
+compiler flags each universe needs — `-scalajs`, or the Scala Native plugin — follow from it
+rather than being supplied by hand.
+
+### Linking artifacts
+
+A `Linker` is parameterized by the artifact it produces, and each artifact is producible from
+exactly one universe. Linking takes a compilation and an output location, and returns the path of
+what it built:
+
+```scala
+Linker[Artifact.Jar](List(jarOptions.name(t"app.jar")), List(Linker.EntryPoint(Fqcn(t"Main"))))
+. link(Compilation(output, classpath), destination)
+```
+
+From classfiles come an executable `Jar`, a `Dex` archive of Dalvik bytecode, and a complete,
+signed and aligned Android `Apk`. From Scala.js IR come `Js` — as an ECMAScript module, a CommonJS
+module or a plain script, the module system being part of the artifact's type — a `Wasm` module
+with JavaScript glue, and a standalone `Wasi` component at a stated interface version. From Scala
+Native IR comes a `Binary`, whose platform and architecture are chosen at link time as a triple.
+Every universe additionally produces a `Library`, packaging unlinked output for downstream
+assembly.
+
+The typing is not decorative. A native linker option applied to a JavaScript linker does not
+compile; an executable JAR with two entry points is rejected; and the linkages that need extra
+tooling — DEX, APK, WASI — arrive only with an explicit import of the module that provides them,
+so a build that cannot link a target says so where the code is written:
+
+```scala
+import dexLinkages.given
+```
+
 ### Other languages
 
-`Javac` compiles Java sources through the same shape of API, and a Kotlin counterpart exists for
-mixed builds — so a tool that orchestrates compilation does not change idiom per language.
+`Javac` compiles Java sources through the same shape of API, and `Kotlinc` does the same for
+Kotlin — so a tool that orchestrates compilation does not change idiom per language, and a mixed
+Scala/Kotlin/Java application links into one artifact.

--- a/doc/modules/compression.md
+++ b/doc/modules/compression.md
@@ -71,8 +71,8 @@ framing, standing to `Xz` as `Deflate` stands to `Gzip`. Both default to preset 
 3 favour speed and 4 to 9 favour ratio, and an explicit preset is selected with
 `Xz.compress(stream, preset)` or `Xz.compressor(preset)`.
 
-`Lzw` is the compression of TIFF and PDF streams. The JDK offers no implementation, so this one
-is native and available everywhere. Its `earlyChange` parameter — both sides widening their
+`Lzw` is the compression of TIFF and PDF streams. The JDK offers no implementation of it at all,
+so this one is written from the specification. Its `earlyChange` parameter — both sides widening their
 codes one table entry sooner — is on by default, which is what TIFF, PDF and every known encoder
 produce; the parameterized `Lzw.compressor` and `Lzw.decompressor` serve formats that state it
 explicitly.

--- a/doc/modules/compression.md
+++ b/doc/modules/compression.md
@@ -1,0 +1,86 @@
+## Compression
+
+### About
+
+The formats that carry the world's bytes — [DEFLATE](https://en.wikipedia.org/wiki/Deflate) and
+its `gzip` and `zlib` wrappers, [Brotli](https://en.wikipedia.org/wiki/Brotli),
+[XZ](https://en.wikipedia.org/wiki/XZ_Utils) and raw LZMA2, and
+[LZW](https://en.wikipedia.org/wiki/Lempel–Ziv–Welch) — compress and decompress data through one
+pair of methods. The format is a type, and `compress` and `decompress` serve every one of them,
+over a whole value or as a stage in a [streaming](streams.md) pipeline.
+
+Every format is implemented in pure Scala, so it works on every platform Soundness targets. On
+the JVM, DEFLATE and its wrappers are additionally served by the platform's native zlib, chosen
+when the code is built rather than at each call site, so the JVM pays nothing for the
+portability.
+
+### On compression
+
+Compression libraries usually present as codecs to be constructed, fed and finished: an object
+with a buffer, a `setInput`, a `deflate`, a `finish`, and an easily-mistaken loop around them.
+The format is a string or an integer, the framing is a flag, and whether a given call has
+produced everything it will produce is a question the caller has to answer.
+
+Here the format is a type — `Gzip`, `Brotli`, `Xz` — and the operation is a method on the data.
+Because the same instance describes both the whole-value and the streaming form, the two agree
+byte for byte, and a value compressed one way decompresses the other. Everything comes from the
+`soundness` package:
+
+```scala
+import soundness.*
+```
+
+### Compressing a value
+
+A block of bytes compresses and decompresses by naming the format:
+
+```scala
+val payload = t"the quick brown fox".in[Data]
+
+val compressed = payload.compress[Gzip]
+compressed.decompress[Gzip]   // the original bytes
+```
+
+### Compressing a stream
+
+The same names attach to a stream, where they become pipeline stages: the data is transformed as
+it flows, and nothing larger than the pipeline's buffers is held:
+
+```scala
+file.stream.compress[Gzip].writeTo(destination)
+archive.stream.decompress[Gzip].read[Text]
+```
+
+Whole-value and streaming forms interoperate freely: a value compressed as a whole decompresses
+through a stream, and a stream's output decompresses as a value.
+
+### The formats
+
+`Deflate` is the raw algorithm; `Zlib` adds its two-byte header and checksum; `Gzip` adds the
+header, timestamp and CRC that `.gz` files carry. These are the formats of HTTP content
+encoding, ZIP entries and PNG chunks, and they are the fastest of the set.
+
+`Brotli` compresses smaller than DEFLATE at comparable speed, and is the modern web's content
+encoding. Both directions need the whole value before producing output — the decoder because
+backward references may reach across the entire window, the encoder because it chooses its
+framing from the total length — so a Brotli stage buffers where a DEFLATE stage does not.
+
+`Xz` is the high-ratio codec: LZMA2 inside the `.xz` container, with a CRC-64 check, matching
+what the `xz` command-line tool produces. `Lzma2` is the same codec without the container
+framing, standing to `Xz` as `Deflate` stands to `Gzip`. Both default to preset 6; presets 0 to
+3 favour speed and 4 to 9 favour ratio, and an explicit preset is selected with
+`Xz.compress(stream, preset)` or `Xz.compressor(preset)`.
+
+`Lzw` is the compression of TIFF and PDF streams. The JDK offers no implementation, so this one
+is native and available everywhere. Its `earlyChange` parameter — both sides widening their
+codes one table entry sooner — is on by default, which is what TIFF, PDF and every known encoder
+produce; the parameterized `Lzw.compressor` and `Lzw.decompressor` serve formats that state it
+explicitly.
+
+### Where compression appears
+
+Compression is rarely used alone. It is how [archives](archives.md) store their entries and how
+tar archives travel; how [HTTP](http-client.md) bodies are encoded on the wire; how
+[container](docker.md) image layers are addressed; and how [PDF](pdf.md) content streams are
+stored. In each case the format is the same type named here, so a layer, an entry or a body
+decompresses with the operation described above.

--- a/doc/modules/concurrency.md
+++ b/doc/modules/concurrency.md
@@ -63,6 +63,22 @@ supervise:
   async(3).bind(n => async(n + 4)).await()             // 7
 ```
 
+`sequence` runs its tasks in parallel and collects the results *in order*, so the ordering of the
+results says nothing about the order in which they finished. `race` returns the first to finish
+and the rest are cancelled, since their results were not wanted.
+
+### Naming tasks
+
+A task may be given a name, checked as the code compiles against the rules for a task name — no
+path separators, since names compose into a hierarchy mirroring the scope tree:
+
+```scala
+val name: Name[Async] = n"worker"
+```
+
+Named tasks make a running program legible: a stack trace, a monitor dump or a debugger shows
+`server/connection-4/reader` rather than an anonymous thread number.
+
 ### Cancellation
 
 A task is cancelled with `cancel`, and a cancellable task cooperates by pausing at points where it
@@ -93,6 +109,23 @@ supervise:
 
 A `daemon` is fire-and-forget work — a background loop, a listener — that the scope does not wait for
 and cancels when it ends. It runs for the life of its scope and no longer.
+
+A daemon's body is *hygienic*: it cannot capture an error handler from the code that spawned it.
+That is deliberate. The spawning code has already moved on, so a handler there is not in any
+meaningful sense enclosing the daemon, and delivering an error to it would mean resuming a
+computation that has finished. A daemon that fails therefore escalates as a `Fault`, which a
+program intercepts where it handles the unexpected, rather than silently reaching a handler that
+was never intended for it.
+
+### Cancellation in both directions
+
+Cancelling a scope cancels its children, and the *probate* decides what happens to a child that is
+still running when its parent's body completes. Under `cancelProbate` the child is cancelled;
+under `awaitProbate` the parent waits for it.
+
+Cancellation also runs upward: a task that fails propagates its failure to the scope that owns it,
+which cancels the scope's other children. Work that has become pointless therefore stops, rather
+than continuing to consume resources on behalf of a computation that has already failed.
 
 ### Threads and completion
 

--- a/doc/modules/concurrency.md
+++ b/doc/modules/concurrency.md
@@ -101,3 +101,16 @@ to spawn in great numbers, while `platformThreading` uses platform threads. A se
 *probate*, decides what a scope does with a child that has not finished when the scope ends —
 `cancelProbate` cancels it, `awaitProbate` waits for it — so the policy for tidying up concurrent work
 is explicit rather than assumed.
+
+### Suspension as an effect
+
+Waiting is not free, and it is not invisible. Awaiting a task or a promise, sleeping, and yielding
+all *suspend* the running strand, and each demands a `Monitor` capability in scope. A method that
+can block therefore says so in its signature, exactly as a method that can fail says so with
+`raises`.
+
+Underneath, the unit of execution is a `Strand` rather than a thread: an abstraction with the four
+operations suspension needs — interrupt, join, park and unpark. A supervisor supplies strands, and
+a supervisor is a value, so a scheduler that is not built on threads at all — an event loop over
+WebAssembly's waitable sets, for instance — plugs in as a supervisor without any change to the
+code that spawns and awaits.

--- a/doc/modules/cryptography.md
+++ b/doc/modules/cryptography.md
@@ -9,8 +9,10 @@ do not permit, such as a stream mode with a padding, does not compile; and the w
 DES, small RSA keys, unauthenticated modes — require an explicit permission in scope before they
 can be used at all.
 
-Keys are typed by their cipher, and a private key's bytes are reachable only inside an `expose`
-block, so where secret material is used is visible in the code's structure.
+Keys are typed by their cipher, and a private key's bytes are reachable only inside an `uncloak`
+block, so where secret material is used is visible in the code's structure. Where that material
+is *stored* while it is not in use is an explicit choice too: a `Cloak` in scope decides between
+the heap, off-heap memory, and encrypted-at-rest variants of both.
 
 ### On cryptography
 
@@ -29,12 +31,21 @@ a provider in scope:
 import soundness.*
 import strategies.throwUnsafely
 import providers.javaStdlibProvider
+import cloaks.cloakHeap
 ```
+
+There is deliberately no default `Cloak`: constructing any secret value — a password, a
+symmetric key, a private key — needs one in scope, so the storage decision is always written
+down. `cloakHeap` keeps the material in a private byte array; `cloakOffHeap` moves it out of
+the Java heap, so it does not appear in a heap dump; `cloakVeiledHeap` and `cloakVeiledOffHeap`
+additionally keep it encrypted under an ephemeral key between uses. No cloak defends against a
+debugger in the same process; what the stronger ones shrink is the window during which
+cleartext is reachable from a heap dump or core file.
 
 ### Symmetric encryption
 
 A symmetric key is generated for its cipher — algorithm, key size, and optionally the mode and
-padding, all in the type — and encryption happens inside the key's `expose` block, with the
+padding, all in the type — and encryption happens inside the key's `uncloak` block, with the
 [initialization vector](https://en.wikipedia.org/wiki/Initialization_vector) supplied explicitly:
 
 ```scala
@@ -43,17 +54,38 @@ import blockCipherPadding.pkcs7
 
 val key = SymmetricKey.generate[Aes[256]]()
 
-val ciphertext = key.expose:
-  t"Hello world".encrypt(InitializationVector.random)
-
-key.expose:
-  ciphertext.decrypt.text   // t"Hello world"
+key.uncloak:
+  t"Hello world".encrypt(InitializationVector.random).decrypt.as[Text]
+// t"Hello world"
 ```
 
-Streams encrypt chunk by chunk, so large data never assembles in memory. Decrypting with the wrong
-key raises a `CryptoError` naming the failure. AES's mode and padding may also be fixed in the
-key's type — `Aes[256] over Cbc against Pkcs7` — and a pairing the specification forbids does not
-compile.
+`uncloak` lends the key to its block as an `Encryptor` and `Decryptor` capability, and capture
+checking confines both: neither the capability nor a closure that would use it later can escape
+the block, so the compiler — not a convention — keeps the key's use inside its scope.
+
+Streams encrypt chunk by chunk through cipher *ducts*, so large data never assembles in memory,
+and a stream encrypted piecewise decrypts as a whole value, or the reverse:
+
+```scala
+key.uncloak:
+  t"Hello world".in[Data].stream.encrypt(InitializationVector.random).memoize.decrypt.as[Text]
+```
+
+Decrypting with the wrong key raises a `CryptoError` naming the failure. AES's mode and padding
+may also be fixed in the key's type — `Aes[256] over Cbc against Pkcs7` — and a pairing the
+specification forbids does not compile.
+
+### Passwords
+
+A `Password` is a cloaked secret like a key, but with no cipher attached. Its cleartext is
+reachable only inside `uncloak`, as a `Cleartext` capability, and its `show` form never reveals
+it:
+
+```scala
+val password = Password(t"hunter2")
+password.uncloak(String(cleartext.chars).tt)   // t"hunter2"
+password.show                                  // t"Password(•••)"
+```
 
 ### Public-key encryption and signing
 
@@ -63,10 +95,10 @@ with the private key and verifies with the public:
 ```scala
 val privateKey = PrivateKey.generate[Rsa[2048]]()
 
-val message = privateKey.public.expose:
+val message = privateKey.public.uncloak:
   t"secret".encrypt(InitializationVector.random)
 
-privateKey.expose(message.decrypt.text)
+privateKey.uncloak(message.decrypt.as[Text])
 
 val signer = PrivateKey.generate[Dsa[2048]]()
 val signature = signer.sign(document)
@@ -91,8 +123,60 @@ handling secret material is deliberate:
 ```scala
 privateKey.public.pem.serialize
 privateKey.pem(Divulgence)
-Pem.parse(pemText)
+pemText.read[Pem]
 ```
+
+PEM parses incrementally, so a source holding many blocks — a certificate chain, a bundle of
+keys — yields them one at a time, lazily, rather than as one parsed document:
+
+```scala
+chainText.read[LazyList[Pem]].map(_.label).to(List)
+```
+
+Text that is not part of a block — the `subject=…` lines OpenSSL writes between certificates —
+is skipped, and a source with no blocks at all reads as an empty sequence rather than an error.
+
+### ASN.1 and DER
+
+The structures underneath PKIX — certificates, keys, signatures — are
+[ASN.1](https://en.wikipedia.org/wiki/ASN.1) values carried in
+[DER](https://en.wikipedia.org/wiki/X.690#DER_encoding). An `Asn1` value models that structure
+directly, as an enumeration of the universal types PKIX uses, and `Der` is the encoded form:
+
+```scala
+val value = Asn1.Sequence(List(Asn1.Integer(BigInt(1)), Asn1.Utf8String(t"hello")))
+
+val bytes = value.in[Der]        // the DER octets
+bytes.as[Asn1]                   // the same value again
+```
+
+DER is canonical, so a document has exactly one valid encoding, and the codec enforces that in
+both directions: an overlong length, a non-minimal integer, an unsorted `SET`, an indefinite
+length, or trailing bytes all raise an `Asn1Error` whose reason names the fault and the byte
+offset at which it was found.
+
+Decoding is total. A tag this layer does not model — `T61String`, `BMPString`, `ENUMERATED`, an
+implicitly tagged value — decodes to `Asn1.Unknown`, carrying its content octets verbatim, so
+decoding and re-encoding reproduce the original bytes exactly. That property is what verifying
+a signature over a certificate's `TBSCertificate` depends on: a structure can be taken apart,
+inspected, and put back together without disturbing the bytes the signature covers.
+
+### Keystores
+
+A [PKCS#12](https://en.wikipedia.org/wiki/PKCS_12) keystore is opened for the duration of a
+scope, with the password given as a flag — an opaque `Password`, so its cleartext is reached only
+through the scoped `Cleartext` capability, and the character array the platform needs is zeroed
+once the store is loaded:
+
+```scala
+path.open[Keystore](Password(t"sesame")):
+  keystore.aliases
+  keystore.certificate(t"server")
+```
+
+A missing alias is `Unset`. A wrong password and a corrupt store are deliberately
+indistinguishable — both are `Unreadable` — since telling them apart would say which of the two
+went wrong to someone guessing.
 
 ### Weak algorithms
 

--- a/doc/modules/css.md
+++ b/doc/modules/css.md
@@ -103,3 +103,51 @@ hook by which [HTML](html.md) class attributes are checked against the styles th
 Selectors are structural values covering the full modern grammar — combinators including the column
 `||`, attribute tests, `:is`, `:not`, `:has`, `An+B` expressions and nesting `&` — so a selector can
 be built, inspected and rendered rather than spliced together as text.
+
+A parsed selector is a tree, not a string: a compound selector holds its simple parts, a complex
+selector holds compounds joined by combinators, and a selector list holds alternatives. Each part
+is a typed case, so a program can ask what a selector actually matches:
+
+```scala
+t"a > b".read[Css]        // a child combinator between two type selectors
+t"a:hover".read[Css]      // a type selector with a pseudo-class
+t"p::before".read[Css]    // a pseudo-element
+```
+
+Attribute selectors carry their matcher — presence, exact, prefix, suffix, substring, dash-match
+and whitespace-match — and the case-sensitivity modifier where one is given, so `[href^="https" i]`
+is understood rather than merely preserved.
+
+`An+B` arguments to `:nth-child` and its siblings parse to their coefficients, with `odd` and
+`even` normalized to `2n+1` and `2n`, and an `of` clause kept alongside. `:is`, `:not` and `:has`
+carry selector lists as their arguments, so their contents are themselves inspectable.
+
+Namespaced type selectors — `svg|rect`, `*|a` and the default-namespace `|a` — keep their prefix
+distinctly, since the three mean different things.
+
+### Property validation
+
+Parsing checks property names against the known set, so a misspelling is an error rather than a
+declaration that silently does nothing:
+
+```scala
+capture[CssErrors](t"a { colour: red }".read[Css]).errors.head.reason
+// CssError.Reason.UnknownProperty(t"colour")
+```
+
+Errors accumulate: a rule with several bad declarations reports all of them, so a stylesheet is
+corrected in one pass. The error type is plural — `CssErrors` — because reporting one fault at a
+time from a document that has several is the wrong shape for the job.
+
+### Checking class names against a stylesheet
+
+The point of knowing which classes and ids a stylesheet defines is to check the markup that uses
+them. Binding a stylesheet resource makes its names available at compiletime, and an
+[HTML](html.md) attribute referring to a name resolves to `class` or `id` according to which the
+stylesheet declares — so a misspelled class name in a template is a compile error, and the right
+attribute is used without saying which:
+
+```scala
+given (Styles at "/site.css") = Styles(cp"/site.css")
+import cssBindings.checkedBinding
+```

--- a/doc/modules/csv.md
+++ b/doc/modules/csv.md
@@ -42,6 +42,15 @@ to the format:
 t"hello,world".read[Sheet].rows.head   // Dsv(t"hello", t"world")
 ```
 
+A `Sheet` is materialized: its rows are an array, replayable, indexable and cheap to compare. A
+file too large to hold needs no sheet at all — `rows` on a character [stream](streams.md) yields
+the rows one at a time, parsed by the same reader, so a quoted cell spanning chunk and line
+boundaries is handled exactly as it is in a materialized sheet:
+
+```scala
+source.rows.map(_[Text](t"name").or(t"?")).to(List)
+```
+
 ### Decoding to a case class
 
 A row decodes into a case class with `as`, taking the cells in order; a nested case class simply
@@ -96,6 +105,26 @@ Seq(Name(t"Ada", t"Lovelace")).dsv.show   // t"Ada\tLovelace"
 A cell is quoted only when it contains the delimiter, a quote, or a line break, and a quote
 within a cell is doubled — the conventions the format prescribes, applied on the way out and
 understood on the way in.
+
+### Parsing directly to a type
+
+Building a `Dsv` for every row, only to decode it and throw it away, is wasted work. A type that
+opts in with a `Dsv.Parsable` instance is parsed straight from the source, its cells addressed in
+place in the parser's row buffer, with no row value built at all:
+
+```scala
+case class Stat(name: Text, count: Int, note: Optional[Text])
+
+object Stat:
+  given parsable: Stat is Dsv.Parsable = Dsv.Parsable.derived
+
+t"z,9,note".read[Stat in Dsv]           // Stat(t"z", 9, t"note")
+t"a,1\nb,2".read[List[Stat] in Dsv]     // both records
+source.rowsOf[Stat].map(_.count).to(List)
+```
+
+Fields are matched by header name where the format has a header and positionally where it does
+not, and an `Optional` field that the row does not reach is `Unset` rather than an error.
 
 ### Addressing cells by name
 

--- a/doc/modules/csv.md
+++ b/doc/modules/csv.md
@@ -108,6 +108,45 @@ A cell is quoted only when it contains the delimiter, a quote, or a line break, 
 within a cell is doubled — the conventions the format prescribes, applied on the way out and
 understood on the way in.
 
+### Column spans
+
+A nested case class occupies as many columns as it has fields, and that count is computed from
+the type rather than discovered while parsing. Each field's *span* says how many columns it
+consumes, so a decoder knows where one field ends and the next begins even when several are
+nested:
+
+```scala
+case class Name(first: Text, last: Text)
+case class Person(id: Int, name: Name, age: Int)
+
+Spannable.derived[Person].spans().to(List)   // List(1, 2, 1)
+Spannable.derived[Person].spans().sum        // 4 columns in total
+```
+
+An `Optional` field spans one column, and a row that stops short of it decodes it as `Unset`
+rather than failing — which is what a trailing optional column in a real spreadsheet means:
+
+```scala
+case class Greeting(word: Text, name: Optional[Text])
+
+t"hello,world".read[Greeting in Dsv]   // Greeting(t"hello", t"world")
+t"hello".read[Greeting in Dsv]         // Greeting(t"hello", Unset)
+```
+
+### Header names
+
+Where a format carries a header, the column names in the file rarely match Scala's field names.
+A *redesignation* in scope maps between them, so a header of `Target Person` matches a field
+named `targetPerson` with no per-field annotation:
+
+```scala
+import dsvRedesignations.capitalizedWordsRedesignation
+```
+
+`unchangedRedesignation` keeps the field name as it is; `lowerWordsRedesignation`,
+`lowerDottedRedesignation` and `lowerSlashedRedesignation` cover the other conventions files
+tend to use. A single field that does not follow the convention is renamed with `@name`.
+
 ### Parsing directly to a type
 
 Building a `Dsv` for every row, only to decode it and throw it away, is wasted work. A type that
@@ -146,3 +185,10 @@ import dynamicDsvAccess.enabled
 val row = t"greeting,number\nhello,23".read[Sheet].rows.head
 row.number[Int]   // 23
 ```
+
+### Reporting every bad cell
+
+A spreadsheet exported from elsewhere is rarely wrong in only one place, and a decoder that stops
+at the first bad cell makes fixing it a series of guesses. Under an accruing strategy, every cell
+that fails is reported — missing cells and unparseable ones together — each identified by its
+column, so one pass over a file yields the whole list of what to correct.

--- a/doc/modules/csv.md
+++ b/doc/modules/csv.md
@@ -48,6 +48,8 @@ the rows one at a time, parsed by the same reader, so a quoted cell spanning chu
 boundaries is handled exactly as it is in a materialized sheet:
 
 ```scala
+import caesura.rows
+
 source.rows.map(_[Text](t"name").or(t"?")).to(List)
 ```
 
@@ -120,6 +122,13 @@ object Stat:
 
 t"z,9,note".read[Stat in Dsv]           // Stat(t"z", 9, t"note")
 t"a,1\nb,2".read[List[Stat] in Dsv]     // both records
+```
+
+A stream yields records the same way, through `caesura.rowsOf`:
+
+```scala
+import caesura.rowsOf
+
 source.rowsOf[Stat].map(_.count).to(List)
 ```
 

--- a/doc/modules/daemons.md
+++ b/doc/modules/daemons.md
@@ -66,6 +66,24 @@ execute:
 The daemon retires itself after six idle hours, when its state files are removed, or on demand —
 the built-in `'{admin}'` subcommand reports the daemon's pid and kills it.
 
+### Asking for a cooked terminal
+
+The launcher puts the terminal into raw mode before it connects, so that keypresses can be
+forwarded to an interactive session. That is wrong for a command that just wants a line of input:
+without the terminal driver's help there is no echo, and Backspace arrives as a literal byte
+inside the line. `cooked` asks the launcher for canonical mode for the duration of a block, and
+raw mode is restored afterwards:
+
+```scala
+execute:
+  service.cooked:
+    Out.println(t"Name?")
+    In.read[Text]
+```
+
+Echo and line editing then come from the terminal driver itself. A launcher with no such channel
+— a pipe, or an older stub — leaves the request to expire harmlessly.
+
 ### The service bus
 
 Concurrent invocations of one daemon share a typed *bus*: an invocation broadcasts a message and

--- a/doc/modules/database.md
+++ b/doc/modules/database.md
@@ -68,3 +68,30 @@ box.assign(shelf)        // does not compile: no Box -< Shelf relation
 
 The last line is the point: the schema is not documentation but a type, and an operation outside it
 never runs because it never compiles.
+
+`ref` finds the reference for a value already stored, raising a `DataError` where it is not —
+which is how a value arriving from elsewhere is matched to what the database already holds,
+rather than stored a second time.
+
+### Interning
+
+`store` *interns*: storing an equal value twice yields the same reference, so identity in the
+database is by value rather than by allocation. That is what makes a reference safe to compare, to
+use as a key, and to hold in place of the value it names.
+
+A reference is an opaque handle rather than a pointer or an index into a table the caller can see,
+so a reference from one database cannot be dereferenced against another — the type says which
+database it belongs to, and there is no way to construct one that lies.
+
+### Querying
+
+`lookup` follows one relation. Where a query must select rather than traverse, a `Listable`
+instance lists the references whose values satisfy a predicate:
+
+```scala
+summon[Box is Listable].list(_.name.starts(t"a"))
+```
+
+Because the predicate is an ordinary function over the stored type, a query is written in Scala
+rather than in a query language embedded in strings — and is therefore checked by the compiler
+like the rest of the program.

--- a/doc/modules/decoding.md
+++ b/doc/modules/decoding.md
@@ -182,7 +182,56 @@ t"North" match
 Some types accept an empty input and some do not, and a form or a configuration
 often needs to know which before it asks for a value. A `Requirable` instance
 answers that: a type is _required_ when an empty input cannot produce one. The
-judgement follows from the type's decoder, so no separate declaration is needed.
+judgement follows from the type's decoder, so no separate declaration is needed —
+the decoder is simply run against the empty text, and whether it succeeds is the
+answer:
+
+```scala
+summon[Int is Requirable].required     // true: "" is not a number
+```
+
+This is what lets a [form](forms.md) mark its mandatory fields without a second
+declaration that could disagree with the decoder.
+
+### Enumerations by name and position
+
+An enumeration's cases are known to the compiler, so an `Enumerable` instance is
+derived from the type rather than written. It gives the enumeration's name, its
+cases in declaration order, and lookup in both directions — by name and by
+ordinal — each returning `Optional` rather than raising, since neither a name nor
+an index is guaranteed to correspond to a case:
+
+```scala
+enum Direction:
+  case North, South, East, West
+
+val enumerable = summon[Direction is Enumerable]
+
+enumerable.values             // every case, in order
+enumerable.value(t"North")    // Direction.North
+enumerable.value(Prim)        // Direction.North, by position
+enumerable.name(Direction.South)   // t"South"
+enumerable.index(Direction.East)   // 2
+```
+
+This is the machinery beneath `As[Direction]` and beneath the enumeration
+handling of every format's derived codecs, so all of them agree about what a
+case is called.
+
+### Round-tripping an identifier
+
+Some conversions are not to a Scala type at all, but from one textual form to
+another: a database column named `first_name` and a field named `firstName`, or a
+header written `Content-Type` and read `contentType`. An `Identifiable` states
+both directions of such a mapping as a pair of text functions:
+
+```scala
+val snakeCase = Identifiable[Column](encoder, decoder)
+```
+
+Because it is a `Typeclass.Pure`, the compiler knows the conversion captures
+nothing, so it may be shared freely and applied wherever the naming convention
+is needed rather than being threaded through as an argument.
 
 ### Defining your own
 

--- a/doc/modules/decoding.md
+++ b/doc/modules/decoding.md
@@ -25,7 +25,7 @@ no result rather than raising, which is exactly what pattern matching wants. An
 the direction of the conversion: a value `is Decodable in Text` reads _out of_
 text, and text `is Extractable to Int` reads _toward_ an integer.
 
-The everyday surface is small — the `decode` method and the `As` extractor — and
+The everyday surface is small — the `as` method and the `As` extractor — and
 the sections below start there before turning to the typeclasses underneath and
 how to write instances for your own types. Everything comes from the `soundness`
 package:
@@ -36,11 +36,11 @@ import soundness.*
 
 ### Decoding a value
 
-The `decode` method reads a typed value out of text. The target type is supplied
+The `as` method reads a typed value out of text. The target type is supplied
 explicitly, and a matching `Decodable` instance does the work:
 
 ```scala
-t"123".decode[Int]   // 123
+t"123".as[Int]   // 123
 ```
 
 Decoding can fail — the text might not be a number — so it needs an error-handling
@@ -50,8 +50,8 @@ fails:
 ```scala
 import strategies.throwUnsafely
 
-t"123".decode[Int]    // 123
-t"hello".decode[Int]  // raises a NumberError
+t"123".as[Int]    // 123
+t"hello".as[Int]  // raises a NumberError
 ```
 
 A `NumberError` reports both the offending text and why it failed: text that is
@@ -59,18 +59,18 @@ not a number at all is _unparseable_, while a number outside the target type's
 range is _out of range_. Decoding to a `Byte` distinguishes the two:
 
 ```scala
-t"300".decode[Byte]   // raises a NumberError: 300 is out of range for a Byte
-t"abc".decode[Byte]   // raises a NumberError: abc is unparseable
+t"300".as[Byte]   // raises a NumberError: 300 is out of range for a Byte
+t"abc".as[Byte]   // raises a NumberError: abc is unparseable
 ```
 
 Instances come built in for the primitive number types, for `Char`, and for types
 defined elsewhere in Soundness such as `Uuid` and `Fqcn`. Other modules add their
-own, which is why the same `decode` reads a date, a hostname or a URL once the
+own, which is why the same `as` reads a date, a hostname or a URL once the
 relevant module is imported:
 
 ```scala
-t"2024-01-15".decode[Date]
-t"example.com".decode[Hostname]
+t"2024-01-15".as[Date]
+t"example.com".as[Hostname]
 ```
 
 Because the error capability is an ordinary given, the strategy that handles a
@@ -78,14 +78,13 @@ failed decode is chosen at the call site, not fixed by the decoder. Recovering
 with a default, rather than raising, is a matter of changing the strategy:
 
 ```scala
-safely(t"hello".decode[Int]).or(0)   // 0
+safely(t"hello".as[Int]).or(0)   // 0
 ```
 
 ### Extracting in patterns
 
-// "raising one" should be "raising an exception".
-
-Pattern matching needs a conversion that declines to match instead of raising one.
+Pattern matching needs a conversion that declines to match instead of raising an
+exception.
 That is the `As` extractor: `As[Int]` succeeds when the scrutinee yields an `Int`
 and falls through to the next case when it does not.
 
@@ -189,7 +188,7 @@ judgement follows from the type's decoder, so no separate declaration is needed.
 
 The four typeclasses are the seams along which Soundness extends. Writing an
 instance is writing the single conversion function; the framework supplies the
-`decode` method, the `As` extractor and the rest.
+`as` method, the `As` extractor and the rest.
 
 A `Decodable` instance maps an input to a value, mapping each recognized form to
 its result:
@@ -220,6 +219,6 @@ given (Text is Extractable to Int) => Text is Extractable to Percent =
 ```
 
 The conversions in the standard library follow these same shapes, so a type
-defined this way is decoded with `decode`, matched with `As`, and composed into
+defined this way is decoded with `as`, matched with `As`, and composed into
 the patterns of every other type without any further wiring — the payoff of
 naming the conversion once and letting its fallibility live in the type.

--- a/doc/modules/derivation.md
+++ b/doc/modules/derivation.md
@@ -71,6 +71,48 @@ Person(t"Ada", 36).present   // t"Person(name=Ada, age=36)"
 
 Nested structures derive recursively: a case class of case classes needs nothing more.
 
+### What a derivation can see
+
+Inside `conjunction`, each field carries more than its value. `label` is the field's name as
+written, `index` its position, `typeName` the enclosing type's name, and `contextual` the instance
+of the typeclass being derived for that field's type. A derivation can therefore produce something
+that mentions the structure, not only something that folds over it:
+
+```scala
+Labels.derived[Person].labels    // List(t"name", t"age", t"male")
+Labels.derived[Empty].labels     // Nil
+```
+
+An empty product is a product with no fields, and a single-field product is not special-cased —
+both derive from the same rule, which is where hand-written instances usually go wrong.
+
+Inside `disjunction`, `variant` narrows the value to its actual case, so the body is typed at that
+case rather than at the sum, and the case's own label is available for a discriminator.
+
+### Deriving beyond codecs
+
+Nothing about the engine is specific to encoding. Any typeclass whose instances compose
+structurally derives the same way — including the arithmetic ones, which combine two values of a
+product field by field:
+
+```scala
+import arithmetic.addable
+
+Pair(t"foo", 10) + Pair(t"bar", 15)   // Pair(t"foobar", 25)
+```
+
+Addition on `Pair` is addition on each field, so `Text` concatenates while `Int` sums, with no
+instance written for `Pair` at all. `Subtractable`, `Multiplicable` and their siblings follow the
+same rule.
+
+### When derivation fails
+
+A typeclass may sensibly derive for products but not for coproducts, or the reverse. Extending
+`ProductDerivation` rather than `Derivation` says so, and applying it to a sum type is then a
+compile error naming the mismatch rather than a runtime surprise. A type with no `Mirror` at all —
+an ordinary trait, a class that is not a case class — likewise fails at the point of derivation,
+where the message can say what is missing.
+
 ### Per-field instances
 
 Occasionally one field of one type needs a different instance from the default — a special codec

--- a/doc/modules/diffing.md
+++ b/doc/modules/diffing.md
@@ -81,3 +81,37 @@ import strategies.throwUnsafely
 changes.serialize            // a Stream[Text] in unix diff format
 diffStream.read[Diff[Text]]  // parsed back to a value
 ```
+
+### Redrafts
+
+The unix format is precise and unforgiving: a patch must state its context exactly, with the right
+line numbers, or it does not apply. That is right for a version-control system and wrong for a
+person — or a language model — proposing an edit in prose.
+
+A *redraft* is the forgiving form. It states only the lines to remove and the lines to add, with
+unchanged lines omitted entirely, and finds where they belong:
+
+```scala
+Redraft.parse(LazyList(t"- line2", t"+ new line 2a")).patch(source)
+// the second line replaced
+
+Redraft.parse(LazyList(t"+ line0")).patch(source)
+// inserted before the first line
+```
+
+Where a redraft is ambiguous — the lines it names appear more than once — that is reported rather
+than resolved by guessing, so an edit is never applied in the wrong place.
+
+### Evolution
+
+A diff compares two versions. An *evolution* tracks an element through many, so that a value
+present in the first version and the last can be recognised as the same value even where it
+disappeared and returned in between:
+
+```scala
+val evolution = evolve(versions)
+evolution(Ter)   // the third version, reconstructed
+```
+
+Each version is addressed by ordinal, and reconstructing one gives back exactly what it was — the
+structure a document history, an undo stack, or a series of drafts wants.

--- a/doc/modules/display.md
+++ b/doc/modules/display.md
@@ -73,6 +73,41 @@ List(t"one", t"two").inspect      // t"""[t"one", t"two"]"""
 the distinction the two audiences call for. A custom `Inspectable` is written just as a
 `Showable` is, where the structural default is not wanted.
 
+The source form is a real source form: control characters and quotes are escaped as Scala would
+escape them, so an inspected value could be pasted back into code, and a text containing a newline
+is distinguishable from one containing the two characters `\` and `n`:
+
+```scala
+t"Hello\nworld".inspect     // t"t\"Hello\\nworld\""
+t"Hello \"world\"".inspect  // the quotes escaped
+```
+
+Collections render in forms chosen so that the *kind* of collection is visible without naming it,
+and so that nesting is unambiguous — a map with arrows, a list in brackets, an optional value in
+its own brackets or as a circle when unset:
+
+```scala
+Map(1 -> 2, 3 -> 4).inspect     // t"{1 → 2, 3 → 4}"
+Map[Int, Int]().inspect         // t"{}"
+Set(1).inspect                  // a set, not an optional
+```
+
+Enumerations and sealed hierarchies derive too, and a case object renders as its bare name rather
+than with empty parentheses, since it has no fields to show:
+
+```scala
+(Dog(t"Rex"): Animal).inspect   // t"""Dog(name:t"Rex")"""
+(Cat: Animal).inspect           // t"Cat"
+```
+
+### The fallback chain
+
+`Inspectable` is total, but it is not indiscriminate. Asked to inspect a value, it tries in turn:
+the type's own `Inspectable` instance, then its `Showable`, then a structural rendering derived
+from its shape, and only then a last-resort rendering. A type that has said how it should look is
+therefore shown that way in debugging output too, and a type that has said nothing still produces
+something useful rather than a hash code.
+
 ### Booleans
 
 A boolean has no single obvious rendering — "yes" and "no", "on" and "off", "true" and

--- a/doc/modules/docker.md
+++ b/doc/modules/docker.md
@@ -46,14 +46,14 @@ digests the format requires:
 ```scala
 def entry(name: Text, content: Text): Tar.Entry =
   Tar.Entry.File
-   ( path  = name.decode[Relative on Tar],
+   ( path  = name.as[Relative on Tar],
      mode  = UnixMode(),
      user  = UnixUser(0),
      group = UnixGroup(0),
      mtime = 0.bits.u32,
-     data  = LazyList(content.data) )
+     data  = TarBody(content.in[Data]) )
 
-val layer = Layer(Tarfile(LazyList(entry(t"hello.txt", t"hello world\n"))))
+val layer = Layer(Tarfile(List(entry(t"hello.txt", t"hello world\n"))))
 ```
 
 An `Image` assembles one or more layers with a configuration — the command to run, the
@@ -78,6 +78,23 @@ image.manifest     // the OCI manifest tying config and layers together
 `image.archive` is the whole image as an OCI tar layout — the form a runtime imports. Read
 as bytes and written to a file, it produces an image that `docker load` or containerd will
 accept.
+
+### Reading an image
+
+An existing OCI archive — a file or a block of bytes — is read by *opening* it, which makes
+its contents available for the duration of a scope and no longer:
+
+```scala
+archive.open[Image](): handle ?=>
+  handle.index                                    // the top-level index
+  handle.manifest                                 // the manifest it names
+  handle.imageConfig                              // the image configuration
+  handle.verified(handle.manifest.layers.head)    // a layer, digest-checked
+```
+
+Reaching a layer three ways makes the cost explicit: `compressed` yields the stored bytes
+untouched, `layer` decompresses them as a stream, and `verified` decompresses and checks the
+content against the digest the manifest declares, raising an `OciError` if they disagree.
 
 ### Connecting to a daemon
 

--- a/doc/modules/environment.md
+++ b/doc/modules/environment.md
@@ -81,4 +81,35 @@ variables(EDITOR = t"vim"):
 
 Substituting an entirely different environment — `environments.emptyEnvironment`, or one built
 for a test — replaces every lookup within its scope, so code that reads the environment can be
-exercised without depending on the machine it runs on.
+exercised without depending on the machine it runs on. `systems.emptySystem` does the same for
+system properties, so a test need not depend on the JVM it happens to run under either.
+
+### Standard directories
+
+The [XDG base directory specification](https://specifications.freedesktop.org/basedir-spec/latest/)
+says where a program's data, configuration, cache and state belong, honouring the user's
+environment where it is set and falling back to the specification's defaults where it is not.
+`Xdg` gives each of them, and the search paths for data and configuration:
+
+```scala
+Xdg.configHome[Path on Linux]   // ~/.config, or $XDG_CONFIG_HOME
+Xdg.cacheHome[Path on Linux]
+Xdg.dataDirs[Path on Linux]     // the search path, in order
+```
+
+Using these rather than a hard-coded `~/.myapp` is what makes a program's files land where the
+user's backup, sync and cleanup tools expect them.
+
+A temporary directory comes from `temporaryDirectory`, and the directory the program was launched
+in from `workingDirectory`, each resolved to the path type asked for.
+
+### The machine
+
+`Architecture` names the processor a program is running on, parsed from the platform's own
+reporting into a typed value — `X86(64)`, `Arm(64)`, `Ppc(64, littleEndian = true)` and the rest —
+so code that must choose a native library or a code path by architecture matches on a value
+rather than on a string whose spelling varies by platform.
+
+`termcaps.environmentTermcap` reports what the terminal can do, deciding colour depth from
+`COLORTERM` where it is set and from `tput` otherwise, which is how styled output degrades
+correctly on a terminal that cannot show it.

--- a/doc/modules/errors.md
+++ b/doc/modules/errors.md
@@ -22,7 +22,7 @@ response. And in both, the error is often reduced to a string, which loses the s
 would let a program inspect or react to it.
 
 Soundness keeps the failure in the type and the detail in the value. An error is a value
-carrying a typed [message](expressive-errors.md); a method advertises the errors it can raise
+carrying a typed [message](../philosophy/expressive-errors.md); a method advertises the errors it can raise
 in its return type; and the decision of what to do belongs to the caller, expressed as a
 contextual strategy. Because the strategy is an ordinary given, one body of fallible code
 serves every response. The names come from the `soundness` package, with a diagnostics choice

--- a/doc/modules/errors.md
+++ b/doc/modules/errors.md
@@ -117,6 +117,73 @@ accrue(Invalid(Nil)) { (all, error) => all.add(error) }:
 Each field is checked even if an earlier one failed, and the accumulated `Invalid` carries all
 the problems at once.
 
+### Saying where a failure was
+
+An accumulated list of errors is only useful if each one says where it came from. A *focus* is the
+position within a structure that the code is currently working on, and `track` maintains it as a
+traversal descends. Under `validate`, a recorded error is paired with the focus at the moment it
+was raised:
+
+```scala
+Pointer(t"a")(t"b")(t"c").text   // t"a.b.c"
+```
+
+The pointer type is chosen by the structure being traversed — a `JsonPointer` for
+[JSON](json.md), a path for [XML](xml.md), a column for [CSV](csv.md) — so the position is
+reported in the vocabulary of the data rather than as an index into something internal. This is
+the machinery beneath every "which field failed" report in the format modules.
+
+### Inspecting a failure directly
+
+Three related operations turn a failure into a value rather than a control-flow event.
+
+`capture` runs a block that is expected to fail and returns the error, which is what a test
+asserting on a failure needs. A block that succeeds is itself an error — an `ExpectationError` —
+since the test was checking the wrong thing:
+
+```scala
+capture[PortError](connect(80)).port
+```
+
+`attempt` makes no such demand, returning an `Attempt` that is either a success carrying the value
+or a failure carrying the error, for code that must branch on both:
+
+```scala
+attempt[PortError](connect(80))   // Attempt.Success(…) or Attempt.Failure(…)
+```
+
+`amalgamate` combines several fallible computations, gathering their errors into one.
+
+### Deferring a fallible computation
+
+A fallible computation cannot be stored as an ordinary value, because its ability to fail is part
+of its type and needs a tactic to discharge. `defer` holds the unapplied body, and applying it
+runs it against whatever tactic is in scope *then*:
+
+```scala
+val held = defer(riskyOperation())
+
+recover:
+  case error => fallback
+. protect:
+    held()
+```
+
+Each application re-evaluates the body, so a deferred computation is a recipe rather than a cached
+result — which is what makes it usable under a different strategy each time.
+
+### Translating and escalating
+
+`Mitigable` is the typeclass behind `mitigate`: an instance says how one error type becomes
+another, and importing `strategies.mitigation` applies it automatically where a caller expects the
+outer type. A low-level failure therefore reaches an API boundary already translated into that
+boundary's vocabulary, without every call site restating the translation.
+
+Two further strategies sit at the ends of the range. `throwUnsafely` throws, with no capability
+required, which suits prototyping and scripts. `throwSafely` also throws, but demands a `CanThrow`
+capability, so the possibility remains visible in the types. Between them sit the recovering,
+accruing and optional strategies, and the choice is always at the call site.
+
 ### Diagnostics
 
 An `Error` can capture a stack trace or omit it, decided by the `Diagnostics` given in scope:

--- a/doc/modules/filesystem.md
+++ b/doc/modules/filesystem.md
@@ -78,6 +78,14 @@ file.open[File](Write, OpenFlag.Create): handle ?=>
 val text = file.open[File]()(file.stream.read[Data]).utf8
 ```
 
+Where a whole small file is wanted, and the ceremony of a scope buys nothing, `read` and `write`
+act directly on the path:
+
+```scala
+path.write(t"Hello world")
+path.read[Text]
+```
+
 The mode is not merely a runtime flag: it is carried in the handle's type as a set of *grants*.
 Opening with the default `Read` mode yields a handle that grants only reading, and a write
 through it does not compile; `Read & Write` grants both. A whole class of mistakes — writing
@@ -93,6 +101,25 @@ directory.open[Directory](Read & Write): dir ?=>
   (dir/"greeting.txt").overwrite(t"Hello directory")
   dir.base.entries.to(List).map(_.name)
 ```
+
+### Exclusive access
+
+`Exclusive` is a third grant, alongside `Read` and `Write`, and it means what it says: no other
+scope in the program may hold an overlapping path open while it lasts. Overlap is by containment,
+not by equality — a directory and something beneath it overlap; two siblings do not:
+
+```scala
+directory.open[Directory](Read & Exclusive): dir ?=>
+  // nothing else in this program may open `directory` or anything under it
+```
+
+Two ordinary reads may coexist. An exclusive open conflicts with an overlapping open in either
+direction — whether the exclusive scope is the outer or the inner one — and the conflict is an
+`IoError` whose reason is `Busy`, raised at the point of the second open rather than discovered
+as corruption later. The claim is released when the scope ends, however it ends.
+
+For a *file* rather than a directory, `Exclusive` additionally takes an operating-system lock, so
+exclusivity holds against other processes and not merely within this one.
 
 ### Creating as a scope
 

--- a/doc/modules/filesystem.md
+++ b/doc/modules/filesystem.md
@@ -33,8 +33,8 @@ import soundness.*
 import strategies.throwUnsafely
 import systems.javaSystem
 import temporaryDirectories.systemTemporaryDirectory
-import filesystemOptions.createNonexistentParents.enabled
 import filesystemOptions.overwritePreexisting.enabled
+import filesystemOptions.deleteRecursively.enabled
 ```
 
 ### Files and directories
@@ -50,22 +50,83 @@ val file = directory/t"notes.txt"
 file.create[File]()
 ```
 
-`create[File]()` and `create[Directory]()` bring the entry into being, drawing on the policy
-givens in scope — here, creating any missing parent directories and overwriting anything already
-present.
+`create[File]()` and `create[Directory]()` bring the entry into being, and refuse to destroy
+anything by default: creating over something that exists, or under a parent that does not, is an
+`IoError`. Where that is the intent, a flag says so at the call site rather than an import saying
+it for the whole file:
+
+```scala
+target.create[File](CreateFlag.Replace)
+target.create[Directory](CreateFlag.Parents)
+```
+
+`Fifo` and `Socket` are entries too, created the same way.
 
 ### Reading and writing
 
-A file is read and written by opening it, which yields a handle that behaves as a byte source and
-sink for the [stream](streams.md) operations. Writing sends a value to the handle; reading pulls
-the handle in as a chosen type:
+A file is read and written by *opening* it. `open` names the form to open the path as, and the
+mode to open it in, and runs a block with a handle for its capability. The handle exists only
+for the duration of the block, so the descriptor cannot outlive the scope that owns it:
 
 ```scala
 import charEncoders.utf8Encoder
 import charDecoders.utf8Decoder
 
-file.open(t"Hello, world".writeTo(_))
-val text = file.open(_.read[Text])
+file.open[File](Write, OpenFlag.Create): handle ?=>
+  handle.write(LazyList(t"Hello, world".in[Data]))
+
+val text = file.open[File]()(file.stream.read[Data]).utf8
+```
+
+The mode is not merely a runtime flag: it is carried in the handle's type as a set of *grants*.
+Opening with the default `Read` mode yields a handle that grants only reading, and a write
+through it does not compile; `Read & Write` grants both. A whole class of mistakes — writing
+through a read-only handle, holding a descriptor past its scope — becomes a compile error
+rather than a runtime failure.
+
+For a path that names a directory, opening confines what may be reached through it. Paths
+derived from the handle live on a *fresh plane* of their own, so `..` does not compile, and a
+path obtained from one open directory cannot be written under another:
+
+```scala
+directory.open[Directory](Read & Write): dir ?=>
+  (dir/"greeting.txt").overwrite(t"Hello directory")
+  dir.base.entries.to(List).map(_.name)
+```
+
+### Creating as a scope
+
+`create` is the counterpart of `open`: where opening acts on something that exists, creating
+brings it into being and hands back a handle over it, for the same lexical scope. Content
+written within the scope is committed when the block completes, and a scope that fails leaves
+nothing behind:
+
+```scala
+target.create[File](): handle ?=>
+  handle.write(LazyList(t"payload".in[Data]))
+
+target.create[Directory](): dir ?=>
+  (dir/"inner.txt").overwrite(t"hello")
+```
+
+A *scratch* directory is created and removed by its scope, whether the scope succeeds or fails:
+
+```scala
+base.open[Scratch](Read & Write): scratch ?=>
+  (scratch/"file.txt").overwrite(t"data")
+```
+
+### Memory-mapped access
+
+A file opened as `Ram` is memory-mapped, and serves positional reads and writes without
+streaming through it. The `Write` grant is required to write, as everywhere else:
+
+```scala
+file.open[Ram](): ram ?=>
+  ram(2, 3)               // three bytes from offset 2
+
+file.open[Ram](Read & Write): ram ?=>
+  ram(3L) = t"XYZ".in[Data]
 ```
 
 ### Copying, moving and deleting
@@ -109,17 +170,30 @@ Base.Usr.Share()   // /usr/share
 
 ### Watching for changes
 
-A directory is watched within a scope, which yields a stream of `WatchEvent`s — a file created,
-modified or deleted — and stops watching when the scope ends:
+A directory is watched by opening it as `Watch`, which yields a stream of `WatchEvent`s — a
+file created, modified or deleted. The registration lasts exactly as long as the block:
 
 ```scala
-directory.watch: watch =>
-  watch.stream.each:
+directory.open[Watch](): watcher ?=>
+  watcher.stream.each:
     case WatchEvent.NewFile(dir, file) => Out.println(t"created $file")
     case WatchEvent.Modify(dir, file)  => Out.println(t"modified $file")
     case WatchEvent.Delete(dir, file)  => Out.println(t"deleted $file")
     case _                             => ()
 ```
 
+Several paths are watched together by opening a list of them, which yields one event stream
+across all of them.
+
 The default watcher uses the operating system's own file-change notifications; where those are
 unavailable, `watchers.polling` checks at an interval instead.
+
+### Choosing a backend
+
+Nothing above names a platform API. The primitive operations a filesystem must offer — stat,
+open, read, write, list, link, delete — are gathered into a `FilesystemBackend` for a plane,
+and everything else is defined in terms of them. The `java.nio` implementation is
+`filesystemBackends.virtualMachine`, and a WASI implementation over `wasi:filesystem` is
+supplied by `galilei.wasi`, so the same code reads and writes files on the JVM and inside a
+WebAssembly component. An operation a backend cannot support raises an `IoError` whose reason
+is `Unsupported`, rather than approximating it.

--- a/doc/modules/fonts.md
+++ b/doc/modules/fonts.md
@@ -57,4 +57,39 @@ font.leftSideBearing('H')
 ```
 
 The font's header exposes the scaling factor — units per em — that relates design units to em
-measurements, along with the ascender and descender heights that vertical layout needs.
+measurements, along with the glyph bounding box and the ascender and descender heights that
+vertical layout needs.
+
+Character-to-glyph mapping covers the `cmap` subtable formats fonts actually use, and the best
+subtable is chosen by Unicode preference rather than by taking the first one present. A character
+the font does not map yields the missing glyph, rather than an error or a wrong glyph.
+
+### Names and metadata
+
+A font describes itself in its `name`, `post` and `OS/2` tables, and those descriptions are read
+directly rather than guessed at:
+
+```scala
+font.fontName      // the PostScript name
+font.familyName    // the family name
+font.post.italicAngle
+font.os2.capHeight
+```
+
+Records are decoded from both UTF-16BE and Macintosh encodings, preferring Windows-English where
+several are present. Weight, typographic metrics, x-height and embedding rights come from `OS/2`,
+which is exactly what building a [PDF](pdf.md) font descriptor needs.
+
+### Subsetting
+
+Embedding a whole font to render a page of text is wasteful, and often not permitted. `subset`
+builds a new font containing only the glyphs a given set of characters needs:
+
+```scala
+val reduced = font.subset(t"Hello world")
+```
+
+Subsetting is not simply a matter of keeping the glyphs a text maps to. A composite glyph is
+assembled from others, so the retained set is the transitive closure under composition — computed
+from the glyph outlines themselves, so an accented character keeps the components it is drawn
+from.

--- a/doc/modules/foreign-interop.md
+++ b/doc/modules/foreign-interop.md
@@ -60,6 +60,40 @@ Scala values pass as arguments where an `Interoperable` instance maps them onto 
 type — text to a string, the sized numbers to their foreign widths — so the boundary is typed in
 both directions.
 
+### Kotlin and Java facades
+
+A JVM library written in Kotlin sits on the same classpath, so its declarations need no separate
+file: they are in the classfiles, in the `@Metadata` a Kotlin compiler writes. Those declarations
+are read at compiletime, and a *facade* wraps a live value so that its members are reached as
+though they were Scala's — each access materializing as a direct, statically-typed JVM call, with
+no reflection and no wrapper object:
+
+```scala
+val pair = make[kotlin.Pair[Text, Text]](t"a", t"b")
+val first: Text = pair.first
+
+val regex = make[kotlin.text.Regex](t"[0-9]+")
+regex.matches(t"123")                          // true
+```
+
+`make` constructs a value, `companion` reaches a companion object's members, and `singleton`
+reaches an object's. Types substitute through, so `pair.first` is a `Text` and not an `Any`, and
+`Text` passes wherever a `CharSequence` is expected. Kotlin's nullability is honoured: a nullable
+result is an `Optional`, absent where Kotlin would return null.
+
+Properties read as members and `var` properties accept assignment, through the getters and
+setters Kotlin generated; assigning to a `val` does not compile. A Kotlin function-type parameter
+takes an ordinary Scala lambda, whose own parameter is a facade over the Kotlin type, so the
+value inside it navigates too:
+
+```scala
+regex.replace(t"a1b2", (m: Facade over kotlin.text.MatchResult) => t"<${m.value}>")
+// t"a<1>b<2>"
+```
+
+A member the class does not declare, or an argument of the wrong type, is a compile error — and
+where the name is close to a real one, the error suggests it, spelled as Kotlin spells it.
+
 ### Expressions, not effects
 
 Navigation builds an *expression* — a typed AST of references, selections and applications — and

--- a/doc/modules/generic-data.md
+++ b/doc/modules/generic-data.md
@@ -57,3 +57,20 @@ Person(t"John", 30).pojo    // Array("John", 30)
 Because both sides derive the codec from the same type definition, the encoding needs no schema on
 the wire — but it also means both sides must agree on that definition, and a mismatch surfaces as
 a typed `PojoError` when decoding, not as silent corruption.
+
+`Pojo` is an opaque type over the JDK types it permits, so a `Pojo` cannot be confused with an
+arbitrary `Object`, and the only way to produce one is through an encoder. Decoding is fallible
+and says so: `as` needs an error strategy, and a shape that does not match the expected type
+raises rather than casting and hoping.
+
+### Where it is used
+
+The obvious case is a classloader boundary. Code loaded in an isolated loader — a plugin, a
+compiled fragment, a sandboxed extension — shares the JDK's classes with its host and nothing else,
+so the JDK's classes are exactly the vocabulary the two can speak.
+
+The same reasoning applies across a process boundary, which is what [staged](staging.md) remote
+execution uses: the arguments to a staged computation are encoded here, sent, and decoded on the
+far side against the type the staged code expects. Nothing about the representation is specific to
+either use, so any boundary that can carry boxed primitives, strings and object arrays can carry a
+Scala value.

--- a/doc/modules/generic-data.md
+++ b/doc/modules/generic-data.md
@@ -27,7 +27,7 @@ import soundness.*
 
 ### Encoding and decoding
 
-A value encodes with `pojo`, and decodes back with `decode` — fallibly, since the receiving side
+A value encodes with `pojo`, and decodes back with `as` — fallibly, since the receiving side
 must state the type it expects, and the data may not match:
 
 ```scala
@@ -37,7 +37,7 @@ case class Group(persons: List[Person], size: Int)
 val group = Group(List(Person(t"John", 30), Person(t"Jane", 25)), 2)
 
 val transportable = group.pojo         // arrays, strings and boxes only
-safely(transportable.decode[Group])    // the original Group, on the other side
+safely(transportable.as[Group])    // the original Group, on the other side
 ```
 
 Nested case classes, collections and enumerations all derive their conversions, so any data-shaped

--- a/doc/modules/geography.md
+++ b/doc/modules/geography.md
@@ -84,5 +84,5 @@ typed error naming the fault when the URI is malformed — and encodes back:
 ```scala
 import strategies.throwUnsafely
 
-t"geo:51.5,0.1".decode[Geolocation].location
+t"geo:51.5,0.1".as[Geolocation].location
 ```

--- a/doc/modules/geography.md
+++ b/doc/modules/geography.md
@@ -55,6 +55,15 @@ Compass[8](Angle.degrees(315))   // Northwest
 The winds are ordinary enumerations — `CardinalWind`, `IntercardinalWind`, `HalfWind` — so a bearing
 can be matched, stored and shown like any other value.
 
+The number of points is a type argument rather than a runtime parameter, so the *type* of a
+resolved bearing says which rose it came from: a `CardinalWind` cannot be passed where a
+sixteen-point `HalfWind` is expected, and a match on a four-point bearing is exhaustive over four
+cases rather than sixteen.
+
+A rose with a different number of points is added by implementing `Directional`, which is a single
+method from an angle to a value, so a domain with its own sectors — a wind-rose with twelve points,
+a radar with sixty — uses the same `Compass` machinery.
+
 ### Locations
 
 A `Location` pairs a latitude and longitude, constructed from angles, and answers geographic
@@ -73,7 +82,19 @@ here.geohash(6)                   // a six-character geohash
 
 The surface distance is itself an `Angle` — the fraction of the great circle between the points —
 which multiplies by a planet's radius to give a length, keeping the geometry separate from the
-choice of sphere.
+choice of sphere. A calculation on Earth and the same calculation on Mars differ only in the
+radius they are multiplied by.
+
+A `Location` is stored as a packed pair of fixed-point angles rather than two boxed doubles, so a
+collection of positions costs one machine word each. A type that has a position — a city, a
+station, a photograph — supplies a `Locatable` instance and is then accepted wherever a location
+is, so the geographic operations apply to domain values directly rather than requiring their
+coordinates to be extracted first.
+
+Geohashes are the usual base-32 encoding, and share the property that matters: two locations close
+together usually share a prefix, so a prefix query is a coarse proximity search. "Usually" is the
+honest word — the encoding's cell boundaries mean two points either side of one share nothing —
+which is why a geohash prefix is a first filter rather than an answer.
 
 ### Geo URIs
 

--- a/doc/modules/git.md
+++ b/doc/modules/git.md
@@ -93,3 +93,52 @@ A `GitBranch`, `GitTag` and `GitHash` name the three kinds of reference, and a `
 them or a relative expression such as `Refspec.head()` for `HEAD`. Because each is its own type, an
 operation that expects a branch will not accept a tag, and a hash carries the guarantee that it is a
 well-formed forty-character identifier.
+
+Reference names follow Git's own rules — no leading dot, no `..`, no control characters, no
+trailing `.lock`, and the rest — checked as [names](names.md) on their own plane, so an invalid
+branch name is rejected where it is written rather than by Git at the point of use.
+
+### Diffs
+
+`diff` reports changes as structured values rather than as patch text to re-parse. Each `FileDiff`
+carries the paths on both sides, the kind of change — added, modified, deleted, renamed, copied —
+and its hunks, each hunk a list of edits:
+
+```scala
+val files = worktree.diff().to(List)
+files.head.changeKind      // ChangeKind.Modified
+files.head.hunks.flatMap(_.edits)
+```
+
+The same parser reads a patch from anywhere — a file, an email, a code-review comment — so a tool
+that inspects or applies patches works with values, including the awkward cases: renames with
+similarity indices, binary files, mode changes, and files with no trailing newline.
+
+### Merging, cherry-picking and reverting
+
+`merge` takes the reference to merge and a fast-forward policy, so whether a merge commit is
+created is stated rather than inherited from configuration:
+
+```scala
+worktree.merge(GitBranch(t"feature"), ff = FastForward.Only)
+worktree.merge(GitBranch(t"feature"), ff = FastForward.Never, message = t"Merge feature")
+```
+
+`cherryPick` and `revert` apply and undo a single commit's changes. A conflict is a typed failure
+naming the paths that conflict, rather than a non-zero exit status and a message to parse.
+
+### Remotes, notes and the reflog
+
+Remotes are added, listed and removed as values, each reporting its name and URL. Notes attach
+arbitrary text to a commit without altering it, in a chosen namespace, which is how build
+attestations, review state and other out-of-band metadata travel with a repository:
+
+```scala
+worktree.repo.addRemote(t"origin", t"git@example.com:foo/bar.git")
+
+worktree.repo.notes.add(hash, t"a note body")
+worktree.repo.notes.show(hash)   // Unset where there is no note
+```
+
+`reflog` gives the local history of where a reference has pointed, newest first — the record that
+makes a mistaken reset recoverable.

--- a/doc/modules/graphs.md
+++ b/doc/modules/graphs.md
@@ -53,6 +53,30 @@ dag.descendants(8)     // the sub-graph beneath 8
 dag.invert             // the graph with every edge reversed
 ```
 
+`ancestors` is the counterpart of `descendants`, giving what depends on a node rather than what it
+depends on, and `lineage` gives both together — the node's whole causal neighbourhood, which is
+what "why is this here, and what breaks if I remove it" asks for.
+
+`sources` gives the nodes with no dependencies, which is where a build or an installation starts,
+and `subgraph` restricts the graph to a chosen set of nodes.
+
+Everything that could encounter a cycle says so: `sorted`, `reachable`, `descendants` and their
+kin raise a `DagError`, since a cyclic graph has no topological order and no finite reachable set.
+`hasCycle` asks the question directly, for code that would rather check than handle.
+
+### Folding over a graph
+
+A traversal computes a value for every node from the values of the nodes it depends on, in an
+order that guarantees the dependencies are computed first:
+
+```scala
+dag.traversal[Int]((childValues, node) => childValues.sum + 1)
+```
+
+This is the shape of most real work over a dependency graph — computing a build order's costs,
+propagating a version constraint, accumulating a transitive set — expressed once rather than as a
+hand-written recursion with its own visited-set bookkeeping.
+
 ### Closure and reduction
 
 The transitive `closure` adds an edge wherever a path exists; the transitive `reduction` removes

--- a/doc/modules/hashing.md
+++ b/doc/modules/hashing.md
@@ -63,6 +63,31 @@ Person(t"Alice", 30).digest[Sha2[256]]
 
 A digest is itself digestible, so a hash can be combined into a larger structure and hashed again.
 
+### Hashing a stream
+
+Data too large to hold is hashed as it passes. The digest accumulates over successive windows,
+carrying partial blocks across the boundaries between them, so the result is identical whatever
+sizes the chunks happen to arrive in — including chunks of one byte, and windows that begin part
+way into a buffer:
+
+```scala
+file.stream.digest[Sha2[256]].serialize[Hex]
+```
+
+This is what makes a digest computable over a [stream](streams.md) with bounded memory, and it is
+why hashing composes with [compression](compression.md) and [encryption](cryptography.md) in one
+pipeline rather than requiring the data to be materialized between them.
+
+### BLAKE3
+
+`Blake3` is the pure-Scala implementation, and it offers the algorithm's three modes: an ordinary
+hash, a *keyed* hash for message authentication, and key *derivation* from a context string. All
+three are checked against the official test vectors, at every input length the vectors cover, so
+the implementation is verified rather than merely tested for self-consistency.
+
+Its output is extendable: a BLAKE3 digest may be taken at any length, not only at 256 bits, which
+is what makes it usable as a key-derivation function as well as a hash.
+
 ### Rendering a digest
 
 A digest's bytes render in any base encoding — hexadecimal for display, Base64 where it must be

--- a/doc/modules/hashing.md
+++ b/doc/modules/hashing.md
@@ -45,6 +45,11 @@ t"Hello world".digest[Sha2[256]].serialize[Hex]
 The provider in scope supplies the algorithms — `javaStdlibProvider` for the SHA and MD5 family and
 CRC-32, and `soundnessProvider` for the pure-Scala BLAKE3.
 
+`javaStdlibProvider` names the JDK's `MessageDigest` where there is one. Off the JVM there is
+not, so the same import selects pure-Scala implementations of MD5, SHA-1, SHA-2 and CRC-32,
+validated byte for byte against the JDK's. Code that hashes therefore reads the same, and
+produces the same digests, on the JVM, in a browser and inside a WebAssembly component.
+
 ### Hashing your own types
 
 Any value that can be reduced to bytes is digestible, and a case class derives that automatically

--- a/doc/modules/http-client.md
+++ b/doc/modules/http-client.md
@@ -75,6 +75,42 @@ url"https://example.com/submit".submit(Http.Post, accept = media"application/jso
 a stream, or a value parsed from the body. The status is a value to inspect or to receive in its own
 right, so a program decides what a given status means rather than having it decided for it.
 
+### Sessions
+
+A single request opens a connection and closes it. Where several requests go to the same origin,
+a *session* opens one connection and lends it to a scope, so the requests within share it:
+
+```scala
+url"https://example.com".session: session ?=>
+  session.fetch(request)
+  session.fetch(request)
+```
+
+The protocol is fixed for the session's lifetime. For `https`, ALPN chooses it during the TLS
+handshake: a *multiplexed* HTTP/2 session, on which fetches interleave over one connection, or a
+*sequential* HTTP/1.1 one. Plaintext `http` is always sequential, with keep-alive pinning one
+connection across the scope's fetches.
+
+The scope is enforced, not merely conventional. The result type is quantified outside the block,
+so a value still borrowing the live connection — a response body streaming from it — cannot
+escape; a value that has been memoized may. Leaving a response unconsumed does not derail the
+session: the next fetch drains what remains of the previous body to reach the response boundary.
+
+### Choosing a transport
+
+The transport is a given. `httpBackends.virtualMachine` uses the JVM's own `java.net.http`;
+`httpBackends.native` speaks Soundness's wire codecs directly over a socket, with no
+`java.net.http` involved:
+
+```scala
+import httpBackends.native
+```
+
+The native backend pools kept-alive HTTP/1.1 connections per origin, and negotiates by ALPN over
+TLS, driving the exchange with the HTTP/2 or HTTP/1.1 driver the peer selected on the same
+socket. A pooled socket the server has since closed is discovered on use and replaced by a single
+retry on a fresh connection. Other platforms supply their own backends the same way.
+
 ### Redirects
 
 Redirects are followed by default, up to a limit. Importing a stricter policy stops them, after

--- a/doc/modules/http-client.md
+++ b/doc/modules/http-client.md
@@ -135,3 +135,15 @@ raises a `ConnectError` naming the reason:
 ```scala
 capture[ConnectError](url"http://no-such-host.invalid/".fetch()).reason   // ConnectError.Reason.Dns
 ```
+
+A TLS failure is distinguished from a network one, and its own reason says at which stage it
+failed. An expired certificate, a certificate for the wrong host, a revoked one, a broken cipher
+suite, an undersized Diffie–Hellman group — each is refused at the handshake rather than accepted
+with a warning nobody reads. The client is tested against the
+[badssl.com](https://badssl.com/) suite of deliberately-broken endpoints, so the refusals are
+verified rather than assumed.
+
+Where a connection genuinely must be made to a host whose certificate cannot be validated — a
+development server with a self-signed certificate — a relaxed `TlsAcceptance` in scope permits it.
+Making that an explicit, searchable import is the point: accepting an unvalidated certificate is a
+decision, not a default.

--- a/doc/modules/http-server.md
+++ b/doc/modules/http-server.md
@@ -6,11 +6,12 @@ An HTTP server is a handler: a function from a request to a response, served on 
 runs one with a single expression — the handler reads the ambient request, matches on its method
 and path, and returns a typed response whose `Content-Type` follows from the value it carries. The
 raw-socket backend speaks modern HTTP/1.1 — keep-alive, pipelining, chunked bodies, TLS,
-`100-continue` and protocol upgrades — on a virtual thread per connection.
+`100-continue` and protocol upgrades — on a virtual thread per connection, and speaks HTTP/2 on
+any connection whose TLS handshake negotiates it.
 
 Above HTTP/1.1 sit the neighbouring protocols: [WebSockets](https://en.wikipedia.org/wiki/WebSocket)
-upgrade a request into a message stream handled as a state machine, and an HTTP/2 client speaks
-h2c for the gRPC-style protocols that require it.
+upgrade a request into a message stream handled as a state machine, and HTTP/2 multiplexes many
+requests over one connection, for browsers and for the gRPC-style protocols that require it.
 
 ### On serving HTTP
 
@@ -87,10 +88,32 @@ The implementation handles the protocol's sharp edges — masking, fragmentation
 UTF-8 validation, close codes — and conforms to the
 [Autobahn](https://github.com/crossbario/autobahn-testsuite) test suite.
 
+### Request and response bodies
+
+A request body is a stream, not a block of bytes that must arrive before the handler runs: a
+large upload is consumed as it is received, and a response body is framed off its stream
+block by block, so neither side is held in memory. The body belongs to the handler's scope —
+it is the connection's, and the connection ends — so a handler that wants to keep a body past
+its response memoizes it explicitly.
+
 ### HTTP/2
 
-An HTTP/2 connection speaks cleartext h2c with prior knowledge — the flavour gRPC and other
-multiplexed protocols use between services — with full
-[HPACK](https://datatracker.ietf.org/doc/html/rfc7541) header compression. It slots in as an
-[HTTP client](http-client.md) transport over an `Http2.Endpoint`, and carries the
+A TLS listening socket offers `h2` then `http/1.1` by ALPN, and a connection that negotiates
+`h2` is driven by the HTTP/2 engine instead of the HTTP/1.1 keep-alive loop. The handler
+contract is unchanged, so an existing application serves HTTP/2 with no alteration:
+
+```scala
+supervise:
+  SocketServer(8443, ssl = sslContext).handle:
+    Http.Response(Http.Ok)(t"Hello over h2!")
+```
+
+Each client-initiated stream is handled on its own virtual thread, so requests multiplexed on
+one connection run concurrently. The engine implements flow control, trailers, and full
+[HPACK](https://datatracker.ietf.org/doc/html/rfc7541) header compression, and tolerates the
+frame types it does not act on — `PRIORITY`, `PUSH_PROMISE`, extensions — rather than failing
+the connection.
+
+Cleartext h2c with prior knowledge — the flavour used between services — is spoken over an
+`Http2.Endpoint`, which is also an [HTTP client](http-client.md) transport, and carries the
 [gRPC](rpc.md) support built on top of it.

--- a/doc/modules/hyphenation.md
+++ b/doc/modules/hyphenation.md
@@ -77,5 +77,40 @@ given Hyphenation = englishHyphenation.extending(patterns = Seq(t"klm9nop"))
 t"klmnop".hyphenate(hyphen = '-')   // t"klm-nop"
 ```
 
+Patterns are merged by taking the higher score at each position, so an added pattern with an odd
+score reinstates a break that a standard even-scored pattern had forbidden — which is how one word
+is corrected without disturbing the rest of the language.
+
+Some words no pattern gets right. An *exception* states a word's breaks outright, and takes
+precedence over the algorithm:
+
+```scala
+given Hyphenation = englishHyphenation.extending(exceptions = Seq(t"hy-phenation"))
+```
+
+The standard English set already carries the exception list TeX ships, so `associate` breaks as
+`as-so-ciate` and `table` as `ta-ble`, where the patterns alone would not.
+
 A whole language is supplied the same way: `Hyphenation.fromTex` reads any TeX hyphenation
 pattern file, so the languages published for TeX are available by loading their patterns.
+
+### Text that is not one word
+
+Hyphenation applies to letters, and text is rarely only letters. Each run of letters is
+hyphenated independently, and everything else — spaces, punctuation, digits — passes through
+untouched:
+
+```scala
+t"hello, world!".hyphenate(hyphen = '-')      // unchanged: both words are too short
+t"the algorithm runs".hyphenate(hyphen = '-') // t"the al-go-rithm runs"
+```
+
+`syllables` follows the same rule, yielding the non-letter runs as segments of their own, so
+reassembling the segments reproduces the original text exactly.
+
+### When no patterns are available
+
+A language for which no pattern set has been loaded hyphenates nothing rather than guessing:
+`hyphenate` returns the text unchanged, and `breakPoints` is empty. A line-wrapping algorithm
+therefore degrades to breaking at spaces, which is the correct behaviour, rather than inventing
+breaks in a language whose rules it does not know.

--- a/doc/modules/images.md
+++ b/doc/modules/images.md
@@ -2,10 +2,16 @@
 
 ### About
 
-Raster images — PNG, JPEG, GIF and BMP — read into a `Raster` value with the format in its type,
-just as [audio](audio.md) carries its format. A `Raster in Png` and a `Raster in Jpeg` are distinct
-types; converting between them is one method; and the image itself is an immutable grid of pixels,
-each read as a typed [color](colors.md), with cropping, flipping and rotation producing new images.
+Raster images — PNG, JPEG, WebP, GIF and BMP — read into a `Raster` value with the format in its
+type, just as [audio](audio.md) carries its format. A `Raster in Png` and a `Raster in Jpeg` are
+distinct types; converting between them is one method; and the image itself is an immutable grid
+of pixels, each read as a typed [color](colors.md), with cropping, flipping and rotation
+producing new images.
+
+A raster may also carry its *pixel layout* in its type — how many bits each channel occupies and
+in what order — so a pixel is read with a single shift and mask, computed as the code compiles
+rather than dispatched at runtime. Every codec is implemented directly, so images read and write
+on every platform, not only on the JVM.
 
 ### On raster images
 
@@ -58,6 +64,40 @@ are made:
 val gradient = Raster(256, 1)((x, y) => Chroma(x, 0, 255 - x))
 ```
 
+### Pixel layouts
+
+A layout is a tuple of channel types, most significant first — `(Red[10], Green[12], Blue[10])`
+is exactly the packing of a 32-bit RGB pixel, and `Rgba` names the familiar eight-bit one. A
+raster built with a layout gives typed access, and `pixel` compiles to one constant shift and
+mask:
+
+```scala
+val raster = Raster[Rgba](2, 2): (x, y) =>
+  Pixel[Rgba](Srgb(x.toDouble, y.toDouble, 1.0))
+
+raster.pixel(1, 0).red
+raster.pixel(1, 0).alpha
+```
+
+`repack` converts between layouts, adding a fully-opaque alpha channel where the target has one
+and scaling the channels where their depths differ; repacking to the layout a raster already has
+returns the same raster. A `descriptor` reports the layout at runtime, for the operations that
+must work whatever it is.
+
+### Canvases
+
+A `Raster` is immutable, and generating one pixel at a time through `Raster(w, h)(…)` is not
+always the shape a drawing algorithm wants. Opening a raster as a `Canvas` gives a scoped handle
+over its buffer instead. Any canvas reads; only one opened with the `Write` grant may be written
+to, and the write mutates in place:
+
+```scala
+raster.open[Canvas](Read & Write): canvas ?=>
+  canvas(0, 0) = Pixel[Rgb](Srgb(1.0, 0.0, 0.0))
+```
+
+`snapshot` takes an independent copy, so a derived image is unaffected by later writes.
+
 ### Transforming
 
 Cropping, flipping and quarter-turn rotation each produce a new image:
@@ -78,4 +118,10 @@ symmetrically with reading:
 
 ```scala
 val jpegBytes = image.to[Jpeg].read[Data]
+val webpBytes = image.to[Webp].read[Data]
 ```
+
+The codecs — PNG with its filters, baseline and progressive JPEG, WebP in both its lossy VP8 and
+lossless forms, GIF with its LZW, and BMP — are written directly against the formats. A backend
+seam picks between them and the platform's own imaging library where one exists, so the same code
+converts an image on the JVM, in a browser, and inside a WebAssembly component.

--- a/doc/modules/internationalization.md
+++ b/doc/modules/internationalization.md
@@ -63,7 +63,7 @@ setting. A language code decodes to a `Locale`, falling back to English for a co
 recognised:
 
 ```scala
-val locale = t"fr".decode[Locale[en & pl & fr & de & es]]
+val locale = t"fr".as[Locale[en & pl & fr & de & es]]
 ```
 
 With that locale in scope, every polyglot covering those languages reads in the user's language,

--- a/doc/modules/interpolation.md
+++ b/doc/modules/interpolation.md
@@ -82,3 +82,44 @@ An interpolator's parsing logic is ordinary code, and it runs in both worlds: at
 literals, giving compile errors; and at runtime for dynamically-built input, giving typed errors.
 The two cannot drift apart, because they are the same code — a guarantee no hand-written macro
 plus separate runtime parser can make.
+
+### Parts and origins
+
+`interpolate` receives two type parameters that carry what the compiler knows about the literal.
+`parts` is a tuple of the literal fragments as singleton string types, so the interpolator sees
+the text of each; `origins` carries where each fragment began in the source file, so an error
+reported against a character within a fragment resolves to that character's position in the file
+rather than to the start of the expression:
+
+```scala
+inline given interpolable: MediaType is Interpolable:
+  transparent inline def interpolate[parts <: Tuple, origins <: Tuple](inline insertions: Any*)
+  :   MediaType =
+
+    ${internal.mediaInterpolator[parts]('insertions)}
+```
+
+That is what makes a compile error underline the misspelled subtype in `media"text/plian"`
+instead of the whole literal.
+
+### Returning a precise type
+
+The prefix method is `transparent inline`, so an interpolator may return something more specific
+than its declared type — this is how a literal can carry what it *is* into the type system rather
+than merely validating itself. A path literal returns a path on a particular platform; a name
+literal returns a name proved to be valid for its plane; a schema-checked document literal returns
+a document typed by its schema.
+
+The cost of that precision is that the result type depends on the literal's content, so the
+literal must be known at compiletime. Where it is not, the corresponding runtime parser — the same
+code — returns the general type and a typed error.
+
+### Choosing between compiletime and runtime
+
+An interpolator is the right tool where a literal has a syntax and that syntax can be checked. It
+is the wrong tool where the content is genuinely dynamic: there is nothing to check as the code
+compiles, and the interpolator's machinery buys nothing over the runtime parser it delegates to.
+
+The convention throughout is therefore to offer both — `url"…"` for a literal and `as[Url]` for
+text obtained at runtime — with the same code behind each, so a program can move a value from one
+to the other without a change in behaviour.

--- a/doc/modules/json.md
+++ b/doc/modules/json.md
@@ -167,6 +167,34 @@ t"""{"radius":1.0,"kind":"Circle"}""".read[Json].as[Shape]   // Shape.Circle(1.0
 `@name` renames a case's discriminator value just as it renames a field, so the wire
 form and the Scala name can differ.
 
+A discriminator field alongside the case's own fields is only one of the conventions in use, and
+the others are chosen by a `Discriminable` given rather than by writing a codec. A *wrapper*
+encoding puts the whole variant inside a single-key object named for the case:
+
+```scala
+given Shape is Discriminable in Json = Json.DiscriminantWrapper()
+
+(Shape.Circle(1.0): Shape).in[Json].show
+// t"""{"Circle":{"radius":1.0}}"""
+```
+
+An *envelope* encoding names the tag field and the payload field:
+
+```scala
+given Shape is Discriminable in Json = Json.DiscriminantEnvelope(t"type", t"value")
+
+(Shape.Square(2.0): Shape).in[Json].show
+// t"""{"type":"Square","value":{"side":2.0}}"""
+```
+
+Each works both through the tree and through [direct parsing](#case-classes-and-enumerations),
+and direct parsing does not require the tag to come first: a document whose `type` field trails
+its `value` reads just as one whose tag leads. A wrapper object with more than one key is not a
+valid variant, and raises `JsonError.Reason.Absent` rather than guessing which key was meant.
+
+Anything more exotic is a `Discriminable` written by hand — three methods saying how to attach a
+tag, how to read one, and how to reach the variant — and codecs derived from it work unchanged.
+
 ### Building JSON
 
 Beyond encoding a typed value, a `Json` value can be assembled directly. `Json.make`
@@ -308,6 +336,21 @@ than thrown at the first, and each is tagged with a [JSON Pointer](https://en.wi
 to the field that failed — `#/age` and `#/email` for two missing fields — so a whole
 document's problems can be reported at once.
 
+The pointer comes from a *focus* the decoder maintains as it descends, and which an accruing
+strategy reads through `prior`. Decoding a contact whose person and address are each wrong in
+two places yields four errors, pointed at `#/person/age`, `#/person/email` and so on — the whole
+tree's faults in one pass, each locatable, rather than the first fault and nothing else:
+
+```scala
+Validate[Issues, [r] =>> r raises JsonError, Json.Focus]
+  ( Issues(),
+    { case error: JsonError => accrual + (prior.let(_.pointer.encode).or(t"#"), error) } )
+. protect(document.as[Contact])
+```
+
+Missing and wrong-typed fields accrue together, and a field that is absent contributes exactly
+one error rather than one per attempt to read it.
+
 ### Inspecting the structure
 
 Two equal documents compare equal regardless of the order of their object keys, and a
@@ -326,16 +369,32 @@ Json.unseal(t"42".read[Json]).isLong          // true
 Json.unseal(t""""x"""".read[Json]).primitive  // JsonPrimitive.String
 ```
 
+The predicates are finer than the primitives: `isLong` and `isDouble` distinguish the two
+numeric representations, and `isNumber` covers both, so code that cares about the difference can
+ask, and code that does not need not. `isString`, `isBoolean`, `isNull`, `isObject` and `isArray`
+complete the set.
+
 ### Numbers and precision
 
-JSON numbers have no inherent precision limit, and Soundness can keep them exact. The
-number mode in scope decides how parsed numbers are stored: `fullNumberMode` retains
-every digit as a binary-coded decimal, while `doubleNumberMode` keeps a `Double` where
-that is enough. The mode is chosen by import:
+JSON numbers have no inherent precision limit, and most parsers quietly impose one. The number
+mode in scope decides what happens to a number too long to hold in the parser's fast path — about
+fifteen digits — while everything shorter is decoded identically whatever the mode:
 
 ```scala
 import numberModes.fullNumberMode
 ```
+
+`fullNumberMode` keeps every digit, accumulating them as a binary-coded decimal at the cost of an
+allocation for that number. It is the default, because losing digits silently is the wrong thing
+to do by default.
+
+`doubleNumberMode` drops the overflow and computes a `Double` from the leading digits — matching
+what Jawn, Circe, Jsoniter and Jackson do — which is the mode to choose for a like-for-like
+throughput comparison, or where the data is known to be within a double's range.
+
+`bcdNumberMode` also drops the overflow but emits the raw packed accumulator with no allocation
+at all. The `Long` it yields carries BCD nibbles rather than the number's value, so it is
+throughput at the price of treating those numbers as opaque.
 
 ### NDJSON
 
@@ -383,6 +442,16 @@ val tracked = Json.parseTracked(t"{\n  \"a\": 42\n}")
 tracked.locate(JsonPointer()(t"a")).let(_.line)   // 2
 ```
 
+A position covers the whole of the value it names, so a negative number's extent includes its
+minus sign, and an object or array is located as the span from its opening brace to its closing
+one. `locateKey` gives the position of the *key* matching the final segment rather than its
+value, which is what underlining a misspelled field name needs.
+
+A pointer that does not resolve — a key the document lacks, an index past the end of an array —
+returns `Unset` rather than raising, so probing a document for a position is safe. Under ordinary,
+untracked parsing every `locate` returns `Unset`, which is how a program that does not want the
+cost pays none of it.
+
 ### Schemas
 
 A [JSON Schema](https://en.wikipedia.org/wiki/JSON_Schema) describes the permitted
@@ -428,10 +497,53 @@ alice.verify[Employee].name.as[Text]   // t"Alice"
 
 alice.verify[Employee].nope            // does not compile: no such field
 alice.verify[Employee].name(0)         // does not compile: name is not an array
+alice.verify[Employee].name.deeper     // does not compile: a scalar has no fields
 ```
+
+Navigation runs to any depth, through nested objects and into arrays, with each step checked:
+
+```scala
+posting.verify[Posting].workplace.city.as[Text]
+squad.verify[Squad].members(1).name.as[Text]
+```
+
+Verified navigation needs no `dynamicJsonAccess` import — the schema, not a blanket enabler, is
+what licenses it. Reaching a field of an *unverified* document still requires the enabler, and
+the error says so, so the two kinds of access cannot be confused.
 
 This closes the usual gap in working with JSON: a path through a document is checked
 against the type it is supposed to have, before the program runs.
+
+### Overriding one field's encoder
+
+A derived encoder uses, for each field, whatever instance is in scope for that field's type — and
+a given in scope changes every field of that type at once, which is rarely what a single
+awkward field calls for. A `Specific` names the path instead, so an override applies along one
+spine and nowhere else:
+
+```scala
+val shout: Text is Json.Encodable = Json.Encodable(() => Morphology.Str): text => Json(text.upper)
+
+given (Firm is Specific over Json.Encodable) =
+  specifically:
+    case root.deputy.name() => shout
+
+Firm(Worker(t"ann", 30), Worker(t"bob", 40)).in[Json].show
+// t"""{"boss":{"name":"ann","age":30},"deputy":{"name":"BOB","age":40}}"""
+```
+
+The boss's name is untouched: only the path named is overridden. A path ending at a collection
+takes an encoder for the collection, so re-deriving it against a local given re-encodes its
+elements — the way to change how the members of one list are written without changing that type
+everywhere:
+
+```scala
+given (Crew is Specific over Json.Encodable) =
+  specifically:
+    case root.members() =>
+      given Worker is Json.Encodable = nameOnly
+      summon[List[Worker] is Json.Encodable]
+```
 
 ### Typed records from a schema
 

--- a/doc/modules/json.md
+++ b/doc/modules/json.md
@@ -75,14 +75,16 @@ and decoder from the fields, so a value converts to an object and back:
 ```scala
 case class Person(name: Text, age: Int)
 
-Person(t"Alice", 30).json.show   // t"""{"name":"Alice","age":30}"""
+Person(t"Alice", 30).in[Json].show   // t"""{"name":"Alice","age":30}"""
 
 t"""{"name": "Bob", "age": 40}""".read[Json].as[Person]
 // Person(t"Bob", 40)
 ```
 
-The `json` method encodes any value for which an encoder is derived, and `show`
-renders the result. Nested case classes and collections of them derive in turn, so a
+The `in[Json]` method encodes any value for which an encoder is derived, and `show`
+renders the result. (`in` is the general codec vocabulary: `value.in[Format]` encodes
+and `value.as[Type]` decodes, whatever the format.) Nested case classes and
+collections of them derive in turn, so a
 whole structure converts in one step. Decoding straight from text to a type combines
 the two:
 
@@ -94,6 +96,19 @@ t"""{"rowers":[{"name":"Bob","age":40}],"cox":{"name":"Carol","age":25}}"""
 // Crew(List(Person(t"Bob", 40)), Person(t"Carol", 25), None)
 ```
 
+This is not a shorthand for parsing and then decoding. A type with a `Json.Parsable` instance is
+read *directly* from the source: the parser is composed for that type as the code compiles, and
+fields are taken from the token stream as they arrive, so no `Json` tree is ever built. What is
+saved is the whole intermediate structure — allocation, boxing, and a second traversal:
+
+```scala
+object Person:
+  given parsable: Person is Json.Parsable = Json.Parsable.derived
+```
+
+The tree route remains for documents whose shape is not known in advance, or where the tree is
+itself the point.
+
 ### Optional fields and defaults
 
 A field typed as `Optional` (or `Option`) is omitted from the output when it is
@@ -102,7 +117,7 @@ absent, and supplied as `Unset` (or `None`) when missing on the way in:
 ```scala
 case class Profile(name: Text, age: Optional[Int])
 
-Profile(t"Eve", Unset).json.show   // t"""{"name":"Eve"}"""
+Profile(t"Eve", Unset).in[Json].show   // t"""{"name":"Eve"}"""
 ```
 
 A field with a default takes that default when the document omits it:
@@ -122,7 +137,7 @@ want a different one:
 ```scala
 case class Record(@name[Json](t"first_name") firstName: Text, @name(t"yob") year: Int)
 
-Record(t"Ann", 1984).json.show   // t"""{"first_name":"Ann","yob":1984}"""
+Record(t"Ann", 1984).in[Json].show   // t"""{"first_name":"Ann","yob":1984}"""
 ```
 
 ### Tagged unions
@@ -138,7 +153,7 @@ enum Shape:
   case Circle(radius: Double)
   case Square(side: Double)
 
-(Shape.Circle(1.0): Shape).json.show
+(Shape.Circle(1.0): Shape).in[Json].show
 // t"""{"radius":1.0,"kind":"Circle"}"""
 ```
 
@@ -158,7 +173,7 @@ Beyond encoding a typed value, a `Json` value can be assembled directly. `Json.m
 builds an object from named arguments, each itself a `Json`:
 
 ```scala
-Json.make(a = 1.json, b = t"two".json, c = true.json).show
+Json.make(a = 1.in[Json], b = t"two".in[Json], c = true.in[Json]).show
 // t"""{"a":1,"b":"two","c":true}"""
 ```
 
@@ -173,7 +188,7 @@ j"""{"a": $x}"""        // an object with a from a value
 val xs = List(2, 3, 4)
 j"""[1, $xs*]"""        // [1, 2, 3, 4]
 
-val rest: Map[Text, Json] = Map(t"b" -> 2.json, t"c" -> 3.json)
+val rest: Map[Text, Json] = Map(t"b" -> 2.in[Json], t"c" -> 3.in[Json])
 j"""{"a": 1, $rest}"""  // {"a": 1, "b": 2, "c": 3}
 ```
 
@@ -259,8 +274,8 @@ case class Role(name: Text)
 case class Entity(name: Text, age: Int, roles: List[Role])
 case class Org(name: Text, leader: Entity)
 
-val org = Org(t"The Beatles", Entity(t"John", 40, List(Role(t"Leader")))).json
-org.lens(_.leader.age = 41.json).as[Org]
+val org = Org(t"The Beatles", Entity(t"John", 40, List(Role(t"Leader")))).in[Json]
+org.lens(_.leader.age = 41.in[Json]).as[Org]
 // the leader's age updated to 41
 ```
 
@@ -271,7 +286,7 @@ indented formatting adds newlines and indentation for reading:
 
 ```scala
 import formatting.indentedJsonFormatting
-List(1, 2, 3).json.show   // pretty-printed across several lines
+List(1, 2, 3).in[Json].show   // pretty-printed across several lines
 ```
 
 ### Errors
@@ -325,13 +340,18 @@ import numberModes.fullNumberMode
 ### NDJSON
 
 [Newline-delimited JSON](https://en.wikipedia.org/wiki/JSON_streaming) — a stream of
-independent documents, one per line — is represented by `Ndjson`, which wraps a stream
-of `Json` values:
+independent documents, one per line — needs no type of its own. A source is split into
+records at its line boundaries with `delineate`, and each record is read as `Json`:
 
 ```scala
-val stream = Stream(t"1".read[Json], t"2".read[Json], t"3".read[Json])
-Ndjson(stream).stream.map(_.as[Int]).to(List)   // List(1, 2, 3)
+import lineSeparation.adaptiveLinefeedLineSeparation
+
+t"1\n2\n3".source[Text].delineate.records.map(_.read[Json].as[Int]).to(List)
+// List(1, 2, 3)
 ```
+
+Because each line is read independently, the values need not share a shape; a
+heterogeneous log reads just as well as a uniform one.
 
 ### JSON Pointers
 
@@ -370,7 +390,7 @@ shape of a document. Soundness derives a schema from a Scala type, and a schema 
 renders to a standard JSON Schema document:
 
 ```scala
-(JsonSchema.Integer(): JsonSchema).json.show   // contains "type":"integer"
+(JsonSchema.Integer(): JsonSchema).in[Json].show   // contains "type":"integer"
 ```
 
 A field can carry a description for the generated schema with the `@memo` annotation,
@@ -441,9 +461,9 @@ types of its date-and-time library. An `Instant` and a `Duration` travel as a wh
 number of milliseconds:
 
 ```scala
-import chronometries.posix
+import chronometries.unix
 
-Instant(1700000000000L).json.show                       // t"1700000000000"
+Instant(1700000000000L).in[Json].show                       // t"1700000000000"
 t"5000".read[Json].as[Duration].value                   // 5.0
 ```
 

--- a/doc/modules/markdown.md
+++ b/doc/modules/markdown.md
@@ -38,6 +38,18 @@ import strategies.throwUnsafely
 val document = Parser.parse(t"# Title\n\nSome **bold** text.")
 ```
 
+Markdown also parses incrementally from a [stream](streams.md), reading lines as they arrive
+rather than holding the source. Only the tree, and each paragraph's deferred raw text, is
+retained, so a long document is parsed without ever being materialized:
+
+```scala
+val streamed = Parser.parse(source)
+readme.read[Markdown of Layout]
+```
+
+The whole CommonMark conformance suite passes through the streaming entry, one character per
+chunk, so a document split at any point parses to the same tree as the whole text.
+
 ### Rendering to HTML
 
 A parsed document renders to HTML with `html`, and the result shows as an HTML string. A block

--- a/doc/modules/mathematics.md
+++ b/doc/modules/mathematics.md
@@ -93,6 +93,40 @@ Matrix[2, 2]((1.0, 2.0), (3.0, 4.0)).inverse
 // Matrix[2, 2]((-2.0, 1.0), (1.5, -0.5))
 ```
 
+The `adjugate` — the transpose of the cofactor matrix — is available in its own right, since it is
+defined over any ring and not only where division is possible, so an integer matrix has an
+adjugate where it has no inverse:
+
+```scala
+Matrix[2, 2]((1, 2), (3, 4)).adjugate   // Matrix[2, 2]((4, -2), (-3, 1))
+```
+
+`frobeniusNorm` gives the matrix's magnitude — the square root of the sum of the squares of its
+entries — and `eigenvalues` computes the values for which the matrix has an eigenvector, as an
+`Optional` since not every matrix has real eigenvalues:
+
+```scala
+Matrix[2, 2]((3.0, 0.0), (0.0, 4.0)).frobeniusNorm   // 5.0
+Matrix[2, 2]((2.0, 1.0), (1.0, 2.0)).eigenvalues     // 1.0 and 3.0
+```
+
+### Elements that are not numbers
+
+Nothing above requires the entries to be `Double`s. Vectors and matrices are generic in their
+element type, and the operations resolve through the arithmetic typeclasses, so anything with the
+right structure works — including typed [quantities](quantities.md), where the dimensions compose
+as the arithmetic does:
+
+```scala
+val v1 = Vector(5*Inch, 2*Inch, Inch)
+val v2 = Vector(2*Inch, 3*Inch, 6*Inch)
+
+v1.dot(v2)   // 22 square inches — the units multiplied too
+```
+
+A dot product of lengths is an area, and the type says so. The same holds for complex entries, for
+exact rationals, and for any other element type with the operations the computation needs.
+
 ### Permutations
 
 A `Permutation` is a reversible rearrangement, built from the reordered indexes and applied to any

--- a/doc/modules/media-types.md
+++ b/doc/modules/media-types.md
@@ -48,7 +48,7 @@ media"application/jsom"   // does not compile: did you mean application/json?
 A parsed `MediaType` exposes its parts, and parameters are added as named arguments:
 
 ```scala
-val mediaType = t"application/json; charset=UTF-8".decode[MediaType]
+val mediaType = t"application/json; charset=UTF-8".as[MediaType]
 
 mediaType.group      // Media.Group.Application
 mediaType.basic      // t"application/json" — without parameters

--- a/doc/modules/money.md
+++ b/doc/modules/money.md
@@ -83,6 +83,10 @@ val priced = Gbp(2.30).tax(0.2)   // Price(Gbp(2.30), Gbp(0.46))
 priced.inclusive                  // Gbp(2.76)
 ```
 
+Tax rounds *up* to the minor unit, which is what tax authorities require and what a naive
+rounding gets wrong in exactly the cases that matter: twenty per cent of £2.94 is £0.588, charged
+as £0.59 rather than £0.58.
+
 A `Price` deliberately has no `show`: whether to display the inclusive or exclusive amount is a
 decision the application must make explicitly, by showing the member it means.
 
@@ -113,3 +117,10 @@ isin"GB00BH4HKS39"          // a valid ISIN
 isin"GB00BH4HKS3"           // does not compile: wrong length
 Luhn.check(17893729974L)    // true
 ```
+
+An `IsinError` says which rule was broken — the length, the country prefix, the permitted
+characters, or the Luhn check on the final digit — so a rejected identifier can be reported
+precisely rather than as "invalid".
+
+An `Isin` is an opaque type over a `Long`, so a validated identifier costs nothing to hold or
+compare, and cannot be confused with an unvalidated string.

--- a/doc/modules/names.md
+++ b/doc/modules/names.md
@@ -96,3 +96,34 @@ is how a path element containing a slash fails where it is written.
 `MustNotMatch` cover most namespaces, and each knows how to describe itself — which is where the
 error messages, and the compile errors, get their words. A namespace with a rule none of these
 express defines its own, as `DomId` does, by pairing a predicate with its description.
+
+A rule is therefore two things: a check, and a phrase describing what it demands. Writing one is
+supplying both:
+
+```scala
+object MustEnd extends Rule({ text => m"must end with $text" }, _.ends(_))
+```
+
+Because the description is part of the rule rather than written at each use, the compile error for
+a bad literal and the runtime error for bad input say the same thing, in the same words.
+
+`JavaIdentifier` shows the other shape a rule can take: rather than parameterizing on text to
+compare against, it parameterizes on the *description*, and checks against a predicate of its own —
+which is what a rule expressible as a predicate but not as a comparison needs.
+
+### Combining rules
+
+A plane's rules conjoin: a name must satisfy all of them, and the first violated is the one
+reported, so an error names a single concrete fault rather than a list of everything wrong.
+Writing a plane is therefore stating its rules in the order they should be reported.
+
+Because a plane is a type, one plane's names are not another's. A `Name[Tag]` cannot be passed
+where a `Name[Branch]` is expected even if the two happen to have identical rules — which is the
+point, since the rules may diverge later and the two namespaces were never the same thing.
+
+### Length limits
+
+A `Nominative` carries a `Limit` alongside its `Self`, which is how a plane states a maximum
+length: a filesystem whose names may not exceed 255 bytes, a protocol field of fixed width, a
+database column. The limit is part of the plane's type, so it is checked where a name is
+constructed rather than where it is finally written out.

--- a/doc/modules/network-addresses.md
+++ b/doc/modules/network-addresses.md
@@ -86,6 +86,45 @@ tcp"443"
 
 An unused ephemeral port is obtained from the operating system with `Port[Tcp]()`.
 
+### Subnets
+
+A subnet is written with its prefix length, and checked as the code compiles. Host bits below the
+prefix are masked away, so a subnet written carelessly is corrected rather than misinterpreted:
+
+```scala
+subnet"192.168.0.0/24"
+subnet"255.123.143.0/12".show   // t"255.112.0.0/12" — the host bits masked
+subnet"2001:db8::/32"
+```
+
+A subnet answers whether an address falls within it, which is what an access rule or a
+routing decision needs, and it is a value rather than a pair of strings to compare by hand.
+
+### Named services
+
+The well-known services have names, and those names are checked against the service registry —
+including which transport each is registered for. Asking for a service over the wrong transport
+does not compile:
+
+```scala
+tcp"smtp"      // Port[Tcp](25)
+udp"docker"    // does not compile: Docker is registered over TCP
+```
+
+### Interfaces and ephemeral ports
+
+The machine's own network interfaces enumerate as typed values, each reporting whether it is a
+loopback, and each addressable by name:
+
+```scala
+NetworkInterface.all()
+NetworkInterface.all().exists(_.loopback)
+```
+
+`Port[Tcp]()` with no number allocates an unused port, which is what a test server or a
+dynamically-bound service needs — and the port it returns is one that can actually be bound,
+rather than a guess that may race with another process.
+
 ### MAC addresses
 
 A MAC address is written with `mac"…"` and decoded from text, validated as six hexadecimal groups:

--- a/doc/modules/network-addresses.md
+++ b/doc/modules/network-addresses.md
@@ -37,7 +37,7 @@ as typed members:
 ```scala
 url"https://example.com:8080/path?query=1#top"
 
-t"https://example.com/".decode[HttpUrl]
+t"https://example.com/".as[HttpUrl]
 ```
 
 A hole in the interpolator substitutes a value in the right place — a number becomes the port, a text
@@ -65,12 +65,12 @@ ip"192.168.0.0.0.1"   // does not compile: too many groups
 
 ### Email addresses
 
-An email address is written with `email"…"` and parsed from text with `decode`, validated against the
+An email address is written with `email"…"` and parsed from text with `as`, validated against the
 rules for a well-formed address:
 
 ```scala
 email"test@example.com"
-t"simple@example.com".decode[EmailAddress]
+t"simple@example.com".as[EmailAddress]
 ```
 
 ### Ports
@@ -96,7 +96,7 @@ mac"01-23-45-ab-cd-ef"
 
 ### Parsing at runtime
 
-Every identifier that has a literal form also decodes from text with `decode`, naming the target type.
+Every identifier that has a literal form also decodes from text with `as`, naming the target type.
 A value that does not conform raises a typed error — an `HostnameError`, an `IpAddressError`, an
 `EmailAddressError` — that names precisely what was wrong, so a program validating user input can
 report the fault rather than merely rejecting the value.

--- a/doc/modules/network-addresses.md
+++ b/doc/modules/network-addresses.md
@@ -117,6 +117,8 @@ The machine's own network interfaces enumerate as typed values, each reporting w
 loopback, and each addressable by name:
 
 ```scala
+import urticose.NetworkInterface
+
 NetworkInterface.all()
 NetworkInterface.all().exists(_.loopback)
 ```

--- a/doc/modules/numbers.md
+++ b/doc/modules/numbers.md
@@ -106,6 +106,41 @@ once, and `min`, `max` and the collection reductions `minimum` and `maximum` rea
 List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.2 < _ < 1.4)   // List(1.3)
 ```
 
+### Arbitrary precision
+
+Where a value must be exact and no fixed width will do — a monetary total, a coordinate in a
+document, a figure read from a file that promised nothing about its size — a `Decimal` holds a
+sign, an arbitrary magnitude and a decimal scale:
+
+```scala
+Decimal(1234567890123L)
+Decimal(-1234567, 4)      // -123.4567
+Decimal(0.1)              // raises a DecimalError if the double is not exact
+Decimal.parse(t"-12.34e+2")
+```
+
+A decimal literal written in source becomes a `Decimal` directly where one is expected, and
+`text` renders it back, so the round trip is exact:
+
+```scala
+Decimal(-1234567, 4).text   // t"-123.4567"
+```
+
+Values are canonical: trailing zeros are absorbed into the scale as a value is constructed, and
+zero has one representation, so two numerically equal decimals are the same value. There is no
+counterpart of `BigDecimal`'s trap where `equals` and `compareTo` disagree.
+
+Division cannot always be exact, so it says what it wants: a scale and a rounding mode, given
+rather than assumed.
+
+```scala
+left.divide(right, scale = 10, Decimal.Rounding.HalfEven)
+```
+
+The implementation is pure Scala rather than a wrapper over the JVM's `BigDecimal`, so decimals
+work on every platform — and nothing in it depends on 64-bit-native arithmetic, which matters
+where `Long` is emulated.
+
 ### Bounded numbers
 
 A number can carry its permitted range in its type, written with `~`. A literal outside the

--- a/doc/modules/numbers.md
+++ b/doc/modules/numbers.md
@@ -66,6 +66,15 @@ Division by zero is checked the same way, by importing `arithmeticOptions.divisi
 after which `/` may raise a `DivisionError`. Where the check is not imported, the operations
 keep their bare machine behaviour and cost nothing.
 
+The two checks are independent, so a program that must not wrap but is content to trust its
+divisors imports only the first. Both are `inline`, and the unchecked forms compile to the same
+instructions the hardware would have executed anyway — the choice costs nothing where it is not
+taken.
+
+Overflow detection is exact rather than approximate: it distinguishes the cases where a signed
+addition genuinely overflows from those where it merely crosses zero, so a sum of the most
+negative value with itself is caught while ordinary negative arithmetic is not disturbed.
+
 ### Bit manipulation
 
 The `B*` types are for treating a number as a set of bits. They carry the shifts, rotations
@@ -79,7 +88,22 @@ flags.hex           // t"000000f0"
 ```
 
 `<<<` and `>>>` rotate rather than shift, `~` inverts, and individual bits are read and
-written with `bit`, `set`, `clear` and `flip`.
+written with `bit`, `set`, `clear` and `flip`. Bits are addressed by
+[ordinal](https://en.wikipedia.org/wiki/Ordinal_number) — `Prim` is the first, `Sec` the second —
+so a bit index cannot be confused with the off-by-one convention of whichever specification is
+being implemented:
+
+```scala
+B64(Data(0, 0, 0, 0, 0, 0, 0, 6)).bit(Sec)   // true
+```
+
+Rendering a bit pattern pads to the type's width rather than dropping leading zeros, so the
+number of characters says which type produced it:
+
+```scala
+(-1: Byte).hex       // t"ff", two characters
+(-1: Byte).binary    // eight characters
+```
 
 ### Mathematics
 
@@ -96,6 +120,23 @@ negative remainder:
 
 The trigonometric and logarithmic functions are available as plain functions — `cos`, `sin`,
 `exp`, `ln`, `log10` — alongside the constants `π`, `euler` and `φ`.
+
+`**` widens rather than truncating: raising a `Short` to a power that exceeds a `Short`'s range
+gives the right answer rather than a wrapped one, and a fractional exponent gives a fractional
+result:
+
+```scala
+(200: Short) ** 2.0    // 40000.0, not a truncated Short
+(1000: Short) ** 1.5
+```
+
+The collection statistics are extension methods too. `median` finds the middle value without
+sorting the whole collection — a selection algorithm rather than a sort — and averages the two
+middle values where the count is even:
+
+```scala
+Iterable[Double](7, 25, 1, 24, 2, 3, 23, 4, 22, 5, 21).median   // 7.0
+```
 
 ### Comparisons
 

--- a/doc/modules/optics.md
+++ b/doc/modules/optics.md
@@ -92,3 +92,29 @@ summoned, passed around and composed, for the cases where the access itself is t
 val nameLens = summon["name" is Lens from Json onto Json]
 nameLens.modify(document)(transform)
 ```
+
+### Naming paths without traversing them
+
+The same path syntax that writes an update can name a position without going there. A `Specific`
+maps paths to values, which is how a derived typeclass is overridden at one field rather than for
+a whole type:
+
+```scala
+val orgSpecific: Org is Specific over (Codec in Json) =
+  specifically:
+    case root.cto.name() => nameCodec
+    case root.ceo.age()  => ageCodec
+```
+
+The paths are checked against the type's structure as the code compiles, so a misspelled field or
+a path that does not exist is a compile error, and each value must have the right type for the
+field it names. The result is an ordinary map keyed by the path, which a derivation consults as it
+visits each field:
+
+```scala
+orgSpecific.instances.keySet   // Set("cto.name", "ceo.age")
+```
+
+This is what the [JSON](json.md) per-field encoder override is built on, and the mechanism is not
+specific to codecs — any typeclass whose derivation consults a `Specific` can be overridden the
+same way.

--- a/doc/modules/optional-values.md
+++ b/doc/modules/optional-values.md
@@ -120,3 +120,46 @@ in both directions:
 name.option                    // Some(t"Ada"): Option[Text]
 Some(t"Ada").optional          // t"Ada": Optional[Text]
 ```
+
+### What it costs
+
+An `Optional[Text]` *is* a `Text` — there is no wrapper, so a present value costs nothing to hold,
+nothing to pass, and nothing to read. That is the whole reason for the design: `Option` allocates
+a `Some` for every present value, which in a data structure of a million records is a million
+objects that exist only to say "yes, there is one".
+
+The operations are inlined too, and `or` is optimized as it compiles: a chain of fallbacks
+collapses rather than building intermediate optionals, and a fallback whose value is a constant
+becomes a constant.
+
+The cost of that representation is that `Optional[Optional[T]]` cannot exist — absence has one
+representation, so it cannot nest. This is checked as the code compiles: a type that could not be
+made optional unambiguously is rejected where it is written.
+
+### Requiring an unambiguous type
+
+Three type-level facts support that check, and are occasionally useful directly.
+
+`Concrete` witnesses that a type is a definite type rather than an abstract one, which matters
+because an abstract type might later be instantiated to something already optional. `Distinct`
+witnesses that a type is not a member of a given union — the check that keeps `Unset` out of the
+value type. `Mandatable` strips the optionality from a type, giving the type a present value has.
+
+A generic method that takes an `Optional[value]` for an abstract `value` therefore demands
+evidence that `value` is concrete, and the demand appears in its signature rather than as a
+failure at a call site far away.
+
+### Defaults
+
+`presume` and `default` draw on a `Default` instance, which supplies the value a type falls back
+to. Instances exist for the types with an obvious zero — empty text, zero, an empty collection —
+and a type declares its own by defining one:
+
+```scala
+given Default[Volume] = Volume(0)
+
+setting.presume   // Volume(0) where the setting is unset
+```
+
+A `Default` is a by-name thunk rather than a value, so a default that is expensive to compute is
+computed only where it is used.

--- a/doc/modules/packaging.md
+++ b/doc/modules/packaging.md
@@ -75,3 +75,20 @@ scalac -Xplugin:umbrageous.jar -P:umbrageous:com.example:shaded *.scala
 
 Every package matching `com.example` compiles as `shaded.com.example`, and references follow, so
 two versions of the same library coexist in one classpath without touching each other.
+
+### Android applications
+
+An Android application is a further target of the same [linking](compiler.md) scheme rather than
+a separate toolchain. Classfiles link to Dalvik bytecode as an `Artifact.Dex`, and an
+`Artifact.Apk` goes further: the dexed code, a binary `AndroidManifest.xml`, zip-aligned and
+signed, ready to install:
+
+```scala
+import apkLinkages.given
+
+Linker[Artifact.Apk](List(apkOptions.minApi(24)))
+. link(Compilation(output, classpath), destination)
+```
+
+The manifest is built from a typed configuration and encoded as Android's binary XML, and signing
+uses the APK signature scheme, so no external `aapt`, `zipalign` or `apksigner` is involved.

--- a/doc/modules/paths.md
+++ b/doc/modules/paths.md
@@ -87,12 +87,12 @@ a.conjunction(b)   // % / "home" / "work"
 
 ### Text and paths
 
-A path renders to text with `encode`, and text parses to a path with `decode`, naming the platform
+A path renders to text with `encode`, and text parses to a path with `as`, naming the platform
 whose rules should apply. A path that breaks those rules fails to decode:
 
 ```scala
 (Drive('D') / "Foo").encode          // t"D:\\Foo"
-t"/home/work".decode[Path on Linux]  // % / "home" / "work"
+t"/home/work".as[Path on Linux]  // % / "home" / "work"
 ```
 
 ### Deconstructing

--- a/doc/modules/paths.md
+++ b/doc/modules/paths.md
@@ -105,3 +105,32 @@ path match
   case root /: t"home" /: rest => rest
   case _                       => path.relative
 ```
+
+The root is matched too, which matters where a platform has more than one — a Windows drive
+letter, a UNC share — since the root is part of what a path *is* rather than a prefix of its text.
+
+### Paths in the type
+
+A path's element names may be carried in its type, so that a path known at compiletime is known
+precisely:
+
+```scala
+val path: Path of ("bar", "foo") = % / "foo" / "bar"
+```
+
+The names appear innermost-first, matching how the path is constructed. A path built entirely from
+literals therefore has a type describing exactly where it points, which is what lets a
+[classpath](classpath.md) resource or a project-relative file be checked as the code compiles.
+
+Where the elements are not known — a path built from runtime text, or one read from a
+[filesystem](filesystem.md) listing — the type simply says `Path on Linux`, and the operations are
+the same.
+
+### What a relative path knows
+
+A relative path carries its platform too, so a `Relative on Linux` cannot be applied to a Windows
+path. It also carries how far up it reaches, in its `Relation`, so a relative path that ascends
+above a root can be rejected where it is written rather than resolving to nowhere at runtime.
+
+`^` ascends one level and `?` marks the current location, so `? / ^ / "more"` reads as "up one,
+then into `more`" — the form `toward` produces.

--- a/doc/modules/pdf.md
+++ b/doc/modules/pdf.md
@@ -1,0 +1,171 @@
+## PDF
+
+### About
+
+A [PDF](https://en.wikipedia.org/wiki/PDF) document reads as a typed value: its pages and their
+geometry, the text laid out on them, the fonts they use, its metadata, bookmarks, links and
+attachments. Documents are also edited — content replaced, pages appended or removed, fonts
+embedded, metadata and links set — and an edit appends to the file rather than rewriting it, so
+the original bytes survive untouched.
+
+Everything is implemented directly against the format: the object syntax, the cross-reference
+tables, the stream filters, the encryption. Nothing is delegated to an external PDF library.
+
+### On PDF
+
+PDF's outer layer is COS, a small object language of numbers, names, strings, arrays,
+dictionaries and streams, addressed by indirect references and indexed by a cross-reference
+table at the end of the file. Its inner layer is a content stream: a stack machine whose
+operators place glyphs on a page. Neither layer is hard, and both are unforgiving — a
+cross-reference offset that is wrong by one byte, a stream whose declared length disagrees with
+its content, an object that is present in an update and absent in the original.
+
+Reading such a format well means never assuming the file is well-formed and never holding more
+of it than is needed. A document is *opened*, which maps the file and reads its cross-reference
+table; pages, metadata and text are read through that scope; and a stream's payload is pulled
+lazily, decoded through its filter chain, rather than materialized on arrival. Where a document
+is damaged past the point its cross-reference table can be trusted, it can be recovered by
+scanning the file for objects directly.
+
+Everything comes from the `soundness` package:
+
+```scala
+import soundness.*
+import strategies.throwUnsafely
+```
+
+### Opening a document
+
+A document is opened from a path or from bytes, and read within the scope of the block. The
+`pdf` accessor reaches the contextual document:
+
+```scala
+PdfFile(path).open[Pdf]():
+  pdf.version.major
+```
+
+Opening for writing takes the `Read & Write` mode, and yields the document as a handle whose
+editing operations are reachable only with the `Write` grant:
+
+```scala
+PdfFile(path).open(Read & Write): doc ?=>
+  doc.setRotation(doc.pages(0), Page.Rotation.Quarter)
+```
+
+An encrypted document is opened by supplying its password, which is checked as the document is
+opened rather than when a string is first decrypted:
+
+```scala
+PdfFile(path).open(Password(t"open sesame")):
+  pdf.info.title
+```
+
+The standard security handler is supported through RC4 and AES-256; a public-key handler raises
+a `PdfError` naming the encryption it cannot use.
+
+### Pages
+
+The page tree flattens into a sequence, with each page's geometry resolved against the
+inheritance the format allows — a media box declared on the tree root applies to every page
+beneath it, a crop box defaults to the media box, and a trim box to the crop box. Boxes are
+[quantities](quantities.md) in points, not bare numbers:
+
+```scala
+PdfFile(path).open():
+  pdf.pages.length
+  pdf.pages(0).mediaBox.width       // Quantity[Points[1]]
+  pdf.pages(0).rotation             // Page.Rotation.Quarter
+  pdf.pages(1).width                // axes exchanged, if quarter-turned
+```
+
+A page's `width` and `height` account for its rotation, and a `/UserUnit` scales the boxes, so
+the dimensions read are the ones the page presents.
+
+### Extracting text
+
+A page's `text` runs its content stream and reconstructs the reading order from the positions of
+the glyphs: a gap along a baseline becomes a space, a change of baseline becomes a newline, and
+adjacent shows run together:
+
+```scala
+PdfFile(path).open():
+  pdf.pages(0).text
+```
+
+Positioned runs are available too, for a reader that needs coordinates rather than a paragraph.
+
+### Metadata, navigation and attachments
+
+The document information dictionary reads as a `PdfInfo`, with its dates parsed from PDF's `D:`
+format — including its offset, where one is given — and a malformed date reported as absent
+rather than as an error. Named destinations resolve through either the modern name tree or the
+old `/Dests` dictionary, and bookmarks form a tree of `Bookmark` values:
+
+```scala
+PdfFile(path).open():
+  pdf.info.title
+  pdf.destinations.at(t"intro")
+  pdf.bookmarks
+  pdf.attachments.head.filename
+  pdf.pages(0).annotations
+```
+
+An annotation is a typed case — `Annotation.Link` with its rectangle and URI, `Annotation.Note`
+with its contents — rather than a dictionary to be inspected by key.
+
+### Editing
+
+Editing operations run inside a write scope and are committed as an incremental update: the
+original bytes stay where they were, and the changed objects are appended with a fresh
+cross-reference section. A reader that only understands the original file still sees a valid
+document.
+
+```scala
+PdfFile(path).open(Read & Write): doc ?=>
+  val operators = List
+    ( PdfOperator.BeginText, PdfOperator.SetFont(t"F1", 12),
+      PdfOperator.Offset(72, 720), PdfOperator.ShowText(winAnsi(t"Written")),
+      PdfOperator.EndText )
+
+  doc.setContents(doc.pages(0), operators)
+  doc.setInfo(PdfInfo(t"A Title", t"An Author", Unset, Unset, Unset, Unset, Unset, Unset))
+  doc.addLink(doc.pages(0), rect, uri = t"https://soundness.dev/")
+```
+
+`appendPage` and `removePage` change the page tree, `setBox` and `setRotation` change a page's
+geometry, and `setBookmarks` and `setAnnotations` replace those structures wholesale. Editing
+operations that need a new object use `allocate` and `newStream`, which take the next free
+object number.
+
+A [TrueType font](fonts.md) is embedded with `embedFont`, which writes the program as a
+`FontFile2` and builds the simple WinAnsi font dictionary around it; `addResource` names it on a
+page so content can select it:
+
+```scala
+PdfFile(path).open(Read & Write): doc ?=>
+  val font = doc.embedFont(Ttf(fontProgram), t"MyFont")
+  doc.addResource(doc.pages(0), t"Font", t"F1", font)
+```
+
+### Stream payloads
+
+A PDF stream's payload is read lazily, through whatever chain of filters the stream declares —
+`FlateDecode`, `LZWDecode`, `ASCII85Decode`, `ASCIIHexDecode`, `RunLengthDecode`, and the PNG
+and TIFF predictors that often follow them. The payload arrives as a
+[stream](streams.md) of bytes, so a large embedded file or image is never held whole:
+
+```scala
+PdfFile(path).open():
+  pdf(2, 0) match
+    case body: Cos.Body => pdf.spring(body)()
+    case _              => Stream()
+```
+
+### Recovering a damaged document
+
+Where a cross-reference table is missing or wrong — a truncated download, a file repaired by
+another tool — the table is rebuilt rather than trusted: the whole file is scanned for `N G obj`
+markers, the latest copy of each object winning, and the trailer recovered from a surviving
+`trailer` dictionary or from the catalog itself. Individually shifted offsets are corrected as
+objects resolve. A document that any conformant reader would open, opens here too, and is read
+exactly like any other.

--- a/doc/modules/processes.md
+++ b/doc/modules/processes.md
@@ -75,6 +75,28 @@ and read exactly as a single command:
 (sh"echo 'Hello world'" | sh"sed s/e/a/g").exec[Text]().trim   // t"Hallo world"
 ```
 
+Pipelines flatten rather than nest, so a three-stage pipeline is one pipeline of three commands
+however it was assembled, and a pipeline piped into a command extends it:
+
+```scala
+(sh"echo a" | sh"cat" | sh"wc").commands.length   // 3
+```
+
+### Commands inside commands
+
+A command substituted into another is escaped as a single argument, which is what invoking a shell
+requires and what hand-built command strings get wrong:
+
+```scala
+val inner = sh"echo 'Hello world'"
+sh"sh -c '$inner'".exec[Text]().trim   // t"Hello world"
+
+Command(t"echo", t"a b").escape        // t"'echo' 'a b'"
+```
+
+An argument containing a space, a quote or a metacharacter is therefore carried through
+untouched — there is no point at which it becomes a string a shell might re-split.
+
 ### Forking
 
 `fork` starts the command without waiting, returning a `Job` that can be awaited for its result,
@@ -84,8 +106,37 @@ inspected, or stopped:
 val job = sh"sleep 5".fork[Unit]()
 job.alive        // true
 job.abort()      // ask it to stop
+job.kill()       // insist
 job.await()      // block for the result
 ```
+
+`exec` blocks until the command finishes; `fork` returns as soon as it has started, which is the
+whole difference between the two. A `Job` also exposes the operating-system process behind it —
+its `pid`, and the process object itself — for the occasions where a signal must be sent or a
+process tree inspected:
+
+```scala
+job.pid          // Pid(…), rendered as ↯1234
+job.process      // the underlying OS process
+```
+
+A `Pid` is a distinct type rather than a number, so it cannot be confused with an exit code or a
+file descriptor, and it renders and parses in its own form.
+
+### Failure
+
+A command that cannot be run at all — a missing binary, a directory that is not executable —
+raises an `ExecError` carrying the command that failed, so the error names what was attempted
+rather than reporting an operating-system errno:
+
+```scala
+capture[ExecError](sh"no-such-binary".exec[Text]()).command.arguments.head
+// t"no-such-binary"
+```
+
+A command that runs and *fails* is a different matter: its exit status is part of its result, and
+what a non-zero status means is the caller's decision. Asking for an `Exit` gives the status
+itself; asking for a `Text` or a stream gives the output, with the status available alongside.
 
 ### An implied output type
 

--- a/doc/modules/protobuf.md
+++ b/doc/modules/protobuf.md
@@ -61,6 +61,41 @@ case class Typed
 A nested case class is a nested message, and an enumeration or sealed hierarchy encodes as proto3's
 `oneof`, with the variant chosen by field number.
 
+### Presence, repetition and maps
+
+Proto3's treatment of absence is a well-known source of confusion, and the type says which
+behaviour applies. An `Optional` field has explicit presence: unset, it writes nothing, and reads
+back as `Unset` — distinct from a field that is present and zero.
+
+A `List` field is repeated, and keeps its order and its default elements: a list of `0, 1, 2`
+round-trips as three elements rather than losing the zero. Repeated numbers are packed into a
+single length-delimited field, as proto3 requires of a writer, while a reader accepts both packed
+and unpacked forms, as it requires of a reader.
+
+A `Map` becomes the standard repeated key–value entry messages, so a `Map[Text, Int]` is on the
+wire exactly what `map<string, int32>` would be:
+
+```scala
+case class Labels(@field(1) labels: Map[Text, Text])
+case class Tags(@field(1) tags: List[Text])
+case class MaybeName(@field(1) name: Optional[Text])
+```
+
+### Navigating a message
+
+A message is number-keyed rather than name-keyed, so an optic selects a field by its number: `Prim`
+is field 1, `Sec` field 2, and so on. A lens reaches through nested messages and replaces a field
+without disturbing the rest:
+
+```scala
+import protobufConversion.encodable
+
+wrapper.lens(_(Prim) = Point(7, 8).in[Protobuf]).as[Wrapper]
+```
+
+This is what to use where a message must be relayed with one field altered and everything else —
+including fields this program does not know about — passed through untouched.
+
 ### Compatibility
 
 Compatibility with `protoc` is by construction and by test: the canonical example message from the
@@ -73,7 +108,17 @@ Sample(150).in[Protobuf].encode   // the bytes 08 96 01
 ```
 
 Decoding accepts both packed and unpacked repeated fields, as the proto3 specification requires of
-a conforming reader.
+a conforming reader, and the encodings of the sized numeric types are checked against golden wire
+vectors rather than merely round-tripped — a round trip agrees with itself even when both
+directions are wrong.
+
+Where a message needs no interoperability, the field numbers may be left off entirely: an
+unannotated message numbers its fields from one in declaration order, which is what `protoc` would
+have produced for the same declarations.
+
+```scala
+case class Unnumbered(value: Int, other: Int)   // fields 1 and 2
+```
 
 ### Errors
 

--- a/doc/modules/protobuf.md
+++ b/doc/modules/protobuf.md
@@ -36,7 +36,7 @@ case class Person(@field(1) name: Text, @field(2) age: Int)
 Encoding produces the message value and then its bytes; decoding reads bytes back to the type:
 
 ```scala
-val bytes = Person(t"Alice", 30).protobuf.encode   // the wire bytes
+val bytes = Person(t"Alice", 30).in[Protobuf].encode   // the wire bytes
 
 Stream(bytes).read[Person in Protobuf]             // Person(t"Alice", 30)
 ```
@@ -69,7 +69,7 @@ protobuf documentation encodes to its documented bytes:
 ```scala
 case class Sample(@field(1) value: Int)
 
-Sample(150).protobuf.encode   // the bytes 08 96 01
+Sample(150).in[Protobuf].encode   // the bytes 08 96 01
 ```
 
 Decoding accepts both packed and unpacked repeated fields, as the proto3 specification requires of

--- a/doc/modules/quantities.md
+++ b/doc/modules/quantities.md
@@ -338,6 +338,18 @@ def displacement
   initial*time + 0.5*accel*time*time
 ```
 
+### What it costs at runtime
+
+None of this survives to the bytecode. A `Quantity` is an opaque type over a `Double`, its units
+exist only in the type, and every operation is `inline`, so a dimensional calculation compiles to
+the same arithmetic instructions the equivalent bare `Double` arithmetic would produce — no
+boxing, no wrapper objects, and no virtual dispatch to a typeclass.
+
+That is a property worth checking rather than asserting, and it is checked: the test suite
+inspects the compiled bytecode of representative calculations and fails if a typeclass dispatch
+appears where inlined arithmetic should be. A performance guarantee that is only claimed tends to
+stop being true.
+
 Both terms of the sum come out as a distance — a velocity times a time, and an
 acceleration times a time squared — so the addition type-checks and the result is a
 distance. Passing an argument in the wrong units, or returning the wrong dimension,

--- a/doc/modules/quantities.md
+++ b/doc/modules/quantities.md
@@ -106,12 +106,12 @@ width*depth         // 1.8288 square metres
 
 ### Converting
 
-A quantity converts explicitly to another compatible unit with `in`, naming the
+A quantity converts explicitly to another compatible unit with `to`, naming the
 target unit family:
 
 ```scala
-(3*Foot).in[Metres]   // 0.9144 metres
-(3*Metre).in[Feet]    // 9.8425… feet
+(3*Foot).to[Metres]   // 0.9144 metres
+(3*Metre).to[Feet]    // 9.8425… feet
 ```
 
 `normalize` does the same, written with the fully-powered unit type:
@@ -282,7 +282,7 @@ like any other:
 import temperatureScales.celsiusScale
 (zero[Temperature] + 300*Kelvin).show   // t"26.9 °C"
 
-(Fahrenheit(100) - zero[Temperature]).in[Rankines].show   // t"560 °R"
+(Fahrenheit(100) - zero[Temperature]).to[Rankines].show   // t"560 °R"
 ```
 
 Reading the same temperature on a different scale is a matter of importing a

--- a/doc/modules/randomness.md
+++ b/doc/modules/randomness.md
@@ -79,6 +79,25 @@ case class Latitude(degrees: Double)
 given Latitude is Randomizable = summon[Double is Randomizable].map(d => Latitude(d % 90))
 ```
 
+Where field-by-field generation *is* right, an instance derives from the type, so a case class of
+randomizable fields is randomizable and a sealed hierarchy picks among its variants — which is
+what property-based [testing](testing.md) needs to generate values of an arbitrary type.
+
+### Reproducing a run
+
+A failing randomized test is worth nothing if it cannot be run again. Under
+`seededRandomization` the whole scope is a function of its `Seed`, so recording the seed of a
+failing run and supplying it again reproduces exactly the same values — including the sizes of
+generated collections, which are drawn from the same generator:
+
+```scala
+Seed(42L).stochastic:
+  arbitrary[List[Int]]()
+```
+
+Nesting is deterministic too: a scope's generator is derived from its enclosing one, so restoring
+the outer seed restores the inner sequence.
+
 ### Shuffling and coin-tosses
 
 A `Random` in scope also shuffles a sequence and answers a fair coin-toss, the small conveniences

--- a/doc/modules/rpc.md
+++ b/doc/modules/rpc.md
@@ -115,15 +115,15 @@ is a diagnosis rather than a hang.
 
 A protocol implementation that only round-trips against itself proves nothing: two matching bugs
 look exactly like correctness. The HTTP/2 and gRPC codecs are therefore checked against *golden
-bytes* — the exact octets a frame must serialize to — and against the specifications' own
-published test vectors:
+bytes* — the exact octets each frame must serialize to, written out in the tests — as well as
+round-tripped. A gRPC message's framing is one flag byte and a four-byte length, and the encoder
+is checked to produce exactly that:
 
 ```scala
-Frame.Settings(Nil, ack = true).serialize   // 000000040100000000
-GrpcFraming.encode(payload)                 // flag byte, then a 4-byte length
+GrpcFraming.encode(payload)   // 00 00 00 00 05, then the payload
 ```
 
 HPACK's header compression is verified against every example in
 [RFC 7541](https://datatracker.ietf.org/doc/html/rfc7541)'s appendices, with and without Huffman
-coding, and the Huffman codec against the strings the specification tabulates. Where a
+coding, and the `Huffman` codec against the strings the specification tabulates. Where a
 specification publishes vectors, they are what the implementation is measured against.

--- a/doc/modules/rpc.md
+++ b/doc/modules/rpc.md
@@ -95,7 +95,35 @@ length prefix, a `Content-Length` header as LSP uses, or line endings:
 stream.iterator.frames[LengthPrefix]     // length-prefixed messages
 input.iterator.frames[ContentLength]     // header-framed messages, byte-counted
 lines.iterator.frames[CrLf]              // CRLF-separated lines
+lines.iterator.frames[Linefeed]          // or bare linefeeds, or CR alone
+framed.iterator.frames[GrpcFraming]      // gRPC's flag byte and 4-byte length
+```
+
+Framing is independent of how the bytes arrive. A message split across three chunks, two messages
+in one chunk, and a final message with no terminator are all handled, because the framer keeps its
+own position rather than assuming chunk boundaries mean anything:
+
+```scala
+LazyList(t"one\ntwo\nth", t"ree").iterator.frames[Linefeed].to(List)
+// List("one", "two", "three")
 ```
 
 A truncated or malformed frame raises a `FrameError` naming what was wrong, so a protocol failure
 is a diagnosis rather than a hang.
+
+### Verifying a wire format
+
+A protocol implementation that only round-trips against itself proves nothing: two matching bugs
+look exactly like correctness. The HTTP/2 and gRPC codecs are therefore checked against *golden
+bytes* — the exact octets a frame must serialize to — and against the specifications' own
+published test vectors:
+
+```scala
+Frame.Settings(Nil, ack = true).serialize   // 000000040100000000
+GrpcFraming.encode(payload)                 // flag byte, then a 4-byte length
+```
+
+HPACK's header compression is verified against every example in
+[RFC 7541](https://datatracker.ietf.org/doc/html/rfc7541)'s appendices, with and without Huffman
+coding, and the Huffman codec against the strings the specification tabulates. Where a
+specification publishes vectors, they are what the implementation is measured against.

--- a/doc/modules/sockets.md
+++ b/doc/modules/sockets.md
@@ -74,6 +74,40 @@ socket.duplex: duplex =>
   duplex.stream.head
 ```
 
+### Sessions
+
+A *session* is the same idea stated as a scope: `session` opens a connection to the target, lends
+it to the block, and closes it when the block ends. The result type is quantified outside the
+block, so a value still borrowing the live connection cannot escape it, while a memoized value
+can:
+
+```scala
+endpoint.session: connection ?=>
+  converse(connection)
+```
+
+This is what an [HTTP session](http-client.md) is built on, and how concurrent requests multiplex
+on one HTTP/2 connection without a parked daemon: the loan and the scope coincide.
+
+### TLS
+
+A TLS connection is made through a secure endpoint, with the trust policy a contextual value. The
+handshake may offer [ALPN](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation)
+protocols, in preference order, and the protocol the peer selected is reported back on the
+connection — the seam an HTTP client uses to choose between an HTTP/2 and an HTTP/1.1 driver over
+one socket. Offering nothing preserves the plain-TLS handshake that `wss` peers expect.
+
+### Choosing a backend
+
+Nothing above names a platform API. The primitive operations each role needs — bind and accept,
+connect and converse, receive and reply, dispatch a datagram — are gathered into a
+`SocketBackend`, and the loops that compose them stay platform-neutral. The
+`java.nio.channels` implementation is `socketBackends.virtualMachine`, and backends over
+`wasi:sockets` and over Scala Native's sockets supply the same operations, so the same protocol
+code runs on the JVM, inside a WebAssembly component, and in a native binary. An operation a
+backend cannot support — Unix-domain sockets or TLS on WASI — raises the appropriate error rather
+than approximating it.
+
 ### Socket options
 
 The socket options of the underlying platform — `SO_REUSEADDR`, keep-alive, buffer sizes, timeouts —

--- a/doc/modules/sockets.md
+++ b/doc/modules/sockets.md
@@ -117,7 +117,45 @@ TCP-only option cannot be applied to a UDP socket:
 ```scala
 import socketOptions.reuseAddressSocketOption
 import socketOptions.keepAliveSocketOption
+import socketOptions.broadcastSocketOption
 ```
+
+Options are collected from scope as a set rather than passed at each call, so a program's socket
+policy is stated once. `SO_REUSEADDR` for a server that must restart without waiting out
+`TIME_WAIT`, `SO_BROADCAST` for a UDP socket that sends to a broadcast address, `TCP_NODELAY` for
+a protocol that must not wait for Nagle's algorithm, buffer sizes and timeouts — each is typed by
+the transports that accept it, and a backend silently skips an option its platform does not
+support rather than failing.
+
+### Messages and their conversions
+
+What a socket sends and receives is not bytes but values. `Transmissible` says how a value becomes
+bytes on the way out, and `Ingressive` how bytes become a value on the way in, so a protocol is
+written in its own vocabulary:
+
+```scala
+Ingressive.bytes         // received as raw Data
+Ingressive.text          // decoded through the character encoding in scope
+Ingressive.decoder[Port] // decoded to any type with a Decodable instance
+```
+
+A `Port` received over the wire is therefore a `Port`, validated on arrival, rather than text to
+be checked later.
+
+### Conversations as state machines
+
+`exchange` drives a client-side protocol as a state machine: each received message yields a
+`Control` saying what happens next. `Continue` carries the new state — or none, leaving it
+unchanged — and `Terminate` ends the conversation:
+
+```scala
+socket.exchange(initial):
+  case (state, message) =>
+    if done(message) then Terminate else Continue(next(state, message))
+```
+
+Writing a protocol this way keeps its states explicit, rather than implied by where control
+happens to be in a sequence of interleaved reads and writes.
 
 ### Errors
 

--- a/doc/modules/stack-traces.md
+++ b/doc/modules/stack-traces.md
@@ -48,6 +48,49 @@ result is a trace that reads as the program was written, not as it was compiled.
 Whether Soundness's own errors capture traces at all is the `Diagnostics` choice described in
 [error handling](errors.md) — traces for debugging, omitted where errors are expected and handled.
 
+### Resolving frames to their source
+
+Demangling can only tidy a compiled name up. `$anonfun$3` becomes `λ₃`, which says a lambda ran
+but not *which* lambda — and the names that most need explaining are exactly the ones the compiler
+mints after its output is pickled: anonymous functions, initialisers, bridges, specialisations. No
+amount of rewriting recovers them, because the information is not in the name.
+
+Position does what name cannot. The compiler records the extent of every definition, so the line a
+frame already carries is enough to find the definition it came from. Importing a resolver makes
+every trace captured in that scope carry it:
+
+```scala
+import stackResolutions.tastyStackResolution
+```
+
+A resolved `Frame` gains a `Source`: the path of the file, the chain of enclosing definitions, the
+definition's own source name, and what kind of definition it is. `displayClass` and
+`displayMethod` give the resolved names where they are known and fall back to the demangled ones
+where they are not, so a renderer needs no branch of its own:
+
+```scala
+frame.displayClass    // the enclosing definitions, in source terms
+frame.displayMethod   // the definition's own name
+frame.source.let(_.kind)
+```
+
+The `Kind` distinguishes a method from a lambda, a value, a constructor, an extension or a default
+argument — and, separately, marks the kinds that are pure plumbing: bridges, forwarders,
+initialisers and specialisations, which `plumbing` reports so that a renderer can dim or drop
+them.
+
+Resolution costs one file read per top-level class named in the trace, so it is opt-in rather than
+automatic. A trace already in hand is resolved explicitly instead of by import:
+
+```scala
+trace.resolved
+```
+
+The capability to read those files is one this layer deliberately does not have: the default
+resolver does nothing, and an implementation is supplied from a module that has a classpath. That
+is what keeps stack traces working unchanged where no such capability exists — in a browser, in a
+native binary, inside a WebAssembly component.
+
 ### Codepoints
 
 A `Codepoint` is the source file and line of a call site, captured automatically wherever a method

--- a/doc/modules/staging.md
+++ b/doc/modules/staging.md
@@ -70,3 +70,25 @@ What crosses the boundary must be serializable, and the transport is a `Stageabl
 instances carry values as [Pojo](generic-data.md) trees or as JSON. A captured value with no
 transportable form is rejected when the block compiles — the boundary is in the types, not
 discovered at a distance.
+
+### What is cached, and when it is not
+
+Compiling a block is expensive, so the result is cached — but the cache key matters. It is the
+*fingerprint of the staged tree* together with the call site, not the call site alone.
+
+That distinction is load-bearing. One call site inside an inline method may expand to a different
+tree at each use, and keying on the call site alone would silently re-run the first expansion for
+every subsequent one. Keying on the tree means several distinct expansions from one site each
+compile once, while calls that differ only in the data they transport share a single compilation —
+which is the behaviour that makes dispatching from a generic or inline context safe.
+
+A spliced value is evaluated once per dispatch, not once per occurrence: `${job.name}` used twice
+in a block refers to the same marshalled value rather than evaluating `job.name` twice.
+
+### Errors across the boundary
+
+Code running elsewhere can fail, and the failure has to come back. An error raised in the staged
+block is carried across and re-raised at the call site, so `dispatch` reports the failure of the
+remote computation rather than reporting that the remote computation could not be reached. A
+failure of the rig itself — a subprocess that would not start, a classloader that could not be
+built — is distinct, since the two call for different responses.

--- a/doc/modules/streams.md
+++ b/doc/modules/streams.md
@@ -118,14 +118,14 @@ present themselves as stages.
 A pipeline ends in a *terminal* operation, which drains the endpoint and closes it:
 
 ```scala
-stream.memoize                       // drain into one immutable value
+stream.memoize                          // drain into one immutable value
 stream.sweep((storage, start, n) => …)  // drain, seeing each raw window
-stream.fold(0L)((total, storage, start, n) => …)  // window-level fold
 ```
 
-`sweep` and `fold` expose the raw window rather than boxed elements, so a byte-level reduction
-runs over the array with no per-element cost. `take` and `drop` bound a stream without draining
-it, releasing the remainder of the upstream unread.
+`sweep` — and `fold`, its accumulating counterpart — expose the raw window rather than boxed
+elements, so a byte-level reduction runs over the array with no per-element cost. `take` and
+`drop` bound a stream without draining it, releasing the remainder of the upstream unread. These
+three are reached through `import zephyrine.{take, drop, fold}`.
 
 Where a pipeline ends in a *push* chain rather than a value, `pump` is the single point at which
 data crosses from the pull side to the push side:

--- a/doc/modules/streams.md
+++ b/doc/modules/streams.md
@@ -3,15 +3,19 @@
 ### About
 
 Data that arrives or departs over time — a file too large to hold in memory, a network
-connection, the output of a process — is handled as a stream. A `Stream` is a lazy sequence,
-usually of bytes or of text, and one set of polymorphic operations moves data between sources
-and sinks: `read` pulls a source in as a chosen type, `writeTo` sends a value to a
-destination, and `stream` exposes a value as a stream of pieces.
+connection, the output of a process — is handled as a stream. One set of polymorphic operations
+moves data between sources and sinks: `read` pulls a source in as a chosen type, `writeTo` sends
+a value to a destination, and `stream` exposes a value as a stream of pieces.
 
 What can be read, and what can be written, is decided by typeclasses. A type that describes how
 it becomes a stream can be read; a type that describes how it consumes one can be written to; so
 a new source or sink joins the same `read` and `writeTo` as everything else, with no bespoke
 plumbing.
+
+Underneath those operations is a streaming *kernel* whose central type is a `Stream`: not a lazy
+sequence of chunks, but a pull endpoint over a buffer whose readable window is handed to exactly
+one consumer, without copying. Backpressure is intrinsic to it, and the compiler enforces the
+single ownership its zero-copy window depends on.
 
 ### On streaming
 
@@ -20,12 +24,28 @@ are read and written by side effect, one imperative call at a time, with the rea
 for buffering, decoding, and closing. Nothing in a method's type says whether it streams, what
 element it streams, or how the bytes become text.
 
-A stream here is an immutable lazy list, so it is a value like any other: it can be mapped,
-filtered and combined, and it is consumed only as far as it is needed, which is what keeps a
-large source from being pulled wholly into memory. Reading and writing are polymorphic over the
-element type and the participating types, so the same `read` yields text, bytes, or a stream of
-either, according to the type asked for. Everything comes from the `soundness` package, with a
-character encoding and decoding in scope for the text/byte boundary:
+The obvious functional answer — a lazy list of chunks — fixes the typing and loses the
+performance: every chunk is an allocation, every stage copies, and the memoization that makes a
+lazy list replayable is exactly what keeps a large source alive in memory when nothing wanted it
+kept.
+
+Soundness takes a third route. A `Stream` is a *pull endpoint*: a consumer calls `refill` with
+the amount it is prepared to take, and gets back a window into a buffer, which it reads and then
+skips past. Nothing is copied and nothing is retained. A consumer that does not pull demands
+nothing, so backpressure is not a mechanism bolted on but the absence of a call. Stages compose
+as nested calls on the consumer's thread, with no queues and no synchronization, until a stage
+explicitly crosses a thread boundary.
+
+That design has one requirement: a window belongs to one consumer, and a stream must not be read
+twice or shared. This is checked, not merely documented. Streams are exclusive capabilities, and
+the streaming modules compile with [capture and separation checking](../philosophy/capture-checking.md)
+enabled, so aliasing a stream, or letting one escape the scope that owns its source, is a
+compile error. Where replay really is wanted, `memoize` drains the stream once into an immutable
+value which may then be shared freely — the explicit, bounded replacement for a lazy list's
+implicit caching.
+
+Everything comes from the `soundness` package, with a character encoding and decoding in scope
+for the text/byte boundary:
 
 ```scala
 import soundness.*
@@ -43,7 +63,6 @@ val source = t"The quick brown fox"
 
 source.read[Text]            // t"The quick brown fox"
 source.read[Data]            // the UTF-8 bytes
-source.read[Stream[Text]]    // the text in chunks
 ```
 
 The same `read` works on any source with a `Readable` instance — a file, a network socket, a
@@ -72,6 +91,65 @@ given Record is Streamable by Text = record => Stream(record.fields.join(t","))
 With that instance in scope a `Record` can be `read`, `writeTo` a destination, or `stream`ed,
 without any further definitions.
 
+### Streaming a value
+
+`stream` turns a value into a pull endpoint, and `source` does the same through a `Streamable`
+instance, naming the element type:
+
+```scala
+val bytes = t"The quick brown fox".in[Data].stream   // Stream[Data]
+val text = document.source[Text]                     // Stream[Text]
+```
+
+### Composing a pipeline
+
+A stage transforms a stream into a differently-typed stream. `via` attaches one on the pull
+side, and the whole chain runs on the consumer's thread as nested refills — no threads, no
+queues, no intermediate collections:
+
+```scala
+file.stream.via(decompressor).via(decoder)
+```
+
+The stage may be a `Duct` — the kernel's transformation type — or any descriptor value with a
+`Ductile` instance, which is how compression formats, cipher modes and character codings all
+present themselves as stages.
+
+A pipeline ends in a *terminal* operation, which drains the endpoint and closes it:
+
+```scala
+stream.memoize                       // drain into one immutable value
+stream.sweep((storage, start, n) => …)  // drain, seeing each raw window
+stream.fold(0L)((total, storage, start, n) => …)  // window-level fold
+```
+
+`sweep` and `fold` expose the raw window rather than boxed elements, so a byte-level reduction
+runs over the array with no per-element cost. `take` and `drop` bound a stream without draining
+it, releasing the remainder of the upstream unread.
+
+Where a pipeline ends in a *push* chain rather than a value, `pump` is the single point at which
+data crosses from the pull side to the push side:
+
+```scala
+stream.pump(intake)
+```
+
+### Records
+
+Between raw windows and materialized collections sits record-granularity streaming: rows,
+events, frames, messages. A `Records[record]` is a stream whose windows are chunks of records,
+so credit counts records rather than bytes. `delineate` splits a character source into lines,
+and `records` iterates the parsed records of such a stream:
+
+```scala
+import lineSeparation.adaptiveLinefeedLineSeparation
+
+t"1\n2\n3".source[Text].delineate.records.map(_.as[Int]).to(List)   // List(1, 2, 3)
+```
+
+Records are immutable values, so — unlike windows — they cross stage and thread boundaries by
+reference.
+
 ### Standard streams
 
 Standard output and error are reached through `Out` and `Err`, which print through the `Stdio`
@@ -86,45 +164,46 @@ Err.println(t"a warning")
 ### Producing a stream over time
 
 Where the elements of a stream are produced by one part of a program and consumed by another, a
-`Spool` bridges the two: values are `put` into it as they arise, and its `stream` yields them in
-order until it is stopped:
+`Relay` bridges the two: any number of producers `put` records into it as they arise, one of
+them eventually calls `stop`, and a single reader owns the resulting stream:
 
 ```scala
-val spool = Spool[Text]()
-spool.put(t"first")
-spool.put(t"second")
-spool.stop()
-spool.stream   // Stream(t"first", t"second")
+val relay = Relay[Text]()
+relay.put(t"first")
+relay.put(t"second")
+relay.stop()
+relay.stream
 ```
 
-### Combining streams
+A relay's refill blocks for the first record and then drains whatever else has already arrived
+into the same window, so records batch across the thread boundary instead of paying a hand-off
+each. For byte and character traffic between two threads, a `Conduit` is the strictly
+single-producer, single-consumer, block-structured counterpart: data crosses in blocks through a
+bounded queue, so a writer that outpaces its reader parks — cross-thread backpressure — and the
+free capacity is exactly the credit the reader reports as demand.
 
-Several streams merge into one, interleaving their elements as they arrive, with `multiplex`.
-Because the merge draws from all sources concurrently, it runs inside a supervised scope:
+### Combining and replicating streams
+
+`Confluence` merges several streams into one, in arrival order, running one pump per input; a
+slow consumer backpressures every input, and the merged stream ends when all of them have. Both
+draw on concurrency, so they run inside a supervised scope:
 
 ```scala
 import threading.platformThreading
 
-val evens = Stream(2, 4, 6)
-val odds = Stream(1, 3, 5)
-supervise(evens.multiplex(odds).to(Set))   // Set(1, 2, 3, 4, 5, 6)
+supervise(Confluence(first, second, third))
 ```
+
+`Divergence` is the opposite: one source is delivered to several subscribers, each chunk
+materialized once and shared immutably between them. A full subscriber queue parks the pump, so
+the slowest subscriber gates the source — the correct behaviour for replication.
 
 ### Compression
 
-A byte stream compresses and decompresses with a named scheme — [Gzip](https://en.wikipedia.org/wiki/Gzip),
-`Zlib` or `Deflate` — and a single block of bytes has eager `gzip` and `gunzip`:
+A byte stream compresses and decompresses with a named scheme, as a stage in a pipeline or over
+a whole value; see [compression](compression.md) for the formats available:
 
 ```scala
-Stream(Data(1, 2, 3, 5, 8)).compress[Gzip].decompress[Gzip]   // the original bytes
-```
-
-### Framing
-
-A stream of bytes carrying length-prefixed frames — a common shape in network protocols —
-splits into its frames with `framed`, naming the width of the length prefix. A truncated frame
-raises a `StreamError`:
-
-```scala
-Stream(Data(0, 0, 0, 3, 10, 20, 30)).framed[U32]()   // Stream(Data(10, 20, 30))
+Data(1, 2, 3, 5, 8).compress[Gzip].decompress[Gzip]   // the original bytes
+file.stream.decompress[Gzip].read[Text]
 ```

--- a/doc/modules/svg.md
+++ b/doc/modules/svg.md
@@ -71,6 +71,32 @@ typed angles of [geography](geography.md):
 Rectangle((0, 0), 1, 1).translate(Delta(5, 0)).rotate(Angle.degrees(45))
 ```
 
+A transform is recorded on the figure rather than applied to its coordinates, so the geometry a
+figure was defined with is the geometry it keeps, and the rendered element carries a `transform`
+attribute — which is what makes the output editable in a drawing program afterwards:
+
+```scala
+Rectangle((0, 0), 10, 5).translate(Delta(3, 4)).xml.show
+// <rect x="0.0" y="0.0" width="10.0" height="5.0" transform="translate(3.0,4.0)"/>
+```
+
+Transforms compose in the order they are applied, and several may be supplied at construction
+instead. A tuple may stand for a delta, with unary `+` reading as a displacement:
+
+```scala
+Rectangle((0, 0), 10, 5).translate(+(3, 4))
+```
+
+### Identifiers
+
+A figure or definition may carry an `SvgId`, which is what a gradient reference, an animation
+target or a `<use>` element needs to name it. The identifier is a distinct type rather than text,
+so a reference to a definition that does not exist is not silently rendered:
+
+```scala
+Outline(id = SvgId(t"plus")).moveTo((0, 0)).closed
+```
+
 ### Gradients and color
 
 A linear gradient is a definition with typed stops, each an offset in `[0, 1]` — a
@@ -90,3 +116,17 @@ its XML header, or parsed back from SVG text:
 val drawing = Svg(50, 50, figures = List(plus))
 Document(drawing, enc"UTF-8").show   // <?xml version="1.0" …?><svg …>
 ```
+
+Parsing runs the other way, reading SVG text back into typed figures and definitions, so a drawing
+produced elsewhere can be inspected, measured or altered rather than merely embedded:
+
+```scala
+val svg = t"""<svg width="50" height="50"><rect x="0" y="0" width="10" height="10"/></svg>"""
+        . read[Svg]
+
+(svg.width, svg.height, svg.figures.length)   // (50.0f, 50.0f, 1)
+```
+
+Because an `Svg` is an [XML](xml.md) value underneath, a drawing embeds directly into an
+[HTML](html.md) page with no serialization step between, and the same drawing serves as a
+standalone `.svg` file when wrapped in a `Document`.

--- a/doc/modules/syntax-highlighting.md
+++ b/doc/modules/syntax-highlighting.md
@@ -75,3 +75,26 @@ Scala.highlight(source, caret = source.length.z).completions
 
 Because the proposals come from the same compiler that will eventually compile the code, they are
 never guesses.
+
+Members after a `.` are the easy case. A bare identifier being typed is harder, because the
+statement containing it does not typecheck — that is precisely its state while it is being
+written — and a batch compilation discards the tree. Completions therefore come from the
+compiler's interactive driver, which keeps error trees, so in-scope terms and types complete
+wherever the caret is, and in a type position the offers are narrowed to types, modules and
+packages.
+
+### Completing keywords and dynamic members
+
+Two kinds of proposal the compiler cannot make are supplied alongside its own.
+
+*Keywords* are grammatical, not semantic: what may follow depends on the tokens before the caret,
+not on any symbol table. A trie over reversed token contexts, derived from a corpus of real Scala
+and looking back only as far as remains relevant, answers what keywords could come next and what
+the grammar expects there — so `case ` offers what a case may begin with, and a position that
+must be a type offers no keywords at all.
+
+*Dynamic* members have no symbols to offer at all. Where the caret sits on a selection whose
+qualifier derives from `scala.Dynamic`, the type's companion is asked which members its
+refinement admits, if it implements the interface for saying so. That is how a
+[foreign](foreign-interop.md) value completes with the members its foreign declarations name, and
+how any `Dynamic` type can offer honest completions rather than none.

--- a/doc/modules/tables.md
+++ b/doc/modules/tables.md
@@ -76,3 +76,61 @@ import tableStyles.thinRoundedTableStyle
 
 Styled [terminal text](terminal.md) works as cell content, so a table of highlighted or colored
 values lays out by its visible width, not the length of its escape codes.
+
+### Alignment
+
+Each column states how its content sits within the width it is given. `Left` pads on the right,
+`Right` pads on the left, and `Center` splits the padding, putting the odd column on the right
+where it cannot be split evenly. `Justify` spreads the spaces between words so that every line
+but the last reaches the full width — the newspaper setting, which suits a prose column and
+nothing else.
+
+Vertical alignment matters as soon as one cell wraps: a wrapped cell makes its whole row taller,
+and the other cells in that row sit at the top, middle or bottom of the extra height according to
+their `VerticalAlignment`.
+
+### Titles
+
+A derived table titles its columns from the field names, capitalized — `linesOfCode` becomes
+`Lines Of Code`. Where that is not the wanted title, a `TableRelabelling` overrides it by name,
+so the Scala field keeps its name and the table gets its own:
+
+```scala
+given TableRelabelling[Library]:
+  def relabelling() = Map(t"linesOfCode" -> t"LoC")
+```
+
+An explicitly-defined column names itself, and `retitle` renames one after the fact, which is
+useful where a table definition is shared and one caller wants a different heading.
+
+### Reusing a column definition
+
+A `Column` is parameterized by the row type it reads from, which would make a column defined for
+one type useless for another. `contramap` adapts it, so a column defined once — with its
+alignment, sizing and title — serves every type that can produce the value it displays:
+
+```scala
+val nameColumn = Column[Text](t"Name")(identity)
+val libraryName = nameColumn.contramap[Library](_.name)
+```
+
+### Tabulating something that is not a case class
+
+A sequence of anything with a `Tabulable` instance tabulates, so a list of plain integers or of
+text renders as a one-column table without a wrapper type. That instance is also the seam for a
+type whose columns are not its fields — a record read from a schema, or a value whose display
+columns are computed.
+
+### When the table does not fit
+
+Below some width, no arrangement of columns is satisfactory, and what should happen then is a
+policy rather than a fixed behaviour. The `columnAttenuation` given decides: `ignoreAttenuation`
+renders anyway, at whatever quality the width allows, while `failAttenuation` raises a
+`TableError` rather than producing something misleading.
+
+```scala
+import columnAttenuation.failAttenuation
+```
+
+A report written to a file, where nobody will see that the columns were mangled, wants the
+failure; an interactive display, where the user can widen the window, wants the rendering.

--- a/doc/modules/tel.md
+++ b/doc/modules/tel.md
@@ -73,7 +73,39 @@ doc.verify[Assignment].office.city.as[Text]   // t"Town"
 
 Unverified dynamic access — reaching into a document whose shape is only informally known — is
 available too, enabled by `import dynamicTelAccess.enabled`, keeping the checked and unchecked
-styles visibly distinct.
+styles visibly distinct. A keyword may legitimately repeat, which a single-valued accessor cannot
+express, so `fields` returns every matching child in document order:
+
+```scala
+t"item 1\nitem 2\nitem 3\n".read[Tel].fields(t"item").map(_.primaryAtom).toList
+// List(t"1", t"2", t"3")
+```
+
+### Editing without destroying the file
+
+The reason a TEL document keeps its comments, blank lines and layout is so that a program can
+change one value and write the file back without reformatting everything a person wrote.
+
+`modify` replaces a field's compound, or appends it where the field is absent:
+
+```scala
+import dynamicTelAccess.enabled
+
+document.modify("name", Tel.scalar(t"Bob"))
+```
+
+Finer edits go through mutation operations addressed by a pointer, which change exactly what they
+name and leave the surrounding presentation alone — rewriting a single atom of a line, attaching a
+remark to a compound, inserting or removing a child:
+
+```scala
+val pointer = Tel.Pointer.of(t"name")
+Mutation(document, Mutation.Op.UpdateAtom(pointer, 0, t"Bob")).document.vouch.show
+// t"name Bob\n"
+```
+
+The result is a document, not a string, so a sequence of edits composes and the file is rendered
+once at the end.
 
 ### Schemas
 
@@ -89,6 +121,51 @@ val schema = Tels.tels[Person](t"person")
 errors with a path to the offending element; under an accruing strategy every fault in a document is
 collected and reported together.
 
+A schema is built in *layers*: a base structure, and overlays that add or refine fields. This is
+how a schema shared between several programs is extended by one of them without forking it, and
+how an optional feature's fields appear only where the feature is in use.
+
+Field values are checked by named *validators*, and the built-in registry covers the kinds a
+configuration language needs — `string` accepting anything, `identifier` accepting kebab-case
+names and rejecting a leading hyphen, and the numeric and enumerated kinds. A schema may name its
+own validators, so a domain constraint lives in the schema rather than in every program that reads
+it.
+
+### Recovering from errors
+
+An indentation-based language is easy to get slightly wrong, and a parser that gives up at the
+first mistake is unhelpful when a person is editing a file. Parsing therefore recovers, and the
+schema informs the recovery: a line indented ambiguously is attached to the candidate the schema
+admits, so a `child` keyword valid inside `parent` but not at the root is recovered to the deeper
+position rather than the nearer one.
+
+Errors are reported with their line and column, and a document whose faults were recovered still
+yields a tree — which is what an editor, a language server, or a tool reporting several problems
+at once requires.
+
+### Documents in a stream
+
+A single source may hold several documents in sequence, and reads as a list of them:
+
+```scala
+source.read[List[Tel]]
+```
+
+### Typed records from a schema
+
+Where the schema is authoritative and no Scala type mirrors it, a `TelBlueprint` reads it at
+compiletime and produces typed records from matching documents. Each field reads at the type the
+schema declares, an optional field is absent where the document omits it, and a *flag* field —
+a keyword with no value — reads as a boolean, `true` where present and `false` where not:
+
+```scala
+val record = ContactRecords.record(t"name Alice\nage 30\n".read[Tel])
+record.name       // t"Alice", per the schema
+```
+
+A field the schema does not describe is a compile error, so the shape of the data is taken from
+the schema and checked by the compiler, with no Scala type restating it.
+
 ### BinTEL
 
 A typed document encodes to BinTEL — a compact binary form guided by the schema — and decodes back;
@@ -100,4 +177,25 @@ doc.valueHash(schema)                // a BLAKE3 digest of the content
 ```
 
 A *self-contained* BinTEL frame carries its schema with it, so a document can travel to a reader
-that has never seen its schema and still decode.
+that has never seen its schema and still decode:
+
+```scala
+Bintel.selfContained(document, schemaDocument)
+```
+
+The alternative is to send the data alone and identify the schema by its *signature* — a short
+fingerprint computed from the schema itself, so a reader can confirm it holds the right schema
+before decoding a byte of data. A schema with no layers signs in thirty-three bytes.
+
+The value hash is over the document's content, not its bytes: two documents that differ only in
+comments, whitespace or key order hash identically, while a document whose values differ does not.
+That makes it usable as a cache key or a change detector, where hashing the file would report a
+change whenever someone reflowed it.
+
+```scala
+document.valueHash(schema)   // deterministic; unchanged by presentation
+```
+
+Numbers in BinTEL are varint-encoded and values are typed by the schema rather than tagged in the
+stream, which is where the compactness comes from; the format's framing carries a length so that
+several documents may share one stream.

--- a/doc/modules/terminal-emulator.md
+++ b/doc/modules/terminal-emulator.md
@@ -60,7 +60,37 @@ styled.buffer.style(Prim, Prim).foreground   // Chroma(100, 150, 200)
 ```
 
 The cursor position, its visibility, and the window title set by the application are read from the
-terminal state directly.
+terminal state directly:
+
+```scala
+pty.state.cursor       // where the cursor sits
+pty.state.hideCursor   // whether DECTCEM hid it
+pty.state.title        // the title set by an OSC sequence
+```
+
+The window title arrives through an operating-system-command sequence, terminated by either the
+bell character or a string terminator, and both spellings are accepted, since applications use
+both.
+
+### What is understood
+
+The emulator covers the vocabulary a real application uses. Text and cursor movement — including
+carriage return, line feed, backspace and tabs advancing to the next eight-column stop — and the
+positioning, erasing and scrolling sequences behave as a terminal's do: `ED 2` clears the screen,
+`EL 2` clears the line, and the cursor save and restore pair works as `DECSC` and `DECRC`.
+
+Styling comes through `SGR`: the attribute flags, the sixteen palette colours with their bright
+variants as distinct entries, the 256-colour palette, and 24-bit colour. Resetting with `SGR 0`
+affects the cells written afterwards, not those already on screen, exactly as a terminal does.
+
+DEC private modes are honoured where they change what a test would observe — `?25` hiding and
+showing the cursor — and silently ignored where they do not, so an application that switches to
+the alternate screen buffer is not derailed by an emulator that refuses the sequence. Sequences
+carrying arbitrary payloads — `DCS`, `APC`, `PM`, `SOS` — are absorbed up to their terminator
+rather than interpreted, which is what a terminal that does not implement them does.
+
+`RIS` resets the terminal to its initial state, so a test can start a fresh scenario without
+building a new emulator.
 
 ### Reports
 

--- a/doc/modules/terminal.md
+++ b/doc/modules/terminal.md
@@ -89,5 +89,17 @@ interactive: terminal ?=>
   form(Mode.Inline)(file(sidebar, body))
 ```
 
-Sizes solve as fractions with minima and maxima, focus moves between widgets with Tab, and
-repaints touch only the cells that changed.
+Sizes solve as fractions with minima and maxima, and focus moves between widgets with Tab.
+
+### Redrawing without flicker
+
+Rendering keeps a model of what is actually on the screen, and each frame is diffed against it,
+so a repaint overprints only the runs that changed and an identical frame emits nothing at all.
+Full-screen output is buffered and flushed as one write rather than as a stream of small ones. A
+geometry change or a resize takes the full redraw path, because nothing about the previous
+contents can then be relied upon.
+
+An inline block — one that leaves scrollback intact — has a further problem: the terminal may
+reflow its lines when the window narrows, moving the block out from under the cursor. Rather than
+redrawing in the wrong place, an inline block re-establishes where it is after a resize, so a
+running interface survives a reflow instead of scribbling over the scrollback above it.

--- a/doc/modules/testing.md
+++ b/doc/modules/testing.md
@@ -34,7 +34,7 @@ object Tests extends Suite(m"Parser tests"):
   def run(): Unit =
     suite(m"Numbers"):
       test(m"a decimal integer parses"):
-        t"42".decode[Int]
+        t"42".as[Int]
       . assert(_ == 42)
 ```
 
@@ -49,6 +49,46 @@ test(m"the mean converges"):
   results.mean.vouch
 . assert(_ === 0.0 +/- 0.02)
 ```
+
+A test may also carry a *moniker*: a compiletime-checked identifier that names it stably, so a
+selection or a chart can address it even after its description is reworded:
+
+```scala
+test(n"square", m"square a number")(3*3).assert(_ == 9)
+```
+
+### Spreading a test over axes
+
+A test is a name and zero or more *axes*. Given an axis, the body runs once per value and each
+verdict is recorded at that coordinate, so one test covers a family of cases without becoming a
+loop whose failures all report the same name:
+
+```scala
+test(m"double every value").over(Axis(t"n")(1, 2, 3, 4)): n =>
+  n*2
+. assert((n, result) => result == n*2)
+```
+
+An enumeration's companion is an axis in its own right, needing no list of values:
+
+```scala
+test(m"enum companions form axes").over(Codec): codec =>
+  codec.ordinal
+. assert((codec, ordinal) => ordinal >= 0 && ordinal < 3)
+```
+
+Two axes spread a test over a grid, rendered as a crosstab. A partial body leaves gaps, which
+appear as empty positions rather than as failures — an honest way to say a combination does not
+apply:
+
+```scala
+test(m"biaxial spread with a gap").over(Axis(t"x")(1, 2, 3), Axis(t"y")(10, 20)):
+  case (x, y) if x + y != 23 => x*y
+. assert((x, y, result) => result == x*y)
+```
+
+The assertion sees the axis values alongside the result, so a predicate can depend on where it
+is in the grid.
 
 ### Failure as a contrast
 
@@ -75,8 +115,66 @@ This is how Soundness's own guarantees are tested — that a wrong-currency addi
 literal, an undeclared relation genuinely fails to compile — and any project building invariants
 into types needs the same: the *impossibility* is the feature, and this makes it testable.
 
-### Running
+### Measuring, not just asserting
+
+A test need not end in a verdict. Three further kinds record measurements, and all four land in
+the same report: a name, its axes, and a sparse map of cells whose figures come from one closed
+set, so every kind renders the same way and charts the same way.
+
+A `Bench` measures speed. Its body is a quoted expression, [staged](staging.md) and dispatched in
+its own JVM, so the measurement is not distorted by the rest of the suite:
+
+```scala
+val bench = Bench()
+
+bench(m"decode directly")(target = 1*Second, operationSize = size):
+  '{ Benchmarks.decodeUsersDirect() }
+```
+
+A `Stress` measures what a throughput figure hides: allocation per operation, peak heap, and the
+live set retained under sustained concurrency. It runs for a wall-clock target at a stated
+concurrency, and may be given a constrained heap or a CPU limit, so a design can be shown to hold
+up where it matters:
+
+```scala
+val stress = Stress()
+val constrained = Stress(heap = t"128m")
+
+stress(m"cross-thread hand-off")(target = 2*Second, concurrency = 16):
+  '{ … }
+```
+
+A `Profile` answers where the time went, rendering a histogram of the hottest methods by self
+time from JFR execution samples, coloured by package:
+
+```scala
+val profile = Profile()
+
+profile(m"pipeline hotspots")(target = 5*Second):
+  '{ … }
+```
+
+Benchmarks spread over axes as tests do, staging one program per distinct implementation and
+dispatching each cell in its own JVM; a baseline anchors one axis value and the rest render
+relative to it. A stress *sweep* records its steps as coordinates on an emergent axis of a single
+test, rather than as a family of differently-named tests.
+
+### Running and selecting
 
 A `Suite` is a main class: run directly, it executes its tests with live progress on a terminal
 and plain output on CI, reports each failure with its contrast, and exits nonzero if any test
 failed — all a build needs to gate on.
+
+A suite executable also accepts selection terms, so a subset can be run without editing the code.
+Hashes, monikers and name globs identify tests and union with each other; `kind:` filters and
+axis constraints intersect with that union:
+
+```sh
+mysuite square 'parser*'      # by moniker, then by name glob
+mysuite kind:bench            # only the benchmarks
+mysuite parser=jacinta 'N<32' # only cells matching these axis constraints
+mysuite --list                # enumerate what matches, and run nothing
+```
+
+Unselected assertions never execute, and unselected benchmark cells are skipped, so a selection
+costs only what it runs.

--- a/doc/modules/text.md
+++ b/doc/modules/text.md
@@ -154,6 +154,86 @@ import proximities.levenshteinProximity
 t"Hello world".proximity(t"Hello orld")   // 1
 ```
 
+Comparing one word against a whole vocabulary that way is quadratic, and a spelling suggestion
+needs it to be fast. A `Lexicon` is a
+[BK-tree](https://en.wikipedia.org/wiki/BK-tree) over the words, which uses the triangle
+inequality the distance metric obeys to prune most of the vocabulary without measuring it:
+
+```scala
+val lexicon = Lexicon(words)
+
+lexicon.search("book", 0)   // exact matches only
+lexicon.search("booq", 1)   // everything within one edit
+```
+
+A search at distance zero is an exact lookup; widening the radius admits progressively more
+distant candidates, which is how a "did you mean" suggestion is produced from a large word list.
+
+### Prefix dictionaries
+
+Where lookup is by exact key rather than by proximity, a `Dictionary` maps text to values through
+a trie, so a lookup costs the length of the key rather than a hash of the whole of it, and a
+prefix query costs the length of the prefix:
+
+```scala
+val dictionary = Dictionary(t"color" -> 0, t"colour" -> 1)
+
+dictionary(t"color")     // 0
+dictionary.size          // 2
+```
+
+### Graphemes and width
+
+A character is not a unit of text a person would recognise. `é` may be one code point or two, and
+a family emoji is several joined together, so counting `Char`s answers the wrong question.
+`Writing` gives a text's *grapheme clusters* — what a reader would call characters — and the
+boundaries between them:
+
+```scala
+Writing(t"abc").graphemeCount   // 3
+Writing(t"").boundaries.toList  // List(0)
+```
+
+Nor is a grapheme one column wide on a terminal. Under a metric in scope, `metrics` gives the
+display width the terminal will actually use — one for ASCII, one for a letter with a combining
+accent, two for CJK and for most emoji — which is what aligning columns of text requires:
+
+```scala
+import textMetrics.wideCharacterWidthMetric
+
+Grapheme("a").metrics    // 1
+Grapheme("é").metrics    // 1 — a base plus a combining mark
+Grapheme("日").metrics   // 2
+```
+
+### Rendering numbers
+
+Turning a number into text involves a choice — how many digits are worth showing — that
+`toString` makes badly. A `Decimalizer` in scope states it as significant figures, and is what
+every `show` of a floating-point number consults:
+
+```scala
+Decimalizer(3).decimalize(-math.Pi)   // t"-3.14"
+```
+
+The same value therefore renders consistently everywhere in a program, and changing the precision
+is one given rather than a search for format strings.
+
+### Multi-line literals
+
+Prose in source code wants to be wrapped for the reader, and unwrapped for the output. The
+`txt"…"` interpolator collapses a wrapped paragraph into a single line, treats a blank line as a
+paragraph break, and strips the indentation the source needed:
+
+```scala
+txt"""Hello
+      world"""      // t"Hello world"
+
+txt"""Hello
+
+      world"""      // t"Hello\nworld"
+```
+
 ### Any textual type
 
 Every operation above is defined over the `Textual` typeclass, not over `Text` alone. A type

--- a/doc/modules/text.md
+++ b/doc/modules/text.md
@@ -138,7 +138,7 @@ Text encodes to bytes through the character encoding in scope, and bytes decode 
 ```scala
 import charEncoders.utf8Encoder
 
-val bytes = t"Adélaïde".data   // the UTF-8 bytes
+val bytes = t"Adélaïde".in[Data]   // the UTF-8 bytes
 bytes.utf8                     // t"Adélaïde"
 ```
 

--- a/doc/modules/time.md
+++ b/doc/modules/time.md
@@ -262,6 +262,31 @@ t"P1Y2M3DT4H5M6S".as[Timespan] // the same span
 dur"P1Y2M3DT4H5M6S"                // checked at compiletime
 ```
 
+### Periods
+
+Two points of the same kind bound a `Period` with `~`, which is a half-open interval: the start is
+included, the finish is not, so consecutive periods tile a timeline without overlapping at their
+boundaries.
+
+`by` walks a period at a step, yielding each point:
+
+```scala
+(Instant(0L) ~ Instant(3_600_000L)).by(15*Minute)   // four instants
+Period(2024-Jan-1, 2024-Jan-5).by(1*Day)            // four dates
+```
+
+`segments` divides it into sub-periods rather than points, which is what a calendar view or a
+bucketed report needs. A step that does not divide the period evenly drops the remainder by
+default, or keeps it as a short final segment on request:
+
+```scala
+(Instant(0L) ~ Instant(3_600_000L)).segments(15*Minute)                 // four segments
+(Instant(0L) ~ Instant(3_600_000L)).segments(25*Minute, partial = true) // three, the last short
+```
+
+Because a period is generic in its point type, the same operations serve instants, dates and
+timestamps, with the step expressed in whatever units that kind of point moves by.
+
 ### Arithmetic on dates
 
 Adding a span to a date moves it forward. Days and weeks are regular — they need
@@ -430,6 +455,22 @@ val earlier = Moment(2024-Oct-27, clock, tz"Europe/London")
 val later = Moment(2024-Oct-27, clock, tz"Europe/London", Occurrence.Second)
 later.instant.long - earlier.instant.long   // 3600000
 ```
+
+### The zone database
+
+The rules behind all of this come from the [tz database](https://www.iana.org/time-zones), and its
+source files are parsed directly rather than reached through a platform API. The parser
+understands the format's own vocabulary — `Rule` lines with their `Sun>=8`-style day
+specifications, `Zone` lines with their offsets and formats, and `Link` aliases — so a database
+newer than the platform's own can be loaded, which matters when a government changes its rules at
+short notice:
+
+```scala
+Tzdb.parse(t"northamerica", lines)
+```
+
+A file that does not exist, or a line the format does not permit, raises a `TzdbError` naming the
+fault rather than silently producing a zone with the wrong rules.
 
 ### Calendars
 

--- a/doc/modules/time.md
+++ b/doc/modules/time.md
@@ -82,12 +82,12 @@ brings it into scope explicitly:
 import calendars.gregorianCalendar
 ```
 
-A date read from text uses `decode`. The `ts` interpolator does the same for a
+A date read from text uses `as`. The `ts` interpolator does the same for a
 literal known at compiletime, where it validates the digits just as the
 hyphenated form does:
 
 ```scala
-val parsed = t"2011-12-13".decode[Date]   // 2011-Dec-13
+val parsed = t"2011-12-13".as[Date]   // 2011-Dec-13
 val literal = ts"2024-12-31"              // 2024-Dec-31
 ```
 
@@ -152,7 +152,7 @@ literal:
 
 ```scala
 val built = Timestamp(2023-May-28, Clockface(14, 30, 59))
-val parsed = t"2024-01-15T14:30:59".decode[Timestamp]
+val parsed = t"2024-01-15T14:30:59".as[Timestamp]
 val literal = ts"2023-05-28T14:30:59"
 ```
 
@@ -192,7 +192,7 @@ each other, and parse from text:
 ```scala
 Year(2024) + 5           // Year(2029)
 Year(1999) < Year(2000)  // true
-t"2024".decode[Year]     // Year(2024)
+t"2024".as[Year]     // Year(2024)
 ```
 
 A year and a month together form a `Monthstamp`, written with `-`. Subtracting a
@@ -258,7 +258,7 @@ val span = Timespan(years = 1, months = 2, days = 3, hours = 4, minutes = 5,
     seconds = Quantity(6.0))
 
 span.encode                        // P1Y2M3DT4H5M6S
-t"P1Y2M3DT4H5M6S".decode[Timespan] // the same span
+t"P1Y2M3DT4H5M6S".as[Timespan] // the same span
 dur"P1Y2M3DT4H5M6S"                // checked at compiletime
 ```
 
@@ -321,11 +321,11 @@ given Holidays = Holidays(List
 
 An instant is a moment in physical time, with no reference to any calendar or
 clock. An `Instant` is measured along a timeline, and the timeline is part of its
-type. The POSIX timeline counts milliseconds from the
+type. The `Unix` timeline — POSIX time — counts milliseconds from the
 [Unix epoch](https://en.wikipedia.org/wiki/Unix_time):
 
 ```scala
-import chronometries.posix
+import chronometries.unix
 
 val epoch = Instant(0L)   // 1970-01-01T00:00:00Z
 ```
@@ -400,7 +400,7 @@ in London in summer than in winter, because British Summer Time is in force:
 ```scala
 import instantDecodables.iso8601InstantDecodable
 
-val summer = t"2024-07-15T12:00:00Z".decode[Instant over Posix]
+val summer = t"2024-07-15T12:00:00Z".as[Instant over Unix]
 summer.in(tz"Europe/London").time.hour   // 13
 ```
 
@@ -711,12 +711,12 @@ import yearFormats.fullYears
 Civil time and physical time disagree by a whole number of seconds, and the number
 grows. Since 1972, [leap seconds](https://en.wikipedia.org/wiki/Leap_second) have
 been inserted into [UTC](https://en.wikipedia.org/wiki/Coordinated_Universal_Time)
-to keep clocks aligned with the Earth's slowing rotation. A POSIX instant ignores
-them, so the elapsed seconds between two POSIX instants can be short by the leap
+to keep clocks aligned with the Earth's slowing rotation. A `Unix` instant ignores
+them, so the elapsed seconds between two `Unix` instants can be short by the leap
 seconds that fell between them.
 
 [International Atomic Time](https://en.wikipedia.org/wiki/International_Atomic_Time)
-(TAI) has no such discontinuities. Converting a POSIX instant to the TAI timeline
+(TAI) has no such discontinuities. Converting a `Unix` instant to the TAI timeline
 adds the leap seconds that have accumulated by that instant — thirty-seven of them
 by 2017 — and the conversion round-trips exactly:
 
@@ -724,9 +724,9 @@ by 2017 — and the conversion round-trips exactly:
 import calendars.gregorianCalendar
 import instantDecodables.iso8601InstantDecodable
 
-val instant = t"2017-06-15T00:00:00Z".decode[Instant over Posix]
+val instant = t"2017-06-15T00:00:00Z".as[Instant over Unix]
 instant.over[Tai].long - instant.long    // 37000
-instant.over[Tai].over[Posix] == instant // true
+instant.over[Tai].over[Unix] == instant // true
 ```
 
 Because the timelines are distinct types, subtracting an instant on one from an

--- a/doc/modules/trees.md
+++ b/doc/modules/trees.md
@@ -72,3 +72,54 @@ tightens the layout; `LayeredDagDiagram` arranges nodes in levels instead of lan
 A diagram exposes its rows — the tiles and the node of each line — so a consumer can render lines
 itself: colored labels for one kind of node, annotations appended to another. The box-drawing
 characters stay the style's business, and the meaning stays the caller's.
+
+```scala
+diagram.nodes    // the node of each line, in drawing order
+diagram.tiles    // the tiles of each line
+diagram.map { tiles => node => renderMyself(tiles, node) }
+```
+
+A `TreeTile` is one of four things: a branch, a last branch, an extender carrying a line down past
+a node, or a space. A style says what each becomes, and a `TextualTreeStyle` says it as four short
+pieces of text, which is all a new style needs:
+
+```scala
+val myStyle = TextualTreeStyle[Text](t"  ", t"└─", t"├─", t"│ ")
+```
+
+Because the style is parameterized by the line type rather than fixed to `Text`, a diagram renders
+directly into styled [terminal output](terminal.md), with the tree furniture in one colour and the
+labels in another, and the widths still computed correctly.
+
+### Supplying the tree
+
+A tree can be given in two ways. `TreeDiagram.by` takes a function from node to children, which
+suits a structure that is already in hand:
+
+```scala
+TreeDiagram.by[Taxon](_.children)(root)
+```
+
+`TreeDiagram.apply` instead takes roots and finds children through an `Expandable` instance on the
+node type, which suits a node type whose children are what it means by children — a filesystem
+path, a dependency, a syntax node:
+
+```scala
+given Taxon is Expandable = _.children
+
+TreeDiagram(root)
+```
+
+The lines are produced lazily, so a large or deep tree is drawn as far as it is consumed rather
+than all at once.
+
+### Choosing a graph layout
+
+The three graph diagrams answer different questions. `DagDiagram` is dense: every edge is drawn,
+in a grid of connecting tiles, which is what a small graph with complicated edges needs.
+`LaneDagDiagram` puts each node on a vertical lane, as version-control history is drawn, which
+suits a long graph with few concurrent branches. `LayeredDagDiagram` arranges nodes into levels
+by depth, which suits showing what depends on what rather than what happened in what order.
+
+All three take a `Dag`, and all three raise a `DagError` where the graph is not acyclic — a cycle
+has no drawing, so it is reported rather than approximated.

--- a/doc/modules/versioning.md
+++ b/doc/modules/versioning.md
@@ -31,7 +31,7 @@ type, raising a `SemverError` for a malformed version:
 
 ```scala
 val version = v"1.4.2"
-t"2.0.0-rc.1".decode[Semver]
+t"2.0.0-rc.1".as[Semver]
 
 v"1.2"   // does not compile: not a semantic version
 ```

--- a/doc/modules/xml.md
+++ b/doc/modules/xml.md
@@ -41,6 +41,52 @@ header:
 val doc = t"<message>hello world</message>".read[Xml]
 ```
 
+The distinction matters. `read` yields the content; `load` yields a `Document`, pairing the root
+with its `Header` — the version, and the encoding and standalone declarations where they are
+given — so a document round-trips with its declaration intact rather than losing it on the way in:
+
+```scala
+supervise:
+  t"""<?xml version="1.0"?><root>content</root>""".load[Xml]
+// Document(elem(t"root", TextNode(t"content")), Header(t"1.0", Unset, Unset))
+```
+
+Anything in the prolog — a comment, a processing instruction, a `<!DOCTYPE>` — is kept as a node
+before the root rather than discarded, so a stylesheet instruction survives a read and a write.
+
+### The node types
+
+An `Xml` value is one of the node kinds the specification defines, and each is a distinct type
+rather than a tagged string. `Element` holds a name, attributes and children; `TextNode` holds
+character data; and the rest carry what other libraries tend to flatten away:
+
+- `Cdata` keeps a `<![CDATA[…]]>` section as a section, so text that contains `<not a tag>`
+  survives a round trip without being escaped into something else.
+- `Comment` keeps `<!-- … -->`, wherever it appears.
+- `ProcessingInstruction` keeps a target and its data, including the empty-data case `<?target?>`.
+- `Doctype` keeps a `<!DOCTYPE>` declaration, which serializes back verbatim.
+- `Fragment` holds a sequence of nodes with no single parent, which is what a prolog plus a root
+  amounts to.
+
+The five predefined entities — `&amp;`, `&lt;`, `&gt;`, `&quot;` and `&apos;` — resolve on the way
+in and are re-escaped on the way out, as are numeric character references in both decimal and
+hexadecimal.
+
+### Namespaces
+
+Namespace declarations are attributes, and prefixed names are names, so both survive parsing
+unaltered:
+
+```scala
+t"""<a xmlns="http://example.com"/>""".read[Xml]
+t"""<a xmlns:p="http://example.com"/>""".read[Xml]
+t"<p:a/>".read[Xml]
+```
+
+Nothing is rewritten into a resolved form, so a document written with prefixes is written back
+with the same prefixes — which is what matters where the document's exact bytes are covered by a
+signature, or where a downstream consumer matches on the prefix.
+
 ### Reading values
 
 An `Xml` value converts to a Scala type with `as`. Content that cannot be read as the target type
@@ -66,9 +112,51 @@ t"<Worker><name>Alice</name><age>30</age></Worker>".read[Worker in Xml]
 // Worker(t"Alice", 30)
 ```
 
-A field marked `@attribute` becomes an attribute rather than a child element, and `@name` renames the
-wire label where the Scala name and the XML name should differ. An enumeration encodes as an element
-named for its case.
+A field marked `@attribute` becomes an attribute rather than a child element, and round-trips as
+one:
+
+```scala
+case class Book(title: Text, @attribute isbn: Text)
+
+Book(t"Dune", t"0441013597").in[Xml]
+// x"""<Book isbn="0441013597"><title>Dune</title></Book>"""
+```
+
+`@name` renames the wire label where the Scala name and the XML name should differ, and
+`@name[Xml]` confines the rename to XML, leaving other formats to their own. It renames the
+element of an enumeration's *variant* too, so a `Light.Stop` may travel as `<red>`:
+
+```scala
+enum Light:
+  case @name[Xml](t"red") Stop(seconds: Int)
+  case @name(t"green") Go(seconds: Int)
+  case Wait(seconds: Int)
+
+(Light.Stop(30): Light).in[Xml]   // x"<red><seconds>30</seconds></red>"
+```
+
+A sum type decodes by its element label, so the element's name selects the variant; a label
+naming no variant raises an `XmlError` rather than falling through to a default.
+
+### What decoding tolerates
+
+Real XML is untidy, and a decoder that insists on tidiness is of little use. Text, comments and
+processing instructions interleaved between the children a type expects are ignored, so a
+document with prose between its fields decodes as though the prose were not there:
+
+```scala
+t"<root>hello<name>A</name><!--c--><?pi data?> <age>4</age>bye</root>".read[Worker in Xml]
+// Worker(t"A", 4)
+```
+
+Entities in leaf text expand as they are read. Repeated elements gather into a collection field in
+document order, and they need not be contiguous — a `<songs>` before the `<name>` and another
+after it still form one list, in the order they appeared. Recursive types tie through their own
+derivation, so a tree of arbitrary depth encodes and decodes without a hand-written codec.
+
+Where a nested value is missing altogether, a `Default` for its type turns what would be a cascade
+of sub-field errors into a single error at the point the value should have been, with the default
+used to carry on — which is what a validation pass reporting to a human wants.
 
 ### Writing XML literally
 
@@ -119,3 +207,42 @@ import formatting.indentedXmlFormatting
 
 Worker(t"Alice", 30).in[Xml].show   // indented across several lines
 ```
+
+### Paths
+
+An [XPath](https://en.wikipedia.org/wiki/XPath)-like path names a location within a document. The
+`xp"…"` interpolator writes one and checks it as the code compiles, with a step's ordinal
+defaulting to the first match and `@` naming an attribute:
+
+```scala
+xp"/root[1]/child[2]".encode   // t"/root[1]/child[2]"
+xp"/root[1]/@id".encode        // t"/root[1]/@id"
+xp"/root/child".encode         // t"/root[1]/child[1]"
+```
+
+Paths are what positions and accrued errors are reported against, so an error from decoding a
+large document names the element that caused it.
+
+### Positions and errors
+
+A malformed document raises a `ParseError` whose position is not merely a line number but a range:
+the offset and length of the text at fault, so a tool can underline exactly the mismatched closing
+tag or the unterminated attribute rather than the whole line.
+
+Positions of *well-formed* content are recorded on request, in the same way as for
+[JSON](json.md#source-positions):
+
+```scala
+import parsing.trackPositions
+
+val tracked = source.load[Xml]
+```
+
+Under an accruing strategy, decoding reports every fault in the document at once, each with the
+path to the element that failed, rather than stopping at the first.
+
+### XML over HTTP
+
+An `Xml` value serves as a request or response body with the `application/xml` media type, and a
+body parses back to `Xml` on arrival, so an XML API is consumed and offered with no glue between
+the XML and [HTTP](http-client.md) layers.

--- a/doc/modules/xml.md
+++ b/doc/modules/xml.md
@@ -59,7 +59,7 @@ reads back the same way regardless of the order of the children:
 ```scala
 case class Worker(name: Text, age: Int)
 
-Worker(t"Alice", 30).xml
+Worker(t"Alice", 30).in[Xml]
 // x"<Worker><name>Alice</name><age>30</age></Worker>"
 
 t"<Worker><name>Alice</name><age>30</age></Worker>".read[Worker in Xml]
@@ -117,5 +117,5 @@ adds newlines and indentation for reading:
 ```scala
 import formatting.indentedXmlFormatting
 
-Worker(t"Alice", 30).xml.show   // indented across several lines
+Worker(t"Alice", 30).in[Xml].show   // indented across several lines
 ```

--- a/doc/modules/yaml.md
+++ b/doc/modules/yaml.md
@@ -47,15 +47,20 @@ A multi-document stream — documents separated by `---` — reads as a list:
 t"---\n1\n---\n2\n---\n3".read[List[Yaml]].map(_.as[Int])   // List(1, 2, 3)
 ```
 
+A source need not be text held in memory. The parser reads straight from a byte or character
+[stream](streams.md), refilling as it goes, rather than concatenating the input first — so a
+large document parses without ever being materialized, and a `---` marker split across two chunks
+is still a document boundary.
+
 ### Encoding
 
-A value encodes to YAML with `yaml`, and renders as block-style text with `show`, given a
+A value encodes to YAML with `in[Yaml]`, and renders as block-style text with `show`, given a
 formatting in scope:
 
 ```scala
 import formatting.blockYamlFormatting
 
-Person(t"Alice", 30).yaml.show
+Person(t"Alice", 30).in[Yaml].show
 // name: Alice
 // age: 30
 ```
@@ -89,7 +94,7 @@ import dynamicYamlAccess.enabled
 val doc = t"{name: Alice, age: 30}".read[Yaml]
 doc.name.as[Text]      // t"Alice"
 (doc.age = 31)         // a new document
-doc.lens(_.age = 31.yaml)
+doc.lens(_.age = 31.in[Yaml])
 ```
 
 ### Positions and accumulated errors

--- a/doc/modules/yaml.md
+++ b/doc/modules/yaml.md
@@ -52,6 +52,67 @@ A source need not be text held in memory. The parser reads straight from a byte 
 large document parses without ever being materialized, and a `---` marker split across two chunks
 is still a document boundary.
 
+### Scalars, quoting and block styles
+
+YAML's scalars are where most of its surprises live, and each style is handled as specified.
+Plain scalars resolve by their content — `true` is a boolean, `42` an integer, `~` and `null` a
+null — while quoted scalars are always text, so `"42"` stays a string. Single quotes take no
+escapes but double them to include one; double quotes take the full escape set.
+
+Block scalars carry their own newline handling. `|` keeps line breaks and `>` folds them into
+spaces, and a chomping indicator says what to do with the trailing newline — `-` strips it, `+`
+keeps every one:
+
+```scala
+t"text: |\n  line1\n  line2".read[Yaml].as[Map[Text, Text]]   // t"line1\nline2\n"
+t"text: >\n  line1\n  line2".read[Yaml].as[Map[Text, Text]]   // t"line1 line2\n"
+t"text: |-\n  line1\n  line2".read[Yaml].as[Map[Text, Text]]  // t"line1\nline2"
+```
+
+Comments are ignored wherever they may appear — after a scalar, on a line of their own — and
+leading, trailing and line-trailing whitespace is handled as the specification requires rather
+than as it happens to fall.
+
+### Tags
+
+A tag overrides the resolution a scalar's content would otherwise get, which is how YAML says
+"this number is a string" and the reverse:
+
+```scala
+t"!!str 42".read[Yaml].as[Text]       // t"42"
+t"!!int \"42\"".read[Yaml].as[Int]    // 42
+t"!!float 7".read[Yaml].as[Double]    // 7.0
+```
+
+### Anchors and aliases
+
+An anchor names a node and an alias refers back to it, so a document need not repeat itself.
+Aliases resolve as the document is read, whatever the anchored node was — a scalar, a flow
+sequence or mapping, or a whole block:
+
+```scala
+t"a: &x 1\nb: *x".read[Yaml].as[Map[Text, Int]]
+// Map(t"a" -> 1, t"b" -> 1)
+
+t"defaults: &d\n  n: 7\nuse: *d".read[Yaml].as[Map[Text, Inner]]
+// both keys hold the same mapping
+```
+
+This is what makes YAML configuration files terse, and what makes a naive parser get them wrong.
+
+### Numbers
+
+A YAML number, like a JSON one, has no inherent precision limit. Numbers beyond a `Long`'s or a
+`Double`'s range are kept exactly, as binary-coded decimals, so a long identifier or a precise
+decimal read from a configuration file is not silently rounded on the way through.
+
+### Conformance
+
+The parser is checked against the [YAML test suite](https://github.com/yaml/yaml-test-suite), the
+community's shared corpus of cases — including the ones designed to break parsers. Cases outside
+the supported subset are recorded as known gaps rather than quietly skipped, so the coverage is
+stated rather than claimed.
+
 ### Encoding
 
 A value encodes to YAML with `in[Yaml]`, and renders as block-style text with `show`, given a

--- a/doc/philosophy/direct-style.md
+++ b/doc/philosophy/direct-style.md
@@ -13,7 +13,7 @@ sit inside an argument list, inside an interpolated string, inside a condition â
 anywhere an expression can go â€”
 
 ```scala
-val greeting = t"Hello, ${name.decode[EmailAddress].localPart}!"
+val greeting = t"Hello, ${name.as[EmailAddress].localPart}!"
 ```
 
 whereas monadic values compose only through their combinators. The same line, with

--- a/doc/philosophy/elegant-prose.md
+++ b/doc/philosophy/elegant-prose.md
@@ -11,7 +11,7 @@ Prose is learnable by analogy, and so is a well-designed API. A reader who has s
 `text.read[Json]` should correctly guess that `text.read[Markdown]` parses Markdown,
 that `bytes.read[Audio in Wave]` reads a WAV file, and that `stream.read[Csv]` would
 read CSV — one verb, meaning the same thing across every format. The same analogy runs
-through the whole vocabulary: whatever can be decoded is `text.decode[T]`, whatever can
+through the whole vocabulary: whatever can be decoded is `text.as[T]`, whatever can
 be shown is `value.show`, whatever streams is `source.stream[Data]`, every checked
 literal is an interpolator (`url"…"`, `p"…"`, `json"…"`, `v"…"`), and every serialized
 form round-trips through the same pair of operations. Learning one corner of Soundness

--- a/doc/philosophy/small-apis.md
+++ b/doc/philosophy/small-apis.md
@@ -1,7 +1,7 @@
 # Small APIs
 
 Soundness keeps its APIs small by giving one operation one name. A single polymorphic
-method — `read`, `decode`, `show` — serves every type that supports it, instead of a
+method — `read`, `as`, `show` — serves every type that supports it, instead of a
 family of near-duplicates that differ only in what they apply to. There is one obvious
 way to do a thing, so there is less to learn, less to remember, and less chance of
 reaching for the wrong variant. The breadth of what an API can do comes from the range

--- a/doc/tags.md
+++ b/doc/tags.md
@@ -5,10 +5,15 @@ ambience: envvar system-properties configuration xdg directories environment
 anamnesis: database entity persistence storage data-access
 anthology: scala-compiler compilation programmatic-compiler diagnostics
 anticipation: integration typeclass-bridges abstract-typeclasses cross-module
+aperture: open create scoped-resource handle capability grant mode
+apoplexy: openapi swagger api-specification rest schema
+archimedes: mathml equations mathematical-notation rendering
 austronesian: pojo java-interop serialization classloader-isolation
 aviation: time date calendar timezone iso8601 rfc1123 holidays leap-seconds tzdb
 baroque: complex-numbers math imaginary algebra
+beneficence: build-plugin publishing artifacts distribution
 bitumen: tar archive pax tarball unix-permissions
+breviloquence: cbor binary-json concise-binary serialization
 burdock: bootstrap installer self-installer
 cacophony: audio sound aiff wav playback recording stereo waveform
 caduceus: email smtp mime sender attachment envelope
@@ -17,7 +22,6 @@ camouflage: cache lru-cache memoization
 capricious: random rng probability gaussian gamma distribution sampling seed
 cardinality: refinement-types numeric-range bounded-numbers ranges
 cataclysm: css stylesheet selectors keyframes media-queries fonts typesafe-css
-cellulose: codl config configuration-language declarative
 charisma: chemistry periodic-table chemical-equation molecule chemical-formula
 chiaroscuro: diff comparison contrast similarity test-assertions decomposition
 coaxial: socket tcp udp networking domain-socket bindable connection
@@ -25,6 +29,7 @@ contextual: string-interpolation interpolator typesafe-interpolation custom-inte
 contingency: error-handling exceptions tactics recovery validation effects
 cosmopolite: i18n internationalization locale language polyglot l10n
 decorum: compiler-plugin code-style linting static-analysis
+delicious: semantic-diagnostics compiler-errors explanations diagnostics
 dendrology: tree-diagram dag-diagram ascii-tree visualization tree-rendering
 denominative: ordinal indexing zero-based one-based interval
 digression: stacktrace codepoint fqcn introspection debugging
@@ -39,6 +44,7 @@ ethereal: daemon ipc background-process service-installer client-server
 eucalyptus: logging logs realm logger structured-logging
 exegesis: lsp language-server-protocol ide-integration
 exoskeleton: cli command-line application-framework entrypoint shell-completion
+facsimile: pdf cos document page-tree text-extraction annotations bookmarks
 frontier: implicits given-search compile-time-reflection enumeration
 fulminate: error-messages diagnostics fail-fast structured-messages internationalization-messages
 galilei: filesystem io files directories symlinks volumes posix
@@ -48,6 +54,7 @@ gesticulate: mime media-types multipart content-type assets
 gigantism: macros metaprogramming compile-time scala-compiler-internals
 gnossienne: reference foreign-key entity-reference resolvable
 gossamer: text strings text-utilities decimal-formatting bidi unicode joining
+graffiti: templates text-templates interpolation html-templates
 guillotine: shell process subprocess command-execution posix sh
 hallucination: image png jpeg gif bmp raster image-io
 harlequin: syntax-highlighting source-code tokenization scala-parser
@@ -59,13 +66,13 @@ hypotenuse: numeric overflow division integer-arithmetic ordered
 imperial: directory-layout home-directory base-directory filesystem-layout xdg
 inimitable: uuid identifier guid
 iridescence: color color-spaces rgb cielab hsl srgb palette theme colorimetry
-jacinta: json parser serialization json-pointer ndjson dynamic-access
+jacinta: json parser serialization json-pointer json-schema schema-validation dynamic-access
 kaleidoscope: regex glob pattern-matching scanner regular-expressions
 larceny: compiler-plugin compile-error testing compile-time-testing
 legerdemain: forms widgets html-forms input fields
+locomotion: protobuf protocol-buffers wire-format binary-serialization
 mandible: bytecode jvm classfile class-file
 mercator: functor monad applicative typeclass functional-programming
-merino: json parser fast-parser json-ast
 metamorphose: permutations combinatorics factoradic lehmer
 monotonous: base64 base32 hex binary-encoding base-encoding serialization
 mosquito: matrix linear-algebra math vector
@@ -78,14 +85,19 @@ parasite: async threading concurrency tasks promise daemon supervision
 perihelion: websocket frame ws-protocol
 phoenicia: fonts typography ttf truetype font-metrics opentype
 plutocrat: currency money price finance luhn isin fixed-point
+pneumatic: compression deflate gzip zlib brotli xz lzma2 lzw
 polaris: binary-serialization buffer pack unpack byte-buffer
+polysyllabic: hyphenation liang-algorithm line-breaking typesetting
 polyvinyl: structural-types records anonymous-records type-providers
 prepositional: typeclass type-infrastructure refinement-types abstract-types
+prescience: staging macro-typeclass code-generation expansion-time
 probably: testing test-runner property-testing benchmark assertions
 profanity: terminal tui keyboard line-editor interactive console
+prophesy: completions dynamic-types tab-completion ide-suggestions
 proscenium: re-exports stdlib utilities boilerplate-reduction
 punctuation: markdown commonmark prose text-formatting
 quantitative: units quantities dimensional-analysis si-units measurements physics
+querencia: dom browser typed-dom web-ui client-side
 revolution: jar-manifest semver versioning
 rudiments: utilities core-library bijection loops indexable
 savagery: svg vector-graphics 2d-graphics path shapes
@@ -94,24 +106,27 @@ sedentary: benchmarking performance-testing micro-benchmark
 serpentine: path filesystem-paths posix windows linux relative-path absolute-path
 spectacular: show pretty-printing display inspect
 stenography: typename qualified-names imports symbol-rendering scala-types
+stratiform: tel configuration-language records schema binary-tel
 superlunary: staging remote-execution multi-stage-programming distributed-computing
 surveillance: file-watcher filesystem file-events directory-monitoring nio
 symbolism: operators arithmetic typeclass operator-overloading algebra
 synesthesia: mcp model-context-protocol llm ai-protocol
 tarantula: webdriver browser-automation chrome firefox selenium
 telekinesis: http http-client cookies authentication rest-client web-requests
-turbulence: streams io stdio gzip compression streaming reactive
+turbulence: streams io stdio streaming reactive line-separation
 typonym: type-level type-list type-map heterogeneous reflection
+ultimatum: inline-arrays resizing collections tuples
 ulysses: bloom-filter probabilistic-data-structures palimpsest
 umbrageous: compiler-plugin shading namespace-isolation
 urticose: hostname email-address ip-address mac-address port network-identifiers endpoint
 vacuous: optional null-safety option maybe nullable
 vexillology: bit-flags flags enumeration bitfield
 vicarious: catalog proxy type-indexed records
-villainy: json-schema schema-validation jsonschema
 wisteria: derivation product-types sum-types case-class typeclass-derivation magnolia
+xenophile: ffi foreign-interop wit webidl typescript kotlin wasm native
 xylophone: xml xml-schema typesafe-xml dynamic-xml
 yossarian: pty terminal-emulator ansi-escape screen-buffer vt100 cursor
+ypsiloid: yaml parser serialization yaml-ast anchors
 zephyrine: parser parsing cursor emitter sparse-format
 zeppelin: zip archive zip-file compression
 ziggurat: installer bootstrap deployment payload


### PR DESCRIPTION
The tutorials in `doc/` were written at #1480 and have not been revised since, while around 160 commits changed the API they describe. Every tutorial has been checked against the code it documents and corrected, and then expanded to cover the parts of each API a reader reaches as soon as the straightforward case is behind them. Two capabilities that had no tutorial at all now have one, and the platform-compatibility matrix and module tag list have been regenerated.

## Documentation

### Corrections

The codec-vocabulary change of #1534 was the most pervasive drift:

```scala
t"2024-01-15".as[Date]                  // was .decode[Date]
Person(t"Alice", 30).in[Json].show      // was .json.show
t"café".in[Data]                        // was .data
(3*Foot).to[Metres]                     // was .in[Metres]
```

Substantially revised for what changed since: **streams** (the kernel's pull endpoints, `Relay`, `Confluence`/`Divergence`, and what separation checking guarantees), **filesystem**, **archives**, **containers**, **audio** and **images** (the `open`/`create` scheme with grants in the handle's type), **HTTP client and server** and **sockets** (sessions, ALPN-negotiated HTTP/2, pluggable backends), **compilation** and **packaging** (universes, `Linker` artifacts, Android packages, semantic diagnostics), **testing** (axes, `Bench`/`Stress`/`Profile`, command-line selection), and **stack traces** (TASTy-resolved frames, from #1669).

Two capabilities had no tutorial at all, and now do: `doc/modules/compression.md` for DEFLATE, Brotli, XZ, LZMA2 and LZW, and `doc/modules/pdf.md` for reading, editing and text-extracting PDF documents.

### Expansion

Each tutorial now goes past its introductory case — JSON's wrapper and envelope sum encodings and per-path encoder overrides, XML's node types and namespaces, YAML's block-scalar chomping and anchors, TEL's presentation-preserving edits and schema-aware error recovery, Git's structured diffs and forgiving redraft patches, aperture's `Exclusive` grant and its containment semantics, pixel layouts computed at compiletime, the evidence that makes optionals zero-cost and non-nesting, and the reasoning behind designs that look surprising until explained.

Where a claim is checkable, the tutorials now say what checks it: the bytecode-shape test behind the zero-cost dimensional arithmetic, BLAKE3's official vectors, HPACK's RFC 7541 appendices, the YAML test suite, and the badssl.com endpoints the HTTP client's TLS refusals are verified against.

### Data files

`doc/compatibility.tsv` gains the modules added since it was generated, drops cordillera (now `telekinesis.http2`), corrects eight stale rows, and adds a `native` column for Scala Native support. `doc/tags.md` gains eighteen modules it never listed and drops three that no longer exist.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
