### PR TITLE
Return Unset and guard partial parses in HTML attributes, PAX, and profiling

### DIFF
--- a/lib/bitumen/src/core/bitumen.Pax.scala
+++ b/lib/bitumen/src/core/bitumen.Pax.scala
@@ -68,7 +68,11 @@ object Pax:
         raise(TarError(TarError.Reason.BadPaxRecord(data)))
         pos = data.length
       else
-        val length = data.slice(pos, lengthEnd).ascii.s.toInt
+        // The scanned slice is all ASCII digits, so the only way `toInt` can fail is an
+        // overflowing run of digits; fall back to 0 so the `length < 1` check below rejects it.
+        val length =
+          try data.slice(pos, lengthEnd).ascii.s.toInt
+          catch case _: NumberFormatException => 0
 
         if length < 1 || pos + length > data.length || data(pos + length - 1) != '\n'.toByte
         then

--- a/lib/honeycomb/src/core/honeycomb.Unattributive.scala
+++ b/lib/honeycomb/src/core/honeycomb.Unattributive.scala
@@ -49,8 +49,13 @@ object Unattributive:
   // given truth: Boolean is Attributive to Truth = (key, value) =>
   //   (key, if value then t"true" else t"false")
 
-  given int: Whatwg.Integral is Unattributive to Optional[Int] = _.let(_.s.toInt)
-  given positiveInt: Whatwg.PositiveInt is Unattributive to Optional[Int] = _.let(_.s.toInt)
+  given int: Whatwg.Integral is Unattributive to Optional[Int] =
+    _.lay(Unset): text =>
+      try text.s.toInt catch case _: NumberFormatException => Unset
+
+  given positiveInt: Whatwg.PositiveInt is Unattributive to Optional[Int] =
+    _.lay(Unset): text =>
+      try text.s.toInt catch case _: NumberFormatException => Unset
 
   given cssClassList: Whatwg.CssClassList is Unattributive to List[Text] =
     _.let(_.cut(t" ")).or(Nil)

--- a/lib/sedentary/src/core/sedentary.Profile.scala
+++ b/lib/sedentary/src/core/sedentary.Profile.scala
@@ -174,8 +174,8 @@ extends Rig:
 
       val hotspots =
         Hotspots
-          ( results.head.s.toLong,
-            results.tail.map: line =>
+          ( results.prim.let(_.s.toLong).or(0L),
+            results.drop(1).map: line =>
               line.cut(t"\t") match
                 case count :: className :: method :: Nil =>
                   Hotspots.Frame


### PR DESCRIPTION
Three unchecked partial parses that could throw at runtime are replaced with the library's safe idioms. The most user-visible was in honeycomb, where reading an integer HTML attribute (e.g. `colspan`, `rows`) promised an `Optional[Int]` but threw a `NumberFormatException` on a malformed value instead of yielding `Unset`; it now decodes safely. The other two harden format-constrained parses in bitumen's PAX tar-header decoding and sedentary's profiler-output decoding.

Reading an integer-typed HTML attribute now returns `Unset` for a non-numeric value rather than throwing:

```scala
val cell = t"""<td colspan="three">data</td>""".read[Html of "td"]
cell.colspan  // Unset (previously threw NumberFormatException)
```

A valid value still decodes as before:

```scala
val cell = t"""<td colspan="3">data</td>""".read[Html of "td"]
cell.colspan  // 3
```

Internally, parsing a PAX extended-header record with an overflowing length field now reports a `BadPaxRecord` error instead of throwing, and profiler hotspot decoding tolerates empty output without a `NoSuchElementException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)