### PR TITLE
Mix colors by parts, with Photoshop blend modes

### DIFF
--- a/doc/modules/colors.md
+++ b/doc/modules/colors.md
@@ -92,6 +92,57 @@ WebColors.Ivory.to[Cielab].mix(WebColors.DeepPink.to[Cielab])
 Mixing in sRGB blends the screen values; mixing in CIELAB blends what the eye perceives,
 which gives a more natural midpoint between two colors.
 
+### Mixing by parts
+
+`mix` takes two colors at a time. To combine several, multiply each by the number of
+parts of it going into the mixture and add them up, the way a painter measures paint
+onto a palette. A mixing mode is chosen by importing one:
+
+```scala
+import mixing.proportional
+
+5*WebColors.Red + 3*WebColors.Yellow   // Srgb(1, 0.375, 0) — an orange
+```
+
+`5*Red` is a `Daub`: an amount of a color, which is still that color — one part of red
+and five parts of red are both red. A `Daub` is a `Color`, so a mixture converts,
+renders and measures like any other, and the parts matter only when more paint is added:
+
+```scala
+val mixture = 5*WebColors.Red + 3*WebColors.Yellow
+mixture.to[Cielab]
+mixture.to[Hsl].hue.degrees   // 22.5
+```
+
+Parts are proportions, so `5*Red + 3*Yellow` and `50*Red + 30*Yellow` are the same color,
+and a third daub is weighted against the total so far rather than against its neighbour:
+
+```scala
+1*WebColors.Red + 1*WebColors.Lime + 1*WebColors.Blue   // an even third of each
+```
+
+### Mixing modes
+
+`proportional` averages the colors, which is what `mix` does. The other modes are the
+blend modes of Photoshop and GIMP — `multiply`, `screen`, `overlay`, `hardLight`,
+`softLight`, `darken`, `lighten`, `colorDodge`, `colorBurn`, `difference`, `exclusion`,
+`linearDodge` and `linearBurn` — and each is imported the same way:
+
+```scala
+import mixing.multiply
+
+1*WebColors.Yellow + 1*WebColors.Cyan   // Srgb(0.5, 1, 0) — a green, as paint mixes
+```
+
+A daub's share of the total parts acts as its opacity: the mode is applied at full
+strength and the result mixed back in that proportion, exactly as a layer's opacity
+slider works. Only `proportional` is therefore commutative — under any other mode
+`5*Red + 3*Yellow` differs from `3*Yellow + 5*Red`, just as reordering two layers does.
+
+Every mode but `proportional` reads coordinates as fractions of full intensity, so they
+are offered only for sRGB, CMY and CMYK. Asking for `multiply` in CIELAB, where lightness
+runs to 100, will not compile rather than quietly meaning something else.
+
 ### Adjusting
 
 Hue, saturation and lightness are what a person reaches for to adjust a color, so those

--- a/lib/iridescence/src/core/iridescence.Blendable.scala
+++ b/lib/iridescence/src/core/iridescence.Blendable.scala
@@ -30,35 +30,42 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package iridescence
 
-// `Channel` clashes with perihelion's WebSocket `Channel` in the umbrella; reach the pixel
-// channel machinery via `iridescence.Channel`.
-export
-  iridescence
-  . { Alpha, Blendable, Blue, Brightness, Cielab, Cmy, Cmyk, Cmyk8, Color, Colorimetry, Cyan, dark,
-      Daub, Green, Grey, Hsl, Hsv, Key, light, Magenta, Mixing, Palette, Perceptual, Pixel, pixel,
-      PixelOpaque, Red, rgb, Rgb, Rgba, Rgb12, Rgb12Opaque, Rgb32, rgb32, Rgb32Opaque, Solarized,
-      Spectrum, Srgb, Theme, Tonal, WebColors, Xyz, Yellow }
+// Blending works coordinate by coordinate, so a space needs only to say how a pointwise operation
+// over its coordinates rebuilds a color. `Hsl` and `Hsv` have no instance: their hue is an angle on
+// a circle, and averaging two hues coordinatewise would take the long way round whenever the pair
+// straddles zero — mixing two reds would give cyan.
+object Blendable:
+  given srgb: Srgb is Blendable = (left, right, operation) =>
+    Srgb
+      ( operation(left.red, right.red),
+        operation(left.green, right.green),
+        operation(left.blue, right.blue) )
 
