### PR TITLE
Test nine untested modules, and fix Short multiplication

### DIFF
--- a/lib/ambience/src/test/ambience_test.scala
+++ b/lib/ambience/src/test/ambience_test.scala
@@ -34,6 +34,248 @@ package ambience
 
 import soundness.*
 
+import errorDiagnostics.stackTracesDiagnostics
+
+case class FakePath(text: Text)
+
+given fakePath: FakePath is Instantiable across Paths from Text = FakePath(_)
+
+def fixedEnvironment(entries: (Text, Text)*): Environment =
+  val map = entries.to(Map)
+  name => map.at(name)
+
+def fixedSystem(entries: (Text, Text)*): System =
+  val map = entries.to(Map)
+  name => map.at(name)
+
 object Tests extends Suite(m"Ambience Tests"):
   def run(): Unit =
-    ()
+    suite(m"Architecture tests"):
+      test(m"Decode a 32-bit x86 architecture"):
+        t"x86".as[Architecture]
+      . assert(_ == Architecture.X86(32))
+
+      test(m"Decode the alternative name for 32-bit x86"):
+        t"i386".as[Architecture]
+      . assert(_ == Architecture.X86(32))
+
+      test(m"Decode a 64-bit x86 architecture"):
+        t"x86_64".as[Architecture]
+      . assert(_ == Architecture.X86(64))
+
+      test(m"Decode the alternative name for 64-bit x86"):
+        t"amd64".as[Architecture]
+      . assert(_ == Architecture.X86(64))
+
+      test(m"Decode a 32-bit ARM architecture"):
+        t"arm".as[Architecture]
+      . assert(_ == Architecture.Arm(32))
+
+      test(m"Decode a 64-bit ARM architecture"):
+        t"aarch64".as[Architecture]
+      . assert(_ == Architecture.Arm(64))
+
+      test(m"Decode a big-endian PowerPC architecture"):
+        t"ppc64".as[Architecture]
+      . assert(_ == Architecture.Ppc(64, false))
+
+      test(m"Decode a little-endian PowerPC architecture"):
+        t"ppc64le".as[Architecture]
+      . assert(_ == Architecture.Ppc(64, true))
+
+      test(m"Decode a SPARC architecture"):
+        t"sparcv9".as[Architecture]
+      . assert(_ == Architecture.Sparc(64))
+
+      test(m"Decode a MIPS architecture"):
+        t"mips64".as[Architecture]
+      . assert(_ == Architecture.Mips(64))
+
+      test(m"Decode a RISC-V architecture"):
+        t"riscv64".as[Architecture]
+      . assert(_ == Architecture.RiscV)
+
+      test(m"Decode a 31-bit S/390 architecture"):
+        t"s390".as[Architecture]
+      . assert(_ == Architecture.S390(31))
+
+      test(m"An unrecognized architecture keeps its name"):
+        t"vax".as[Architecture]
+      . assert(_ == Architecture.Other(t"vax"))
+
+    suite(m"Environment tests"):
+      test(m"Read a defined environment variable"):
+        given environment: Environment = fixedEnvironment(t"HOME" -> t"/home/jack")
+        unsafely(Environment[Text](t"HOME"))
+      . assert(_ == t"/home/jack")
+
+      test(m"An undefined environment variable raises an error"):
+        given environment: Environment = fixedEnvironment()
+        unsafely(capture[EnvironmentError](Environment[Text](t"HOME"))).variable
+      . assert(_ == t"HOME")
+
+      test(m"The empty environment defines nothing"):
+        environments.emptyEnvironment.variable(t"HOME")
+      . assert(_ == Unset)
+
+      test(m"Select an environment variable by name"):
+        given environment: Environment = fixedEnvironment(t"LANG" -> t"en_GB.UTF-8")
+        unsafely(Environment.lang[Text])
+      . assert(_ == t"en_GB.UTF-8")
+
+      test(m"A camel-case selector maps to a screaming-snake-case name"):
+        given environment: Environment = fixedEnvironment(t"XDG_CONFIG_HOME" -> t"/cfg")
+        unsafely(Environment.xdgConfigHome[Text])
+      . assert(_ == t"/cfg")
+
+      test(m"An environment variable can be decoded"):
+        given environment: Environment = fixedEnvironment(t"COLUMNS" -> t"80")
+        unsafely(Environment.columns[Int])
+      . assert(_ == 80)
+
+    suite(m"Variable naming tests"):
+      test(m"A single-word variable name is upper-cased"):
+        summon[Variable["term", Text]].defaultName
+      . assert(_ == t"TERM")
+
+      test(m"A multi-word variable name is snake-cased"):
+        summon[Variable["xdgDataHome", Text]].defaultName
+      . assert(_ == t"XDG_DATA_HOME")
+
+      test(m"A variable's default name is unset until derived"):
+        summon[Variable["term", Text]].name
+      . assert(_ == Unset)
+
+    suite(m"Variable override tests"):
+      test(m"An overridden variable takes precedence"):
+        given environment: Environment = fixedEnvironment(t"HOME" -> t"/home/jack")
+
+        variables(home = t"/home/jill"):
+          unsafely(Environment[Text](t"HOME"))
+      . assert(_ == t"/home/jill")
+
+      test(m"A variable not overridden falls back to the environment"):
+        given environment: Environment = fixedEnvironment(t"HOME" -> t"/home/jack")
+
+        variables(term = t"xterm"):
+          unsafely(Environment[Text](t"HOME"))
+      . assert(_ == t"/home/jack")
+
+      test(m"An overridden name is snake-cased"):
+        given environment: Environment = fixedEnvironment()
+
+        variables(xdgDataHome = t"/data"):
+          unsafely(Environment[Text](t"XDG_DATA_HOME"))
+      . assert(_ == t"/data")
+
+      test(m"Several variables can be overridden at once"):
+        given environment: Environment = fixedEnvironment()
+
+        variables(home = t"/home/jill", term = t"xterm"):
+          (unsafely(Environment[Text](t"HOME")), unsafely(Environment[Text](t"TERM")))
+      . assert(_ == (t"/home/jill", t"xterm"))
+
+    suite(m"System property tests"):
+      test(m"Read a defined system property"):
+        given system: System = fixedSystem(t"user.home" -> t"/home/jack")
+        unsafely(System.properties.user.home[Text]())
+      . assert(_ == t"/home/jack")
+
+      test(m"An undefined system property raises an error"):
+        given system: System = fixedSystem()
+        unsafely(capture[PropertyError](System.properties.user.home[Text]())).property
+      . assert(_ == t"user.home")
+
+      test(m"The empty system defines no properties"):
+        systems.emptySystem(t"user.home")
+      . assert(_ == Unset)
+
+      test(m"The Java system reads a real property"):
+        systems.javaSystem(t"java.version") == Unset
+      . assert(_ == false)
+
+    suite(m"Directory tests"):
+      test(m"The home directory comes from the `user.home` property"):
+        given system: System = fixedSystem(t"user.home" -> t"/home/jack")
+        Directories.homeText
+      . assert(_ == t"/home/jack")
+
+      test(m"The XDG data home defaults below the home directory"):
+        given system: System = fixedSystem(t"user.home" -> t"/home/jack")
+        given environment: Environment = fixedEnvironment()
+        Xdg.dataHome[FakePath]
+      . assert(_ == FakePath(t"/home/jack/.local/share"))
+
+      test(m"The XDG config home defaults below the home directory"):
+        given system: System = fixedSystem(t"user.home" -> t"/home/jack")
+        given environment: Environment = fixedEnvironment()
+        Xdg.configHome[FakePath]
+      . assert(_ == FakePath(t"/home/jack/.config"))
+
+      test(m"The XDG data home is taken from the environment when set"):
+        given system: System = fixedSystem(t"user.home" -> t"/home/jack")
+        given environment: Environment = fixedEnvironment(t"XDG_DATA_HOME" -> t"/data")
+        Xdg.dataHome[FakePath]
+      . assert(_ == FakePath(t"/data"))
+
+      test(m"The XDG runtime directory is unset when the environment omits it"):
+        given environment: Environment = fixedEnvironment()
+        Xdg.runtimeDir[FakePath]
+      . assert(_ == Unset)
+
+      test(m"The XDG data directories have standard defaults"):
+        given system: System = fixedSystem(t"user.home" -> t"/home/jack")
+        given environment: Environment = fixedEnvironment()
+        Xdg.dataDirs[FakePath]
+      . assert(_ == List(FakePath(t"/usr/local/share"), FakePath(t"/usr/share")))
+
+      test(m"The XDG config directories have a standard default"):
+        given system: System = fixedSystem(t"user.home" -> t"/home/jack")
+        given environment: Environment = fixedEnvironment()
+        Xdg.configDirs[FakePath]
+      . assert(_ == List(FakePath(t"/etc/xdg")))
+
+      test(m"On Windows the config home is the roaming app data directory"):
+        given system: System =
+          fixedSystem(t"user.home" -> t"C:\\Users\\Jack", t"os.name" -> t"Windows 11")
+
+        given environment: Environment = fixedEnvironment()
+        Directories.configHome[FakePath]
+      . assert(_ == FakePath(t"C:\\Users\\Jack\\AppData\\Roaming"))
+
+      test(m"On Windows the cache home is the local app data directory"):
+        given system: System =
+          fixedSystem(t"user.home" -> t"C:\\Users\\Jack", t"os.name" -> t"Windows 11")
+
+        given environment: Environment = fixedEnvironment()
+        Directories.cacheHome[FakePath]
+      . assert(_ == FakePath(t"C:\\Users\\Jack\\AppData\\Local"))
+
+      test(m"On Windows the data directories come from `PROGRAMDATA`"):
+        given system: System =
+          fixedSystem(t"user.home" -> t"C:\\Users\\Jack", t"os.name" -> t"Windows 11")
+
+        given environment: Environment = fixedEnvironment()
+        Directories.dataDirs[FakePath]
+      . assert(_ == List(FakePath(t"C:\\ProgramData")))
+
+    suite(m"Working directory tests"):
+      test(m"The working directory comes from the `user.dir` property"):
+        given system: System = fixedSystem(t"user.dir" -> t"/tmp/work")
+        workingDirectories.systemWorkingDirectory.directory()
+      . assert(_ == t"/tmp/work")
+
+      test(m"The default working directory is absolute"):
+        workingDirectories.defaultWorkingDirectory.directory().starts(t"/")
+      . assert(_ == true)
+
+    suite(m"Error message tests"):
+      test(m"An environment error names the missing variable"):
+        val error = unsafely(EnvironmentError(t"HOME"))
+        error.message.text
+      . assert(_ == m"the environment variable HOME was not defined".text)
+
+      test(m"A property error names the missing property"):
+        val error = unsafely(PropertyError(t"user.home"))
+        error.message.text
+      . assert(_ == m"the system property user.home was not defined".text)

