### PR TITLE
Sign with RSA and ECDSA, and generate self-signed X.509 certificates

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -568,6 +568,7 @@ object soundness extends Toolchain:
     panopticon.core, camouflage.core, ulysses.core, polyvinyl.core, polaris.core, zeppelin.core,
     xylophone.core, anamnesis.core, jacinta.time, jacinta.schema, gnossienne.core, jacinta.records,
     stratiform.core, stratiform.time, vexillology.core, enigmatic.cose, enigmatic.openssl,
+    enigmatic.x509,
     stratiform.binary, stratiform.records, bitumen.core, bitumen.jvm, breviloquence.core, distillate.core,
     embarcadero.oci, locomotion.core, ypsiloid.core, stratiform.base256)
 
@@ -1292,6 +1293,13 @@ object enigmatic extends Library:
     override def nativeSources = Task.Sources(moduleDir, moduleDir / os.up / "core-native")
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+  // X.509 certificates: ASN.1 assembly over `core`'s ciphers, plus aviation for validity periods,
+  // whose transitive dependencies nothing that only wants ciphers and PEM should have to carry.
+  object x509 extends Component(core, aviation.core):
+    override def scalaJs = false // transitively JVM-only, through `core`
+    override def scalaNative = true
+    override def scalacOptions = Task:
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object cose extends Component(core, breviloquence.core):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
@@ -1305,7 +1313,7 @@ object enigmatic extends Library:
     override def nativeModuleDeps = super.nativeModuleDeps :+ xenophile.scalanative.native
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
-  object test extends Tests(core, cose, openssl):
+  object test extends Tests(core, cose, openssl, x509):
     // Not `settings.cc`: the suite's `NoPadding` tests trip the tactic-capturing
     // padding given (pure `using cipher` params can't accept capturing evidence
     // yet); `CaptureTests` opts into capture checking per-file instead. `-Ycc-new`

--- a/doc/errors/524.md
+++ b/doc/errors/524.md
@@ -1,0 +1,60 @@
+# `SN-524` — `CertificateError`
+
+Raised when Enigmatic cannot build an X.509 certificate.
+
+## Cause
+
+Certificate generation refuses inputs that would produce a structurally
+valid certificate that no verifier would accept — a serial number
+outside the range X.509 permits, a validity period that never opens, a
+key whose encoding is not a `SubjectPublicKeyInfo`, or a cipher and
+digest with no object identifier assigned to the pair. The message is
+`could not build the certificate because $reason`.
+
+## Variants
+
+### `SN-524.1` — `UnknownAlgorithm`
+
+The cipher and the ambient `SignatureDigest` have no signature algorithm
+object identifier between them. RSA and ECDSA have identifiers assigned
+for SHA-256, SHA-384 and SHA-512 only.
+
+**Example.** `[↯SN-524.1] could not build the certificate because no signature algorithm is assigned to SHA1`
+
+**Resolution.** Choose one of the digests that has an identifier; the
+default, SHA-256, is what every current certificate profile mandates.
+
+### `SN-524.2` — `BadPublicKey`
+
+The key's public half was not a DER `SubjectPublicKeyInfo`, so it cannot
+be embedded in a certificate.
+
+**Example.** `[↯SN-524.2] could not build the certificate because the public key was not a SubjectPublicKeyInfo`
+
+**Resolution.** This indicates a provider that does not follow the
+`Crypto` contract's key encodings; check which provider is in scope.
+
+### `SN-524.3` — `BadSerialNumber`
+
+The serial number was zero or negative. RFC 5280 requires a positive
+integer.
+
+**Example.** `[↯SN-524.3] could not build the certificate because the serial number was negative or zero`
+
+**Resolution.** Use a positive serial number; for a certificate
+authority it must also be unique among the certificates it has issued.
+
+### `SN-524.4` — `BadValidity`
+
+The validity period's end was not after its start.
+
+**Example.** `[↯SN-524.4] could not build the certificate because the validity period ended before it began`
+
+**Resolution.** Build the period with the earlier instant first, as
+`notBefore ~ notAfter`.
+
+## See also
+
+- Source: `lib/enigmatic/src/x509/enigmatic.CertificateError.scala`
+- `SN-523` — `Asn1Error`, raised when the certificate's DER cannot be
+  read back

--- a/lib/enigmatic/doc/basics.md
+++ b/lib/enigmatic/doc/basics.md
@@ -61,3 +61,33 @@ decoder yields `Asn1.Unknown` for an implicit tag instead.
 universal types outside the PKIX subset modelled here, such as `T61String` and
 `BMPString`. It is what makes decoding total, and what makes the round-trip above hold for
 certificates in the wild.
+
+### Certificates
+
+A self-signed certificate needs a name, a key, a validity period and a serial number:
+```scala
+import chronometries.unix
+
+val subject = Distinguished(commonName = t"example.com", organization = t"Example Ltd")
+val key = PrivateKey.generate[Rsa[2048]]()
+val validity = now() ~ (now() + 365*Day)
+
+val certificate =
+  Certificate.selfSigned
+   (subject, key, validity, BigInt(1), alternatives = List(t"example.com", t"www.example.com"))
+
+val armored: Text = certificate.pem.serialize
+```
+The certificate is version 3, and carries basic constraints, key usage and a subject key
+identifier; `alternatives` become `dNSName` subject alternative names, which is what TLS
+clients check. Passing `authority = true` marks it as a certificate authority and gives it
+the key usage to sign other certificates.
+
+The signature algorithm follows the key and the ambient `SignatureDigest`: an `Rsa` key under
+the default digest signs with `sha256WithRSAEncryption`, an `Ecdsa[256]` key with
+`ecdsa-with-SHA256`. `Ecdsa` is available where the provider offers it; `Rsa` always signs.
+
+Reading a certificate back is the ordinary codec:
+```scala
+val parsed: Certificate = armored.read[Certificate in Pem]
+```

--- a/lib/enigmatic/doc/features.md
+++ b/lib/enigmatic/doc/features.md
@@ -1,7 +1,8 @@
 - symmetric encryption with AES
 - asymmetric encryption/decryption using RSA
-- signing with DSA
-- AES, RSA and DSA key generation
+- signing with RSA, ECDSA and DSA
+- AES, RSA, ECDSA and DSA key generation
 - calculation of HMACs for SHA-256, SHA-1 and MD5
 - an ASN.1 value model with a canonical DER encoder and a strict DER decoder
 - byte-exact round-tripping of X.509 certificates, PKCS#10 requests and other DER content
+- generation of self-signed X.509 certificates, with v3 extensions

--- a/lib/enigmatic/src/core-jvm/enigmatic.JavaStdlibCrypto.scala
+++ b/lib/enigmatic/src/core-jvm/enigmatic.JavaStdlibCrypto.scala
@@ -36,6 +36,8 @@ import java.security as js, js.spec as jss, js.interfaces as jsi
 import javax.crypto as jc, javax.crypto.spec.*
 
 import anticipation.*
+import contingency.*
+import distillate.*
 import fulminate.*
 import gossamer.*
 import rudiments.*
@@ -98,6 +100,110 @@ object JavaStdlibCrypto extends Crypto:
 
       val spec = jss.RSAPublicKeySpec(key.getModulus, key.getPublicExponent)
       keyFactory().generatePublic(spec).nn.getEncoded.nn.immutable(using Unsafe)
