### PR TITLE
Write an incremental update in the form of the section it chains to

### DIFF
--- a/lib/facsimile/src/core/facsimile.PdfWriter.scala
+++ b/lib/facsimile/src/core/facsimile.PdfWriter.scala
@@ -133,28 +133,6 @@ private[facsimile] object PdfWriter:
     // anything is freed) into ascending consecutive subsections.
     val numbers = (changed ++ freed ++ (if freed.isEmpty then Nil else List(0))).distinct.sorted
 
-    ascii(t"xref\n")
-
-    subsections(numbers).each: (first, run) =>
-      ascii(t"$first ${run.length}\n")
-
-      run.each: number =>
-        if number == 0 then ascii(t"0000000000 65535 f \n")
-        else if pdf.freed.contains(number) then
-          val generation = pdf.xref.entries.at(number) match
-            case Xref.Entry.Direct(_, gen) => gen + 1
-            case _                         => 1
-
-          ascii(t"0000000000 ${pad5(generation)} f \n")
-        else
-          val generation = pdf.xref.entries.at(number) match
-            case Xref.Entry.Direct(_, gen) => gen
-            case _                         => 0
-
-          ascii(t"${pad10(offsets(number))} ${pad5(generation)} n \n")
-
-    val size = pdf.nextNumber
-
     // The trailer carries forward the original `/Root`, `/Info`, `/Encrypt` and `/ID`, with
     // any write-scope overrides (e.g. a newly-created `/Info`) taking precedence.
     val carried = List(t"Root", t"Info", t"Encrypt", t"ID").flatMap: key =>
@@ -162,7 +140,80 @@ private[facsimile] object PdfWriter:
 
     val entries = (carried.to(Map) ++ pdf.trailerOverrides).to(List)
 
-    ascii(t"trailer\n<< /Size $size")
+    // A file whose newest cross-reference section is a stream takes a stream for its update too.
+    // The two forms cannot be chained through `/Prev`, which is defined to address a section of
+    // the same kind (ISO 32000-1 §7.5.8.4); a file that mixes them is one some readers accept and
+    // others reject outright.
+    if pdf.xref.streamed
+    then streamed(pdf, raw, ascii, xrefOffset, numbers, offsets, entries)
+    else
+      ascii(t"xref\n")
+
+      subsections(numbers).each: (first, run) =>
+        ascii(t"$first ${run.length}\n")
+
+        run.each: number =>
+          if number == 0 then ascii(t"0000000000 65535 f \n")
+          else if pdf.freed.contains(number) then
+            val generation = pdf.xref.entries.at(number) match
+              case Xref.Entry.Direct(_, gen) => gen + 1
+              case _                         => 1
+
+            ascii(t"0000000000 ${pad5(generation)} f \n")
+          else
+            val generation = pdf.xref.entries.at(number) match
+              case Xref.Entry.Direct(_, gen) => gen
+              case _                         => 0
+
+            ascii(t"${pad10(offsets(number))} ${pad5(generation)} n \n")
+
+      ascii(t"trailer\n<< /Size ${pdf.nextNumber}")
+
+      entries.each: (key, value) =>
+        ascii(t" /$key ")
+        appendObject(pdf, raw, ascii, value)
+
+      pdf.xref.startxref.let: previous => ascii(t" /Prev $previous")
+
+      ascii(t" >>\nstartxref\n$xrefOffset\n%%EOF\n")
+
+    builder.result().immutable(using Unsafe)
+
+  // The update's cross-reference section as a cross-reference stream (ISO 32000-2 §7.5.8): an
+  // ordinary indirect object whose dictionary serves as the trailer and whose payload holds one
+  // fixed-width binary row per object.
+  //
+  // The stream is an object in its own right, so it occupies the next free number and appears in
+  // its own table. Rows are written uncompressed: a section covering a handful of changed objects
+  // is a few dozen bytes, and `/Filter` would cost more in dictionary than it saved in payload.
+  private def streamed
+    ( pdf:     Pdf,
+      raw:     Data => Unit,
+      ascii:   Text => Unit,
+      offset:  Long,
+      numbers: List[Int],
+      offsets: scala.collection.mutable.HashMap[Int, Long],
+      entries: List[(Text, Cos)] )
+  :   Unit raises PdfError =
+
+    val number = pdf.nextNumber
+    val rows = (numbers :+ number).distinct.sorted
+
+    // `/W [1 4 2]`: one byte of entry type, four of offset — enough for any file this side of
+    // 4 GB — and two of generation.
+    def field(value: Long, width: Int): Unit =
+      raw(IArray.tabulate(width) { index => (value >> 8*(width - 1 - index) & 0xff).toByte })
+
+    def row(kind: Int, second: Long, third: Int): Unit =
+      field(kind, 1)
+      field(second, 4)
+      field(third, 2)
+
+    val index = subsections(rows).flatMap((first, run) => List(first, run.length))
+
+    ascii(t"$number 0 obj\n<< /Type /XRef /Size ${number + 1} /W [1 4 2] /Index [")
+    ascii(index.map(_.toString.tt).join(t" "))
+    ascii(t"] /Length ${rows.length*7}")
 
     entries.each: (key, value) =>
       ascii(t" /$key ")
