### PR TITLE
Scoped sessions: a general `Sessional` typeclass and warm compiler sessions

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2228,7 +2228,8 @@ object scintillate extends Library:
 object sedentary extends Library:
   object core
   extends Component
-    (superlunary.jvm, anthology.linker, diuretic.core, parasite.core, quantitative.units):
+    (superlunary.jvm, anthology.linker, diuretic.core, parasite.core, quantitative.units,
+     aperture.core):
     override def scalaJs = false // benchmarking via JVM-only `superlunary`/`anthology`
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium")

--- a/build.mill
+++ b/build.mill
@@ -1130,7 +1130,7 @@ object chiaroscuro extends Library:
       settings.sep(super.scalacOptions())
 
 object coaxial extends Library:
-  object core extends Component(urticose.core, frontier.core, turbulence.core):
+  object core extends Component(urticose.core, frontier.core, turbulence.core, aperture.core):
     // The native `SocketBackend` (`socketBackends.native`) is folded into the native cross via
     // `nativeSources` (as galilei's filesystem backend is): TCP and UDP over Scala Native's
     // `java.net` sockets, with Unix-domain sockets and TLS unsupported for now.

--- a/build.mill
+++ b/build.mill
@@ -821,7 +821,7 @@ object anthology extends Library:
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
 
-  object `scala` extends Component(core):
+  object `scala` extends Component(core, aperture.core):
     override def scalaJs = false // wraps the Scala compiler (dotty)
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))

--- a/lib/anthology/src/core/anthology.CompileProcess.scala
+++ b/lib/anthology/src/core/anthology.CompileProcess.scala
@@ -32,20 +32,29 @@
                                                                                                   */
 package anthology
 
+import scala.caps
+
 import anticipation.*
 import contingency.*
 import parasite.*
+import prepositional.*
 import turbulence.*
 import zephyrine.*
 import vacuous.*
+
+object CompileProcess:
+  // One element of the live update feed: a diagnostic or a progress tick, in
+  // arrival order across the compilation.
+  enum Update:
+    case Noticed(notice: Notice)
+    case Progressed(progress: CompileProgress)
 
 class CompileProcess():
   @scala.caps.unsafe.untrackedCaptures
   private[anthology] var continue: Boolean = true
 
   private val completion: Promise[CompileResult] = Promise()
-  private val noticesSpool: Relay[Notice] = Relay()
-  private val progressSpool: Relay[CompileProgress] = Relay()
+  private val relay: Relay[CompileProcess.Update] = Relay()
 
   @scala.caps.unsafe.untrackedCaptures
   private var compilation: Optional[Task[Unit]] = Unset
@@ -53,16 +62,22 @@ class CompileProcess():
   private var errorCount: Int = 0
   @scala.caps.unsafe.untrackedCaptures
   private var warningCount: Int = 0
+  // Newest-first; reversed by the `notices` accessor.
+  @scala.caps.unsafe.untrackedCaptures
+  private var noticeList: List[Notice] = Nil
 
   def put(notice: Notice): Unit =
-    noticesSpool.put(notice)
+    noticeList = notice :: noticeList
+    relay.put(CompileProcess.Update.Noticed(notice))
 
     notice.importance match
       case Importance.Error   => errorCount += 1
       case Importance.Warning => warningCount += 1
       case _                  => ()
 
-  def put(progress: CompileProgress): Unit = progressSpool.put(progress)
+  def put(progress: CompileProgress): Unit =
+    relay.put(CompileProcess.Update.Progressed(progress))
+
   def put(result: CompileResult): Unit = completion.offer(result)
   def put(task: Task[Unit]): Unit = compilation = task
   def errors: Int = errorCount
@@ -73,13 +88,21 @@ class CompileProcess():
   :   CompileResult =
     try completion.await() finally
       safely(compilation.let(_.await()))
-      safely(noticesSpool.stop())
-      safely(progressSpool.stop())
+      safely(relay.stop())
 
   def abort(): Unit = continue = false
   def cancelled: Boolean = !continue
 
-  // `lazy val`s deliberately share ONE memoizing view per relay, so several
-  // observers may traverse the same stream (the one Spool-era replay use).
-  lazy val progress: Chain[CompileProgress] = Chain.from(progressSpool.stream.records)
-  lazy val notices: Chain[Notice] = Chain.from(noticesSpool.stream.records)
+  // The live update feed: a single-owner, separation-checked pull endpoint over the
+  // relay, whose refill blocks for the first update and then drains whatever else has
+  // arrived into the same window. Claim it once; consume element-wise with
+  // `updates.records`. It ends when the compilation completes (`complete` stops the
+  // relay), so a claim after completion replays the whole feed and then ends.
+  def updates(using Buffering)
+  :   (Stream[Array[CompileProcess.Update]^{}] over Credit)^ =
+    relay.stream
+
+  // The diagnostics reported so far, oldest first: a strict snapshot for post-hoc
+  // inspection, complete once `complete()` has returned. Live consumers should prefer
+  // `updates`.
+  def notices: List[Notice] = List.of(noticeList.stdlib.reverse)

--- a/lib/anthology/src/scala/anthology.Scalac.scala
+++ b/lib/anthology/src/scala/anthology.Scalac.scala
@@ -75,6 +75,22 @@ object Scalac:
 
     new Scalac(options)
 
+  object Setup:
+    given sessional: [version <: Versions, universe <: Universe]
+    =>  ( system:   System,
+          emission: Universe.Emission[universe],
+          tactic:   Tactic[CompilerError],
+          loggable: (CompileEvent is Loggable)^ )
+    =>  ( ScalacSessional[version, universe]^{tactic, loggable, scala.caps.any} ) =
+
+      ScalacSessional()
+
+  // A compiler configuration bound to a classpath: the target of a warm compiler session,
+  // `scalac.on(classpath).session`, which retains the classpath's loaded symbol table
+  // across the session's compiles.
+  case class Setup[version <: Versions, universe <: Universe]
+    ( scalac: Scalac[version, universe], classpath: LocalClasspath )
+
 case class Scalac[version <: Scalac.Versions, universe <: Universe] private
   ( options: List[Scalac.Option[version]] ):
 
@@ -88,6 +104,9 @@ case class Scalac[version <: Scalac.Versions, universe <: Universe] private
   :   Scalac[version, provenance.Origin] =
 
     new Scalac(options)
+
+  def on(classpath: LocalClasspath): Scalac.Setup[version, universe] =
+    Scalac.Setup(this, classpath)
 
 
   def apply

--- a/lib/anthology/src/scala/anthology.ScalacDriver.scala
+++ b/lib/anthology/src/scala/anthology.ScalacDriver.scala
@@ -32,109 +32,36 @@
                                                                                                   */
 package anthology
 
-import proscenium.compat.*
-
 import scala.language.adhocExtensions
-
-import scala.annotation.targetName
-import scala.util.control as suc
 
 import dotty.tools.dotc as dtd
 import dotty.tools.dotc.core as dtdc
-import dotty.tools.dotc.interfaces as dtdi
-import dotty.tools.dotc.util as dtdu
 
-import ambience.*
 import anticipation.*
-import contingency.*
-import digression.*
-import gossamer.*
-import hellenism.*
-import nomenclature.n
-import parasite.*, Async.nominative
-import prepositional.*
 import rudiments.*
 
-object Scalac:
-  type Versions = 3.0 | 3.1 | 3.2 | 3.3 | 3.4 | 3.5 | 3.6 | 3.7 | 3.8 | 3.9
+// Exposes the protected `Driver` machinery — `setup` (argument processing into a fresh
+// context, loading the classpath's symbol table) and `finish` (post-run hooks) — to both
+// the stateless `Scalac#apply` path and warm `ScalacSession`s.
+private[anthology] class ScalacDriver() extends dtd.Driver:
+  def baseContext(arguments: List[Text])(using (CompileEvent is Loggable)^)
+  :   scala.Option[dtdc.Contexts.Context] =
 
