### PR TITLE
Complete and correct the error-code documentation

### DIFF
--- a/doc/errors/001.md
+++ b/doc/errors/001.md
@@ -1,0 +1,22 @@
+# `SN-001` — Query parameter type mismatch
+
+Raised at compiletime when a named query parameter is given a value of the wrong type.
+
+## Cause
+
+Legerdemain builds query strings from named arguments, checking each value against the type
+the parameter was declared to take.
+
+## Example message
+
+```
+[↯SN-001] the parameter <key> takes values of <type>
+```
+
+## Resolution
+
+Supply a value of the declared type, or change the parameter's declaration.
+
+## See also
+
+- Source: `lib/legerdemain/src/core/legerdemain.internal.scala`

--- a/doc/errors/013.md
+++ b/doc/errors/013.md
@@ -20,4 +20,4 @@ Place exactly one space between the two tokens identified.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 1238)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/015.md
+++ b/doc/errors/015.md
@@ -19,4 +19,4 @@ Strip the trailing whitespace; many editors can do this on save.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 435)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/017.md
+++ b/doc/errors/017.md
@@ -46,4 +46,4 @@ A name segment is a reserved Java keyword.
 
 ## See also
 
-- Source: `lib/digression/src/core/digression.FqcnError.scala` (line 51)
+- Source: `lib/digression/src/core/digression.FqcnError.scala`

--- a/doc/errors/029.md
+++ b/doc/errors/029.md
@@ -1,0 +1,29 @@
+# `SN-029` — `recover` argument must be match cases
+
+Raised at compiletime when the argument to `recover` is not written as a literal block of
+`case` clauses.
+
+## Cause
+
+`recover` inspects the cases as the code compiles, so that it knows which error types are
+handled. A partial function computed elsewhere, or passed as a value, cannot be inspected.
+
+## Example message
+
+```
+[↯SN-029] argument to `recover` should be a partial function implemented as match cases
+```
+
+## Resolution
+
+Write the cases inline:
+
+```scala
+recover:
+  case error: IoError => fallback
+. protect(readConfiguration())
+```
+
+## See also
+
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/031.md
+++ b/doc/errors/031.md
@@ -1,0 +1,31 @@
+# `SN-031` — `YamlError`
+
+Raised when a YAML document cannot be parsed, or cannot be read as the type asked for.
+
+## Cause
+
+Ypsiloid reports both parse failures and conversion failures through this error. A parse
+failure means the text is not well-formed YAML; a conversion failure means the document is
+valid but does not have the shape the target type requires.
+
+## Variants
+
+### `SN-031.1` — `NotType`
+
+**Example.** `[↯SN-031.1] the YAML value had type <found> instead of <expected>`
+
+### `SN-031.2` — `Absent`
+
+**Example.** `[↯SN-031.2] the YAML value was not present`
+
+
+## Resolution
+
+For a parse failure, check the document against the YAML specification — indentation and
+block-scalar indicators are the usual culprits. For a conversion failure, compare the
+document's shape with the type's fields; under an accruing strategy every mismatch is
+reported at once, each with a path to the offending node.
+
+## See also
+
+- Source: `lib/ypsiloid/src/core/ypsiloid.YamlError.scala`

--- a/doc/errors/039.md
+++ b/doc/errors/039.md
@@ -23,4 +23,4 @@ text or a truncated patch.
 
 ## See also
 
-- Source: `lib/dissonance/src/core/dissonance.DiffError.scala` (line 38)
+- Source: `lib/dissonance/src/core/dissonance.DiffError.scala`

--- a/doc/errors/044.md
+++ b/doc/errors/044.md
@@ -23,4 +23,4 @@ triggered this halt.
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.internal.scala` (line 68)
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/046.md
+++ b/doc/errors/046.md
@@ -19,4 +19,4 @@ Provide a value in the range `-32768`–`32767`.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (line 144)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/051.md
+++ b/doc/errors/051.md
@@ -22,4 +22,4 @@ Provide a `Double` singleton literal type as the lower bound (e.g.
 
 ## See also
 
-- Source: `lib/cardinality/src/core/cardinality.internal.scala` (line 101)
+- Source: `lib/cardinality/src/core/cardinality.internal.scala`

--- a/doc/errors/059.md
+++ b/doc/errors/059.md
@@ -23,4 +23,4 @@ pointer; correct the source structure.
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.Validation.scala` (line 65)
+- Source: `lib/contingency/src/core/contingency.Validation.scala`

--- a/doc/errors/066.md
+++ b/doc/errors/066.md
@@ -1,0 +1,23 @@
+# `SN-066` — Path is not valid on any platform
+
+Raised at compiletime when a path literal is valid on neither Windows nor POSIX.
+
+## Cause
+
+A path literal whose platform is not stated must be valid on at least one platform for the
+literal to have a meaning.
+
+## Example message
+
+```
+[↯SN-066] The path <name> is not a valid Windows or POSIX path
+```
+
+## Resolution
+
+Correct the path, or state the platform explicitly — a path valid on one platform and not
+the other is accepted when it says which it is for.
+
+## See also
+
+- Source: `lib/galilei/src/core/galilei.internal.scala`

--- a/doc/errors/069.md
+++ b/doc/errors/069.md
@@ -20,4 +20,4 @@ Restructure the method to take exactly one parameter list.
 
 ## See also
 
-- Source: `lib/obligatory/src/core/obligatory.internal.scala` (lines 255 and 354)
+- Source: `lib/obligatory/src/json/obligatory.internal.scala`

--- a/doc/errors/077.md
+++ b/doc/errors/077.md
@@ -78,6 +78,38 @@ The address contains `::` more than once, which would be ambiguous.
 **Resolution.** Use `::` at most once per address; expand any extras
 to explicit `0` groups.
 
+### `SN-077.9` — `Ipv4SubnetPrefixOutOfRange`
+
+An IPv4 subnet's prefix length is outside the range a 32-bit address permits.
+
+**Example.** `[↯SN-077.9] the prefix length 40 is not in the range 0-32`
+
+**Resolution.** Use a prefix length between 0 and 32.
+
+### `SN-077.10` — `Ipv6SubnetPrefixOutOfRange`
+
+An IPv6 subnet's prefix length is outside the range a 128-bit address permits.
+
+**Example.** `[↯SN-077.10] the prefix length 200 is not in the range 0-128`
+
+**Resolution.** Use a prefix length between 0 and 128.
+
+### `SN-077.11` — `SubnetPrefixNotNumeric`
+
+The text after the `/` in a subnet is not a number.
+
+**Example.** `[↯SN-077.11] the prefix length ab is not a number`
+
+**Resolution.** Write the prefix length in decimal, as in `192.168.0.0/24`.
+
+### `SN-077.12` — `SubnetWrongFormat`
+
+A subnet is not a single address and prefix separated by one `/`.
+
+**Example.** `[↯SN-077.12] the subnet contains 3 slash-separated parts instead of 2`
+
+**Resolution.** Write the subnet as `address/prefix`, with exactly one slash.
+
 ## See also
 
-- Source: `lib/urticose/src/core/urticose.IpAddressError.scala` (line 67)
+- Source: `lib/urticose/src/core/urticose.IpAddressError.scala`

--- a/doc/errors/079.md
+++ b/doc/errors/079.md
@@ -24,4 +24,4 @@ Adjust the value to satisfy the rule, or pick a different
 
 ## See also
 
-- Source: `lib/nomenclature/src/core/nomenclature.NameError.scala` (line 38)
+- Source: `lib/nomenclature/src/core/nomenclature.NameError.scala`

--- a/doc/errors/080.md
+++ b/doc/errors/080.md
@@ -1,0 +1,37 @@
+# `SN-080` — `MonikerError`
+
+Raised when a moniker — a stable, compiletime-checked identifier — is not valid.
+
+## Cause
+
+A moniker names something so it can be referred to across edits: a test, a benchmark cell,
+a schema field. Its syntax is restricted so that it can appear unquoted on a command line
+and in a report.
+
+## Variants
+
+### `SN-080.1` — `Unreadable`
+
+**Example.** `[↯SN-080.1] the vocabulary could not be read`
+
+### `SN-080.2` — `OutOfRange`
+
+**Example.** `[↯SN-080.2] the number <n> is outside the representable range`
+
+### `SN-080.3` — `Malformed`
+
+**Example.** `[↯SN-080.3] <name> is not of the form <adjective>-<animal>`
+
+### `SN-080.4` — `UnknownWord`
+
+**Example.** `[↯SN-080.4] the word <word> does not appear in the vocabulary`
+
+
+## Resolution
+
+Use an identifier made of letters, digits and the permitted separators, beginning with a
+letter. The reason names the specific rule that was broken.
+
+## See also
+
+- Source: `lib/nomenclature/src/lexicon/nomenclature.MonikerError.scala`

--- a/doc/errors/081.md
+++ b/doc/errors/081.md
@@ -20,4 +20,4 @@ Use an hour value 0–12; specify `am`/`pm` to disambiguate.
 
 ## See also
 
-- Source: `lib/aviation/src/core/aviation.internal.scala` (line 147)
+- Source: `lib/aviation/src/core/aviation.internal.scala`

--- a/doc/errors/089.md
+++ b/doc/errors/089.md
@@ -21,4 +21,4 @@ one.
 
 ## See also
 
-- Source: `lib/nomenclature/src/core/nomenclature.protointernal.scala` (line 103)
+- Source: `lib/nomenclature/src/core/nomenclature.protointernal.scala`

--- a/doc/errors/091.md
+++ b/doc/errors/091.md
@@ -22,4 +22,4 @@ Rewrite the lambda in a simpler form (e.g. `(x: Int) => x + 1`).
 
 ## See also
 
-- Source: `lib/mandible/src/core/mandible.internal.scala` (line 58)
+- Source: `lib/mandible/src/core/mandible.internal.scala`

--- a/doc/errors/093.md
+++ b/doc/errors/093.md
@@ -21,4 +21,4 @@ Use a minute value 0–59 in the literal.
 
 ## See also
 
-- Source: `lib/aviation/src/core/aviation.internal.scala` (line 145)
+- Source: `lib/aviation/src/core/aviation.internal.scala`

--- a/doc/errors/114.md
+++ b/doc/errors/114.md
@@ -1,0 +1,23 @@
+# `SN-114` — `accrue` argument must be match cases
+
+Raised at compiletime when the argument to `accrue` is not written as a literal block of
+`case` clauses.
+
+## Cause
+
+As with `recover`, the cases are inspected at compiletime to determine which error types are
+accrued, so the argument must be written inline.
+
+## Example message
+
+```
+[↯SN-114] argument to `accrue` should be a partial function implemented as match cases
+```
+
+## Resolution
+
+Write the cases inline rather than passing a partial function computed elsewhere.
+
+## See also
+
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/117.md
+++ b/doc/errors/117.md
@@ -28,4 +28,4 @@ to avoid the foreign throw.
 
 ## See also
 
-- Source: `lib/fulminate/src/core/fulminate.UncheckedError.scala` (line 49)
+- Source: `lib/fulminate/src/core/fulminate.UncheckedError.scala`

--- a/doc/errors/118.md
+++ b/doc/errors/118.md
@@ -19,4 +19,4 @@ Remove or correct the offending character.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (line 67)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/122.md
+++ b/doc/errors/122.md
@@ -1,0 +1,34 @@
+# `SN-122` — `SvgError`
+
+Raised when SVG content cannot be read as the typed figures Savagery models.
+
+## Cause
+
+Savagery parses SVG into typed shapes, paths, gradients and transforms. Content that is
+well-formed XML but not SVG this parser models — an unknown element, or an attribute that
+is not a number where one is required — is reported here.
+
+## Variants
+
+### `SN-122.1` — `NotAnSvg`
+
+**Example.** `[↯SN-122.1] the root element was <<label>> instead of <svg>`
+
+### `SN-122.2` — `MalformedPathData`
+
+**Example.** `[↯SN-122.2] the path data <data> could not be parsed`
+
+### `SN-122.3` — `MalformedColor`
+
+**Example.** `[↯SN-122.3] the color <color> could not be parsed`
+
+
+## Resolution
+
+Check that the element and its attributes are among those Savagery models. An SVG produced
+by a drawing program may contain constructs outside that subset; reading it as plain
+[XML](../modules/xml.md) is the fallback.
+
+## See also
+
+- Source: `lib/savagery/src/core/savagery.SvgError.scala`

--- a/doc/errors/131.md
+++ b/doc/errors/131.md
@@ -38,4 +38,4 @@ Place a single `package <module>` declaration on line 33, where
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 482)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/135.md
+++ b/doc/errors/135.md
@@ -21,4 +21,4 @@ with the appropriate number of spaces.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 293)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/137.md
+++ b/doc/errors/137.md
@@ -1,0 +1,22 @@
+# `SN-137` — Hexadecimal literal has an odd number of digits
+
+Raised at compiletime when a hexadecimal literal does not have an even number of digits.
+
+## Cause
+
+Each byte is two hexadecimal digits, so an odd count leaves one digit that names no whole
+byte.
+
+## Example message
+
+```
+[↯SN-137] a hexadecimal value must have an even number of digits
+```
+
+## Resolution
+
+Add a leading zero to the digit that stands alone.
+
+## See also
+
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/139.md
+++ b/doc/errors/139.md
@@ -19,4 +19,4 @@ Use a port between 1 and 65535.
 
 ## See also
 
-- Source: `lib/urticose/src/core/urticose.PortError.scala` (line 39)
+- Source: `lib/urticose/src/core/urticose.PortError.scala`

--- a/doc/errors/140.md
+++ b/doc/errors/140.md
@@ -1,0 +1,26 @@
+# `SN-140` — `given` continuation alignment
+
+Raised by the Decorum compiler plugin when the house-style rule on `given` continuation alignment is broken.
+
+## Cause
+
+A `=>` continuing a `given` signature onto the next line must align at the column the
+house style prescribes, so that the parts of a multi-line contextual definition line up.
+
+## Example message
+
+```
+[↯SN-140] `=>` continuation of a `given` signature should align at column <s> (found <leadingCols>)
+```
+
+## Resolution
+
+Align the continuation as the message directs. The column follows from the definition's
+anchor rather than being chosen freely.
+
+This is a style rule rather than a correctness one. The house style is set out in
+`doc/standards/syntax.md`.
+
+## See also
+
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/142.md
+++ b/doc/errors/142.md
@@ -55,4 +55,4 @@ header.
 
 ## See also
 
-- Source: `lib/obligatory/src/core/obligatory.FrameError.scala` (line 50)
+- Source: `lib/obligatory/src/core/obligatory.FrameError.scala`

--- a/doc/errors/147.md
+++ b/doc/errors/147.md
@@ -1,0 +1,35 @@
+# `SN-147` — `LspError`
+
+Raised when a Language Server Protocol operation fails.
+
+## Cause
+
+Exegesis implements the LSP wire protocol. This error covers a malformed message, an
+unexpected sequence of messages, and a request the server cannot satisfy.
+
+## Variants
+
+### `SN-147.1` — `ParseError`
+
+**Example.** `[↯SN-147.1] the message could not be parsed as JSON`
+
+### `SN-147.2` — `UnknownMethod`
+
+**Example.** `[↯SN-147.2] the method name was not recognised by the server`
+
+### `SN-147.3` — `InvalidParams`
+
+**Example.** `[↯SN-147.3] the parameters were not valid for the requested method`
+
+
+## Resolution
+
+The reason distinguishes a protocol fault from a request that was well-formed but could not
+be served. A protocol fault usually means client and server disagree about the protocol
+version or the message framing.
+
+> This error previously used the code `SN-631`, which collided with `UpgradeError`.
+
+## See also
+
+- Source: `lib/exegesis/src/core/exegesis.LspError.scala`

--- a/doc/errors/148.md
+++ b/doc/errors/148.md
@@ -19,4 +19,4 @@ Remove or correct the offending character.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (line 99)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/149.md
+++ b/doc/errors/149.md
@@ -19,4 +19,4 @@ Inspect the cause chain. Confirm the input is well-formed XML.
 
 ## See also
 
-- Source: `lib/xylophone/src/core/xylophone.XmlError.scala` (line 42)
+- Source: `lib/xylophone/src/core/xylophone.XmlError.scala`

--- a/doc/errors/151.md
+++ b/doc/errors/151.md
@@ -21,4 +21,4 @@ accessor.
 
 ## See also
 
-- Source: `lib/gossamer/src/core/gossamer.RangeError.scala` (line 40)
+- Source: `lib/gossamer/src/core/gossamer.RangeError.scala`

--- a/doc/errors/159.md
+++ b/doc/errors/159.md
@@ -112,6 +112,6 @@ part to permit it.
 
 ## See also
 
-- Source: `lib/urticose/src/core/urticose.EmailAddressError.scala` (line 73)
+- Source: `lib/urticose/src/core/urticose.EmailAddressError.scala`
 - `SN-892` — hostname validation
 - `SN-077` — IP-address validation

--- a/doc/errors/167.md
+++ b/doc/errors/167.md
@@ -20,4 +20,4 @@ Pad or trim the literal to one of the supported widths.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (line 77)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/169.md
+++ b/doc/errors/169.md
@@ -21,4 +21,4 @@ or similar resource scope).
 
 ## See also
 
-- Source: `lib/obligatory/src/core/obligatory.internal.scala` (line 251)
+- Source: `lib/obligatory/src/json/obligatory.internal.scala`