+
+  def rsaSignature(digest: Text): Crypto.SignatureScheme =
+    new Signatory(t"${digest}withRSA", t"RSA"):
+      def generateKeyPair(bits: Int): Data =
+        val generator = js.KeyPairGenerator.getInstance("RSA").nn
+        generator.initialize(bits)
+
+        generator.generateKeyPair().nn.getPrivate.nn.getEncoded.nn.immutable(using Unsafe)
+
+      def privateToPublic(privateKey: Data): Data = JavaStdlibCrypto.rsa.privateToPublic(privateKey)
+
+  // ECDSA over a NIST prime curve. The curve is chosen by key size, since `KeyPairGenerator` needs
+  // a curve name rather than a bit count for EC; P-521 really is 521 bits, not 512.
+  def ecdsa(digest: Text): Crypto.SignatureScheme =
+    new Signatory(t"${digest}withECDSA", t"EC"):
+      def generateKeyPair(bits: Int): Data =
+        val curve = bits match
+          case 256 => "secp256r1"
+          case 384 => "secp384r1"
+          case 521 => "secp521r1"
+          case _   => panic(m"there is no NIST prime curve of $bits bits")
+
+        val generator = js.KeyPairGenerator.getInstance("EC").nn
+        generator.initialize(jss.ECGenParameterSpec(curve), js.SecureRandom())
+        val pair = generator.generateKeyPair().nn
+
+        val privateKey = pair.getPrivate.nn.getEncoded.nn.immutable(using Unsafe)
+        val publicKey = pair.getPublic.nn.getEncoded.nn.immutable(using Unsafe)
+
+        embedPublicKey(privateKey, publicKey)
+
+      def privateToPublic(privateKey: Data): Data = extractPublicKey(privateKey)
+
+  // An EC public key is `d·G`, and recovering it from the scalar `d` needs curve arithmetic that
+  // neither `KeyFactory` nor `BigInteger` will do — and that this module has no business
+  // reimplementing. RFC 5915 provides for the public key to be carried alongside the scalar, in an
+  // optional `[1] EXPLICIT BIT STRING`, which is what OpenSSL emits and what the JDK accepts but
+  // does not itself write. Embedding it at generation makes `privateToPublic` a lookup.
+  //
+  // `PrivateKeyInfo` is `SEQUENCE { version, algorithm, OCTET STRING }`, whose octets hold RFC
+  // 5915's `ECPrivateKey`; `SubjectPublicKeyInfo` is `SEQUENCE { algorithm, BIT STRING }` with the
+  // same `algorithm` field, so no part of it has to be rebuilt.
+  private def embedPublicKey(privateKey: Data, publicKey: Data): Data =
+    val bits = decode(publicKey) match
+      case Asn1.Sequence(List(_, bits: Asn1.BitString)) => bits
+      case _                                            => panic(m"the EC public key was bad")
+
+    decode(privateKey) match
+      case Asn1.Sequence(List(version, algorithm, Asn1.OctetString(inner))) =>
+        val extended: Asn1 = decode(inner) match
+          case Asn1.Sequence(elements) => Asn1.Sequence(elements :+ Asn1.Tagged(1, true, bits))
+          case _                       => panic(m"the EC private key was not an ECPrivateKey")
+
+        val octets = Asn1.OctetString(extended.in[Der].data)
+        val info: Asn1 = Asn1.Sequence(List(version, algorithm, octets))
+
+        info.in[Der].data
+
+      case _ => panic(m"the EC private key was not a PrivateKeyInfo")
+
+  private def extractPublicKey(privateKey: Data): Data =
+    decode(privateKey) match
+      case Asn1.Sequence(List(_, algorithm, Asn1.OctetString(inner))) =>
+        val bits = decode(inner) match
+          case Asn1.Sequence(elements) => elements.collectFirst:
+            case Asn1.Tagged(1, true, bits: Asn1.BitString) => bits
+
+          case _ => None
+
+        bits match
+          case Some(bits) =>
+            val info: Asn1 = Asn1.Sequence(List(algorithm, bits))
+            info.in[Der].data
+
+          case None =>
+            panic(m"the EC private key carried no public key")
+
+      case _ => panic(m"the EC private key was not a PrivateKeyInfo")
+
+  // Key material this module generated itself; a failure to parse it back is a defect, not an
+  // input error.
+  private def decode(data: Data): Asn1 = unsafely(Der(data).as[Asn1])
+
+  // The shared shape of the two digest-parameterized signature schemes: a JCE `Signature`
+  // transformation and a `KeyFactory` for the key algorithm. Key generation and public-key
+  // recovery differ per algorithm and are left abstract.
+  private abstract class Signatory(transformation: Text, algorithm: Text)
+  extends Crypto.SignatureScheme:
+    private def instance(): js.Signature = js.Signature.getInstance(transformation.s).nn
+    private def keyFactory(): js.KeyFactory = js.KeyFactory.getInstance(algorithm.s).nn
+
+    def sign(data: Data, privateKey: Data): Data =
+      val sig = instance()
+      sig.initSign(keyFactory().generatePrivate(jss.PKCS8EncodedKeySpec(privateKey.to(Array))))
+      sig.update(data.to(Array))
+
+      sig.sign().nn.immutable(using Unsafe)
+
+    def verify(data: Data, signature0: Data, publicKey: Data): Boolean =
+      val sig = instance()
+      sig.initVerify(keyFactory().generatePublic(jss.X509EncodedKeySpec(publicKey.to(Array))))
+      sig.update(data.to(Array))
+
+      sig.verify(signature0.to(Array))
 
   def dsa: Crypto.SignatureScheme = new Crypto.SignatureScheme:
     private def signature(): js.Signature = js.Signature.getInstance("DSA").nn

--- a/lib/enigmatic/src/core-native/enigmatic.JavaStdlibCrypto.scala
+++ b/lib/enigmatic/src/core-native/enigmatic.JavaStdlibCrypto.scala
@@ -46,6 +46,7 @@ object JavaStdlibCrypto extends Crypto:
   def random: Crypto.Random = unavailable
   def aes: Crypto.SymmetricCipher = unavailable
   def rsa: Crypto.PublicKeyCipher = unavailable
+  def rsaSignature(digest: Text): Crypto.SignatureScheme = unavailable
   def hmac(algorithm: Text): Crypto.Mac = unavailable
 
   def des: Crypto.SymmetricCipher = unavailable

--- a/lib/enigmatic/src/core-native/enigmatic.JavaStdlibCrypto.scala
+++ b/lib/enigmatic/src/core-native/enigmatic.JavaStdlibCrypto.scala
@@ -49,6 +49,11 @@ object JavaStdlibCrypto extends Crypto:
   def rsaSignature(digest: Text): Crypto.SignatureScheme = unavailable
   def hmac(algorithm: Text): Crypto.Mac = unavailable
 
+  // Structural members exist here only where something references them — `OpensslCrypto`
+  // delegates its `ecdsa` to this object, so the stub must carry it (as `dsa`, which nothing
+  // delegates, need not be).
+  def ecdsa(digest: Text): Crypto.SignatureScheme = unavailable
+
   def des: Crypto.SymmetricCipher = unavailable
   def tripleDes: Crypto.SymmetricCipher = unavailable
   def blowfish: Crypto.SymmetricCipher = unavailable

--- a/lib/enigmatic/src/core/enigmatic.Crypto.scala
+++ b/lib/enigmatic/src/core/enigmatic.Crypto.scala
@@ -97,3 +97,9 @@ trait Crypto:
   def aes: Crypto.SymmetricCipher
   def rsa: Crypto.PublicKeyCipher
   def hmac(algorithm: Text): Crypto.Mac
