### PR TITLE
Expand the philosophy documents with worked examples

### DIFF
--- a/doc/modules/concurrency.md
+++ b/doc/modules/concurrency.md
@@ -6,7 +6,8 @@ Concurrency in Soundness is structured. A task is spawned inside a supervised sc
 the scope does not complete until its tasks have. A task runs a computation on a thread and yields a
 result that is awaited; a failure in a task propagates to the scope rather than vanishing; and
 cancelling a scope cancels everything beneath it. Whether tasks run on the JVM's platform threads or
-its lightweight virtual threads is a choice made in scope.
+its lightweight virtual threads is a choice made in scope. The reasoning behind this shape
+is set out under [structured concurrency](../philosophy/structured-concurrency.md).
 
 ### On concurrency
 

--- a/doc/modules/cryptography.md
+++ b/doc/modules/cryptography.md
@@ -59,7 +59,8 @@ key.uncloak:
 // t"Hello world"
 ```
 
-`uncloak` lends the key to its block as an `Encryptor` and `Decryptor` capability, and capture
+`uncloak` is a [delimited scope](../philosophy/delimited-scopes.md): it lends the key to its
+block as an `Encryptor` and `Decryptor` capability, and capture
 checking confines both: neither the capability nor a closure that would use it later can escape
 the block, so the compiler — not a convention — keeps the key's use inside its scope.
 

--- a/doc/modules/decoding.md
+++ b/doc/modules/decoding.md
@@ -6,7 +6,9 @@ A running program receives much of its data as loose, untyped text: command-line
 arguments, environment variables, configuration files, the fields captured by a
 regular expression, a line typed at a prompt. Soundness turns that text into
 typed values — an `Int`, a `Uuid`, an email address — and reflects in the types
-the one thing every such conversion shares: it might not succeed.
+the one thing every such conversion shares: it might not succeed. Making that
+possibility explicit, rather than returning a plausible value for input it cannot read, is
+what [total transitions](../philosophy/total-transitions.md) demands.
 
 ### On conversion
 

--- a/doc/modules/errors.md
+++ b/doc/modules/errors.md
@@ -25,8 +25,12 @@ Soundness keeps the failure in the type and the detail in the value. An error is
 carrying a typed [message](../philosophy/expressive-errors.md); a method advertises the errors it can raise
 in its return type; and the decision of what to do belongs to the caller, expressed as a
 contextual strategy. Because the strategy is an ordinary given, one body of fallible code
-serves every response. The names come from the `soundness` package, with a diagnostics choice
-that decides whether errors capture stack traces:
+serves every response — which is the whole of the
+[error-handling](../philosophy/error-handling.md) principle, and the reason fallible calls
+still read as ordinary [direct-style](../philosophy/direct-style.md) code.
+
+The names come from the `soundness` package, with a diagnostics choice that decides whether
+errors capture stack traces:
 
 ```scala
 import soundness.*

--- a/doc/modules/filesystem.md
+++ b/doc/modules/filesystem.md
@@ -66,7 +66,9 @@ target.create[Directory](CreateFlag.Parents)
 
 A file is read and written by *opening* it. `open` names the form to open the path as, and the
 mode to open it in, and runs a block with a handle for its capability. The handle exists only
-for the duration of the block, so the descriptor cannot outlive the scope that owns it:
+for the duration of the block, so the descriptor cannot outlive the scope that owns it — the
+shape described under [delimited scopes](../philosophy/delimited-scopes.md), and enforced by
+[capture checking](../philosophy/capture-checking.md):
 
 ```scala
 import charEncoders.utf8Encoder
@@ -223,4 +225,5 @@ and everything else is defined in terms of them. The `java.nio` implementation i
 `filesystemBackends.virtualMachine`, and a WASI implementation over `wasi:filesystem` is
 supplied by `galilei.wasi`, so the same code reads and writes files on the JVM and inside a
 WebAssembly component. An operation a backend cannot support raises an `IoError` whose reason
-is `Unsupported`, rather than approximating it.
+is `Unsupported`, rather than approximating it. Narrowing the platform's surface to a seam
+this small is [decoupling](../philosophy/decoupling.md) applied within a module.

--- a/doc/modules/html.md
+++ b/doc/modules/html.md
@@ -22,9 +22,11 @@ element may be nested in any other, attributes are arbitrary strings, and a docu
 that violates the specification is discovered, if at all, only when a browser renders
 it wrongly.
 
-Soundness encodes the specification in the types. Each tag is a value whose type knows
-its name, what it may contain, and what attributes it admits, and the rules of the
-specification are enforced where the markup is written. The vocabulary, the
+Soundness encodes the specification in the types, so an invalid document becomes an
+[impossible state](../philosophy/impossible-states.md) rather than something to validate
+afterwards. Each tag is a value whose type knows its name, what it may contain, and what
+attributes it admits, and the rules of the specification are enforced where the markup is
+written. The vocabulary, the
 containment rules, and the parsing and emitting behaviour all come from a contextual
 description of the specification — currently the
 [WHATWG HTML Living Standard](https://html.spec.whatwg.org/), what most people mean by

--- a/doc/modules/interpolation.md
+++ b/doc/modules/interpolation.md
@@ -7,7 +7,8 @@ quoting must balance, a `json"…"` that must parse — are all built on one pie
 defining custom [string interpolators](https://docs.scala-lang.org/scala3/book/string-interpolation.html).
 An interpolator defined with it validates its literal content as the code compiles, reporting an
 error at the exact character at fault, and accepts substitutions only of the types it declares,
-each checked for the position it occupies.
+each checked for the position it occupies. This is the principal instrument of
+[safety by construction](../philosophy/safety-by-construction.md).
 
 Defining one does not mean writing a macro by hand: the compilation-time plumbing — capturing the
 literal parts and their positions in the source file — is done once, and an interpolator's author

--- a/doc/modules/logging.md
+++ b/doc/modules/logging.md
@@ -7,12 +7,15 @@ type, with the `logs` infix type, and emits a value of a typed event rather than
 string: instead of returning `Int` we would return `Int logs SomeEvent`. A logger placed in the caller's scope receives those events and writes them
 somewhere — a terminal, a file, the system log. With no logger in scope, logging is
 silent and costs nothing, so declaring that a method logs imposes no obligation on the
-code that calls it.
+code that calls it. A `logs` clause is an
+[honest signature](../philosophy/honest-signatures.md) at work: it states what the method
+actually emits, so a caller knows what there is to route.
 
 Because a logger is an ordinary contextual value, several can be in scope at once, and
 every event fans out to each of them. Each logger determines its own severity threshold, its
 own rendering and its own destination. The decision of where logs go, and at what detail, belongs to the
-application, not to the libraries it uses.
+application, not to the libraries it uses. Choosing that by what is in scope is
+[declarative context](../philosophy/declarative-context.md).
 
 ### On logging
 

--- a/doc/modules/money.md
+++ b/doc/modules/money.md
@@ -4,9 +4,11 @@
 
 Money is a fixed-point amount of a particular currency, and Soundness keeps the currency in the
 type: a `Money in "EUR"` and a `Money in "GBP"` cannot be added together, because adding euros to
-pounds is not a sum but a mistake. Within a currency, amounts add, subtract, scale, divide and
-compare; an amount splits into equal shares without losing a penny; and a price carries its tax
-alongside its principal.
+pounds is not a sum but a mistake. Parameterizing by the currency is how an
+[impossible state](../philosophy/impossible-states.md) is ruled out by the type.
+
+Within a currency, amounts add, subtract, scale, divide and compare; an amount splits into
+equal shares without losing a penny; and a price carries its tax alongside its principal.
 
 Thirty-seven currencies come defined, each a value that constructs amounts, and rendering an
 amount uses either its symbol or its ISO code, chosen by a style in scope.

--- a/doc/modules/names.md
+++ b/doc/modules/names.md
@@ -7,7 +7,8 @@ in a namespace with its own rules about what a valid name looks like, and Soundn
 such a name as a `Name` whose rules are part of its type. A `Name[DomId]` is known to satisfy the
 rules for DOM ids; a literal that breaks them is a compile error; and text arriving at runtime
 becomes a `Name` only by passing the same validation, with a typed error naming the exact rule it
-broke.
+broke. Possessing a `Name` is therefore proof that it is valid — an instance of
+[safety by construction](../philosophy/safety-by-construction.md).
 
 The rules themselves are types — `MustNotContain["/"]`, `MustNotEqual[".."]`, `MustMatch[…]` —
 composed by intersection, so a namespace's constraints are written once, read directly from the

--- a/doc/modules/numbers.md
+++ b/doc/modules/numbers.md
@@ -10,7 +10,8 @@ the checking is opt-in, paid for only where it is wanted.
 
 Bounded types go further: a number can carry its permitted range in its type, so a value
 outside `[0, 1]` is a compile error where it is written, and arithmetic on bounded numbers
-works out the range of the result.
+works out the range of the result. A range in the type is the plainest way to make an
+[impossible state](../philosophy/impossible-states.md) unrepresentable.
 
 ### On numbers
 

--- a/doc/modules/optics.md
+++ b/doc/modules/optics.md
@@ -7,7 +7,8 @@ it by hand — nested `copy` calls that grow with the depth of the data. A
 [lens](https://en.wikipedia.org/wiki/Bidirectional_transformation) does the rebuilding instead:
 the `lens` method takes an update written as a plain path assignment, `_.ceo.name = t"Bill"`, and
 returns the new structure. Optics such as `Each` and `Filter` extend a path through the elements
-of a collection, so one assignment can update many values at once.
+of a collection, so one assignment can update many values at once. Lenses are what make
+[immutability](../philosophy/immutability.md) practical rather than merely principled.
 
 The same mechanism serves the dynamic data formats — [JSON](json.md), [XML](xml.md),
 [YAML](yaml.md), [CBOR](cbor.md) — so a deep update looks identical whether the structure is a

--- a/doc/modules/optional-values.md
+++ b/doc/modules/optional-values.md
@@ -24,8 +24,9 @@ case where a value is simply present.
 An `Optional` keeps the safety of `Option` — absence is in the type, and the compiler makes
 sure it is handled — while behaving like the value itself when present. It rests on Scala's
 [union types](https://docs.scala-lang.org/scala3/reference/new-types/union-types.html):
-`Unset | value` needs no wrapper, and because a union is a set, the same type never nests.
-Everything comes from the `soundness` package:
+`Unset | value` needs no wrapper, and because a union is a set, the same type never nests —
+the [optionality](../philosophy/optionality.md) principle in its purest form. Everything
+comes from the `soundness` package:
 
 ```scala
 import soundness.*

--- a/doc/modules/paths.md
+++ b/doc/modules/paths.md
@@ -5,7 +5,8 @@
 A path is a sequence of names leading through a hierarchy, and Soundness keeps the facts about
 it in its type. An absolute path is a `Path`, rooted on some value; a relative path is a
 `Relative`, a number of steps up followed by a descent; and both are typed by the *platform* they
-belong to, so a `Path on Linux` and a `Path on Windows` are distinct. The elements of a path
+belong to, so a `Path on Linux` and a `Path on Windows` are distinct. The `on` clause is one of the
+[infix types](../philosophy/infix-types.md) used throughout. The elements of a path
 built in source are known to the compiler, so path arithmetic — descending, ascending, finding the
 route from one to another — is checked as the code compiles.
 