--- a/doc/errors/191.md
+++ b/doc/errors/191.md
@@ -1,0 +1,29 @@
+# `SN-191` — `DagError`
+
+Raised when a graph operation requires an acyclic graph and the graph has a cycle.
+
+## Cause
+
+A topological sort, a reachability query and a transitive reduction are all undefined on a
+cyclic graph. Rather than looping or returning a partial answer, the operation reports the
+cycle.
+
+## Variants
+
+### `SN-191.1` — `NodeMissing`
+
+**Example.** `[↯SN-191.1] the node <node> is not present in the graph`
+
+### `SN-191.2` — `Cyclic`
+
+**Example.** `[↯SN-191.2] the graph contains a cycle`
+
+
+## Resolution
+
+Break the cycle, or ask a question that is defined on cyclic graphs. `hasCycle` tests for
+one without raising, for code that would rather check than handle.
+
+## See also
+
+- Source: `lib/acyclicity/src/core/acyclicity.DagError.scala`

--- a/doc/errors/205.md
+++ b/doc/errors/205.md
@@ -25,4 +25,4 @@ absent.
 
 ## See also
 
-- Source: `lib/legerdemain/src/core/legerdemain.QueryError.scala` (line 44)
+- Source: `lib/legerdemain/src/core/legerdemain.QueryError.scala`

--- a/doc/errors/218.md
+++ b/doc/errors/218.md
@@ -25,4 +25,4 @@ individually.
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.Errors.scala` (line 54)
+- Source: `lib/contingency/src/core/contingency.Errors.scala`

--- a/doc/errors/224.md
+++ b/doc/errors/224.md
@@ -22,4 +22,4 @@ Provide a `Double` singleton literal type as the upper bound (e.g.
 
 ## See also
 
-- Source: `lib/cardinality/src/core/cardinality.internal.scala` (line 98)
+- Source: `lib/cardinality/src/core/cardinality.internal.scala`

--- a/doc/errors/229.md
+++ b/doc/errors/229.md
@@ -24,4 +24,4 @@ asking for a `Ref` to it.
 
 ## See also
 
-- Source: `lib/anamnesis/src/core/anamnesis.DataError.scala` (line 44)
+- Source: `lib/anamnesis/src/core/anamnesis.DataError.scala`

--- a/doc/errors/230.md
+++ b/doc/errors/230.md
@@ -21,4 +21,4 @@ calls, operators, or after `=`.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 303)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/250.md
+++ b/doc/errors/250.md
@@ -53,4 +53,4 @@ the allowed set `[0-9A-Za-z-]`.
 
 ## See also
 
-- Source: `lib/revolution/src/core/revolution.SemverError.scala` (line 51)
+- Source: `lib/revolution/src/core/revolution.SemverError.scala`

--- a/doc/errors/251.md
+++ b/doc/errors/251.md
@@ -1,0 +1,32 @@
+# `SN-251` — `CssError`
+
+Raised when a stylesheet contains a construct that is not valid CSS.
+
+## Cause
+
+Cataclysm checks property names against the known set and parses selectors against the full
+modern grammar, so a misspelled property or a malformed selector is reported rather than
+passed to a browser that will silently ignore it.
+
+## Variants
+
+| Code | Reason | Message |
+| --- | --- | --- |
+| `SN-251.1` | `UnterminatedComment` | a comment was not terminated |
+| `SN-251.2` | `UnterminatedString` | a string literal was not terminated |
+| `SN-251.3` | `UnexpectedEnd` | the input ended before a rule was closed |
+| `SN-251.4` | `UnexpectedChar` | the character <char> was not expected here |
+| `SN-251.5` | `EmptySelector` | a selector was expected but none was found |
+| `SN-251.6` | `UnknownProperty` | <name> is not a recognized CSS property |
+| `SN-251.7` | `BadValue` | <value> is not a valid value for the <property> property |
+| `SN-251.8` | `UnsupportedValue` | the value of <name> uses an unsupported type |
+| `SN-251.9` | `InvalidName` | <name> is not a valid CSS identifier |
+
+## Resolution
+
+Correct the property name or the selector. Errors accumulate: a rule with several faults
+reports all of them, which is why the error type is plural — `CssErrors` carries the list.
+
+## See also
+
+- Source: `lib/cataclysm/src/core/cataclysm.CssError.scala`

--- a/doc/errors/259.md
+++ b/doc/errors/259.md
@@ -21,4 +21,4 @@ Use an `Optional[T]` value at the call site.
 
 ## See also
 
-- Source: `lib/vacuous/src/core/vacuous.internal.scala` (line 87)
+- Source: `lib/vacuous/src/core/vacuous.internal.scala`

--- a/doc/errors/264.md
+++ b/doc/errors/264.md
@@ -22,4 +22,4 @@ network errors, truncated files, or cancelled producers.
 
 ## See also
 
-- Source: `lib/turbulence/src/core/turbulence.StreamError.scala` (line 39)
+- Source: `lib/turbulence/src/core/turbulence.StreamError.scala`

--- a/doc/errors/265.md
+++ b/doc/errors/265.md
@@ -41,4 +41,4 @@ interface, or bind to `0.0.0.0` / `::` for any interface.
 
 ## See also
 
-- Source: `lib/coaxial/src/core/coaxial.BindError.scala` (line 48)
+- Source: `lib/coaxial/src/core/coaxial.BindError.scala`

--- a/doc/errors/266.md
+++ b/doc/errors/266.md
@@ -1,0 +1,34 @@
+# `SN-266` — `ConnectionError`
+
+Raised when an established socket connection fails during use.
+
+## Cause
+
+This is distinct from a failure to connect, which is a `ConnectError`. A `ConnectionError`
+means the connection was made and then failed — during an accept, a transmission, or a
+close.
+
+## Variants
+
+### `SN-266.1` — `Accept`
+
+**Example.** `[↯SN-266.1] a new connection could not be accepted`
+
+### `SN-266.2` — `Transmit`
+
+**Example.** `[↯SN-266.2] data could not be transmitted to the connection`
+
+### `SN-266.3` — `Close`
+
+**Example.** `[↯SN-266.3] the connection could not be closed cleanly`
+
+
+## Resolution
+
+The reason distinguishes the operation that failed. A connection failing during
+transmission is usually the peer closing, a timeout, or the network; retrying is reasonable
+where the protocol is idempotent.
+
+## See also
+
+- Source: `lib/coaxial/src/core/coaxial.ConnectionError.scala`

--- a/doc/errors/271.md
+++ b/doc/errors/271.md
@@ -18,6 +18,30 @@ thrown.
 
 Install `tmux` and ensure it is on the `PATH` of the process.
 
+### `SN-271.1` — `ShellNotInstalled`
+
+The shell that tmux was asked to run is not on the `PATH`.
+
+**Example.** `[↯SN-271.1] can't drive tmux: the shell binary `fish` is not installed`
+
+**Resolution.** Install the shell, or name one that is present.
+
+### `SN-271.2` — `SessionDied`
+
+The tmux session ended while the program was driving it.
+
+**Example.** `[↯SN-271.2] can't drive tmux: the tmux session terminated unexpectedly`
+
+**Resolution.** The session was killed, or the command inside it exited. Check the tmux server's own logs.
+
+### `SN-271.3` — `ExecFailed`
+
+The `tmux` binary could not be executed at all.
+
+**Example.** `[↯SN-271.3] can't drive tmux: could not execute tmux`
+
+**Resolution.** Install tmux, or ensure it is on the `PATH` of the process.
+
 ## See also
 
-- Source: `lib/exoskeleton/src/rig/exoskeleton.Tmux.scala` (line 137)
+- Source: `lib/exoskeleton/src/rig/exoskeleton.Tmux.scala`

--- a/doc/errors/280.md
+++ b/doc/errors/280.md
@@ -1,0 +1,44 @@
+# `SN-280` — `PdfError`
+
+Raised when a PDF document cannot be read.
+
+## Cause
+
+Facsimile parses PDF's COS object layer directly. This error covers a malformed object, a
+cross-reference table that cannot be trusted, an unsupported encryption handler, and a
+password that does not open the document.
+
+## Variants
+
+| Code | Reason | Message |
+| --- | --- | --- |
+| `SN-280.1` | `NotPdf` | the file does not begin with a PDF header |
+| `SN-280.2` | `Truncated` | the PDF file ended unexpectedly |
+| `SN-280.3` | `MissingStartxref` | no startxref keyword could be found at the end of the file |
+| `SN-280.4` | `MalformedXref` | the cross-reference section at offset <offset> could not be interpreted |
+| `SN-280.5` | `Unparseable` | <expected> was expected at offset <offset> |
+| `SN-280.6` | `MissingObject` | the object <objectNumber> <generation> was missing or invalid |
+| `SN-280.7` | `CircularReference` | resolving the object <objectNumber> returned to itself |
+| `SN-280.8` | `MissingEntry` | the required dictionary entry <key> was absent |
+| `SN-280.9` | `TypeMismatch` | the dictionary entry <key> was not <expected> |
+| `SN-280.10` | `UnknownFilter` | the stream filter <name> is not recognized |
+| `SN-280.11` | `CorruptStream` | a stream could not be decoded with the <filter> filter |
+| `SN-280.12` | `MalformedOperator` | the content operator <operator> had malformed operands |
+| `SN-280.13` | `UnsupportedEncryption` | the encryption scheme (version <version>) is not supported |
+| `SN-280.14` | `BadPassword` | the password was incorrect |
+| `SN-280.15` | `CircularPageTree` | the page tree contains a cycle |
+| `SN-280.16` | `Io` | an I/O operation failed: <detail> |
+| `SN-280.17` | `WriteUnsupported` | this document cannot be written (only an unencrypted, on-disk file with a valid |
+
+## Resolution
+
+Where the cross-reference table is at fault, the reader rebuilds it by scanning for object
+headers, so a document any conformant reader would open should open here too; a fault
+reported anyway means the file is damaged beyond that recovery. A wrong password is
+reported at the point the document is opened, not when a string is first decrypted.
+
+> This error previously used the code `SN-728`, which collided with an obligatory macro error.
+
+## See also
+
+- Source: `lib/facsimile/src/core/facsimile.PdfError.scala`

--- a/doc/errors/282.md
+++ b/doc/errors/282.md
@@ -23,4 +23,4 @@ characters.
 
 ## See also
 
-- Source: `lib/hieroglyph/src/core/hieroglyph.CharEncodeError.scala` (line 37)
+- Source: `lib/hieroglyph/src/core/hieroglyph.CharEncodeError.scala`

--- a/doc/errors/284.md
+++ b/doc/errors/284.md
@@ -1,0 +1,36 @@
+# `SN-284` — `TarError`
+
+Raised when a tar archive cannot be read or written.
+
+## Cause
+
+Bitumen parses tar entries lazily from a byte stream, so a fault is reported when the
+malformed structure is reached rather than when the archive is opened.
+
+## Variants
+
+| Code | Reason | Message |
+| --- | --- | --- |
+| `SN-284.1` | `NameTooLong` | the <field> field is <length> bytes, exceeding the USTAR limit of <maximum> bytes |
+| `SN-284.2` | `BadMagic` | the USTAR magic bytes are not valid (got <actual> bytes) |
+| `SN-284.3` | `BadChecksum` | the header checksum did not match (header recorded <expected> but the recomputed value is <actual>) |
+| `SN-284.4` | `UnknownTypeFlag` | the entry type flag <code> is not recognised |
+| `SN-284.5` | `TruncatedStream` | the archive stream ended unexpectedly (needed <needed> bytes, got <got>) |
+| `SN-284.6` | `BadOctal` | the <field> field did not contain a valid octal value |
+| `SN-284.7` | `BadPaxRecord` | a PAX extended-header record could not be parsed |
+| `SN-284.8` | `BadName` | the entry name <text> is not a valid POSIX relative path |
+| `SN-284.9` | `BadSparseMap` | the GNU sparse map <text> could not be parsed |
+| `SN-284.10` | `DeviceCreationUnsupported` | the special device entry at <path> could not be created on this filesystem |
+| `SN-284.11` | `WriteUnsupported` | TAR archives cannot yet be opened for writing |
+| `SN-284.12` | `AlreadyExists` | an archive already exists at this path |
+| `SN-284.13` | `CannotWrite` | the archive could not be written: <detail> |
+
+## Resolution
+
+A truncated archive usually means an incomplete download or a stream that ended early; a
+checksum failure means a corrupt header. Writing errors generally reflect a value the
+format cannot represent — a name too long for the chosen long-name format, say.
+
+## See also
+
+- Source: `lib/bitumen/src/core/bitumen.TarError.scala`

--- a/doc/errors/285.md
+++ b/doc/errors/285.md
@@ -1,0 +1,33 @@
+# `SN-285` — `OciError`
+
+Raised when an OCI container image is malformed or cannot be read.
+
+## Cause
+
+An OCI image is a tar archive with a prescribed layout: an `oci-layout` marker, an
+`index.json`, and blobs addressed by digest. This error covers a missing or malformed
+member, an unsupported digest algorithm, and a blob whose content does not match its digest.
+
+## Variants
+
+| Code | Reason | Message |
+| --- | --- | --- |
+| `SN-285.1` | `MissingLayout` | the archive does not contain an oci-layout marker |
+| `SN-285.2` | `UnsupportedLayout` | the image layout version <version> is not supported |
+| `SN-285.3` | `MissingIndex` | the archive does not contain an index.json document |
+| `SN-285.4` | `MissingBlob` | the blob <digest> is not present in the archive |
+| `SN-285.5` | `DigestMismatch` | the blob addressed as <expected> has the digest <actual> |
+| `SN-285.6` | `InvalidBlob` | the blob <digest> could not be interpreted: <detail> |
+| `SN-285.7` | `UnsupportedDigest` | the digest algorithm <algorithm> is not supported |
+| `SN-285.8` | `NoManifest` | the image index lists no manifests |
+| `SN-285.9` | `WriteUnsupported` | OCI image archives cannot be opened for writing |
+
+## Resolution
+
+A digest mismatch means the image is corrupt or has been altered, and should not be
+trusted. A missing blob usually means an incomplete pull. `verified` checks digests;
+`layer` and `compressed` do not.
+
+## See also
+
+- Source: `lib/embarcadero/src/oci/embarcadero.OciError.scala`

--- a/doc/errors/287.md
+++ b/doc/errors/287.md
@@ -19,4 +19,4 @@ Provide a value in the range `-128`–`127`.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (line 164)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/293.md
+++ b/doc/errors/293.md
@@ -21,4 +21,4 @@ has not been corrupted. More specific reasons may be added in future.
 
 ## See also
 
-- Source: `lib/mandible/src/core/mandible_core.scala` (line 89)
+- Source: `lib/mandible/src/core/mandible_core.scala`

--- a/doc/errors/295.md
+++ b/doc/errors/295.md
@@ -1,0 +1,28 @@
+# `SN-295` — `ClassfileError`
+
+Raised when a JVM classfile cannot be read or its bytecode extracted.
+
+## Cause
+
+Mandible parses classfiles to expose methods and their instructions. This error covers a
+classfile that is not present on the classpath and one whose structure cannot be parsed.
+
+## Variants
+
+### `SN-295.1` — `ClassfileMissing`
+
+**Example.** `[↯SN-295.1] the generated classfile could not be opened`
+
+### `SN-295.2` — `ClassfileUnreadable`
+
+**Example.** `[↯SN-295.2] the generated classfile could not be read`
+
+## Resolution
+
+A missing classfile usually means the classpath passed to the reader differs from the one
+the code was compiled against. A parse failure means the file is truncated, or uses a
+classfile version beyond what the parser models.
+
+## See also
+
+- Source: `lib/mandible/src/core/mandible_core.scala`

--- a/doc/errors/304.md
+++ b/doc/errors/304.md
@@ -22,4 +22,4 @@ pattern to avoid repetition.
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.internal.scala` (line 109)
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/306.md
+++ b/doc/errors/306.md
@@ -41,4 +41,4 @@ The cause does not match either of the more specific variants.
 
 ## See also
 
-- Source: `lib/superlunary/src/core/superlunary.RemoteError.scala` (line 51)
+- Source: `lib/superlunary/src/core/superlunary.RemoteError.scala`

--- a/doc/errors/312.md
+++ b/doc/errors/312.md
@@ -1,0 +1,29 @@
+# `SN-312` — Lambda bracketing
+
+Raised by the Decorum compiler plugin when the house-style rule on lambda bracketing is broken.
+
+## Cause
+
+How a lambda is bracketed depends on its shape: a multi-line lambda uses the colon-argument
+form, an underscore lambda is wrapped in parentheses, and a named-parameter lambda in braces.
+
+## Variants
+
+| Code | Message |
+| --- | --- |
+| `SN-312.1` | named-parameter lambda must be wrapped in `{…}`, not `(…)` (or use `f: x => …` since the lambda is last on the line) |
+| `SN-312.2` | lambda is the last thing on its line; prefer `f: x => …` over `f { x => … }` |
+| `SN-312.3` | multi-line lambda must use a colon-arg `f: x => …` form, not `<s>` |
+| `SN-312.4` | anonymous (`_`-)lambda must be wrapped in `(…)`, not `<s>` |
+
+## Resolution
+
+Use the form the message names. The rule exists so that a reader can tell a lambda's shape
+from its brackets alone.
+
+This is a style rule rather than a correctness one. The house style is set out in
+`doc/standards/syntax.md`.
+
+## See also
+
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/315.md
+++ b/doc/errors/315.md
@@ -21,4 +21,4 @@ value reported in the message.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 1560)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/323.md
+++ b/doc/errors/323.md
@@ -20,4 +20,4 @@ Bring a `Monitor` into scope at the call site (e.g. via `Daemon`).
 
 ## See also
 
-- Source: `lib/obligatory/src/core/obligatory.internal.scala` (line 252)
+- Source: `lib/obligatory/src/json/obligatory.internal.scala`

--- a/doc/errors/325.md
+++ b/doc/errors/325.md
@@ -21,4 +21,4 @@ encoding of the source.
 
 ## See also
 
-- Source: `lib/monotonous/src/core/monotonous.SerializationError.scala` (line 38)
+- Source: `lib/monotonous/src/core/monotonous.SerializationError.scala`

--- a/doc/errors/326.md
+++ b/doc/errors/326.md
@@ -21,4 +21,4 @@ column within the run.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 1478)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/331.md
+++ b/doc/errors/331.md
@@ -22,4 +22,4 @@ computation to avoid intermediate overflow.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.OverflowError.scala` (line 37)
+- Source: `lib/hypotenuse/src/core/hypotenuse.OverflowError.scala`

--- a/doc/errors/333.md
+++ b/doc/errors/333.md
@@ -38,6 +38,14 @@ month name).
 
 **Resolution.** Use one of the documented names for the kind.
 