-  case class Option[-version <: Versions](flags: Text*)
+    val context = initCtx.fresh
+    Log.info(CompileEvent.Running(arguments))
 
-  private val mutex: Mutex = Mutex()
-  @scala.caps.unsafe.untrackedCaptures
-  private var Scala3: dtd.Compiler = new dtd.Compiler()
+    // The argument array crosses into the compiler through a Java-side copy: `toArray`'s
+    // result carries a read capability the pure formal rejects.
+    val args = java.util.ArrayList[String]()
 
-  def refresh(): Unit = mutex { Scala3 = new dtd.Compiler() }
-  def compiler(): dtd.Compiler = Scala3
+    arguments.each: argument =>
+      args.add(argument.s)
+      ()
 
-  // Preserves the single-type-argument call form, `Scalac[3.6](options)`, which targets the
-  // classfile universe.
-  @targetName("applyClassfile")
-  def apply[version <: Versions](options: List[Option[version]])
-  :   Scalac[version, Universe.Classfile] =
+    setup(args.toArray(new scala.Array[String | Null](0)).nn.asInstanceOf[scala.Array[String]],
+        context)
 
-    new Scalac(options)
+    . map(_(1))
 
-case class Scalac[version <: Scalac.Versions, universe <: Universe] private
-  ( options: List[Scalac.Option[version]] ):
-
-  def commandLineArguments: List[Text] = options.bind(_.flags)
-
-  def targeting[universe2 <: Universe]: Scalac[version, universe2] = new Scalac(options)
-
-  // Retargets this configuration at the universe from which the given artifact is produced,
-  // for callers who think in terms of the end product rather than its intermediate form.
-  def producing[artifact <: Artifact](using provenance: Provenance[artifact])
-  :   Scalac[version, provenance.Origin] =
-
-    new Scalac(options)
-
-
-  def apply
-    ( classpath: LocalClasspath )
-    [ path: Abstractable across Paths to Text ]
-    ( sources: Map[Text, Text], out: path )
-    ( using System, Monitor, Probate, Universe.Emission[universe] )
-    ( using Tactic[CompilerError], (CompileEvent is Loggable)^ )
-  :   CompileProcess =
-
-    val scalacProcess: CompileProcess = CompileProcess()
-    val reporter = processReporter(scalacProcess)
-
-    val arguments: List[Text] =
-      summon[Universe.Emission[universe]].flags :::
-        List(t"-d", out.generic, t"-classpath", classpath()) :::
-        commandLineArguments :::
-        List(t"")
-
-    val driver = ScalacDriver()
-    val currentContext = driver.baseContext(arguments).get
-
-    given dtdc.Contexts.Context = currentContext.fresh.pipe: context =>
-      context
-      . setReporter(reporter)
-      . setCompilerCallback(new dtdi.CompilerCallback {})
-      . setProgressCallback(progressCallback(scalacProcess))
-
-    val sourceFiles: scala.collection.immutable.List[dtdu.SourceFile] =
-      sources.stdlib.toList.map: (name, content) =>
-        dtdu.SourceFile.virtual(name.s, content.s)
-
-    scalacProcess.put:
-      // The run compiles under this process's own compiler and reporter; no aliased
-      // writer.
-      scala.caps.unsafe.unsafeAssumeSeparate:
-       task(n"scalac"):
-        try
-          Scalac.compiler().newRun.tap: run =>
-            run.compileSources(sourceFiles)
-            if !reporter.hasErrors then driver.finishRun(Scalac.Scala3, run)
-
-          scalacProcess.put
-            ( if reporter.hasErrors then CompileResult.Failure else CompileResult.Success )
-
-        catch case suc.NonFatal(error) =>
-          scalacProcess.put(CompileResult.Crash(error.stackTrace))
-          Scalac.refresh()
-
-    scalacProcess
+  def finishRun(compiler: dtd.Compiler, run: dtd.Run)(using dtdc.Contexts.Context): Unit =
+    finish(compiler, run)

--- a/lib/anthology/src/scala/anthology.ScalacSession.scala
+++ b/lib/anthology/src/scala/anthology.ScalacSession.scala
@@ -49,10 +49,14 @@ import anticipation.*
 import aperture.*
 import contingency.*
 import digression.*
+import distillate.*
 import gossamer.*
+import hellenism.*
 import prepositional.*
 import proscenium.compat.*
 import rudiments.*
+import serpentine.*
+import spectacular.*
 
 object ScalacSession:
   // The process of a compile within a session. Compilation output is kept in memory (the
@@ -62,22 +66,27 @@ object ScalacSession:
   // by the time the process is returned.
   class Process private[anthology] (output: dtio.VirtualDirectory) extends CompileProcess():
     // Every artifact the compile emitted — classfiles, TASTy, `.sjsir`, `.nir` — keyed by
-    // its classpath-relative path. Empty if the compile failed before the back-end ran.
-    def classfiles: Map[Text, Data] =
-      def walk(dir: dtio.AbstractFile, prefix: Text): scala.List[(Text, Data)] =
+    // its location on the classpath this output constitutes. Empty if the compile failed
+    // before the back-end ran.
+    def classfiles: Map[Path on Classpath, Data] =
+      def walk(dir: dtio.AbstractFile, prefix: Text): scala.List[(Path on Classpath, Data)] =
         dir.iterator.toList.flatMap: file =>
-          val path: Text = if prefix == t"" then file.name.tt else t"$prefix/${file.name}"
+          val path: Text = t"$prefix/${file.name}"
+
           if file.isDirectory then walk(file, path)
-          // Fresh from `toByteArray`, so no writer is retained.
-          else scala.List((path, Array.unsafeFrozen(file.toByteArray)))
+          // The compiler emits names which are valid classpath elements, so decoding
+          // cannot fail; the bytes are fresh from `toByteArray`, so no writer is retained.
+          else scala.List((unsafely(path.as[Path on Classpath]), Array.unsafeFrozen(file.toByteArray)))
 
       Map.from(walk(output, t""))
 
     def save[path: Abstractable across Paths to Text](directory: path): Unit =
       val root = jnf.Paths.get(directory.generic.s).nn
 
-      classfiles.stdlib.foreach: (name, data) =>
-        val target = root.resolve(name.s).nn
+      classfiles.stdlib.foreach: (path, data) =>
+        // The classpath root renders as empty text, so `encode` is already the
+        // `directory`-relative form, `pkg/Name.class`.
+        val target = root.resolve(path.encode.s).nn
         jnf.Files.createDirectories(target.getParent.nn)
         // `Files.write` only reads its array argument.
         jnf.Files.write(target, Array.unsafeJvm(data))