-package colorimetry:
-  export
-    iridescence.colorimetry
-    . { adobeRgb, coolFluorescent, coolWhiteFluorescent, d50Simulator, d65Simulator, daylight,
-        daylightFluorescentF1, daylightFluorescentF5, daylightFluorescentF7, equalEnergy,
-        iccProfilePcs, incandescentTungsten, liteWhiteFluorescent, midMorningDaylight,
-        northSkyDaylight, oldDaylight, oldDirectSunlightAtNoon, philipsTl83, philipsTl84,
-        philipsTl85, srgb, sylvaniaF40, ultralume30, ultralume40, ultralume50, warmWhiteFluorescent,
-        whiteFluorescent }
+  given cmy: Cmy is Blendable = (left, right, operation) =>
+    Cmy
+      ( operation(left.cyan, right.cyan),
+        operation(left.magenta, right.magenta),
+        operation(left.yellow, right.yellow) )
 
-package luminosity:
-  export iridescence.luminosity.{darkBrightness, lightBrightness}
+  given cmyk: Cmyk is Blendable = (left, right, operation) =>
+    Cmyk
+      ( operation(left.cyan, right.cyan),
+        operation(left.magenta, right.magenta),
+        operation(left.yellow, right.yellow),
+        operation(left.key, right.key) )
 
-package mixing:
-  export
-    iridescence.mixing
-    . { colorBurn, colorDodge, darken, difference, exclusion, hardLight, lighten, linearBurn,
-        linearDodge, multiply, overlay, proportional, screen, softLight }
+  given cielab: Cielab is Blendable = (left, right, operation) =>
+    Cielab
+      ( operation(left.lightness, right.lightness),
+        operation(left.blueYellow, right.blueYellow),
+        operation(left.greenRed, right.greenRed) )
 
-package themes:
-  export iridescence.themes.solarizedTheme
+  given xyz: Xyz is Blendable = (left, right, operation) =>
+    Xyz(operation(left.x, right.x), operation(left.y, right.y), operation(left.z, right.z))
+
+trait Blendable:
+  type Self <: Color
+
+  def zip(left: Self, right: Self, operation: (Double, Double) => Double): Self

--- a/lib/iridescence/src/core/iridescence.Color.scala
+++ b/lib/iridescence/src/core/iridescence.Color.scala
@@ -34,12 +34,29 @@ package iridescence
 
 import anticipation.*
 import prepositional.*
+import symbolism.*
 
 object Color:
   given chromatic: [form <: Color: Perceptual in Srgb as perceptual] => Color in form is Chromatic =
     color =>
       val srgb = color.to[Srgb]
       Chroma((srgb.red*255).toInt, (srgb.green*255).toInt, (srgb.blue*255).toInt)
+
+  // Lifting a color to a `Daub` lives here, rather than in `Daub`'s companion, because `Daub`
+  // appears only in the result: the implicit scope searched for `5*Red` is built from `Int` and
+  // the color's type, and `Color`'s companion is the one place common to every space.
+  //
+  // `Multiplicable`'s `Operand` is an invariant type member, so it must be the operand's own type
+  // rather than `Color in topic`, which would never match a concrete `Srgb`. The space comes from
+  // the bound instead, which normalizes `5*WebColors.Red` (a `Color in Srgb`) and `5*Srgb(1, 0, 0)`
+  // to the same `Daub[Srgb]`, so the two can be added to one another.
+  given multiplicable: [topic <: Color, color <: Color in topic]
+  =>  Double is Multiplicable by color to Daub[topic] =
+    Multiplicable: (parts, color) => Daub(parts, color.to[topic])
+
+  given wholeMultiplicable: [topic <: Color, color <: Color in topic]
+  =>  Int is Multiplicable by color to Daub[topic] =
+    Multiplicable: (parts, color) => Daub(parts, color.to[topic])
 
 
 // A `Color` is a pure value (it holds no capabilities), so it extends `Pure`; this keeps `this.type`