+### `SN-333.4` — `Gap`
+
+A wall-clock time names an instant that does not exist, because the clocks moved forward past it.
+
+**Example.** `[↯SN-333.4] the date was not valid because the wall-clock time does not exist in its timezone (a spring-forward DST gap)`
+
+**Resolution.** Choose a `GapPolicy`: the default pushes the time forward past the gap, and others push it backward or raise this error. Import the policy that suits the application.
+
 ## See also
 
-- Source: `lib/aviation/src/core/aviation.TimeError.scala` (line 60)
+- Source: `lib/aviation/src/core/aviation.TimeError.scala`

--- a/doc/errors/337.md
+++ b/doc/errors/337.md
@@ -42,5 +42,5 @@ accessor if the field may legitimately be missing.
 
 ## See also
 
-- Source: `lib/jacinta/src/core/jacinta.JsonError.scala` (line 53)
+- Source: `lib/jacinta/src/core/jacinta.JsonError.scala`
 - `SN-415` — JSON pointer resolution failure

--- a/doc/errors/339.md
+++ b/doc/errors/339.md
@@ -1,25 +1,11 @@
-# `SN-339` — `PositionalError`
+# `SN-339` — `PositionalError` (retired)
 
-Raised by a Contextual `Interpolator` for a parse error whose
-position within the interpolated string is known.
+This error no longer exists. The page is kept so that the code is not reused, and so
+that a reference to it from an older release can still be resolved.
 
-## Cause
+## What became of it
 
-When the interpolator reports an `InterpolationError` with explicit
-offset and length, the macro emits a positional compiler error
-pinned to that span. The runtime form is a `PositionalError`.
-
-## Example message
-
-```
-[↯SN-339] error unexpected character at position 12
-```
-
-## Resolution
-
-Inspect the highlighted span in the source and correct the input
-syntax according to the interpolator's rules.
-
-## See also
-
-- Source: `lib/contextual/src/core/contextual.Interpolator.scala` (line 57 and line 169)
+Contextual's `Interpolator` API, which raised this error, was replaced by the
+`Interpolable` typeclass and the `interpolation[…]` entry point. An interpolator now
+reports a parse failure through its own error type, positioned by the `origins` the
+macro is given, so there is no shared positional error to document.

--- a/doc/errors/340.md
+++ b/doc/errors/340.md
@@ -1,0 +1,21 @@
+# `SN-340` — Port number out of range
+
+Raised at compiletime when a port literal is outside the range 1–65535.
+
+## Cause
+
+TCP and UDP port numbers occupy sixteen bits, and zero is reserved.
+
+## Example message
+
+```
+[↯SN-340] the TCP port number 70000 is not in the range 1-65535
+```
+
+## Resolution
+
+Use a port between 1 and 65535.
+
+## See also
+
+- Source: `lib/urticose/src/core/urticose.internal.scala`

--- a/doc/errors/349.md
+++ b/doc/errors/349.md
@@ -20,4 +20,4 @@ Use a syntactically correct UUID, e.g.
 
 ## See also
 
-- Source: `lib/inimitable/src/core/inimitable.UuidError.scala` (line 38)
+- Source: `lib/inimitable/src/core/inimitable.UuidError.scala`

--- a/doc/errors/350.md
+++ b/doc/errors/350.md
@@ -55,4 +55,4 @@ recent `start` index.
 
 ## See also
 
-- Source: `lib/obligatory/src/core/obligatory.SseError.scala` (line 54)
+- Source: `lib/obligatory/src/json/obligatory.SseError.scala`

--- a/doc/errors/353.md
+++ b/doc/errors/353.md
@@ -58,5 +58,5 @@ omit the suffix.
 
 ## See also
 
-- Source: `lib/gesticulate/src/core/gesticulate.MediaTypeError.scala` (line 62)
+- Source: `lib/gesticulate/src/core/gesticulate.MediaTypeError.scala`
 - `SN-937` — multipart MIME parsing

--- a/doc/errors/353.md
+++ b/doc/errors/353.md
@@ -8,7 +8,7 @@ MIME type).
 Gesticulate parses media types of the form `type/subtype[+suffix]
 [; parameter=value]*`. The variants flag specific syntactic problems.
 The message is `the value $value is not a valid media type;
-${reason.message}`.
+<reason>`.
 
 ## Variants
 

--- a/doc/errors/356.md
+++ b/doc/errors/356.md
@@ -20,4 +20,4 @@ manually.
 
 ## See also
 
-- Source: `lib/mercator/src/core/mercator.internal.scala` (line 156)
+- Source: `lib/mercator/src/core/mercator.internal.scala`

--- a/doc/errors/364.md
+++ b/doc/errors/364.md
@@ -20,6 +20,22 @@ parser was not expecting one.
 **Resolution.** Either escape the quote according to the format's
 quoting rules, or quote the entire field.
 
+### `SN-364.2` — `Absent`
+
+The row has no cell at the position the decoder expected.
+
+**Example.** `[↯SN-364.2] could not decode the cell because the cell was absent`
+
+**Resolution.** Check that the row has as many columns as the target type has fields, remembering that a nested case class spans several columns. A trailing `Optional` field may legitimately be absent.
+
+### `SN-364.3` — `Unparseable`
+
+A cell's text could not be read as the type the field declares.
+
+**Example.** `[↯SN-364.3] could not decode the cell because the value abc could not be parsed as Int`
+
+**Resolution.** Correct the data, or widen the field's type. Under an accruing strategy every bad cell in the file is reported at once.
+
 ## See also
 
-- Source: `lib/caesura/src/core/caesura.DsvError.scala` (line 45)
+- Source: `lib/caesura/src/core/caesura.DsvError.scala`

--- a/doc/errors/366.md
+++ b/doc/errors/366.md
@@ -32,4 +32,4 @@ fix the server or use a different one.
 
 ## See also
 
-- Source: `lib/telekinesis/src/core/telekinesis.HttpResponseError.scala` (line 49)
+- Source: `lib/telekinesis/src/core/telekinesis.HttpResponseError.scala`

--- a/doc/errors/367.md
+++ b/doc/errors/367.md
@@ -1,0 +1,41 @@
+# `SN-367` — `HttpRequestError`
+
+Raised when an HTTP request cannot be constructed or sent.
+
+## Cause
+
+This covers faults in the request itself — a URL that cannot be expressed, an invalid
+header, a body that cannot be framed — as distinct from a failing response, which is an
+`HttpError`, or a failing connection, which is a `ConnectError`.
+
+## Variants
+
+### `SN-367.1` — `Expectation`
+
+**Example.** `[↯SN-367.1] <found> was found when <expected> was expected`
+
+### `SN-367.2` — `Version`
+
+**Example.** `[↯SN-367.2] the HTTP version <value> was invalid`
+
+### `SN-367.3` — `Host`
+
+**Example.** `[↯SN-367.3] the host <value> was missing or invalid`
+
+### `SN-367.4` — `UriTooLong`
+
+**Example.** `[↯SN-367.4] the request line exceeded the maximum length`
+
+### `SN-367.5` — `HeadersTooLarge`
+
+**Example.** `[↯SN-367.5] the request headers exceeded the maximum size`
+
+
+## Resolution
+
+The reason names the part of the request at fault. A header value containing a line break,
+or a method the transport does not support, are the common cases.
+
+## See also
+
+- Source: `lib/telekinesis/src/core/telekinesis.HttpRequestError.scala`

--- a/doc/errors/368.md
+++ b/doc/errors/368.md
@@ -1,0 +1,34 @@
+# `SN-368` — `WebsocketError`
+
+Raised when a WebSocket peer violates the protocol.
+
+## Cause
+
+Perihelion implements RFC 6455 strictly, including the requirements other implementations
+often relax: masking, fragmentation rules, control-frame limits, UTF-8 validity of text
+frames, and the permitted close codes.
+
+## Variants
+
+| Code | Reason | Message |
+| --- | --- | --- |
+| `SN-368.1` | `Unmasked` | the client sent an unmasked frame |
+| `SN-368.2` | `BadOpcode` | the frame used the reserved opcode <code> |
+| `SN-368.3` | `BadControl` | a control frame was fragmented or exceeded 125 bytes |
+| `SN-368.4` | `BadFragmentation` | the message fragmentation was invalid |
+| `SN-368.5` | `TooLarge` | the frame payload of <size> bytes exceeded the limit |
+| `SN-368.6` | `InvalidText` | a text frame contained invalid UTF-8 |
+| `SN-368.7` | `ReservedBits` | a reserved header bit (RSV1/2/3) was set |
+| `SN-368.8` | `BadClose` | the close frame had a malformed payload or invalid code |
+| `SN-368.9` | `Masked` | the server sent a masked frame |
+| `SN-368.10` | `Handshake` | the WebSocket handshake failed because <detail> |
+
+## Resolution
+
+A violation is the peer's fault rather than the local program's; the right response is
+usually to close the connection with the appropriate close code, which the implementation
+does. The message names the requirement that was broken.
+
+## See also
+
+- Source: `lib/perihelion/src/core/perihelion.WebsocketError.scala`

--- a/doc/errors/372.md
+++ b/doc/errors/372.md
@@ -21,4 +21,4 @@ code.
 
 ## See also
 
-- Source: `lib/profanity/src/core/profanity.DismissError.scala` (line 38)
+- Source: `lib/profanity/src/core/profanity.DismissError.scala`

--- a/doc/errors/374.md
+++ b/doc/errors/374.md
@@ -1,0 +1,34 @@
+# `SN-374` — `OutletError`
+
+Raised when audio cannot be played to an output device.
+
+## Cause
+
+An outlet is a physical or virtual audio output. This error covers a device that is not
+available, one that is in use, and one that cannot accept the audio's sample rate, bit
+depth or channel layout.
+
+## Variants
+
+### `SN-374.1` — `Unavailable`
+
+**Example.** `[↯SN-374.1] the audio line could not be opened`
+
+### `SN-374.2` — `UnsupportedConfiguration`
+
+**Example.** `[↯SN-374.2] the requested configuration is not supported`
+
+### `SN-374.3` — `Closed`
+
+**Example.** `[↯SN-374.3] the playback has already been stopped`
+
+
+## Resolution
+
+Check the device is present and not exclusively held by another process. Where the
+configuration is at fault, convert the audio to a format the device accepts, or query the
+outlet before playing.
+
+## See also
+
+- Source: `lib/cacophony/src/core/cacophony.OutletError.scala`

--- a/doc/errors/380.md
+++ b/doc/errors/380.md
@@ -20,4 +20,4 @@ Remove or rename overloads, or supply a `Functor` instance manually.
 
 ## See also
 
-- Source: `lib/mercator/src/core/mercator.internal.scala` (line 117)
+- Source: `lib/mercator/src/core/mercator.internal.scala`

--- a/doc/errors/383.md
+++ b/doc/errors/383.md
@@ -22,4 +22,4 @@ the MTA is reachable. More specific reasons may be added in future.
 
 ## See also
 
-- Source: `lib/caduceus/src/core/caduceus.CourierError.scala` (line 40)
+- Source: `lib/caduceus/src/core/caduceus.CourierError.scala`

--- a/doc/errors/385.md
+++ b/doc/errors/385.md
@@ -82,4 +82,4 @@ classpath; the Aviation distribution provides them.
 
 ## See also
 
-- Source: `lib/aviation/src/core/aviation.TzdbError.scala` (line 60)
+- Source: `lib/aviation/src/core/aviation.TzdbError.scala`

--- a/doc/errors/389.md
+++ b/doc/errors/389.md
@@ -47,4 +47,4 @@ The input was empty.
 
 ## See also
 
-- Source: `lib/enigmatic/src/core/enigmatic.PemError.scala` (line 51)
+- Source: `lib/enigmatic/src/core/enigmatic.PemError.scala`

--- a/doc/errors/397.md
+++ b/doc/errors/397.md
@@ -117,4 +117,4 @@ repeated subpattern entirely if it should never match.
 
 ## See also
 
-- Source: `lib/kaleidoscope/src/core/kaleidoscope.RegexError.scala` (line 85)
+- Source: `lib/kaleidoscope/src/core/kaleidoscope.RegexError.scala`

--- a/doc/errors/398.md
+++ b/doc/errors/398.md
@@ -20,4 +20,4 @@ Move the `object` declaration above the type declaration.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 1350)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/401.md
+++ b/doc/errors/401.md
@@ -1,0 +1,28 @@
+# `SN-401` — Type cannot be proven distinct from a union
+
+Raised at compiletime when a type cannot be shown to be distinct from the members of a
+union.
+
+## Cause
+
+`Optional[value]` is the union `Unset | value`, which relies on the compiler being able to
+see that `value` is not itself `Unset`. For an abstract type it cannot, so the evidence is
+requested explicitly.
+
+## Example message
+
+```
+[↯SN-401] type <T> cannot be proven distinct from <union>
+```
+
+## Resolution
+
+Require `Concrete` evidence for the type parameter:
+
+```scala
+def firstOrElse[value: Concrete](values: List[Optional[value]], fallback: value): value
+```
+
+## See also
+
+- Source: `lib/vacuous/src/core/vacuous.internal.scala`

--- a/doc/errors/402.md
+++ b/doc/errors/402.md
@@ -25,4 +25,4 @@ different rule (see `SN-811`).
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 928)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/405.md
+++ b/doc/errors/405.md
@@ -39,4 +39,4 @@ clamp the value before decoding.
 
 ## See also
 
-- Source: `lib/distillate/src/core/distillate.NumberError.scala` (line 49)
+- Source: `lib/distillate/src/core/distillate.NumberError.scala`

--- a/doc/errors/415.md
+++ b/doc/errors/415.md
@@ -22,7 +22,31 @@ located.
 document` before resolving pointers that reference it; or
 override `Registry.lookup` to fetch the document on demand.
 
+### `SN-415.2` — `ExpectedHash`
+
+A JSON reference does not begin with `#`.
+
+**Example.** `[↯SN-415.2] the JSON reference was not valid because a JSON reference must begin with '#'`
+
+**Resolution.** Begin the reference with `#`, as in `#/foo/bar`.
+
+### `SN-415.3` — `ExpectedSlash`
+
+A JSON reference's fragment does not begin with `/`.
+
+**Example.** `[↯SN-415.3] the JSON reference was not valid because a JSON reference fragment must begin with '/'`
+
+**Resolution.** Begin the fragment with `/`, as in `#/foo`. A bare `#` addressing the whole document is also valid.
+
+### `SN-415.4` — `BadEscape`
+
+A `~` in a JSON reference is not followed by `0` or `1`.
+
+**Example.** `[↯SN-415.4] the JSON reference was not valid because a '~' in a JSON reference must be followed by '0' or '1'`
+
+**Resolution.** Escape a literal `~` as `~0` and a literal `/` as `~1`. No other escape is defined.
+
 ## See also
 
-- Source: `lib/jacinta/src/core/jacinta.JsonPointerError.scala` (line 44)
+- Source: `lib/jacinta/src/core/jacinta.JsonPointerError.scala`
 - `SN-337` — typed JSON access errors

--- a/doc/errors/418.md
+++ b/doc/errors/418.md
@@ -1,0 +1,28 @@
+# `SN-418` — `NetworkInterfaceError`
+
+Raised when a network interface cannot be enumerated or looked up.
+
+## Cause
+
+Interfaces are read from the operating system. This error covers a name matching no
+interface, and a failure of the underlying enumeration.
+
+## Variants
+
+### `SN-418.1` — `Enumeration`
+
+**Example.** `[↯SN-418.1] the network interfaces could not be enumerated because <message>`
+
+### `SN-418.2` — `Inspection`
+
+**Example.** `[↯SN-418.2] the interface <name> could not be inspected because <message>`
+
+
+## Resolution
+
+Check the name against `NetworkInterface.all()`, which lists what is actually present.
+Interface names are not portable between operating systems.
+
+## See also
+
+- Source: `lib/urticose/src/core/urticose.NetworkInterfaceError.scala`

--- a/doc/errors/420.md
+++ b/doc/errors/420.md
@@ -75,4 +75,4 @@ The value of a `u=` (uncertainty) parameter was not a valid number.
 
 ## See also
 
-- Source: `lib/geodesy/src/core/geodesy.GeolocationError.scala` (line 56)
+- Source: `lib/geodesy/src/core/geodesy.GeolocationError.scala`

--- a/doc/errors/421.md
+++ b/doc/errors/421.md
@@ -23,4 +23,4 @@ Use a documented escape sequence; for a literal backslash, write
 
 ## See also
 
-- Source: `lib/fulminate/src/core/fulminate.EscapeError.scala` (line 35)
+- Source: `lib/fulminate/src/core/fulminate.EscapeError.scala`