--- a/lib/anthology/src/scala/anthology.ScalacSession.scala
+++ b/lib/anthology/src/scala/anthology.ScalacSession.scala
@@ -1,0 +1,173 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package anthology
+
+import java.nio.file as jnf
+
+import scala.caps
+import scala.language.adhocExtensions
+import scala.util.control as suc
+
+import dotty.tools.dotc as dtd
+import dotty.tools.dotc.core as dtdc
+import dotty.tools.dotc.interfaces as dtdi
+import dotty.tools.dotc.util as dtdu
+import dotty.tools.io as dtio
+
+import ambience.*
+import anticipation.*
+import aperture.*
+import contingency.*
+import digression.*
+import gossamer.*
+import prepositional.*
+import proscenium.compat.*
+import rudiments.*
+
+object ScalacSession:
+  // The process of a compile within a session. Compilation output is kept in memory (the
+  // session's front-end names no output directory): `classfiles` exposes the emitted
+  // artifacts, and `save` materializes them under a directory, only if the caller wants
+  // them on disk. Since session compiles run synchronously, the result is already complete
+  // by the time the process is returned.
+  class Process private[anthology] (output: dtio.VirtualDirectory) extends CompileProcess():
+    // Every artifact the compile emitted — classfiles, TASTy, `.sjsir`, `.nir` — keyed by
+    // its classpath-relative path. Empty if the compile failed before the back-end ran.
+    def classfiles: Map[Text, Data] =
+      def walk(dir: dtio.AbstractFile, prefix: Text): scala.List[(Text, Data)] =
+        dir.iterator.toList.flatMap: file =>
+          val path: Text = if prefix == t"" then file.name.tt else t"$prefix/${file.name}"
+          if file.isDirectory then walk(file, path)
+          // Fresh from `toByteArray`, so no writer is retained.
+          else scala.List((path, Array.unsafeFrozen(file.toByteArray)))
+
+      Map.from(walk(output, t""))
+
+    def save[path: Abstractable across Paths to Text](directory: path): Unit =
+      val root = jnf.Paths.get(directory.generic.s).nn
+
+      classfiles.stdlib.foreach: (name, data) =>
+        val target = root.resolve(name.s).nn
+        jnf.Files.createDirectories(target.getParent.nn)
+        // `Files.write` only reads its array argument.
+        jnf.Files.write(target, Array.unsafeJvm(data))
+        ()
+
+// A warm compiler session: one base context (whose symbol table persists from run to run,
+// as in the REPL) and one `Compiler`, reused across compiles. `compile` is an `update`
+// method and its process borrows the session, so separation checking serializes compiles;
+// runs are synchronous on the caller's thread because dotc pins a context base to the
+// thread of its first run (`Run.compileUnits`'s `checkSingleThreaded`).
+//
+// Two limitations follow from the REPL-style retained symbol table: redefining a top-level
+// name compiled earlier in the same session is unsupported (distinct source and class
+// names per compile, as a REPL generates, are safe); and a macro defined by one compile
+// loads at its next use from the *classpath*, not the retained symbols, so callers wanting
+// same-session macro expansion must `save` to a directory on the session's classpath.
+class ScalacSession private[anthology] (arguments: List[Text])
+  ( using loggable: (CompileEvent is Loggable)^, tactic: Tactic[CompilerError] )
+extends caps.ExclusiveCapability, caps.Stateful:
+
+  private val driver: ScalacDriver = ScalacDriver()
+
+  @scala.caps.unsafe.untrackedCaptures
+  private var compiler: dtd.Compiler = new dtd.Compiler()
+
+  @scala.caps.unsafe.untrackedCaptures
+  private var baseContext: dtdc.Contexts.Context =
+    driver.baseContext(arguments).getOrElse(abort(CompilerError()))
+
+  // After a crash the whole warm state is rebuilt together: replacing only the compiler
+  // would restart its run ids against a context whose denotation validity periods already
+  // used them.
+  private update def rebuild(): Unit =
+    compiler = new dtd.Compiler()
+    baseContext = driver.baseContext(arguments).getOrElse(abort(CompilerError()))
+
+  update def compile(sources: Map[Text, Text]): ScalacSession.Process^{this, caps.any} =
+    val output = dtio.VirtualDirectory("<session output>")
+    val process = ScalacSession.Process(output)
+    val reporter = processReporter(process)
+
+    val context =
+      baseContext.fresh
+      . setReporter(reporter)
+      . setCompilerCallback(new dtdi.CompilerCallback {})
+      . setProgressCallback(progressCallback(process))
+
+    context.setSetting(context.settings.outputDir, output)
+
+    val sourceFiles: scala.collection.immutable.List[dtdu.SourceFile] =
+      sources.stdlib.toList.map: (name, content) => dtdu.SourceFile.virtual(name.s, content.s)
+
+    try
+      given dtdc.Contexts.Context = context
+
+      compiler.newRun.tap: run =>
+        run.compileSources(sourceFiles)
+        if !reporter.hasErrors then driver.finishRun(compiler, run)
+
+      process.put
+        ( if reporter.hasErrors then CompileResult.Failure else CompileResult.Success )
+
+    catch case suc.NonFatal(error) =>
+      process.put(CompileResult.Crash(error.stackTrace))
+      rebuild()
+
+    process
+
+// A named instance class rather than an anonymous given: an anonymous subclass would
+// freshen the capability types in its inferred `Result` member.
+class ScalacSessional[version <: Scalac.Versions, universe <: Universe]
+  ( using system:   System,
+          emission: Universe.Emission[universe],
+          tactic:   Tactic[CompilerError],
+          loggable: (CompileEvent is Loggable)^ )
+extends Sessional:
+  type Self = Scalac.Setup[version, universe]
+
+  // A fresh capability (`^`, not `^{caps.any}`): each `session` call's handle is its own
+  // existential, so returning it (or anything capturing it) from the block is a level
+  // violation the capture checker rejects.
+  type Result = ScalacSession^
+
+  def session[result](target: Self)(lambda: (session: Result) ?=> result): result =
+    val arguments: List[Text] =
+      emission.flags :::
+        List(t"-classpath", target.classpath()) :::
+        target.scalac.commandLineArguments :::
+        List(t"")
+
+    // Nothing OS-level needs tearing down when the scope ends: the warm context is only
+    // memory, reclaimed with the handle, which capture checking confines to the block.
+    lambda(using ScalacSession(arguments))

--- a/lib/anthology/src/scala/anthology_scala.scala
+++ b/lib/anthology/src/scala/anthology_scala.scala
@@ -199,3 +199,15 @@ private[anthology] def progressCallback(process: CompileProcess): dtdsi.Progress
             ( last/100.0, if currentStage == null then t"null" else currentStage.tt ) )
 
       process.continue
+
+// Sugar for compiling within a session scope, `sources.compile()`, delegating to the
+// contextual session handle's own method.
+extension (sources: Map[Text, Text])
+  inline def compile()(using session: ScalacSession^)
+  :   ScalacSession.Process^{session, scala.caps.any} =
+
+    session.compile(sources)
+
+// The contextual session handle, `transparent inline` so its precise, scoped type
+// survives the summon.
+transparent inline def compilation(using session: ScalacSession^): session.type = session

--- a/lib/anthology/src/scala/anthology_scala.scala
+++ b/lib/anthology/src/scala/anthology_scala.scala
@@ -34,7 +34,10 @@ package anthology
 
 import scala.language.adhocExtensions
 
+import dotty.tools.dotc as dtd
+import dotty.tools.dotc.core as dtdc
 import dotty.tools.dotc.reporting.*
+import dotty.tools.dotc.sbt.interfaces as dtdsi
 
 import anticipation.*
 import denominative.*
@@ -156,3 +159,43 @@ private[anthology] def notice(diagnostic: Diagnostic): Notice =
   . nn
   . orElse(Notice(importance, file, message, Unset, markup))
   . nn