--- a/lib/caduceus/src/test/caduceus_test.scala
+++ b/lib/caduceus/src/test/caduceus_test.scala
@@ -34,5 +34,199 @@ package caduceus
 
 import soundness.*
 
+import errorDiagnostics.stackTracesDiagnostics
+
+class TestCourier() extends Courier:
+  type Result = Unit
+
+  var emails: List[Email] = Nil
+  var envelopes: List[Envelope] = Nil
+
+  def send(message: Document[Email]): Unit =
+    emails = message.root :: emails
+    envelopes = message.metadata :: envelopes
+
+case class Report(title: Text, body: Text)
+
 object Tests extends Suite(m"Caduceus tests"):
-  def run(): Unit = ()
+  def run(): Unit =
+    val jack = unsafely(EmailAddress.parse(t"jack@example.com"))
+    val jill = unsafely(EmailAddress.parse(t"jill@example.com"))
+    val jane = unsafely(EmailAddress.parse(t"jane@example.com"))
+
+    suite(m"Email body tests"):
+      test(m"A text-only body has text but no HTML"):
+        val body = Email.Body(t"hello")
+        (body.text, body.html)
+      . assert(_ == (t"hello", Unset))
+
+      test(m"An HTML-only body has HTML but no text"):
+        val body = Email.Body.HtmlOnly(t"<p>hello</p>")
+        (body.text, body.html)
+      . assert(_ == (Unset, t"<p>hello</p>"))
+
+      test(m"An alternatives body has both text and HTML"):
+        val body = Email.Body(t"hello", t"<p>hello</p>")
+        (body.text, body.html)
+      . assert(_ == (t"hello", t"<p>hello</p>"))
+
+      test(m"A text-only body is plain text"):
+        Email.Body(t"hello").contentType
+      . assert(_ == media"text/plain")
+
+      test(m"An HTML-only body is HTML"):
+        Email.Body.HtmlOnly(t"<p>hello</p>").contentType
+      . assert(_ == media"text/html")
+
+      test(m"An alternatives body is multipart"):
+        Email.Body(t"hello", t"<p>hello</p>").contentType
+      . assert(_ == media"multipart/alternative")
+
+    suite(m"Email content tests"):
+      test(m"Content without inlines has the body's content type"):
+        Email.Content(Email.Body(t"hello")).contentType
+      . assert(_ == media"text/plain")
+
+      test(m"Content with an inline is related multipart"):
+        val inline = Email.Inline(t"cid1", media"image/png", LazyList())
+        Email.Content(Email.Body(t"hello"), inline).contentType
+      . assert(_ == media"multipart/related")
+
+      test(m"A message without attachments has the content's type"):
+        Email.Message(Email.Content(Email.Body(t"hello"))).contentType
+      . assert(_ == media"text/plain")
+
+      test(m"A message with an attachment is mixed multipart"):
+        val asset = Asset(t"report.txt", media"text/plain", LazyList())
+        Email.Message(Email.Content(Email.Body(t"hello")), List(asset)).contentType
+      . assert(_ == media"multipart/mixed")
+
+    suite(m"Sendable tests"):
+      test(m"Text becomes a plain-text email"):
+        Email(t"hello").text
+      . assert(_ == t"hello")
+
+      test(m"Text becomes an email with no HTML"):
+        Email(t"hello").html
+      . assert(_ == Unset)
+
+      test(m"An email is sendable as itself"):
+        val email = Email(t"hello")
+        Email(email)
+      . assert(_ == Email(t"hello"))
+
+      test(m"An email starts with no headers"):
+        Email(t"hello").headers
+      . assert(_ == Map())
+
+      test(m"An email starts with no attachments"):
+        Email(t"hello").attachments
+      . assert(_ == Nil)
+
+      test(m"An email starts with no inlines"):
+        Email(t"hello").inlines
+      . assert(_ == Nil)
+
+      test(m"Contramap a Sendable onto another type"):
+        val sendable = Sendable.text.contramap[Report](_.body)
+        sendable.email(Report(t"Q3", t"all good")).text
+      . assert(_ == t"all good")
+
+    suite(m"Attachment tests"):
+      val asset = Asset(t"report.txt", media"text/plain", LazyList())
+
+      test(m"An Asset attaches as itself"):
+        Attachable.asset.attachment(asset)
+      . assert(_ == asset)
+
+      test(m"Attaching adds the asset to the email"):
+        Email(t"hello").attach(asset).attachments
+      . assert(_ == List(asset))
+
+      test(m"Attaching twice keeps both assets in order"):
+        val other = Asset(t"data.csv", media"text/csv", LazyList())
+        Email(t"hello").attach(asset).attach(other).attachments.map(_.name)
+      . assert(_ == List(t"report.txt", t"data.csv"))
+
+      test(m"Attaching does not change the body"):
+        Email(t"hello").attach(asset).text
+      . assert(_ == t"hello")
+
+      test(m"Contramap an Attachable onto another type"):
+        val attachable = Attachable.asset.contramap[Report]: report =>
+          Asset(report.title, media"text/plain", LazyList())
+
+        attachable.attachment(Report(t"Q3", t"all good")).name
+      . assert(_ == t"Q3")
+
+    suite(m"Envelope tests"):
+      test(m"A single recipient becomes a one-element list"):
+        Envelope.many[EmailAddress](jack)
+      . assert(_ == List(jack))
+
+      test(m"A list of recipients is kept as it is"):
+        Envelope.many[EmailAddress](List(jack, jill))
+      . assert(_ == List(jack, jill))
+
+      test(m"An empty list of recipients stays empty"):
+        Envelope.many[EmailAddress](Nil)
+      . assert(_ == Nil)
+
+    suite(m"Sending tests"):
+      test(m"Sending records the subject"):
+        given courier: TestCourier = TestCourier()
+        given sender: Sender = Sender(jack)
+        t"hello".send(subject = t"Greetings", to = jill)
+        courier.envelopes.head.subject
+      . assert(_ == t"Greetings")
+
+      test(m"Sending records the sender"):
+        given courier: TestCourier = TestCourier()
+        given sender: Sender = Sender(jack)
+        t"hello".send(subject = t"Greetings", to = jill)
+        courier.envelopes.head.from
+      . assert(_ == jack)
+
+      test(m"Sending records a single recipient"):
+        given courier: TestCourier = TestCourier()
+        given sender: Sender = Sender(jack)
+        t"hello".send(subject = t"Greetings", to = jill)
+        courier.envelopes.head.to
+      . assert(_ == List(jill))
+
+      test(m"Sending records several recipients"):
+        given courier: TestCourier = TestCourier()
+        given sender: Sender = Sender(jack)
+        t"hello".send(subject = t"Greetings", to = List(jill, jane))
+        courier.envelopes.head.to
+      . assert(_ == List(jill, jane))
+
+      test(m"Copied and blind-copied recipients are recorded"):
+        given courier: TestCourier = TestCourier()
+        given sender: Sender = Sender(jack)
+        t"hello".send(subject = t"Greetings", to = jill, cc = jane, bcc = jack)
+        val envelope = courier.envelopes.head
+        (envelope.cc, envelope.bcc)
+      . assert(_ == (List(jane), List(jack)))
+
+      test(m"Recipients default to empty lists"):
+        given courier: TestCourier = TestCourier()
+        given sender: Sender = Sender(jack)
+        t"hello".send(subject = t"Greetings", to = jill)
+        val envelope = courier.envelopes.head
+        (envelope.cc, envelope.bcc, envelope.replyTo)
+      . assert(_ == (Nil, Nil, Nil))
+
+      test(m"The sent email carries the body"):
+        given courier: TestCourier = TestCourier()
+        given sender: Sender = Sender(jack)
+        t"hello".send(subject = t"Greetings", to = jill)
+        courier.emails.head.text
+      . assert(_ == t"hello")
+
+    suite(m"Error message tests"):
+      test(m"A courier error names both parties and the subject"):
+        val error = CourierError(jack, jill, t"Greetings")
+        error.message.text
+      . assert(_ == t"unable to send email from jack@example.com to jill@example.com with "+
+          t"subject Greetings")