--- a/doc/errors/423.md
+++ b/doc/errors/423.md
@@ -22,4 +22,4 @@ Contingency's pattern-aware operations.
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.internal.scala` (line 115)
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/427.md
+++ b/doc/errors/427.md
@@ -50,4 +50,4 @@ size, or build a smaller permutation.
 
 ## See also
 
-- Source: `lib/metamorphose/src/core/metamorphose.PermutationError.scala` (line 59)
+- Source: `lib/metamorphose/src/core/metamorphose.PermutationError.scala`

--- a/doc/errors/430.md
+++ b/doc/errors/430.md
@@ -1,0 +1,28 @@
+# `SN-430` — `MathmlError`
+
+Raised when MathML content cannot be read as the typed elements Archimedes models.
+
+## Cause
+
+Archimedes represents MathML as typed elements, so an element or attribute outside the
+subset it models cannot be constructed or parsed.
+
+## Variants
+
+### `SN-430.1` — `NotMathml`
+
+**Example.** `[↯SN-430.1] the root element was <<label>> instead of <math>`
+
+### `SN-430.2` — `UnknownElement`
+
+**Example.** `[↯SN-430.2] the element <<label>> is not a known MathML element`
+
+
+## Resolution
+
+Check the element against the MathML specification and against what Archimedes models.
+Presentation MathML is covered more fully than content MathML.
+
+## See also
+
+- Source: `lib/archimedes/src/core/archimedes.MathmlError.scala`

--- a/doc/errors/431.md
+++ b/doc/errors/431.md
@@ -1,0 +1,44 @@
+# `SN-431` — `ErgoError`
+
+Raised when a mathematical expression written in the Ergo shorthand cannot be parsed.
+
+## Cause
+
+Ergo is a compact syntax for mathematical notation, expanded into MathML. This error covers
+a malformed expression: unbalanced grouping, an unknown operator, or a missing operand.
+
+## Variants
+
+### `SN-431.1` — `Empty`
+
+**Example.** `[↯SN-431.1] the expression was empty`
+
+### `SN-431.2` — `BadOpener`
+
+**Example.** `[↯SN-431.2] the expression must start with a bracket, not <char>`
+
+### `SN-431.3` — `Unclosed`
+
+**Example.** `[↯SN-431.3] a group was not closed with <expected>`
+
+### `SN-431.4` — `UnexpectedEnd`
+
+**Example.** `[↯SN-431.4] the expression ended unexpectedly`
+
+### `SN-431.5` — `MissingBody`
+
+**Example.** `[↯SN-431.5] the <char> introducer must be followed by a group`
+
+### `SN-431.6` — `Unsupported`
+
+**Example.** `[↯SN-431.6] the <<label>> element has no ergo representation`
+
+
+## Resolution
+
+The message names the position and the construct at fault. Where an expression is genuinely
+complex, writing the MathML directly is the alternative.
+
+## See also
+
+- Source: `lib/archimedes/src/core/archimedes.ErgoError.scala`

--- a/doc/errors/438.md
+++ b/doc/errors/438.md
@@ -23,4 +23,4 @@ while server errors (5xx) usually warrant a retry.
 
 ## See also
 
-- Source: `lib/telekinesis/src/core/telekinesis.HttpError.scala` (line 41)
+- Source: `lib/telekinesis/src/core/telekinesis.HttpError.scala`

--- a/doc/errors/440.md
+++ b/doc/errors/440.md
@@ -43,4 +43,4 @@ stopped one.
 
 ## See also
 
-- Source: `lib/cacophony/src/core/cacophony.FeedError.scala` (line 49)
+- Source: `lib/cacophony/src/core/cacophony.FeedError.scala`

--- a/doc/errors/441.md
+++ b/doc/errors/441.md
@@ -20,4 +20,4 @@ Add a blank line after the last `import`.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 587)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/443.md
+++ b/doc/errors/443.md
@@ -1,0 +1,36 @@
+# `SN-443` — `LinkError`
+
+Raised when linking a compilation into an artifact fails.
+
+## Cause
+
+Linking turns a compilation's output into an executable JAR, a JavaScript bundle, a native
+binary or an Android package. This error covers the linker terminating abnormally, and the
+entry-point requirements each artifact imposes.
+
+## Variants
+
+### `SN-443.1` — `Failed`
+
+**Example.** `[↯SN-443.1] the linker terminated abnormally`
+
+### `SN-443.3` — `NoEntryPoint`
+
+**Example.** `[↯SN-443.3] a native executable requires exactly one entry point`
+
+### `SN-443.4` — `ManyEntryPoints`
+
+**Example.** `[↯SN-443.4] an executable JAR permits at most one entry point`
+
+
+## Resolution
+
+An executable JAR permits at most one entry point and a native executable requires exactly
+one; the reason says which rule was broken. A linker that terminated abnormally carries its
+stack trace.
+
+> This error previously used the code `SN-779`, which collided with `CompilerError`.
+
+## See also
+
+- Source: `lib/anthology/src/linker/anthology.LinkError.scala`

--- a/doc/errors/444.md
+++ b/doc/errors/444.md
@@ -26,4 +26,4 @@ Adjust the leading whitespace on the continuation line to match.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 1253 and 1261)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/454.md
+++ b/doc/errors/454.md
@@ -21,4 +21,4 @@ an issue.
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.internal.scala` (line 118)
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/461.md
+++ b/doc/errors/461.md
@@ -19,4 +19,4 @@ Provide a value in the range `-32768`–`32767`.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (line 145)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/465.md
+++ b/doc/errors/465.md
@@ -21,4 +21,4 @@ introduce the `Unset` case explicitly.
 
 ## See also
 
-- Source: `lib/vacuous/src/core/vacuous.internal.scala` (line 47)
+- Source: `lib/vacuous/src/core/vacuous.internal.scala`