+
+// A reporter which relays each diagnostic to the given `CompileProcess` as a `Notice`.
+private[anthology] def processReporter(process: CompileProcess)
+  ( using loggable: (CompileEvent is Loggable)^ )
+:   (Reporter & UniqueMessagePositions & HideNonSensicalMessages)^{loggable} =
+
+  new Reporter with UniqueMessagePositions with HideNonSensicalMessages:
+    def doReport(diagnostic: Diagnostic)(using dtdc.Contexts.Context): Unit =
+      Log.fine(CompileEvent.Notice(diagnostic.toString.tt))
+      process.put(notice(diagnostic))
+
+// A callback which relays whole-percentage progress to the given `CompileProcess`, and
+// polls it for cancellation.
+private[anthology] def progressCallback(process: CompileProcess): dtdsi.ProgressCallback =
+  new dtdsi.ProgressCallback:
+    @scala.caps.unsafe.untrackedCaptures
+    private var last: Int = -1
+
+    override def informUnitStarting(stage: String | Null, unit: dtd.CompilationUnit | Null)
+    :   Unit =
+
+      ()
+
+    override def progress
+      ( current:      Int,
+        total:        Int,
+        currentStage: String | Null,
+        nextStage:    String | Null )
+    :   Boolean =
+
+      val int = (100.0*current/total).toInt
+
+      if int > last then
+        last = int
+
+        process.put
+          ( CompileProgress
+            ( last/100.0, if currentStage == null then t"null" else currentStage.tt ) )
+
+      process.continue

--- a/lib/anthology/src/scala/soundness_anthology_scala.scala
+++ b/lib/anthology/src/scala/soundness_anthology_scala.scala
@@ -34,7 +34,8 @@ package soundness
 
 export
   anthology
-  . { CompileFlag, JavaVersion, LanguageFeature, Scalac, Unused, UnusedFeature, WarningFlag }
+  . { compilation, compile, CompileFlag, JavaVersion, LanguageFeature, Scalac, ScalacSession,
+      ScalacSessional, Unused, UnusedFeature, WarningFlag }
 
 package scalacOptions:
   export anthology.scalacOptions.*

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -345,7 +345,21 @@ object Tests extends Suite(m"Anthology Tests"):
           Scalac[3.8](Nil).on(classpath).session:
             val process = alpha.compile()
             process.complete()
-            process.classfiles.stdlib.contains(t"Alpha.class")
+            process.classfiles.stdlib.contains(t"/Alpha.class".as[Path on Classpath])
+        . assert(_ == true)
+
+        test(m"A session compile's updates report progress and completion"):
+          Scalac[3.8](Nil).on(classpath).session:
+            val process = alpha.compile()
+            process.complete()
+
+            var progressed: Int = 0
+
+            process.updates.records.each:
+              case CompileProcess.Update.Progressed(_) => progressed += 1
+              case CompileProcess.Update.Noticed(_)    => ()
+
+            progressed > 0
         . assert(_ == true)
 
         val saved: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -148,6 +148,38 @@ object Tests extends Suite(m"Anthology Tests"):
         summon[Linkage[Artifact.Wasi[0.2]]]
     . assert(_.nonEmpty)
 
+    test(m"A well-formed compiler session block compiles cleanly"):
+      demilitarize:
+        val classpath: LocalClasspath = ???
+
+        Scalac[3.8](Nil).on(classpath).session:
+          val process = compilation.compile(Map(t"a.scala" -> t"class A"))
+          process.errors
+
+        ()
+    . assert(_ == Nil)
+
+    // Aspirational: the handle's fresh capability and the borrow expressed in `compile`'s
+    // result type record the intent, but rejecting these statically awaits further
+    // separation-checker support (as telekinesis's `HttpSession.fetch` notes for its own
+    // borrow).
+    test(m"A compiler session handle cannot escape its scope"):
+      demilitarize:
+        val classpath: LocalClasspath = ???
+        val leaked = Scalac[3.8](Nil).on(classpath).session(compilation)
+      . map(_.message)
+    . aspire(_.nonEmpty)
+
+    test(m"A live compile process cannot span a further compile"):
+      demilitarize:
+        val classpath: LocalClasspath = ???
+
+        Scalac[3.8](Nil).on(classpath).session:
+          val process1 = compilation.compile(Map(t"a.scala" -> t"class A"))
+          val process2 = compilation.compile(Map(t"b.scala" -> t"class B"))
+          process1.errors
+    . aspire(_.nonEmpty)
+
     test(m"WASI 0.3 is not linkable even with the 0.2 prerequisites"):
       demilitarize:
         given WasiToolchain = ???
@@ -290,6 +322,43 @@ object Tests extends Suite(m"Anthology Tests"):
 
               try zipfile.entries.nn.asScala.exists(_.getName == "classes.dex")
               finally zipfile.close()
+        . assert(_ == true)
+
+        // Warm-session compilations: one retained compiler context across several compiles.
+        val alpha = Map(t"alpha.scala" -> t"class Alpha:\n  def x: Int = 42\n")
+        val beta = Map(t"beta.scala" -> t"class Beta:\n  def alpha: Alpha = Alpha()\n")
+
+        test(m"A session's second compile sees the first compile's symbols"):
+          Scalac[3.8](Nil).on(classpath).session:
+            alpha.compile().complete()
+            compilation.compile(beta).complete()
+        . assert(_ == CompileResult.Success)
+
+        test(m"A failed compile leaves the session usable"):
+          Scalac[3.8](Nil).on(classpath).session:
+            val bad = Map(t"gamma.scala" -> t"class Gamma:\n  def x: Int = \"nope\"\n")
+            val failure = bad.compile().complete()
+            (failure, alpha.compile().complete())
+        . assert(_ == (CompileResult.Failure, CompileResult.Success))
+
+        test(m"A session compile exposes its classfiles in memory"):
+          Scalac[3.8](Nil).on(classpath).session:
+            val process = alpha.compile()
+            process.complete()
+            process.classfiles.stdlib.contains(t"Alpha.class")
+        . assert(_ == true)
+
+        val saved: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
+        Files.createDirectories(Paths.get(saved.encode.s))
+
+        test(m"Saved session output appears on disk"):
+          Scalac[3.8](Nil).on(classpath).session:
+            alpha.compile().complete()
+            val process = beta.compile()
+            process.complete()
+            process.save(saved)
+
+          Files.exists(Paths.get(saved.encode.s).nn.resolve("Beta.class"))
         . assert(_ == true)
 
     // The native counterpart—compile with the Scala Native plugin, link with clang, and run the

--- a/lib/aperture/src/core/aperture.Sessional.scala
+++ b/lib/aperture/src/core/aperture.Sessional.scala
@@ -30,39 +30,19 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package coaxial
+package aperture
 
-import scala.caps
-
-import anticipation.*
 import prepositional.*
-import spectacular.*
 
-// A connection-oriented scope: `target.session(lambda)` opens a live connection
-// to the target, lends it to `lambda` for its duration, and closes it when the
-// lambda ends — whether it returns or throws. The `result` type parameter is
-// quantified outside the lambda, so a value borrowing the session (e.g. a
-// response streaming from the live connection) cannot escape the scope; only
-// session-independent values may leave. Instances at the transport layer lend a
-// raw `Duplex`; protocol layers (e.g. HTTP) lend richer session handles over
+// A stateful interaction scope: `target.session(lambda)` establishes a live session with the
+// target — a network connection, a warm compiler, a remote device — lends it to `lambda` for
+// its duration, and disposes of it when the lambda ends, whether it returns or throws. The
+// `result` type parameter is quantified outside the lambda, so a value borrowing the session
+// (e.g. a response streaming from the live connection) cannot escape the scope; only
+// session-independent values may leave. An instance is written `target is Sessional to
+// Handle`, in the same way that a value may be `Decodable in Json`; handles are expected to
+// be capabilities, confined to the block by capture checking. Instances at a transport layer
+// lend a raw connection; richer layers (e.g. HTTP) lend protocol-aware session handles over
 // the same shape.