--- a/lib/iridescence/src/core/iridescence.Daub.scala
+++ b/lib/iridescence/src/core/iridescence.Daub.scala
@@ -30,35 +30,39 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package iridescence
 
-// `Channel` clashes with perihelion's WebSocket `Channel` in the umbrella; reach the pixel
-// channel machinery via `iridescence.Channel`.
-export
-  iridescence
-  . { Alpha, Blendable, Blue, Brightness, Cielab, Cmy, Cmyk, Cmyk8, Color, Colorimetry, Cyan, dark,
-      Daub, Green, Grey, Hsl, Hsv, Key, light, Magenta, Mixing, Palette, Perceptual, Pixel, pixel,
-      PixelOpaque, Red, rgb, Rgb, Rgba, Rgb12, Rgb12Opaque, Rgb32, rgb32, Rgb32Opaque, Solarized,
-      Spectrum, Srgb, Theme, Tonal, WebColors, Xyz, Yellow }
+import prepositional.*
+import symbolism.*
 
-package colorimetry:
-  export
-    iridescence.colorimetry
-    . { adobeRgb, coolFluorescent, coolWhiteFluorescent, d50Simulator, d65Simulator, daylight,
-        daylightFluorescentF1, daylightFluorescentF5, daylightFluorescentF7, equalEnergy,
-        iccProfilePcs, incandescentTungsten, liteWhiteFluorescent, midMorningDaylight,
-        northSkyDaylight, oldDaylight, oldDirectSunlightAtNoon, philipsTl83, philipsTl84,
-        philipsTl85, srgb, sylvaniaF40, ultralume30, ultralume40, ultralume50, warmWhiteFluorescent,
-        whiteFluorescent }
+// A `Daub` is an amount of paint: a color together with the number of parts of it going into a
+// mix. `5*Red` is five parts red, and adding daubs lays each over the total accumulated so far,
+// weighted by its share. Since a `Daub` is itself a `Color` — five parts red is still red — an
+// expression like `5*Red + 3*Yellow` needs no unwrapping to be converted, rendered or measured;
+// `parts` matters only when another daub is added to it.
+object Daub:
+  given addable: [topic <: Color]
+  =>  ( blendable: topic is Blendable, mixing: topic is Mixing )
+  =>  Daub[topic] is Addable by Daub[topic] to Daub[topic] =
+    Addable: (left, right) =>
+      // No paint of a color is not a faint wash of it: a daub of no parts takes no part in the
+      // mix at all. Without this, `0*Red + 1*Blue` under `multiply` would still darken by red,
+      // because the backdrop is consulted whatever its weight.
+      if left.parts == 0.0 then right else if right.parts == 0.0 then left else
+        val parts = left.parts + right.parts
+        val share = right.parts/parts
 
-package luminosity:
-  export iridescence.luminosity.{darkBrightness, lightBrightness}
+        // The mode is applied at full strength, then mixed back in the new daub's share of the
+        // total — a layer laid over the backdrop at that opacity.
+        val blend = (backdrop: Double, layer: Double) =>
+          backdrop + (mixing.blend(backdrop, layer) - backdrop)*share
 
-package mixing:
-  export
-    iridescence.mixing
-    . { colorBurn, colorDodge, darken, difference, exclusion, hardLight, lighten, linearBurn,
-        linearDodge, multiply, overlay, proportional, screen, softLight }
+        Daub(parts, blendable.zip(left.color, right.color, blend))
 
-package themes:
-  export iridescence.themes.solarizedTheme
+  given perceptual: [topic <: Color, form <: Color]
+  =>  ( perceptual: topic is Perceptual in form )
+  =>  Daub[topic] is Perceptual in form =
+    daub => perceptual.convert(daub.color)
+
+case class Daub[topic <: Color](parts: Double, color: topic) extends Color:
+  type Form = Daub[topic]

