### PR TITLE
Close the remaining gaps in Stratiform's mirrored literal-atom delimiters

### DIFF
--- a/lib/stratiform/res/test/stratiform/corpus/pos.index
+++ b/lib/stratiform/res/test/stratiform/corpus/pos.index
@@ -43,6 +43,7 @@ literal-atom-custom-delimiter
 literal-atom-delimiter-in-payload
 literal-atom-delimiter-partial-match
 literal-atom-empty-payload
+literal-atom-flush-delimiter-in-payload
 literal-atom-from-nested
 literal-atom-multiline-payload
 literal-atom-nested-compound

--- a/lib/stratiform/src/core/stratiform.Mutation.scala
+++ b/lib/stratiform/src/core/stratiform.Mutation.scala
@@ -617,16 +617,20 @@ object Mutation:
     Text(delimiter)
 
   // True if `s` contains a line consisting of zero-or-more spaces followed
-  // exactly by `delimiter`.
+  // exactly by `delimiter`. A trailing CR is stripped before the comparison
+  // because the parser strips one too when recognising the closing delimiter
+  // line (§15); without that, a payload line of `<spaces><delimiter>CR` would
+  // pass this check yet close the atom early on re-parse.
   private def collidesWithDelimiterLine(s: String, delimiter: String): Boolean =
     var start = 0
     var found = false
 
     while !found && start <= s.length do
       val nl = s.indexOf('\n', start)
-      val end = if nl < 0 then s.length else nl
+      val lineEnd = if nl < 0 then s.length else nl
       var i = start
-      while i < end && s.charAt(i) == ' ' do i += 1
+      while i < lineEnd && s.charAt(i) == ' ' do i += 1
+      val end = if lineEnd > i && s.charAt(lineEnd - 1) == '\r' then lineEnd - 1 else lineEnd
       if s.substring(i, end).nn == delimiter then found = true
       start = if nl < 0 then s.length + 1 else nl + 1
 

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1272,6 +1272,29 @@ object Tests extends Suite(m"Stratiform Tests"):
           case _: Tel.Atom.Inline  => "inline"
       . assert(_ == "literal")
 
+      // A top-level literal atom's delimiter line is six spaces plus the
+      // delimiter (§15), and the parser strips a trailing CR before matching
+      // it, so `      ---\r` in the payload must count as a §22.2 collision.
+      val crCollision = t"before\n      ---\r\nafter\n"
+
+      test(m"A CR-terminated delimiter line in the payload extends the delimiter"):
+        val tel    = doc("note x\n")
+        val ptr    = Tel.Pointer.of(t"note")
+        val result = Mutation(tel, Mutation.Op.UpdateAtom(ptr, 0, crCollision))
+        result.childCompounds.head.atoms.head match
+          case Tel.Atom.Literal(delimiter, _) => delimiter
+          case _                              => t""
+      . assert(_ == t"----")
+
+      test(m"A payload line of delimiter-then-CR survives a round-trip"):
+        val tel    = doc("note x\n")
+        val ptr    = Tel.Pointer.of(t"note")
+        val result = Mutation(tel, Mutation.Op.UpdateAtom(ptr, 0, crCollision))
+        result.document.vouch.show.read[Tel].childCompounds.head.atoms.head match
+          case Tel.Atom.Literal(_, text) => text
+          case _                         => t""
+      . assert(_ == crCollision)
+
     suite(m"Tel.fields repeated-keyword accessor"):
       test(m"fields returns all matching children in order"):
         val tel = t"item 1\nitem 2\nitem 3\n".read[Tel]


### PR DESCRIPTION
Stratiform's literal atoms now behave consistently with the TEL §15 rule that a closing delimiter line mirrors its opening line byte-for-byte: the corpus fixture covering a flush-left delimiter inside a payload is now actually executed by the test suite, and a value containing a delimiter line terminated by a carriage return no longer round-trips into a prematurely-closed atom.

Most of the TEL §15 literal-delimiter change shipped previously. Two gaps remained.

The `literal-atom-flush-delimiter-in-payload` corpus fixture — the one case asserting that a flush-left `END` inside a payload stays payload rather than closing an atom opened at indent 6 — was present in the corpus directory but missing from `pos.index`, which is what the test loader enumerates. It had never run. It now does, across all six positive-case drivers.

More substantively, `Mutation`'s atom-form safety check did not strip a trailing carriage return from a payload line, but the parser does when matching a closing delimiter line. A value containing a line of six spaces, `---`, then CR was therefore judged literal-safe with the default `---` delimiter, and re-parsed as a premature close:

```scala
val value = t"before\n      ---\r\nafter\n"
Mutation(tel, Mutation.Op.UpdateAtom(pointer, 0, value))
// before: delimiter stayed `---`; re-parsing recovered only `before`
// now:    delimiter extends to `----`; the value round-trips intact
```

Closes #1491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)