### PR TITLE
Rename `Typename` to `Designator`

### DIFF
--- a/lib/delicious/src/test/delicious_test.scala
+++ b/lib/delicious/src/test/delicious_test.scala
@@ -202,13 +202,13 @@ object Tests extends Suite(m"Delicious Tests"):
       val placeholder =
         Placeholder(0, PlaceholderKind.LocalType, t"Local", 0, Unset, t"Bad.Local")
 
-      val list = Syntax.Simple(Typename(t"scala.collection.immutable.List"))
+      val list = Syntax.Simple(Designator(t"scala.collection.immutable.List"))
       val syntax =
         Syntax.Application(list, List(Syntax.Primitive(t"\"⟨scala-diag:0⟩\"")), false)
 
       Reifier.substitute(syntax, List(placeholder))
     . assert(_ == Syntax.Application
-        ( Syntax.Simple(Typename(t"scala.collection.immutable.List")),
+        ( Syntax.Simple(Designator(t"scala.collection.immutable.List")),
           List(Syntax.Symbolic(t"Bad.Local")),
           false ))
 

--- a/lib/stenography/src/core/soundness_stenography_core.scala
+++ b/lib/stenography/src/core/soundness_stenography_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export stenography.{Bindings, Imports, Syntax, Typename}
+export stenography.{Bindings, Imports, Syntax, Designator}

--- a/lib/stenography/src/core/stenography.Designator.scala
+++ b/lib/stenography/src/core/stenography.Designator.scala
@@ -40,40 +40,45 @@ import rudiments.*
 import symbolism.*
 import vacuous.*
 
-object Typename:
-  def fromUrl(text: Text): Typename = apply(text.s.replaceAll("~", "#").nn.tt)
+object Designator:
+  def fromUrl(text: Text): Designator = apply(text.s.replaceAll("~", "#").nn.tt)
 
-  def apply(text: Text): Typename =
-    def recur(i: Ordinal, start: Ordinal, typename: Optional[Typename]): Typename =
+  def apply(text: Text): Designator =
+    def recur(i: Ordinal, start: Ordinal, designator: Optional[Designator]): Designator =
       def next = text.segment(start thru i - 1)
 
       text.at(i) match
-        case Unset => typename.lay(Typename.Top(next))(Typename.Term(_, next))
-        case '.'   => recur(i + 1, i + 1, typename.lay(Typename.Top(next))(Typename.Term(_, next)))
-        case '#'   => recur(i + 1, i + 1, typename.lay(Typename.Top(next))(Typename.Type(_, next)))
-        case char  => recur(i + 1, start, typename)
+        case Unset => designator.lay(Designator.Top(next))(Designator.Term(_, next))
+
+        case '.' =>
+          recur(i + 1, i + 1, designator.lay(Designator.Top(next))(Designator.Term(_, next)))
+        case '#' =>
+          recur(i + 1, i + 1, designator.lay(Designator.Top(next))(Designator.Type(_, next)))
+
+        case char =>
+          recur(i + 1, start, designator)
 
     recur(Prim, Prim, Unset)
 
 
-enum Typename:
+enum Designator:
   case Top(name: Text)
-  case Term(parent0: Typename, name: Text)
-  case Type(parent0: Typename, name: Text)
+  case Term(parent0: Designator, name: Text)
+  case Type(parent0: Designator, name: Text)
 
   def name: Text
   def child(name: Text, isType: Boolean) = if isType then Type(this, name) else Term(this, name)
   def qualified: Text = text(using Imports.empty)
 
-  def companionObject: Typename = this match
+  def companionObject: Designator = this match
     case Type(parent, name) => Term(parent, name)
     case other              => other
 
-  def companionType: Typename = this match
+  def companionType: Designator = this match
     case Term(parent, name) => Type(parent, name)
     case other              => other
 
-  def parent: Optional[Typename] = this match
+  def parent: Optional[Designator] = this match
     case Type(parent, _) => parent
     case Term(parent, _) => parent
     case Top(_)          => Unset

--- a/lib/stenography/src/core/stenography.Imports.scala
+++ b/lib/stenography/src/core/stenography.Imports.scala
@@ -35,6 +35,6 @@ package stenography
 object Imports:
   val empty: Imports = Imports(Set(), Set())
 
-case class Imports(typenames: Set[Typename], direct: Set[Typename]):
-  def has(typename: Typename): Boolean = typenames.contains(typename)
-  def hasDirect(typename: Typename): Boolean = direct.contains(typename)
+case class Imports(designators: Set[Designator], direct: Set[Designator]):
+  def has(designator: Designator): Boolean = designators.contains(designator)
+  def hasDirect(designator: Designator): Boolean = direct.contains(designator)

--- a/lib/stenography/src/core/stenography.Syntax.scala
+++ b/lib/stenography/src/core/stenography.Syntax.scala
@@ -43,7 +43,7 @@ import symbolism.*
 import vacuous.*
 
 object Syntax:
-  inline def name[typename <: AnyKind]: Text = ${stenography.internal.typename[typename]}
+  inline def name[designator <: AnyKind]: Text = ${stenography.internal.designator[designator]}
 
   val Space: Symbolic = Symbolic(" ")
   val Colon: Symbolic = Symbolic(": ")
@@ -99,9 +99,9 @@ object Syntax:
           case ValDef(name, meta, default) if name.startsWith("evidence$") =>
 
           apply(meta.tpe) match
-            case Infix(Simple(typename), "is", right)          => List(typename -> right)
-            case Application(Simple(typename), List(right), _) => List(typename -> right)
-            case _                                             => Nil
+            case Infix(Simple(designator), "is", right)          => List(designator -> right)
+            case Application(Simple(designator), List(right), _) => List(designator -> right)
+            case _                                               => Nil
 
       case _ =>
         Nil
@@ -194,7 +194,7 @@ object Syntax:
       case other =>
         Declaration(true, List(), apply(other))
 
-  def term(using Quotes, Bindings)(repr: quotes.reflect.TermRef): Typename = apply(repr) match
+  def term(using Quotes, Bindings)(repr: quotes.reflect.TermRef): Designator = apply(repr) match
     case Value(value) => value
     case _            => panic(m"expected a Value")
 
@@ -211,25 +211,24 @@ object Syntax:
       repr.absolve match
         case ThisType(ref) =>
           apply(ref) match
-            case Simple(Typename.Type(parent, name)) => Simple(Typename.Term(parent, name))
-            case syntax                              => syntax
+            case Simple(Designator.Type(parent, name)) => Simple(Designator.Term(parent, name))
+            case syntax                                => syntax
 
         case typeRef@TypeRef(NoPrefix(), name) =>
-          Simple(Typename.Top(name))
+          Simple(Designator.Top(name))
 
         case typeRef@TypeRef(prefix, name) =>
           val module = typeRef.typeSymbol.flags.is(Flags.Module)
           val name2 = if module then name.dropRight(1) else name
 
           if prefix.typeSymbol.flags.is(Flags.Package)
-          then Simple(Typename.Type(Typename(prefix.show.tt), name2))
+          then Simple(Designator.Type(Designator(prefix.show.tt), name2))
           else apply(prefix) match
-            case value@Value(typename) =>
-              if isPackage(name2) then value
-              else Simple(Typename.Type(typename, name2))
+            case value@Value(designator) =>
+              if isPackage(name2) then value else Simple(Designator.Type(designator, name2))
 
-            case simple@Simple(typename) =>
-              if isPackage(name2) then simple else Simple(Typename.Type(typename, name2))
+            case simple@Simple(designator) =>
+              if isPackage(name2) then simple else Simple(Designator.Type(designator, name2))
 
             case refined@Structural(base, members, defs) =>
               if members.defines(name) then members(name.tt) else Projection(refined, name.tt)
@@ -244,19 +243,19 @@ object Syntax:
               Primitive("<unknown>")
 
         case termRef@TermRef(NoPrefix(), name) =>
-          Value(Typename.Top(name))
+          Value(Designator.Top(name))
 
         case termRef@TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), name) =>