--- a/lib/charisma/src/test/charisma_test.scala
+++ b/lib/charisma/src/test/charisma_test.scala
@@ -34,6 +34,248 @@ package charisma
 
 import soundness.*
 
+import PeriodicTable.*
+
 object Tests extends Suite(m"Charisma Tests"):
   def run(): Unit =
-    ()
+    suite(m"Periodic table tests"):
+      test(m"Look up an element by atomic number"):
+        PeriodicTable(26)
+      . assert(_ == Fe)
+
+      test(m"Look up the first element by atomic number"):
+        PeriodicTable(1)
+      . assert(_ == H)
+
+      test(m"Look up the last element by atomic number"):
+        PeriodicTable(118)
+      . assert(_ == Og)
+
+      test(m"An atomic number of zero has no element"):
+        PeriodicTable(0)
+      . assert(_ == Unset)
+
+      test(m"An atomic number beyond the table has no element"):
+        PeriodicTable(119)
+      . assert(_ == Unset)
+
+      test(m"Look up an element by symbol"):
+        PeriodicTable(t"Cu")
+      . assert(_ == Cu)
+
+      test(m"An unknown symbol has no element"):
+        PeriodicTable(t"Zz")
+      . assert(_ == Unset)
+
+      test(m"Symbol lookup is case-sensitive"):
+        PeriodicTable(t"cu")
+      . assert(_ == Unset)
+
+      test(m"Every element's number matches its position"):
+        PeriodicTable.elements.indices.all: index =>
+          PeriodicTable.elements(index).number == index + 1
+      . assert(_ == true)
+
+      test(m"Every element has a distinct symbol"):
+        PeriodicTable.symbols.size
+      . assert(_ == 118)
+
+      test(m"An element is shown as its symbol"):
+        Fe.show
+      . assert(_ == t"Fe")
+
+      test(m"Element 119 has a systematic name"):
+        PeriodicTable.element(119).name
+      . assert(_ == t"Ununennium")
+
+      test(m"Element 119 has a systematic symbol"):
+        PeriodicTable.element(119).symbol
+      . assert(_ == t"Uue")
+
+      test(m"Element 120 has a systematic name"):
+        PeriodicTable.element(120).name
+      . assert(_ == t"Unbinilium")
+
+      test(m"Doubled `i`s are elided from systematic names"):
+        PeriodicTable.element(122).name
+      . assert(_ == t"Unbibium")
+
+      test(m"A systematic element keeps its atomic number"):
+        PeriodicTable.element(126).number
+      . assert(_ == 126)
+
+    suite(m"Molecule construction tests"):
+      test(m"An element on its own is a single-atom molecule"):
+        O.molecule.elements
+      . assert(_ == Map(O -> 1))
+
+      test(m"A subscripted element repeats the atom"):
+        O[2].elements
+      . assert(_ == Map(O -> 2))
+
+      test(m"Combining elements sums their atoms"):
+        (H[2]*O).elements
+      . assert(_ == Map(H -> 2, O -> 1))
+
+      test(m"Combining three elements accumulates atoms"):
+        (C[6]*H[12]*O[6]).elements
+      . assert(_ == Map(C -> 6, H -> 12, O -> 6))
+
+      test(m"Multiplying a molecule scales every atom"):
+        (H[2]*O ** 3).elements
+      . assert(_ == Map(H -> 6, O -> 3))
+
+      test(m"A new molecule is uncharged"):
+        (H[2]*O).charge
+      . assert(_ == 0)
+
+      test(m"A new molecule has no physical state"):
+        (H[2]*O).state
+      . assert(_ == Unset)
+
+      test(m"Unary minus decrements the charge"):
+        (-Cl.molecule).charge
+      . assert(_ == -1)
+
+      test(m"Unary plus increments the charge"):
+        (+(N*H[4])).charge
+      . assert(_ == 1)
+
+      test(m"An explicit charge replaces the existing one"):
+        (S*O[4]).ion(-2).charge
+      . assert(_ == -2)
+
+      test(m"Combining molecules sums their charges"):
+        (Na.molecule.ion(1)*Cl.molecule.ion(-1)).charge
+      . assert(_ == 0)
+
+      test(m"Multiplying a molecule scales its charge"):
+        ((S*O[4]).ion(-2) ** 3).charge
+      . assert(_ == -6)
+
+      test(m"A physical state can be attached to a molecule"):
+        (Na*Cl).inState(PhysicalState.Aqueous).state
+      . assert(_ == PhysicalState.Aqueous)
+
+    suite(m"Molecule rendering tests"):
+      test(m"Water is rendered with a subscript"):
+        (H[2]*O).show
+      . assert(_ == t"H₂O")
+
+      test(m"Elements are ordered alphabetically without carbon"):
+        (S*O[4]).show
+      . assert(_ == t"O₄S")
+
+      test(m"Carbon and hydrogen lead in an organic molecule"):
+        (C[6]*H[12]*O[6]).show
+      . assert(_ == t"C₆H₁₂O₆")
+
+      test(m"Carbon leads even without hydrogen"):
+        (C*O[2]).show
+      . assert(_ == t"CO₂")
+
+      test(m"A single anion charge is a bare minus sign"):
+        (-Cl.molecule).show
+      . assert(_ == t"Cl⁻")
+
+      test(m"A single cation charge is a bare plus sign"):
+        (+(N*H[4])).show
+      . assert(_ == t"H₄N⁺")
+
+      test(m"A charge above one is rendered as a superscript"):
+        (S*O[4]).ion(-2).show
+      . assert(_ == t"O₄S²⁻")
+
+      test(m"A multi-digit charge is rendered as superscripts"):
+        C.molecule.ion(12).show
+      . assert(_ == t"C¹²⁺")
+
+      test(m"A physical state is appended to the molecule"):
+        (Na*Cl).inState(PhysicalState.Aqueous).show
+      . assert(_ == t"ClNa(aq)")
+
+      test(m"A charge precedes the physical state"):
+        (-Cl.molecule).inState(PhysicalState.Aqueous).show
+      . assert(_ == t"Cl⁻(aq)")
+
+      test(m"Physical states are rendered in parentheses"):
+        PhysicalState.values.to(List).map(_.show)
+      . assert(_ == List(t"(s)", t"(l)", t"(g)", t"(aq)"))
+
+    suite(m"Chemical formula tests"):
+      test(m"A molecule's formula has a single term"):
+        (H[2]*O).formula.molecules
+      . assert(_ == ListMap((H[2]*O) -> 1))
+
+      test(m"Scaling a molecule gives a formula with a coefficient"):
+        (H[2]*2).molecules
+      . assert(_ == ListMap(H[2] -> 2))
+
+      test(m"Summing formulae collects both terms"):
+        (H[2]*2 + O[2]).molecules
+      . assert(_ == ListMap(H[2] -> 2, O[2] -> 1))
+
+      test(m"Summing the same molecule twice adds its coefficients"):
+        (H[2]*2 + H[2]*3).molecules
+      . assert(_ == ListMap(H[2] -> 5))
+
+      test(m"A formula's atoms tally every molecule"):
+        (H[2]*2 + O[2]).atoms
+      . assert(_ == Map(H -> 4, O -> 2))
+
+      test(m"An empty coefficient is omitted when rendering"):
+        (H[2]*O).formula.show
+      . assert(_ == t"H₂O")
+
+      test(m"A coefficient is rendered before the molecule"):
+        (H[2]*2).show
+      . assert(_ == t"2H₂")
+
+      test(m"Formula terms are joined with a plus sign"):
+        (H[2]*2 + O[2]).show
+      . assert(_ == t"2H₂ + O₂")
+
+    suite(m"Chemical equation tests"):
+      val hydrogen = H[2]
+      val oxygen = O[2]
+      val water = H[2]*O
+
+      test(m"A balanced equation has matching atom counts"):
+        (hydrogen*2 + oxygen --> water*2).balanced
+      . assert(_ == true)
+
+      test(m"An unbalanced equation has differing atom counts"):
+        (hydrogen + oxygen --> water).balanced
+      . assert(_ == false)
+
+      test(m"An equation records its left-hand side"):
+        (hydrogen*2 + oxygen --> water*2).lhs.atoms
+      . assert(_ == Map(H -> 4, O -> 2))
+
+      test(m"An equation records its right-hand side"):
+        (hydrogen*2 + oxygen --> water*2).rhs.atoms
+      . assert(_ == Map(H -> 4, O -> 2))
+
+      test(m"A net-forward equation uses a single arrow"):
+        (hydrogen*2 + oxygen --> water*2).show
+      . assert(_ == t"2H₂ + O₂ → 2H₂O")
+
+      test(m"Reactions are rendered with distinct arrows"):
+        Reaction.values.to(List).map(_.show)
+      . assert(_ == List(t"→", t"⇄", t"⇋", t"↔", t"="))
+
+      test(m"A resonance equation has a resonance reaction"):
+        (water <-> water).reaction
+      . assert(_ == Reaction.Resonance)
+
+      test(m"A both-directions equation is reversible"):
+        (water <=> water).reaction
+      . assert(_ == Reaction.BothDirections)
+
+      test(m"An equilibrium equation is at equilibrium"):
+        (water <~> water).reaction
+      . assert(_ == Reaction.Equilibrium)
+
+      test(m"A stoichiometric equation is stoichiometric"):
+        (water === water).reaction
+      . assert(_ == Reaction.Stoichiometric)