--- a/doc/errors/470.md
+++ b/doc/errors/470.md
@@ -20,4 +20,4 @@ Add the missing case(s), or use a wildcard fallback.
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.internal.scala` (line 110)
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/472.md
+++ b/doc/errors/472.md
@@ -1,0 +1,33 @@
+# `SN-472` — `RedraftError`
+
+Raised when a redraft cannot be applied to a source.
+
+## Cause
+
+A redraft states only the lines to remove and add, and finds where they belong. This error
+covers a redraft whose removals do not appear in the source, and one whose placement is
+ambiguous because they appear more than once.
+
+## Variants
+
+### `SN-472.1` — `NoMatch`
+
+**Example.** `[↯SN-472.1] no matching line could be found in the original`
+
+### `SN-472.2` — `Ambiguous`
+
+**Example.** `[↯SN-472.2] the change could be interpreted in more than one way`
+
+### `SN-472.3` — `Unanchored`
+
+**Example.** `[↯SN-472.3] there is not enough context to locate the change unambiguously`
+
+
+## Resolution
+
+Ambiguity is reported rather than resolved by guessing, so an edit is never applied in the
+wrong place. Add surrounding context lines to make the placement unique.
+
+## See also
+
+- Source: `lib/dissonance/src/core/dissonance.RedraftError.scala`

--- a/doc/errors/473.md
+++ b/doc/errors/473.md
@@ -1,0 +1,34 @@
+# `SN-473` — Quote and splice layout
+
+Raised by the Decorum compiler plugin when the house-style rule on quote and splice layout is broken.
+
+## Cause
+
+The layout of a quoted or spliced block is prescribed in detail: where the opener sits, how
+far the body is indented, where the closing brace goes, and what spacing surrounds an inline
+quote. Staged code then reads consistently with the code around it.
+
+## Variants
+
+| Code | Message |
+| --- | --- |
+| `SN-473.1` | indent <leadingCols> cannot exceed previous line's indent <s> by more than <step> |
+| `SN-473.2` | closing `}` of a multi-line quote/splice at column <cols> does not align with its opening `{` at column <opener> |
+| `SN-473.3` | `<arr>` and `{` of a multi-line quote/splice must be separated by exactly one space |
+| `SN-473.4` | the `<arr> {` opener of a multi-line quote/splice must be alone on its line (only enclosing `(` / `{` permitted) |
+| `SN-473.5` | body of a multi-line quote/splice must be indented to column <top> (found <leadingCols>) |
+| `SN-473.6` | closing `}` of a multi-line quote/splice must be alone on its line (only trailing `)` / `}` permitted) |
+| `SN-473.7` | no space is permitted directly after `<prefix><text>` in an inline quote/splice |
+| `SN-473.8` | indented scope body must be indented to column <top> (anchor + 2); found column <leadingCols> |
+| `SN-473.9` | the body-introducing `=` of a multi-line definition signature must be the last token on the signature's final line |
+
+## Resolution
+
+Follow the layout the message names; the sub-code identifies which aspect is at fault.
+
+This is a style rule rather than a correctness one. The house style is set out in
+`doc/standards/syntax.md`.
+
+## See also
+
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/487.md
+++ b/doc/errors/487.md
@@ -21,4 +21,4 @@ is being applied to and confirm it matches the documented form.
 
 ## See also
 
-- Source: `lib/nomenclature/src/core/nomenclature.protointernal.scala` (lines 142, 145)
+- Source: `lib/nomenclature/src/core/nomenclature.protointernal.scala`

--- a/doc/errors/493.md
+++ b/doc/errors/493.md
@@ -21,4 +21,4 @@ non-interactive code path.
 
 ## See also
 
-- Source: `lib/profanity/src/core/profanity.TerminalError.scala` (line 39)
+- Source: `lib/profanity/src/core/profanity.TerminalError.scala`

--- a/doc/errors/514.md
+++ b/doc/errors/514.md
@@ -23,4 +23,4 @@ HostnameError`.
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.internal.scala` (line 140)
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/515.md
+++ b/doc/errors/515.md
@@ -50,4 +50,4 @@ ISIN body that caused the mismatch.
 
 ## See also
 
-- Source: `lib/plutocrat/src/core/plutocrat.IsinError.scala` (line 59)
+- Source: `lib/plutocrat/src/core/plutocrat.IsinError.scala`

--- a/doc/errors/519.md
+++ b/doc/errors/519.md
@@ -24,4 +24,4 @@ matches it exactly (case sensitivity, anchors, etc.).
 
 ## See also
 
-- Source: `lib/gnossienne/src/core/gnossienne.ReferenceError.scala` (line 45)
+- Source: `lib/gnossienne/src/core/gnossienne.ReferenceError.scala`

--- a/doc/errors/520.md
+++ b/doc/errors/520.md
@@ -20,4 +20,4 @@ Match against an element node, not the doctype.
 
 ## See also
 
-- Source: `lib/honeycomb/src/core/honeycomb.Honeycomb.scala` (line 200)
+- Source: `lib/honeycomb/src/core/honeycomb.Honeycomb.scala`

--- a/doc/errors/521.md
+++ b/doc/errors/521.md
@@ -64,5 +64,5 @@ typically a low-level I/O fault.
 
 ## See also
 
-- Source: `lib/enigmatic/src/core/enigmatic.CryptoError.scala` (line 52)
+- Source: `lib/enigmatic/src/core/enigmatic.CryptoError.scala`
 - `SN-389` — `PemError`, raised when PEM-encoded keys cannot be parsed

--- a/doc/errors/522.md
+++ b/doc/errors/522.md
@@ -1,0 +1,29 @@
+# `SN-522` — `KeystoreError`
+
+Raised when a PKCS#12 keystore cannot be opened or read.
+
+## Cause
+
+A keystore is opened for the duration of a scope, with its password supplied as a flag.
+This error covers a store that cannot be read and a write that is not supported.
+
+## Variants
+
+### `SN-522.1` — `Unreadable`
+
+**Example.** `[↯SN-522.1] the keystore could not be read with the given password`
+
+### `SN-522.2` — `WriteUnsupported`
+
+**Example.** `[↯SN-522.2] keystores cannot yet be opened for writing`
+
+
+## Resolution
+
+A wrong password and a corrupt store are deliberately indistinguishable — both are
+`Unreadable` — since telling them apart would reveal which of the two went wrong to someone
+guessing. Writing to a keystore is not yet supported.
+
+## See also
+
+- Source: `lib/enigmatic/src/core/enigmatic.KeystoreError.scala`

--- a/doc/errors/532.md
+++ b/doc/errors/532.md
@@ -37,4 +37,4 @@ A group contains characters that are not hex digits.
 
 ## See also
 
-- Source: `lib/urticose/src/core/urticose.MacAddressError.scala` (line 56)
+- Source: `lib/urticose/src/core/urticose.MacAddressError.scala`

--- a/doc/errors/537.md
+++ b/doc/errors/537.md
@@ -89,4 +89,4 @@ after `ESC`.
 
 ## See also
 
-- Source: `lib/yossarian/src/core/yossarian.PtyEscapeError.scala` (line 65)
+- Source: `lib/yossarian/src/core/yossarian.PtyEscapeError.scala`

--- a/doc/errors/538.md
+++ b/doc/errors/538.md
@@ -19,4 +19,4 @@ Remove or rename overloads, or supply a `Monad` instance manually.
 
 ## See also
 
-- Source: `lib/mercator/src/core/mercator.internal.scala` (line 157)
+- Source: `lib/mercator/src/core/mercator.internal.scala`

--- a/doc/errors/540.md
+++ b/doc/errors/540.md
@@ -20,4 +20,4 @@ that the resource is included in the build artefact.
 
 ## See also
 
-- Source: `lib/hellenism/src/core/hellenism.ClasspathError.scala` (line 38)
+- Source: `lib/hellenism/src/core/hellenism.ClasspathError.scala`

--- a/doc/errors/541.md
+++ b/doc/errors/541.md
@@ -21,4 +21,4 @@ Use a JVM-supported encoding name. Standard encodings like
 
 ## See also
 
-- Source: `lib/hieroglyph/src/core/hieroglyph.internal.scala` (line 69)
+- Source: `lib/hieroglyph/src/core/hieroglyph.internal.scala`

--- a/doc/errors/545.md
+++ b/doc/errors/545.md
@@ -53,4 +53,4 @@ that can read the directory.
 
 ## See also
 
-- Source: `lib/surveillance/src/core/surveillance.WatchError.scala` (line 52)
+- Source: `lib/surveillance/src/core/surveillance.WatchError.scala`

--- a/doc/errors/546.md
+++ b/doc/errors/546.md
@@ -1,0 +1,36 @@
+# `SN-546` — `YamlPathError`
+
+Raised when a YAML path expression is malformed.
+
+## Cause
+
+A YAML path names a location within a document. Its syntax is checked when written as a
+literal and when parsed at runtime, by the same parser.
+
+## Variants
+
+### `SN-546.1` — `UnknownDocument`
+
+**Example.** `[↯SN-546.1] the registry contains no document at the path's URL`
+
+### `SN-546.2` — `ExpectedHash`
+
+**Example.** `[↯SN-546.2] a YAML path must begin with '#'`
+
+### `SN-546.3` — `ExpectedSlash`
+
+**Example.** `[↯SN-546.3] a YAML path fragment must begin with '/'`
+
+### `SN-546.4` — `BadEscape`
+
+**Example.** `[↯SN-546.4] a '~' in a YAML path must be followed by '0' or '1'`
+
+
+## Resolution
+
+The reason names the character or construct at fault. A path must begin at the root, and
+each step must be a key or an index.
+
+## See also
+
+- Source: `lib/ypsiloid/src/core/ypsiloid.YamlPathError.scala`

--- a/doc/errors/552.md
+++ b/doc/errors/552.md
@@ -22,4 +22,4 @@ failure is expected.
 
 ## See also
 
-- Source: `lib/parasite/src/core/parasite.RetryError.scala` (line 37)
+- Source: `lib/parasite/src/core/parasite.RetryError.scala`

--- a/doc/errors/557.md
+++ b/doc/errors/557.md
@@ -22,4 +22,4 @@ the lookup with a unit that is already part of the `Quanta`.
 
 ## See also
 
-- Source: `lib/abacist/src/core/abacist.internal.scala` (line 157)
+- Source: `lib/abacist/src/core/abacist.internal.scala`

--- a/doc/errors/560.md
+++ b/doc/errors/560.md
@@ -1,0 +1,29 @@
+# `SN-560` — Multi-line interpolated-string layout
+
+Raised by the Decorum compiler plugin when the house-style rule on multi-line interpolated-string layout is broken.
+
+## Cause
+
+The content of a multi-line interpolated string begins on the line after the opening quotes,
+and its lines are indented consistently with the opening.
+
+## Variants
+
+| Code | Message |
+| --- | --- |
+| `SN-560.1` | the content of a multi-line `<info><q>` string must begin on the line after the opening quotes |
+| `SN-560.2` | the content of a multi-line `<info><q>` string must be indented to column <expected> |
+| `SN-560.3` | a line of a multi-line `<info><q>` string must not be indented less than the first content line (column <expected>) |
+| `SN-560.4` | the closing `<q>` of a multi-line `<info><q>` string must be alone on its line, aligned with the opening quotes (column <col>) |
+
+## Resolution
+
+Move the content onto its own line and indent it as the message directs, which keeps the
+string's content visually distinct from the code around it.
+
+This is a style rule rather than a correctness one. The house style is set out in
+`doc/standards/syntax.md`.
+
+## See also
+
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/562.md
+++ b/doc/errors/562.md
@@ -1,0 +1,28 @@
+# `SN-562` — `XPathError`
+
+Raised when an XML path expression is malformed.
+
+## Cause
+
+The `xp"…"` interpolator checks a path as the code compiles; the same parser reads a path
+obtained at runtime, and reports a fault here.
+
+## Variants
+
+### `SN-562.1` — `ExpectedSlash`
+
+**Example.** `[↯SN-562.1] an XPath must begin with '/'`
+
+### `SN-562.2` — `BadStep`
+
+**Example.** `[↯SN-562.2] the path step is not a valid XPath step`
+
+
+## Resolution
+
+A step is a name with an optional ordinal in brackets, or `@` followed by an attribute
+name. The reason names the position at fault.
+
+## See also
+
+- Source: `lib/xylophone/src/core/xylophone.XPathError.scala`

--- a/doc/errors/564.md
+++ b/doc/errors/564.md
@@ -40,6 +40,14 @@ indicating the file is not a font Phoenicia recognises.
 **Resolution.** Confirm the file is a TrueType or OpenType font and
 not corrupted; check that the file was opened in binary mode.
 
+### `SN-564.4` — `MissingEncoding`
+
+The font declares no character-to-glyph mapping this reader can use.
+
+**Example.** `[↯SN-564.4] the font contains no usable character encoding`
+
+**Resolution.** Use a font with a Unicode `cmap` subtable. A font carrying only a legacy Macintosh or symbol encoding cannot map characters to glyphs.
+
 ## See also
 
-- Source: `lib/phoenicia/src/core/phoenicia.FontError.scala` (line 49)
+- Source: `lib/phoenicia/src/core/phoenicia.FontError.scala`

--- a/doc/errors/569.md
+++ b/doc/errors/569.md
@@ -21,4 +21,4 @@ of the type, or supply an `Identity` instance manually.
 
 ## See also
 
-- Source: `lib/mercator/src/core/mercator.internal.scala` (line 85)
+- Source: `lib/mercator/src/core/mercator.internal.scala`

--- a/doc/errors/570.md
+++ b/doc/errors/570.md
@@ -20,4 +20,4 @@ etc.) and is correctly encoded.
 
 ## See also
 
-- Source: `lib/telekinesis/src/core/telekinesis.AuthError.scala` (line 39)
+- Source: `lib/telekinesis/src/core/telekinesis.AuthError.scala`

--- a/doc/errors/582.md
+++ b/doc/errors/582.md
@@ -20,4 +20,4 @@ Pad the minutes to two digits (e.g. write `9.05` rather than `9.5`).
 
 ## See also
 
-- Source: `lib/aviation/src/core/aviation.internal.scala` (line 156)
+- Source: `lib/aviation/src/core/aviation.internal.scala`

--- a/doc/errors/585.md
+++ b/doc/errors/585.md
@@ -20,4 +20,4 @@ Bring or derive a `Functor` instance first.
 
 ## See also
 
-- Source: `lib/mercator/src/core/mercator.internal.scala` (line 130)
+- Source: `lib/mercator/src/core/mercator.internal.scala`

--- a/doc/errors/586.md
+++ b/doc/errors/586.md
@@ -1,0 +1,19 @@
+# `SN-586` — `ToolchainError`
+
+Raised when a native tool the linker needs is not on the `PATH`.
+
+## Cause
+
+Linking a native binary or an Android package shells out to tools the JVM does not
+provide — `clang` for native linking, and R8 and the signing tools for an APK. This error
+names the tool that could not be found.
+
+## Resolution
+
+Install the named tool, or add it to the `PATH` of the process running the build.
+
+> This error previously used the code `SN-779`, which collided with `CompilerError`.
+
+## See also
+
+- Source: `lib/anthology/src/linker/anthology.ToolchainError.scala`

--- a/doc/errors/589.md
+++ b/doc/errors/589.md
@@ -90,4 +90,4 @@ reported code.
 
 ## See also
 
-- Source: `lib/tarantula/src/core/tarantula.WebDriverError.scala` (line 60)
+- Source: `lib/tarantula/src/core/tarantula.WebDriverError.scala`

--- a/doc/errors/591.md
+++ b/doc/errors/591.md
@@ -21,4 +21,4 @@ via `.or`.
 
 ## See also
 
-- Source: `lib/vacuous/src/core/vacuous.UnsetError.scala` (line 38)
+- Source: `lib/vacuous/src/core/vacuous.UnsetError.scala`

--- a/doc/errors/593.md
+++ b/doc/errors/593.md
@@ -20,4 +20,4 @@ Bring an `Online` instance into scope at the call site.
 
 ## See also
 
-- Source: `lib/obligatory/src/core/obligatory.internal.scala` (line 250)
+- Source: `lib/obligatory/src/json/obligatory.internal.scala`

--- a/doc/errors/594.md
+++ b/doc/errors/594.md
@@ -21,4 +21,4 @@ problem in the input.
 
 ## See also
 
-- Source: `lib/zephyrine/src/core/zephyrine.ParseError.scala` (line 39)
+- Source: `lib/zephyrine/src/core/zephyrine.ParseError.scala`

--- a/doc/errors/595.md
+++ b/doc/errors/595.md
@@ -1,0 +1,34 @@
+# `SN-595` — `CborError`
+
+Raised when CBOR data cannot be decoded.
+
+## Cause
+
+Breviloquence decodes CBOR strictly, reporting the byte offset at which a fault was found.
+This error covers truncated input, trailing bytes after a complete value, reserved head
+bytes, and values that do not fit the type asked for.
+
+## Variants
+
+| Code | Reason | Message |
+| --- | --- | --- |
+| `SN-595.1` | `Truncated` | the input was truncated at byte <offset> |
+| `SN-595.2` | `Reserved` | a reserved CBOR head byte <byte> was found at byte <offset> |
+| `SN-595.3` | `BadSimpleValue` | an invalid simple value <value> was found at byte <offset> |
+| `SN-595.4` | `InvalidUtf8` | invalid UTF-8 was found at byte <offset> |
+| `SN-595.5` | `Overflow` | an integer too large for Long was found at byte <offset> |
+| `SN-595.6` | `UnexpectedBreak` | an unexpected break stop code was found at byte <offset> |
+| `SN-595.7` | `Trailing` | unexpected trailing bytes were found from byte <offset> |
+| `SN-595.8` | `OutOfRange` | the array index was out of range |
+| `SN-595.9` | `NotType` | the CBOR value had type <found> instead of <expected> |
+| `SN-595.10` | `NonStringKey` | the map key was not a string |
+| `SN-595.11` | `Absent` | the CBOR value was not present |
+
+## Resolution
+
+For a binary format the offset is most of the diagnosis: render the document in RFC 8949
+diagnostic notation with `show` to see what the bytes around it mean.
+
+## See also
+
+- Source: `lib/breviloquence/src/core/breviloquence.CborError.scala`

--- a/doc/errors/596.md
+++ b/doc/errors/596.md
@@ -1,0 +1,32 @@
+# `SN-596` — `CoseError`
+
+Raised when a COSE structure is malformed or its signature does not verify.
+
+## Cause
+
+COSE — CBOR Object Signing and Encryption — carries signed and encrypted payloads in CBOR.
+This error covers a structure that does not match the specification's shape, an algorithm
+that is not supported, and a signature that does not verify.
+
+## Variants
+
+| Code | Reason | Message |
+| --- | --- | --- |
+| `SN-596.1` | `MalformedStructure` | the COSE structure was not well-formed |
+| `SN-596.2` | `UnknownTag` | the CBOR tag <tag> is not a COSE message tag |
+| `SN-596.3` | `UnsupportedAlgorithm` | the COSE algorithm identifier <id> is not supported |
+| `SN-596.4` | `AlgorithmMismatch` | expected COSE algorithm <want> but found <got> |
+| `SN-596.5` | `VariantMismatch` | expected a <want> COSE message but found a <got> |
+| `SN-596.6` | `VerificationFailed` | the COSE signature or MAC did not verify |
+| `SN-596.7` | `CborParseError` | the COSE message contained malformed CBOR |
+| `SN-596.8` | `DetachedPayloadRequired` | the COSE message has a detached payload |
+
+## Resolution
+
+A signature that does not verify means the payload has been altered or the wrong key was
+used, and the payload must not be trusted. A structural fault usually means producer and
+consumer disagree about which COSE message type is in use.
+
+## See also
+
+- Source: `lib/enigmatic/src/cose/enigmatic.CoseError.scala`

--- a/doc/errors/602.md
+++ b/doc/errors/602.md
@@ -1,0 +1,25 @@
+# `SN-602` — No handler available for the error type
+
+Raised at compiletime when fallible code is used with no strategy in scope for the error it
+raises.
+
+## Cause
+
+A `raises` clause is discharged by a `Tactic` in scope. Without one, the compiler cannot
+decide what a failure should do.
+
+## Example message
+
+```
+[↯SN-602] There is no available handler for IoError
+```
+
+## Resolution
+
+Import a strategy — `strategies.throwUnsafely` while prototyping — or handle the error with
+`recover`, `safely` or `accrue`. Importing `explainMissingContext` makes the compiler name
+the imports that would satisfy the search.
+
+## See also
+
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/605.md
+++ b/doc/errors/605.md
@@ -1,0 +1,78 @@
+# `SN-605` — `TelError`
+
+Raised when a TEL document is not valid.
+
+## Cause
+
+TEL is an indentation-structured language with a schema layer, and this error covers the
+whole of its syntax: the pragma line, indentation, literals, comments, tabulation and schema
+conformance. Every reason carries the position at which it was found.
+
+## Variants
+
+| Code | Reason | Message |
+| --- | --- | --- |
+| `SN-605.101` | `BomPresent` | the document begins with a byte-order mark |
+| `SN-605.102` | `PragmaNotFirst` | the pragma is not the first non-blank line |
+| `SN-605.103` | `PragmaTooLong` | the pragma extends beyond the first 4096 bytes |
+| `SN-605.104` | `BadVersion` | the pragma version is not of the form x.y |
+| `SN-605.105` | `BadSigil` | the pragma sigil is not a permitted symbolic character |
+| `SN-605.106` | `LessThanMargin` | the line begins with fewer spaces than the document margin |
+| `SN-605.107` | `OddIndentation` | the relative indentation after the margin is odd |
+| `SN-605.108` | `TrailingSpaces` | the non-blank line has trailing spaces |
+| `SN-605.109` | `CommentNotPreceded` | the comment is not preceded by a blank line, comment, start, or lesser indent |
+| `SN-605.110` | `UnmatchedDedent` | the line indent does not match any open compound |
+| `SN-605.111` | `OverIndentation` | the line is indented more than one level deeper than the previous compound |
+| `SN-605.112` | `ChildOfNonCompound` | the line is a child of a comment, tabulation, or tabulated row |
+| `SN-605.113` | `DuplicateSource` | the compound already has a source or literal atom |
+| `SN-605.114` | `DuplicateLiteral` | the compound already has a source or literal atom |
+| `SN-605.115` | `UnclosedLiteral` | the literal atom reaches end of file before its closing delimiter |
+| `SN-605.116` | `RowWrongIndent` | the tabulated row has a different indent from its tabulation line |
+| `SN-605.117` | `HardSpaceWrongPosition` | a hard space on the tabulated row does not end at a column boundary |
+| `SN-605.118` | `ConsecutiveSpacesInValue` | consecutive spaces appear within a keyword or column value |
+| `SN-605.119` | `ColumnValueTooWide` | the column value exceeds the maximum width for its column |
+| `SN-605.120` | `BadTabulationHeading` | the tabulation line heading is malformed |
+| `SN-605.121` | `BadLineEnding` | line endings are inconsistent or a CR is not followed by an LF |
+| `SN-605.122` | `BadSchemaIdentifier` | the schema identifier is neither a valid URL nor a BASE-256 schema signature |
+| `SN-605.123` | `ExtraPragmaContent` | the pragma line has extra atoms or a remark |
+| `SN-605.201` | `DuplicateKeywordInStruct` | the same keyword appears more than once in a struct |
+| `SN-605.202` | `EmptySelectVariants` | the SelectDefinition has an empty variants list |
+| `SN-605.203` | `RootRequiredAtom` | the root struct has a required atom-assignable member |
+| `SN-605.204` | `DefaultOnOptional` | a non-required member must not specify a default |
+| `SN-605.205` | `DuplicateLayerName` | two or more layers share the same name |
+| `SN-605.206` | `LayerKeywordCollision` | the layer introduces a keyword colliding with the base |
+| `SN-605.207` | `LayerFieldTypeMismatch` | a layer Field's declared type conflicts with the base |
+| `SN-605.208` | `BadSchemaSigil` | the schema sigil is not a permitted symbolic character |
+| `SN-605.209` | `TelKeywordReserved` | the keyword `tel` is reserved in user schemas |
+| `SN-605.210` | `UnresolvedReference` | a Reference or SelectRef names an undeclared TypeName |
+| `SN-605.211` | `DuplicateDefinition` | two or more Definitions share the same name |
+| `SN-605.212` | `ExcludeMissingVariant` | Exclude names a variant absent from the base |
+| `SN-605.213` | `ExcludeEmptiesRequired` | Exclude would empty a SelectDefinition that a required SelectRef references |
+| `SN-605.214` | `LayerVariantAddition` | a layer SelectDefinition introduces a variant absent from the base |
+| `SN-605.215` | `LayerLoosenRequired` | a layer cannot loosen the `required` axis |
+| `SN-605.216` | `LayerLoosenRepeatable` | a layer cannot loosen the `repeatable` axis |
+| `SN-605.217` | `ExcludeOutsideSelect` | Exclude appears outside a SelectDefinition body |
+| `SN-605.218` | `ReferenceKindMismatch` | a Reference / SelectRef resolves to a Definition of the wrong kind |
+| `SN-605.301` | `NonStructCompound` | the compound's type is not a Struct |
+| `SN-605.302` | `TooManyAtoms` | more atoms than assignable member positions |
+| `SN-605.303` | `AtomAtNonAssignablePos` | the atom is at a non-atom-assignable member position |
+| `SN-605.304` | `AtomVariantUnmatched` | the atom text matches no variant keyword of the SelectRef |
+| `SN-605.305` | `AtomFlagKeywordMismatch` | the atom text does not match the Flag member's keyword |
+| `SN-605.306` | `UnknownKeyword` | the compound keyword is not recognised for the parent |
+| `SN-605.307` | `RequiredMemberAbsent` | a required member is absent and has no default |
+| `SN-605.308` | `NonRepeatableTooMany` | a non-repeatable member is filled more than once |
+| `SN-605.309` | `MembersNonContiguous` | compound children of the same member are not contiguous |
+| `SN-605.310` | `ValidatorRejected` | a scalar value or struct failed a named validator |
+| `SN-605.311` | `FlagWithContent` | the Flag-typed compound has atoms or compound children |
+| `SN-605.401` | `Absent` | a required value was absent |
+| `SN-605.402` | `NotScalar` | the value <value> could not be parsed as <expected> |
+
+## Resolution
+
+The message names the position and the rule. Parsing recovers where it can, so a document
+with several faults reports each rather than stopping at the first, and the schema informs
+the recovery — an ambiguously indented line is attached to the candidate the schema admits.
+
+## See also
+
+- Source: `lib/stratiform/src/core/stratiform.TelError.scala`

--- a/doc/errors/606.md
+++ b/doc/errors/606.md
@@ -1,0 +1,41 @@
+# `SN-606` — `MutationError`
+
+Raised when an edit to a TEL document cannot be applied.
+
+## Cause
+
+TEL documents are edited through mutation operations addressed by a pointer, which change
+exactly what they name and leave the surrounding presentation alone. This error covers a
+pointer that does not resolve and an operation that does not apply to what it names.
+
+## Variants
+
+### `SN-606.1` — `PointerNotFound`
+
+**Example.** `[↯SN-606.1] the pointer does not resolve to a compound`
+
+### `SN-606.2` — `AtomIndexOutOfRange`
+
+**Example.** `[↯SN-606.2] the atom index is out of range for the target compound`
+
+### `SN-606.3` — `RemarkAbsent`
+
+**Example.** `[↯SN-606.3] the target compound has no remark to remove`
+
+### `SN-606.4` — `FlagAlreadySet`
+
+**Example.** `[↯SN-606.4] the flag is already set on the target compound`
+
+### `SN-606.5` — `FlagNotSet`
+
+**Example.** `[↯SN-606.5] the flag is not set on the target compound`
+
+## Resolution
+
+Check the pointer against the document — a compound removed by an earlier operation in the
+same sequence is the usual cause. Operations apply in order, so each sees the result of
+those before it.
+
+## See also
+
+- Source: `lib/stratiform/src/core/stratiform.MutationError.scala`

--- a/doc/errors/607.md
+++ b/doc/errors/607.md
@@ -1,0 +1,24 @@
+# `SN-607` — `Base256Error`
+
+Raised when BASE-256 encoded data is malformed.
+
+## Cause
+
+BASE-256 is the encoding TEL uses to carry binary data in a text document. This error means
+the encoded text contains a character the alphabet does not define.
+
+## Variants
+
+### `SN-607.1` — `NotInAlphabet`
+
+**Example.** `[↯SN-607.1] the character `<character>` (<cp>) at position <position> is not in the BASE-256 alphabet`
+
+## Resolution
+
+The data has been altered in transit, or re-encoded by something that did not preserve the
+byte values — a text editor changing line endings, or a transport that is not eight-bit
+clean.
+
+## See also
+
+- Source: `lib/stratiform/src/base256/stratiform.Base256Error.scala`

--- a/doc/errors/608.md
+++ b/doc/errors/608.md
@@ -1,0 +1,28 @@
+# `SN-608` — `VarintError`
+
+Raised when a variable-length integer in BinTEL is malformed.
+
+## Cause
+
+BinTEL encodes integers as varints, seven bits per byte with a continuation flag. This error
+covers a varint that runs past the end of the input and one too long to represent the value
+it claims.
+
+## Variants
+
+### `SN-608.1` — `Truncated`
+
+**Example.** `[↯SN-608.1] the varint is truncated — a continuation byte was expected`
+
+### `SN-608.2` — `Overflow`
+
+**Example.** `[↯SN-608.2] the varint encodes a value that does not fit in 64 bits`
+
+## Resolution
+
+The stream is truncated or corrupt. A varint longer than the target type permits usually
+means reader and writer disagree about the field's type.
+
+## See also
+
+- Source: `lib/stratiform/src/binary/stratiform.VarintError.scala`

--- a/doc/errors/609.md
+++ b/doc/errors/609.md
@@ -1,0 +1,36 @@
+# `SN-609` — `BintelError`
+
+Raised when a BinTEL document cannot be decoded.
+
+## Cause
+
+BinTEL is TEL's binary encoding, guided by a schema. This error covers malformed framing, a
+schema signature that does not match the reader's schema, and content that does not conform
+to the schema it claims.
+
+## Variants
+
+| Code | Reason | Message |
+| --- | --- | --- |
+| `SN-609.1` | `BadMagic` | the magic number is missing or matches neither B2 C4 B5 BB (external mode) nor B2 C4 B5 BC (self-contained mode) |
+| `SN-609.2` | `VarintError` | a variable-length integer in the stream is invalid |
+| `SN-609.3` | `BadSignatureLength` | the schema signature length is not a valid palimpsest length under any (H, k_i, k_r) |
+| `SN-609.4` | `BadSignature` | the schema signature does not decode against the library |
+| `SN-609.5` | `BadKeywordIndex` | a keyword index exceeds the parent's flat-keyword count |
+| `SN-609.6` | `ValueTruncated` | a Scalar value's byte length extends beyond end of input |
+| `SN-609.7` | `BadUtf8` | a Scalar value's bytes are not valid UTF-8 |
+| `SN-609.8` | `TrailingBytes` | the document root completed with input bytes remaining |
+| `SN-609.9` | `UnexpectedEoi` | the decoder requested bytes beyond end of input |
+| `SN-609.10` | `ReferenceUnresolved` | a Reference type in the schema does not resolve |
+| `SN-609.11` | `EmbeddedSignatureMismatch` | the signature recomputed from the embedded schema body does not equal the carried signature |
+| `SN-609.12` | `EmbeddedSchemaUndecodable` | the embedded schema body does not decode as a valid TEL document under tel-schema |
+
+## Resolution
+
+A signature mismatch means the reader holds a different schema from the writer; check the
+signature before decoding rather than after. A self-contained frame carries its schema, so
+it decodes without one being held locally.
+
+## See also
+
+- Source: `lib/stratiform/src/binary/stratiform.BintelError.scala`

--- a/doc/errors/613.md
+++ b/doc/errors/613.md
@@ -21,4 +21,4 @@ the constraint type is accessible from the call site.
 
 ## See also
 
-- Source: `lib/nomenclature/src/core/nomenclature.protointernal.scala` (line 151)
+- Source: `lib/nomenclature/src/core/nomenclature.protointernal.scala`

--- a/doc/errors/616.md
+++ b/doc/errors/616.md
@@ -1,0 +1,28 @@
+# `SN-616` — Symbolic infix operator continuation
+
+Raised by the Decorum compiler plugin when the house-style rule on symbolic infix operator continuation is broken.
+
+## Cause
+
+An infix operator continuing an expression onto another line terminates the first line
+rather than beginning the second, and the continuation is indented two columns past the
+anchor.
+
+## Variants
+
+| Code | Message |
+| --- | --- |
+| `SN-616.1` | a multi-line infix operator must terminate the first line, not begin the continuation line |
+| `SN-616.2` | a multi-line infix continuation must be indented <op> columns (found <op>) |
+
+## Resolution
+
+Move the operator to the end of the first line and indent the continuation as directed.
+Reading down the left margin then shows the structure of the expression.
+
+This is a style rule rather than a correctness one. The house style is set out in
+`doc/standards/syntax.md`.
+
+## See also
+
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/624.md
+++ b/doc/errors/624.md
@@ -1,4 +1,4 @@
-# `SN-624` — `RecordSchemaError`
+# `SN-624` — `JsonBlueprintError`
 
 Raised when a JSON value does not satisfy the schema it is being
 validated against.
@@ -50,4 +50,4 @@ loosen the pattern.
 
 ## See also
 
-- Source: `lib/jacinta/src/records/jacinta.RecordSchemaError.scala`
+- Source: `lib/jacinta/src/records/jacinta.JsonBlueprintError.scala`

--- a/doc/errors/630.md
+++ b/doc/errors/630.md
@@ -45,4 +45,4 @@ interface.
 
 ## See also
 
-- Source: `lib/synesthesia/src/core/synesthesia.McpError.scala` (line 48)
+- Source: `lib/synesthesia/src/core/synesthesia.McpError.scala`

--- a/doc/errors/631.md
+++ b/doc/errors/631.md
@@ -1,0 +1,36 @@
+# `SN-631` — `UpgradeError`
+
+Raised when a daemon cannot apply an upgrade to itself.
+
+## Cause
+
+An Ethereal application can replace its own binary. This error covers a download that
+failed, a signature that does not verify, and a replacement that could not be written.
+
+## Variants
+
+### `SN-631.1` — `CannotReadSource`
+
+**Example.** `[↯SN-631.1] the upgrade source could not be read`
+
+### `SN-631.2` — `CannotWritePending`
+
+**Example.** `[↯SN-631.2] the .pending file could not be written`
+
+### `SN-631.3` — `CannotResolveLauncher`
+
+**Example.** `[↯SN-631.3] the running launcher's path is not available`
+
+### `SN-631.4` — `CannotRespawnLauncher`
+
+**Example.** `[↯SN-631.4] the launcher could not be relaunched`
+
+## Resolution
+
+A signature failure means the replacement is not signed by the key built into the running
+binary, and it must not be installed. Where no public key was built in, self-upgrade is not
+available at all.
+
+## See also
+
+- Source: `lib/ethereal/src/core/ethereal.UpgradeError.scala`

--- a/doc/errors/632.md
+++ b/doc/errors/632.md
@@ -22,4 +22,4 @@ sufficient privilege.
 
 ## See also
 
-- Source: `lib/scintillate/src/server/scintillate.ServerError.scala` (line 38)
+- Source: `lib/scintillate/src/server/scintillate.ServerError.scala`

--- a/doc/errors/648.md
+++ b/doc/errors/648.md
@@ -21,4 +21,4 @@ Rewrite the argument as `{ case … => …; case … => … }`.
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.internal.scala` (line 284)
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/658.md
+++ b/doc/errors/658.md
@@ -20,4 +20,4 @@ Insert a single blank line on line 34.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 519)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/659.md
+++ b/doc/errors/659.md
@@ -21,4 +21,4 @@ Remove or rename the extra `apply` overloads, or supply an
 
 ## See also
 
-- Source: `lib/mercator/src/core/mercator.internal.scala` (line 86)
+- Source: `lib/mercator/src/core/mercator.internal.scala`

--- a/doc/errors/660.md
+++ b/doc/errors/660.md
@@ -1,23 +1,10 @@
-# `SN-660` — Interpolator extension method must be `inline`
+# `SN-660` — Interpolator extension method must be `inline` (retired)
 
-Raised at compile time when the `StringContext` extension method
-that calls the Contextual `Interpolator` is not declared `inline`.
+This error no longer exists. The page is kept so that the code is not reused, and so
+that a reference to it from an older release can still be resolved.
 
-## Cause
+## What became of it
 
-Contextual relies on `inline` to expand the interpolator at the call
-site. If the parameter is not `inline`, the macro cannot proceed.
-
-## Example message
-
-```
-[↯SN-660] the StringContext extension method parameter does not appear to be inline
-```
-
-## Resolution
-
-Mark the relevant parameter (or the extension method) as `inline`.
-
-## See also
-
-- Source: `lib/contextual/src/core/contextual.Interpolator.scala` (line 150)
+This check belonged to Contextual's `Interpolator` API, which was replaced by the
+`Interpolable` typeclass. A prefix method is now declared `transparent inline` as part of
+the pattern, and the requirement is enforced by the signature rather than by a check.

--- a/doc/errors/677.md
+++ b/doc/errors/677.md
@@ -22,4 +22,4 @@ Insert a blank line after the return-type line.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 1300)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/683.md
+++ b/doc/errors/683.md
@@ -1,0 +1,22 @@
+# `SN-683` — Value exceeds its upper bound
+
+Raised at compiletime when a literal is greater than the maximum its bounded type permits.
+
+## Cause
+
+A bounded numeric type carries its range in its type, so a literal outside the range is
+rejected where it is written.
+
+## Example message
+
+```
+[↯SN-683] the value 1.5 is greater than the upper bound for this value, 1.0
+```
+
+## Resolution
+
+Use a value within the range, or widen the type's bounds.
+
+## See also
+
+- Source: `lib/cardinality/src/core/cardinality.internal.scala`

--- a/doc/errors/685.md
+++ b/doc/errors/685.md
@@ -139,7 +139,111 @@ repository.
 **Resolution.** Run the operation against a non-bare clone, or use a
 form of the operation that does not need a work tree.
 
+### `SN-685.14` — `ResetFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.14] the Git operation could not be completed because the reset operation failed`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.15` — `MvFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.15] the Git operation could not be completed because the move operation failed`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.16` — `ReflogFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.16] the Git operation could not be completed because the reflog could not be read`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.17` — `DiffFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.17] the Git operation could not be completed because the diff could not be computed`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.18` — `WorktreeFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.18] the Git operation could not be completed because the worktree operation failed`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.19` — `MergeFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.19] the Git operation could not be completed because the merge could not be completed`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.20` — `CherryPickFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.20] the Git operation could not be completed because the cherry-pick could not be completed`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.21` — `RevertFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.21] the Git operation could not be completed because the revert could not be completed`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.22` — `RemoteFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.22] the Git operation could not be completed because the remote operation failed`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.23` — `CheckoutFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.23] the Git operation could not be completed because the checkout could not be completed`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.24` — `PushFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.24] the Git operation could not be completed because the push operation failed`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.25` — `NotesFailed`
+
+The `git` invocation for this operation exited with a failure status.
+
+**Example.** `[↯SN-685.25] the Git operation could not be completed because the notes operation failed`
+
+**Resolution.** Git's own output on the error stream explains what went wrong; the operation is reported here as having failed, not why. Run the equivalent command by hand to see Git's diagnosis.
+
+### `SN-685.26` — `NoteNotFound`
+
+The object exists, but carries no note in the namespace queried.
+
+**Example.** `[↯SN-685.26] the Git operation could not be completed because no note was attached to the given object`
+
+**Resolution.** Check the namespace: `notes.show` reads the default namespace unless another is named. An object with no note is not an error in every workflow, so consider `safely`.
+
 ## See also
 