--- a/lib/iridescence/src/core/iridescence.Mixing.scala
+++ b/lib/iridescence/src/core/iridescence.Mixing.scala
@@ -30,35 +30,20 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package iridescence
 
-// `Channel` clashes with perihelion's WebSocket `Channel` in the umbrella; reach the pixel
-// channel machinery via `iridescence.Channel`.
-export
-  iridescence
-  . { Alpha, Blendable, Blue, Brightness, Cielab, Cmy, Cmyk, Cmyk8, Color, Colorimetry, Cyan, dark,
-      Daub, Green, Grey, Hsl, Hsv, Key, light, Magenta, Mixing, Palette, Perceptual, Pixel, pixel,
-      PixelOpaque, Red, rgb, Rgb, Rgba, Rgb12, Rgb12Opaque, Rgb32, rgb32, Rgb32Opaque, Solarized,
-      Spectrum, Srgb, Theme, Tonal, WebColors, Xyz, Yellow }
+// How a layer's coordinate combines with the backdrop it is laid over — the blend modes of
+// Photoshop and GIMP, in the separable form the W3C compositing specification gives them. A daub's
+// share of the total parts is its opacity: the mode is applied at full strength and the result
+// mixed back in that proportion, which is exactly what a layer's opacity slider does. Only
+// `proportional` is therefore commutative; under every other mode `5*Red + 3*Yellow` differs from
+// `3*Yellow + 5*Red`, just as reordering two layers does.
+//
+// There is deliberately no default instance in this companion. A mode reachable through the
+// implicit scope would be found whenever the imported one did not apply — mixing CIELAB under
+// `import mixing.multiply` would quietly fall back to a proportional mix rather than being
+// rejected — so the mode is always named by an import from `mixing`.
+trait Mixing:
+  type Self <: Color
 
-package colorimetry:
-  export
-    iridescence.colorimetry
-    . { adobeRgb, coolFluorescent, coolWhiteFluorescent, d50Simulator, d65Simulator, daylight,
-        daylightFluorescentF1, daylightFluorescentF5, daylightFluorescentF7, equalEnergy,
-        iccProfilePcs, incandescentTungsten, liteWhiteFluorescent, midMorningDaylight,
-        northSkyDaylight, oldDaylight, oldDirectSunlightAtNoon, philipsTl83, philipsTl84,
-        philipsTl85, srgb, sylvaniaF40, ultralume30, ultralume40, ultralume50, warmWhiteFluorescent,
-        whiteFluorescent }
-
-package luminosity:
-  export iridescence.luminosity.{darkBrightness, lightBrightness}
-
-package mixing:
-  export
-    iridescence.mixing
-    . { colorBurn, colorDodge, darken, difference, exclusion, hardLight, lighten, linearBurn,
-        linearDodge, multiply, overlay, proportional, screen, softLight }
-
-package themes:
-  export iridescence.themes.solarizedTheme
+  def blend(backdrop: Double, layer: Double): Double

--- a/lib/iridescence/src/core/iridescence.Tonal.scala
+++ b/lib/iridescence/src/core/iridescence.Tonal.scala
@@ -30,35 +30,21 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package iridescence
 
-// `Channel` clashes with perihelion's WebSocket `Channel` in the umbrella; reach the pixel
-// channel machinery via `iridescence.Channel`.
-export
-  iridescence
-  . { Alpha, Blendable, Blue, Brightness, Cielab, Cmy, Cmyk, Cmyk8, Color, Colorimetry, Cyan, dark,
-      Daub, Green, Grey, Hsl, Hsv, Key, light, Magenta, Mixing, Palette, Perceptual, Pixel, pixel,
-      PixelOpaque, Red, rgb, Rgb, Rgba, Rgb12, Rgb12Opaque, Rgb32, rgb32, Rgb32Opaque, Solarized,
-      Spectrum, Srgb, Theme, Tonal, WebColors, Xyz, Yellow }
+// Marks a space whose coordinates all run from 0 to 1, which is what every mixing mode except
+// `proportional` assumes: `multiply` is a product of coordinates and `screen` a product of their
+// complements, and neither describes anything where a coordinate can be 100 or negative. `Cielab`
+// and `Xyz` therefore have no instance, so they mix proportionally or not at all.
+object Tonal:
+  given srgb: Srgb is Tonal = new Tonal:
+    type Self = Srgb
 