--- a/lib/contextual/src/test/contextual_test.scala
+++ b/lib/contextual/src/test/contextual_test.scala
@@ -34,6 +34,149 @@ package contextual
 
 import soundness.*
 
+case class Slug(text: Text)
+
+object Slug:
+  def assemble(parts: List[Any], insertions: List[Any]): Text =
+    val head = parts.head.toString.tt
+
+    val rest = parts.tail.zip(insertions).map: (part, insertion) =>
+      insertion.toString.tt+part.toString.tt
+
+    (head :: rest).join
+
+  given interpolable: Slug is Interpolable:
+    transparent inline def interpolate[parts <: Tuple, origins <: Tuple]
+                            (inline insertions: Any*)
+    :   Slug =
+
+      Slug(assemble(compiletime.constValueTuple[parts].toList.reverse, insertions.to(List)))
+
+  given extrapolable: Slug is Extrapolable:
+    transparent inline def extrapolate[parts <: Tuple, origins <: Tuple](scrutinee: Slug)
+    :   Extrapolation[Slug] =
+
+      scrutinee.text == assemble(compiletime.constValueTuple[parts].toList.reverse, Nil)
+
+case class Parts(values: List[Text])
+
+object Parts:
+  given interpolable: Parts is Interpolable:
+    transparent inline def interpolate[parts <: Tuple, origins <: Tuple]
+                            (inline insertions: Any*)
+    :   Parts =
+
+      Parts(Parts.texts(compiletime.constValueTuple[parts].toList))
+
+  def texts(values: List[Any]): List[Text] = values.map(_.toString.tt)
+
+case class Tag(name: Text)
+
+object Tag:
+  given embeddable: Tag is Embeddable by Text in Slug = _.name
+
+extension (inline context: StringContext)
+  transparent inline def slug: Interpolation = interpolation[Slug](context)
+  transparent inline def rawParts: Interpolation = interpolation[Parts](context)
+
 object Tests extends Suite(m"Contextual Tests"):
   def run(): Unit =
-    ()
+    suite(m"Interpolation tests"):
+      test(m"Interpolate a literal with no substitutions"):
+        slug"hello"
+      . assert(_ == Slug(t"hello"))
+
+      test(m"Interpolate an empty literal"):
+        slug""
+      . assert(_ == Slug(t""))
+
+      test(m"Interpolate a single substitution"):
+        val name = t"world"
+        slug"hello $name"
+      . assert(_ == Slug(t"hello world"))
+
+      test(m"Interpolate several substitutions"):
+        val first = 1
+        val second = 2
+        slug"$first and $second"
+      . assert(_ == Slug(t"1 and 2"))
+
+      test(m"A substitution may start the literal"):
+        val prefix = t"pre"
+        slug"${prefix}fix"
+      . assert(_ == Slug(t"prefix"))
+
+      test(m"A doubled dollar is a literal dollar"):
+        slug"cost: $$5"
+      . assert(_ == Slug(t"cost: $$5"))
+
+      test(m"The transport tuple holds the parts in reverse order"):
+        val hole = 1
+        rawParts"a${hole}b${hole}c".values
+      . assert(_ == List(t"c", t"b", t"a"))
+
+      test(m"The transport tuple includes empty leading parts"):
+        val hole = 1
+        rawParts"$hole".values
+      . assert(_ == List(t"", t""))
+
+    suite(m"Extrapolation tests"):
+      test(m"A matching literal pattern succeeds"):
+        Slug(t"hello") match
+          case slug"hello" => t"matched"
+          case _           => t"unmatched"
+      . assert(_ == t"matched")
+
+      test(m"A non-matching literal pattern fails"):
+        Slug(t"goodbye") match
+          case slug"hello" => t"matched"
+          case _           => t"unmatched"
+      . assert(_ == t"unmatched")
+
+      test(m"An empty pattern matches only an empty value"):
+        Slug(t"") match
+          case slug"" => t"matched"
+          case _      => t"unmatched"
+      . assert(_ == t"matched")
+
+    suite(m"Embeddable tests"):
+      test(m"Embed a value into its operand type"):
+        Tag.embeddable.embed(Tag(t"widget"))
+      . assert(_ == t"widget")
+
+      test(m"Contramap an embedding onto another type"):
+        val embeddable = Tag.embeddable.contramap[Int](count => Tag(count.show))
+        embeddable.embed(42)
+      . assert(_ == t"42")
+
+      test(m"An Embeddable value provides a Substitution"):
+        summon[Substitution[Text, Tag, "x"]].embed(Tag(t"widget"))
+      . assert(_ == t"widget")
+
+    suite(m"Source-position mapping tests"):
+      test(m"Unescaped text maps to itself"):
+        val mapping = Interpolation.buildMapping("hello", "hello")
+        List(0, 1, 4, 5).map(mapping)
+      . assert(_ == List(0, 1, 4, 5))
+
+      test(m"An empty value maps to the start"):
+        Interpolation.buildMapping("", "")(0)
+      . assert(_ == 0)
+
+      test(m"A doubled dollar consumes two source characters"):
+        val mapping = Interpolation.buildMapping("a$$b", "a$b")
+        List(0, 1, 2, 3).map(mapping)
+      . assert(_ == List(0, 1, 3, 4))
+
+      test(m"A unicode escape consumes six source characters"):
+        val mapping = Interpolation.buildMapping("\\u0041b", "Ab")
+        List(0, 1, 2).map(mapping)
+      . assert(_ == List(0, 6, 7))
+
+      test(m"A negative index maps to the start"):
+        Interpolation.buildMapping("hello", "hello")(-1)
+      . assert(_ == 0)
+
+      test(m"An index beyond the end maps to the last position"):
+        Interpolation.buildMapping("hello", "hello")(99)
+      . assert(_ == 5)