-- Source: `lib/octogenarian/src/core/octogenarian.GitError.scala` (line 70)
+- Source: `lib/octogenarian/src/core/octogenarian.GitError.scala`
 - `SN-976` — invalid Git reference syntax

--- a/doc/errors/686.md
+++ b/doc/errors/686.md
@@ -20,4 +20,4 @@ Replace the wildcard with a typed pattern (e.g. `error: SomeError`).
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.internal.scala` (line 130)
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/689.md
+++ b/doc/errors/689.md
@@ -19,4 +19,4 @@ Provide a value in the range 0-255.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (line 154)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/691.md
+++ b/doc/errors/691.md
@@ -22,4 +22,4 @@ arguments, and whether the binary exists.
 
 ## See also
 
-- Source: `lib/guillotine/src/core/guillotine.ExecError.scala` (line 39)
+- Source: `lib/guillotine/src/core/guillotine.ExecError.scala`

--- a/doc/errors/698.md
+++ b/doc/errors/698.md
@@ -1,27 +1,10 @@
-# `SN-698` — `InterpolationError`
+# `SN-698` — `InterpolationError` (retired)
 
-Raised by a Contextual `Interpolator` when the interpolated content
-cannot be parsed.
+This error no longer exists. The page is kept so that the code is not reused, and so
+that a reference to it from an older release can still be resolved.
 
-## Cause
+## What became of it
 
-Each interpolator implementation reports failures by throwing this
-error with a `Message` and an optional offset and length. It is
-also raised at compile time via `halt(1, …)` when the interpolator
-detects a problem during macro expansion.
-
-## Example message
-
-```
-[↯SN-698] unexpected character at 12 - 1
-```
-
-## Resolution
-
-Adjust the interpolated string to satisfy the interpolator's syntax;
-inspect the embedded message for the specific complaint.
-
-## See also
-
-- Source: `lib/contextual/src/core/contextual.InterpolationError.scala` (line 41)
-- Compile-time site: `lib/contextual/src/core/contextual.Interpolator.scala` (line 174)
+Contextual's `Interpolator` API, which raised this error, was replaced by the
+`Interpolable` typeclass. Each interpolator now defines its own error type, so a failure
+is reported in the vocabulary of the thing being parsed rather than through a shared one.

--- a/doc/errors/700.md
+++ b/doc/errors/700.md
@@ -1,0 +1,40 @@
+# `SN-700` — `ProtobufError`
+
+Raised when Protocol Buffers wire data cannot be decoded.
+
+## Cause
+
+Locomotion decodes proto3 wire format directly. This error covers a truncated message, a
+malformed varint, an unexpected wire type for a field number, and a length-delimited field
+running past the end of the message.
+
+## Variants
+
+### `SN-700.1` — `Truncated`
+
+**Example.** `[↯SN-700.1] the protobuf data ended unexpectedly at offset <offset>`
+
+### `SN-700.2` — `MalformedVarint`
+
+**Example.** `[↯SN-700.2] a varint was malformed at offset <offset>`
+
+### `SN-700.3` — `UnexpectedWireType`
+
+**Example.** `[↯SN-700.3] an unexpected wire type, <found>, was encountered at offset <offset>`
+
+### `SN-700.4` — `Overflow`
+
+**Example.** `[↯SN-700.4] a numeric value was too large for its type at offset <offset>`
+
+### `SN-700.5` — `MissingField`
+
+**Example.** `[↯SN-700.5] the required field number <number> was missing`
+
+## Resolution
+
+The message carries the byte offset. An unexpected wire type usually means reader and writer
+disagree about a field's type — the field number matched but the encoding did not.
+
+## See also
+
+- Source: `lib/locomotion/src/core/locomotion.ProtobufError.scala`

--- a/doc/errors/704.md
+++ b/doc/errors/704.md
@@ -22,4 +22,4 @@ conventions.
 
 ## See also
 
-- Source: `lib/nomenclature/src/core/nomenclature.protointernal.scala` (line 121)
+- Source: `lib/nomenclature/src/core/nomenclature.protointernal.scala`

--- a/doc/errors/709.md
+++ b/doc/errors/709.md
@@ -21,4 +21,4 @@ Provide a value in the range 0-255.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (line 155)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/714.md
+++ b/doc/errors/714.md
@@ -43,4 +43,4 @@ IPv6 rules.
 
 ## See also
 
-- Source: `lib/urticose/src/url/urticose.UrlError.scala` (line 62)
+- Source: `lib/urticose/src/url/urticose.UrlError.scala`

--- a/doc/errors/716.md
+++ b/doc/errors/716.md
@@ -22,4 +22,4 @@ a recognised result type.
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.internal.scala` (line 134)
+- Source: `lib/contingency/src/core/contingency.internal.scala`

--- a/doc/errors/721.md
+++ b/doc/errors/721.md
@@ -24,6 +24,6 @@ RPC interface; check for typos.
 
 ## See also
 
-- Source: `lib/obligatory/src/core/obligatory.JsonRpcError.scala` (line 44)
+- Source: `lib/obligatory/src/json/obligatory.JsonRpcError.scala`
 - `SN-983` — generic RPC failure
 - `SN-728` — missing `Tactic[JsonRpcError]` at compile time