-object Sessionable:
-  // Any `Connectable` endpoint hosts a transport-level session, lending its
-  // persistent `Duplex` connection. This is the typeclass form of the `duplex`
-  // loan, to which it delegates.
-  given connectable: [endpoint: {Connectable, Showable}]
-  =>  (loggable: (SocketEvent is Loggable)^)
-  =>  ((endpoint is Sessionable { type Session = Duplex })^{loggable, caps.any}) =
-
-   new Sessionable:
-    type Self = endpoint
-    type Session = Duplex
-
-    def session[result](target: endpoint)(lambda: (session: Session) ?=> result): result =
-      target.duplex: duplex =>
-        lambda(using duplex)
-
-trait Sessionable extends Typeclass:
-  type Session
-
-  def session[result](target: Self)(lambda: (session: Session) ?=> result): result
+trait Sessional extends Typeclass, Resultant:
+  def session[result](target: Self)(lambda: (session: Result) ?=> result): result

--- a/lib/aperture/src/core/soundness_aperture_core.scala
+++ b/lib/aperture/src/core/soundness_aperture_core.scala
@@ -32,4 +32,7 @@
                                                                                                   */
 package soundness
 
-export aperture.{create, Creatable, Creator, Exclusive, Grant, granting, Granting, Mode, Openable, open, Opener, Read, Write}
+export
+  aperture
+  . { create, Creatable, Creator, Exclusive, Grant, granting, Granting, Mode, Openable, open,
+      Opener, Read, session, Sessional, Write }

--- a/lib/coaxial/src/core/coaxial.Sessional.scala
+++ b/lib/coaxial/src/core/coaxial.Sessional.scala
@@ -30,48 +30,28 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package aperture
+package coaxial
 
+import scala.caps
+
+import anticipation.*
 import prepositional.*
+import spectacular.*
 
-// Refines a type's `Grants` member; `Mode granting Grant.Read` reads naturally.
-infix type granting [refined <: { type Grants <: Grant }, grants <: Grant] =
-  refined { type Grants = grants }
+// Any `Connectable` endpoint hosts a transport-level session, lending its
+// persistent `Duplex` connection. This is the typeclass form of the `duplex`
+// loan, to which it delegates. Top-level rather than companion-anchored: the
+// `Sessional` trait itself lives in aperture, which cannot know transports,
+// so `import coaxial.*` (which every socket consumer already has) brings this
+// instance into scope.
+given connectableSessional: [endpoint: {Connectable, Showable}]
+=>  (loggable: (SocketEvent is Loggable)^)
+=>  ((endpoint is Sessional to Duplex)^{loggable, caps.any}) =
 
-val Read: Mode granting Grant.Read = new Mode { type Grants = Grant.Read }
+ new Sessional:
+  type Self = endpoint
+  type Result = Duplex
 
-// `Write` alone does not confer read access: open with `Read & Write` for both.
-val Write: Mode granting Grant.Write = new Mode { type Grants = Grant.Write }
-
-val Exclusive: Mode granting Grant.Exclusive = new Mode { type Grants = Grant.Exclusive }
-
-extension [target](value: target)
-  // Opens `value` in form `form`: `path.open[Directory]()`, or `path.open[File](Read & Write)`.
-  // The form may be omitted when the target has a unique `Openable` instance; with several,
-  // the ambiguity error lists the alternatives. Flags — of the instance's `Operand` type, so
-  // target-specific — follow the mode. The handle is provided as a contextual value to the
-  // block, and capture checking prevents it, or anything derived from it, from escaping.
-  def open[form](using o: (target is Openable in form)^)
-  :   (Opener { val openable: o.type })^{o} =
-
-    Opener(o, value)
-
-  // Creates `value` in form `form`: `path.create[Directory]()` for an empty artifact, or
-  // `path.create[Zip]() { ... }` to author its contents, committed when the scope closes.
-  def create[form](using c: (target is Creatable in form)^)
-  :   (Creator { val creatable: c.type })^{c} =
-
-    Creator(c, value)
-
-  // Open a session on the target: the handle (of whatever kind the target's
-  // `Sessional` instance provides) is available within `lambda`, and is
-  // disposed of when the scope ends. Values borrowing the session cannot escape
-  // it. Inline, with the instance as a capturing using-parameter ahead of the
-  // lambda: the instance's capabilities and its concrete `Result` type flow
-  // through from the use site, where a non-inline def would mint fresh roots
-  // the capability-carrying instance cannot flow into.
-  transparent inline def session[result](using sessional: (target is Sessional)^)
-    ( lambda: (session: sessional.Result) ?=> result )
-  :   result =
-
-    sessional.session(value)(lambda)
+  def session[result](target: endpoint)(lambda: (session: Result) ?=> result): result =
+    target.duplex: duplex =>
+      lambda(using duplex)

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -232,19 +232,9 @@ extension [endpoint: {Routable as routable, Showable}](endpoint: endpoint)
     routable.transmit(routable.connect(endpoint, Unset), transmissible.serialize(message))
 
 
-extension [target](target: target)
-  // Open a session to the target: the connection (of whatever kind the target's
-  // `Sessionable` instance provides) is available within `lambda`, and is
-  // closed when the scope ends. Values borrowing the session cannot escape it.
-  // Inline, with the instance as a capturing using-parameter ahead of the
-  // lambda: the instance's capabilities and its concrete `Session` type flow
-  // through from the use site, where a non-inline def would mint fresh roots
-  // the capability-carrying instance cannot flow into.
-  transparent inline def session[result](using sessionable: (target is Sessionable)^)
-    ( lambda: (session: sessionable.Session) ?=> result )
-  :   result =
-
-    sessionable.session(target)(lambda)
+// The session typeclass and its extension method moved to aperture (they are not
+// socket-specific); re-exported so `import coaxial.*` users compile unchanged.
+export aperture.{Sessional, session}
 
 extension [endpoint: {Connectable as connectable, Showable}](endpoint: endpoint)
   // Open a persistent, bidirectional connection for the duration of `lambda` and

--- a/lib/coaxial/src/core/soundness_coaxial_core.scala
+++ b/lib/coaxial/src/core/soundness_coaxial_core.scala
@@ -34,9 +34,9 @@ package soundness
 
 export
   coaxial