--- a/lib/diuretic/src/test/diuretic_test.scala
+++ b/lib/diuretic/src/test/diuretic_test.scala
@@ -34,6 +34,146 @@ package diuretic
 
 import soundness.*
 
+import java.io as ji
+import java.net as jn
+import java.nio.file as jnf
+import java.time as jt
+import java.util as ju
+
 object Tests extends Suite(m"Diuretic Tests"):
   def run(): Unit =
-    ()
+    suite(m"java.time.Instant tests"):
+      test(m"Instantiate an Instant from epoch milliseconds"):
+        JavaTimeInstant(1000000000000L)
+      . assert(_ == jt.Instant.ofEpochMilli(1000000000000L))
+
+      test(m"Abstract an Instant to epoch milliseconds"):
+        JavaTimeInstant.genericize(jt.Instant.ofEpochMilli(1000000000000L).nn)
+      . assert(_ == 1000000000000L)
+
+      test(m"Instant conversion round-trips"):
+        JavaTimeInstant.genericize(JavaTimeInstant(1234567890123L))
+      . assert(_ == 1234567890123L)
+
+      test(m"The epoch is zero milliseconds"):
+        JavaTimeInstant.genericize(jt.Instant.EPOCH.nn)
+      . assert(_ == 0L)
+
+      test(m"An Instant before the epoch is negative"):
+        JavaTimeInstant.genericize(JavaTimeInstant(-1000L))
+      . assert(_ == -1000L)
+
+    suite(m"java.util.Date tests"):
+      test(m"Instantiate a Date from epoch milliseconds"):
+        JavaUtilDate(1000000000000L)
+      . assert(_ == ju.Date(1000000000000L))
+
+      test(m"Abstract a Date to epoch milliseconds"):
+        JavaUtilDate.genericize(ju.Date(1000000000000L))
+      . assert(_ == 1000000000000L)
+
+      test(m"Date conversion round-trips"):
+        JavaUtilDate.genericize(JavaUtilDate(-42L))
+      . assert(_ == -42L)
+
+    suite(m"Long instant and duration tests"):
+      test(m"A Long instant is itself"):
+        JavaLongInstant(99L)
+      . assert(_ == 99L)
+
+      test(m"Abstracting a Long instant is the identity"):
+        JavaLongInstant.genericize(99L)
+      . assert(_ == 99L)
+
+      test(m"A Long duration is itself"):
+        JavaLongDuration(99L)
+      . assert(_ == 99L)
+
+      test(m"Abstracting a Long duration is the identity"):
+        JavaLongDuration.genericize(99L)
+      . assert(_ == 99L)
+
+    suite(m"java.nio.file.Path tests"):
+      test(m"Instantiate a Path from text"):
+        JavaNioPath(t"/tmp/example")
+      . assert(_ == jnf.Paths.get("/tmp/example").nn)
+
+      test(m"Abstract an absolute Path to text"):
+        JavaNioPath.genericize(jnf.Paths.get("/tmp/example").nn)
+      . assert(_ == t"/tmp/example")
+
+      test(m"A relative Path is abstracted as an absolute path"):
+        JavaNioPath.genericize(jnf.Paths.get("example").nn).starts(t"/")
+      . assert(_ == true)
+
+      test(m"Path conversion round-trips for an absolute path"):
+        JavaNioPath.genericize(JavaNioPath(t"/tmp/example"))
+      . assert(_ == t"/tmp/example")
+
+      test(m"Redundant separators are normalized away"):
+        JavaNioPath.genericize(JavaNioPath(t"/tmp//example"))
+      . assert(_ == t"/tmp/example")
+
+    suite(m"java.io.File tests"):
+      test(m"Instantiate a File from text"):
+        JavaIoFile(t"/tmp/example")
+      . assert(_ == ji.File("/tmp/example"))
+
+      test(m"Abstract an absolute File to text"):
+        JavaIoFile.genericize(ji.File("/tmp/example"))
+      . assert(_ == t"/tmp/example")
+
+      test(m"A relative File is abstracted as an absolute path"):
+        JavaIoFile.genericize(ji.File("example")).starts(t"/")
+      . assert(_ == true)
+
+      test(m"File conversion round-trips for an absolute path"):
+        JavaIoFile.genericize(JavaIoFile(t"/tmp/example"))
+      . assert(_ == t"/tmp/example")
+
+    suite(m"java.net.URL tests"):
+      test(m"Instantiate a URL from text"):
+        JavaNetUrl(t"https://soundness.dev/index.html")
+      . assert(_.toString.nn == "https://soundness.dev/index.html")
+
+      test(m"Abstract a URL to text"):
+        JavaNetUrl.genericize(jn.URI("https://soundness.dev/").nn.toURL().nn)
+      . assert(_ == t"https://soundness.dev/")
+
+      test(m"URL conversion round-trips"):
+        JavaNetUrl.genericize(JavaNetUrl(t"https://soundness.dev/index.html"))
+      . assert(_ == t"https://soundness.dev/index.html")
+
+      test(m"A URL with a query string round-trips"):
+        JavaNetUrl.genericize(JavaNetUrl(t"https://soundness.dev/search?q=text"))
+      . assert(_ == t"https://soundness.dev/search?q=text")
+
+      test(m"A URL with an explicit port round-trips"):
+        JavaNetUrl.genericize(JavaNetUrl(t"http://localhost:8080/api"))
+      . assert(_ == t"http://localhost:8080/api")
+
+    suite(m"Interface given tests"):
+      test(m"A java.time.Instant interface is available"):
+        import interfaces.instants.javaTimeInstant
+        summon[JavaTimeInstant.type]
+      . assert(_ == JavaTimeInstant)
+
+      test(m"A java.nio.file.Path interface is available"):
+        import interfaces.paths.javaNioPath
+        summon[JavaNioPath.type]
+      . assert(_ == JavaNioPath)
+
+      test(m"A java.net.URL interface is available"):
+        import interfaces.urls.javaNetUrl
+        summon[JavaNetUrl.type]
+      . assert(_ == JavaNetUrl)
+
+      test(m"A java.nio.file.Path represents the Paths domain"):
+        demilitarize:
+          erased val representative = summon[jnf.Path is Representative of Paths]
+      . assert(_ == Nil)
+
+      test(m"A java.io.File represents the Paths domain"):
+        demilitarize:
+          erased val representative = summon[ji.File is Representative of Paths]
+      . assert(_ == Nil)

--- a/lib/gigantism/src/test/gigantism_test.scala
+++ b/lib/gigantism/src/test/gigantism_test.scala
@@ -34,5 +34,58 @@ package gigantism
 
 import soundness.*
 