+
+  // RSASSA-PKCS1-v1_5 over the named digest, e.g. `t"SHA256"`. Signing is baseline rather than
+  // structural, unlike `dsa` and `ecdsa`, because `Rsa` itself both encrypts and signs, and its
+  // given asks only for a `Crypto`; a provider offering RSA encryption but not RSA signatures is
+  // not a combination worth expressing.
+  def rsaSignature(digest: Text): Crypto.SignatureScheme

--- a/lib/enigmatic/src/core/enigmatic.Ecdsa.scala
+++ b/lib/enigmatic/src/core/enigmatic.Ecdsa.scala
@@ -32,88 +32,29 @@
                                                                                                   */
 package enigmatic
 
+import scala.reflect.Selectable.reflectiveSelectable
+
 import anticipation.*
-import gastronomy.*
-import gossamer.*
-import prepositional.*
-import gastronomy.Concession
 
-extension [encodable: Encodable in Data](value: encodable)
-  def hmac[algorithm <: Algorithm](key: Data)
-    ( using hash:            Hash in algorithm,
-            crypto:          Crypto,
-            erased weakness: Permit[HashWeakness[algorithm]] )
-  :   Hmac in algorithm =
+// ECDSA over a NIST prime curve, with the curve chosen by key size: 256 is P-256 (`secp256r1`),
+// 384 is P-384 and 521 is P-521. Unlike `Rsa`, ECDSA is not part of the mandatory provider
+// baseline, so — like `Dsa` — it is reached through a structural refinement, and a provider that
+// does not offer it is a compile error at the use site rather than a failure at run time.
+object Ecdsa:
+  given value: [bits <: 256 | 384 | 521: ValueOf]
+  =>  ( digest: SignatureDigest,
+        crypto: Crypto { def ecdsa(digest: Text): Crypto.SignatureScheme } )
+  =>  Ecdsa[bits] =
+    Ecdsa(crypto.ecdsa(digest.token))
 
-    Hmac(crypto.hmac(hash.hmacName).mac(key, encodable.encode(value)))
+class Ecdsa[bits <: 256 | 384 | 521: ValueOf](scheme: Crypto.SignatureScheme)
+extends Cipher, Signing:
+  type Size = bits
 
-// The digest an asymmetric signature is taken over. `SignatureDigest`'s companion supplies
-// SHA-256, so importing one of these is only necessary to choose something else.
-package signatureDigests:
-  given sha256Signature: SignatureDigest = SignatureDigest(t"SHA256")
-  given sha384Signature: SignatureDigest = SignatureDigest(t"SHA384")
-  given sha512Signature: SignatureDigest = SignatureDigest(t"SHA512")
+  def keySize: bits = valueOf[bits]
+  def genKey(): Data = scheme.generateKeyPair(keySize)
+  def privateToPublic(keyData: Data): Data = scheme.privateToPublic(keyData)
+  def sign(data: Data, keyData: Data): Data = scheme.sign(data, keyData)
 
-package blockCipherMode:
-  export Cbc.mode as cbc
-  export Ctr.mode as ctr
-  export Cfb.mode as cfb
-  export Ofb.mode as ofb
-  // `Ecb.mode` is not re-exported: it is now a context-function given (it requires
-  // an erased `Permit[Concession.Ecb]`), and re-exporting such a given trips a
-  // compiler assertion. ECB is summoned from its own companion; use `over Ecb`.
-
-package blockCipherPadding:
-  export Pkcs7.padding as pkcs7
-  export Iso10126.padding as iso10126
-  // `NoPadding` is not re-exported for import-based inference: its `given` takes a
-  // `Tactic[CryptoError]`, and re-exporting a context-function given trips a
-  // compiler assertion ("bad adapt"). Use `against NoPadding` explicitly instead.
-
-// The initialization vector is now supplied explicitly at the encryption site —
-// `InitializationVector.random` / `.fixed(…)` / `.zero` — so there is no
-// `initializationVector` given namespace.
-
-// The JDK crypto provider is derived from the shared `Provider.JavaStdlib` marker
-// in `Crypto`'s companion, so `import providers.javaStdlibProvider` (from
-// gastronomy) enables both hashing and cryptography. OpenSSL (crypto-only) is
-// selected directly via `import providers.opensslProvider` in the openssl module.
-
-// The `Permit`/`Concession` machinery and the `crypto.permit…Crypto` aggregates
-// live in gastronomy (shared with hashing); the cipher concessions they cover are
-// mapped from cipher types by `Weakness`/`Authentication` in `enigmatic.Weakness`.
-
-
-// The cipher-side concession match types. The shared `Concession` markers, `Permit`
-// and the `crypto.permit…Crypto` aggregates live in gastronomy; these map a cipher
-// type to its concession.
-
-// The algorithm/key-length concession of a cipher type, extracted by matching the
-// (possibly `over`/`against`-refined) cipher. Anything not named here — AES,
-// RSA-2048, HMAC — is `Acceptable` and needs no permission.
-type Weakness[cipher] = cipher match
-  case Des          => Concession.Des
-  case TripleDes[?] => Concession.TripleDes
-  case Rc2[?]       => Concession.Rc2
-  case Blowfish[?]  => Concession.Blowfish
-  case Rsa[1024]    => Concession.SmallRsa
-  case Dsa[?]       => Concession.Dsa
-  case _            => Concession.Acceptable
-
-
-// Every (non-AEAD) block cipher is unauthenticated; asymmetric ciphers are not
-// classified this way. When authenticated encryption is added, its ciphers will
-// fall through to `Acceptable` here.
-type Authentication[cipher] = cipher match
-  case BlockCipher => Concession.Unauthenticated
-  case _           => Concession.Acceptable
-
-
-// Matches a JCE exception by class name, walking superclasses, so the platform-neutral core can
-// map the failures a JVM provider throws to `CryptoError`s without referencing `javax.crypto` or
-// `java.security` types — which do not exist on Scala Native, whose providers throw none of them.
-private[enigmatic] def securityException(error: Throwable, name: String): Boolean =
-  def recur(cls: Class[?] | Null): Boolean =
-    cls != null && (cls.nn.getName == name || recur(cls.nn.getSuperclass))
-
-  recur(error.getClass)
+  def verify(data: Data, signature: Data, keyData: Data): Boolean =
+    scheme.verify(data, signature, keyData)

--- a/lib/enigmatic/src/core/enigmatic.Rsa.scala
+++ b/lib/enigmatic/src/core/enigmatic.Rsa.scala
@@ -35,9 +35,17 @@ package enigmatic
 import anticipation.*
 
 object Rsa:
-  given value: [bits <: 1024 | 2048: ValueOf] => (crypto: Crypto) => Rsa[bits] = Rsa(crypto.rsa)
+  given value: [bits <: 1024 | 2048 | 3072 | 4096: ValueOf]
+  =>  ( digest: SignatureDigest, crypto: Crypto )
+  =>  Rsa[bits] =
+    Rsa(crypto.rsa, crypto.rsaSignature(digest.token))
 
-class Rsa[bits <: 1024 | 2048: ValueOf](cipher: Crypto.PublicKeyCipher) extends Cipher, Encryption:
+// RSA both encrypts and signs. The two are distinct primitives sharing one key pair: `encrypt`
+// and `decrypt` use raw RSA, while `sign` and `verify` use RSASSA-PKCS1-v1_5 over the digest
+// named by the ambient `SignatureDigest` (SHA-256 unless overridden).
+class Rsa[bits <: 1024 | 2048 | 3072 | 4096: ValueOf]
+  ( cipher: Crypto.PublicKeyCipher, scheme: Crypto.SignatureScheme )
+extends Cipher, Encryption, Signing:
   type Size = bits
 
   def keySize: bits = valueOf[bits]
