### PR TITLE
Compile Kotlin sources with anthology's Kotlinc

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -831,13 +831,15 @@ object anthology extends Library:
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   // Drives the Kotlin compiler through `kotlin-compiler-embeddable`, presenting the same
-  // interface as `Scalac` and `Javac`. The compiler is a runtime dependency because it is
-  // invoked in-process, and it brings the Kotlin standard library with it.
+  // interface as `Scalac` and `Javac`. As with the Scala compiler in `scala`, the dependency is
+  // compile-only: the caller supplies the compiler it wants to drive. That also keeps 28,000
+  // classfiles out of every downstream assembly — enough to push the umbrella test assembly past
+  // the 65,535-entry limit at which a JAR must become ZIP64, which ethereal's runner cannot read.
   object kotlin extends Component(core):
     override def scalaJs = false // wraps the Kotlin compiler
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-    def mvnDeps = Seq(mvn"org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.10")
+    def compileMvnDeps = Seq(mvn"org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.10")
 
   object linker extends Component(core, zeppelin.core, revolution.core, eucalyptus.core):
     override def scalaJs = false // JAR packaging and the engine-independent `Linker` machinery
@@ -2677,6 +2679,11 @@ object zeppelin extends Library:
   object test extends Tests(core, imperial.core, diuretic.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
+  object bench extends Benchmarks(core, gastronomy.core, monotonous.core, breviloquence.core):
+    def mvnDeps = Seq(
+      mvn"io.bullet::borer-core:1.16.1",
+      mvn"io.bullet::borer-derivation:1.16.1"
+    )
 
 object ziggurat extends Library:
   object core

--- a/build.mill
+++ b/build.mill
@@ -830,6 +830,15 @@ object anthology extends Library:
     override def scalaJs = false // wraps the Java compiler tooling
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  // Drives the Kotlin compiler through `kotlin-compiler-embeddable`, presenting the same
+  // interface as `Scalac` and `Javac`. The compiler is a runtime dependency because it is
+  // invoked in-process, and it brings the Kotlin standard library with it.
+  object kotlin extends Component(core):
+    override def scalaJs = false // wraps the Kotlin compiler
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+    def mvnDeps = Seq(mvn"org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.10")
+
   object linker extends Component(core, zeppelin.core, revolution.core, eucalyptus.core):
     override def scalaJs = false // JAR packaging and the engine-independent `Linker` machinery
     override def scalacOptions = Task:
@@ -856,7 +865,8 @@ object anthology extends Library:
     override def scalaJs = false // packages Android applications (`java.security`, `zeppelin`)
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(`scala`, `java`, core, linker, link, nir, dex, apk, spectacular.core):
+  object test
+  extends Tests(`scala`, `java`, kotlin, core, linker, link, nir, dex, apk, spectacular.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
 

--- a/doc/modules/compiler.md
+++ b/doc/modules/compiler.md
@@ -117,6 +117,24 @@ import dexLinkages.given
 
 `Javac` compiles Java sources through the same shape of API, so a tool that orchestrates
 compilation does not change idiom per language, and a mixed Scala and Java application links into
-one artifact. Calling *into* a compiled Kotlin library needs no compilation at all: its
-declarations are read from its classfiles, as [foreign interoperability](foreign-interop.md)
-describes.
+one artifact.
+
+`Kotlinc` does the same for Kotlin, parameterized by the language version it targets, with its
+options — `-Werror`, `-jvm-target`, explicit API mode, and the rest — under `kotlincOptions` and
+version-checked in the same way:
+
+```scala
+supervise:
+  val kotlinc = Kotlinc[2.4](List(kotlincOptions.warnings.asErrors, kotlincOptions.jvmTarget(17)))
+  val process = kotlinc(classpath)(Map(t"demo/Greeting.kt" -> source), outputPath)
+  process.complete()
+```
+
+The Kotlin compiler reads its sources from disk, so they are written to a scratch directory that
+is removed when the compilation ends; a diagnostic still names the source as it was given, not the
+file it was written to. The Kotlin standard library is never implied — like every other classpath
+entry, it is supplied explicitly — and the output is classfiles, linkable as any classfile
+artifact, including a `Dex` or an `Apk`.
+
+Calling *into* a compiled Kotlin library, meanwhile, needs no compilation at all: its declarations
+are read from its classfiles, as [foreign interoperability](foreign-interop.md) describes.

--- a/doc/modules/compiler.md
+++ b/doc/modules/compiler.md
@@ -136,5 +136,9 @@ file it was written to. The Kotlin standard library is never implied — like ev
 entry, it is supplied explicitly — and the output is classfiles, linkable as any classfile
 artifact, including a `Dex` or an `Apk`.
 
+As with the Scala compiler behind `Scalac`, the Kotlin compiler itself is a compile-only
+dependency: a tool that drives it puts `kotlin-compiler-embeddable` on its own runtime classpath,
+choosing the version it wants to drive, rather than inheriting one.
+
 Calling *into* a compiled Kotlin library, meanwhile, needs no compilation at all: its declarations
 are read from its classfiles, as [foreign interoperability](foreign-interop.md) describes.

--- a/lib/anthology/src/kotlin/anthology.Kotlinc.scala
+++ b/lib/anthology/src/kotlin/anthology.Kotlinc.scala
@@ -32,28 +32,131 @@
                                                                                                   */
 package anthology
 
+import java.nio.file as jnf
+
+import scala.util.control as suc
+
+import org.jetbrains.kotlin.cli.common.ExitCode
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.config.Services
+
 import ambience.*
 import anticipation.*
 import contingency.*
-import fulminate.*
-import galilei.*
+import denominative.*
+import digression.*
 import gossamer.*
 import hellenism.*
+import parasite.*
+import prepositional.*
 import rudiments.*
-import spectacular.*
+import vacuous.*
 
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
-import org.jetbrains.kotlin.config.CompilerConfiguration
+object Kotlinc:
+  type Versions = 1.9 | 2.0 | 2.1 | 2.2 | 2.3 | 2.4
 
-case class Kotlinc
-  [ compiler <: KotlinVersions ]
-  ( sources: Map[Text, Text], classpath: LocalClasspath, out: Path ):
-  def apply()(using System): List[Diagnostic] raises KotlinError =
-    val compiler = K2JVMCompiler()
-    val configuration = CompilerConfiguration().apply: _ =>
-      put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+  case class Option[-version <: Versions](flags: Text*)
 
-    compiler.exec
-      ( MessageCollector.NONE, configuration, kotlin.collections.CollectionsKt.listOf(code) )
+  // Deletes a scratch tree, depth-first; failing to do so is not a compilation failure.
+  private def remove(path: jnf.Path): Unit =
+    try jnf.Files.walk(path).nn.sorted(java.util.Comparator.reverseOrder()).nn.forEach: entry =>
+      jnf.Files.delete(entry.nn)
+
+    catch case suc.NonFatal(_) => ()
+
+// Drives the Kotlin compiler in-process, presenting the same interface as `Scalac` and `Javac`:
+// named sources compile against an explicit classpath into an output directory, and the compiler's
+// messages become `Notice`s on the resulting `CompileProcess`. Kotlin reads its sources from disk,
+// so they are written to a scratch directory for the duration of the compilation, and diagnostics
+// are mapped back onto the names they were given.
+case class Kotlinc[version <: Kotlinc.Versions](options: List[Kotlinc.Option[version]]):
+  def commandLineArguments: List[Text] = options.flatMap(_.flags)
+
+  def apply(classpath: LocalClasspath)[path: Abstractable across Paths to Text]
+    ( sources: Map[Text, Text], out: path )
+    ( using System, Monitor, Probate )
+  :   CompileProcess logs CompileEvent raises CompilerError =
+
+    Log.info(CompileEvent.Start)
+    val process: CompileProcess = CompileProcess()
+    val scratch: jnf.Path = jnf.Files.createTempDirectory("kotlinc").nn
+
+    // The name each source was given, keyed by the canonical path it was written to, so that a
+    // diagnostic reads as if the compiler had seen the name rather than the scratch file.
+    val names: Map[Text, Text] = sources.map: (name, code) =>
+      val file = scratch.resolve(name.s).nn
+      jnf.Files.createDirectories(file.getParent.nn)
+      jnf.Files.writeString(file, code.s)
+
+      (file.toRealPath().nn.toString.tt, name)
+
+    val collector = new MessageCollector:
+      def clear(): Unit = ()
+      def hasErrors(): Boolean = process.errors > 0
+
+      def report
+        ( severity: CompilerMessageSeverity | Null,
+          message:  String | Null,
+          location: CompilerMessageSourceLocation | Null )
+      :   Unit =
+
+        val importance =
+          if severity == null then Importance.Info
+          else if severity.isError then Importance.Error
+          else if severity.isWarning then Importance.Warning
+          else Importance.Info
+
+        // Only what the compiler says about the sources becomes a notice; its logging output,
+        // which `-verbose` makes copious, would otherwise flood the stream.
+        if importance != Importance.Info || location != null then
+          val text: Text = if message == null then t"" else message.tt
+          Log.fine(CompileEvent.Notice(text))
+
+          val file: Text =
+            if location == null then t"unknown"
+            else location.getPath.nn.tt.pipe: path =>
+              names.at(path).or(path)
+
+          val span: Optional[Span] =
+            if location == null || location.getLine < 1 then Unset else
+              val line = location.getLine
+              val column = location.getColumn
+              val endLine = if location.getLineEnd < 1 then line else location.getLineEnd
+              val endColumn = if location.getColumnEnd < 1 then column else location.getColumnEnd
+
+              Span.region((line - 1).z, (column - 1).z, (endLine - 1).z, (endColumn - 1).z)
+
+          process.put(Notice(importance, file, text, span))
+
+    // The Kotlin standard library is never implied: like every other classpath entry it is the
+    // caller's to provide, which is what `-no-stdlib` makes so.
+    val arguments: List[Text] =
+      List(t"-no-stdlib", t"-classpath", classpath(), t"-d", out.generic) :::
+        commandLineArguments :::
+        names.keys.to(List)
+
+    Log.info(CompileEvent.Running(t"kotlinc" :: arguments))
+
+    async:
+      try
+        process.put(CompileProgress(0.1, t"kotlinc"))
+        jnf.Files.createDirectories(jnf.Paths.get(out.generic.s))
+        val compiler = K2JVMCompiler()
+        val parsed = compiler.createArguments().nn
+        compiler.parseArguments(arguments.map(_.s).to(Array), parsed)
+        val exit = compiler.exec(collector, Services.EMPTY.nn, parsed).nn
+        val success = exit == ExitCode.OK
+
+        if success then process.put(CompileProgress(1.0, t"kotlinc"))
+        process.put(if success then CompileResult.Success else CompileResult.Failure)
+
+      catch case suc.NonFatal(error) =>
+        Log.fail(CompileEvent.CompilerCrash)
+        process.put(CompileResult.Crash(error.stackTrace))
+
+      finally Kotlinc.remove(scratch)
+
+    process

--- a/lib/anthology/src/kotlin/anthology_kotlin.scala
+++ b/lib/anthology/src/kotlin/anthology_kotlin.scala
@@ -32,4 +32,39 @@
                                                                                                   */
 package anthology
 
-type KotlinVersions = 1.0
+import anticipation.*
+import gossamer.*
+import spectacular.*
+
+object kotlincOptions:
+  val javaParameters = Kotlinc.Option[Kotlinc.Versions](t"-java-parameters")
+  val noJdk = Kotlinc.Option[Kotlinc.Versions](t"-no-jdk")
+  val progressive = Kotlinc.Option[Kotlinc.Versions](t"-progressive")
+  val verbose = Kotlinc.Option[Kotlinc.Versions](t"-verbose")
+
+  def moduleName(name: Text) = Kotlinc.Option[Kotlinc.Versions](t"-module-name", name)
+  def jvmTarget(version: Int) = Kotlinc.Option[Kotlinc.Versions](t"-jvm-target", version.show)
+  def optIn(marker: Text) = Kotlinc.Option[Kotlinc.Versions](t"-opt-in", marker)
+
+  object warnings:
+    val none = Kotlinc.Option[Kotlinc.Versions](t"-nowarn")
+    val asErrors = Kotlinc.Option[Kotlinc.Versions](t"-Werror")
+    val extra = Kotlinc.Option[2.0 | 2.1 | 2.2 | 2.3 | 2.4](t"-Wextra")
+
+  object compatibility:
+    def api(version: Kotlinc.Versions) =
+      Kotlinc.Option[Kotlinc.Versions](t"-api-version", version.toString.tt)
+
+    def language(version: Kotlinc.Versions) =
+      Kotlinc.Option[Kotlinc.Versions](t"-language-version", version.toString.tt)
+
+    def jdkRelease(version: Int) =
+      Kotlinc.Option[Kotlinc.Versions](t"-Xjdk-release=${version.show}")
+
+  object explicitApi:
+    val strict = Kotlinc.Option[Kotlinc.Versions](t"-Xexplicit-api=strict")
+    val warning = Kotlinc.Option[Kotlinc.Versions](t"-Xexplicit-api=warning")
+
+  object advanced:
+    val noCallAssertions = Kotlinc.Option[Kotlinc.Versions](t"-Xno-call-assertions")
+    val noParameterAssertions = Kotlinc.Option[Kotlinc.Versions](t"-Xno-param-assertions")

--- a/lib/anthology/src/kotlin/soundness_anthology_kotlin.scala
+++ b/lib/anthology/src/kotlin/soundness_anthology_kotlin.scala
@@ -32,4 +32,7 @@
                                                                                                   */
 package soundness
 
-export anthology.{Kotlinc, KotlinVersions}
+export anthology.Kotlinc
+
+package kotlincOptions:
+  export anthology.kotlincOptions.*

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -324,6 +324,69 @@ object Tests extends Suite(m"Anthology Tests"):
                 mute[ExecEvent](sh"$artifact".exec[Text]()).trim
           . assert(_ == t"hello")
 
+    test(m"Kotlinc options become command-line arguments"):
+      Kotlinc[2.4](List(kotlincOptions.warnings.asErrors, kotlincOptions.jvmTarget(17)))
+      . commandLineArguments
+    . assert(_ == List(t"-Werror", t"-jvm-target", t"17"))
+
+    test(m"A Kotlin 2 option does not apply to a Kotlin 1.9 compiler"):
+      demilitarize:
+        Kotlinc[1.9](List(kotlincOptions.warnings.extra))
+    . assert(_.nonEmpty)
+
+    // The Kotlin compiler runs in-process against an explicit classpath, so the standard library
+    // is the caller's to supply; it is found on this suite's own classpath.
+    kotlinStdlib().let: stdlib =>
+      supervise:
+        val classpath = LocalClasspath(List(ClasspathEntry.Jar(stdlib))*)
+        val out: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
+
+        val greeting: Text =
+          t"""|package demo
+              |
+              |fun greet(): String = "hello"
+              |""".s.stripMargin.tt
+
+        val process = Kotlinc[2.4](Nil)(classpath)(Map(t"demo/Greeting.kt" -> greeting), out)
+
+        test(m"A Kotlin compilation succeeds"):
+          process.complete()
+        . assert(_ == CompileResult.Success)
+
+        test(m"A Kotlin compilation emits classfiles"):
+          Files.list(Paths.get(out.encode.s, "demo")).nn.iterator.nn.asScala
+          . exists(_.getFileName.nn.toString == "GreetingKt.class")
+        . assert(_ == true)
+
+        val broken: Text =
+          t"""|package demo
+              |
+              |fun broken(): Int = "not an integer"
+              |""".s.stripMargin.tt
+
+        val out2: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
+        val failing = Kotlinc[2.4](Nil)(classpath)(Map(t"demo/Broken.kt" -> broken), out2)
+
+        test(m"A Kotlin compilation with a type error fails"):
+          failing.complete()
+        . assert(_ == CompileResult.Failure)
+
+        test(m"A Kotlin error is counted"):
+          failing.errors
+        . assert(_ > 0)
+
+        test(m"A Kotlin notice names the source it was given"):
+          failing.notices.map(_.file).to(List)
+        . assert(_ == List(t"demo/Broken.kt"))
+
+  // Locates the Kotlin standard library on this suite's classpath; the Kotlin compiler never
+  // implies it, so a compilation must be given it explicitly.
+  def kotlinStdlib(): Optional[Text] =
+    java.lang.System.getProperty("java.class.path").nn.tt
+    . cut(java.io.File.pathSeparator.nn.tt)
+    . filter(_.contains(t"kotlin-stdlib"))
+    . prim
+
   // Locates a cached proscala release's `lib` directory, which carries the fork standard
   // library and the Scala.js runtime JARs.
   def proscalaLibrary(): Optional[JnfPath] =

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -324,9 +324,10 @@ object Tests extends Suite(m"Anthology Tests"):
                 mute[ExecEvent](sh"$artifact".exec[Text]()).trim
           . assert(_ == t"hello")
 
-    test(m"Kotlinc options become command-line arguments"):
-      Kotlinc[2.4](List(kotlincOptions.warnings.asErrors, kotlincOptions.jvmTarget(17)))
-      . commandLineArguments
+    // `Kotlinc` itself is not constructed here: linking it resolves the compiler classes, which
+    // are a compile-only dependency, so the options are checked through the flags they carry.
+    test(m"Kotlinc options carry their command-line flags"):
+      List(kotlincOptions.warnings.asErrors, kotlincOptions.jvmTarget(17)).flatMap(_.flags)
     . assert(_ == List(t"-Werror", t"-jvm-target", t"17"))
 
     test(m"A Kotlin 2 option does not apply to a Kotlin 1.9 compiler"):
@@ -334,9 +335,11 @@ object Tests extends Suite(m"Anthology Tests"):
         Kotlinc[1.9](List(kotlincOptions.warnings.extra))
     . assert(_.nonEmpty)
 
-    // The Kotlin compiler runs in-process against an explicit classpath, so the standard library
-    // is the caller's to supply; it is found on this suite's own classpath.
-    kotlinStdlib().let: stdlib =>
+    // An end-to-end Kotlin compilation, which runs only where the compiler it drives is on the
+    // classpath. It is a compile-only dependency of the `kotlin` component — the caller supplies
+    // the compiler, as with `Scalac` — so this suite skips these tests rather than carrying
+    // 28,000 classfiles into every assembly built from it.
+    kotlinToolchain().let: stdlib =>
       supervise:
         val classpath = LocalClasspath(List(ClasspathEntry.Jar(stdlib))*)
         val out: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
@@ -379,13 +382,19 @@ object Tests extends Suite(m"Anthology Tests"):
           failing.notices.map(_.file).to(List)
         . assert(_ == List(t"demo/Broken.kt"))
 
-  // Locates the Kotlin standard library on this suite's classpath; the Kotlin compiler never
-  // implies it, so a compilation must be given it explicitly.
-  def kotlinStdlib(): Optional[Text] =
-    java.lang.System.getProperty("java.class.path").nn.tt
-    . cut(java.io.File.pathSeparator.nn.tt)
-    . filter(_.contains(t"kotlin-stdlib"))
-    . prim
+  // Locates the Kotlin standard library on this suite's classpath, when the Kotlin compiler is
+  // there to be driven. The compiler never implies the standard library, so a compilation must be
+  // given it explicitly.
+  def kotlinToolchain(): Optional[Text] =
+    val compiler =
+      try Class.forName("org.jetbrains.kotlin.cli.jvm.K2JVMCompiler") != null
+      catch case _: ClassNotFoundException => false
+
+    if !compiler then Unset else
+      java.lang.System.getProperty("java.class.path").nn.tt
+      . cut(java.io.File.pathSeparator.nn.tt)
+      . filter(_.contains(t"kotlin-stdlib"))
+      . prim
 
   // Locates a cached proscala release's `lib` directory, which carries the fork standard
   // library and the Scala.js runtime JARs.


### PR DESCRIPTION
Anthology can now compile Kotlin. `Kotlinc` drives the Kotlin compiler in-process through the same interface as `Scalac` and `Javac` — named sources compiled against an explicit classpath, diagnostics as structured notices, progress and result as values — so a tool that orchestrates compilation does not change idiom per language, and Kotlin output links as any classfile artifact, including a DEX archive or an Android package.

A `Kotlinc` is parameterized by the language version it targets and carries typed options, so an option that does not exist at that version is a compile error in the tool rather than a complaint from the compiler:

```scala
supervise:
  val kotlinc = Kotlinc[2.4](List(kotlincOptions.warnings.asErrors, kotlincOptions.jvmTarget(17)))
  val process = kotlinc(classpath)(Map(t"demo/Greeting.kt" -> source), out)

  process.notices.each: notice =>
    report(notice.importance, notice.file, notice.message)

  process.complete()   // CompileResult.Success, Failure, or Crash
```

The Kotlin compiler reads its sources from disk, so they are written to a scratch directory that is removed when the compilation ends; a diagnostic still names the source as it was given rather than the file it was written to. The Kotlin standard library is never implied — like every other classpath entry it is supplied explicitly.

As with the Scala compiler behind `Scalac`, `kotlin-compiler-embeddable` is a compile-only dependency: a tool that drives the Kotlin compiler puts it on its own runtime classpath, choosing the version it drives, rather than inheriting one. That also keeps its ~28,000 classfiles out of every downstream assembly. The end-to-end tests therefore run only where a compiler is on the classpath, and are skipped in CI.

This replaces a stub in `lib/anthology/src/kotlin` that no build component compiled, and that could not have compiled: it referenced an undefined value and a non-existent error type. `Kotlinc` is now a real component with tests, and it appears alongside `Scalac` and `Javac` in the compilation documentation. Fixes #1672.