+case class Colour(name: Text)
+
+case class Shape(name: Text)
+
+case class Missing(name: Text)
+
+object Colours:
+  given red: Colour = Colour(t"red")
+  given green: Colour = Colour(t"green")
+  given blue: Colour = Colour(t"blue")
+
+object Shapes:
+  given square: Shape = Shape(t"square")
+
 object Tests extends Suite(m"Gigantism Tests"):
-  def run(): Unit = ()
+  def run(): Unit =
+    suite(m"Summoning every instance"):
+      test(m"No instances are found when none are in scope"):
+        every[Missing].values
+      . assert(_ == Nil)
+
+      test(m"A single instance in scope is found"):
+        import Shapes.square
+        every[Shape].values
+      . assert(_ == List(Shape(t"square")))
+
+      test(m"Every mutually-ambiguous instance in scope is found"):
+        import Colours.{red, green, blue}
+        every[Colour].values.map(_.name).to(Set)
+      . assert(_ == Set(t"red", t"green", t"blue"))
+
+      test(m"Only the imported instances are found"):
+        import Colours.{red, blue}
+        every[Colour].values.map(_.name).to(Set)
+      . assert(_ == Set(t"red", t"blue"))
+
+      test(m"Instances are not found outside their import scope"):
+        every[Colour].values
+      . assert(_ == Nil)
+
+      test(m"A locally-defined instance is found"):
+        given local: Shape = Shape(t"triangle")
+        every[Shape].values
+      . assert(_ == List(Shape(t"triangle")))
+
+      test(m"Local and imported instances are both found"):
+        import Shapes.square
+        given local: Shape = Shape(t"triangle")
+        every[Shape].values.map(_.name).to(Set)
+      . assert(_ == Set(t"square", t"triangle"))
+
+      test(m"The default given collects every instance"):
+        import Colours.{red, green}
+        summon[Every[Colour]].values.map(_.name).to(Set)
+      . assert(_ == Set(t"red", t"green"))

--- a/lib/gnossienne/src/test/gnossienne_test.scala
+++ b/lib/gnossienne/src/test/gnossienne_test.scala
@@ -34,5 +34,104 @@ package gnossienne
 
 import soundness.*
 
+import errorDiagnostics.stackTracesDiagnostics
+
+case class Person(@index email: Text, name: Text)
+
+case class Product(@index code: Int, description: Text)
+
 object Tests extends Suite(m"Gnossienne Tests"):
-  def run(): Unit = ()
+  def run(): Unit =
+    val jack = Person(t"jack@example.com", t"Jack")
+    val jill = Person(t"jill@example.com", t"Jill")
+    val people = Set(jack, jill)
+
+    val widget = Product(1001, t"Widget")
+    val gadget = Product(1002, t"Gadget")
+    val products = Set(widget, gadget)
+
+    suite(m"Resolvable tests"):
+      test(m"The indexed field is identified by name"):
+        given resolvable: Person is Resolvable by Text = unsafely(Resolvable(people))
+        resolvable.field
+      . assert(_ == t"email")
+
+      test(m"An indexed Int field is identified by name"):
+        given resolvable: Product is Resolvable by Int = unsafely(Resolvable(products))
+        resolvable.field
+      . assert(_ == t"code")
+
+      test(m"Resolve an entity from its key"):
+        given resolvable: Person is Resolvable by Text = unsafely(Resolvable(people))
+        unsafely(resolvable.resolve(t"jill@example.com"))
+      . assert(_ == jill)
+
+      test(m"Resolving an unknown key raises an error"):
+        given resolvable: Person is Resolvable by Text = unsafely(Resolvable(people))
+
+        unsafely:
+          capture[ReferenceError](resolvable.resolve(t"nobody@example.com")).reference
+      . assert(_ == t"nobody@example.com")
+
+      test(m"An unresolvable reference reports why it failed"):
+        given resolvable: Person is Resolvable by Text = unsafely(Resolvable(people))
+
+        unsafely:
+          capture[ReferenceError](resolvable.resolve(t"nobody@example.com")).reason
+      . assert(_ == ReferenceError.Reason.NotFound)
+
+    suite(m"Reference tests"):
+      test(m"A reference to an entity holds its key"):
+        given resolvable: Person is Resolvable by Text = unsafely(Resolvable(people))
+        jack.ref.key
+      . assert(_ == t"jack@example.com")
+
+      test(m"A reference resolves back to its entity"):
+        given resolvable: Person is Resolvable by Text = unsafely(Resolvable(people))
+        unsafely(jack.ref())
+      . assert(_ == jack)
+
+      test(m"A reference to an Int-keyed entity holds its key"):
+        given resolvable: Product is Resolvable by Int = unsafely(Resolvable(products))
+        widget.ref.key
+      . assert(_ == 1001)
+
+      test(m"An Int-keyed reference resolves back to its entity"):
+        given resolvable: Product is Resolvable by Int = unsafely(Resolvable(products))
+        unsafely(gadget.ref())
+      . assert(_ == gadget)
+
+      test(m"A reference constructed from a key resolves"):
+        given resolvable: Person is Resolvable by Text = unsafely(Resolvable(people))
+        unsafely(Reference[Person](t"jill@example.com")())
+      . assert(_ == jill)
+
+      test(m"A reference to a missing entity fails to resolve"):
+        given resolvable: Person is Resolvable by Text = unsafely(Resolvable(people))
+
+        unsafely:
+          capture[ReferenceError](Reference[Person](t"nobody@example.com")()).reference
+      . assert(_ == t"nobody@example.com")
+
+    suite(m"Reference codec tests"):
+      test(m"A reference encodes as its key"):
+        given resolvable: Person is Resolvable by Text = unsafely(Resolvable(people))
+        jack.ref.encode
+      . assert(_ == t"jack@example.com")
+
+      test(m"A reference decodes from its key"):
+        given resolvable: Person is Resolvable by Text = unsafely(Resolvable(people))
+        t"jill@example.com".as[Reference to Person].key
+      . assert(_ == t"jill@example.com")
+
+      test(m"A decoded reference resolves to its entity"):
+        given resolvable: Person is Resolvable by Text = unsafely(Resolvable(people))
+        unsafely(t"jill@example.com".as[Reference to Person]())
+      . assert(_ == jill)
+
+    suite(m"Error message tests"):
+      test(m"A reference error explains what could not be found"):
+        val error = ReferenceError(t"nobody@example.com", ReferenceError.Reason.NotFound)
+        error.message.text
+      . assert(_ == t"the reference nobody@example.com could not be resolved because no target "+
+          t"with that reference was found in the store")

--- a/lib/polaris/src/test/polaris_test.scala
+++ b/lib/polaris/src/test/polaris_test.scala
@@ -34,5 +34,161 @@ package polaris
 
 import soundness.*
 
+case class Header(magic: Int, version: Short, flags: Byte)
+
+object Header:
+  given debufferable: Header is Debufferable = Debufferable.derived
+
+case class Pair(left: Short, right: Short)
+
+object Pair:
+  given debufferable: Pair is Debufferable = Debufferable.derived
+
+case class Nested(header: Header, pair: Pair)
+
+object Nested:
+  given debufferable: Nested is Debufferable = Debufferable.derived
+
 object Tests extends Suite(m"Polaris Tests"):