@@ -47,3 +55,7 @@ class Rsa[bits <: 1024 | 2048: ValueOf](cipher: Crypto.PublicKeyCipher) extends 
   // RSA uses no initialization vector; the explicit `iv` is ignored.
   def encrypt(bytes: Data, key: Data, iv: InitializationVector): Data = cipher.encrypt(bytes, key)
   def genKey(): Data = cipher.generateKeyPair(keySize)
+  def sign(data: Data, keyData: Data): Data = scheme.sign(data, keyData)
+
+  def verify(data: Data, signature: Data, keyData: Data): Boolean =
+    scheme.verify(data, signature, keyData)

--- a/lib/enigmatic/src/core/enigmatic.SignatureDigest.scala
+++ b/lib/enigmatic/src/core/enigmatic.SignatureDigest.scala
@@ -33,87 +33,19 @@
 package enigmatic
 
 import anticipation.*
-import gastronomy.*
 import gossamer.*
-import prepositional.*
-import gastronomy.Concession
 
-extension [encodable: Encodable in Data](value: encodable)
-  def hmac[algorithm <: Algorithm](key: Data)
-    ( using hash:            Hash in algorithm,
-            crypto:          Crypto,
-            erased weakness: Permit[HashWeakness[algorithm]] )
-  :   Hmac in algorithm =
-
-    Hmac(crypto.hmac(hash.hmacName).mac(key, encodable.encode(value)))
-
-// The digest an asymmetric signature is taken over. `SignatureDigest`'s companion supplies
-// SHA-256, so importing one of these is only necessary to choose something else.
-package signatureDigests:
+// The digest an asymmetric signature is taken over. RSA and ECDSA sign a hash of the message
+// rather than the message itself, and the choice of hash is part of the signature algorithm's
+// identity — `SHA256withRSA` is a different algorithm from `SHA384withRSA`, with its own object
+// identifier — so it is fixed when the cipher is summoned rather than chosen per signature.
+//
+// SHA-256 is the default, since it is what every certificate profile in current use mandates.
+// Import `signatureDigests.sha384Signature` or `signatureDigests.sha512Signature` to override it;
+// an imported given outranks the one below.
+object SignatureDigest:
   given sha256Signature: SignatureDigest = SignatureDigest(t"SHA256")
-  given sha384Signature: SignatureDigest = SignatureDigest(t"SHA384")
-  given sha512Signature: SignatureDigest = SignatureDigest(t"SHA512")
 
-package blockCipherMode:
-  export Cbc.mode as cbc
-  export Ctr.mode as ctr
-  export Cfb.mode as cfb
-  export Ofb.mode as ofb
-  // `Ecb.mode` is not re-exported: it is now a context-function given (it requires
-  // an erased `Permit[Concession.Ecb]`), and re-exporting such a given trips a
-  // compiler assertion. ECB is summoned from its own companion; use `over Ecb`.
-
-package blockCipherPadding:
-  export Pkcs7.padding as pkcs7
-  export Iso10126.padding as iso10126
-  // `NoPadding` is not re-exported for import-based inference: its `given` takes a
-  // `Tactic[CryptoError]`, and re-exporting a context-function given trips a
-  // compiler assertion ("bad adapt"). Use `against NoPadding` explicitly instead.
-
-// The initialization vector is now supplied explicitly at the encryption site —
-// `InitializationVector.random` / `.fixed(…)` / `.zero` — so there is no
-// `initializationVector` given namespace.
-
-// The JDK crypto provider is derived from the shared `Provider.JavaStdlib` marker
-// in `Crypto`'s companion, so `import providers.javaStdlibProvider` (from
-// gastronomy) enables both hashing and cryptography. OpenSSL (crypto-only) is
-// selected directly via `import providers.opensslProvider` in the openssl module.
-
-// The `Permit`/`Concession` machinery and the `crypto.permit…Crypto` aggregates
-// live in gastronomy (shared with hashing); the cipher concessions they cover are
-// mapped from cipher types by `Weakness`/`Authentication` in `enigmatic.Weakness`.
-
-
-// The cipher-side concession match types. The shared `Concession` markers, `Permit`
-// and the `crypto.permit…Crypto` aggregates live in gastronomy; these map a cipher
-// type to its concession.
-
-// The algorithm/key-length concession of a cipher type, extracted by matching the
-// (possibly `over`/`against`-refined) cipher. Anything not named here — AES,
-// RSA-2048, HMAC — is `Acceptable` and needs no permission.
-type Weakness[cipher] = cipher match
-  case Des          => Concession.Des
-  case TripleDes[?] => Concession.TripleDes
-  case Rc2[?]       => Concession.Rc2
-  case Blowfish[?]  => Concession.Blowfish
-  case Rsa[1024]    => Concession.SmallRsa
-  case Dsa[?]       => Concession.Dsa
-  case _            => Concession.Acceptable
-
-
-// Every (non-AEAD) block cipher is unauthenticated; asymmetric ciphers are not
-// classified this way. When authenticated encryption is added, its ciphers will
-// fall through to `Acceptable` here.
-type Authentication[cipher] = cipher match
-  case BlockCipher => Concession.Unauthenticated
-  case _           => Concession.Acceptable
-
-
-// Matches a JCE exception by class name, walking superclasses, so the platform-neutral core can
-// map the failures a JVM provider throws to `CryptoError`s without referencing `javax.crypto` or
-// `java.security` types — which do not exist on Scala Native, whose providers throw none of them.
-private[enigmatic] def securityException(error: Throwable, name: String): Boolean =
-  def recur(cls: Class[?] | Null): Boolean =
-    cls != null && (cls.nn.getName == name || recur(cls.nn.getSuperclass))
-
-  recur(error.getClass)
+// `token` is the digest's name as it appears in a JCE transformation, e.g. `SHA256` in
+// `SHA256withRSA`. It has no hyphen, unlike the same digest's name as a `Hash`.
+case class SignatureDigest(token: Text)

--- a/lib/enigmatic/src/core/soundness_enigmatic_core.scala
+++ b/lib/enigmatic/src/core/soundness_enigmatic_core.scala
@@ -39,12 +39,15 @@ export
   . { Aes, Blowfish, BlockCipher, BlockCipherMode, BlockCipherPadding, Cbc, Cfb, Cipher,
       CipherSession, Cleartext, cleartext, Cloak, Crypto, CryptoError, Ctr, decrypt, Decryptor,
       Des, Divulgence,
-      Dsa, Ecb, encrypt, Encryptor, Encryption,
+      Dsa, Ecb, Ecdsa, encrypt, Encryptor, Encryption,
       Hmac, hmac, InitializationVector, Iso10126, JavaStdlibCrypto, KeystoreError,
       NoPadding, Ofb, Pem, PemError,
       PemLabel, Password,
       Permits, Pkcs7, PrivateKey, PublicKey, Rc2, Rsa, Signature, Signing,
-      Symmetric, SymmetricKey, TripleDes, uncloak }
+      SignatureDigest, Symmetric, SymmetricKey, TripleDes, uncloak }
+
+package signatureDigests:
+  export enigmatic.signatureDigests.{sha256Signature, sha384Signature, sha512Signature}
 
 package blockCipherMode:
   export enigmatic.blockCipherMode.{cbc, cfb, ctr, ofb}