-  . { Bindable, BindError, Connectable, ConnectionError, Control, DomainSocket,
-      DomainSocketEndpoint, duplex, Duplex, Duplexable, exchange, Ingressive, listen, Packet,
-      react, Routable, Transmitter, Serviceable, session, Sessionable, SocketBackend, SocketEvent,
+  . { Bindable, BindError, Connectable, connectableSessional, ConnectionError, Control,
+      DomainSocket, DomainSocketEndpoint, duplex, Duplex, Duplexable, exchange, Ingressive,
+      listen, Packet, react, Routable, Transmitter, Serviceable, SocketBackend, SocketEvent,
       SocketOption, SocketService, Transmissible, transmit, UdpResponse }
 
 package socketOptions:

--- a/lib/obligatory/src/grpc/obligatory.Grpc.scala
+++ b/lib/obligatory/src/grpc/obligatory.Grpc.scala
@@ -32,9 +32,16 @@
                                                                                                   */
 package obligatory
 
+import scala.caps
+
 import anticipation.*
+import coaxial.*
+import contingency.*
+import cordillera.*
 import fulminate.*
 import gossamer.*
+import parasite.*
+import spectacular.*
 import vacuous.*
 
 // The gRPC vocabulary. Grouped under `Grpc` so its generic names — `Status`,
@@ -72,6 +79,23 @@ object Grpc:
   // `/<package>.<Service>/<Method>`, e.g. `/grpc.health.v1.Health/Check`.
   case class Method(service: Text, rpc: Text):
     def path: Text = t"/$service/$rpc"
+
+  object Endpoint:
+    given sessional: [endpoint: {Connectable, Showable}]
+    =>  ( monitor:    Monitor,
+          probate:    Probate,
+          asyncError: Tactic[AsyncError],
+          loggable:   (SocketEvent is Loggable)^ )
+    =>  ( GrpcSessional[endpoint]^{monitor, asyncError, loggable, caps.any} ) =
+
+      GrpcSessional()
+
+  // A gRPC endpoint: the target of a scoped channel, `Grpc.Endpoint(endpoint).session:
+  // channel ?=> …`, whose underlying HTTP/2 connection lives exactly as long as the
+  // block — no parked daemon holds the connection open, because the loan and the scope
+  // coincide.
+  case class Endpoint[endpoint: {Connectable, Showable}]
+    ( endpoint: Http2.Endpoint[endpoint], defaults: Metadata = Metadata() )
 
   // Custom call metadata: arbitrary key/value pairs sent as HTTP/2 headers
   // alongside the gRPC pseudo-headers (e.g. containerd's `containerd-namespace`).

--- a/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
+++ b/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
@@ -35,6 +35,7 @@ package obligatory
 import scala.caps
 
 import anticipation.*
+import coaxial.*
 import contingency.*
 import cordillera.*
 import distillate.*
@@ -43,11 +44,36 @@ import locomotion.*
 import parasite.*
 import prepositional.*
 import rudiments.*
+import spectacular.*
 import telekinesis.*
 import turbulence.*
 import urticose.*
 import vacuous.*
 import zephyrine.*
+
+// A scoped gRPC channel over cordillera's `Http2.EndpointSessional` flow: the HTTP/2
+// connection is opened and its handshake completed, the channel is lent to the lambda,
+// and the connection (with its reader/writer daemons) is torn down when the scope ends —
+// unlike `GrpcChannel.apply`, whose connection is held open by a parked daemon until the
+// enclosing `supervise` scope ends. A named instance class rather than an anonymous
+// given: an anonymous subclass would freshen the capability types in its inferred
+// `Result` member.
+class GrpcSessional[endpoint: {Connectable, Showable}]
+  ( using monitor:    Monitor,
+          probate:    Probate,
+          asyncError: Tactic[AsyncError],
+          loggable:   (SocketEvent is Loggable)^ )
+extends Sessional:
+  type Self = Grpc.Endpoint[endpoint]
+
+  // A fresh capability (`^`, not `^{caps.any}`): each `session` call's handle is its own
+  // existential, so returning it (or anything capturing it) from the block is a level
+  // violation the capture checker rejects.
+  type Result = GrpcChannel^
+
+  def session[result](target: Self)(lambda: (session: Result) ?=> result): result =
+    target.endpoint.session: connection ?=>
+      lambda(using new GrpcChannel(connection, target.endpoint.authority, target.defaults))
 
 object GrpcChannel:
   // Open a channel to a cleartext-h2c endpoint, completing the HTTP/2 handshake. The

--- a/lib/obligatory/src/grpc/soundness_obligatory_grpc.scala
+++ b/lib/obligatory/src/grpc/soundness_obligatory_grpc.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export obligatory.{Grpc, GrpcChannel, GrpcError, GrpcFraming}
+export obligatory.{Grpc, GrpcChannel, GrpcError, GrpcFraming, GrpcSessional}

--- a/lib/obligatory/src/test/obligatory_test.scala
+++ b/lib/obligatory/src/test/obligatory_test.scala
@@ -222,6 +222,24 @@ object Tests extends Suite(m"Obligatory Tests"):
           channel.unary[Ping, Pong](method, Ping(t"ping")).message
       . assert(_ == t"pong")
 
+      test(m"a scoped channel session makes a unary call and tears down with the scope"):
+        supervise:
+          val (clientSide, serverSide) = pair()
+
+          runServer(serverSide, (hpack, id) =>
+            List
+              ( okHeaders(hpack, id),
+                Frame.Data(id, GrpcFraming.encode(Pong(t"pong").in[Protobuf].encode), endStream = false),
+                trailers(hpack, id, List(HpackEntry(t"grpc-status", t"0")), true) ))
+
+          case class Loopback(duplex: Duplex)
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
+          given (Loopback is Showable) = _ => t"loopback"
+
+          Grpc.Endpoint(Http2.Endpoint(Loopback(clientSide), t"localhost")).session: channel ?=>
+            channel.unary[Ping, Pong](method, Ping(t"ping")).message
+      . assert(_ == t"pong")
+
       test(m"a non-Ok trailing status raises a GrpcError"):
         supervise:
           val (clientSide, serverSide) = pair()

--- a/lib/perihelion/src/core/perihelion.WsConnection.scala
+++ b/lib/perihelion/src/core/perihelion.WsConnection.scala
@@ -32,15 +32,23 @@
                                                                                                   */
 package perihelion
 
+import scala.caps
+
 import anticipation.*
 import coaxial.*
+import contingency.*
 import parasite.*
+import prepositional.*
+import rudiments.*
+import zephyrine.*
 
 // A live WebSocket client connection: the underlying byte `Duplex`, the outgoing frame
 // `Channel` (masking each frame with `Masking.Client`), the reassembled inbound frame
 // stream left after the `101` handshake, and the background pump copying spooled frames
 // onto the socket. It is the `Connection` type of the `WsUrl is Duplexable` instance
-// (`wsClient`), so a client is driven by Coaxial's `react`/`exchange`.
+// (`wsClient`), so a client is driven by Coaxial's `react`/`exchange` — or lent directly
+// by a session scope (`url.session`), whose free-form send-and-read style these methods
+// serve.
 class WsConnection
   ( private[perihelion] val duplex:  Duplex,
     private[perihelion] val channel: Channel,
@@ -48,4 +56,26 @@ class WsConnection
     // The connection's pull endpoint (a neutral `AnyRef` carrier for the exclusive
     // `Stream[Data] over Credit`), already advanced past the `101` handshake.
     private[perihelion] val inbound: AnyRef,
-    private[perihelion] val pump:    Daemon )
+    private[perihelion] val pump:    Daemon ):
+
+  // The reassembled inbound messages, one element per complete message: Ping/Pong and
+  // Close are handled by the shared `Reader`, and chunk boundaries frame messages.
+  def messages(using Tactic[WebsocketError]): (Stream[Data] over Credit)^{this, caps.any} =
+    given Masking = masking
+
+    val stream =
+      Reader(() => inbound.asInstanceOf[(Stream[Data] over Credit)^], channel)
+      . messages.map(_.bytes)
+
+    Stream(stream.stdlib.iterator)
+
+  // Sends one message as one complete frame, masked at the `Channel` boundary.
+  def send(consume message: (Stream[Data] over Credit)^): Unit =
+    channel.enqueue(message.memoize)
+
+  def close()(using Monitor^): Unit =
+    given Masking = masking
+    safely(channel.enqueue(Frame.Close(1000, Data()).encode))
+    channel.stop()
+    safely(pump.attend())
+    duplex.close()

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -284,28 +284,45 @@ given wsClient: ( online:            Online,
 
     def receive(connection: WsConnection)
     :   (zephyrine.Stream[Data] over zephyrine.Credit)^{this, caps.any} =
-      given Masking = connection.masking
 
-      val messages =
-        Reader
-          ( () => connection.inbound.asInstanceOf[(zephyrine.Stream[Data] over zephyrine.Credit)^],
-            connection.channel )
-        . messages.map(_.bytes)
-
-      // One reassembled message per refill window: chunk boundaries frame messages.
-      zephyrine.Stream(messages.stdlib.iterator)
+      connection.messages
 
     def transmit
       ( connection: WsConnection,
         consume input: (zephyrine.Stream[Data] over zephyrine.Credit)^ )
     :   Unit =
+
       // One `transmit` carries one message = one complete frame, masked at the
       // `Channel` boundary; see `Transmissible`.
-      connection.channel.enqueue(input.memoize)
+      connection.send(input)
 
-    def close(connection: WsConnection): Unit =
-      given Masking = connection.masking
-      safely(connection.channel.enqueue(Frame.Close(1000, Data()).encode))
-      connection.channel.stop()
-      safely(connection.pump.attend())
-      connection.duplex.close()
+    def close(connection: WsConnection): Unit = connection.close()
+
+// A scoped WebSocket session: the connection — handshake completed, frame pump running —
+// is lent to the lambda for free-form `send`/`messages` use, and closed (with a `1000`
+// Close frame) when the scope ends. For state-machine-style consumption, `url.react` and
+// `url.exchange` remain the natural forms; the session serves interactions that do not
+// fit a per-message handler. A named instance class rather than an anonymous given: an
+// anonymous subclass would freshen the capability types in its inferred `Result` member.
+class WsSessional
+  ( using duplexable: ((WsUrl is Duplexable) { type Output = Data
+                                               type Connection = WsConnection })^,
+          monitor:    Monitor )
+extends Sessional:
+  type Self = WsUrl
+
+  // A fresh capability (`^`, not `^{caps.any}`): each `session` call's handle is its own
+  // existential, so returning it (or anything capturing it) from the block is a level
+  // violation the capture checker rejects.
+  type Result = WsConnection^
+
+  def session[result](target: WsUrl)(lambda: (session: Result) ?=> result): result =
+    val connection = duplexable.connect(target, Unset)
+    try lambda(using connection) finally connection.close()
+
+given wsSessional: ( duplexable: ((WsUrl is Duplexable) { type Output = Data
+                                                          type Connection = WsConnection })^,
+                     monitor:    Monitor )
+=>  (WsSessional^{duplexable, monitor, caps.any}) =
+
+  WsSessional()

--- a/lib/sedentary/src/core/sedentary.BenchmarkDevice.scala
+++ b/lib/sedentary/src/core/sedentary.BenchmarkDevice.scala
@@ -34,6 +34,7 @@ package sedentary
 
 import ambience.*
 import anticipation.*
+import aperture.*
 import contingency.*
 import eucalyptus.*
 import galilei.*
@@ -70,14 +71,15 @@ trait BenchmarkDevice extends Findable:
 
   def undeploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError
 
-class NetworkDevice(user: Text, host: Hostname) extends BenchmarkDevice:
-  def deploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError =
-    safely(sh"scp $path $user@$host:$uuid.jar".exec[Exit]()).lest(BenchError())
+object NetworkDevice:
+  given sessional: (error: Tactic[BenchError]) => NetworkDeviceSessional =
+    NetworkDeviceSessional()
 
-  def invoke
-    ( path: Path on Linux, input: Text, heap: Optional[Text] = Unset,
-      cpus: Optional[Int] = Unset )
-  :   Text raises BenchError =
+  // The measurement JVM's invocation, shared by the per-call and session forms; see
+  // `BenchmarkDevice.invoke` for the meaning of `heap` and `cpus`.
+  private[sedentary] def measurement
+    ( path: Path on Linux, input: Text, heap: Optional[Text], cpus: Optional[Int] )
+  :   Command =
 
     val size = heap.or(t"1g")
 
@@ -85,25 +87,92 @@ class NetworkDevice(user: Text, host: Hostname) extends BenchmarkDevice:
 
     val processors = cpus.lay(List[Text]()): n => List(t"-XX:ActiveProcessorCount=$n")
 
-    val command =
-      sh"""
-        $pin
-        java
-          -XX:+AlwaysPreTouch
-          -Xms$size
-          -Xmx$size
-          -XX:CICompilerCount=2
-          -XX:+UseSerialGC
-          $processors
-          -jar ${path.name}
-          '$input'
-          2> /dev/null
-      """
+    sh"""
+      $pin
+      java
+        -XX:+AlwaysPreTouch
+        -Xms$size
+        -Xmx$size
+        -XX:CICompilerCount=2
+        -XX:+UseSerialGC
+        $processors
+        -jar ${path.name}
+        '$input'
+        2> /dev/null
+    """
+
+  // A benchmark device multiplexing every operation over one OpenSSH ControlMaster
+  // connection (`device.session`), so `deploy`, `invoke` and `undeploy` skip the per-call
+  // SSH handshake the plain `NetworkDevice` pays.
+  class Session private[sedentary] (device: NetworkDevice, socket: Text)
+  extends BenchmarkDevice:
+    def deploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError =
+      val user = device.user
+      val host = device.host
+
+      safely(sh"scp -o ControlPath=$socket $path $user@$host:$uuid.jar".exec[Exit]())
+      . lest(BenchError())
+
+    def invoke
+      ( path: Path on Linux, input: Text, heap: Optional[Text] = Unset,
+        cpus: Optional[Int] = Unset )
+    :   Text raises BenchError =
+
+      val user = device.user
+      val host = device.host
+      val command = NetworkDevice.measurement(path, input, heap, cpus)
+
+      safely(sh"""ssh -o ControlPath=$socket $user@$host ${command.escape}""".exec[Text]())
+      . lest(BenchError())
+
+    def undeploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError =
+      val user = device.user
+      val host = device.host
+
+      safely(sh"ssh -o ControlPath=$socket $user@$host rm $path".exec[Text]())
+      . lest(BenchError())
+
+class NetworkDevice(val user: Text, val host: Hostname) extends BenchmarkDevice:
+  def deploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError =
+    val user = this.user
+    val host = this.host
+    safely(sh"scp $path $user@$host:$uuid.jar".exec[Exit]()).lest(BenchError())
+
+  def invoke
+    ( path: Path on Linux, input: Text, heap: Optional[Text] = Unset,
+      cpus: Optional[Int] = Unset )
+  :   Text raises BenchError =
+
+    val user = this.user
+    val host = this.host
+    val command = NetworkDevice.measurement(path, input, heap, cpus)
 
     safely(sh"""ssh $user@$host ${command.escape}""".exec[Text]()).lest(BenchError())
 
   def undeploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError =
+    val user = this.user
+    val host = this.host
     safely(sh"ssh $user@$host rm $path".exec[Text]()).lest(BenchError())
+
+// A scoped session on a `NetworkDevice`: an OpenSSH ControlMaster connection is opened
+// (and authenticated) once, the multiplexing `Session` device is lent to the lambda, and
+// the master connection is closed when the scope ends. A named instance class rather than
+// an anonymous given, matching the capture-checked instances elsewhere; this module is
+// not yet capture-checked, so the handle carries no capability annotations here.
+class NetworkDeviceSessional(using error: Tactic[BenchError]) extends Sessional:
+  type Self = NetworkDevice
+  type Result = NetworkDevice.Session
+
+  def session[result](target: NetworkDevice)(lambda: (session: Result) ?=> result): result =
+    val user = target.user
+    val host = target.host
+    val socket: Text = t"/tmp/sedentary-${Uuid()}.ssh"
+
+    safely(sh"ssh -M -N -f -o ControlPath=$socket $user@$host".exec[Exit]())
+    . lest(BenchError())
+
+    try lambda(using NetworkDevice.Session(target, socket))
+    finally safely(sh"ssh -O exit -o ControlPath=$socket $user@$host".exec[Exit]()).let(_ => ())
 
 object LocalhostDevice extends BenchmarkDevice:
   def deploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError = ()

--- a/lib/sedentary/src/core/soundness_sedentary_core.scala
+++ b/lib/sedentary/src/core/soundness_sedentary_core.scala
@@ -33,4 +33,4 @@
 package soundness
 
 export sedentary.{Bench, BenchError, BenchmarkDevice, LocalhostDevice, NetworkDevice,
-    OperationSize, Profile, Stress}
+    NetworkDeviceSessional, OperationSize, Profile, Stress}