--- a/doc/errors/728.md
+++ b/doc/errors/728.md
@@ -21,4 +21,4 @@ Bring a `Tactic[JsonRpcError]` into scope (typically via
 
 ## See also
 
-- Source: `lib/obligatory/src/core/obligatory.internal.scala` (line 140)
+- Source: `lib/obligatory/src/json/obligatory.internal.scala`

--- a/doc/errors/735.md
+++ b/doc/errors/735.md
@@ -21,4 +21,4 @@ Pass a `Double` literal directly to the macro.
 
 ## See also
 
-- Source: `lib/aviation/src/core/aviation.internal.scala` (line 161)
+- Source: `lib/aviation/src/core/aviation.internal.scala`

--- a/doc/errors/740.md
+++ b/doc/errors/740.md
@@ -1,0 +1,21 @@
+# `SN-740` — `DecimalError`
+
+Raised when a value cannot be represented as an arbitrary-precision decimal.
+
+## Cause
+
+A `Decimal` is constructed from text, from an integer, or from a `Double`. From text, this
+error means the text is not a decimal number; from a `Double`, that the double has no exact
+decimal representation.
+
+## Resolution
+
+For text, check the syntax — an optional sign, digits, an optional point and an optional
+exponent. For a `Double`, the failure is telling you the binary value is not exactly the
+decimal you intended; construct from text, or from an unscaled integer and a scale.
+
+> This error previously used the code `SN-869`, which collided with `EnvironmentError`.
+
+## See also
+
+- Source: `lib/hypotenuse/src/core/hypotenuse.DecimalError.scala`

--- a/doc/errors/742.md
+++ b/doc/errors/742.md
@@ -1,0 +1,26 @@
+# `SN-742` — Definition not exported to `soundness`
+
+Raised by the Decorum compiler plugin when the house-style rule on definition not exported to `soundness` is broken.
+
+## Cause
+
+Every public definition is re-exported into the `soundness` umbrella package so that
+`import soundness.*` reaches it. This rule reports definitions that are not.
+
+## Variants
+
+| Code | Message |
+| --- | --- |
+| `SN-742.1` | the <subject> defined but not exported to the `soundness` package: <listed> |
+
+## Resolution
+
+Add the definition to the module's `soundness_*.scala` export list. If it is deliberately
+internal, make it private rather than leaving it public and unexported.
+
+This is a style rule rather than a correctness one. The house style is set out in
+`doc/standards/syntax.md`.
+
+## See also
+
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/750.md
+++ b/doc/errors/750.md
@@ -1,41 +1,9 @@
-# `SN-750` — `BcodlError`
+# `SN-750` — `BcodlError` (retired)
 
-Raised when Cellulose's BCoDL (binary CoDL) parser encounters
-unexpected input.
+This error no longer exists. The page is kept so that the code is not reused, and so
+that a reference to it from an older release can still be resolved.
 
-## Cause
+## What became of it
 
-The BCoDL parser reads a binary stream guided by a CoDL schema. When
-the input deviates from the schema or the framing is wrong, this
-error is raised. The constructor takes a `reason: Reason` and the
-byte `position` at which the mismatch was detected; the rendered
-message is `the BCoDL input was not valid at $position because
-$reason`.
-
-## Variants
-
-### `SN-750.1` — `BadHeader`
-
-The four-byte magic prefix `0xb1c0d1` was not present at the start
-of the input.
-
-**Example.** `[↯SN-750.1] the BCoDL input was not valid at 0 because the magic bytes 0xb1c0d1 were not found at the start of the input`
-
-**Resolution.** Confirm the input is a BCoDL stream rather than raw
-CoDL or some other format.
-
-### `SN-750.2` — `MissingKey`
-
-The schema entry referenced by the input has no key — typically a
-schema/document mismatch.
-
-**Example.** `[↯SN-750.2] the BCoDL input was not valid at 0 because the schema entry has no key`
-
-**Resolution.** Verify the schema used to read matches the schema
-used to write; check that no schema entries are anonymous where the
-input expects a named key.
-
-## See also
-
-- Source: `lib/cellulose/src/core/cellulose.BcodlError.scala` (line 46)
-- `SN-949` — high-level CoDL schema errors
+The `cellulose` module, which implemented CoDL and its binary form BCoDL, has been
+removed. Its role is filled by [TEL](../modules/tel.md), whose binary encoding is BinTEL.

--- a/doc/errors/751.md
+++ b/doc/errors/751.md
@@ -39,6 +39,70 @@ characters disallowed by the format.
 
 **Resolution.** Sanitise the name to a valid entry path.
 
+### `SN-751.4` — `UnsupportedMethod`
+
+The entry is compressed with a method other than *stored* or *deflate*.
+
+**Example.** `[↯SN-751.4] the compression method 12 is not supported`
+
+**Resolution.** Recompress the archive with deflate, or store the entry uncompressed.
+
+### `SN-751.5` — `MissingEocd`
+
+No end-of-central-directory record was found, so the archive's index cannot be located.
+
+**Example.** `[↯SN-751.5] no end-of-central-directory record could be found`
+
+**Resolution.** The file is not a ZIP archive, or its tail is missing. Check that it downloaded completely.
+
+### `SN-751.6` — `TruncatedArchive`
+
+The archive ends before a structure it declared was complete.
+
+**Example.** `[↯SN-751.6] the ZIP archive ended unexpectedly`
+
+**Resolution.** The file is incomplete. Obtain it again.
+
+### `SN-751.7` — `BadSignature`
+
+A record does not begin with the four-byte signature the format requires there.
+
+**Example.** `[↯SN-751.7] an expected record signature (67324752) was absent`
+
+**Resolution.** The archive is corrupt, or the offset was computed from a damaged index. Recovering the entries by scanning may work where the index does not.
+
+### `SN-751.8` — `Zip64Error`
+
+The ZIP64 extensions, which carry sizes and offsets too large for the original format, could not be interpreted.
+
+**Example.** `[↯SN-751.8] the ZIP64 metadata could not be interpreted`
+
+**Resolution.** The archive uses ZIP64 in a way this reader does not support, or the metadata is damaged.
+
+### `SN-751.9` — `WriteUnsupported`
+
+The archive was opened with the `Write` grant, which opening as `Zip` does not offer.
+
+**Example.** `[↯SN-751.9] ZIP archives cannot yet be opened for writing`
+
+**Resolution.** Build the archive with `Zipfile.write`, which takes the entries and produces a new archive, rather than opening an existing one for modification.
+
+### `SN-751.10` — `AlreadyExists`
+
+Creating an archive found something already at the path.
+
+**Example.** `[↯SN-751.10] an archive already exists at this path`
+
+**Resolution.** Choose another path, or pass `CreateFlag.Replace` to overwrite deliberately.
+
+### `SN-751.11` — `CannotWrite`
+
+The archive could not be written, for a reason the underlying filesystem reported.
+
+**Example.** `[↯SN-751.11] the archive could not be written: permission denied`
+
+**Resolution.** The detail carries the operating system's explanation; act on that.
+
 ## See also
 
-- Source: `lib/zeppelin/src/core/zeppelin.ZipError.scala` (line 52)
+- Source: `lib/zeppelin/src/core/zeppelin.ZipError.scala`

--- a/doc/errors/764.md
+++ b/doc/errors/764.md
@@ -19,4 +19,4 @@ Provide a value in the range 0-65535.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (line 134)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/768.md
+++ b/doc/errors/768.md
@@ -19,4 +19,4 @@ Provide a value in the range `-128`–`127`.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (line 165)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/770.md
+++ b/doc/errors/770.md
@@ -21,4 +21,4 @@ where being offline is acceptable.
 
 ## See also
 
-- Source: `lib/urticose/src/core/urticose.OfflineError.scala` (line 38)
+- Source: `lib/urticose/src/core/urticose.OfflineError.scala`

--- a/doc/errors/772.md
+++ b/doc/errors/772.md
@@ -19,4 +19,4 @@ Provide a value in the range 0-65535.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (line 135)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/779.md
+++ b/doc/errors/779.md
@@ -23,4 +23,4 @@ specific variants may be added as the module evolves.
 
 ## See also
 
-- Source: `lib/anthology/src/core/anthology.CompilerError.scala` (line 38)
+- Source: `lib/anthology/src/core/anthology.CompilerError.scala`

--- a/doc/errors/783.md
+++ b/doc/errors/783.md
@@ -19,4 +19,4 @@ Remove the surplus blank lines.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 184)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/789.md
+++ b/doc/errors/789.md
@@ -22,4 +22,4 @@ Edit the literal so it satisfies the rule.
 
 ## See also
 
-- Source: `lib/nomenclature/src/core/nomenclature.protointernal.scala` (line 148)
+- Source: `lib/nomenclature/src/core/nomenclature.protointernal.scala`

--- a/doc/errors/790.md
+++ b/doc/errors/790.md
@@ -1,0 +1,23 @@
+# `SN-790` — No `Encodable in Query` instance
+
+Raised at compiletime when a value has no instance describing how it becomes a query
+parameter.
+
+## Cause
+
+Values enter a query string through an `Encodable in Query` instance, so a type with none
+cannot be encoded.
+
+## Example message
+
+```
+[↯SN-790] there is no contextual Encodable in Query instance for values of type Widget
+```
+
+## Resolution
+
+Define an instance for the type, or convert the value to one that has one.
+
+## See also
+
+- Source: `lib/legerdemain/src/core/legerdemain.internal.scala`

--- a/doc/errors/794.md
+++ b/doc/errors/794.md
@@ -21,4 +21,4 @@ may be added in future.
 
 ## See also
 
-- Source: `lib/sedentary/src/core/sedentary.BenchError.scala` (line 38)
+- Source: `lib/sedentary/src/core/sedentary.BenchError.scala`

--- a/doc/errors/799.md
+++ b/doc/errors/799.md
@@ -25,4 +25,4 @@ source files.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 468)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/815.md
+++ b/doc/errors/815.md
@@ -22,4 +22,4 @@ in code before the read) or use an `Optional` accessor.
 
 ## See also
 
-- Source: `lib/ambience/src/core/ambience.PropertyError.scala` (line 41)
+- Source: `lib/ambience/src/core/ambience.PropertyError.scala`

--- a/doc/errors/822.md
+++ b/doc/errors/822.md
@@ -35,5 +35,5 @@ target locations.
 
 ## See also
 
-- Source: `lib/exoskeleton/src/core/exoskeleton.InstallError.scala` (line 51)
+- Source: `lib/exoskeleton/src/core/exoskeleton.InstallError.scala`
 - `SN-271` — tmux launcher cannot be executed

--- a/doc/errors/824.md
+++ b/doc/errors/824.md
@@ -21,4 +21,4 @@ non-ASCII-aware type instead.
 
 ## See also
 
-- Source: `lib/gossamer/src/core/gossamer.internal.scala` (line 133)
+- Source: `lib/gossamer/src/core/gossamer.internal.scala`

--- a/doc/errors/831.md
+++ b/doc/errors/831.md
@@ -54,4 +54,4 @@ platform's rules before composing them into a path.
 
 ## See also
 
-- Source: `lib/serpentine/src/core/serpentine.PathError.scala` (line 63)
+- Source: `lib/serpentine/src/core/serpentine.PathError.scala`

--- a/doc/errors/833.md
+++ b/doc/errors/833.md
@@ -1,0 +1,28 @@
+# `SN-833` — Anchor alignment
+
+Raised by the Decorum compiler plugin when the house-style rule on anchor alignment is broken.
+
+## Cause
+
+A type-annotation `:` aligns with its definition's anchor, and a heavy `(` or `[` opening a
+continuation must follow a tight expression on a line of its own.
+
+## Variants
+
+| Code | Message |
+| --- | --- |
+| `SN-833.1` | keyword `<elem>` must start on the same line as `<anchor>` (line <anchorLine>) or on a new line in column <anchorCol> (found line <elem>, column <elem>) |
+| `SN-833.2` | body after `<elem>` must be indented onto a new line because an earlier body in this sequence is |
+| `SN-833.3` | type-annotation `:` should align with the definition's anchor at column <a> (found <a>) |
+| `SN-833.4` | heavy `(`/`[` continuation must follow a tight expression on its own line; the preceding line contains a top-level operator or assignment, so the anchor is mid-line |
+
+## Resolution
+
+Align to the anchor the message names; the sub-code identifies which alignment rule applies.
+
+This is a style rule rather than a correctness one. The house style is set out in
+`doc/standards/syntax.md`.
+
+## See also
+
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/838.md
+++ b/doc/errors/838.md
@@ -1,0 +1,22 @@
+# `SN-838` — Value below its lower bound
+
+Raised at compiletime when a literal is less than the minimum its bounded type permits.
+
+## Cause
+
+A bounded numeric type carries its range in its type, so a literal outside the range is
+rejected where it is written.
+
+## Example message
+
+```
+[↯SN-838] the value -0.5 is less than the lower bound for this value, 0.0
+```
+
+## Resolution
+
+Use a value within the range, or widen the type's bounds.
+
+## See also
+
+- Source: `lib/cardinality/src/core/cardinality.internal.scala`

--- a/doc/errors/840.md
+++ b/doc/errors/840.md
@@ -70,4 +70,4 @@ be added in future.
 
 ## See also
 
-- Source: `lib/orthodoxy/src/core/orthodoxy.OAuthError.scala` (line 61)
+- Source: `lib/orthodoxy/src/core/orthodoxy.OAuthError.scala`

--- a/doc/errors/841.md
+++ b/doc/errors/841.md
@@ -22,4 +22,4 @@ fix the code so that it really does fail.
 
 ## See also
 
-- Source: `lib/contingency/src/core/contingency.ExpectationError.scala` (line 41)
+- Source: `lib/contingency/src/core/contingency.ExpectationError.scala`

--- a/doc/errors/846.md
+++ b/doc/errors/846.md
@@ -1,0 +1,41 @@
+# `SN-846` — `OpenApiError`
+
+Raised when an OpenAPI document is malformed or cannot be interpreted.
+
+## Cause
+
+Apoplexy reads OpenAPI specifications to derive typed clients. This error covers a document
+that does not match the OpenAPI schema, a reference that does not resolve, and a construct
+outside the subset Apoplexy models.
+
+## Variants
+
+### `SN-846.1` — `Malformed`
+
+**Example.** `[↯SN-846.1] the OpenAPI document could not be parsed`
+
+### `SN-846.2` — `UnsupportedVersion`
+
+**Example.** `[↯SN-846.2] the OpenAPI version <version> is not supported; only 3.x is supported`
+
+### `SN-846.3` — `UnresolvableRef`
+
+**Example.** `[↯SN-846.3] the reference <pointer> could not be resolved`
+
+### `SN-846.4` — `UnsupportedRef`
+
+**Example.** `[↯SN-846.4] the reference <pointer> is not supported; only #/components/schemas references work`
+
+### `SN-846.5` — `BadParameterLocation`
+
+**Example.** `[↯SN-846.5] <value> is not a valid parameter location; expected one of path, query, header or cookie`
+
+## Resolution
+
+An unresolved reference usually means a `$ref` pointing outside the document, which is not
+followed. Where a construct is unsupported, the specification may still be usable with that
+operation excluded.
+
+## See also
+
+- Source: `lib/apoplexy/src/core/apoplexy.OpenApiError.scala`

--- a/doc/errors/847.md
+++ b/doc/errors/847.md
@@ -23,4 +23,4 @@ the Decorum documentation for the full list of permitted patterns.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 1371)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/865.md
+++ b/doc/errors/865.md
@@ -22,4 +22,4 @@ key type to one that has a `Parametric` instance.
 
 ## See also
 
-- Source: `lib/legerdemain/src/core/legerdemain.internal.scala` (line 66)
+- Source: `lib/legerdemain/src/core/legerdemain.internal.scala`