-          Value(Typename.Top(name))
+          Value(Designator.Top(name))
 
         case termRef@TermRef(prefix, name) =>
           apply(prefix) match
-            case value@Value(typename) =>
+            case value@Value(designator) =>
               if repr.toString.contains("inline") then System.out.nn.println(name)
-              if isPackage(name) then value else Value(Typename.Term(typename, name))
+              if isPackage(name) then value else Value(Designator.Term(designator, name))
 
-            case simple@Simple(typename) =>
-              if isPackage(name) then simple else Value(Typename.Term(typename, name))
+            case simple@Simple(designator) =>
+              if isPackage(name) then simple else Value(Designator.Term(designator, name))
 
             case refined@Structural(base, members, defs) =>
               if members.defines(name) then members(name.tt) else Projection(refined, name.tt)
@@ -426,7 +425,7 @@ object Syntax:
           if retry then apply(repr.typeSymbol.typeRef, false) else Primitive("<unknown>")
 
 enum Syntax:
-  case Simple(typename: Typename)
+  case Simple(designator: Designator)
   case Symbolic(text: Text)
   case Primitive(text: Text)
   case Projection(base: Syntax, text: Text)
@@ -439,7 +438,7 @@ enum Syntax:
   case Named(isUsing: Boolean, name: Text, syntax: Syntax)
   case Sequence(style: '(' | '[' | '{', syntaxes: List[Syntax])
   case Declaration(method: Boolean, syntaxes: List[Syntax], result: Syntax)