-package colorimetry:
-  export
-    iridescence.colorimetry
-    . { adobeRgb, coolFluorescent, coolWhiteFluorescent, d50Simulator, d65Simulator, daylight,
-        daylightFluorescentF1, daylightFluorescentF5, daylightFluorescentF7, equalEnergy,
-        iccProfilePcs, incandescentTungsten, liteWhiteFluorescent, midMorningDaylight,
-        northSkyDaylight, oldDaylight, oldDirectSunlightAtNoon, philipsTl83, philipsTl84,
-        philipsTl85, srgb, sylvaniaF40, ultralume30, ultralume40, ultralume50, warmWhiteFluorescent,
-        whiteFluorescent }
+  given cmy: Cmy is Tonal = new Tonal:
+    type Self = Cmy
 
-package luminosity:
-  export iridescence.luminosity.{darkBrightness, lightBrightness}
+  given cmyk: Cmyk is Tonal = new Tonal:
+    type Self = Cmyk
 
-package mixing:
-  export
-    iridescence.mixing
-    . { colorBurn, colorDodge, darken, difference, exclusion, hardLight, lighten, linearBurn,
-        linearDodge, multiply, overlay, proportional, screen, softLight }
-
-package themes:
-  export iridescence.themes.solarizedTheme
+trait Tonal:
+  type Self <: Color

--- a/lib/iridescence/src/core/iridescence_core.scala
+++ b/lib/iridescence/src/core/iridescence_core.scala
@@ -52,6 +52,71 @@ package luminosity:
   given darkBrightness: Brightness = Brightness.Dark
   given lightBrightness: Brightness = Brightness.Light
 
+// The blend modes, named as Photoshop and GIMP name them and defined as the W3C compositing
+// specification defines them, for `Daub` arithmetic to add through. All but `proportional` read
+// coordinates as fractions of full intensity, so they are offered only for the spaces marked
+// `Tonal`; asking for `multiply` in CIELAB, where lightness runs to 100, will not compile.
+package mixing:
+  // The layer replaces the backdrop, so mixing it back in proportion leaves a plain weighted
+  // average — what pairwise `mix` does, and the only mode that means anything in a space whose
+  // coordinates are not confined to 0..1.
+  given proportional: [topic <: Color] => topic is Mixing = (_, layer) => layer
+
+  given multiply: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) => backdrop*layer
+
+  given screen: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) => backdrop + layer - backdrop*layer
+
+  given darken: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) => math.min(backdrop, layer)
+
+  given lighten: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) => math.max(backdrop, layer)
+
+  given difference: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) => math.abs(backdrop - layer)
+
+  given exclusion: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) => backdrop + layer - 2*backdrop*layer
+
+  given linearDodge: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) => math.min(1.0, backdrop + layer)
+
+  given linearBurn: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) => math.max(0.0, backdrop + layer - 1)
+
+  given hardLight: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) =>
+      if layer <= 0.5 then 2*backdrop*layer else 1 - 2*(1 - backdrop)*(1 - layer)
+
+  // Overlay is hard light with the two operands exchanged: the backdrop, rather than the layer,
+  // decides whether the pair is multiplied or screened.
+  given overlay: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) =>
+      if backdrop <= 0.5 then 2*backdrop*layer else 1 - 2*(1 - backdrop)*(1 - layer)
+
+  given softLight: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) =>
+      if layer <= 0.5 then backdrop - (1 - 2*layer)*backdrop*(1 - backdrop) else
+        val toward =
+          if backdrop <= 0.25 then ((16*backdrop - 12)*backdrop + 4)*backdrop
+          else math.sqrt(backdrop)
+
+        backdrop + (2*layer - 1)*(toward - backdrop)
+
+  given colorDodge: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) =>
+      if backdrop == 0.0 then 0.0
+      else if layer == 1.0 then 1.0
+      else math.min(1.0, backdrop/(1 - layer))
+
+  given colorBurn: [topic <: Color: Tonal] => topic is Mixing =
+    (backdrop, layer) =>
+      if backdrop == 1.0 then 1.0
+      else if layer == 0.0 then 0.0
+      else 1 - math.min(1.0, (1 - backdrop)/layer)
+
 package colorimetry:
   given incandescentTungsten: Colorimetry = Colorimetry(109.850, 100, 35.585, 111.144, 100, 35.2)
 