--- a/lib/enigmatic/src/openssl/enigmatic.OpensslCrypto.scala
+++ b/lib/enigmatic/src/openssl/enigmatic.OpensslCrypto.scala
@@ -103,6 +103,11 @@ object OpensslCrypto extends Crypto:
   // is a panicking stub, `rsa` is simply unavailable).
   def rsa: Crypto.PublicKeyCipher = JavaStdlibCrypto.rsa
 
+  def rsaSignature(digest: Text): Crypto.SignatureScheme =
+    JavaStdlibCrypto.rsaSignature(digest)
+
+  def ecdsa(digest: Text): Crypto.SignatureScheme = JavaStdlibCrypto.ecdsa(digest)
+
   private def digest(algorithm: Text): Pointer = algorithm match
     case t"HmacSHA256" => Foreign["library", Native].EVP_sha256().invoke[Pointer]
     case t"HmacSHA384" => Foreign["library", Native].EVP_sha384().invoke[Pointer]

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -709,6 +709,164 @@ object Tests extends Suite(m"Enigmatic tests"):
           case _                                                       => false
       . assert(identity)
 
+    suite(m"X.509 certificates"):
+      import java.io as ji
+      import java.security as js, js.cert as jsc
+
+      import chronometries.unix
+
+      val subject = Distinguished
+                     ( commonName = t"asn1.example.com",
+                       organization = t"Propensive",
+                       country = t"GB" )
+
+      val period = Instant(1_600_000_000_000L) ~ Instant(1_900_000_000_000L)
+
+      def certificate(): Certificate =
+        val key = PrivateKey.generate[Rsa[2048]]()
+        Certificate.selfSigned(subject, key, period, BigInt(1), alternatives = List(t"example.com"))
+
+      // The JDK's X.509 implementation is an independent reader of what enigmatic writes: it
+      // parses the structure, decodes every field, and — through `verify` — checks the signature
+      // over the exact `TBSCertificate` bytes it re-derived from the encoding. `openssl x509` and
+      // `openssl verify` agree with it, but cannot be run from here.
+      def parse(certificate: Certificate): jsc.X509Certificate =
+        val factory = jsc.CertificateFactory.getInstance("X.509").nn
+        val bytes = ji.ByteArrayInputStream(certificate.in[Der].data.mutable(using Unsafe))
+
+        factory.generateCertificate(bytes).nn.asInstanceOf[jsc.X509Certificate]
+
+      def publicKey(certificate: Certificate): js.PublicKey = parse(certificate).getPublicKey.nn
+
+      test(m"The JDK parses a generated certificate and checks its signature"):
+        val certificate0 = certificate()
+        parse(certificate0).verify(publicKey(certificate0))
+        true
+      . assert(identity)
+
+      test(m"The JDK checks an ECDSA certificate's signature"):
+        val key = PrivateKey.generate[Ecdsa[256]]()
+        val certificate0 = Certificate.selfSigned(subject, key, period, BigInt(3))
+        parse(certificate0).verify(publicKey(certificate0))
+        true
+      . assert(identity)
+
+      test(m"A tampered certificate fails the JDK's signature check"):
+        val certificate0 = certificate()
+        val bytes = certificate0.in[Der].data.mutable(using Unsafe).clone.nn
+        // Flip a bit inside the signature, which the structure keeps well-formed.
+        bytes(bytes.length - 1) = (bytes(bytes.length - 1) ^ 0xff.toByte).toByte
+        val tampered = Certificate(Der(bytes.immutable(using Unsafe)).as[Asn1])
+
+        try
+          parse(tampered).verify(publicKey(certificate0))
+          false
+        catch case _: js.GeneralSecurityException => true
+      . assert(identity)
+
+      test(m"The JDK reads back the subject, serial number and validity"):
+        val parsed = parse(certificate())
+
+        List
+         ( parsed.getSubjectX500Principal.nn.getName.nn.tt,
+           parsed.getSerialNumber.nn.toString.nn.tt,
+           parsed.getNotBefore.nn.getTime.toString.tt )
+      . assert(_ == List(t"CN=asn1.example.com,O=Propensive,C=GB", t"1", t"1600000000000"))
+
+      test(m"The JDK reads back the subject alternative names"):
+        val names = parse(certificate()).getSubjectAlternativeNames.nn
+        names.size
+      . assert(_ == 1)
+
+      test(m"A certificate authority is marked as one"):
+        val key = PrivateKey.generate[Rsa[2048]]()
+
+        val authority =
+          Certificate.selfSigned(subject, key, period, BigInt(9), authority = true)
+
+        // `getBasicConstraints` returns the path-length constraint for a CA, and -1 otherwise.
+        (parse(authority).getBasicConstraints, parse(certificate()).getBasicConstraints)
+      . assert(_ == (Int.MaxValue, -1))
+
+      test(m"A self-signed certificate is a well-formed X.509 structure"):
+        certificate().asn1 match
+          case Asn1.Sequence(List(Asn1.Sequence(_), Asn1.Sequence(_), _: Asn1.BitString)) => true
+          case _                                                                          => false
+      . assert(identity)
+
+      test(m"A certificate round-trips through DER byte-exactly"):
+        val der = certificate().in[Der]
+        der.as[Certificate].in[Der] == der
+      . assert(identity)
+
+      test(m"A certificate round-trips through PEM"):
+        val original = certificate()
+        val read: Certificate = original.pem.serialize.read[Certificate in Pem]
+        read.in[Der] == original.in[Der]
+      . assert(identity)
+
+      test(m"The certificate is version 3 with the given serial number"):
+        certificate().asn1 match
+          case Asn1.Sequence(List(Asn1.Sequence(tbs), _, _)) => tbs.take(2)
+          case _                                             => Nil
+      . assert(_ == List(Asn1.Tagged(0, true, Asn1.Integer(BigInt(2))), Asn1.Integer(BigInt(1))))
+
+      test(m"The signature verifies against the certificate's own public key"):
+        val key = PrivateKey.generate[Rsa[2048]]()
+        val cert = Certificate.selfSigned(subject, key, period, BigInt(7))
+
+        cert.asn1 match
+          case Asn1.Sequence(List(tbs, _, Asn1.BitString(bytes, 0))) =>
+            key.public.verify(tbs.in[Der].data, Signature[Rsa[2048]](bytes))
+
+          case _ => false
+      . assert(identity)
+
+      test(m"An ECDSA certificate is signed and verifies"):
+        val key = PrivateKey.generate[Ecdsa[256]]()
+        val cert = Certificate.selfSigned(subject, key, period, BigInt(3))
+
+        cert.asn1 match
+          case Asn1.Sequence(List(tbs, _, Asn1.BitString(bytes, 0))) =>
+            key.public.verify(tbs.in[Der].data, Signature[Ecdsa[256]](bytes))
+
+          case _ => false
+      . assert(identity)
+
+      test(m"The signature algorithm identifier matches the digest"):
+        val key = PrivateKey.generate[Rsa[2048]]()
+        val cert = Certificate.selfSigned(subject, key, period, BigInt(1))
+
+        cert.asn1 match
+          case Asn1.Sequence(List(_, algorithm, _)) => algorithm
+          case _                                    => Asn1.Null
+      . assert(_ == Asn1.Sequence(List(Asn1.ObjectId(List(1, 2, 840, 113549, 1, 1, 11)), Asn1.Null)))
+
+      test(m"A serial number of zero is refused"):
+        capture[CertificateError]:
+          val key = PrivateKey.generate[Rsa[2048]]()
+          Certificate.selfSigned(subject, key, period, BigInt(0))
+        . reason
+      . assert(_ == CertificateError.Reason.BadSerialNumber)
+
+      test(m"A validity period that ends before it starts is refused"):
+        capture[CertificateError]:
+          val key = PrivateKey.generate[Rsa[2048]]()
+          val backwards = Instant(1_900_000_000_000L) ~ Instant(1_600_000_000_000L)
+          Certificate.selfSigned(subject, key, backwards, BigInt(1))
+        . reason
+      . assert(_ == CertificateError.Reason.BadValidity)
+
+      test(m"A distinguished name encodes its attributes in conventional order"):
+        val identifiers = Distinguished.sequence(subject) match
+          case Asn1.Sequence(elements) => elements.collect:
+            case Asn1.Set(List(Asn1.Sequence(List(Asn1.ObjectId(arcs), _)))) => arcs
+
+          case _ => Nil
+
+        identifiers
+      . assert(_ == List(List(2, 5, 4, 6), List(2, 5, 4, 10), List(2, 5, 4, 3)))
+
     suite(m"ASN.1 and DER"):
       // DER is canonical, so `encode` is the equality of record: the byte-carrying cases of `Asn1`
       // are case classes over `IArray[Byte]`, whose synthesized `equals` compares arrays by

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -299,6 +299,9 @@ object Tests extends Suite(m"Enigmatic tests"):
         def rsa: Crypto.PublicKeyCipher = JavaStdlibCrypto.rsa
         def hmac(algorithm: Text): Crypto.Mac = JavaStdlibCrypto.hmac(algorithm)
 