-  case Value(typename: Typename)
+  case Value(designator: Designator)
   case Compound(syntaxes: List[Syntax])
   case Match(scrutinee: Syntax, cases: List[Syntax])
 
@@ -478,7 +477,7 @@ enum Syntax:
   def qualified: Text = text(using Imports.empty)
 
   def text(using imports: Imports): Text = this match
-    case Simple(typename)        => typename.text
+    case Simple(designator)      => designator.text
     case Symbolic(text)          => text
     case Projection(base, text)  => s"${base.text}#$text".tt
     case Primitive(text)         => text
@@ -488,7 +487,7 @@ enum Syntax:
     case Sequence('(', elements) => s"(${elements.map(_.text).mkString(", ")})".tt
     case Sequence('[', elements) => s"[${elements.map(_.text).mkString(", ")}]".tt
     case Sequence('{', elements) => s"{${elements.map(_.text).mkString(", ")}}".tt
-    case Value(typename)         => s"${typename.text}.type".tt
+    case Value(designator)       => s"${designator.text}.type".tt
     case Compound(syntaxes)      => syntaxes.map(_.text).mkString.tt
 
     case Match(scrutinee, cases) =>
@@ -499,7 +498,7 @@ enum Syntax:
 
     case Application(left, elements, infix) =>
       left match
-        case Simple(Typename.Type(parent, name)) if infix && imports.has(parent) =>
+        case Simple(Designator.Type(parent, name)) if infix && imports.has(parent) =>
           Infix(elements(0), name, elements(1)).text
 
         case _ =>

--- a/lib/stenography/src/core/stenography.internal.scala
+++ b/lib/stenography/src/core/stenography.internal.scala
@@ -40,37 +40,37 @@ import gigantism.*
 object internal:
   import dotty.tools.dotc.*
 
-  def typename[typename <: AnyKind: Type]: Macro[Text] = Expr(name[typename])
+  def designator[designator <: AnyKind: Type]: Macro[Text] = Expr(name[designator])
 
-  def name[typename <: AnyKind: Type](using Quotes): Text =
+  def name[designator <: AnyKind: Type](using Quotes): Text =
     import quotes.reflect.*
-    name(TypeRepr.of[typename])
+    name(TypeRepr.of[designator])
 
   def name(using Quotes)(typeRepr: quotes.reflect.TypeRepr): Text =
     given Bindings = Bindings()
 