--- a/lib/iridescence/src/test/iridescence_test.scala
+++ b/lib/iridescence/src/test/iridescence_test.scala
@@ -183,6 +183,136 @@ object Tests extends Suite(m"Iridescence tests"):
         Srgb(0.2, 0.4, 0.6).mix(Srgb(0.8, 0.6, 0.4))
       . assert(_ == Srgb(0.5, 0.5, 0.5))
 
+    suite(m"Proportional mixing"):
+      import mixing.proportional
+
+      given Srgb is Checkable against Srgb = (left, right) =>
+        left.red === (right.red +/- 1e-9)
+        && left.green === (right.green +/- 1e-9)
+        && left.blue === (right.blue +/- 1e-9)
+
+      test(m"one part of a color is that color"):
+        (1*Srgb(0.2, 0.4, 0.6)).to[Srgb]
+      . assert(_ == Srgb(0.2, 0.4, 0.6))
+
+      test(m"five parts of a color is still that color"):
+        (5*Srgb(0.2, 0.4, 0.6)).to[Srgb]
+      . assert(_ == Srgb(0.2, 0.4, 0.6))
+
+      test(m"equal parts average the channels"):
+        (1*Srgb(0.2, 0.4, 0.6) + 1*Srgb(0.8, 0.6, 0.4)).to[Srgb]
+      . assert(_ === Srgb(0.5, 0.5, 0.5))
+
+      test(m"unequal parts weight the mix"):
+        (3*Srgb(0.0, 0.0, 0.0) + 1*Srgb(1.0, 1.0, 1.0)).to[Srgb]
+      . assert(_ === Srgb(0.25, 0.25, 0.25))
+
+      test(m"parts are proportions, not absolutes"):
+        (30*Srgb(0.0, 0.0, 0.0) + 10*Srgb(1.0, 1.0, 1.0)).to[Srgb]
+      . assert(_ === Srgb(0.25, 0.25, 0.25))
+
+      test(m"a third daub is weighted against the running total"):
+        (1*Srgb(1.0, 0, 0) + 1*Srgb(0, 1.0, 0) + 1*Srgb(0, 0, 1.0)).to[Srgb]
+      . assert(_ === Srgb(1.0/3, 1.0/3, 1.0/3))
+
+      test(m"proportional mixing is commutative"):
+        (5*Srgb(0.2, 0.4, 0.6) + 3*Srgb(0.8, 0.6, 0.4)).to[Srgb]
+      . assert(_ === (3*Srgb(0.8, 0.6, 0.4) + 5*Srgb(0.2, 0.4, 0.6)).to[Srgb])
+
+      test(m"fractional parts mix"):
+        (0.5*Srgb(0.0, 0.0, 0.0) + 0.5*Srgb(1.0, 1.0, 1.0)).to[Srgb]
+      . assert(_ === Srgb(0.5, 0.5, 0.5))
+
+      test(m"a daub converts to another space"):
+        (1*Srgb(0.0, 0.0, 0.0) + 1*Srgb(1.0, 1.0, 1.0)).to[Cmy]
+      . assert(_ == Cmy(0.5, 0.5, 0.5))
+
+      test(m"CIELAB mixes on its own coordinates"):
+        (1*Cielab(0, 0, 0) + 1*Cielab(40, 20, 10)).to[Cielab]
+      . assert(_ == Cielab(20, 10, 5))
+
+      // `WebColors` entries are typed `Color in Srgb` rather than `Srgb`, so these also pin the
+      // inference that normalizes both spellings to the same `Daub[Srgb]`.
+      test(m"five parts red and three parts yellow make an orange"):
+        (5*WebColors.Red + 3*WebColors.Yellow).to[Srgb]
+      . assert(_ === Srgb(1, 0.375, 0))
+
+      test(m"a mixture of named colors converts to another space"):
+        (5*WebColors.Red + 3*WebColors.Yellow).to[Hsl].hue.degrees
+      . assert(_ === 22.5 +/- 1e-9)
+
+      test(m"a named color and a literal color mix together"):
+        (5*WebColors.Red + 3*Srgb(1, 1, 0)).to[Srgb]
+      . assert(_ === Srgb(1, 0.375, 0))
+
+    suite(m"Mixing modes"):
+      given Srgb is Checkable against Srgb = (left, right) =>
+        left.red === (right.red +/- 1e-9)
+        && left.green === (right.green +/- 1e-9)
+        && left.blue === (right.blue +/- 1e-9)
+
+      test(m"multiply darkens toward the product of the channels"):
+        import mixing.multiply
+        (1*Srgb(1.0, 0.5, 0.5) + 1*Srgb(0.5, 0.5, 1.0)).to[Srgb]
+      . assert(_ === Srgb(0.75, 0.375, 0.5))
+
+      test(m"screen lightens toward white"):
+        import mixing.screen
+        (1*Srgb(0.5, 0.5, 0.5) + 1*Srgb(0.5, 0.5, 0.5)).to[Srgb]
+      . assert(_ === Srgb(0.625, 0.625, 0.625))
+
+      test(m"darken pulls each channel toward the lower of the two"):
+        import mixing.darken
+        (1*Srgb(0.2, 0.8, 0.5) + 1*Srgb(0.6, 0.4, 0.5)).to[Srgb]
+      . assert(_ === Srgb(0.2, 0.6, 0.5))
+
+      test(m"lighten pulls each channel toward the higher of the two"):
+        import mixing.lighten
+        (1*Srgb(0.2, 0.8, 0.5) + 1*Srgb(0.6, 0.4, 0.5)).to[Srgb]
+      . assert(_ === Srgb(0.4, 0.8, 0.5))
+
+      test(m"difference pulls each channel toward the gap between them"):
+        import mixing.difference
+        (1*Srgb(0.2, 0.8, 0.5) + 1*Srgb(0.6, 0.4, 0.5)).to[Srgb]
+      . assert(_ === Srgb(0.3, 0.6, 0.25))
+
+      test(m"a mode acts in proportion to the added daub's share"):
+        import mixing.multiply
+        (3*Srgb(1.0, 1.0, 1.0) + 1*Srgb(0.0, 0.0, 0.0)).to[Srgb]
+      . assert(_ === Srgb(0.75, 0.75, 0.75))
+
+      test(m"a smaller share of the same daub moves the backdrop less"):
+        import mixing.multiply
+        (9*Srgb(1.0, 1.0, 1.0) + 1*Srgb(0.0, 0.0, 0.0)).to[Srgb]
+      . assert(_ === Srgb(0.9, 0.9, 0.9))
+
+      test(m"a mode other than proportional is not commutative"):
+        import mixing.difference
+        (3*Srgb(0.8, 0.8, 0.8) + 1*Srgb(0.2, 0.2, 0.2)).to[Srgb]
+      . assert(_ === Srgb(0.75, 0.75, 0.75))
+
+      test(m"the same two daubs in the other order give a different color"):
+        import mixing.difference
+        (1*Srgb(0.2, 0.2, 0.2) + 3*Srgb(0.8, 0.8, 0.8)).to[Srgb]
+      . assert(_ === Srgb(0.5, 0.5, 0.5))
+
+      test(m"yellow and cyan multiply to a green, as paint mixes"):
+        import mixing.multiply
+        (1*WebColors.Yellow + 1*WebColors.Cyan).to[Srgb]
+      . assert(_ === Srgb(0.5, 1, 0))
+
+      test(m"a daub of no parts takes no part in the mix"):
+        import mixing.multiply
+        (0*Srgb(1.0, 0.0, 0.0) + 1*Srgb(0.0, 0.0, 1.0)).to[Srgb]
+      . assert(_ === Srgb(0.0, 0.0, 1.0))
+
+      test(m"a channel mode is rejected in a space with unbounded coordinates"):
+        demilitarize:
+          import mixing.multiply
+          1*Cielab(0, 0, 0) + 1*Cielab(40, 20, 10)
+        . map(_.message)
+      . assert(!_.nil)
+
     suite(m"Cielab manipulation"):
       test(m"delta to self is zero"):
         Cielab(50, 10, -20).delta(Cielab(50, 10, -20))