--- a/lib/telekinesis/src/http2/cordillera.Http2.scala
+++ b/lib/telekinesis/src/http2/cordillera.Http2.scala
@@ -393,18 +393,18 @@ object Http2:
   // body, an open `Http2Stream` — cannot escape the scope; memoized values may.
   // Concurrent `fetch`es within the scope multiplex on the one connection.
   // A named instance class rather than an anonymous given: an anonymous
-  // subclass would freshen the capability types in its inferred `Session`
+  // subclass would freshen the capability types in its inferred `Result`
   // member, which then fails to match the declared refinement.
-  class EndpointSessionable[endpoint: {Connectable, Showable}]
+  class EndpointSessional[endpoint: {Connectable, Showable}]
     ( using monitor:    Monitor,
             probate:    Probate,
             asyncError: Tactic[AsyncError],
             loggable:   (SocketEvent is Loggable)^ )
-  extends Sessionable:
+  extends Sessional:
     type Self = Endpoint[endpoint]
-    type Session = Http2Connection^{caps.any}
+    type Result = Http2Connection^{caps.any}
 
-    def session[result](target: Endpoint[endpoint])(lambda: (session: Session) ?=> result)
+    def session[result](target: Endpoint[endpoint])(lambda: (session: Result) ?=> result)
     :   result =
 
       target.endpoint.duplex: duplex =>