-    val outer: List[Typename] = quotes.absolve match
+    val outer: List[Designator] = quotes.absolve match
       case quotes: runtime.impl.QuotesImpl =>
         given context: core.Contexts.Context = quotes.ctx
 
         context.compilationUnit.tpdTree.absolve match
           case ast.tpd.PackageDef(root, statements) =>
-            Typename(root.show) :: statements.collect:
-              case ast.tpd.Import(name, _) => Typename(name.show)
+            Designator(root.show) :: statements.collect:
+              case ast.tpd.Import(name, _) => Designator(name.show)
 
           case _ =>
             Nil
 
       case _ => Nil
 
-    val imports: Set[Typename] = metaprogramming.imports.map(_.term).map(Syntax.term(_)).to(Set)
+    val imports: Set[Designator] = metaprogramming.imports.map(_.term).map(Syntax.term(_)).to(Set)
 
     // Build the `direct` set by drilling into every wildcard import that's in
     // scope (including REPL-accumulated imports across earlier lines, captured
     // by `metaprogramming.imports`) and collecting type aliases carrying the
     // `Exported` flag. Those aliases' *target* types are reachable via just
     // their leaf in the current scope, so we render them that way.
-    val direct: Set[Typename] = quotes.absolve match
+    val direct: Set[Designator] = quotes.absolve match
       case quotes: runtime.impl.QuotesImpl =>
         given context: core.Contexts.Context = quotes.ctx
 
@@ -82,16 +82,16 @@ object internal:
 
         .toSet
 
-      case _ => Set.empty[Typename]
+      case _ => Set.empty[Designator]
 
     given Imports =
-      Imports(Set(Typename("scala"), Typename("scala.Predef")) ++ imports ++ outer, direct)
+      Imports(Set(Designator("scala"), Designator("scala.Predef")) ++ imports ++ outer, direct)
 
     Syntax(typeRepr).text
 
   private def exportedTargets(using Quotes, dotty.tools.dotc.core.Contexts.Context)
     ( rootSym: dotty.tools.dotc.core.Symbols.Symbol )
-  :   List[Typename] =
+  :   List[Designator] =
 
     import dotty.tools.dotc.core.{Flags, Types}
     import quotes.reflect.TypeRepr
@@ -109,8 +109,8 @@ object internal:
             // Add both forms so the same import path can shorten references
             // to either the type itself or its companion (e.g. `Textual` and
             // `Textual.foo` both resolve via `import soundness.*`).
-            case Syntax.Simple(typename) => List(typename, typename.companionObject)
-            case _                       => Nil
+            case Syntax.Simple(designator) => List(designator, designator.companionObject)
+            case _                         => Nil
 
         case _ =>
           Nil

--- a/lib/stenography/src/test/stenography_test.scala
+++ b/lib/stenography/src/test/stenography_test.scala
@@ -45,16 +45,16 @@ import symbolism.*
 object Tests extends Suite(m"Stenography Tests"):
   def run(): Unit =
     test(m"Decode a term"):
-      Typename(t"immutable.List")
-    . assert(_ == Typename.Term(Typename.Top("immutable"), "List"))
+      Designator(t"immutable.List")
+    . assert(_ == Designator.Term(Designator.Top("immutable"), "List"))
 
     test(m"Decode a type of a term"):
-      Typename(t"immutable.List#Value")
-    . assert(_ == Typename.Term(Typename.Type(Typename.Top("immutable"), "List"), "Value"))
+      Designator(t"immutable.List#Value")
+    . assert(_ == Designator.Term(Designator.Type(Designator.Top("immutable"), "List"), "Value"))
 
     test(m"Decode a term of a term"):
-      Typename(t"immutable.List.Value")
-    . assert(_ == Typename.Term(Typename.Term(Typename.Top("immutable"), "List"), "Value"))
+      Designator(t"immutable.List.Value")
+    . assert(_ == Designator.Term(Designator.Term(Designator.Top("immutable"), "List"), "Value"))
 
     test(m"Show `Int`"):
       Syntax.name[Int]


### PR DESCRIPTION
The correct term for `Typename` is actually `Designator`, so this is what is used from now on.