--- a/doc/errors/868.md
+++ b/doc/errors/868.md
@@ -22,4 +22,4 @@ the dividend before dividing.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.DivisionError.scala` (line 39)
+- Source: `lib/hypotenuse/src/core/hypotenuse.DivisionError.scala`

--- a/doc/errors/869.md
+++ b/doc/errors/869.md
@@ -22,4 +22,4 @@ default by using `Optional` access methods rather than the strict ones.
 
 ## See also
 
-- Source: `lib/ambience/src/core/ambience.EnvironmentError.scala` (line 41)
+- Source: `lib/ambience/src/core/ambience.EnvironmentError.scala`

--- a/doc/errors/876.md
+++ b/doc/errors/876.md
@@ -1,0 +1,22 @@
+# `SN-876` — Name is not valid in any namespace in scope
+
+Raised at compiletime when a name literal satisfies none of the namespaces available.
+
+## Cause
+
+An `n"…"` literal is resolved against the namespaces in scope. This error means no namespace
+in scope admits it.
+
+## Example message
+
+```
+[↯SN-876] the name my/name is not a valid identifier in any namespace in scope
+```
+
+## Resolution
+
+Correct the name, or bring the intended namespace into scope so that its rules apply.
+
+## See also
+
+- Source: `lib/nomenclature/src/core/nomenclature.protointernal.scala`

--- a/doc/errors/891.md
+++ b/doc/errors/891.md
@@ -1,28 +1,9 @@
-# `SN-891` — `Break`
+# `SN-891` — `Break` (retired)
 
-Raised internally by Contingency to escape from a nested
-computation, carrying a value back to a surrounding handler.
+This error no longer exists. The page is kept so that the code is not reused, and so
+that a reference to it from an older release can still be resolved.
 
-## Cause
+## What became of it
 
-`Break[result]` is thrown by `boundary`/`break` constructs that need
-to short-circuit out of an inner scope with a typed value. It is not
-intended to be caught by user code.
-
-## Example message
-
-```
-[↯SN-891] escaping
-```
-
-## Resolution
-
-Do not catch `Break` directly. If this error escapes a
-`boundary`-style block, an inner control-flow construct is leaking;
-review the use of `break` and the matching `boundary`. The error is
-constructed with `Diagnostics.omit`, so its stack is intentionally
-suppressed.
-
-## See also
-
-- Source: `lib/contingency/src/core/contingency.Break.scala` (line 39)
+Contingency no longer uses an exception to escape a nested computation, so this error
+no longer exists.

--- a/doc/errors/892.md
+++ b/doc/errors/892.md
@@ -54,4 +54,4 @@ A label starts with `-`, which DNS does not allow.
 
 ## See also
 
-- Source: `lib/urticose/src/core/urticose.HostnameError.scala` (line 55)
+- Source: `lib/urticose/src/core/urticose.HostnameError.scala`

--- a/doc/errors/899.md
+++ b/doc/errors/899.md
@@ -21,4 +21,4 @@ manually.
 
 ## See also
 
-- Source: `lib/mercator/src/core/mercator.internal.scala` (line 116)
+- Source: `lib/mercator/src/core/mercator.internal.scala`

--- a/doc/errors/902.md
+++ b/doc/errors/902.md
@@ -45,4 +45,4 @@ ranges.
 
 ## See also
 
-- Source: `lib/aviation/src/core/aviation.TimestampError.scala` (line 49)
+- Source: `lib/aviation/src/core/aviation.TimestampError.scala`

--- a/doc/errors/909.md
+++ b/doc/errors/909.md
@@ -22,4 +22,4 @@ interacting; handle the error if races are possible.
 
 ## See also
 
-- Source: `lib/guillotine/src/core/guillotine.PidError.scala` (line 38)
+- Source: `lib/guillotine/src/core/guillotine.PidError.scala`

--- a/doc/errors/913.md
+++ b/doc/errors/913.md
@@ -21,4 +21,4 @@ Run the JVM in a context where `user.dir` is set, or use an
 
 ## See also
 
-- Source: `lib/ambience/src/core/ambience.WorkingDirectoryError.scala` (line 38)
+- Source: `lib/ambience/src/core/ambience.WorkingDirectoryError.scala`

--- a/doc/errors/914.md
+++ b/doc/errors/914.md
@@ -1,0 +1,28 @@
+# `SN-914` — `ApiError`
+
+Raised when a request to a described API does not succeed.
+
+## Cause
+
+This is a failure of the call rather than of the specification: a non-success status, or a
+response body that does not match what the specification declared.
+
+## Variants
+
+### `SN-914.1` — `Status`
+
+**Example.** `[↯SN-914.1] the server responded with an unsuccessful status, <code>`
+
+### `SN-914.2` — `Malformed`
+
+**Example.** `[↯SN-914.2] the response body was not valid JSON`
+
+## Resolution
+
+A status failure carries the status, so a caller can distinguish a client fault from a server
+one. A body that does not match its declared schema means the service and its specification
+have diverged.
+
+## See also
+
+- Source: `lib/apoplexy/src/core/apoplexy.ApiError.scala`

--- a/doc/errors/915.md
+++ b/doc/errors/915.md
@@ -1,0 +1,24 @@
+# `SN-915` — Not a valid port
+
+Raised at compiletime when a named-service literal does not name a port registered for that
+transport.
+
+## Cause
+
+The `tcp"…"` and `udp"…"` interpolators check a service name against the registry, including
+which transport it is registered for.
+
+## Example message
+
+```
+[↯SN-915] docker is not a valid UDP port
+```
+
+## Resolution
+
+Check the service name and the transport. Docker, for instance, is registered over TCP, so
+`udp"docker"` does not compile.
+
+## See also
+
+- Source: `lib/urticose/src/core/urticose.internal.scala`

--- a/doc/errors/916.md
+++ b/doc/errors/916.md
@@ -28,4 +28,4 @@ specific reasons may be added as the module evolves.
 
 ## See also
 
-- Source: `lib/austronesian/src/core/austronesian.PojoError.scala` (line 38)
+- Source: `lib/austronesian/src/core/austronesian.PojoError.scala`

--- a/doc/errors/924.md
+++ b/doc/errors/924.md
@@ -1,0 +1,28 @@
+# `SN-924` — `for`-comprehension layout
+
+Raised by the Decorum compiler plugin when the house-style rule on `for`-comprehension layout is broken.
+
+## Cause
+
+Generators in a `for` comprehension align with the first generator's left-hand side, and
+blank lines separate enumerators where the rule requires them.
+
+## Variants
+
+| Code | Message |
+| --- | --- |
+| `SN-924.1` | `<-`/`=` should be vertically aligned at column <anchorOpCol> (found <gl>) |
+| `SN-924.2` | generator should align with the first generator's LHS at column <anchorLhsCol> (found <gl>) |
+| `SN-924.3` | `if` filter should align with `<-`/`=` at column <anchorOpCol> (found <gl>) |
+| `SN-924.4` | `if` filter must not be separated from the preceding enumerator by a blank line |
+
+## Resolution
+
+Align the generators and place the blank lines as the message directs.
+
+This is a style rule rather than a correctness one. The house style is set out in
+`doc/standards/syntax.md`.
+
+## See also
+
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/926.md
+++ b/doc/errors/926.md
@@ -19,4 +19,4 @@ Adjust the indentation to the nearest multiple of 2.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 311)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/929.md
+++ b/doc/errors/929.md
@@ -21,5 +21,5 @@ prefer the corresponding IANA zone (`America/Los_Angeles`,
 
 ## See also
 
-- Source: `lib/aviation/src/core/aviation.TimezoneError.scala` (line 38)
+- Source: `lib/aviation/src/core/aviation.TimezoneError.scala`
 - `SN-385` — TZDB parsing errors

--- a/doc/errors/937.md
+++ b/doc/errors/937.md
@@ -60,4 +60,4 @@ A part's `Content-Disposition` header has the wrong format.
 
 ## See also
 
-- Source: `lib/gesticulate/src/core/gesticulate.MultipartError.scala` (line 57)
+- Source: `lib/gesticulate/src/core/gesticulate.MultipartError.scala`

--- a/doc/errors/946.md
+++ b/doc/errors/946.md
@@ -21,4 +21,4 @@ indicated column.
 
 ## See also
 
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 1605)
+- Source: `lib/decorum/src/plugin/decorum.Checker.scala`

--- a/doc/errors/947.md
+++ b/doc/errors/947.md
@@ -20,4 +20,4 @@ if the broader range is intentional.
 
 ## See also
 
-- Source: `lib/gossamer/src/core/gossamer.BoundsError.scala` (line 53)
+- Source: `lib/gossamer/src/core/gossamer.BoundsError.scala`

--- a/doc/errors/949.md
+++ b/doc/errors/949.md
@@ -1,55 +1,10 @@
-# `SN-949` — `CodlError`
+# `SN-949` — `CodlError` (retired)
 
-Raised when a CoDL document does not match its schema.
+This error no longer exists. The page is kept so that the code is not reused, and so
+that a reference to it from an older release can still be resolved.
 
-## Cause
+## What became of it
 
-Cellulose's CoDL parser binds keys, indexed values, and identifier
-parameters according to a schema. When the document violates a
-schema rule, this error is thrown. The message is `the CoDL was not
-valid because $reason`.
-
-## Variants
-
-### `SN-949.1` — `BadFormat`
-
-A value (optionally `label`-tagged) is not in the format the schema
-expects.
-
-**Example.** `[↯SN-949.1] the CoDL was not valid because the value version is not in the right format`
-
-**Resolution.** Adjust the value to satisfy the schema's format, or
-relax the schema.
-
-### `SN-949.2` — `MissingValue`
-
-A required key has no value in the document.
-
-**Example.** `[↯SN-949.2] the CoDL was not valid because the key name does not exist in the document`
-
-**Resolution.** Add the missing key, or mark it optional in the
-schema.
-
-### `SN-949.3` — `MissingIndexValue`
-
-A positional index has no value in the document.
-
-**Example.** `[↯SN-949.3] the CoDL was not valid because the index 2 does not exist in the document`
-
-**Resolution.** Provide the positional value, or change the schema's
-arity.
-
-### `SN-949.4` — `MultipleIds`
-
-More than one parameter of a key is marked as the identifier — at
-most one is allowed.
-
-**Example.** `[↯SN-949.4] the CoDL was not valid because multiple parameters of name have been marked as identifiers`
-
-**Resolution.** Mark exactly one parameter of the key as the
-identifier.
-
-## See also
-
-- Source: `lib/cellulose/src/core/cellulose.CodlError.scala` (line 58)
-- `SN-750` — low-level BCoDL parser error
+The `cellulose` module, which implemented CoDL, has been removed. Its role is filled by
+[TEL](../modules/tel.md), which is a schema-typed, indentation-based data language of the
+same kind.

--- a/doc/errors/954.md
+++ b/doc/errors/954.md
@@ -21,4 +21,4 @@ Character Database.
 
 ## See also
 
-- Source: `lib/hieroglyph/src/core/hieroglyph.internal.scala` (line 87)
+- Source: `lib/hieroglyph/src/core/hieroglyph.internal.scala`

--- a/doc/errors/955.md
+++ b/doc/errors/955.md
@@ -19,4 +19,4 @@ Use a non-negative literal value.
 
 ## See also
 
-- Source: `lib/aviation/src/core/aviation.internal.scala` (line 146)
+- Source: `lib/aviation/src/core/aviation.internal.scala`

--- a/doc/errors/957.md
+++ b/doc/errors/957.md
@@ -22,4 +22,4 @@ code that contains it.
 
 ## See also
 
-- Source: `lib/rudiments/src/core/rudiments.internal.scala` (line 95)
+- Source: `lib/rudiments/src/core/rudiments.internal.scala`

--- a/doc/errors/966.md
+++ b/doc/errors/966.md
@@ -22,4 +22,4 @@ Express the bound using `<`, `<=`, `>`, or `>=` against a constant.
 
 ## See also
 
-- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala` (lines 195, 212, 223)
+- Source: `lib/hypotenuse/src/core/hypotenuse.protointernal.scala`

--- a/doc/errors/970.md
+++ b/doc/errors/970.md
@@ -21,4 +21,4 @@ re-derive the `Functor`.
 
 ## See also
 
-- Source: `lib/mercator/src/core/mercator.internal.scala` (line 99)
+- Source: `lib/mercator/src/core/mercator.internal.scala`

--- a/doc/errors/976.md
+++ b/doc/errors/976.md
@@ -75,5 +75,5 @@ hexadecimal string.
 
 ## See also
 
-- Source: `lib/octogenarian/src/core/octogenarian.GitRefError.scala` (line 57)
+- Source: `lib/octogenarian/src/core/octogenarian.GitRefError.scala`
 - `SN-685` — Git operation failure variants

--- a/doc/errors/982.md
+++ b/doc/errors/982.md
@@ -1,24 +1,9 @@
-# `SN-982` — Blank line before multi-line case
+# `SN-982` — Blank line before multi-line case (retired)
 
-Raised by the Decorum compiler plugin when a multi-line `case`
-clause is not preceded by a blank line.
+This error no longer exists. The page is kept so that the code is not reused, and so
+that a reference to it from an older release can still be resolved.
 
-## Cause
+## What became of it
 
-Multi-line cases must be separated from the previous case by a
-blank line — except when the multi-line case is the first in its
-scope.
-
-## Example message
-
-```
-[↯SN-982] a blank line is required before a multi-line case (except for the first case)
-```
-
-## Resolution
-
-Insert a blank line before the offending `case`.
-
-## See also
-
-- Source: `lib/decorum/src/plugin/decorum.Checker.scala` (line 1438)
+This Decorum rule was withdrawn. The house style no longer requires a blank line before
+a multi-line `case` clause.

--- a/doc/errors/983.md
+++ b/doc/errors/983.md
@@ -15,5 +15,5 @@ Inspect the cause chain for transport- or protocol-level details.
 
 ## See also
 
-- Source: `lib/obligatory/src/core/obligatory.RpcError.scala` (line 37)
+- Source: `lib/obligatory/src/core/obligatory.RpcError.scala`
 - `SN-721` — JSON-RPC-specific failure

--- a/doc/errors/983.md
+++ b/doc/errors/983.md
@@ -3,6 +3,13 @@
 Raised when an RPC call fails for a reason that cannot be
 expressed by the JSON-RPC error type.
 
+## Cause
+
+Obligatory's transport-level failures — a connection that could not be made, a response that
+never arrived, a message that could not be framed — have no JSON-RPC error code to carry
+them, since the JSON-RPC error object describes faults in a call that did complete. This
+error covers the rest.
+
 ## Example message
 
 ```

--- a/doc/errors/991.md
+++ b/doc/errors/991.md
@@ -22,4 +22,4 @@ concreteness.
 
 ## See also
 
-- Source: `lib/vacuous/src/core/vacuous.internal.scala` (line 53)
+- Source: `lib/vacuous/src/core/vacuous.internal.scala`

--- a/doc/errors/999.md
+++ b/doc/errors/999.md
@@ -58,4 +58,4 @@ The cause does not match any of the more specific variants.
 
 ## See also
 
-- Source: `lib/telekinesis/src/core/telekinesis.ConnectError.scala` (line 72)
+- Source: `lib/telekinesis/src/core/telekinesis.ConnectError.scala`

--- a/doc/errors/README.md
+++ b/doc/errors/README.md
@@ -12,4 +12,14 @@ coloured if the compiler's `-color` setting is on.
 
 Each error is documented in a markdown file at `<d>.md`. When an
 error has variants, every `SN-d.e` is documented as a sub-section
-of the same `<d>.md` file.
+of the same `<d>.md` file, or — where there are more than a handful —
+as a row of a table.
+
+A code is never reused. When an error is removed, its page stays, marked
+`(retired)`, saying what became of it: a reference to the code from an
+older release still resolves, and the number cannot be allocated again
+by accident.
+
+Every page names the source file its error is raised from. It does not
+give a line number, since a line number is invalidated by any edit above
+it and nothing checks that it is still right.

--- a/lib/anthology/src/linker/anthology.LinkError.scala
+++ b/lib/anthology/src/linker/anthology.LinkError.scala
@@ -47,4 +47,4 @@ object LinkError:
     case Reason.ManyEntryPoints => m"an executable JAR permits at most one entry point"
 
 case class LinkError(reason: LinkError.Reason)(using Diagnostics)
-extends Error(779, reason.number)(m"linking failed because $reason")
+extends Error(443, reason.number)(m"linking failed because $reason")

--- a/lib/anthology/src/linker/anthology.ToolchainError.scala
+++ b/lib/anthology/src/linker/anthology.ToolchainError.scala
@@ -36,4 +36,4 @@ import anticipation.*
 import fulminate.*
 
 case class ToolchainError(tool: Text)(using Diagnostics)
-extends Error(779, 2)(m"the native tool $tool is not available on the PATH")
+extends Error(586, 0)(m"the native tool $tool is not available on the PATH")

--- a/lib/exegesis/src/core/exegesis.LspError.scala
+++ b/lib/exegesis/src/core/exegesis.LspError.scala
@@ -46,4 +46,4 @@ object LspError:
     case Reason.InvalidParams => m"the parameters were not valid for the requested method"
 
 case class LspError(reason: LspError.Reason)(using Diagnostics)
-extends Error(631, reason.number)(m"the LSP operation failed because $reason")
+extends Error(147, reason.number)(m"the LSP operation failed because $reason")

--- a/lib/facsimile/src/core/facsimile.PdfError.scala
+++ b/lib/facsimile/src/core/facsimile.PdfError.scala
@@ -109,4 +109,4 @@ object PdfError:
           m"cross-reference table can be edited in place)"
 
 case class PdfError(reason: PdfError.Reason)(using Diagnostics)
-extends Error(728, reason.number)(m"the PDF could not be read because $reason")
+extends Error(280, reason.number)(m"the PDF could not be read because $reason")

--- a/lib/hypotenuse/src/core/hypotenuse.DecimalError.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.DecimalError.scala
@@ -38,4 +38,4 @@ import anticipation.*
 import fulminate.*
 
 case class DecimalError(text: Text)(using Diagnostics)
-extends Error(869, 0)(m"$text is not a representable decimal number")
+extends Error(740, 0)(m"$text is not a representable decimal number")

--- a/lib/nomenclature/src/core/nomenclature.protointernal.scala
+++ b/lib/nomenclature/src/core/nomenclature.protointernal.scala
@@ -170,7 +170,7 @@ object protointernal:
           if acc.exists(_ =:= self) then acc else self :: acc
 
     if planes.nil
-    then halt(914, m"the name $name is not a valid identifier in any namespace in scope")
+    then halt(876, m"the name $name is not a valid identifier in any namespace in scope")
     else planes.reduce(AndType(_, _)).asType.absolve match
       case '[type plane; plane] => '{${Expr(name)}.asInstanceOf[Name[plane]]}
 


### PR DESCRIPTION
`doc/errors/README.md` promises that every error carries a globally-unique `SN-d` code and that each is documented at `<d>.md`, with variants as sub-sections. Measured against those promises the directory had drifted: 50 codes had no page, five codes were used by more than one error, seven pages documented errors that no longer exist, and 48 of the 161 resolvable line references pointed at the wrong line. It now covers every code the source can emit — 225 codes, 232 pages, the difference being seven retired ones.

## Errors

### Duplicate codes reassigned

Five codes were each used by two or more errors, so a user meeting one of them was sent to a page describing the other. The claimant that already had a page keeps the code:

| Was | Now | Moved |
| --- | --- | --- |
| `SN-631` | `SN-147` | `exegesis.LspError` — `ethereal.UpgradeError` keeps 631 |
| `SN-728` | `SN-280` | `facsimile.PdfError` — obligatory's macro error keeps 728 |
| `SN-779` | `SN-443` | `anthology.LinkError` — `anthology.CompilerError` keeps 779 |
| `SN-779` | `SN-586` | `anthology.ToolchainError` |
| `SN-869` | `SN-740` | `hypotenuse.DecimalError` — `ambience.EnvironmentError` keeps 869 |
| `SN-914` | `SN-876` | nomenclature's identifier check — `apoplexy.ApiError` keeps 914 |

This is the only source change: six lines, each altering the first argument of an `Error` constructor or a `halt` call. Each moved error's page notes its former code, so a reference to the old number still leads somewhere sensible.

### Pages

- **Fifty new pages**, covering 42 runtime and macro errors and 8 Decorum lint rules — including `SN-560` and `SN-616`, which shipped with their rules but were never documented. Variants and their messages are taken from the source.
- **Thirty-one missing variants** added across 8 pages. `SN-685` documented 13 of `GitError`'s 26 reasons, `SN-751` 3 of 11, and `SN-077` 8 of 12.
- **Seven pages retired** rather than deleted — Contextual's former `Interpolator` API, the removed `cellulose` module, Contingency's `Break`, and a withdrawn Decorum rule — each saying what became of it, so the codes are not reused and an older reference still resolves.
- **Line references dropped** throughout, keeping the file path. A line number is invalidated by any edit above it and nothing checked them, so they were a cost that only grew.
- Seven `Source:` paths repaired for obligatory files that moved from `src/core` to `src/json`, and `SN-624`'s class renamed `RecordSchemaError` to `JsonBlueprintError`.

The README now records the conventions this established: codes are never reused, a retired error keeps its page, pages name a file but not a line, and a large variant set is tabulated rather than given a section each.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