-  def run(): Unit = ()
+  def run(): Unit =
+    suite(m"Width tests"):
+      test(m"A Byte is one byte wide"):
+        byteWidth[Byte]
+      . assert(_ == 1)
+
+      test(m"A Short is two bytes wide"):
+        byteWidth[Short]
+      . assert(_ == 2)
+
+      test(m"An Int is four bytes wide"):
+        byteWidth[Int]
+      . assert(_ == 4)
+
+      test(m"A Long is eight bytes wide"):
+        byteWidth[Long]
+      . assert(_ == 8)
+
+      test(m"A derived product's width is the sum of its fields'"):
+        byteWidth[Header]
+      . assert(_ == 7)
+
+      test(m"A nested product's width is the sum of its fields'"):
+        byteWidth[Nested]
+      . assert(_ == 11)
+
+    suite(m"Buffer tests"):
+      test(m"A new buffer starts at the beginning"):
+        Buffer(IArray[Byte](1, 2, 3)).offset
+      . assert(_ == 0)
+
+      test(m"A buffer can start at an offset"):
+        Buffer(IArray[Byte](1, 2, 3), 2).offset
+      . assert(_ == 2)
+
+      test(m"Advancing a buffer moves its position"):
+        val buffer = Buffer(IArray[Byte](1, 2, 3))
+        buffer.advance(2)
+        buffer.offset
+      . assert(_ == 2)
+
+      test(m"Reading from a buffer advances it by the value's width"):
+        IArray[Byte](0, 0, 0, 1, 9).buffer:
+          unpack[Int]
+          summon[Buffer].offset
+      . assert(_ == 4)
+
+      test(m"Successive reads continue where the last left off"):
+        IArray[Byte](0, 1, 0, 2).buffer:
+          (unpack[Short], unpack[Short])
+      . assert(_ == (1.toShort, 2.toShort))
+
+    suite(m"Primitive unpacking tests"):
+      test(m"Unpack a Byte"):
+        IArray[Byte](7.toByte).unpackFrom[Byte](0)
+      . assert(_ == 7.toByte)
+
+      test(m"Unpack a negative Byte"):
+        IArray[Byte]((-1).toByte).unpackFrom[Byte](0)
+      . assert(_ == (-1).toByte)
+
+      test(m"Unpack a big-endian Short"):
+        IArray[Byte](1, 2).unpackFrom[Short](0)
+      . assert(_ == 258.toShort)
+
+      test(m"Unpack a negative Short"):
+        IArray[Byte]((-1).toByte, (-1).toByte).unpackFrom[Short](0)
+      . assert(_ == (-1).toShort)
+
+      test(m"Unpack a big-endian Int"):
+        IArray[Byte](0, 0, 1, 0).unpackFrom[Int](0)
+      . assert(_ == 256)
+
+      test(m"Unpack a negative Int"):
+        IArray[Byte]((-1).toByte, (-1).toByte, (-1).toByte, (-1).toByte).unpackFrom[Int](0)
+      . assert(_ == -1)
+
+      test(m"Unpack a big-endian Long"):
+        IArray[Byte](0, 0, 0, 0, 0, 0, 1, 0).unpackFrom[Long](0)
+      . assert(_ == 256L)
+
+      test(m"Unpack from a non-zero offset"):
+        IArray[Byte](9, 9, 0, 0, 1, 0).unpackFrom[Int](2)
+      . assert(_ == 256)
+
+      test(m"Unpacking past the end of the data fails"):
+        try IArray[Byte](0, 0).unpackFrom[Int](0).toString.nn
+        catch case error: ArrayIndexOutOfBoundsException => "out of bounds"
+      . assert(_ == "out of bounds")
+
+    suite(m"Product unpacking tests"):
+      test(m"Unpack a derived product"):
+        IArray[Byte](0, 0, 1, 0, 0, 3, 7).unpackFrom[Header](0)
+      . assert(_ == Header(256, 3.toShort, 7.toByte))
+
+      test(m"Unpack a nested product"):
+        IArray[Byte](0, 0, 1, 0, 0, 3, 7, 0, 1, 0, 2).unpackFrom[Nested](0)
+      . assert(_ == Nested(Header(256, 3.toShort, 7.toByte), Pair(1.toShort, 2.toShort)))
+
+      test(m"Fields are read in declaration order"):
+        IArray[Byte](0, 1, 0, 2).unpackFrom[Pair](0)
+      . assert(_ == Pair(1.toShort, 2.toShort))
+
+      test(m"Reading a product advances the buffer by its width"):
+        IArray[Byte](0, 1, 0, 2, 0, 3, 0, 4).buffer:
+          (unpack[Pair], unpack[Pair])
+      . assert(_ == (Pair(1.toShort, 2.toShort), Pair(3.toShort, 4.toShort)))
+
+    suite(m"Array unpacking tests"):
+      val data = IArray[Byte](0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3)
+
+      test(m"Unpack an array of Ints"):
+        data.unpackFrom[IArray[Int]](0)(3).to(List)
+      . assert(_ == List(1, 2, 3))
+
+      test(m"Unpack a prefix of an array"):
+        data.unpackFrom[IArray[Int]](0)(2).to(List)
+      . assert(_ == List(1, 2))
+
+      test(m"Unpack an empty array"):
+        data.unpackFrom[IArray[Int]](0)(0).to(List)
+      . assert(_ == Nil)
+
+      test(m"Unpack an array from an offset"):
+        data.unpackFrom[IArray[Int]](4)(2).to(List)
+      . assert(_ == List(2, 3))
+
+      test(m"Unpack an array of products"):
+        IArray[Byte](0, 1, 0, 2, 0, 3, 0, 4).unpackFrom[IArray[Pair]](0)(2).to(List)
+      . assert(_ == List(Pair(1.toShort, 2.toShort), Pair(3.toShort, 4.toShort)))
+
+      test(m"An array continuation does not advance the caller's buffer"):
+        data.buffer:
+          unpack[IArray[Int]](3)
+          summon[Buffer].offset
+      . assert(_ == 0)
+
+      test(m"An array continuation can be invoked more than once"):
+        data.buffer:
+          val read = unpack[IArray[Int]]
+          (read(1).to(List), read(2).to(List))
+      . assert(_ == (List(1), List(1, 2)))

--- a/lib/symbolism/src/core/symbolism.Multiplicable.scala
+++ b/lib/symbolism/src/core/symbolism.Multiplicable.scala
@@ -60,7 +60,7 @@ object Multiplicable:
     (multiplicand, multiplier) => multiplicand*multiplier
 
   given short: Short is Multiplicable by Short to Short = Multiplicable:
-    (multiplicand, multiplier) => (multiplicand*multiplier).toByte
+    (multiplicand, multiplier) => (multiplicand*multiplier).toShort
 
   given byte: Byte is Multiplicable by Byte to Byte = Multiplicable:
     (multiplicand, multiplier) => (multiplicand*multiplier).toByte

--- a/lib/symbolism/src/test/symbolism_test.scala
+++ b/lib/symbolism/src/test/symbolism_test.scala
@@ -34,6 +34,236 @@ package symbolism
 
 import soundness.*
 
+case class Vector2(x: Int, y: Int)
+
+object Vector2:
+  given addable: Vector2 is Addable by Vector2 to Vector2 =
+    Addable((left, right) => Vector2(left.x + right.x, left.y + right.y))
+
+  given subtractable: Vector2 is Subtractable by Vector2 to Vector2 =
+    Subtractable((left, right) => Vector2(left.x - right.x, left.y - right.y))
+
+  given multiplicable: Vector2 is Multiplicable by Int to Vector2 =
+    Multiplicable((vector, scale) => Vector2(vector.x*scale, vector.y*scale))
+
+  given divisible: Vector2 is Divisible by Int to Vector2 =
+    Divisible((vector, divisor) => Vector2(vector.x/divisor, vector.y/divisor))
+
+  given negatable: Vector2 is Negatable to Vector2 =
+    Negatable(vector => Vector2(-vector.x, -vector.y))
+
+  given zeroic: Vector2 is Zeroic:
+    def zero: Vector2 = Vector2(0, 0)
+
+  given unital: Vector2 is Unital:
+    protected def makeOne(): Vector2 = Vector2(1, 1)
+
+case class Chunk(text: Text)
+
+object Chunk:
+  given concatenable: Chunk is Concatenable by Chunk =
+    (left, right) => Chunk(left.text+right.text)
+
+  given zeroic: Chunk is Zeroic:
+    def zero: Chunk = Chunk(t"")
+
+case class Fraction(numerator: Int, denominator: Int)
+
+object Fraction:
+  given quotient: Fraction is Quotient:
+    type Topic = Int
+    type Transport = Int
+
+    def decompose(fraction: Fraction): Option[(Int, Int)] =
+      if fraction.denominator == 0 then None
+      else Some((fraction.numerator, fraction.denominator))
+
 object Tests extends Suite(m"Symbolism Tests"):
   def run(): Unit =