@@ -170,9 +221,25 @@ private[facsimile] object PdfWriter:
 
     pdf.xref.startxref.let: previous => ascii(t" /Prev $previous")
 
-    ascii(t" >>\nstartxref\n$xrefOffset\n%%EOF\n")
+    ascii(t" >>\nstream\n")
 
-    builder.result().immutable(using Unsafe)
+    rows.each: entry =>
+      if entry == number then row(1, offset, 0)
+      else if entry == 0 then row(0, 0, 65535)
+      else if pdf.freed.contains(entry) then
+        val generation = pdf.xref.entries.at(entry) match
+          case Xref.Entry.Direct(_, gen) => gen + 1
+          case _                         => 1
+
+        row(0, 0, generation)
+      else
+        val generation = pdf.xref.entries.at(entry) match
+          case Xref.Entry.Direct(_, gen) => gen
+          case _                         => 0
+
+        row(1, offsets(entry), generation)
+
+    ascii(t"\nendstream\nendobj\nstartxref\n$offset\n%%EOF\n")
 
   private def appendObject
     ( pdf: Pdf, raw: Data => Unit, ascii: Text => Unit, cos: Cos,

--- a/lib/facsimile/src/core/facsimile.Xref.scala
+++ b/lib/facsimile/src/core/facsimile.Xref.scala
@@ -79,10 +79,19 @@ private[facsimile] object Xref:
       val mergedEntries = sectionEntries ++ entries
       val mergedTrailer = sectionTrailer ++ trailer
 
-      sectionTrailer.at(t"Prev").let(_.long).lay(Xref(mergedEntries, mergedTrailer, head)): previous =>
-        recur(previous, mergedEntries, mergedTrailer, visited + offset)
+      sectionTrailer.at(t"Prev").let(_.long)
+      . lay(Xref(mergedEntries, mergedTrailer, head, streamed(source, head))): previous =>
+          recur(previous, mergedEntries, mergedTrailer, visited + offset)
 
     recur(head, Map(), Map(), Set())
+
+  // Whether the section at `offset` is a cross-reference stream. The two forms are told apart
+  // exactly as `section` tells them apart: a classic table opens with the `xref` keyword, a
+  // stream with the object number of the indirect object holding it.
+  private def streamed(source: ByteSource, offset: Long): Boolean raises PdfError =
+    CosLexer(new Scan(source, offset)).next() match
+      case CosToken.Keyword(word) if word.s == "xref" => false
+      case _                                          => true
 
   // Recovers a cross-reference table from a damaged file by scanning for `N G obj` markers,
   // the latest offset of each object number winning (an incremental update's newer copy
@@ -377,5 +386,13 @@ private[facsimile] object Xref:
 // the anchor an incremental update chains its own `/Prev` to. It is `Unset` for a table
 // recovered by scanning, which has no valid section to chain to (so writing must rewrite in
 // full rather than append).
+// `streamed` records whether that newest section is a cross-reference STREAM rather than a
+// classic table. An update must be written in the same form as the section it chains to: `/Prev`
+// in a classic trailer is defined to address a classic section, and `/Prev` in a cross-reference
+// stream to address another stream (ISO 32000-1 §7.5.8.4). Chaining across the two forms produces
+// a file that tolerant readers absorb silently and strict ones — CoreGraphics among them — do not.
 private[facsimile] case class Xref
-  ( entries: Map[Int, Xref.Entry], trailer: Map[Text, Cos], startxref: Optional[Long] = Unset )
+  ( entries:   Map[Int, Xref.Entry],
+    trailer:   Map[Text, Cos],
+    startxref: Optional[Long] = Unset,
+    streamed:  Boolean        = false )

--- a/lib/facsimile/src/test/facsimile_test.scala
+++ b/lib/facsimile/src/test/facsimile_test.scala
@@ -1023,6 +1023,48 @@ object Tests extends Suite(m"Facsimile tests"):
           textOf(pdf.resolved(pdf(1, 0)(t"Greeting").or(Cos.Nil)))
       . assert(_ == t"hi")
 
+      // An update must take the same form as the section it chains to: `/Prev` in a classic
+      // trailer addresses a classic section, and `/Prev` in a cross-reference stream addresses
+      // another stream (ISO 32000-1 §7.5.8.4). A classic update over a file whose newest section
+      // is a stream yields a chain that cannot be followed — which poppler and pdf.js absorb
+      // silently and CoreGraphics does not, so it is worth pinning here rather than leaving to a
+      // viewer to find.
+      def appended(source: Data): Text =
+        val path = tempPdf(source)
+
+        PdfFile(path).open(Read & Write): doc ?=>
+          doc.set(Cos.Ref(1, 0), Cos.Dictionary(Map(t"Type" -> Cos.Name(t"Catalog"))))
+
+        String(fileBytes(path).mutable(using Unsafe), "ISO-8859-1").nn.tt.skip(source.length)
+
+      test(m"an update over a cross-reference stream is itself a cross-reference stream"):
+        val tail = appended(xrefStreamDocument())
+        (tail.contains(t"/Type /XRef"), tail.contains(t"trailer"))
+      . assert(_ == (true, false))
+
+      test(m"an update over a classic table is still a classic table"):
+        val tail = appended(document(t"<< /Type /Catalog >>".in[Data]))
+        (tail.contains(t"trailer"), tail.contains(t"/Type /XRef"))
+      . assert(_ == (true, false))
+
+      // The edited object must be found in the new section, and an object compressed into the
+      // ORIGINAL file's object stream must still be found through the chain behind it — which is
+      // what a broken `/Prev` would sever.
+      test(m"an edit over a cross-reference stream keeps the objects behind it reachable"):
+        val path = tempPdf(xrefStreamDocument())
+
+        PdfFile(path).open(Read & Write): doc ?=>
+          doc.set
+           ( Cos.Ref(1, 0),
+             Cos.Dictionary
+              (Map(t"Type" -> Cos.Name(t"Catalog"), t"Answer" -> Cos.Ref(4, 0),
+                   t"Edited" -> Cos.Name(t"yes"))) )
+
+        PdfFile(fileBytes(path)).open[Pdf]():
+          ( pdf(1, 0)(t"Edited").or(Cos.Nil),
+            pdf.resolved(pdf(1, 0)(t"Answer").or(Cos.Nil)) )
+      . assert(_ == (Cos.Name(t"yes"), Cos.Integral(42)))
+
     // A one-page document with Helvetica as `/F1` and the given content stream.
     def contentPage(content: Text): Data =
       document


### PR DESCRIPTION
Editing a PDF and saving it produced a file that macOS Preview and Quick Look would not open, because an incremental update was always written as a classic cross-reference table even when the document being edited used a cross-reference stream, leaving a `/Prev` chain that crosses between the two forms and that ISO 32000-1 does not define. Facsimile now writes an update in the same form as the section it chains to, so a document that used cross-reference streams keeps using them and one with classic tables is unchanged.

Fixes #1691.

## What was wrong

Every incremental update was written as a classic `xref` table whose trailer chained `/Prev` to the previous section's offset, whatever form that section took. Since PDF 1.5, most documents use a cross-reference *stream* instead, so editing a modern file produced a classic trailer whose `/Prev` addressed a stream object.

ISO 32000-1 §7.5.8.4 defines `/Prev` in a classic trailer as addressing a classic section, and `/Prev` in a cross-reference stream as addressing another stream. Mixing them requires the hybrid-reference mechanism and an `/XRefStm` entry, which was never written.

This went unnoticed because tolerant readers absorb it. Poppler, pdf.js and Facsimile's own reader all follow `/Prev`, find a stream where a table was promised, and carry on — Facsimile's reader handles `/XRefStm` properly, so it read back its own malformed output without complaint. CoreGraphics does not, so Preview and Quick Look hang indefinitely on any edited document rather than reporting an error.

## What changed

`Xref` now records whether the file's newest cross-reference section is a stream, and `increment` writes its own section in that same form — a `/Type /XRef` object with `/W [1 4 2]` and an `/Index` built from the same subsections as the classic path, its dictionary carrying the trailer entries and `/Prev`, and the stream object occupying the next free number and appearing in its own table. Rows are uncompressed, since a section covering a few changed objects is a few dozen bytes and a `/Filter` would cost more in dictionary than it saved.

Nothing changes for callers, and documents with classic cross-reference tables are written exactly as before:

```scala
PdfFile(path).open(Read & Write): doc ?=>
  doc.setContents(doc.pages(0), operators)
```

## Tests

Three tests on the existing `xrefStreamDocument()` fixture: that an update over a cross-reference stream is itself a stream and carries no `trailer` keyword, that an update over a classic table is still a classic table, and that an object compressed into the original file's object stream is still reachable after an edit. The last is the one that pins the actual defect, since a `/Prev` chain that cannot be followed loses every object behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)