@@ -412,13 +412,13 @@ object Http2:
         connection.start()
         try lambda(using connection) finally connection.close()
 
-  given sessionable: [endpoint: {Connectable, Showable}]
+  given sessional: [endpoint: {Connectable, Showable}]
   =>  ( monitor:    Monitor,
         probate:    Probate,
         asyncError: Tactic[AsyncError],
         loggable:   (SocketEvent is Loggable)^ )
-  =>  (EndpointSessionable[endpoint]^{monitor, asyncError, loggable, caps.any}) =
-    EndpointSessionable[endpoint]()
+  =>  (EndpointSessional[endpoint]^{monitor, asyncError, loggable, caps.any}) =
+    EndpointSessional[endpoint]()
 
   // An `HttpClient` that speaks HTTP/2 (prior-knowledge h2c) to an `Http2.Endpoint`.
   // It captures the ambient `Monitor`/`Probate` from this given's context — the

--- a/lib/telekinesis/src/http2/telekinesis_http2.scala
+++ b/lib/telekinesis/src/http2/telekinesis_http2.scala
@@ -54,19 +54,19 @@ import vacuous.*
 import zephyrine.*
 
 // A named instance class rather than an anonymous given: an anonymous subclass
-// would freshen the capability types in its inferred `Session` member.
-class UrlSessionable[url <: HttpUrl]
+// would freshen the capability types in its inferred `Result` member.
+class UrlSessional[url <: HttpUrl]
   ( using online:       Online,
           backend:      SocketBackend,
           options:      Every[SocketOption.Tcp],
           buffering:    Buffering,
           tls:          Tls,
           connectError: Tactic[ConnectError] )
-extends Sessionable:
+extends Sessional:
   type Self = url
-  type Session = HttpSession^{caps.any}
+  type Result = HttpSession^{caps.any}
 
-  def session[result](target: url)(lambda: (session: Session) ?=> result): result =
+  def session[result](target: url)(lambda: (session: Result) ?=> result): result =
     import ConnectError.Reason.*
 
     val scheme: Text = target.scheme.name
@@ -128,15 +128,15 @@ extends Sessionable:
 // opened once, lent to the lambda as an `HttpSession`, and closed when the
 // scope ends. Bounded like `Fetchable.httpUrl` so `url"https://..."` literals
 // (whose types are scheme-refined subtypes of `HttpUrl`) resolve the instance.
-given httpUrlSessionable: [url <: HttpUrl]
+given httpUrlSessional: [url <: HttpUrl]
 =>  (online: Online)
 =>  ( backend:      SocketBackend,
       options:      Every[SocketOption.Tcp],
       buffering:    Buffering,
       tls:          Tls,
       connectError: Tactic[ConnectError] )
-=>  (UrlSessionable[url]^{online, connectError, caps.any}) =
-  UrlSessionable[url]()
+=>  (UrlSessional[url]^{online, connectError, caps.any}) =
+  UrlSessional[url]()
 
 // Open the TLS connection for an `https` exchange, offering `h2` and `http/1.1`
 // by ALPN, and mapping handshake and connection failures onto `ConnectError`.

--- a/lib/telekinesis/src/jvm/soundness_telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/soundness_telekinesis_jvm.scala
@@ -33,7 +33,7 @@
 package soundness
 
 export telekinesis.{requestTransmissible, domainSocketFetchable, domainSocketHttpClient,
-    HttpSession, httpUrlSessionable}
+    HttpSession, httpUrlSessional}
 
 package httpBackends:
   export telekinesis.httpBackends.{native, virtualMachine}


### PR DESCRIPTION
This PR generalizes coaxial's scoped-connection typeclass into aperture as `Sessional` — written `target is Sessional to Handle`, consistent with `Openable` — and uses it to give Anthology persistent compiler sessions (#1662): a warm dotty context whose loaded symbol table survives across compiles, taking a REPL-shaped consumer's per-compile cost from ~1s of classpath re-loading to near zero. Three further instances adopt the same scope for WebSockets, gRPC channels and SSH benchmark devices.

## `Sessional` (aperture)

The session typeclass, formerly coaxial's `Sessionable`, now lives in aperture alongside `Openable`, in the prepositional form `target is Sessional to Handle`. `target.session { handle ?=> … }` establishes a live interaction, lends its handle to the block, and disposes of it when the block ends. Existing socket, HTTP and HTTP/2 instances are unchanged in behaviour; `import coaxial.*` users are unaffected via re-exports.

## Warm compiler sessions (anthology)

```scala
Scalac[3.9](options).on(classpath).session:
  sources1.compile()
  sources2.compile().save(out)   // artifacts are in memory; save only if wanted
```

Each `compile` reuses the session's retained symbol table (the mechanism dotty's own REPL uses), so `import somebiglib.*` is paid once per session rather than once per compile. Output goes to an in-memory directory: `process.classfiles` exposes the artifacts as `Map[Path on Classpath, Data]`, and `process.save(dir)` materializes them on disk. Compiles run synchronously on the caller's thread (dotc pins a compiler context to one thread); a crashed compile rebuilds the warm state and the session remains usable. The handle is an exclusive, stateful capability, and each compile's process borrows it.

`CompileProcess` also gains a live update feed: `updates` is a single-owner, separation-checked windowed stream of `CompileProcess.Update` values — diagnostics and progress ticks, interleaved in arrival order — consumed element-wise with `process.updates.records.each { … }`, replacing the previous memoizing `Chain` views (`notices` remains as a strict post-completion snapshot).

## Further sessions

- **WebSockets (perihelion)**: `wsUrl.session { connection ?=> … }` lends the live connection, which gains `send`, `messages` and `close` for free-form use; `react`/`exchange` remain for state-machine consumption.
- **gRPC (obligatory)**: `Grpc.Endpoint(endpoint).session { channel ?=> … }` scopes the channel's HTTP/2 connection to the block, rather than parking a daemon to hold it open.
- **Benchmark devices (sedentary)**: `device.session { device ?=> … }` multiplexes `deploy`/`invoke`/`undeploy` over one OpenSSH ControlMaster connection instead of re-handshaking per call.

Closes #1662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