### PR DESCRIPTION
Colors can now be mixed by proportion rather than only in pairs: multiplying a color by a number gives an amount of it, and adding those amounts together mixes them, the way a painter measures paint onto a palette. `5*Red + 3*Yellow` is five parts red mixed with three parts yellow. The kind of mixing is chosen by importing a mode, and the modes are the blend modes of Photoshop and GIMP — `multiply`, `screen`, `overlay`, `softLight` and the rest — alongside the plain proportional average that pairwise `mix` performs today.

### Mixing by parts

`mix` takes two colors at a time, so combining three meant nesting calls and working out the ratios by hand. Instead:

```scala
import mixing.proportional

5*WebColors.Red + 3*WebColors.Yellow   // Srgb(1, 0.375, 0) — an orange
```

`5*Red` is a `Daub`: an amount of a color, which is still that color — one part of red and five parts of red are both red. A `Daub` is a `Color`, so a mixture converts, renders and measures like any other, and the parts matter only when more paint is added:

```scala
val mixture = 5*WebColors.Red + 3*WebColors.Yellow
mixture.to[Cielab]
mixture.to[Hsl].hue.degrees   // 22.5
```

Parts are proportions, so `5*Red + 3*Yellow` and `50*Red + 30*Yellow` are the same color. Each daub is weighted against the running total rather than against its neighbour, so a third term does not halve the first two:

```scala
1*WebColors.Red + 1*WebColors.Lime + 1*WebColors.Blue   // an even third of each
```

### Mixing modes

`proportional` averages the colors. The others are `multiply`, `screen`, `overlay`, `hardLight`, `softLight`, `darken`, `lighten`, `colorDodge`, `colorBurn`, `difference`, `exclusion`, `linearDodge` and `linearBurn`, each imported the same way:

```scala
import mixing.multiply

1*WebColors.Yellow + 1*WebColors.Cyan   // Srgb(0.5, 1, 0) — a green, as paint mixes
```

A daub's share of the total parts acts as its opacity: the mode is applied at full strength and the result mixed back in that proportion, exactly as a layer's opacity slider works. Only `proportional` is therefore commutative — under any other mode `5*Red + 3*Yellow` differs from `3*Yellow + 5*Red`, just as reordering two layers does.

### What will not compile

There is no default mode. One reachable through the implicit scope would be found whenever the imported mode did not apply, so mixing CIELAB under `import mixing.multiply` would quietly fall back to a proportional mix; instead the mode is always named by an import.

Every mode but `proportional` reads coordinates as fractions of full intensity, so they are offered only for sRGB, CMY and CMYK. Asking for `multiply` in CIELAB, where lightness runs to 100, is rejected:

```scala
import mixing.multiply
1*Cielab(0, 0, 0) + 1*Cielab(40, 20, 10)   // does not compile
```

`Hsl` and `Hsv` support no mixing arithmetic at all. Their hue is an angle on a circle, and averaging two hues coordinatewise would take the long way round whenever the pair straddles zero — mixing two reds would give cyan. Convert to sRGB or CIELAB to mix.