-    ()
+    suite(m"Addable tests"):
+      test(m"Add two Ints through the typeclass"):
+        Addable.int.add(2, 3)
+      . assert(_ == 5)
+
+      test(m"Add two Doubles through the typeclass"):
+        Addable.double.add(0.25, 0.5)
+      . assert(_ == 0.75)
+
+      test(m"Adding an Int to a Double widens the result"):
+        Addable.int2.add(3, 0.5)
+      . assert(_ == 3.5)
+
+      test(m"Adding a Double to an Int widens the result"):
+        Addable.int3.add(0.5, 3)
+      . assert(_ == 3.5)
+
+      test(m"Adding two Shorts narrows back to a Short"):
+        Addable.short.add(1, 2)
+      . assert(_ == 3.toShort)
+
+      test(m"Adding two Shorts wraps on overflow"):
+        Addable.short.add(32767.toShort, 1.toShort)
+      . assert(_ == (-32768).toShort)
+
+      test(m"Adding two Bytes wraps on overflow"):
+        Addable.byte.add(127.toByte, 1.toByte)
+      . assert(_ == (-128).toByte)
+
+      test(m"Add two user-defined values with the `+` operator"):
+        Vector2(1, 2) + Vector2(10, 20)
+      . assert(_ == Vector2(11, 22))
+
+      test(m"A Concatenable value is Addable"):
+        Chunk(t"one") + Chunk(t"two")
+      . assert(_ == Chunk(t"onetwo"))
+
+      test(m"Adding mismatched types is rejected"):
+        demilitarize:
+          Vector2(1, 2) + 1
+      . assert(_.nonEmpty)
+
+    suite(m"Subtractable tests"):
+      test(m"Subtract two Ints through the typeclass"):
+        Subtractable.int.subtract(7, 3)
+      . assert(_ == 4)
+
+      test(m"Subtract two Longs through the typeclass"):
+        Subtractable.long.subtract(7L, 9L)
+      . assert(_ == -2L)
+
+      test(m"Subtracting two Bytes narrows back to a Byte"):
+        Subtractable.byte.subtract(3.toByte, 5.toByte)
+      . assert(_ == (-2).toByte)
+
+      test(m"Subtract two user-defined values with the `-` operator"):
+        Vector2(10, 20) - Vector2(1, 2)
+      . assert(_ == Vector2(9, 18))
+
+    suite(m"Multiplicable tests"):
+      test(m"Multiply two Ints through the typeclass"):
+        Multiplicable.int.multiply(6, 7)
+      . assert(_ == 42)
+
+      test(m"Multiply two Doubles through the typeclass"):
+        Multiplicable.double.multiply(1.5, 4.0)
+      . assert(_ == 6.0)
+
+      test(m"Multiplying two Shorts stays within Short range"):
+        Multiplicable.short.multiply(100.toShort, 3.toShort)
+      . assert(_ == 300.toShort)
+
+      test(m"Multiplying two Bytes narrows back to a Byte"):
+        Multiplicable.byte.multiply(10.toByte, 4.toByte)
+      . assert(_ == 40.toByte)
+
+      test(m"Scale a user-defined value with the `*` operator"):
+        Vector2(3, 4)*3
+      . assert(_ == Vector2(9, 12))
+
+      test(m"Repeat a Concatenable value with the `*` operator"):
+        Chunk(t"ab")*3
+      . assert(_ == Chunk(t"ababab"))
+
+      test(m"Repeating a Concatenable value zero times gives zero"):
+        Chunk(t"ab")*0
+      . assert(_ == Chunk(t""))
+
+    suite(m"Divisible tests"):
+      test(m"Divide two Ints through the typeclass"):
+        Divisible.int.divide(7, 2)
+      . assert(_ == 3)
+
+      test(m"Dividing an Int by a Double widens the result"):
+        Divisible.int2.divide(7, 2.0)
+      . assert(_ == 3.5)
+
+      test(m"Divide a user-defined value with the `/` operator"):
+        Vector2(9, 12)/3
+      . assert(_ == Vector2(3, 4))
+
+    suite(m"Negatable tests"):
+      test(m"Negate an Int through the typeclass"):
+        Negatable.int.negate(5)
+      . assert(_ == -5)
+
+      test(m"Negating a Byte narrows back to a Byte"):
+        Negatable.byte.negate((-128).toByte)
+      . assert(_ == (-128).toByte)
+
+      test(m"Negate a user-defined value with unary minus"):
+        -Vector2(3, -4)
+      . assert(_ == Vector2(-3, 4))
+
+    suite(m"Rootable tests"):
+      test(m"Take the square root of a Double"):
+        16.0.sqrt
+      . assert(_ == 4.0)
+
+      test(m"Take the cube root of a Double"):
+        27.0.cbrt
+      . assert(_ == 3.0)
+
+      test(m"Take the square root of a Float"):
+        16.0f.sqrt
+      . assert(_ == 4.0f)
+
+      test(m"Take the cube root of a Float"):
+        (-27.0f).cbrt
+      . assert(_ == -3.0f)
+
+      test(m"A user-defined root can be summoned"):
+        given fourth: Double is Rootable[4] to Double = Rootable(_.sqrt.sqrt)
+        summon[Double is Rootable[4] to Double].root(81.0)
+      . assert(_ == 3.0)
+
+      test(m"There is no square root for Ints"):
+        demilitarize:
+          16.sqrt
+      . assert(_.nonEmpty)
+
+    suite(m"Zeroic and Unital tests"):
+      test(m"Zero for Int is 0"):
+        zero[Int]
+      . assert(_ == 0)
+
+      test(m"Zero for Double is 0.0"):
+        zero[Double]
+      . assert(_ == 0.0)
+
+      test(m"Zero for String is empty"):
+        zero[String]
+      . assert(_ == "")
+
+      test(m"Zero for a user-defined type"):
+        zero[Vector2]
+      . assert(_ == Vector2(0, 0))
+
+      test(m"One for Int is 1"):
+        summon[Int is Unital].one
+      . assert(_ == 1)
+
+      test(m"One for Float is 1.0"):
+        summon[Float is Unital].one
+      . assert(_ == 1.0f)
+
+      test(m"One for a user-defined type"):
+        summon[Vector2 is Unital].one
+      . assert(_ == Vector2(1, 1))
+
+      test(m"There is no zero for an arbitrary type"):
+        demilitarize:
+          zero[Vector2 => Vector2]
+      . assert(_.nonEmpty)
+
+    suite(m"Quotient tests"):
+      test(m"Decompose a quotient into its parts"):
+        Fraction(3, 4) match
+          case numerator /: denominator => (numerator, denominator)
+          case _                        => (0, 0)
+      . assert(_ == (3, 4))
+
+      test(m"An undecomposable quotient does not match"):
+        Fraction(3, 0) match
+          case numerator /: denominator => t"matched"
+          case _                        => t"unmatched"
+      . assert(_ == t"unmatched")


### PR DESCRIPTION
Nine modules — `ambience`, `caduceus`, `charisma`, `contextual`, `diuretic`, `gigantism`, `gnossienne`, `polaris` and `symbolism` — shipped a test file whose `run()` method was empty, so nothing in them was covered. Each now has a real suite, 283 tests in total, written against the modules' public surfaces. Writing them turned up a truncation bug in `symbolism`'s `Short` multiplication, which is fixed here.

### Fixed: `Short` multiplication truncated to a `Byte`

Multiplying two `Short` values through `Multiplicable` narrowed the result to a `Byte` before widening it back, so any product outside the `Byte` range was silently wrong:

```scala
val area: Short = 100.toShort*3.toShort  // was 44, now 300
```

The `Addable`, `Subtractable` and `Divisible` instances were unaffected.

### New test coverage

The suites are written to pin behaviour that was previously only implied by the implementation, including several things worth knowing if you build on these modules:

- **`contextual`** — the `Transport` tuple passed to an `Interpolable` holds the literal parts in *reverse* source order. Every interpolator in Soundness un-reverses it, but this was undocumented, and a wrong implementation happens to pass for literals whose parts are symmetric. There is now a test that states the ordering directly.
- **`ambience`** — directory resolution is tested through fixed `Environment` and `System` instances, so both the XDG and the Windows branches are covered on any host.
- **`polaris`** — the array continuation returned by `unpack` leaves the caller's read position untouched and may be invoked repeatedly; both are now asserted.
- **`charisma`** — includes the systematic IUPAC names generated for elements beyond oganesson (element 119 is `Uue`, "Ununennium").

No public API changed apart from the `Short` fix.