+        def rsaSignature(digest: Text): Crypto.SignatureScheme =
+          JavaStdlibCrypto.rsaSignature(digest)
+
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.uncloak:
         val first = t"Hello world".encrypt(InitializationVector.random).serialize[Hex]
@@ -620,6 +623,91 @@ object Tests extends Suite(m"Enigmatic tests"):
         val second = key.data(Divulgence)
         first.serialize[Hex] == second.serialize[Hex]
       . assert(_ == true)
+
+    suite(m"Asymmetric signatures"):
+      test(m"An RSA signature verifies against the matching public key"):
+        val key = PrivateKey.generate[Rsa[2048]]()
+        key.public.verify(pangram, key.sign(pangram))
+      . assert(identity)
+
+      test(m"An RSA signature fails against a different key"):
+        val key = PrivateKey.generate[Rsa[2048]]()
+        val other = PrivateKey.generate[Rsa[2048]]()
+        other.public.verify(pangram, key.sign(pangram))
+      . assert(!_)
+
+      test(m"An RSA signature fails over different content"):
+        val key = PrivateKey.generate[Rsa[2048]]()
+        key.public.verify(t"a different message", key.sign(pangram))
+      . assert(!_)
+
+      test(m"The signature digest is selectable"):
+        import signatureDigests.sha512Signature
+        val key = PrivateKey.generate[Rsa[2048]]()
+        key.public.verify(pangram, key.sign(pangram))
+      . assert(identity)
+
+      test(m"A signature made under one digest fails to verify under another"):
+        val key = PrivateKey.generate[Rsa[2048]]()
+        val signature = key.sign(pangram)
+        import signatureDigests.sha512Signature
+        key.public.verify(pangram, signature)
+      . assert(!_)
+
+      test(m"RSA still encrypts and decrypts"):
+        val key = PrivateKey.generate[Rsa[2048]]()
+        val message: Data = key.public.uncloak(t"Hello world".encrypt(InitializationVector.random))
+        key.uncloak(message.decrypt.as[Text])
+      . assert(_ == t"Hello world")
+
+      test(m"An ECDSA signature verifies against the matching public key"):
+        val key = PrivateKey.generate[Ecdsa[256]]()
+        key.public.verify(pangram, key.sign(pangram))
+      . assert(identity)
+
+      test(m"ECDSA works over each NIST prime curve"):
+        val p256 = PrivateKey.generate[Ecdsa[256]]()
+        val p384 = PrivateKey.generate[Ecdsa[384]]()
+        val p521 = PrivateKey.generate[Ecdsa[521]]()
+
+        List
+         (p256.public.verify(pangram, p256.sign(pangram)),
+          p384.public.verify(pangram, p384.sign(pangram)),
+          p521.public.verify(pangram, p521.sign(pangram)))
+      . assert(_ == List(true, true, true))
+
+      test(m"An ECDSA signature fails against a different key"):
+        val key = PrivateKey.generate[Ecdsa[256]]()
+        val other = PrivateKey.generate[Ecdsa[256]]()
+        other.public.verify(pangram, key.sign(pangram))
+      . assert(!_)
+
+      // The JDK does not write RFC 5915's optional public-key field, so enigmatic adds it at
+      // generation; this checks the re-encoded key is still a well-formed `PrivateKeyInfo` that
+      // the JDK reads back, and that the public key recovered from it is the right one.
+      test(m"An ECDSA private key carries its public key in RFC 5915 form"):
+        val key = PrivateKey.generate[Ecdsa[256]]()
+
+        val info = key.pem(Divulgence).as[Der].as[Asn1]
+
+        val inner = info match
+          case Asn1.Sequence(List(_, _, Asn1.OctetString(octets))) => Der(octets).as[Asn1]
+          case _                                                  => Asn1.Null
+
+        inner match
+          case Asn1.Sequence(elements) => elements.collect:
+            case tagged: Asn1.Tagged => tagged.tag
+
+          case _ => Nil
+      . assert(_ == List(1))
+
+      test(m"An ECDSA public key is a well-formed SubjectPublicKeyInfo"):
+        val key = PrivateKey.generate[Ecdsa[256]]()
+
+        Der(key.public.bytes).as[Asn1] match
+          case Asn1.Sequence(List(Asn1.Sequence(_), _: Asn1.BitString)) => true
+          case _                                                       => false
+      . assert(identity)
 
     suite(m"ASN.1 and DER"):
       // DER is canonical, so `encode` is the equality of record: the byte-carrying cases of `Asn1`

