### PR TITLE
Stop a suite from discarding a same-named suite's results

### DIFF
--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -44,7 +44,7 @@ import cloaks.cloakHeap
 
 import alphabets.hexUpperCase
 
-object Tests extends Suite(m"Gastronomy tests"):
+object Tests extends Suite(m"Enigmatic tests"):
 
   val request: Text = t"""
     |-----BEGIN CERTIFICATE REQUEST-----

--- a/lib/hellenism/src/test/hellenism_test.scala
+++ b/lib/hellenism/src/test/hellenism_test.scala
@@ -45,7 +45,7 @@ class TestServiceA extends TestService:
 class TestServiceB extends TestService:
   def name: Text = t"B"
 
-object Tests extends Suite(m"Proscenium Tests"):
+object Tests extends Suite(m"Hellenism Tests"):
   def run(): Unit =
     test(m"check that a classpath file is accessible"):
       cp"/scala/Option.class"

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -164,8 +164,13 @@ final class Report(using environment: Environment)(using palette: TestPalette):
 
     . getOrElse(lines)
 
+  // Non-destructive: a suite is declared once per run, but two distinct suites can share a
+  // `TestId` — `Testable`'s identity is its name and parent, and `Suite`'s own `Testable` is
+  // built on a single source line, so every top-level suite of the same name has the same id.
+  // An unconditional update would replace the earlier suite's whole subtree, silently
+  // discarding everything it had recorded; merging into the existing node keeps both.
   def declare(suite: Testable): Report = this.also:
-    resolve(suite.parent).tests(suite.id) = ReportLine.Suite(suite)
+    resolve(suite.parent).tests.getOrElseUpdate(suite.id, ReportLine.Suite(suite))
 
   def fail(error: Throwable, active: Set[TestId]): Unit = failure0 = (error, active)
 


### PR DESCRIPTION
Two of soundness's test suites shared a name with another suite, and their results were being silently discarded from the aggregate run — so `make test` and the attested build never counted them. Enigmatic's suite was named "Gastronomy tests" and hellenism's "Proscenium Tests", both copy-paste leftovers, and both ran before the suite whose name they shared. The aggregate suite now counts 9799 tests where it counted 9626, and a failing test in either module surfaces where it was previously invisible.

### What went wrong

`Testable` identifies a suite by its name and parent, and `probably.Suite` builds its own `Testable` on a single source line — so every top-level suite shares that `Codepoint`, and a suite's `TestId` is effectively just its name. `Report.declare` then wrote that key unconditionally:

```scala
resolve(suite.parent).tests(suite.id) = ReportLine.Suite(suite)
```

so declaring the second of two same-named suites replaced the first one's entire recorded subtree, discarding everything it had already recorded.

`declare` now merges into an existing node instead of replacing it, so no suite can discard another's results even if the names collide again. The two colliding suites are also renamed, so the two modules' results stay in separate nodes rather than being conflated into one.

### Note for anyone reading a past build

Enigmatic's and hellenism's tests were not covered by any attested build before this change. Both pass, so nothing was hiding — but the coverage was not there.