--- a/doc/modules/quantities.md
+++ b/doc/modules/quantities.md
@@ -6,7 +6,8 @@ Soundness represents physical quantities — a distance, a mass, a speed — as 
 that carry their [units](https://en.wikipedia.org/wiki/Units_of_measurement) in
 their type. Adding a distance to a time is a compile error; multiplying a distance
 by a force gives a quantity whose units are worked out for you; and a quantity
-costs nothing at runtime beyond the `Double` it wraps.
+costs nothing at runtime beyond the `Double` it wraps. That last property is a
+design constraint rather than an optimization; see [zero cost](../philosophy/zero-cost.md).
 
 ### On quantities
 

--- a/doc/modules/sockets.md
+++ b/doc/modules/sockets.md
@@ -106,7 +106,8 @@ connect and converse, receive and reply, dispatch a datagram — are gathered in
 `wasi:sockets` and over Scala Native's sockets supply the same operations, so the same protocol
 code runs on the JVM, inside a WebAssembly component, and in a native binary. An operation a
 backend cannot support — Unix-domain sockets or TLS on WASI — raises the appropriate error rather
-than approximating it.
+than approximating it. Narrowing the platform's surface to a seam this small is
+[decoupling](../philosophy/decoupling.md) applied within a module.
 
 ### Socket options
 

--- a/doc/modules/streams.md
+++ b/doc/modules/streams.md
@@ -10,7 +10,8 @@ a value to a destination, and `stream` exposes a value as a stream of pieces.
 What can be read, and what can be written, is decided by typeclasses. A type that describes how
 it becomes a stream can be read; a type that describes how it consumes one can be written to; so
 a new source or sink joins the same `read` and `writeTo` as everything else, with no bespoke
-plumbing.
+plumbing. One verb per operation, ranging over every type that supports it, is the
+[small-APIs](../philosophy/small-apis.md) discipline.
 
 Underneath those operations is a streaming *kernel* whose central type is a `Stream`: not a lazy
 sequence of chunks, but a pull endpoint over a buffer whose readable window is handed to exactly
@@ -105,7 +106,8 @@ val text = document.source[Text]                     // Stream[Text]
 
 A stage transforms a stream into a differently-typed stream. `via` attaches one on the pull
 side, and the whole chain runs on the consumer's thread as nested refills — no threads, no
-queues, no intermediate collections:
+queues, no intermediate collections. Each stage takes what the last one produced, which is
+[composability](../philosophy/composability.md) in its most literal form:
 
 ```scala
 file.stream.via(decompressor).via(decoder)

--- a/doc/modules/testing.md
+++ b/doc/modules/testing.md
@@ -8,7 +8,8 @@ equality assertion fails, the report is not two `toString`s but a structural *co
 the expected and observed values, aligned field by field and element by element, with the actual
 differences highlighted. And because Soundness moves so many checks to compiletime, tests can
 assert that code *does not compile*: a block that should be rejected is captured, and its compile
-errors become values to inspect.
+errors become values to inspect. Testing that something is impossible is what a
+library built on [correctness](../philosophy/correctness.md) most needs to verify.
 
 ### On testing
 

--- a/doc/modules/time.md
+++ b/doc/modules/time.md
@@ -7,7 +7,9 @@ clock, absolute instants on a physical timeline, the spans between them, the tim
 zones that connect human and physical time, and the rules by which events recur.
 Wherever a value can be known when the code is written, Soundness checks it as
 the code compiles, so a date that cannot exist, or a time zone that was never
-defined, is a compile error rather than a runtime surprise.
+defined, is a compile error rather than a runtime surprise. That is
+[safety by construction](../philosophy/safety-by-construction.md) applied to a domain
+where almost every value has a rule.
 
 ### On time
 

--- a/doc/philosophy/capture-checking.md
+++ b/doc/philosophy/capture-checking.md
@@ -34,3 +34,73 @@ exactly the features that defeat by-eye reasoning about lifetimes, because they 
 *when* code runs from *where* it was written. Capture checking reattaches them — the
 capability's scope travels in the type, so an escape is impossible to write rather than
 inadvisable to attempt.
+
+## Separation checking
+
+Capture checking answers "may this value outlive that scope?". Its companion,
+*separation* checking, answers a second question: "may two references to this value exist
+at once?"
+
+Some resources are safe to share and some are not. A `Stream` in the streaming kernel
+exposes a mutable window into a buffer without copying it, which is what makes the kernel
+fast — and which is only sound if exactly one consumer reads it. Two aliases would each
+consume bytes the other expected.
+
+So a `Stream` is an *exclusive* capability, and aliasing one does not compile:
+
+```scala
+val stream = file.stream
+val other = stream          // does not compile: the stream is exclusive
+```
+
+The modules that depend on this — the kernel itself and its immediate consumers — are
+compiled with separation checking enabled, so the guarantee is checked rather than
+documented. This is what allows a zero-copy design to be offered as an ordinary API
+instead of as an unsafe one with a warning attached.
+
+## What the compiler asks of you
+
+The honest part of this document. Capture checking is not free, and the costs fall on the
+person writing the code, not the person reading it.
+
+**Annotations appear in signatures.** A method returning a value that captures something
+says so — `(Stream[Data] over Credit)^` — and a parameter that will be consumed rather
+than borrowed is marked `consume`. These are real syntax that a reader must learn, and
+they propagate: a signature that returns a capturing value forces its callers'
+signatures to acknowledge it.
+
+**The errors are hard.** A capture violation is reported in terms of capture sets and
+sometimes of skolem variables, which is a considerable distance from "this stream would
+outlive its file". Reading such an error fluently takes practice, and the practice is not
+transferable from ordinary Scala.
+
+**It is still maturing.** Capture checking is a research-grade feature of the compiler,
+and Soundness uses a fork with fixes not yet upstream. Some idioms that ought to work do
+not yet — the aliasing-heavy zlib port in the compression module is compiled with capture
+checking but not separation checking, because the stricter ruleset rejects a faithful
+port of code that is nonetheless correct.
+
+**Some escape hatches remain.** `caps.unsafe.unsafeAssumePure` and
+`@caps.unsafe.untrackedCaptures` exist for the places where the checker cannot yet see
+what the author can prove. Each use is a small hole in the guarantee, and each is
+commented with the argument for why it is sound — which is the right way to hold such a
+thing, but it is not the same as not needing them.
+
+## Why it is worth the cost
+
+Because the alternative is not "no cost" but "the same cost, paid later and by someone
+else".
+
+A stream read after its file closed is a bug that reproduces intermittently, under load,
+in a stack trace pointing at the read rather than at the escape. A closure that raises
+with no handler in scope fails at a call site far from where the closure was made. These
+are among the hardest classes of bug to diagnose, precisely because the cause and the
+symptom are separated by exactly the mechanisms — laziness, closures, concurrency — that
+capture checking exists to track.
+
+The compiler's complaint is early, local, and about the actual mistake. That is a better
+trade than it first looks.
+
+See [delimited scopes](delimited-scopes.md) for the structure this enforces, and
+[expressive errors](expressive-errors.md) for why errors must be pure — `throw` being the
+one channel this analysis cannot see.

--- a/doc/philosophy/composability.md
+++ b/doc/philosophy/composability.md
@@ -6,3 +6,102 @@ so that the result of one operation is the input to the next, types combine to d
 richer types, and capabilities nest within capabilities. Composability is what lets a
 small, consistent set of parts cover an enormous range of uses, and it is treated as a
 deliberate design constraint rather than a property hoped for after the fact.
+
+## Values compose
+
+A [stream](../modules/streams.md) pipeline is the clearest case. Each stage takes a
+stream and yields a stream, so stages chain without adapters and in any order that makes
+sense:
+
+```scala
+file.stream.decompress[Gzip].via(decoder).records
+```
+
+Nothing in that line is special-cased for its neighbours. Decompression does not know it
+is reading from a file; the decoder does not know its input was compressed. Because each
+stage is a value, the chain can be assembled at runtime, held in a variable, or built by
+a function that decides which stages a particular job needs.
+
+## Types compose
+
+An [infix type](infix-types.md) adds one clause without nesting a bracket, so a precise
+type is built up the way an English description is:
+
+```scala
+Path on Linux
+Raster by Rgba in Png
+Text is Decodable in Json
+Element of "ul" over "li" in Whatwg
+```
+
+Each preposition means the same thing wherever it appears, so a reader who has understood
+one such type reads the next by analogy. The alternative — `Element["ul", "li", Whatwg]` —
+carries the same information and tells the reader nothing about which parameter is which.
+
+## Capabilities compose
+
+Two capabilities in scope are two capabilities; there is no combined type to construct
+and no ordering to choose. Fallible, asynchronous and logging code compose by being
+written next to each other:
+
+```scala
+supervise:
+  recover:
+    case error: HttpError => fallback
+  . protect:
+      async(url"https://example.com/".fetch().receive[Text])
+```
+
+This is the property that [direct style](direct-style.md) exists to preserve. Under a
+monadic encoding the same combination requires a transformer stack, and the order in
+which the effects are stacked becomes a decision with consequences. Here it is not a
+decision at all.
+
+## Scopes compose
+
+Because a capability is introduced by a block, and blocks nest, resource lifetimes nest:
+
+```scala
+archive.open[Zip](): zip ?=>
+  target.open[File](Write): handle ?=>
+    handle.write(zip.entries.head.stream)
+```
+
+The inner scope sees both capabilities; each is withdrawn at its own boundary, in the
+right order, whether the block completes or fails. Adding a third resource adds a line
+rather than restructuring the other two — and [capture checking](capture-checking.md)
+proves that nothing escapes outward.
+
+## The constraint this places on design
+
+Composability is easy to describe and hard to keep, because the pressure against it is
+always local. Every special case, every "convenience" overload that takes the pair rather
+than the parts, every operation that works only when called first — each is a small
+convenience that removes a combination someone else needed.
+
+Three rules follow, and they are why some Soundness APIs look more austere than they
+might:
+
+**Return the type you accept.** An operation that takes a stream returns a stream, so it
+can sit in the middle of a chain rather than only at the end.
+
+**Do not fuse what the caller can combine.** There is no `readAndDecompress`, because
+`stream.decompress[Gzip].read[Text]` already exists and the fused version would have to
+be repeated for every pair.
+
+**Make the general case the only case.** If an operation works for `List` but not for a
+stream, the abstraction is wrong — which is why the operations are defined over
+typeclasses rather than over concrete types.
+
+## What it costs
+
+A composable API is less immediately convenient than a fused one. `Tarfile.from(dir).gzip`
+is two calls where `tarGzip(dir)` would be one, and a reader who wanted exactly the fused
+operation pays a small tax for the generality they did not need.
+
+That tax is accepted because it is bounded and the alternative is not: fused operations
+multiply combinatorially, and each one added is a place where the general path and the
+shortcut can drift apart.
+
+See [small APIs](small-apis.md) for the vocabulary this keeps small, and
+[decoupling](decoupling.md) for how independent modules manage to compose at all.

--- a/doc/philosophy/correctness.md
+++ b/doc/philosophy/correctness.md
@@ -10,8 +10,9 @@ starting point, not an extra to be bolted on later.
 
 ## What "a great deal" amounts to
 
-The claim is worth making concrete. In a program built on Soundness, the following are
-compile errors rather than possibilities:
+The claim is worth making concrete. In a program built on Soundness — each line below
+with the relevant module's names in scope — the following are compile errors rather than
+possibilities:
 
 ```scala
 2012-Feb-30                            // a date that does not exist

--- a/doc/philosophy/correctness.md
+++ b/doc/philosophy/correctness.md
@@ -7,3 +7,86 @@ incorrectness impossible — moving checks to compiletime, ruling out invalid st
 making failure visible in the types — so that a program which compiles is already known
 to be right about a great deal. This is what "sound by default" means: safety is the
 starting point, not an extra to be bolted on later.
+
+## What "a great deal" amounts to
+
+The claim is worth making concrete. In a program built on Soundness, the following are
+compile errors rather than possibilities:
+
+```scala
+2012-Feb-30                            // a date that does not exist
+Eur(3.01) + Gbp(2.50)                  // money in mismatched currencies
+url"https:/example.com"                // a malformed URL
+(3*Metre) + (4*Second)                 // incoherent dimensions
+Br(Hr)                                 // a void element given children
+json.verify[Employee].nope             // a field the schema does not declare
+```
+
+And the following are *visible in a signature*, so a caller cannot fail to know about
+them: that an operation might fail and how; that it might block; that it needs the
+network, the filesystem, or a random source; that it logs, and what.
+
+None of this is exotic. Each is an ordinary mistake that ordinary programs make, caught
+by construction rather than by review.
+
+## Where the checking happens
+
+Three mechanisms carry most of the weight, and they are described in their own right
+elsewhere.
+
+Values are checked **as they are constructed**, so possessing one is proof it is
+well-formed — the subject of [safety by construction](safety-by-construction.md).
+
+Types are shaped so that **invalid states have no representation**, and every transition
+between states is **total** — the two golden rules, in
+[impossible states](impossible-states.md) and [total transitions](total-transitions.md).
+
+Requirements are stated **honestly in signatures**, so nothing an operation needs is
+hidden and nothing it declares is unused — [honest signatures](honest-signatures.md).
+
+## The conviction underneath
+
+Any static analysis a programmer can perform, the compiler can perform better; and any
+analysis the compiler can perform, it should.
+
+A programmer checking by eye that every `match` covers every case does the compiler's
+job, less reliably, and does it again after every change. The compiler does it on every
+build, exhaustively, and reports every site affected by adding an enumeration case. The
+question is therefore never *whether* to do the analysis but *who* does it — and the
+answer is the same every time.
+
+This is why exhaustivity warnings are treated as errors rather than as noise, why
+`-Wunused` is on, and why a deliberately partial match must say so with `.absolve`
+rather than being silently permitted. The discipline costs nothing except accidental
+partiality, which is the kind that becomes a bug.
+
+## What correctness is not
+
+**It is not verification.** Soundness does not prove that a program computes the right
+answer. It rules out large, well-understood classes of wrongness — malformed values,
+impossible states, unhandled failures, escaped resources — and leaves the domain logic
+to the programmer and the tests.
+
+**It is not a guarantee about the outside world.** A `Hostname` is syntactically valid;
+whether it resolves is not a static question. The discipline is to encode what is
+genuinely determined by the value and to report the rest as typed failures, rather than
+to invent a type that promises more than it can deliver.
+
+**It is not free of judgement.** Every check moved to compiletime is a constraint on what
+can be written, and a constraint that rules out more mistakes than it rules out
+legitimate programs is a good one. That trade is made case by case, and it is possible to
+get wrong in both directions.
+
+## What it costs
+
+Compiletime, mostly. Type-level computation, inlining and macro expansion are work the
+compiler does on every build so the machine need not do it on every run, and a Soundness
+project compiles more slowly than an equivalent one written loosely.
+
+The second cost is a steeper start. A library that accepts `String` everywhere is easier
+to begin with than one that wants a `Path on Linux`, a `Port` and a `MediaType`; the
+payment comes back at the point where the loose version would have been debugging a
+production incident. That is a real trade, and worth making knowingly rather than by
+assumption.
+
+See [zero cost](zero-cost.md) for why the runtime bill, at least, is close to nothing.

--- a/doc/philosophy/declarative-context.md
+++ b/doc/philosophy/declarative-context.md
@@ -38,3 +38,67 @@ import — from internal machinery. And when a required given is missing, import
 it searches the classpath for the instances that *would* satisfy the search and names
 the imports that provide them, so the response to a missing context is a one-line
 import, not an archaeology session.
+
+## What goes into scope
+
+The range is worth seeing at once, because the uniformity is the point. A single
+mechanism carries choices that other designs would spread across constructor arguments,
+global settings, builder methods and runtime flags:
+
+```scala
+import strategies.throwUnsafely            // what a failure does
+import charEncoders.utf8Encoder            // how text becomes bytes
+import formatting.compactJsonFormatting    // how JSON is rendered
+import dateFormats.iso8601DateFormat       // how dates are shown
+import affirmations.yesNoAffirmation       // how a boolean is shown
+import threading.virtualThreading          // what a task runs on
+import probates.cancelProbate              // what happens to unfinished tasks
+import httpBackends.native                 // which HTTP transport is used
+import filesystemBackends.virtualMachine   // which filesystem implementation
+import calendars.gregorianCalendar         // which calendar a date literal means
+```
+
+One idiom to learn, and the same reasoning — "what is in scope determines what happens" —
+applies to all of them.
+
+## Naming makes the choice legible
+
+A given is named for what it *selects*, not for its type, because the import line is what
+a reader sees. `import strategies.accrue` says something about the code below it;
+`import strategies.given` would not.
+
+This is why the convention matters more here than elsewhere: a contextual value is
+invoked without being written at the call site, so the import is the only place its
+choice is visible. A poorly-named given makes contextual configuration exactly as opaque
+as its critics claim it is.
+
+## What it costs
+
+The honest objection to contextual configuration is action at a distance, and it is not
+wrong.
+
+**The effect is not local to the call site.** A `json.show` renders differently depending
+on an import possibly a hundred lines above, and nothing at the call site says so. A
+reader must know to look. The mitigation is scope precision — the narrower the scope, the
+closer the given is to what it affects — but the tension is real, and a given imported
+file-wide genuinely is action at a distance.
+
+**Ambiguity is a compile error, and a confusing one.** Two givens of the same type in
+scope make the code ambiguous, which is safe but reported in terms of implicit
+resolution rather than "you have chosen two JSON formats". Importing two convention
+bundles that disagree produces exactly this.
+
+**Refactoring can silently change behaviour.** Moving a function to another file moves it
+out of one set of imports and into another. The types still check; the behaviour may
+differ. This is the sharpest edge of the approach, and the reason a project's conventions
+are better collected into one shared object than assembled ad hoc per file.
+
+**There is no runtime override.** Because the configuration is resolved as the code
+compiles, it cannot be changed by a command-line flag or a configuration file without
+threading the decision explicitly. Where runtime configurability is genuinely wanted, the
+value must be an ordinary parameter — and recognising which of the two a given choice
+needs is a design decision, not an automatic one.
+
+See [delimited scopes](delimited-scopes.md) for how the scope is established, and
+[honest signatures](honest-signatures.md) for why the requirements being in the signature
+is what makes this legible at all.

--- a/doc/philosophy/declarative-context.md
+++ b/doc/philosophy/declarative-context.md
@@ -17,7 +17,7 @@ lines:
 import formatting.compactJsonFormatting     // the file's default
 
 def debugDump(json: Json): Text =
-  given JsonFormatting = indentedJsonFormatting   // this function only
+  given Json.Formatting = indentedJsonFormatting   // this function only
   json.show
 
 locally:

--- a/doc/philosophy/decoupling.md
+++ b/doc/philosophy/decoupling.md
@@ -6,3 +6,82 @@ describing only what is needed — let two modules cooperate without either know
 the other, so each can be adopted à la carte and can evolve on its own. The seamless
 integration that users experience comes from these common interfaces, not from a web of
 hard dependencies between components that ought to remain separate.
+
+## The problem, stated concretely
+
+A time library and an HTTP library both need to talk about instants: one produces them,
+the other puts them in `Date` headers. There are three conventional ways to arrange
+that, and all three are bad.
+
+The HTTP library can depend on the time library — imposing it on every user who wanted
+only HTTP. The time library can depend on the HTTP library — absurd, but it happens. Or
+each can define its own instant type, leaving users to convert at every boundary, and
+leaving the two definitions free to disagree.
+
+## The arrangement Soundness uses
+
+A third module defines a *marker* and a pair of typeclasses saying how any type converts
+to and from a common representation:
+
+```scala
+sealed trait Instants   // the marker: "this conversion is about instants"
+
+given Long is Abstractable across Instants to Long
+given Long is Instantiable across Instants from Long
+```
+
+The time library declares that *its* instant type is abstractable across `Instants`. The
+HTTP library declares that it accepts anything abstractable across `Instants`. Neither
+mentions the other, and neither is loaded unless the program uses it.
+
+These markers are small and there are not many: `Instants`, `Durations`, `Dates`,
+`Paths`, `Urls`, `HttpStreams`, `Text`, and a handful more. Each names one concept that
+several libraries need to agree about, and defines nothing but the agreement.
+
+## What it buys
+
+**À la carte adoption.** A program that wants only JSON parsing gets a dependency graph
+containing JSON parsing. The integrations it does not use are not in the build, because
+the modules that provide them are not depended upon.
+
+**Foreign types participate.** The typeclass has no privileged implementations, so a
+`java.time.Instant`, or a type from an unrelated library, becomes usable wherever an
+instant is expected by supplying an instance. Nothing has to be wrapped, and the
+integration lives in the program rather than requiring either library to change.
+
+**Independent evolution.** The time library can change its internal representation
+without the HTTP library recompiling, because what they share is the marker and the
+shape of the conversion, not a type.
+
+## The same principle inside a module
+
+Decoupling operates below the module boundary too, as a *backend seam*: the operations a
+capability needs are gathered into one trait, and the platform-specific implementations
+are supplied separately.
+
+`FilesystemBackend` collects stat, open, read, write, list, link and delete; everything
+in the [filesystem](../modules/filesystem.md) API is defined in terms of them. The
+`java.nio` implementation, the WASI implementation over `wasi:filesystem`, and any
+future one are interchangeable, and the user-facing API mentions no platform at all. The
+same shape gives [sockets](../modules/sockets.md) a `SocketBackend`,
+[compression](../modules/compression.md) its per-platform DEFLATE engines, and
+[images](../modules/images.md) their codecs.
+
+That is what makes the same code run on the JVM, in a browser, in a native binary and
+inside a WebAssembly component: not conditional compilation, but a seam narrow enough
+that several implementations can honestly sit behind it.
+
+## What it costs
+
+Indirection is not free to read. Following how a `Yaml` value becomes an HTTP body means
+finding the `Abstractable across HttpStreams` instance, which is not where either the
+YAML code or the HTTP code is — and a reader who does not know the convention will not
+guess where to look.
+
+The mitigation is that there is *one* convention rather than a different mechanism per
+integration, so the cost is paid once in learning and not once per boundary. But it is a
+real cost, and it is the reason the set of markers is kept small: each one is a piece of
+vocabulary every reader must eventually acquire.
+
+See [honest signatures](honest-signatures.md) for why the typeclasses stay minimal, and
+[composability](composability.md) for what the shared interfaces make possible.

--- a/doc/philosophy/delimited-scopes.md
+++ b/doc/philosophy/delimited-scopes.md
@@ -60,7 +60,7 @@ exception to a few lines:
 import formatting.compactJsonFormatting        // this file
 
 def debugDump(json: Json): Text =
-  given JsonFormatting = indentedJsonFormatting  // this method only
+  given Json.Formatting = indentedJsonFormatting  // this method only
   json.show
 
 locally:

--- a/doc/philosophy/delimited-scopes.md
+++ b/doc/philosophy/delimited-scopes.md
@@ -7,3 +7,98 @@ available inside it and withdraws them at its boundary. The reach of a capabilit
 therefore visible in the structure of the code itself: a capability applies exactly
 where the block says it does, and not beyond. This structural confinement is what
 [capture checking](capture-checking.md) then enforces in the types.
+
+## One shape, everywhere
+
+The same pattern introduces a resource, an error handler, a concurrency context and a
+lent secret. Recognising it once means recognising all of them:
+
+```scala
+path.open[File](Write): handle ?=>       // a file, open for this block
+  handle.write(data)
+
+recover:
+  case error: IoError => fallback
+. protect(readConfiguration())           // a handler, for this block
+
+supervise:                               // a supervisor, for this block
+  async(compute())
+
+key.uncloak:                             // a key, lent to this block
+  message.encrypt(InitializationVector.random)
+```
+
+In each case the capability exists inside the braces and nowhere else, and the block's
+extent is the capability's extent — visible on the page, without reading any
+documentation about lifetimes.
+
+## Why a block rather than a constructor
+
+The alternative is to construct the capability, use it, and release it:
+
+```scala
+val handle = open(path)
+try handle.write(data) finally handle.close()
+```
+
+This has three defects that the block form does not. The `close` can be forgotten, or
+placed where an early return skips it. The handle exists as a value *before* it is valid
+and *after* it is not, so its type says nothing about when it may be used. And nesting
+two of them doubles the ceremony, with the release order stated by hand.
+
+The block form fixes each: there is no release to write, the capability is only in scope
+where it is valid, and nesting two resources is nesting two blocks.
+
+## Scope is a precise instrument
+
+Because the mechanism is ordinary lexical scope, the granularity is whatever the code
+needs. A given imported at the top of a file configures the file; one declared in a
+method configures the method, overriding the wider choice; a `locally` block confines an
+exception to a few lines:
+
+```scala
+import formatting.compactJsonFormatting        // this file
+
+def debugDump(json: Json): Text =
+  given JsonFormatting = indentedJsonFormatting  // this method only
+  json.show
+
+locally:
+  import textSanitizers.strictSanitizer        // these two lines
+  decoder.decoded(untrustedBytes)
+```
+
+Nothing has to support this granularity specially. It falls out of using the language's
+own scoping rather than a bespoke configuration mechanism.
+
+## What "withdrawn at the boundary" really means
+
+Structurally, the capability leaves scope when the block ends. That alone would not stop
+a value from *carrying* it out — a lazy stream still holding an open file, a closure
+still holding an error handler, a task still holding its supervisor. Those escapes are
+exactly what by-eye reasoning misses, because laziness, closures and concurrency detach
+when code runs from where it was written.
+
+[Capture checking](capture-checking.md) closes the gap: the capability's scope travels
+in the value's type, so an escape is a compile error rather than a runtime surprise.
+Delimited scopes state the intent; capture checking makes it a guarantee.
+
+## What it costs
+
+Two costs, both real.
+
+**Rightward drift.** Each nested capability indents the code, and a function needing four
+of them is four levels in before it begins. Scala's colon-lambda syntax keeps this to one
+level per capability rather than one level plus a closing brace, but deeply capable code
+still looks deeply nested — and where that becomes unreadable, the answer is to factor
+the inner work into a method that declares what it needs, not to widen the scopes.
+
+**The capability cannot simply be stored.** A value that needs a file handle at some
+later, unrelated moment cannot hold one; it must either do its work inside the scope or
+take a memoized copy of what it needed. That is a genuine constraint, and it is the
+constraint doing the work: "hold this resource indefinitely and hope" is precisely the
+pattern being ruled out.
+
+See [declarative context](declarative-context.md) for what is put into these scopes, and
+[structured concurrency](structured-concurrency.md) for the case where the scoped thing
+is a set of running tasks.

--- a/doc/philosophy/direct-style.md
+++ b/doc/philosophy/direct-style.md
@@ -36,3 +36,64 @@ control structure of the language works unchanged; and the fallible, the asynchr
 and the pure call all look like calls. Where monadic values must be *sequenced*,
 direct-style expressions merely *occur* — which is why the composition never stops
 being ordinary.
+
+## Ordinary control flow keeps working
+
+The claim is easiest to check on the constructs a monadic encoding has to replace. Each
+of these works unchanged around fallible, asynchronous or resource-holding code:
+
+```scala
+supervise:
+  for url <- urls do                          // an ordinary loop
+    if shouldFetch(url) then                  // an ordinary condition
+      try async(url.fetch().receive[Text])
+      finally record(url)                     // ordinary try/finally
+```
+
+No `traverse`, no `whenA`, no bracket combinator — and no question of which monad the
+`for` is over, because it is not over one. A `while` loop, an early return, a `match`,
+a nested function definition: all of them mean what they mean in Scala.
+
+## Effects still appear in the types
+
+Direct style is not effect-erasure. What an operation needs is in its signature, exactly
+as it would be in the monadic encoding — the difference is that it appears as a
+*requirement* rather than as a wrapper around the result:
+
+```scala
+def fetch(url: HttpUrl)(using Online, Monitor): Text raises HttpError
+```
+
+Network access, suspension, and failure are all visible. What is *not* imposed is a
+change to the shape of the value: the method returns `Text`, so its result composes with
+everything that accepts `Text`, and a caller that has discharged the requirements has an
+ordinary value in hand.
+
+This is the property the monadic encoding trades away. `IO[Either[HttpError, Text]]`
+carries the same information and cannot be passed to anything expecting `Text`.
+
+## What it costs
+
+**Capabilities must be in scope, and that propagates.** A method calling something that
+needs `Online` must either supply it or declare it. This is the same propagation a
+monadic encoding has — there it is in the return type — so it is a cost of honesty rather
+than of direct style, but it is not zero.
+
+**The mechanism is contextual, and contextual code can surprise.** Which strategy is in
+scope determines what a failure does, and a given imported at the top of a file affects
+code far below it. That is the intended power — see
+[declarative context](declarative-context.md) — but a reader who does not check the
+imports can misread what a fallible call will do.
+
+**Some reasoning is genuinely easier with an explicit value.** A monadic value can be
+stored, retried, or passed to a combinator that runs it three times. A direct-style
+fallible expression is not a value in the same way — which is why `defer` exists, to
+hold an unapplied fallible computation where one is genuinely wanted. That it needs a
+mechanism at all is an admission that the wrapper had a use.
+
+**It leans on newer language features.** Context functions, capture checking and
+`transparent inline` are doing the work, and the second of those is still maturing. The
+monadic encoding needs none of them and works on any Scala.
+
+See [delimited scopes](delimited-scopes.md) for how a capability is introduced, and
+[error handling](error-handling.md) for the effect this matters most for.

--- a/doc/philosophy/elegant-prose.md
+++ b/doc/philosophy/elegant-prose.md
@@ -21,3 +21,82 @@ The analogy is a design constraint, not an accident: a new module *must* spell i
 parsing `read`, its rendering `show`, its literals as an interpolator — because the
 moment it invents `parseFrom` or `stringify`, the reader's correct guesses start
 failing, and the prose stops scanning.
+
+## The test
+
+The claim is checkable: read the code aloud and see whether it makes sense to someone who
+knows the domain but not the library.
+
+```scala
+supervise:
+  val server = SocketServer(8080).handle:
+    request.target match
+      case t"/"       => Http.Response(Http.Ok)(homePage)
+      case t"/status" => Http.Response(Http.Ok)(t"OK")
+      case _          => Http.Response(Http.NotFound)(t"No such page")
+```
+
+"Supervise: the server is a socket server on port 8080 that handles — match the request's
+target: for slash, an HTTP response, OK, the home page…". A reader who knows HTTP follows
+that without knowing anything about Soundness.
+
+The same test applied elsewhere:
+
+```scala
+worktree.merge(GitBranch(t"feature"), ff = FastForward.Never, message = t"Merge feature")
+
+path.open[Directory](Read & Exclusive): dir ?=>
+  (dir/"greeting.txt").overwrite(t"Hello directory")
+
+5.25.pm on 2018-Aug-11
+
+key.uncloak:
+  t"Hello world".encrypt(InitializationVector.random).decrypt.as[Text]
+```
+
+Each reads as a statement about the domain rather than as an instruction to a machine.
+
+## What the machinery costs to hide
+
+Prose that reads well is not prose with nothing behind it. Each line above rests on
+several of the other principles at once, and the reader is meant to notice none of them:
+
+`path.open[Directory](Read & Exclusive)` involves a [scoped capability](delimited-scopes.md),
+a type-level grant set, and [capture checking](capture-checking.md) proving the handle
+does not escape. The reader sees a directory being opened for exclusive reading.
+
+`t"2011-12-13".as[Date]` involves a typeclass resolved by target type, a contextual error
+strategy, and a calendar. The reader sees text becoming a date.
+
+`5.25.pm on 2018-Aug-11` involves a compiletime-checked literal, an
+[infix](infix-types.md) constructor, and validation that rejects `13.00.am`. The reader
+sees a time on a date.
+
+That is the aim: machinery that recedes. When the machinery *has* to be visible — when a
+capability must be named, or a type ascribed — it is because the reader genuinely needs
+to know, not because the design leaked.
+
+## Where the prose breaks down
+
+Being honest about this is more useful than the principle stated alone.
+
+**Type ascriptions intrude.** Where inference cannot reach, a type must be written, and a
+long infix type in the middle of an expression stops the sentence dead.
+
+**Error messages are not prose.** A missing given is reported as a failed implicit search,
+in the compiler's vocabulary rather than the library's — which is why
+`explainMissingContext` exists, and why it is a repair rather than a solution.
+
+**Some domains have no good English.** A streaming pipeline reads well; the `Duct` and
+`Intake` vocabulary underneath it does not, and could not, because the concepts have no
+everyday names. The response is to keep such vocabulary below the surface where most
+readers never meet it, not to pretend it reads as prose.
+
+**Reading aloud is a test, not a proof.** Code can scan beautifully and be wrong, and the
+principle is not a substitute for the checking the other principles provide. It makes
+code that is correct *look* correct, and — more usefully — makes code that is wrong look
+wrong to a reader who knows the domain.
+
+See [naming](naming.md) and [small APIs](small-apis.md) for the two disciplines that most
+directly produce this, and [direct style](direct-style.md) for the shape that lets a
+sentence stay a sentence.

--- a/doc/philosophy/error-handling.md
+++ b/doc/philosophy/error-handling.md
@@ -8,3 +8,111 @@ know which. This makes failure visible in the types, with the discipline of chec
 exceptions but none of their rigidity, and it lets the same fallible code be used
 unsafely while prototyping and then made totally safe later, with no rewrite. The
 errors themselves are [expressive, immutable values](expressive-errors.md).
+
+## The separation
+
+An operation says what it can fail with, in its return type, and says nothing about what
+should happen:
+
+```scala
+def loadConfiguration(path: Path on Linux): Configuration raises IoError raises JsonError
+```
+
+The caller supplies the response, as a contextual value. The same body serves every
+response, because the body never mentioned one:
+
+```scala
+import strategies.throwUnsafely       // throw: fine while prototyping
+```
+
+```scala
+safely(loadConfiguration(path)).or(Configuration.default)   // fall back
+```
+
+```scala
+recover:
+  case IoError(path, _, _) => Configuration.default
+  case error: JsonError    => abort(StartupError(error))
+. protect(loadConfiguration(path))                          // handle each case
+```
+
+```scala
+accrue(Invalid(Nil))((all, error) => all.add(error)):
+  case error => ()
+. protect(validateEverything(form))                         // collect them all
+```
+
+Nothing in `loadConfiguration` changes between these. That is the property the whole
+design exists for.
+
+## Why not the alternatives
+
+**Unchecked exceptions** are invisible. A signature says nothing about what might be
+thrown, so a caller learns of a failure when it happens, in production, having written no
+handler because there was nothing to prompt one.
+
+**Java's checked exceptions** are visible and rigid. The error type is welded into every
+signature along the call chain, so adding a failure mode to a leaf function edits every
+caller between it and the handler — and because the compiler demands a response at each
+step, the pressure is toward `catch (Exception e) {}`, which is worse than either.
+
+**`Either` and its relatives** are visible and honest, but they change the *shape* of the
+code: a fallible call cannot sit inside an argument list or an interpolated string, and
+combining failure with asynchrony means stacking transformers. See
+[direct style](direct-style.md) for why that matters more than it first appears.
+
+The Soundness arrangement takes visibility from the checked-exception tradition, the
+ability to choose a response from the functional one, and the shape of ordinary code from
+neither.
+
+## Raising, aborting, and the difference
+
+Two verbs, and the distinction is what makes accrual possible.
+
+`abort` stops the computation: there is no value to continue with. `raise` records the
+error and continues with a supplied fallback — which is what lets a validation pass check
+every field rather than stopping at the first:
+
+```scala
+def parseAge(text: Text): Int raises NumberError =
+  text.as[Int]                       // aborts if it cannot parse
+
+def lenientAge(text: Text): Int raises NumberError =
+  raise(NumberError(text, Unparseable)) yet 0    // records, continues with 0
+```
+
+Under an accruing strategy the recorded errors are collected; under a throwing one the
+first still throws. The operation states which of the two it means, and the strategy
+decides what becomes of it.
+
+## Making the response total
+
+`safely` and `unsafely` are the two escape hatches, and they are deliberately conspicuous.
+`unsafely` discharges the obligation without handling it — legitimate at a program's
+boundary, or in a test that has already established the value is fine, and a searchable
+marker of the places where the guarantee stops.
+
+The intended progression is that a prototype uses `throwUnsafely` throughout, and the
+places that matter are converted to real handling as the program is hardened — with no
+change to the fallible code itself, because it never depended on which was in scope.
+
+## What it costs
+
+**A capability must be in scope.** A method that calls fallible code must either handle
+the failure or declare that it too can fail. That propagation is the mechanism working
+correctly, but it means adding a failure mode to a widely-used function does touch the
+functions that call it — the same cost checked exceptions have, without the rigidity of
+being unable to choose the response.
+
+**Inference has more to do.** `raises` clauses compose through type-level machinery, and
+when the compiler cannot work out which error type is meant, the message is about an
+implicit search rather than about the error. Importing `explainMissingContext` turns that
+into a diagnosis naming the strategy imports that would satisfy it.
+
+**There is a vocabulary to learn.** `raise`, `abort`, `safely`, `unsafely`, `recover`,
+`mitigate`, `accrue`, `capture`, `attempt` — nine words where `try`/`catch` has two. Each
+earns its place, but the learning curve is real and front-loaded.
+
+See [expressive errors](expressive-errors.md) for what an error value carries, and
+[honest signatures](honest-signatures.md) for the wider principle that a signature states
+its true requirements.

--- a/doc/philosophy/expressive-errors.md
+++ b/doc/philosophy/expressive-errors.md
@@ -14,8 +14,8 @@ message:
 
 ```scala
 recover:
-  case IoError(path, _, IoError.Reason.Nonexistent) => create(path)
-  case IoError(_, _, IoError.Reason.PermissionDenied) => escalate()
+  case IoError(path, _, IoError.Reason.Nonexistent, _)      => create(path)
+  case IoError(_, _, IoError.Reason.PermissionDenied, _)    => escalate()
 . protect(openConfiguration())
 ```
 
@@ -24,3 +24,107 @@ the match, not the production behaviour — and can be exactly as discriminating
 situation needs, where string-matching on messages is fragile in every way. The message a
 person reads and the structure a program matches are two renderings of one value, so they
 can never disagree.
+
+## The anatomy of an error
+
+The shape is consistent enough to be worth stating. An error is a case class carrying the
+values that explain it, its distinct causes are a `Reason` enumeration, and its message is
+built with the `m"…"` interpolator from those same values:
+
+```scala
+object IpAddressError:
+  enum Reason(val number: Int) extends Clarification:
+    case Ipv4ByteOutOfRange(byte: Int)        extends Reason(1)
+    case Ipv4ByteNotNumeric(byte: Text)       extends Reason(2)
+    case Ipv6WrongNumberOfGroups(count: Int)  extends Reason(7)
+    case Ipv6MultipleDoubleColons             extends Reason(8)
+
+  object Reason:
+    given communicable: Reason is Communicable =
+      case Ipv4ByteOutOfRange(byte)       => m"the number $byte is not in the range 0-255"
+      case Ipv4ByteNotNumeric(byte)       => m"the part $byte is not a number"
+      case Ipv6WrongNumberOfGroups(count) => m"the address has $count groups, but should have 8"
+      case Ipv6MultipleDoubleColons       => m":: appears more than once"
+```
+
+Note that a reason may carry data of its own — the byte that was out of range, the number
+of groups actually found — so the diagnosis is specific rather than categorical.
+
+The numbers are the error's identity. An error type has a globally-unique `SN-NNN` code
+and each reason a number within it, and every code has a page in `doc/errors` explaining
+the cause and the usual remedies — so `SN-077` in a user's report can be looked up rather
+than guessed at.
+
+Three further properties follow from the shape, and each is worth having.
+
+The message is *derived* from the fields, so it cannot describe a state the value is not
+in. A `Reason` is a closed set, so a handler matching on it is checked for exhaustiveness
+and a new reason is reported at every site that has not considered it. And the values
+that explain the failure are available to the handler, not merely rendered into a
+sentence.
+
+## Messages are values too
+
+A `Message` is not a `Text`. It is a structured value built from interpolated parts, so
+that anything `Communicable` can be embedded and rendered consistently wherever the
+message is shown:
+
+```scala
+m"the port $text is not valid because $reason"
+```
+
+The reason renders through its own `Communicable` instance rather than through
+`toString`, so the phrasing lives with the type it describes and one wording serves every
+message that embeds it. This is also the seam through which messages could be localized:
+the structure survives to the point of rendering rather than being flattened into a string
+at the point of construction.
+
+## Errors are pure
+
+An error may never hold a live capability, and the compiler enforces it: `Error` extends
+`caps.Pure`.
+
+The reason is precise. `throw` is the one channel [capture checking](capture-checking.md)
+cannot see — an exception caught outside a scope arrives with its captures erased — so an
+error carrying a capability would be a hole in the guarantee that scoped things do not
+escape. Purity closes it: no error, however it travels, can smuggle a file handle or an
+error handler out of the scope that confined it.
+
+This has a design consequence worth knowing. An error may carry the *path* that could not
+be opened, but not the open handle; the *URL* that failed, but not the connection. In
+practice that is what a diagnosis wants anyway.
+
+## Stack traces are optional
+
+Capturing a stack trace is the expensive part of constructing an exception, and much of
+the time it is wasted: an error that is expected and handled two frames away has no use
+for one.
+
+Whether an error captures a trace is therefore a contextual choice:
+
+```scala
+import errorDiagnostics.stackTracesDiagnostics   // capture, for debugging
+import errorDiagnostics.emptyDiagnostics         // omit, where the error is expected
+```
+
+The `Diagnostics` parameter appears in every error's constructor for this reason. It is
+the one piece of ceremony the design imposes on defining an error, and it buys the
+ability to use typed errors in hot paths without paying for traces nobody will read.
+
+## What it costs
+
+**Defining an error is more work than throwing a string.** A case class, a `Reason`
+enumeration, a `Communicable` instance and a `Diagnostics` parameter is real ceremony
+against `throw new RuntimeException("bad port")`.
+
+The defence is that the ceremony is proportional to the error's importance and is paid
+once per error type, while the benefit is paid out at every handler — and that the
+alternative degrades predictably: string messages get matched on, then the messages get
+improved, and the matching breaks silently.
+
+**Reason enumerations are a commitment.** Adding a case is a source-breaking change for
+exhaustive handlers, which is the exhaustivity check working as intended, but it does
+mean the set of reasons deserves thought when the error is designed.
+
+See [error handling](error-handling.md) for how these values are raised and responded to,
+and [total transitions](total-transitions.md) for why the exhaustiveness matters.

--- a/doc/philosophy/honest-signatures.md
+++ b/doc/philosophy/honest-signatures.md
@@ -21,3 +21,96 @@ requires is hidden, so a caller sees the true cost; and nothing it declares is u
 so a requirement in a signature is always meaningful. A minimal typeclass is also
 easier to implement — the gap between what an interface demands and what most
 implementations need is exactly where dishonest signatures come from.
+
+## The requirement travels with the instance
+
+A typeclass says only what it abstracts:
+
+```scala
+trait Showable:
+  def text(value: Self): Text
+```
+
+No error, no context, no capability — because showing a value, in general, needs none.
+An instance that *does* need something declares it in its own signature, where it is
+true:
+
+```scala
+given (Tactic[CryptoError]) => PrivateKey is Showable = …
+```
+
+The consequence is that the effective requirements of generic code are decided by the
+instances it resolves. The same function is pure when given a pure instance and fallible
+when given a fallible one, and its own signature — honestly — claims neither.
+
+## What a dishonest signature looks like
+
+The failure mode is easy to recognise once named. An interface is widened so that the
+most demanding implementation fits:
+
+```scala
+trait Codec:
+  def encode(value: Self)(using Online, Tactic[CodecError]): Text
+```
+
+One implementation fetches a schema over the network; one can fail; so the *interface*
+requires both, and now every caller of every codec must supply an `Online` capability
+and an error strategy, whether or not the instance they are using needs either.
+
+This is worse than an inconvenience. The signature has stopped carrying information: a
+reader who sees `Online` can no longer conclude the operation touches the network,
+because the requirement is there for a reason that may not apply. Once a few
+requirements are known to be spurious, none of them can be trusted, and the discipline
+collapses.
+
+## What the signatures do carry
+
+Because they are minimal, the clauses that *are* present mean something:
+
+```scala
+def fetch(url: HttpUrl)(using Online): Http.Response
+def loadConfiguration(path: Path on Linux): Configuration raises IoError
+def install(target: Path on Linux): Unit logs InstallEvent
+def fetchAll(urls: List[HttpUrl])(using Monitor): List[Text]
+```
+
+`Online` means it reaches the network. `raises` means it can fail, and how. `logs` means
+it emits events of that type — so a caller knows what to route where. `Monitor` means it
+can suspend the calling strand.
+
+A method with none of these does none of those things, which is a claim worth being able
+to make.
+
+## Honesty about capture
+
+There is a subtler dishonesty a signature can commit: returning a value that secretly
+depends on something scoped. A stream still holding an open file, a closure still holding
+an error handler — the type says `Stream[Text]` and the truth is "a stream, but only
+while that file is open".
+
+[Capture checking](capture-checking.md) makes that part of the signature too. A value's
+type records the capabilities it captures, so an operation cannot quietly return
+something whose validity is narrower than its type suggests. This is why the honesty
+principle and capture checking belong together: one is about what an operation *needs*,
+the other about what its results *depend on*, and both are cases of a signature stating
+the whole truth.
+
+## What it costs
+
+**Instances carry more.** Pushing requirements onto instances means the instances declare
+them, and a fallible instance's signature is longer than the naive version's. The reader
+who benefits is the one calling the generic code, not the one writing the instance.
+
+**Requirements propagate.** A method calling something that needs `Online` must either
+supply it or declare it. That is the mechanism working — the cost of a signature meaning
+something is that it must be maintained — but it does mean a change deep in a call chain
+can surface at the top.
+
+**Resolution failures are indirect.** When a needed instance is missing, the compiler
+reports a failed implicit search rather than "this operation needs `Online`". Importing
+`explainMissingContext` turns that into a diagnosis naming the import that would satisfy
+it, which is the repair for a cost that would otherwise fall on exactly the people the
+honesty is meant to serve.
+
+See [declarative context](declarative-context.md) for how the requirements are supplied,
+and [error handling](error-handling.md) for the most common of them.

--- a/doc/philosophy/immutability.md
+++ b/doc/philosophy/immutability.md
@@ -7,3 +7,83 @@ and makes a value safe to share freely across threads and scopes without defensi
 copying. An immutable value is also easier to reason about, because its meaning is
 fixed at the moment it is created and cannot be invalidated by code running somewhere
 else.
+
+## Updating without mutating
+
+The objection to immutability is always the same: changing one field deep inside a
+structure means rebuilding every layer above it. That is true, and it is a problem of
+syntax rather than of semantics — so Soundness solves it with syntax. A
+[lens](../modules/optics.md) takes the update written as an ordinary path assignment and
+does the rebuilding:
+
+```scala
+case class Role(name: Text, count: Int)
+case class Person(name: Text, roles: List[Role])
+case class Company(ceo: Person, name: Text)
+
+company.lens(_.ceo.name = t"Bill")
+```
+
+The result is a new `Company`; the original is untouched and any other reference to it
+still sees what it saw. Several updates apply together, and ones sharing a prefix
+rebuild the shared structure once rather than once each:
+
+```scala
+company.lens
+  ( _.ceo.roles = Nil,
+    _.ceo.name = t"Bill" )
+```
+
+The same syntax reaches through collections with `Each` and `Filter`, so "give every
+role a count of zero" is one expression rather than a rebuild written by hand.
+
+## Sharing without copying
+
+An immutable value needs no defensive copy, because there is nothing to defend against.
+A `Data` handed to three threads is read by three threads; a parsed document held in a
+cache cannot be altered by whoever fetched it; a configuration passed to a subsystem
+cannot come back changed.
+
+That is what makes structural sharing safe. A lens rebuilds only the spine it descends,
+and every branch it did not touch is *the same object* in the old value and the new one.
+Immutability is therefore what makes the rebuilding cheap: without it, sharing a
+sub-structure between two values would be a bug.
+
+## Where mutation survives, and why
+
+Immutability is a property of values, not a prohibition on the machine. Three places in
+Soundness are deliberately mutable, and each is confined:
+
+A **builder** mutates a buffer it exclusively owns and yields an immutable value at the
+end. Nothing observes the intermediate states, so nothing depends on them.
+
+The **streaming kernel** exposes a mutable window into a buffer, which is precisely what
+makes it zero-copy. That window belongs to exactly one consumer, and the compiler
+enforces it: a `Stream` is an exclusive capability, so aliasing one, or letting one
+escape the scope that owns its source, does not compile. Mutation is permitted here
+because [capture and separation checking](capture-checking.md) prove that nobody else
+can see it.
+
+A **`Canvas`**, obtained by opening a [raster](../modules/images.md) for writing, mutates
+pixels in place — because generating a large image one pixel-function call at a time is
+the wrong shape for a drawing algorithm. The mutation is scoped to the `open` block and
+gated on the `Write` grant, and `snapshot` takes an independent copy for anything that
+must outlive it.
+
+The pattern is the same in all three: mutation is a local implementation technique with
+a proof of confinement, never a property of a value that others can see.
+
+## What it costs
+
+Rebuilding is not free. A lens update allocates one object per level it descends, so a
+tight loop updating a deep structure allocates more than in-place mutation would. Where
+that matters — and it matters far less often than intuition suggests, since the
+allocations are young and short-lived — the answer is a builder or a scoped mutable
+region, not making the value itself mutable.
+
+The trade is deliberate: pay a little allocation to eliminate a class of bug that is
+otherwise found only in production, on a Tuesday, under load.
+
+See [impossible states](impossible-states.md) for the related discipline on what a value
+may be, and [capture checking](capture-checking.md) for how the confined mutations are
+proved safe.

--- a/doc/philosophy/impossible-states.md
+++ b/doc/philosophy/impossible-states.md
@@ -7,3 +7,100 @@ an illegal value impossible to construct, moving the error from runtime to compi
 A type that can hold only meaningful values needs no defensive checks downstream,
 because the compiler has already ruled out everything else. This pairs with the
 companion rule that transitions between states should be [total](total-transitions.md).
+
+## The shape of the rule
+
+Most validation is written the wrong way round. A value is constructed, then checked,
+and the check's result is discarded — so every subsequent function receives a value that
+*might* be valid and must either trust or re-check it:
+
+```scala
+val port = readPort()          // an Int; could be anything
+if port < 1 || port > 65535 then fail()
+connect(port)                  // connect must trust, or check again
+```
+
+The type-first version makes the check the *only* way to obtain the value, so possessing
+one is proof:
+
+```scala
+val port = text.as[Port]       // a Port, or a typed failure
+connect(port)                  // nothing left to check
+```
+
+`connect` cannot be given an out-of-range port, because no such `Port` exists.
+
+## Three ways a type rules a state out
+
+**By refinement.** A number carries its permitted range in its type, so the range is
+checked where the value is written and arithmetic works out the range of the result:
+
+```scala
+val rate: 0.0 ~ 1.0 = 0.001
+val bad:  0.0 ~ 1.0 = 1.5      // does not compile
+```
+
+**By parameterization.** A property that would otherwise be a field becomes a type
+argument, and values differing in it become different types. Money in one currency
+cannot be added to money in another; a path on one platform cannot be used where another
+is expected; a task on one timeline cannot be subtracted from a task on another:
+
+```scala
+Eur(3.01) + Gbp(2.50)          // does not compile
+Instant(0L).over[Tai] - Instant(0L)   // does not compile
+```
+
+**By construction.** A literal is parsed against its grammar as the code compiles, so a
+malformed one is a compile error rather than a value:
+
+```scala
+2012-Feb-30                    // does not compile: no such date
+url"https://example.com/"      // checked against the URL grammar
+media"application/jsom"        // does not compile: did you mean application/json?
+```
+
+The third is [safety by construction](safety-by-construction.md), which this rule's
+practical work mostly consists of.
+
+## Encoding a state machine
+
+The rule is most valuable where a type has *modes*. The usual encoding gives one class
+every field any mode needs, with the invalid combinations excluded by comment:
+
+```scala
+case class Connection(socket: Optional[Socket], error: Optional[Text], closed: Boolean)
+```
+
+Nothing prevents a `Connection` that is closed *and* holds a socket, or one with neither
+a socket nor an error, and every reader must reconstruct which combinations were meant.
+The enumerated form admits only the states that exist:
+
+```scala
+enum Connection:
+  case Open(socket: Socket)
+  case Failed(reason: Text)
+  case Closed
+```
+
+The four impossible combinations are now unwriteable, and — because the compiler checks
+exhaustiveness — every place that handles a `Connection` is told when a case is added.
+
+## What it costs
+
+Three costs, all real.
+
+**Constructing is fallible.** Turning text into a `Port` can fail, so it needs an error
+strategy in scope. The check has not disappeared; it has moved to a single place and
+left a proof behind.
+
+**Types get more specific, and inference works harder.** A method that used to take an
+`Int` now takes a `Port[Tcp]`, and callers must produce one. That is the point — but it
+does mean a refactor propagates further than it would have.
+
+**Not everything can be ruled out.** A hostname's syntax is checkable; whether it
+resolves is not. The discipline is to encode what is genuinely determined by the value
+and to leave the rest to [honest signatures](honest-signatures.md) and typed errors,
+rather than to invent a type that promises more than it can prove.
+
+See [total transitions](total-transitions.md) for the companion rule, and
+[safety by construction](safety-by-construction.md) for how the checking is done.

--- a/doc/philosophy/infix-types.md
+++ b/doc/philosophy/infix-types.md
@@ -12,3 +12,82 @@ would, and the same `of`, `in`, `by`, or `over` carries the same meaning whereve
 appears. A reader who has understood one such type can read the next by analogy, and a
 writer can describe a precise type by naming its parts in turn rather than assembling a
 deeply parameterised one.
+
+## How they work
+
+Each preposition is a type alias that refines one type member. `in` sets `Form`, `on`
+sets `Plane`, `by` sets `Operand`, `to` sets `Result`:
+
+```scala
+infix type in   [refined, form]                             = refined { type Form = form }
+infix type on   [refined <: { type Plane }, plane]          = refined { type Plane = plane }
+infix type by   [refined <: { type Operand }, operand]      = refined { type Operand = operand }
+infix type to   [refined <: { type Result }, result]        = refined { type Result = result }
+```
+
+That is the whole mechanism. Because each refines a *different* member, they can be
+applied in succession without nesting, and the order does not matter:
+
+```scala
+Text is Decodable in Json
+value is Streamable by Data over Credit
+Element of "ul" over "li" in Whatwg
+```
+
+The set is small and fixed — `in`, `on`, `of`, `by`, `to`, `from`, `over`, `across`,
+`onto`, `against`, `under`, `at` — and each keeps its meaning everywhere. `over` is
+always the transport, `by` is always the operand, `on` is always the plane.
+
+## What the alternative costs
+
+The same types, written conventionally:
+
+```scala
+Decodable[Text, Json]
+Streamable[value, Data, Credit]
+Element["ul", "li", Whatwg]
+```
+
+Three problems, each of which the infix form avoids.
+
+**Position carries the meaning.** In `Element["ul", "li", Whatwg]` a reader must know
+that the first parameter is the tag, the second the permitted children and the third the
+specification. In `Element of "ul" over "li" in Whatwg` the prepositions say so.
+
+**Every parameter must be supplied.** A conventional type constructor takes all its
+arguments or none, so a partially-specified type needs a wildcard for each unmentioned
+position. The infix form mentions only what it constrains: `Text is Decodable` is a
+perfectly good type, and `in Json` narrows it.
+
+**Extending is a breaking change.** Adding a fourth type parameter to `Element[…]`
+invalidates every use. Adding a fourth refinement adds a preposition that existing code
+need not mention.
+
+## Where they read badly
+
+The convention is not free of failure modes, and two are worth knowing.
+
+A type with many clauses can run long, and a long infix type wraps awkwardly across
+lines — `(value is Streamable by Data over Credit) { type Transport = Credit }` is not
+prose by anyone's standard. Where that happens, the answer is usually a named alias
+rather than a longer phrase.
+
+And a preposition is only as good as the analogy it invites. `over` meaning "transport"
+reads naturally in `Stream[Data] over Credit` and less naturally in `Instant over Unix`,
+where the timeline is not transporting anything. The vocabulary is small enough that such
+strains are visible, and they are accepted rather than hidden — the alternative is a
+larger vocabulary in which each word is used less often and remembered less well.
+
+## What it costs
+
+Infix types are unfamiliar. A reader arriving from ordinary Scala has met `A => B` and
+`A & B` and not much else in infix position, so `Text is Decodable in Json` looks like
+several things before it looks like a type. That cost is front-loaded and paid once.
+
+Error messages are the more persistent cost: the compiler reports the *desugared*
+refinement, so a mismatch is described in terms of `{ type Form = Json }` rather than
+`in Json`, and the reader must perform the translation the syntax was meant to spare
+them.
+
+See [composability](composability.md) for the property this is in service of, and
+[elegant prose](elegant-prose.md) for the reading experience it aims at.

--- a/doc/philosophy/naming.md
+++ b/doc/philosophy/naming.md
@@ -22,3 +22,83 @@ a method is generic over `element`, `format`, `duration` or `plane` — never `A
 constraint clauses (`element: Encodable in Json`) read as statements about them. The
 convention costs a few characters per declaration and repays them at every reading,
 which is the trade naming should always make.
+
+## Names that form phrases
+
+A name is chosen for how it reads *in position*, not in isolation. The test is whether
+the resulting expression can be read aloud:
+
+```scala
+5.25.pm on 2018-Aug-11
+key.uncloak(message.decrypt.as[Text])
+worktree.merge(GitBranch(t"feature"), ff = FastForward.Never)
+path.open[Directory](Read & Exclusive)
+```
+
+`on` joins a time to a date because that is the English preposition; `uncloak` says what
+happens to a secret; `Read & Exclusive` reads as the mode it names. None would be
+improved by a more literal name, and several would be worse: `combineTimeAndDate` says
+less than `on` and reads far worse.
+
+The same applies to contextual values, which are named for what they *select* rather
+than for their type, since the import is what a reader sees:
+
+```scala
+import strategies.throwUnsafely
+import charEncoders.utf8Encoder
+import dateFormats.iso8601DateFormat
+import probates.cancelProbate
+```
+
+Someone encountering `import strategies.accrue` in unfamiliar code learns something about
+that code from the import line alone.
+
+## Type parameters as words
+
+The convention is easiest to judge by comparison. A signature in the conventional style:
+
+```scala
+def read[T](using R: Readable[S, T]): T
+```
+
+and the same signature in the Soundness style:
+
+```scala
+def read[result](using readable: value is Readable to result): result
+```
+
+The second says what the pieces *are*: `result` is what is produced, `value` what it is
+read from, and the constraint clause reads as a claim about them. No key is needed to
+decode the letters, and there is no room for the mental slip where `T` in one signature
+means something different from `T` in the next.
+
+## Uniqueness is enforced, not aspired to
+
+Name uniqueness is not merely a convention that reviewers watch for. Because every module
+re-exports into one `soundness` namespace, a clash is a compile error in the umbrella
+module — so a collision is discovered when it is introduced, not when a user meets it.
+
+The consequences appear in the repository's history as deliberate renames: aviation's
+`Posix` timeline became `Unix` to free `soundness.Posix` for the filesystem plane;
+`Transmitter`, `Trust` and `enumerate` were renamed when they collided; MathML's element
+types were nested inside `Mathml` rather than shadowing the general names. Each was
+churn, accepted because the alternative — two meanings for one word, qualified forever —
+is a permanent tax on every reader.
+
+## What it costs
+
+**Renaming is disruptive.** A collision found late means changing a published name and
+breaking downstream code. The policy accepts that, on the grounds that the alternative
+compounds.
+
+**Good names are hard to find.** `Teletype` for styled terminal text took thought that
+`AnsiString` would not have, and the search is not always successful on the first
+attempt.
+
+**A namespace of unique names has many names in it.** `import soundness.*` brings in a
+great deal, and a name that looks free may not be — which is the direct price of the
+umbrella import, and why a new module's names are checked against the whole before it is
+added.
+
+See [elegant prose](elegant-prose.md) for what the naming is in service of, and
+[small APIs](small-apis.md) for why there are fewer names to choose than there might be.

--- a/doc/philosophy/optionality.md
+++ b/doc/philosophy/optionality.md
@@ -45,18 +45,23 @@ inhabitants and no agreed meaning, and it arises whenever a lookup that may fail
 a value that may itself be absent. Code that meets one usually flattens it and hopes the
 two absences meant the same thing.
 
-`Optional` cannot nest, because absence has exactly one representation. The compiler
-enforces that rather than trusting to discipline: a type that could not be made optional
-unambiguously is rejected where it is written, so the ambiguous type never arises to be
-flattened away.
+`Optional` cannot stack, and not by a rule that forbids it. `Optional[value]` is the union
+`Unset | value`, and a union absorbs a repeated member, so `Optional[Optional[Int]]`
+*is* `Optional[Int]` — the same type, arrived at by ordinary type equality rather than by
+a check that rejects it.
+
+The ambiguous type therefore never arises to be flattened away. There is no `Some(None)`
+to disambiguate because there is nothing for it to be.
 
 ## What it costs
 
 Two things, and they are worth stating plainly.
 
-The first is that a *generic* method taking an `Optional[value]` needs evidence that
-`value` is a definite type, since an abstract one might later be instantiated to
-something already optional. That evidence appears in the signature:
+The first is the price of that absorption. It works because the compiler can see both
+members of the union — and for an *abstract* type it cannot: a `value` later instantiated
+to something already optional would merge two absences that were meant to be distinct. So
+a generic method taking an `Optional[value]` needs evidence that `value` is a definite
+type, and the evidence appears in the signature:
 
 ```scala
 def firstOrElse[value: Concrete](values: List[Optional[value]], fallback: value): value =

--- a/doc/philosophy/optionality.md
+++ b/doc/philosophy/optionality.md
@@ -7,3 +7,81 @@ present value is simply the value itself and optionality does not stack into nes
 layers. Absence is dealt with where it arises rather than threaded through the whole
 program, which keeps the common case — a value that is present — direct and
 unencumbered. In Soundness, `null` is treated as both unrepresentable and unnecessary.
+
+## Absence without a wrapper
+
+An `Optional[Text]` *is* a `Text`, or it is `Unset`. There is no `Some` to allocate and
+no `Some` to unwrap:
+
+```scala
+val name: Optional[Text] = t"Ada"
+val missing: Optional[Text] = Unset
+
+name.or(t"anonymous")     // t"Ada"
+missing.or(t"anonymous")  // t"anonymous"
+```
+
+The operations read as the questions they answer. `let` transforms a present value and
+leaves an absent one alone; `lay` supplies a fallback and a transformation together;
+`present` and `absent` ask directly; and `vouch` asserts presence where the surrounding
+code has already established it:
+
+```scala
+name.let(_.upper)              // Optional[Text]
+name.lay(t"nobody")(_.upper)   // Text, either way
+name.present                   // true
+name.vouch                     // Text, panicking if that was a lie
+```
+
+## Why the wrapper costs more than it looks
+
+`Option` allocates one object per present value. In a single expression that is
+invisible; in a table of a million records with three optional columns it is three
+million objects that exist only to say "yes, there is one" — and every read of one is a
+pointer to chase.
+
+The deeper cost is that wrappers *stack*. `Option[Option[T]]` is a legal type with three
+inhabitants and no agreed meaning, and it arises whenever a lookup that may fail returns
+a value that may itself be absent. Code that meets one usually flattens it and hopes the
+two absences meant the same thing.
+
+`Optional` cannot nest, because absence has exactly one representation. The compiler
+enforces that rather than trusting to discipline: a type that could not be made optional
+unambiguously is rejected where it is written, so the ambiguous type never arises to be
+flattened away.
+
+## What it costs
+
+Two things, and they are worth stating plainly.
+
+The first is that a *generic* method taking an `Optional[value]` needs evidence that
+`value` is a definite type, since an abstract one might later be instantiated to
+something already optional. That evidence appears in the signature:
+
+```scala
+def firstOrElse[value: Concrete](values: List[Optional[value]], fallback: value): value =
+  values.compact.prim.or(fallback)
+```
+
+The second is that `Optional` is not a monad and does not pretend to be one. There is no
+`flatMap` threading absence through a `for` comprehension. Absence is handled where it
+arises — with `or`, `let` or `lay` — which is the point rather than an omission: a value
+that might be absent is made definite close to where it was obtained, instead of being
+carried through the program in a wrapper that every later step must accommodate.
+
+## Meeting `Option` at the boundary
+
+Other libraries return `Option`, and a Soundness value sometimes has to become one. The
+conversion is explicit in both directions and confined to the boundary:
+
+```scala
+name.option              // Some(t"Ada"): Option[Text]
+Some(t"Ada").optional    // t"Ada": Optional[Text]
+```
+
+Converting at the edge rather than adopting `Option` throughout is the same discipline
+applied to `null`: a foreign representation is translated once, on arrival, and the
+program's interior speaks one language.
+
+See [zero cost](zero-cost.md) for the general principle this is an instance of, and
+[impossible states](impossible-states.md) for why the non-nesting matters.

--- a/doc/philosophy/safety-by-construction.md
+++ b/doc/philosophy/safety-by-construction.md
@@ -26,3 +26,77 @@ an HTML `<br>` given children is a compile error because the specification says 
 In each case the check is not a runtime validation moved earlier, but a construction
 that only admits valid values — so the invalid state has no representation at all, and
 downstream code inherits the guarantee for free.
+
+## One parser, two moments
+
+The property that makes this trustworthy is that the compiletime and runtime paths are
+*the same code*. An interpolator's parsing logic is ordinary Scala; it runs at
+compiletime against a literal, giving a compile error, and at runtime against dynamic
+input, giving a typed error:
+
+```scala
+url"https://example.com/api"          // checked as the code compiles
+text.as[HttpUrl]                      // checked as the program runs
+```
+
+The two cannot drift, because there is nothing to keep in step. A hand-written macro plus
+a separate runtime parser is the arrangement this avoids: two implementations of one
+grammar, differing in exactly the edge cases nobody tested.
+
+The convention is therefore that every checked literal has a runtime counterpart, and a
+value can move between the two — a configuration read from a file and a default written
+in source produce the same type, with the same guarantees.
+
+## Precision in the return type
+
+An interpolator's prefix method is `transparent inline`, so it may return something more
+specific than its declared type. This is what allows a literal to carry what it *is* into
+the type system rather than merely validating itself:
+
+```scala
+p"/home/user/data.csv"                // a Path, on a specific platform
+n"worker"                             // a Name, valid for its plane
+% / "foo" / "bar"                     // Path of ("bar", "foo") — the elements in the type
+```
+
+The last is the strongest form: the path's element names are in its type, so code that
+receives it knows exactly where it points. That precision is only available for literals,
+which is the honest limit of the technique — text obtained at runtime yields the general
+type, because nothing more is known about it.
+
+## What can and cannot be checked this way
+
+The technique applies where validity is a property of the *value*, decidable from the
+value alone. A URL's syntax, a date's existence, a media type's registration, a regular
+expression's balance, a schema's shape: all decidable, all checked.
+
+It does not apply where validity depends on the world. Whether `example.com` resolves,
+whether a file exists, whether a port is free, whether a certificate is still valid —
+none is knowable when the code compiles, and a type claiming otherwise would be lying.
+Those become typed errors at the point of use, which is [total
+transitions](total-transitions.md) doing the work instead.
+
+The line between the two is worth drawing carefully, because the temptation is to over-claim.
+A `Hostname` promises syntactic validity and nothing more, and the documentation says so
+rather than letting a reader infer that a well-typed hostname is a reachable one.
+
+## What it costs
+
+**Compiletime.** Every literal is parsed by the compiler, and a file dense with them
+compiles measurably more slowly. Macro expansion is the single largest contributor to
+Soundness's own build times.
+
+**Error messages are the macro's responsibility.** A compile error from a failed literal is
+only as good as the message the interpolator produces. Getting a caret onto the offending
+character — rather than underlining the whole expression — takes deliberate work with the
+source positions the interpolator is given, and an interpolator that skimps on it produces
+worse diagnostics than a runtime parser would have.
+
+**Literals must be literals.** A URL assembled from parts at compiletime cannot use the
+interpolator's checking unless the parts are themselves literals. The runtime path is
+always available, but the guarantee is weaker, and the shape of the code differs — which
+occasionally pushes a design toward keeping something literal that would otherwise have
+been computed.
+
+See [impossible states](impossible-states.md) for the rule this serves, and
+[interpolation](../modules/interpolation.md) for how such a literal is built.

--- a/doc/philosophy/small-apis.md
+++ b/doc/philosophy/small-apis.md
@@ -6,3 +6,85 @@ family of near-duplicates that differ only in what they apply to. There is one o
 way to do a thing, so there is less to learn, less to remember, and less chance of
 reaching for the wrong variant. The breadth of what an API can do comes from the range
 of types it ranges over, not from the number of methods it offers.
+
+## One verb, many types
+
+`read` parses a source into the type asked for. There is no `readJson`, no `parseXml`,
+no `fromCsv` — the type argument says what is wanted, and an instance for that type does
+the work:
+
+```scala
+source.read[Json]
+source.read[Xml]
+source.read[Markdown of Layout]
+source.read[Raster in Png]
+source.read[Person in Dsv]
+```
+
+Adding a format adds instances, not methods. The vocabulary a reader must learn does not
+grow when the library does.
+
+The same holds throughout. `as` decodes, `show` renders for a person, `inspect` renders
+for a programmer, `in` encodes into a format, `stream` exposes a value as a stream,
+`digest` hashes, `serialize` renders bytes in a base encoding:
+
+```scala
+t"2024-01-15".as[Date]
+t"example.com".as[Hostname]
+
+person.in[Json]
+person.in[Cbor]
+
+payload.digest[Sha2[256]].serialize[Hex]
+```
+
+## What makes it possible
+
+Three things, and none of them is naming discipline alone.
+
+**Typeclasses supply the meaning.** `read` is one method whose behaviour comes from a
+`Readable` instance; `as` from a `Decodable`; `show` from a `Showable`. The method is a
+name for a *relationship*, not for an implementation.
+
+**The type argument carries the intent** that a longer name would otherwise carry.
+`read[Json]` says as much as `readJson` in the same number of characters, and composes:
+`read[Person in Json]` has no reasonable name at all in the other scheme.
+
+**Uniqueness of names makes the umbrella import safe.** Because there is one `Path` and
+one `Error` in the whole of `soundness`, a single `import soundness.*` never forces a
+choice between two things called the same — which is what allows one verb to be
+genuinely one verb rather than several shadowing each other. See
+[naming](naming.md).
+
+## The counter-pressure
+
+A small API is not an API with few capabilities, and the principle is not "add no
+methods". It is a constraint on *how* capability is added: by widening the range of
+types an existing operation covers, before adding an operation.
+
+Two forces push the other way, and both are legitimate in their place.
+
+The first is when an operation genuinely differs. `read` and `load` are two verbs for
+[XML](../modules/xml.md), because reading yields the content and loading yields the
+document with its header — a real distinction, not a variant. Collapsing them would
+force a flag argument, which is a worse way to say the same thing.
+
+The second is when a domain has its own vocabulary that a general verb would obscure. A
+`Tarfile` has `gzip`, not `in[Gzip]`, because "a gzipped tarball" is the thing the domain
+names. Insisting on the general verb everywhere makes an API uniform and unreadable,
+which trades one kind of learning cost for another.
+
+## What it costs
+
+Polymorphic methods put weight on inference and on error messages. When
+`source.read[Person in Json]` fails because an instance is missing, the compiler's
+default complaint is about an implicit search, not about a missing codec — which is
+further from the problem than "no method `readPerson`" would have been.
+
+That cost is paid down rather than denied: importing `explainMissingContext` turns the
+bare implicit error into a diagnosis that names the import which would satisfy it. The
+trade — a slightly worse failure mode for a much smaller vocabulary — is only worth
+making if the failure mode is repaired, so it is.
+
+See [elegant prose](elegant-prose.md) for why the vocabulary being learnable by analogy
+is the real prize, and [composability](composability.md) for what the uniformity buys.

--- a/doc/philosophy/structured-concurrency.md
+++ b/doc/philosophy/structured-concurrency.md
@@ -6,3 +6,96 @@ propagates to its siblings and its parent rather than vanishing unnoticed, and
 cancelling a scope cancels everything beneath it. Concurrent lifetimes nest like the
 blocks of ordinary code, so parallel work has the same clear beginning and end as
 sequential work, and no task outlives the scope that launched it.
+
+## The scope owns the task
+
+`supervise` opens a scope; `async` spawns within it. The scope does not return until its
+children have settled, whether or not anything awaited them:
+
+```scala
+supervise:
+  val first = async(fetch(urlA))
+  val second = async(fetch(urlB))
+
+  (first.await(), second.await())
+```
+
+The unstructured equivalent — starting two threads and hoping — differs in what happens
+when something goes wrong, which is the only case worth designing for.
+
+## What the structure buys
+
+**A failure has somewhere to go.** A thread that throws has nowhere to report to, so its
+exception is printed, or swallowed, or delivered to a handler that has no idea what was
+being attempted. A task's failure propagates to the scope that owns it, which cancels
+that scope's other children — because work undertaken on behalf of a computation that
+has already failed is work nobody wants finished.
+
+**Cancellation reaches the whole subtree.** Cancelling a scope cancels its children,
+which cancel theirs. There is no set of thread references to maintain and no possibility
+of missing one, because the ownership tree already exists.
+
+**Nothing outlives its reason for existing.** A task cannot outlive the scope that
+launched it, so "is that background work still running?" has a structural answer rather
+than an empirical one.
+
+## What happens at the boundary
+
+A scope must decide what to do about a child still running when the parent's body
+finishes, and that decision is explicit rather than assumed. The *probate* names it:
+
+```scala
+import probates.cancelProbate   // unfinished children are cancelled
+import probates.awaitProbate    // the scope waits for them
+```
+
+Both are defensible and neither is safe to guess at, which is why there is no default.
+
+A `daemon` is the deliberate exception: fire-and-forget work that the scope does not wait
+for and cancels when it ends. It still cannot outlive its scope — it is unstructured only
+in that nothing awaits its result.
+
+## Suspension is visible
+
+Waiting is an effect, and it appears in the types like any other. Awaiting a task or a
+promise, sleeping, and yielding all demand a `Monitor` capability, so a method that can
+block says so in its signature:
+
+```scala
+def fetchAll(urls: List[HttpUrl])(using Monitor): List[Text] = …
+```
+
+This is the same discipline that [honest signatures](honest-signatures.md) apply to
+failure. A caller can see, from the type alone, whether a method might park the thread it
+is called on.
+
+Underneath, the unit of execution is a `Strand` rather than a thread, with the four
+operations suspension needs: interrupt, join, park and unpark. Because a supervisor
+supplies strands and a supervisor is a value, a scheduler that is not built on threads —
+an event loop over WebAssembly's waitable sets — plugs in without changing any code that
+spawns or awaits.
+
+## A daemon's errors do not travel backward
+
+One subtlety follows from taking ownership seriously. A daemon's body cannot capture an
+error handler from the code that spawned it, because by the time the daemon fails, that
+code has moved on — delivering the error there would mean resuming a computation that
+has already finished. A failing daemon therefore escalates as a `Fault`, which a program
+intercepts where it handles the unexpected.
+
+This is the kind of case that unstructured concurrency leaves undefined and that
+structure forces into the open: the question "where does this error go?" always has an
+answer, even when the answer is "not where you might have assumed".
+
+## What it costs
+
+Structure constrains what can be expressed. Work that genuinely must outlive its
+initiating scope — a background service started during a request, say — cannot simply be
+spawned and forgotten; it must be owned by a scope that lives long enough, which means
+arranging one. That is more work than starting a thread, and it is more work for a
+reason: an unowned thread is exactly the thing whose lifetime nobody can subsequently
+reason about.
+
+See [delimited scopes](delimited-scopes.md) for the general shape this is an instance of,
+and [capture checking](capture-checking.md) for how escape is made impossible rather than
+merely discouraged.

--- a/doc/philosophy/total-transitions.md
+++ b/doc/philosophy/total-transitions.md
@@ -19,3 +19,88 @@ analysis a programmer would otherwise perform by memory. A deliberately partial 
 still expressible — `.absolve` marks the assertion, visibly and searchably — so the
 discipline costs nothing except accidental partiality, which is the kind that becomes a
 bug.
+
+## Making an operation total
+
+An operation is partial when it has nothing to return for some of its inputs. There are
+three honest ways to make it total, and one dishonest one.
+
+**Widen the return type to admit absence.** A lookup that may find nothing returns an
+`Optional`, so "not found" is a value rather than an exception or a `null`:
+
+```scala
+enumerable.value(t"North")    // Optional[Direction]
+tracked.locate(pointer)       // Optional[Position] — an unresolved path is not an error
+```
+
+**Widen it to admit failure.** Where the caller should know *why*, the operation raises a
+typed error and the response is chosen at the call site:
+
+```scala
+def parsePort(text: Text): Port raises PortError raises NumberError
+```
+
+**Narrow the input type.** Best of all, where it is available: if the operation is
+undefined for some inputs, take an input type that excludes them. `Port` exists precisely
+so that `connect` need not be partial.
+
+The dishonest way is to return a plausible value for the undefined cases — zero, empty,
+the first element — which converts a detectable failure into a wrong answer that
+propagates.
+
+## Exhaustivity as a change-propagation tool
+
+The most valuable consequence of treating exhaustivity warnings as errors is not that
+today's matches are complete. It is what happens tomorrow, when a case is added:
+
+```scala
+enum Connection:
+  case Open(socket: Socket)
+  case Failed(reason: Text)
+  case Closed
+  case Draining          // added today
+```
+
+Every match on `Connection` that has not considered `Draining` now fails to compile, and
+the compiler lists them. That is precisely the analysis a careful programmer would
+otherwise perform from memory, across a codebase they may not have written — done
+exhaustively, in seconds, on every build.
+
+This is why the warning must be an *error*. As a warning it is advisory, and advisory
+diagnostics accumulate until nobody reads them; as an error it is a tool that makes
+adding a case safe.
+
+## Deliberate partiality, marked
+
+Some matches genuinely cannot be exhaustive, usually because the compiler cannot see an
+invariant the code has already established. Suppressing the warning would hide the
+accidental cases along with the deliberate one, so the assertion is marked instead:
+
+```scala
+expr.absolve match
+  case '{ $value: Int } => …
+```
+
+`absolve` is Scala's `runtimeChecked` under a name that reads as what it means. It marks
+one expression, so nothing else is silenced; it is greppable, so every such assertion can
+be found and reviewed; and it is a claim the writer is making, which is exactly the
+status such an assertion should have.
+
+## Where totality is not achievable
+
+Two limits, worth stating.
+
+**The world is partial.** Opening a file that exists may still fail — the disk, the
+permissions, a race with another process. No return type makes that total; the honest
+response is a typed error, which is totality of the *signature* rather than of the
+operation.
+
+**Some invariants outrun the type system.** Whether a hostname resolves, whether two
+independently-validated values are consistent with each other, whether a schema and a
+document that both parsed actually agree — these are checkable, but not by construction.
+The discipline is to make the check produce a value that carries its result, so that
+downstream code inherits the guarantee rather than repeating the check.
+
+See [impossible states](impossible-states.md) for the companion rule — the two are
+useless apart, since total transitions between meaningless states preserve nothing worth
+preserving.

--- a/doc/philosophy/zero-cost.md
+++ b/doc/philosophy/zero-cost.md
@@ -13,12 +13,15 @@ Nothing, in the common case, because they are not there. An opaque type is its u
 representation with a different name for the compiler's purposes only:
 
 ```scala
-opaque type Text = String
-opaque type Quantity[units] = Double
-opaque type Optional[value] = value | Unset.type
+into opaque type Text <: Matchable & caps.Pure = String & caps.Pure
+opaque type Quantity[units <: Measure] = Double
+opaque type Unset <: Matchable & caps.Pure = Null & caps.Pure
 opaque type Location = Long          // latitude and longitude, packed
 opaque type Isin = Long              // a validated security identifier
 ```
+
+`Optional[value]` is then simply `Unset | value` — a union with a null-backed sentinel,
+so an absent value costs one null reference and a present one costs exactly the value.
 
 A `Quantity[Metres[1]]` is a `Double`. A million of them in an array is a million
 doubles, not a million objects. The units exist while the code is being typechecked and

--- a/doc/philosophy/zero-cost.md
+++ b/doc/philosophy/zero-cost.md
@@ -1,10 +1,101 @@
 # Zero Cost
 
-_(A suggested addition — not on the original list.)_
-
 Soundness pays for its safety at compiletime, not at runtime. Opaque types, inlining,
 and type-level computation mean that the guarantees a type carries — the units on a
 quantity, a validated name, a checked path — usually compile down to the bare value they
 wrap, with no wrapper object allocated and no check left to run. Safety is therefore not
 a tax on performance: the very code that is provably correct is also as fast as the
 unchecked version a careless programmer would have written by hand.
+
+## What the types cost at runtime
+
+Nothing, in the common case, because they are not there. An opaque type is its underlying
+representation with a different name for the compiler's purposes only:
+
+```scala
+opaque type Text = String
+opaque type Quantity[units] = Double
+opaque type Optional[value] = value | Unset.type
+opaque type Location = Long          // latitude and longitude, packed
+opaque type Isin = Long              // a validated security identifier
+```
+
+A `Quantity[Metres[1]]` is a `Double`. A million of them in an array is a million
+doubles, not a million objects. The units exist while the code is being typechecked and
+are gone by the time it runs.
+
+The same reasoning covers the operations. They are `inline`, so a dimensional calculation
+becomes the arithmetic instructions the equivalent bare-`Double` code would have produced
+— no wrapper to allocate, no typeclass method to dispatch to:
+
+```scala
+def displacement
+    ( initial: Quantity[Metres[1] & Seconds[-1]],
+      time:    Quantity[Seconds[1]],
+      accel:   Quantity[Metres[1] & Seconds[-2]] )
+:   Quantity[Metres[1]] =
+  initial*time + 0.5*accel*time*time
+```
+
+Every dimension in that signature is checked as the code compiles. None of it survives
+into the bytecode.
+
+## The claim is tested, not asserted
+
+A performance claim that is only stated tends to stop being true — an inline annotation
+removed, a typeclass method that no longer specialises, and the guarantee is quietly
+gone while the documentation still promises it.
+
+So the test suite reads the compiled bytecode and fails if the guarantee has lapsed. It
+parses the classfile, walks the instructions of representative calculations, and asserts
+that no virtual or interface dispatch to a typeclass operation survives and that no
+boxing appears:
+
+```scala
+def callsTypeclassOp(bytecode: Bytecode): Boolean =
+  val ops = Set(t"negate", t"add", t"subtract", t"multiply", t"divide", t"root", t"op")
+  bytecode.instructions.exists: instruction =>
+    instruction.opcode match
+      case Bytecode.Opcode.Invokevirtual(_, name, _)      => ops.has(name)
+      case Bytecode.Opcode.Invokeinterface(_, name, _, _) => ops.has(name)
+      case _                                              => false
+```
+
+The [metaprogramming](../modules/metaprogramming.md) module exists partly to make this
+possible: if a claim about what the compiler emitted is worth making, it is worth
+checking on every build.
+
+## Where the cost is not zero
+
+Being honest about this matters more than the claim itself.
+
+**Checked arithmetic costs what it checks.** Importing `arithmeticOptions.overflow.checked`
+adds a real test to every addition. The default is unchecked, so the cost is paid only
+where it is asked for — but where it is asked for, it is paid.
+
+**Validation costs once, at construction.** Turning text into a `Port` parses and range-checks
+it. The saving is that nothing downstream checks again, not that the first check is free.
+
+**Some safety is genuinely structural.** A `Stream`'s single-ownership discipline is
+enforced by the type system at no runtime cost, but the buffering and windowing that make
+it zero-copy are real machinery. Capture checking proves the machinery is safe; it does
+not make it disappear.
+
+**Compiletime is the bill.** Type-level computation, inlining and macro expansion are work
+done on every build to avoid work on every run. A Soundness project compiles more slowly
+than a loosely-typed equivalent, and `-Xmax-inlines` is a setting that occasionally has to
+be raised. That is the trade, stated in the direction it actually runs.
+
+## Why this principle is load-bearing
+
+Without it, every other principle in this collection becomes a negotiation. A team that
+believes safety costs performance will reach for the unchecked type in the inner loop —
+and the inner loop is exactly where a mistake is most expensive.
+
+If the safe version is also the fast version, the question never arises. That is why
+"zero cost" is treated as a design constraint on new abstractions rather than as a happy
+observation about existing ones: an abstraction that cannot be made to disappear is
+reconsidered before it is added.
+
+See [correctness](correctness.md) for what the compiletime bill buys, and
+[optionality](optionality.md) for the most pervasive instance of a wrapper removed.

--- a/doc/standards/naming.md
+++ b/doc/standards/naming.md
@@ -1,7 +1,10 @@
 # Method Naming Conventions
 
 This document defines the canonical meanings of named factory and initialisation
-methods used consistently across the codebase.
+methods used consistently across the codebase. For *why* names are chosen as they
+are — phrase-forming methods, word-length type parameters, and uniqueness across the
+whole namespace — see [naming](../philosophy/naming.md) and
+[elegant prose](../philosophy/elegant-prose.md).
 
 ## Standard names
 


### PR DESCRIPTION
The twenty-one documents in `doc/philosophy/` state the principles Soundness is designed around, but most stated them in a single paragraph and left the reader to imagine what each looked like in practice. Each now follows the shape the strongest of them already had: the principle, the mechanism that makes it possible, worked code drawn from the real API, and an honest account of what it costs — including the places where the principle is deliberately not applied. Each is also linked from the module tutorial that most directly motivates it, so a reader who meets a design in practice can find the reasoning behind it.

## Documentation

The collection grows from 370 lines to 2,148, and twenty-eight links now connect the module tutorials to the principles they rest on. Nothing outside `doc/` is touched.

Some examples of what the expansions add:

**Zero cost** shows the opaque declarations that make the guarantee real, and the bytecode-shape test that keeps it true — the test suite parses the compiled classfile and fails if a typeclass dispatch or a boxing operation reappears in a dimensional calculation. It also states the four places the cost is genuinely not zero.

**Capture checking** adds separation checking and the exclusive `Stream`, and is candid about the price: annotations that propagate through signatures, errors phrased in terms of capture sets, a feature still maturing on a compiler fork, and the unsafe escape hatches that remain.

**Error handling** shows one fallible signature under four strategies without its body changing, and sets the design against unchecked exceptions, Java's checked exceptions and `Either` — including what `Either` is genuinely better at.

**Impossible states** gives the three ways a type rules a state out, and a worked comparison between a flag-and-optional-field encoding and the enumerated one.

**Declarative context** lists the range of what goes into scope, and states the action-at-a-distance objection rather than deflecting it — including that moving a function between files can change its behaviour while the types still check.

Two corrections to existing content, both found by checking every sample against the source:

- The `IoError` pattern in `expressive-errors.md` had three positions where the case class has four; its illustrative error shape also omitted the code numbers a real `Error` carries. That example is now `IpAddressError`, copied from the source.
- `optionality.md` claimed that nested optionals are rejected. They are not: `Optional[value]` is the union `Unset | value`, so `Optional[Optional[Int]]` *is* `Optional[Int]` by union absorption. The compile check exists only for abstract types, where the compiler cannot see both members.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