--- a/lib/enigmatic/src/x509/enigmatic.Certificate.scala
+++ b/lib/enigmatic/src/x509/enigmatic.Certificate.scala
@@ -1,0 +1,180 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+
+import anticipation.*
+import aviation.*
+import contingency.*
+import distillate.*
+import fulminate.*
+import gastronomy.*
+import prepositional.*
+import vacuous.*
+
+import CertificateError.Reason
+
+// An X.509 certificate. It is held as the ASN.1 value it is, so that it encodes to DER — and hence
+// to PEM — through the ordinary codec, and so that a certificate read back from the wire re-encodes
+// byte-for-byte, which is what checking its signature depends on.
+object Certificate:
+  given encodable: Certificate is Encodable in Der = _.asn1.in[Der]
+
+  given decodable: (tactic: Tactic[Asn1Error]^)
+  =>  ( (Certificate is Decodable in Der)^{tactic, caps.any} ) =
+    der => Certificate(der.as[Asn1])
+
+  // The instant at which RFC 5280 §4.1.2.5 switches from `UTCTime` to `GeneralizedTime`: midnight
+  // on 1 January 2050, after which a two-digit year is ambiguous.
+  private val Generalized: Long = 2524608000L
+
+  // Extension object identifiers, all under the certificate-extension arc 2.5.29.
+  private val SubjectKeyIdentifier: List[Int] = List(2, 5, 29, 14)
+  private val KeyUsage: List[Int] = List(2, 5, 29, 15)
+  private val SubjectAltName: List[Int] = List(2, 5, 29, 17)
+  private val BasicConstraints: List[Int] = List(2, 5, 29, 19)
+
+  // A self-signed certificate: the subject is its own issuer, and the signature is made with the
+  // private key whose public half the certificate carries. That is the whole of a root certificate
+  // authority, and of the throwaway certificate a test server or a development tool mints for
+  // itself.
+  //
+  // `authority` decides both the basic constraints and the key usage: a certificate authority
+  // signs certificates and revocation lists, while an end-entity certificate signs and encrypts.
+  // `alternatives` are `dNSName` subject alternative names, which is what every TLS client checks
+  // in place of the common name.
+  def selfSigned[cipher <: Cipher]
+    ( subject:      Distinguished,
+      key:          PrivateKey[cipher],
+      validity:     Period[Instant over Unix],
+      serial:       BigInt,
+      authority:    Boolean = false,
+      alternatives: List[Text] = Nil )
+    ( using algorithm:     cipher & Signing,
+            signature:     cipher is SignatureAlgorithm,
+            digest:        SignatureDigest,
+            hash:          Hash in Sha2[256],
+            erased permit: Permit[Weakness[cipher]] )
+    ( using Tactic[CertificateError], Tactic[Asn1Error], Diagnostics )
+  :   Certificate =
+
+    if serial <= 0 then abort(CertificateError(Reason.BadSerialNumber))
+    if validity.finish.long <= validity.start.long then abort(CertificateError(Reason.BadValidity))
+
+    val unknown = CertificateError(Reason.UnknownAlgorithm(digest.token))
+    val identifier = signature.identifier(digest).lay(abort(unknown))(identity)
+
+    // `PublicKey#bytes` is already a DER `SubjectPublicKeyInfo`, so it is decoded rather than
+    // rebuilt, and embedded in the certificate exactly as the provider wrote it.
+    val publicKey = Der(key.public.bytes).as[Asn1]
+
+    val publicBits = publicKey match
+      case Asn1.Sequence(List(_, bits: Asn1.BitString)) => bits
+
+      case _ =>
+        abort(CertificateError(Reason.BadPublicKey))
+
+    val name = Distinguished.sequence(subject)
+
+    val period: Asn1 =
+      Asn1.Sequence(List(instant(validity.start), instant(validity.finish)))
+
+    val constraints: Asn1 =
+      if authority then Asn1.Sequence(List(Asn1.Boolean(true))) else Asn1.Sequence(Nil)
+
+    // Key usage is a named-bit `BIT STRING`, numbered from the most significant bit of the first
+    // octet, with the trailing bits after the last one set declared unused. A certificate authority
+    // needs `keyCertSign` (5) and `cRLSign` (6); an end entity `digitalSignature` (0) and
+    // `keyEncipherment` (2).
+    val usage: Asn1 =
+      if authority then Asn1.BitString(IArray[Byte](0x06.toByte), 1)
+      else Asn1.BitString(IArray[Byte](0xa0.toByte), 5)
+
+    // `dNSName` is `[2] IMPLICIT IA5String`, which is exactly what an implicit tag is for: the
+    // choice is identified by its tag, and the string type never appears on the wire.
+    val alternativeNames: Optional[Asn1] =
+      if alternatives.isEmpty then Unset else
+        val names = alternatives.map: name =>
+          Asn1.Tagged(2, false, Asn1.Ia5String(name))
+
+        entry(SubjectAltName, false, Asn1.Sequence(names))
+
+    val identity0 = Asn1.OctetString(keyIdentifier(publicBits.bytes))
+
+    val extensions =
+      List
+        ( entry(BasicConstraints, true, constraints),
+          entry(KeyUsage, true, usage),
+          entry(SubjectKeyIdentifier, false, identity0),
+          alternativeNames )
+
+    val fields =
+      List
+        ( Asn1.Tagged(0, true, Asn1.Integer(BigInt(2))),
+          Asn1.Integer(serial),
+          identifier,
+          name,
+          period,
+          name,
+          publicKey,
+          Asn1.Tagged(3, true, Asn1.Sequence(extensions.flatMap(_.option))) )
+
+    val tbs: Asn1 = Asn1.Sequence(fields)
+
+    val signed = key.sign(tbs.in[Der].data)
+
+    Certificate(Asn1.Sequence(List(tbs, identifier, Asn1.BitString(signed.bytes, 0))))
+
+  // RFC 5280's `critical` field defaults to `FALSE`, and DER forbids encoding a field that holds
+  // its default, so a non-critical extension omits it entirely.
+  private def entry(identifier: List[Int], critical: Boolean, value: Asn1): Asn1 =
+    val octets = Asn1.OctetString(value.in[Der].data)
+
+    val fields =
+      if critical then List(Asn1.ObjectId(identifier), Asn1.Boolean(true), octets)
+      else List(Asn1.ObjectId(identifier), octets)
+
+    Asn1.Sequence(fields)
+
+  // RFC 7093 method 1: the leftmost 160 bits of the SHA-256 digest of the public key's bit string.
+  // RFC 5280 describes a SHA-1 digest instead, but the two are interchangeable — a key identifier
+  // only has to be unique, not unforgeable — and this avoids making every caller permit SHA-1.
+  private def keyIdentifier(publicKey: Data)(using Hash in Sha2[256]): Data =
+    publicKey.digest[Sha2[256]].data.take(20)
+
+  private def instant(instant: Instant over Unix): Asn1 =
+    val seconds = Math.floorDiv(instant.long, 1000L)
+    if seconds < Generalized then Asn1.UtcTime(seconds) else Asn1.GeneralizedTime(seconds)
+
+case class Certificate(asn1: Asn1):
+  // The armored form, which is how certificates are almost always exchanged.
+  def pem: Pem = Pem(PemLabel.Certificate, asn1.in[Der])

--- a/lib/enigmatic/src/x509/enigmatic.CertificateError.scala
+++ b/lib/enigmatic/src/x509/enigmatic.CertificateError.scala
@@ -1,0 +1,52 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+
+import anticipation.*
+import fulminate.*
+
+object CertificateError:
+  given communicable: Reason is Communicable =
+    case Reason.UnknownAlgorithm(digest) => m"no signature algorithm is assigned to $digest"
+    case Reason.BadPublicKey             => m"the public key was not a SubjectPublicKeyInfo"
+    case Reason.BadSerialNumber          => m"the serial number was negative or zero"
+    case Reason.BadValidity              => m"the validity period ended before it began"
+
+  enum Reason(val number: Int) extends Clarification:
+    case UnknownAlgorithm(digest: Text) extends Reason(1)
+    case BadPublicKey extends Reason(2)
+    case BadSerialNumber extends Reason(3)
+    case BadValidity extends Reason(4)
+
+case class CertificateError(reason: CertificateError.Reason)(using Diagnostics)
+extends Error(524, reason.number)(m"could not build the certificate because $reason")

--- a/lib/enigmatic/src/x509/enigmatic.Distinguished.scala
+++ b/lib/enigmatic/src/x509/enigmatic.Distinguished.scala
@@ -1,0 +1,95 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+
+import anticipation.*
+import prepositional.*
+import vacuous.*
+
+// A distinguished name: the X.501 structure that names a certificate's subject and issuer. Only
+// the attributes that appear in practice are modelled; each is optional, and absent ones are
+// simply not encoded.
+object Distinguished:
+  // The attribute type object identifiers, all under the X.500 attribute arc 2.5.4 except the
+  // email address, which is a PKCS#9 attribute.
+  private val CommonName: List[Int] = List(2, 5, 4, 3)
+  private val Country: List[Int] = List(2, 5, 4, 6)
+  private val Locality: List[Int] = List(2, 5, 4, 7)
+  private val State: List[Int] = List(2, 5, 4, 8)
+  private val Organization: List[Int] = List(2, 5, 4, 10)
+  private val OrganizationalUnit: List[Int] = List(2, 5, 4, 11)
+  private val Email: List[Int] = List(1, 2, 840, 113549, 1, 9, 1)
+
+  // A `Name` is a `SEQUENCE OF RelativeDistinguishedName`, each a `SET OF AttributeTypeAndValue`.
+  // Multi-valued RDNs are legal but almost unheard of, so each attribute becomes its own
+  // single-member set. The order is the conventional one, most general first, which is also the
+  // order `openssl x509` prints.
+  given encodable: Distinguished is Encodable in Der = sequence(_).in[Der]
+
+  private[enigmatic] def sequence(name: Distinguished): Asn1 =
+    val attributes =
+      List
+        ( name.country.let(attribute(Country, _, printable = true)),
+          name.state.let(attribute(State, _)),
+          name.locality.let(attribute(Locality, _)),
+          name.organization.let(attribute(Organization, _)),
+          name.organizationalUnit.let(attribute(OrganizationalUnit, _)),
+          name.commonName.let(attribute(CommonName, _)),
+          name.email.let(attribute(Email, _, ia5 = true)) )
+
+    Asn1.Sequence(attributes.flatMap(_.option))
+
+  // `countryName` is a `PrintableString` by definition, and `emailAddress` an `IA5String`;
+  // everything else is a `UTF8String`, which is what every modern profile prefers.
+  private def attribute
+    ( identifier: List[Int],
+      value:      Text,
+      printable:  Boolean = false,
+      ia5:        Boolean = false )
+  :   Asn1 =
+
+    val text =
+      if printable then Asn1.PrintableString(value)
+      else if ia5 then Asn1.Ia5String(value)
+      else Asn1.Utf8String(value)
+
+    Asn1.Set(List(Asn1.Sequence(List(Asn1.ObjectId(identifier), text))))
+
+case class Distinguished
+  ( commonName:         Optional[Text] = Unset,
+    organization:       Optional[Text] = Unset,
+    organizationalUnit: Optional[Text] = Unset,
+    locality:           Optional[Text] = Unset,
+    state:              Optional[Text] = Unset,
+    country:            Optional[Text] = Unset,
+    email:              Optional[Text] = Unset )

--- a/lib/enigmatic/src/x509/enigmatic.SignatureAlgorithm.scala
+++ b/lib/enigmatic/src/x509/enigmatic.SignatureAlgorithm.scala
@@ -1,0 +1,63 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+
+import anticipation.*
+import gossamer.*
+import vacuous.*
+
+// The `AlgorithmIdentifier` that names a cipher-and-digest pair in a certificate. It is a property
+// of the pair, not of either alone: `sha256WithRSAEncryption` and `sha384WithRSAEncryption` are
+// different object identifiers over the same key type.
+object SignatureAlgorithm:
+  // RSASSA-PKCS1-v1_5 identifiers live under the PKCS#1 arc, and RFC 3279 requires the parameters
+  // field to be present and NULL — not absent.
+  given rsa: [bits <: 1024 | 2048 | 3072 | 4096] => Rsa[bits] is SignatureAlgorithm = digest =>
+    arc(digest, t"SHA256" -> 11, t"SHA384" -> 12, t"SHA512" -> 13).let: last =>
+      Asn1.Sequence(List(Asn1.ObjectId(List(1, 2, 840, 113549, 1, 1, last)), Asn1.Null))
+
+  // ECDSA identifiers live under the ANSI X9.62 arc, and RFC 5758 requires the parameters field to
+  // be absent, since the curve is already named by the public key.
+  given ecdsa: [bits <: 256 | 384 | 521] => Ecdsa[bits] is SignatureAlgorithm = digest =>
+    arc(digest, t"SHA256" -> 2, t"SHA384" -> 3, t"SHA512" -> 4).let: last =>
+      Asn1.Sequence(List(Asn1.ObjectId(List(1, 2, 840, 10045, 4, 3, last))))
+
+  private def arc(digest: SignatureDigest, entries: (Text, Int)*): Optional[Int] =
+    entries.find(_(0) == digest.token).map(_(1)).getOrElse(Unset)
+
+trait SignatureAlgorithm:
+  type Self
+
+  // `Unset` when the cipher and digest have no object identifier between them, which a caller
+  // turns into a `CertificateError` rather than an encoding that no verifier would recognize.
+  def identifier(digest: SignatureDigest): Optional[Asn1]

--- a/lib/enigmatic/src/x509/soundness_enigmatic_x509.scala
+++ b/lib/enigmatic/src/x509/soundness_enigmatic_x509.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export enigmatic.{Certificate, CertificateError, Distinguished, SignatureAlgorithm}


### PR DESCRIPTION
Enigmatic can now sign with RSA and ECDSA, and mint self-signed X.509 certificates. Previously it could sign only with DSA, which no current certificate profile accepts, so nothing here could produce a signature PKIX would honour — and minting a certificate meant shelling out to `openssl` or `keytool`.

### Signing

`Rsa` now signs as well as encrypts — one key pair, two primitives — and `Ecdsa` covers the NIST prime curves:

```scala
val key = PrivateKey.generate[Rsa[2048]]()
val signature = key.sign(message)
key.public.verify(message, signature)
```

The digest comes from an ambient `SignatureDigest` rather than a type parameter, because `SHA256withRSA` and `SHA384withRSA` are different algorithms with different object identifiers, so the choice belongs with the cipher instance rather than with each call. SHA-256 is the default; import `signatureDigests.sha384Signature` or `signatureDigests.sha512Signature` to change it.

`rsaSignature` joins the mandatory provider contract, since `Rsa`'s given asks only for a `Crypto`; `ecdsa` stays structural, like `dsa`, so a provider that doesn't offer it is a compile error at the use site.

### Certificates

```scala
import chronometries.unix

val subject = Distinguished(commonName = t"example.com", organization = t"Example Ltd")
val validity = now() ~ (now() + 365*Day)

val certificate =
  Certificate.selfSigned
   (subject, key, validity, BigInt(1), alternatives = List(t"example.com", t"www.example.com"))

val armored: Text = certificate.pem.serialize
```

The certificate is version 3, carrying basic constraints, key usage and a subject key identifier; `alternatives` become `dNSName` subject alternative names, which is what TLS clients check. `authority = true` marks it as a certificate authority and gives it the key usage to sign other certificates. Reading one back is the ordinary codec: `armored.read[Certificate in Pem]`.

X.509 lives in its own `enigmatic.x509` component because it needs aviation for validity periods, and nothing that only wants ciphers and PEM should carry that.

### Notes on two choices

The subject key identifier uses RFC 7093's SHA-256 method rather than RFC 5280's SHA-1, so callers need not permit weak crypto for an identifier that only has to be unique.

An EC public key is `d·G`, and recovering it from the scalar needs curve arithmetic this module has no business reimplementing — while the JDK does not write RFC 5915's optional public-key field. Generated EC keys are therefore re-encoded to carry it, which the RFC provides for and OpenSSL emits, so `privateToPublic` is a lookup.

### Verification

Checked against implementations other than our own: `openssl x509` decodes every field of a generated certificate, and `openssl verify` accepts the self-signature for both RSA and ECDSA. The committed tests check the same through the JDK's `CertificateFactory`, which re-derives the `TBSCertificate` bytes from the encoding and verifies the signature over them, and rejects a tampered certificate.

This completes stages 2 and 3 of #1653. Stage 4 — PKCS#10 requests, PKCS#8 key reading and certificate inspection — remains open there.
