### PR TITLE
Add the roadmap to production-readiness in doc/roadmap/

### DIFF
--- a/doc/roadmap/api.md
+++ b/doc/roadmap/api.md
@@ -1,0 +1,81 @@
+# API Coherence
+
+Predictability is a safety property. A developer — or an agent — who has learned one corner of
+Soundness should be able to guess the next corner correctly: similar operations share one API,
+variation is expressed in parameters rather than in names, and names are honest. If two
+declarations share a name, they are the same thing; if they differ in name, they differ in
+meaning. An exported surface that violates these rules taxes every user on every lookup, and it
+taxes agents hardest, because agents generalise aggressively from patterns.
+
+The surface has already been measured: `doc/api-reduction-candidates.md` inventories every
+identifier the `soundness` package exports, and classifies the reduction candidates — multi-word
+names that should nest inside the types that prefix them (C1), non-established abbreviations
+(C2), typeclass-backing entities that need not be exported at all (C3), and the homonym and
+synonym tables (C4), where one name means two things or two names mean one. That inventory is
+scaffolding, not documentation: this track applies it category by category, and ends by
+deleting it. The file's absence is the completion signal.
+
+## api-1: multi-word names nest
+
+Horizon: near
+
+The C1 candidates — multi-word names whose prefix already names a same-module type — move
+inside that type: `Foo.Bar`, not `FooBar`. Each move ships with migration instructions once
+`dist-2` establishes the convention.
+
+Done when: the C1 section of the inventory is empty.
+
+## api-2: homonyms and synonyms resolve
+
+Horizon: near
+
+Every C4-homonym pair either unifies into one declaration or one side renames; every C4-synonym
+family collapses onto a single term for the role. Same name, same thing; different name,
+different thing.
+
+Done when: the C4-homonym and C4-synonym sections of the inventory are empty, and a
+same-name-same-thing check runs in the ordinary build (extending `make check-givens`).
+
+## api-3: the backing entities demote
+
+Horizon: mid
+
+The C3 candidates — typeclass-backing entities and nested derivation objects that exist to be
+summoned, not named — are demoted, inlined or de-exported, and the C2 abbreviations are spelled
+out or established.
+
+Done when: the C2, C3 and C3b sections of the inventory are empty.
+
+## api-4: naming conformance is checked
+
+Horizon: mid
+
+The naming standards in `doc/standards/naming.md` and `doc/standards/given-naming.md` gain a
+conformance sweep, so that drift back into incoherence is caught mechanically rather than in
+review.
+
+Done when: a checked-in sweep script reports zero deviations from the naming standards, and
+runs in the ordinary build.
+
+## api-5: the inventory is deleted
+
+Horizon: long
+Needs: api-1, api-2, api-3
+
+When every category is drained, the scaffolding comes down.
+
+Done when:
+
+    test -f doc/api-reduction-candidates.md || echo absent    # absent
+
+## api-6: surface changes flow through the migration convention
+
+Horizon: long
+Needs: dist-2
+
+From here on, coherence is maintained rather than restored: any change to the exported surface
+ships with agent-executable migration instructions, per the convention `dist-2` defines. There
+is no fear of improving an API, because migration is cheap.
+
+Done when: the `dist-2` CI check has been enforced on every surface-changing pull request for
+ten consecutive releases.

--- a/doc/roadmap/breadth.md
+++ b/doc/roadmap/breadth.md
@@ -1,0 +1,85 @@
+# Standards Breadth
+
+Soundness implements standards rather than inventing alternatives to them, and the shelf is
+already long: HTTP/2, WebSocket, TLS, CBOR, Protocol Buffers, tar, zip, xz, PDF, TrueType,
+X.509, COSE, iCalendar, OAuth 2, OpenAPI, LSP, MCP and dozens more, with RFC citations in the
+code. But batteries-included is judged by what a production team reaches for and fails to
+find. This track is a fixed target list, drained in order of how often that reach happens.
+
+The list is deliberately closed: six standards, chosen because each completes a story the
+platform already tells. JOSE/JWT is the largest hole — token-based authentication is ubiquitous,
+and the neighbouring pieces (COSE, OAuth 2, X.509) already exist. TOML is table stakes for
+interoperating with the wider tooling world. WebAuthn completes web authentication. GraphQL
+completes the API-serving story. QUIC/HTTP-3 and IMAP round out transport and mail. Only the
+first three sit inside the production-readiness gate; the rest lie beyond it. A row is complete
+when its module ships with tests, error pages and a topic guide — the same bar as every other
+module, because a battery that is undocumented or partial is not included, merely present.
+
+| Item | Standard | Horizon | In the gate |
+|------|----------|---------|-------------|
+| brd-1 | JOSE: JWS, JWE, JWK, JWT (RFC 7515–7519) | near | yes |
+| brd-2 | TOML | near | yes |
+| brd-3 | WebAuthn | mid | yes |
+| brd-4 | GraphQL | mid | no |
+| brd-5 | QUIC and HTTP/3 (RFC 9000, RFC 9114) | long | no |
+| brd-6 | IMAP (RFC 9051) | long | no |
+
+## brd-1: JOSE
+
+Horizon: near
+
+Signed and encrypted tokens: JWS, JWE, JWK and JWT, building on the primitives enigmatic
+already provides, alongside its COSE support.
+
+Done when: the module ships with tests, `SN-` error pages and a `doc/modules/` topic, and
+round-trips the RFC 7515/7516 example vectors.
+
+## brd-2: TOML
+
+Horizon: near
+
+The configuration format the wider tooling world speaks. Soundness configures itself with TEL;
+it still reads what others write.
+
+Done when: the module ships with tests, `SN-` error pages and a `doc/modules/` topic, and
+passes the standard TOML compliance suite.
+
+## brd-3: WebAuthn
+
+Horizon: mid
+Needs: brd-1
+
+Passwordless authentication for the web stack, completing the story OAuth 2 and JOSE begin.
+The COSE support it depends on already exists.
+
+Done when: the module ships with tests, `SN-` error pages and a `doc/modules/` topic, and a
+scripted registration-and-assertion ceremony passes against a reference authenticator.
+
+## brd-4: GraphQL
+
+Horizon: mid
+
+Schema, parsing, validation and execution, with the same compile-time checking the platform
+applies to HTML and SQL-shaped problems.
+
+Done when: the module ships with tests, `SN-` error pages and a `doc/modules/` topic, and
+passes the GraphQL specification's validation examples.
+
+## brd-5: QUIC and HTTP/3
+
+Horizon: long
+
+The transport successor. HTTP/2 and HPACK are already native; QUIC extends the same treatment
+below them.
+
+Done when: the module ships with tests, `SN-` error pages and a `doc/modules/` topic, and
+interoperates with a reference HTTP/3 server and client.
+
+## brd-6: IMAP
+
+Horizon: long
+
+Mail retrieval, completing what caduceus's SMTP support begins.
+
+Done when: the module ships with tests, `SN-` error pages and a `doc/modules/` topic, and a
+scripted session passes against a reference IMAP server.

--- a/doc/roadmap/breadth.md
+++ b/doc/roadmap/breadth.md
@@ -6,12 +6,12 @@ X.509, COSE, iCalendar, OAuth 2, OpenAPI, LSP, MCP and dozens more, with RFC cit
 code. But batteries-included is judged by what a production team reaches for and fails to
 find. This track is a fixed target list, drained in order of how often that reach happens.
 
-The list is deliberately closed: six standards, chosen because each completes a story the
+The list is deliberately closed: five standards, chosen because each completes a story the
 platform already tells. JOSE/JWT is the largest hole — token-based authentication is ubiquitous,
 and the neighbouring pieces (COSE, OAuth 2, X.509) already exist. TOML is table stakes for
-interoperating with the wider tooling world. WebAuthn completes web authentication. GraphQL
-completes the API-serving story. QUIC/HTTP-3 and IMAP round out transport and mail. Only the
-first three sit inside the production-readiness gate; the rest lie beyond it. A row is complete
+interoperating with the wider tooling world. WebAuthn completes web authentication.
+QUIC/HTTP-3 and IMAP round out transport and mail. Only the first three sit inside the
+production-readiness gate; the rest lie beyond it. A row is complete
 when its module ships with tests, error pages and a topic guide — the same bar as every other
 module, because a battery that is undocumented or partial is not included, merely present.
 
@@ -20,9 +20,8 @@ module, because a battery that is undocumented or partial is not included, merel
 | brd-1 | JOSE: JWS, JWE, JWK, JWT (RFC 7515–7519) | near | yes |
 | brd-2 | TOML | near | yes |
 | brd-3 | WebAuthn | mid | yes |
-| brd-4 | GraphQL | mid | no |
-| brd-5 | QUIC and HTTP/3 (RFC 9000, RFC 9114) | long | no |
-| brd-6 | IMAP (RFC 9051) | long | no |
+| brd-4 | QUIC and HTTP/3 (RFC 9000, RFC 9114) | long | no |
+| brd-5 | IMAP (RFC 9051) | long | no |
 
 ## brd-1: JOSE
 
@@ -55,17 +54,7 @@ The COSE support it depends on already exists.
 Done when: the module ships with tests, `SN-` error pages and a `doc/modules/` topic, and a
 scripted registration-and-assertion ceremony passes against a reference authenticator.
 
-## brd-4: GraphQL
-
-Horizon: mid
-
-Schema, parsing, validation and execution, with the same compile-time checking the platform
-applies to HTML and SQL-shaped problems.
-
-Done when: the module ships with tests, `SN-` error pages and a `doc/modules/` topic, and
-passes the GraphQL specification's validation examples.
-
-## brd-5: QUIC and HTTP/3
+## brd-4: QUIC and HTTP/3
 
 Horizon: long
 
@@ -75,7 +64,7 @@ below them.
 Done when: the module ships with tests, `SN-` error pages and a `doc/modules/` topic, and
 interoperates with a reference HTTP/3 server and client.
 
-## brd-6: IMAP
+## brd-5: IMAP
 
 Horizon: long
 

--- a/doc/roadmap/core.md
+++ b/doc/roadmap/core.md
@@ -59,18 +59,24 @@ Done when:
 
     git grep -l 'import scala.collection' -- lib | grep -v '^lib/proscenium/' | wc -l    # 0
 
-## core-4: raw arrays confined to a declared boundary
+## core-4: indexed access is total by construction
 
 Horizon: mid
-Baseline: 235 files touch `scala.Array` or `scala.IArray` (measured 2026-08-01)
+Baseline: 2244 `while … do` loops across 330 Scala files (measured 2026-08-01)
 
-Raw arrays are legitimate at JDK and erasure boundaries and nowhere else. The boundary must be
-declared, not assumed: a checked-in allowlist of files permitted to touch raw arrays, so that
-every use is either inherent or visible debt. The allowlist then shrinks to the inherent set.
+The `var i = 0; while i < length` pattern is maximally efficient and maximally unsafe: the
+index is just an `Int`, unconstrained by the collection it indexes. The design in
+[#1666](https://github.com/propensive/soundness/issues/1666) makes indexing total by
+construction: an index typed `Ordinal in collection.type` can only exist in range, so the
+`inline` `apply` taking it is total at zero cost, while an unqualified `Ordinal` reaches only
+the fallback `apply` returning `Optional`. Iteration then flows through inline combinators
+that supply dependently-typed ordinals, compiling to the same bytecode as the loops they
+replace.
 
-Done when: an allowlist file exists, is enforced by a check in the ordinary build, and
+Done when: no collection in `lib/` exposes a partial indexed `apply`, and the indexing
+`while`-loop pattern is drained. Interim gauge:
 
-    git grep -lE 'scala\.(Array|IArray)' -- lib | grep -vFf etc/array-boundary.txt | wc -l    # 0
+    git grep -E 'while .* do( |$)' -- 'lib/**/*.scala' | wc -l    # 2244 and falling
 
 ## core-5: nothing Java-shaped at debug time
 

--- a/doc/roadmap/core.md
+++ b/doc/roadmap/core.md
@@ -1,0 +1,94 @@
+# The Standard-Library Drain
+
+Soundness promises that code cannot fail surprisingly at runtime. The Java and Scala standard
+libraries make no such promise: their collections throw on empty heads and missing keys, their
+I/O throws unchecked, their types equivocate about null. Every place a Soundness module reaches
+past its own abstractions into the standard library is a place where that partiality leaks back
+in — and a single leak undermines the claim everywhere, because a user cannot tell a sealed
+surface from a porous one.
+
+The answer is already in place: proscenium is the opaque boundary. Its collections wrap the
+standard library's data structures behind total APIs, its `Array` makes mutation
+separation-checked, and the `-Yimports:java.lang,proscenium` prelude makes the curated surface
+ambient while leaving everything else deliberately out of reach. What remains is the drain: the
+migration shims in `proscenium.compat` exist precisely so that call sites could compile
+unchanged on day one, and every one of them is an independently deletable forwarder. The drain
+loop is deprecate → fix call sites → delete. This track is complete when the standard library
+is invisible — in signatures, in stack traces, in rendered values — everywhere but inside
+proscenium itself.
+
+## core-1: sorted and ordered collections have Soundness equivalents
+
+Horizon: near
+Baseline: 16 files (measured 2026-08-01)
+
+Files using `TreeMap`, `TreeSet`, `TrieMap`, `SortedMap` or `SortedSet` have no opaque type to
+drain to; the equivalents must exist before the drain can take them.
+
+Done when:
+
+    git grep -lE 'TreeMap|TreeSet|TrieMap|SortedMap|SortedSet' -- lib | grep -v '^lib/proscenium/' | wc -l    # 0
+
+## core-2: `proscenium.compat` is empty
+
+Horizon: near → mid
+Needs: core-1
+Baseline: 475 importing files; the compat file is 551 lines (measured 2026-08-01)
+
+The compat file's own header states the contract: each shim is an independently deletable
+inline forwarder, and the file's emptiness is the completion signal. The importer count is the
+interim gauge.
+
+Done when:
+
+    git grep -l 'import proscenium.compat' -- lib | wc -l    # 0
+
+and `lib/proscenium/src/core/proscenium.compat.scala` contains no members.
+
+## core-3: no direct `scala.collection` imports
+
+Horizon: near → mid
+Needs: core-1
+Baseline: 219 files, of which 170 import `scala.collection.mutable` (measured 2026-08-01)
+
+Importing `scala.collection` bypasses the prelude's curation entirely. The mutable imports are
+the larger share, and their replacement is not immutability but *safe* mutability:
+separation-checked structures in the style of `proscenium.Array`.
+
+Done when:
+
+    git grep -l 'import scala.collection' -- lib | grep -v '^lib/proscenium/' | wc -l    # 0
+
+## core-4: raw arrays confined to a declared boundary
+
+Horizon: mid
+Baseline: 235 files touch `scala.Array` or `scala.IArray` (measured 2026-08-01)
+
+Raw arrays are legitimate at JDK and erasure boundaries and nowhere else. The boundary must be
+declared, not assumed: a checked-in allowlist of files permitted to touch raw arrays, so that
+every use is either inherent or visible debt. The allowlist then shrinks to the inherent set.
+
+Done when: an allowlist file exists, is enforced by a check in the ordinary build, and
+
+    git grep -lE 'scala\.(Array|IArray)' -- lib | grep -vFf etc/array-boundary.txt | wc -l    # 0
+
+## core-5: nothing Java-shaped at debug time
+
+Horizon: mid → long
+
+A stack trace, a rendered value or a reported type name never exposes a Java encoding:
+digression renders traces in Soundness terms, and displayed values are the opaque types, not
+their underlying representations. This is what makes debugging feel native rather than hosted.
+
+Done when: a test suite asserts the rendering of representative stack traces, values and type
+names contains no Java encodings, and runs in the ordinary suite.
+
+## core-6: the totality audit
+
+Horizon: long
+
+The claim "no partial APIs" becomes checked rather than asserted: an automated audit — in the
+style of larceny, or at the bytecode level — verifies that no exported operation throws an
+undeclared exception or returns null.
+
+Done when: the audit runs in CI and reports zero violations.

--- a/doc/roadmap/distribution.md
+++ b/doc/roadmap/distribution.md
@@ -13,8 +13,8 @@ exists; what makes that tenable is that every breaking change ships with instruc
 enough for an agent to execute against a downstream codebase. Beyond it lies distribution
 itself: LIRA — one file per library release carrying every compiled representation, with a TEL
 manifest, API-derived versioning and verifiable signatures — is specified but unimplemented,
-and is intended eventually to replace Maven Central as the primary channel. The gate requires
-only that dual publishing works; replacement lies beyond it.
+and replaces Maven Central. The gate requires attested LIRA publishing to be live; switching
+Maven Central publishing off lies just beyond it.
 
 ## dist-1: releases are changelogged
 
@@ -83,26 +83,28 @@ and a transparency log, at minimum-viable scale.
 Done when: a `.lira` file's signature, namespace and transparency-log inclusion are all
 verified by a single command shipped with the tooling.
 
-## dist-7: dual publishing
+## dist-7: LIRA publishing, attested
 
 Horizon: mid
 Needs: dist-3
 
-Every release is published to both Maven Central and LIRA, both attested under the existing
-git-note discipline. This is the gate's requirement: the new channel proven alongside the old,
-with no user forced to move.
+Every release is published as `.lira` files, attested under the same git-note discipline as
+the build itself. This is the gate's requirement: the channel that replaces Maven Central,
+live and verifiable.
 
-Done when: a release ships to both channels, attested, and `make verify-attest` covers both.
+Done when: a release ships to LIRA, attested, and `make verify-attest` covers the published
+artifacts.
 
-## dist-8: LIRA primary
+## dist-8: Maven Central retired
 
 Horizon: long
 Needs: dist-5, dist-6, dist-7
 
-Beyond the gate: fury resolves dependencies from LIRA by default, and a fresh project builds
-with zero Maven resolution. Maven Central remains as a mirror for the ecosystems that need it.
+Beyond the gate: fury resolves dependencies from LIRA, a fresh project builds with zero Maven
+resolution, and the release pipeline no longer publishes to Maven Central at all.
 
-Done when: a fresh fury project builds and runs with the Maven resolver disabled.
+Done when: the release script contains no Maven Central publishing step, and a fresh fury
+project builds and runs with the Maven resolver disabled.
 
 ## dist-9: trust is verifiable by outsiders
 

--- a/doc/roadmap/distribution.md
+++ b/doc/roadmap/distribution.md
@@ -1,0 +1,115 @@
+# Distribution and Release
+
+Trust in a platform is trust in its releases: that they arrive predictably, that they say what
+changed, that breaking changes come with a way through, and that what you download is what was
+built. Soundness already has the rarest of these — every release is attested by a signed,
+verifiable note recording exactly what was built and tested — but the rest of the story is
+thinner: release notes live only in pull-request bodies, and there is no published convention
+for migrating across breaking changes, even though cheap migration is the platform's entire
+answer to API stability.
+
+Migration-first stability is the keystone. APIs change whenever a better or safer design
+exists; what makes that tenable is that every breaking change ships with instructions precise
+enough for an agent to execute against a downstream codebase. Beyond it lies distribution
+itself: LIRA — one file per library release carrying every compiled representation, with a TEL
+manifest, API-derived versioning and verifiable signatures — is specified but unimplemented,
+and is intended eventually to replace Maven Central as the primary channel. The gate requires
+only that dual publishing works; replacement lies beyond it.
+
+## dist-1: releases are changelogged
+
+Horizon: near
+Baseline: no changelog exists; release notes live in pull-request bodies (measured 2026-08-01)
+
+The release notes already written per pull request accumulate into a changelog, and the
+release script refuses to release without one.
+
+Done when: a changelog file exists, and `etc/ci/release.sh` fails when the version being
+released has no entry.
+
+## dist-2: the migration convention
+
+Horizon: near
+
+The keystone item: `doc/standards/migration.md` defines the agent-executable
+migration-instruction format — what changed, how to detect affected code, the exact rewrite,
+and how to verify it — and CI enforces that breaking-labelled pull requests carry instructions
+in that format. Several tracks terminate here: it is what `api-6` flows through and what
+`tool-5` serves to agents.
+
+Done when: `doc/standards/migration.md` exists without a stub marker, and a CI check rejects
+breaking-labelled pull requests lacking conforming migration instructions.
+
+## dist-3: LIRA exists
+
+Horizon: near → mid
+
+The specification gets its reference implementation: a reader and writer for `.lira` files
+carrying classfiles, TASTy, Scala.js IR and Native IR with a TEL manifest, round-tripping the
+current Soundness artifacts.
+
+Done when: the reference implementation round-trips a Soundness release — every published
+component packed into `.lira` files and unpacked byte-identically — in a scripted test.
+
+## dist-4: API-derived versioning
+
+Horizon: mid
+Needs: doc-5
+
+Version numbers become statements about compatibility, computed from the API surface via the
+extraction pipeline, rather than assertions of intent.
+
+Done when: the release pipeline computes each component's version from its extracted API
+surface, and a scripted test demonstrates that an incompatible change forces the version it
+should.
+
+## dist-5: fury publishes LIRA
+
+Horizon: mid
+Needs: tool-4
+
+Publishing is a build-tool concern: fury packs, signs and publishes `.lira` files as part of
+its ordinary release flow.
+
+Done when: `fury publish` produces and publishes signed `.lira` files for a real release.
+
+## dist-6: the trust infrastructure
+
+Horizon: mid → long
+
+The rest of the LIRA distribution design: quantum-safe signatures, DNS-verified namespaces,
+and a transparency log, at minimum-viable scale.
+
+Done when: a `.lira` file's signature, namespace and transparency-log inclusion are all
+verified by a single command shipped with the tooling.
+
+## dist-7: dual publishing
+
+Horizon: mid
+Needs: dist-3
+
+Every release is published to both Maven Central and LIRA, both attested under the existing
+git-note discipline. This is the gate's requirement: the new channel proven alongside the old,
+with no user forced to move.
+
+Done when: a release ships to both channels, attested, and `make verify-attest` covers both.
+
+## dist-8: LIRA primary
+
+Horizon: long
+Needs: dist-5, dist-6, dist-7
+
+Beyond the gate: fury resolves dependencies from LIRA by default, and a fresh project builds
+with zero Maven resolution. Maven Central remains as a mirror for the ecosystems that need it.
+
+Done when: a fresh fury project builds and runs with the Maven resolver disabled.
+
+## dist-9: trust is verifiable by outsiders
+
+Horizon: long
+
+The release process is documented end-to-end so that a third party — not a maintainer — can
+verify any release's attestation from public information alone.
+
+Done when: the verification instructions are published, and a scripted third-party
+verification (no maintainer credentials, public data only) passes for the latest release.

--- a/doc/roadmap/documentation.md
+++ b/doc/roadmap/documentation.md
@@ -1,0 +1,111 @@
+# Documentation and Learnability
+
+Documentation is part of the safety story. An undocumented API invites guessing, and guessing
+is how surprising failures happen — for people and, more acutely, for AI agents, which will
+confidently synthesise whatever the documentation fails to say. The standard is total coverage:
+every module documented, every error code explained, every novel idea specified, and every
+message following a written convention.
+
+The prose exists in three parallel systems today: the topic guides in `doc/modules/` — the
+direction of travel, and where the substantial writing happens — the legacy per-module
+templates in `lib/*/doc/`, inherited from when each module was its own repository, and a
+separate copy of the philosophy material under `web/res/content/`. Three systems means
+divergence, and divergence means one of them is lying. This track collapses them to one,
+completes coverage, and adds the layer that prose cannot provide: generated, searchable API
+documentation — infrastructure that fluence and LIRA's API-derived versioning also depend on.
+It ends with the strongest learnability test there is: an agent, given only the documentation,
+builds and deploys a working application.
+
+## doc-1: every error type has a code and a page
+
+Horizon: near
+Baseline: 121 error types carry `SN-` codes, 39 do not; 233 error pages exist (measured 2026-08-01)
+
+The `SN-` scheme covers the macro-raised compile errors; the remaining runtime error types get
+codes and pages under the same never-reuse discipline, and parity between types, codes and
+pages becomes a CI check so it cannot drift.
+
+Done when: the parity check runs in CI and
+
+    git grep -hE 'extends +Error\((m"|[a-z])' -- lib | wc -l    # 0
+
+## doc-2: the messages standard is written
+
+Horizon: near
+
+`doc/standards/messages.md` is a self-declared stub, despite the message convention being
+load-bearing across every module. The standard gets written: register, structure, vocabulary
+and examples for `m"…"` messages and error text.
+
+Done when:
+
+    grep -c 'Stub' doc/standards/messages.md    # 0
+
+## doc-3: the legacy documentation systems retire
+
+Horizon: near
+Baseline: 92 files still say "built by Fury"; 35 of 133 modules have no `lib/*/doc/` directory (measured 2026-08-01)
+
+The per-module readme boilerplate predates the monorepo and describes a build tool that does
+not yet exist again. Whatever in `lib/*/doc/` is worth keeping migrates into `doc/modules/`
+topics; the rest is deleted rather than left to mislead.
+
+Done when:
+
+    git grep -l 'built by Fury' | wc -l    # 0
+
+and no `lib/*/doc/` directory remains.
+
+## doc-4: every module is covered by a topic
+
+Horizon: mid
+Baseline: 91 topics in `doc/modules/`; 35 modules have no documentation anywhere (measured 2026-08-01)
+
+Every published module is covered by at least one `doc/modules/` topic, and a coverage script
+maps modules to topics so orphans are visible.
+
+Done when: the coverage script runs in the ordinary build and reports zero uncovered modules.
+
+## doc-5: API documentation is generated and published
+
+Horizon: mid
+Baseline: every published `docJar` is empty (measured 2026-08-01)
+
+The extraction pipeline is the shared foundation: fluence searches it (`tool-7`) and
+API-derived versioning diffs it (`dist-4`). Published API documentation is the immediate
+deliverable.
+
+Done when: every published component's documentation artifact is non-empty, and the API
+documentation is published for every release.
+
+## doc-6: the website derives from `doc/`
+
+Horizon: mid
+
+The prose under `web/res/content/` duplicates philosophy material by hand. The website renders
+from `doc/` — one source, no parallel copies.
+
+Done when: `web/res/content/` contains no hand-maintained duplicate of any `doc/` page.
+
+## doc-7: novel ideas are one hop away
+
+Horizon: long
+
+Every novel idea in Soundness — capture checking in practice, separation-checked mutability,
+delimited scopes, declared errors — has a philosophy page, and every API that embodies the idea
+links to it. A reader is never more than one hop from the explanation.
+
+Done when: a link check verifies that each philosophy page is referenced from the topic guides
+of the modules that embody it, and it runs in the ordinary build.
+
+## doc-8: the walkthrough
+
+Horizon: long
+Needs: tool-2, tool-4
+
+The integrative test of learnability, and the gate's final criterion: a from-nothing tutorial
+that an agent can execute end-to-end — new project, build with fury, test with fume, deploy a
+JVM-and-JavaScript web application — using only `doc/` and ecosystem tools.
+
+Done when: the walkthrough is executed by an agent in CI and the run is recorded with each
+release.

--- a/doc/roadmap/index.md
+++ b/doc/roadmap/index.md
@@ -34,11 +34,14 @@ Everything on this roadmap serves one philosophy, elaborated in the
 - **Migration-first stability.** APIs change whenever a better or safer design exists. Stability
   comes not from freezing APIs but from making migration cheap: every breaking change ships with
   instructions precise enough for an agent to execute.
-- **A trusted toolchain.** Building, testing, exploring and distributing Soundness code happens
-  through its own tools — `fury`, `fume`, `flame`, `fluence`, the `exegesis` LSP server and the
-  `synesthesia` MCP server — with releases that are attested, predictable and verifiable, and
-  libraries distributed as LIRA files that are guaranteed to compose safely. TEL is the
-  configuration language wherever configuration is needed.
+- **A trusted toolchain.** Building, testing, debugging, exploring and distributing Soundness
+  code happens through its own tools — `fury`, `fume`, `flame`, `fluence`, the `exegesis` LSP
+  server, a Soundness-native debugger and the `synesthesia` MCP server — with releases that are
+  attested, predictable and verifiable, and libraries distributed as LIRA files that are
+  guaranteed to compose safely. TEL is the configuration language wherever configuration is
+  needed. Soundness is built with the Proscala compiler, which is modifiable whenever safety
+  demands it, under one constraint: published artifacts stay readable from the mainline Scala
+  compiler.
 
 ## How to read this roadmap
 
@@ -88,18 +91,21 @@ The rules that keep this document trustworthy:
    zero; capture checking, separation checking and declared errors hold without exemption; the
    compiler fork is sustainable.
 3. **[Platform parity](platforms.md)** (`plat`) — building for JavaScript, Native, WASI and
-   Android is no harder than for the JVM, with only inherent exclusions, verified in CI.
+   Android is no harder than for the JVM, with only inherent exclusions, verified in CI; the
+   browser is a first-class application target, with web APIs behind typed facades.
 4. **[API coherence](api.md)** (`api`) — one name means one thing; variations are parameters;
    the exported surface is deliberate rather than accidental.
 5. **[Documentation and learnability](documentation.md)** (`doc`) — one documentation system,
    complete coverage, published API docs, and a path from nothing to a working application that
    an agent can follow.
-6. **[The toolchain](tooling.md)** (`tool`) — flame, fury, fume, fluence, the LSP server and the
-   MCP server together replace every Maven-era tool.
+6. **[The toolchain](tooling.md)** (`tool`) — flame, fury, fume, fluence, the LSP server, the
+   debugger and the MCP server together replace every Maven-era tool, with coverage and
+   benchmarks tracked for every commit in git notes.
 7. **[Distribution and release](distribution.md)** (`dist`) — attested, changelogged releases;
-   the migration-instruction convention; LIRA from specification to primary channel.
+   the migration-instruction convention; LIRA from specification to sole channel, retiring
+   Maven Central.
 8. **[Standards breadth](breadth.md)** (`brd`) — the remaining standards a production team
-   expects: JOSE, TOML, WebAuthn, GraphQL, QUIC, IMAP.
+   expects: JOSE, TOML, WebAuthn, QUIC, IMAP.
 
 ## Dependencies
 
@@ -119,11 +125,12 @@ refactoring them is the fix.
 are listed here and never appear as items, because no `Done when:` command of ours can close
 them:
 
-- The scala-wasm fork of `wit-bindgen` is upstreamed, or vendored in-tree with tests
-  (gates `plat-4`).
 - WASI's standard interfaces mature far enough to express full HTTP and UDP (gates `plat-4`).
-- Upstream acceptance of capture-checking and separation-checking fixes from the
-  `propensive/proscala` fork (gates `safety-5`).
+
+The compiler is deliberately *not* on this list: Soundness is built with Proscala, and the
+freedom to modify it — for capture-checking fixes, for the Wasm backend, for whatever safety
+demands — is assumed throughout this roadmap, bounded only by the requirement that published
+artifacts remain readable from mainline Scala (`safety-5`).
 
 ## The gate
 
@@ -144,7 +151,7 @@ new: each entry cites a track item, and the item's `Done when:` command is the a
 11. A scripted LSP editor session passes in CI (`tool-3`).
 12. Every breaking change in the last ten consecutive releases shipped with agent-executable
     migration instructions (`dist-2`).
-13. Every release is published to both Maven Central and LIRA, attested (`dist-7`).
+13. Every release is published as attested LIRA files (`dist-7`).
 14. JOSE, TOML and WebAuthn are shipped (`brd-1`, `brd-2`, `brd-3`).
 
 And one integrative criterion, which is the point of the exercise:
@@ -155,10 +162,10 @@ And one integrative criterion, which is the point of the exercise:
 
 ### Beyond the gate
 
-The gate is not the horizon. Past it lie: LIRA as the primary distribution channel with Maven
-Central as a mirror (`dist-8`); QUIC/HTTP-3 and IMAP (`brd-5`, `brd-6`); WASI at full parity once
-its external gates lift (`plat-4`, `plat-5`); and the compiler fork's features living upstream
-(`safety-5`).
+The gate is not the horizon. Past it lie: Maven Central publishing retired, leaving LIRA as
+the sole channel (`dist-8`); QUIC/HTTP-3 and IMAP (`brd-4`, `brd-5`); WASI at full parity once
+its external gate lifts (`plat-4`, `plat-5`); and the fork's mainline-readability guarantee
+enforced in CI (`safety-5`).
 
 ## For AI agents
 

--- a/doc/roadmap/index.md
+++ b/doc/roadmap/index.md
@@ -1,0 +1,176 @@
+# The Roadmap
+
+Soundness is being built towards a single destination: the point at which a serious team can
+adopt it for real applications. Not a version number, and not a ceremony — a set of measurable
+conditions, listed at the bottom of this page as [the gate](#the-gate). This roadmap describes
+the route: eight parallel tracks, each with its own end-state, phased across three horizons.
+
+## The vision
+
+Everything on this roadmap serves one philosophy, elaborated in the
+[philosophy](../philosophy/composability.md) pages:
+
+- **Safety.** It is difficult or impossible to write Soundness code that fails surprisingly at
+  runtime. Every API is total, or [declares the errors it raises](../philosophy/error-handling.md).
+  Mutability is permitted only where separation checking proves it safe; capture checking
+  enforces what signatures promise. Partiality anywhere — including in the Java and Scala
+  standard libraries beneath us — undermines everything, so partial APIs are replaced, not
+  tolerated.
+- **Coherence.** APIs are predictable, clear and generalised. Similar things share one API;
+  variation is a parameter, not a name. If two things share a name, they are the same thing; if
+  they have different names, they are not.
+- **Batteries included.** One platform for CLI applications, web applications (server and
+  front-end), testing, scientific work and development tooling — built on
+  [open standards](../tags.md), not proprietary inventions, and modular enough that unused
+  batteries cost nothing.
+- **Parity of targets.** JVM, Android, JavaScript and WASM/WASI are all viable targets, no
+  harder to build for than the JVM.
+- **A native-feeling world.** Developing, debugging and running Soundness code never feels like
+  operating an advanced system inside an environment that wasn't designed for it. Java encodings
+  of values are never visible.
+- **Learnable, documented, specified.** Every API is documented; every error message is
+  informative and has a documented page; every novel idea has a specification. Documentation is
+  written so that both people and AI agents can act on it reliably.
+- **Migration-first stability.** APIs change whenever a better or safer design exists. Stability
+  comes not from freezing APIs but from making migration cheap: every breaking change ships with
+  instructions precise enough for an agent to execute.
+- **A trusted toolchain.** Building, testing, exploring and distributing Soundness code happens
+  through its own tools — `fury`, `fume`, `flame`, `fluence`, the `exegesis` LSP server and the
+  `synesthesia` MCP server — with releases that are attested, predictable and verifiable, and
+  libraries distributed as LIRA files that are guaranteed to compose safely. TEL is the
+  configuration language wherever configuration is needed.
+
+## How to read this roadmap
+
+Each track lives in its own file and follows the same shape: a short preamble saying why its
+end-state matters, then a sequence of numbered items. Every item uses one format:
+
+```
+## core-3: no direct `scala.collection` imports
+
+Horizon: near → mid
+Needs: core-1
+Baseline: 219 files (measured 2026-08-01)
+
+One or two sentences of prose.
+
+Done when:
+
+    git grep -l 'import scala.collection' -- lib | grep -v '^lib/proscenium/' | wc -l    # 0
+```
+
+The rules that keep this document trustworthy:
+
+- **Item identifiers are permanent.** They are track-prefixed and sequential, and are never
+  reused — the same discipline as `SN-` error codes. A completed item keeps its heading, gaining
+  a `Done:` line naming the closing commit or pull request. The only exception is an item whose
+  criterion *is* the deletion of an artifact.
+- **Every criterion is a command or an observable fact.** A `Done when:` block contains a
+  runnable command with its expected output as a trailing comment, or states a fact about a
+  file's existence, emptiness, or a CI check's status. Nothing else is admissible. "Mostly
+  complete" and "substantially done" are not criteria; if it cannot be counted, grepped or
+  observed, it does not belong here.
+- **Baselines are dated.** Numbers drift as work proceeds; an agent re-measuring a baseline
+  should expect drift and report it, not silently trust a stale figure.
+- **Horizons are not dates.** *Near* is the current working set; *mid* is what the near horizon
+  unblocks; *long* approaches the track's end-state. Progress is measured by criteria, never by
+  the calendar.
+- **Status lives in [`status.tel`](status.tel).** The prose files say what and why;
+  `status.tel` — one record per item, machine-readable, written in TEL — says where each item
+  stands. Prose never claims completion; it links.
+
+## The tracks
+
+1. **[The standard-library drain](core.md)** (`core`) — no module reaches the Java or Scala
+   standard libraries except through proscenium's opaque boundary; nothing Java-shaped is
+   visible at development or debug time.
+2. **[Capabilities and effects](safety.md)** (`safety`) — the `caps.unsafe` escape hatches reach
+   zero; capture checking, separation checking and declared errors hold without exemption; the
+   compiler fork is sustainable.
+3. **[Platform parity](platforms.md)** (`plat`) — building for JavaScript, Native, WASI and
+   Android is no harder than for the JVM, with only inherent exclusions, verified in CI.
+4. **[API coherence](api.md)** (`api`) — one name means one thing; variations are parameters;
+   the exported surface is deliberate rather than accidental.
+5. **[Documentation and learnability](documentation.md)** (`doc`) — one documentation system,
+   complete coverage, published API docs, and a path from nothing to a working application that
+   an agent can follow.
+6. **[The toolchain](tooling.md)** (`tool`) — flame, fury, fume, fluence, the LSP server and the
+   MCP server together replace every Maven-era tool.
+7. **[Distribution and release](distribution.md)** (`dist`) — attested, changelogged releases;
+   the migration-instruction convention; LIRA from specification to primary channel.
+8. **[Standards breadth](breadth.md)** (`brd`) — the remaining standards a production team
+   expects: JOSE, TOML, WebAuthn, GraphQL, QUIC, IMAP.
+
+## Dependencies
+
+An edge `a ← b` means *a cannot be completed before b* (it may be started). An item's `Needs:`
+line records its hard dependencies, including those within its own track; the list below
+duplicates only the cross-track edges, because those are the ones requiring coordination. If
+this list ever grows much beyond a dozen edges, the tracks are wrongly factored, and
+refactoring them is the fix.
+
+- `api-6 ← dist-2` — surface changes flow through the migration convention once it exists
+- `doc-8 ← tool-2, tool-4` — the walkthrough uses fume and fury
+- `tool-7 ← doc-5` — fluence consumes the API-extraction pipeline
+- `dist-4 ← doc-5` — API-derived versioning needs the same extraction
+- `dist-5 ← tool-4` — fury must build before it can publish
+
+**External gates** — conditions that gate items but are not under this project's control. They
+are listed here and never appear as items, because no `Done when:` command of ours can close
+them:
+
+- The scala-wasm fork of `wit-bindgen` is upstreamed, or vendored in-tree with tests
+  (gates `plat-4`).
+- WASI's standard interfaces mature far enough to express full HTTP and UDP (gates `plat-4`).
+- Upstream acceptance of capture-checking and separation-checking fixes from the
+  `propensive/proscala` fork (gates `safety-5`).
+
+## The gate
+
+Production-readiness is the conjunction of the following criteria. The gate defines nothing
+new: each entry cites a track item, and the item's `Done when:` command is the authority.
+
+1. `proscenium.compat` is empty (`core-2`).
+2. No file outside proscenium imports `scala.collection` (`core-3`).
+3. No `caps.unsafe` escape hatch remains in `lib/` (`safety-4`).
+4. The platform manifest is enforced in CI, its exclusions carry reasons, and an Android APK is
+   built and signed in CI (`plat-1`, `plat-2`, `plat-3`).
+5. `doc/api-reduction-candidates.md` no longer exists (`api-5`).
+6. Every error type has an `SN-` code and a documentation page, checked in CI (`doc-1`).
+7. Every published module is covered by a `doc/modules/` topic (`doc-4`).
+8. API documentation is generated and published for every component (`doc-5`).
+9. `fury build` builds Soundness itself, attestation-equal to the Mill build (`tool-4`).
+10. fume runs the full test suite, and no suite is disabled (`tool-2`).
+11. A scripted LSP editor session passes in CI (`tool-3`).
+12. Every breaking change in the last ten consecutive releases shipped with agent-executable
+    migration instructions (`dist-2`).
+13. Every release is published to both Maven Central and LIRA, attested (`dist-7`).
+14. JOSE, TOML and WebAuthn are shipped (`brd-1`, `brd-2`, `brd-3`).
+
+And one integrative criterion, which is the point of the exercise:
+
+15. An agent, following only the documentation in `doc/`, takes a new project from nothing to a
+    tested, deployed JVM-and-JavaScript web application using only ecosystem tools — and this
+    walkthrough is executed and recorded in CI (`doc-8`).
+
+### Beyond the gate
+
+The gate is not the horizon. Past it lie: LIRA as the primary distribution channel with Maven
+Central as a mirror (`dist-8`); QUIC/HTTP-3 and IMAP (`brd-5`, `brd-6`); WASI at full parity once
+its external gates lift (`plat-4`, `plat-5`); and the compiler fork's features living upstream
+(`safety-5`).
+
+## For AI agents
+
+This document is written to be acted on by agents as much as read by people:
+
+- Item identifiers are stable anchors; cite them (`core-3`, `dist-2`) rather than describing
+  work in prose.
+- Verify any claim of progress by running the item's `Done when:` command; never trust prose or
+  memory over the command's output. Re-measure baselines before relying on them and report
+  drift.
+- Read [`status.tel`](status.tel) for current status; update it in the same commit as the work
+  it describes.
+- When a roadmap item changes a public API, follow the migration-instruction convention defined
+  by `dist-2` in `doc/standards/migration.md` — that convention is what makes "APIs change
+  freely" and "code keeps working" compatible.

--- a/doc/roadmap/platforms.md
+++ b/doc/roadmap/platforms.md
@@ -56,8 +56,10 @@ Baseline: 7 WASI backends; HTTP is GET-only, sockets are TCP-only (measured 2026
 
 The WASI slice — environment, clock, random, sockets, filesystem, HTTP, stdio — proves the WIT
 component-model approach; parity requires the full HTTP method set, UDP, and backends for every
-module whose domain WASI can express. This item is gated externally: the scala-wasm fork of
-`wit-bindgen` must be upstreamed or vendored in-tree, and WASI's own interfaces must mature.
+module whose domain WASI can express. The compiler side of this is within reach: Soundness is
+built with Proscala, so the Wasm backend and the binding generation (today an out-of-tree
+`wit-bindgen` fork, to be vendored) are ours to fix. The genuinely external gate is WASI
+itself: its interfaces must mature far enough to express what the backends need.
 
 Done when: the manifest's WASI column matches the JavaScript column except where the exclusion
 reason names a missing WASI capability. Interim gauge:
@@ -75,3 +77,17 @@ manifest's reasons are themselves the completion signal.
 
 Done when: every exclusion reason in `doc/compatibility.tsv` describes an inherent platform
 limitation, and a reason vocabulary check in CI enforces the distinction.
+
+## plat-6: the browser is a first-class application target
+
+Horizon: mid
+
+Compiling for JavaScript is necessary but not sufficient: a website built with Soundness
+should be written in Soundness end-to-end, with the front-end in Scala.js and every web API —
+DOM, fetch, storage, media — reached through typed facades generated from WebIDL by
+xenophile, over querencia's typed DOM. No hand-written JavaScript, no untyped `js.Dynamic`
+seams. The proof is dogfood: soundness.dev's own front-end, served by the in-tree website,
+built this way.
+
+Done when: the soundness.dev front-end ships as Soundness-compiled Scala.js, with all web API
+access through generated typed facades, and builds in the ordinary build.

--- a/doc/roadmap/platforms.md
+++ b/doc/roadmap/platforms.md
@@ -1,0 +1,77 @@
+# Platform Parity
+
+A batteries-included platform earns the name only if the batteries work where applications
+actually run: on the JVM, in browsers, as native binaries, inside WASM runtimes, and on Android
+devices. The promise is not that every module runs everywhere — a browser has no filesystem —
+but that every exclusion is inherent, stated, and checked, and that building for any target is
+no harder than building for the JVM.
+
+Today the JVM is total, JavaScript and Native cover most modules, WASI is a narrow but real
+slice built on the WASM component model, and Android works end-to-end — D8 dexing and APK
+signing without the Android SDK — but outside the ordinary build. Parity means closing each of
+those qualifications, and the instrument for doing so is a manifest: the platform matrix as
+checked-in data, where every "no" carries a reason, and CI fails when reality regresses from
+the manifest. When the only reasons left are inherent ones, the parity statement holds.
+
+## plat-1: the platform manifest is enforced
+
+Horizon: near
+Baseline: 94 of 132 modules build for JavaScript, 86 for Native (measured 2026-08-01)
+
+`doc/compatibility.tsv` already records the matrix; enforcement makes it a contract rather
+than a report: CI regenerates it and fails on any regression, and every exclusion carries a
+stated reason.
+
+Done when: the ordinary build regenerates the manifest, fails on divergence from the committed
+copy, and no exclusion row has an empty reason. Interim gauge:
+
+    grep -v '^#' doc/compatibility.tsv | awk -F'\t' '$3=="yes"{n++} END{print n}'    # 94 → 132 minus inherent exclusions
+
+## plat-2: Android in the ordinary build
+
+Horizon: near → mid
+
+The dexing and APK-signing path works but is gated on `ANDROID_HOME` and excluded from CI. An
+Android application should be built and signed on every attested run, so regressions surface
+immediately rather than on the next manual attempt.
+
+Done when: `make attest` includes the Android stage, and CI records a signed APK for every
+release.
+
+## plat-3: JavaScript and Native at full non-excluded coverage
+
+Horizon: mid
+Needs: plat-1
+
+Every module builds for JavaScript and Native unless its exclusion reason is inherent, and
+Native coverage is verified by the real binary link check throughout, not compilation alone.
+
+Done when: the manifest shows no JavaScript or Native exclusion whose reason is not inherent,
+and the Native link check covers every Native-capable module.
+
+## plat-4: WASI beyond the first seven backends
+
+Horizon: mid → long
+Baseline: 7 WASI backends; HTTP is GET-only, sockets are TCP-only (measured 2026-08-01)
+
+The WASI slice — environment, clock, random, sockets, filesystem, HTTP, stdio — proves the WIT
+component-model approach; parity requires the full HTTP method set, UDP, and backends for every
+module whose domain WASI can express. This item is gated externally: the scala-wasm fork of
+`wit-bindgen` must be upstreamed or vendored in-tree, and WASI's own interfaces must mature.
+
+Done when: the manifest's WASI column matches the JavaScript column except where the exclusion
+reason names a missing WASI capability. Interim gauge:
+
+    ls -d lib/*/src/wasi | wc -l    # 7 and rising
+
+## plat-5: the parity statement holds
+
+Horizon: long
+Needs: plat-4
+
+The end-state, stated as a fact about the manifest: no exclusion reason anywhere in it means
+"not yet". Every reason is inherent — the platform cannot support the capability — and the
+manifest's reasons are themselves the completion signal.
+
+Done when: every exclusion reason in `doc/compatibility.tsv` describes an inherent platform
+limitation, and a reason vocabulary check in CI enforces the distinction.

--- a/doc/roadmap/safety.md
+++ b/doc/roadmap/safety.md
@@ -8,11 +8,14 @@ as guarantees. Every `caps.unsafe` call is a place where the checker was overrul
 each one is a standing IOU against the safety claim.
 
 The escape hatches are therefore this track's central measure. Some are genuine debt with a
-known retirement recipe; others are blocked on defects in the capture checker itself, which is
-why Soundness compiles with the `propensive/proscala` fork, and why the `rep/` directory
-maintains minimal reproductions of each blocker class. The track ends when the grep for
-`caps.unsafe` returns nothing, and when depending on a forked compiler is either unnecessary or
-demonstrably cheap.
+known retirement recipe; others are blocked on defects in the capture checker itself — and
+those defects are ours to fix, because Soundness is built with the Proscala compiler by
+design. The compiler is modifiable whenever capability or effect checking demands it; the
+`rep/` directory maintains minimal reproductions of each blocker class as the queue of fixes.
+The one constraint is compatibility outward: whatever Proscala does, the artifacts Soundness
+publishes must remain readable by the mainline Scala compiler. The track ends when the grep
+for `caps.unsafe` returns nothing, and that readability guarantee is enforced rather than
+assumed.
 
 ## safety-1: retire `untrackedCaptures`
 
@@ -61,16 +64,17 @@ Done when:
 
     git grep -oE 'unsafeAssumeSeparate|untrackedCaptures|unsafeAssumePure|unsafeErasedValue' -- lib | wc -l    # 0
 
-## safety-5: fork sustainability
+## safety-5: the fork is an asset, not a trap
 
 Horizon: long
 
-Soundness must not depend forever on a compiler only it maintains. Either the fork's
-capture-checking and separation-checking fixes are accepted upstream and `build.mill` consumes
-a stock release, or rebasing the fork onto each upstream release is a documented procedure with
-a measured, bounded cost.
+Building with Proscala is a design decision, not debt: the freedom to fix the capture checker
+is what makes zero escape hatches reachable at all. What keeps that freedom safe is downstream
+readability — every published artifact remains consumable from a project built with the
+mainline Scala compiler — and a rebase onto each upstream release whose cost is known rather
+than feared.
 
-Done when: `build.mill`'s toolchain references an upstream Scala release; or
+Done when: a CI test consumes published Soundness artifacts from a mainline-Scala project, and
 `rep/` documents the rebase procedure and the measured cost of the two most recent rebases.
 
 ## safety-6: separation checking without exemption

--- a/doc/roadmap/safety.md
+++ b/doc/roadmap/safety.md
@@ -1,0 +1,85 @@
+# Capabilities and Effects
+
+Honest signatures are only as honest as their enforcement. Capture checking makes a signature's
+promises about effects verifiable; separation checking makes mutation safe by construction; the
+`raises` mechanism makes failure visible in types. All three are already the default — nearly
+every build component compiles with separation checking enabled — but defaults are not the same
+as guarantees. Every `caps.unsafe` call is a place where the checker was overruled by hand, and
+each one is a standing IOU against the safety claim.
+
+The escape hatches are therefore this track's central measure. Some are genuine debt with a
+known retirement recipe; others are blocked on defects in the capture checker itself, which is
+why Soundness compiles with the `propensive/proscala` fork, and why the `rep/` directory
+maintains minimal reproductions of each blocker class. The track ends when the grep for
+`caps.unsafe` returns nothing, and when depending on a forked compiler is either unnecessary or
+demonstrably cheap.
+
+## safety-1: retire `untrackedCaptures`
+
+Horizon: near
+Baseline: 288 occurrences (measured 2026-08-01)
+
+The retirement recipe is documented and mechanical: the annotated class becomes `caps.Mutable`,
+mutating methods become `update def`, consumers hold `X^`, and mutual back-references are
+flattened.
+
+Done when:
+
+    git grep -o untrackedCaptures -- lib | wc -l    # 0
+
+## safety-2: triage the remaining unsafes
+
+Horizon: near
+Baseline: 323 `unsafeAssumeSeparate`, 273 `unsafeAssumePure`, 45 `unsafeErasedValue` (measured 2026-08-01)
+
+Each occurrence is either fixable now or blocked on a known compiler defect. The triage makes
+the distinction explicit: every surviving occurrence carries a comment naming its `rep/`
+blocker case, so the residue is exactly the blocked set and nothing hides in it.
+
+Done when: every remaining `caps.unsafe` occurrence in `lib/` names a `rep/` case in an
+adjacent comment, verified by a checked-in script reporting zero unannotated occurrences.
+
+## safety-3: resolve the `capturing-raises` blocker
+
+Horizon: mid
+
+The dominant remaining class of capture-checking failure, reproduced minimally in `rep/`, is
+fixed in the proscala fork, unblocking the annotated portion of the unsafe residue.
+
+Done when: the `rep/` reproduction for `capturing-raises` compiles cleanly under the current
+toolchain, and its `rep/DECISIONS.md` entry records the fix.
+
+## safety-4: zero escape hatches
+
+Horizon: mid → long
+Needs: safety-3
+Baseline: 929 occurrences in total (measured 2026-08-01)
+
+With the blockers fixed, the residue burns down to nothing. The grep is the signal.
+
+Done when:
+
+    git grep -oE 'unsafeAssumeSeparate|untrackedCaptures|unsafeAssumePure|unsafeErasedValue' -- lib | wc -l    # 0
+
+## safety-5: fork sustainability
+
+Horizon: long
+
+Soundness must not depend forever on a compiler only it maintains. Either the fork's
+capture-checking and separation-checking fixes are accepted upstream and `build.mill` consumes
+a stock release, or rebasing the fork onto each upstream release is a documented procedure with
+a measured, bounded cost.
+
+Done when: `build.mill`'s toolchain references an upstream Scala release; or
+`rep/` documents the rebase procedure and the measured cost of the two most recent rebases.
+
+## safety-6: separation checking without exemption
+
+Horizon: long
+Baseline: 3 components compile without full separation checking (measured 2026-08-01)
+
+The exemptions — the wasm application build and one test suite — are individually justified
+today, but the end-state has none: every component compiles with separation checking.
+
+Done when: no component in `build.mill` overrides its settings to anything weaker than
+`settings.sep`.

--- a/doc/roadmap/status.tel
+++ b/doc/roadmap/status.tel
@@ -1,0 +1,437 @@
+# Machine-readable index of roadmap items. One `item` record per item across the
+# eight track files in doc/roadmap/. This file is the single source of status:
+# the prose files never claim completion; they link here.
+#
+# Fields:
+#   id         the permanent item identifier (never reused)
+#   track      the track file the item belongs to (without .md)
+#   horizon    near | near-mid | mid | mid-long | long
+#   status     open | done
+#   needs      hard dependency, intra- or cross-track (repeated)
+#   baseline   measured starting point, with measurement date
+#   criterion  the Done-when command or observable fact (authority: the track file)
+#
+# Multi-token values use hard-space mode: a double space after the keyword.
+
+tel 1.0
+
+item
+  id core-1
+  track core
+  horizon near
+  status open
+  baseline  16 files use sorted/ordered stdlib collections (2026-08-01)
+  criterion  git grep -lE 'TreeMap|TreeSet|TrieMap|SortedMap|SortedSet' -- lib | grep -v '^lib/proscenium/' | wc -l == 0
+
+item
+  id core-2
+  track core
+  horizon near-mid
+  status open
+  needs core-1
+  baseline  475 files import proscenium.compat; the compat file is 551 lines (2026-08-01)
+  criterion  git grep -l 'import proscenium.compat' -- lib | wc -l == 0, and the compat file has no members
+
+item
+  id core-3
+  track core
+  horizon near-mid
+  status open
+  needs core-1
+  baseline  219 files import scala.collection, 170 of them scala.collection.mutable (2026-08-01)
+  criterion  git grep -l 'import scala.collection' -- lib | grep -v '^lib/proscenium/' | wc -l == 0
+
+item
+  id core-4
+  track core
+  horizon mid
+  status open
+  baseline  235 files touch scala.Array or scala.IArray (2026-08-01)
+  criterion  allowlist enforced in the ordinary build; grep minus allowlist == 0
+
+item
+  id core-5
+  track core
+  horizon mid-long
+  status open
+  criterion  test suite asserts no Java encodings in rendered traces, values and type names
+
+item
+  id core-6
+  track core
+  horizon long
+  status open
+  criterion  totality audit runs in CI and reports zero violations
+
+item
+  id safety-1
+  track safety
+  horizon near
+  status open
+  baseline  288 untrackedCaptures occurrences (2026-08-01)
+  criterion  git grep -o untrackedCaptures -- lib | wc -l == 0
+
+item
+  id safety-2
+  track safety
+  horizon near
+  status open
+  baseline  323 unsafeAssumeSeparate, 273 unsafeAssumePure, 45 unsafeErasedValue (2026-08-01)
+  criterion  every remaining caps.unsafe occurrence names a rep/ case; script reports zero unannotated
+
+item
+  id safety-3
+  track safety
+  horizon mid
+  status open
+  criterion  the rep/ capturing-raises reproduction compiles cleanly under the current toolchain
+
+item
+  id safety-4
+  track safety
+  horizon mid-long
+  status open
+  needs safety-3
+  baseline  929 caps.unsafe occurrences in total (2026-08-01)
+  criterion  git grep -oE 'unsafeAssumeSeparate|untrackedCaptures|unsafeAssumePure|unsafeErasedValue' -- lib | wc -l == 0
+
+item
+  id safety-5
+  track safety
+  horizon long
+  status open
+  criterion  build.mill consumes an upstream Scala release, or the rebase procedure and its measured cost are documented in rep/
+
+item
+  id safety-6
+  track safety
+  horizon long
+  status open
+  baseline  3 components compile without full separation checking (2026-08-01)
+  criterion  no component in build.mill compiles with anything weaker than settings.sep
+
+item
+  id plat-1
+  track platforms
+  horizon near
+  status open
+  baseline  94 of 132 modules build for JavaScript, 86 for Native (2026-08-01)
+  criterion  CI regenerates doc/compatibility.tsv, fails on divergence, and no exclusion lacks a reason
+
+item
+  id plat-2
+  track platforms
+  horizon near-mid
+  status open
+  criterion  make attest includes the Android stage; CI records a signed APK per release
+
+item
+  id plat-3
+  track platforms
+  horizon mid
+  status open
+  needs plat-1
+  criterion  no JavaScript or Native exclusion in the manifest has a non-inherent reason; Native link check covers every Native-capable module
+
+item
+  id plat-4
+  track platforms
+  horizon mid-long
+  status open
+  baseline  7 WASI backends; HTTP GET-only; sockets TCP-only (2026-08-01)
+  criterion  the manifest WASI column matches the JavaScript column except where the reason names a missing WASI capability
+
+item
+  id plat-5
+  track platforms
+  horizon long
+  status open
+  needs plat-4
+  criterion  every exclusion reason in doc/compatibility.tsv is inherent; a reason-vocabulary check enforces it in CI
+
+item
+  id api-1
+  track api
+  horizon near
+  status open
+  criterion  the C1 section of doc/api-reduction-candidates.md is empty
+
+item
+  id api-2
+  track api
+  horizon near
+  status open
+  criterion  the C4-homonym and C4-synonym sections are empty; a same-name-same-thing check runs in the ordinary build
+
+item
+  id api-3
+  track api
+  horizon mid
+  status open
+  criterion  the C2, C3 and C3b sections are empty
+
+item
+  id api-4
+  track api
+  horizon mid
+  status open
+  criterion  naming-conformance sweep reports zero deviations and runs in the ordinary build
+
+item
+  id api-5
+  track api
+  horizon long
+  status open
+  needs api-1
+  needs api-2
+  needs api-3
+  criterion  doc/api-reduction-candidates.md no longer exists
+
+item
+  id api-6
+  track api
+  horizon long
+  status open
+  needs dist-2
+  criterion  the dist-2 CI check enforced on every surface-changing pull request for ten consecutive releases
+
+item
+  id doc-1
+  track documentation
+  horizon near
+  status open
+  baseline  121 error types carry SN codes, 39 do not; 233 error pages (2026-08-01)
+  criterion  parity check in CI; git grep -hE 'extends +Error\((m"|[a-z])' -- lib | wc -l == 0
+
+item
+  id doc-2
+  track documentation
+  horizon near
+  status open
+  criterion  grep -c 'Stub' doc/standards/messages.md == 0
+
+item
+  id doc-3
+  track documentation
+  horizon near
+  status open
+  baseline  92 files say "built by Fury"; 35 of 133 modules have no lib/*/doc/ (2026-08-01)
+  criterion  git grep -l 'built by Fury' | wc -l == 0, and no lib/*/doc/ directory remains
+
+item
+  id doc-4
+  track documentation
+  horizon mid
+  status open
+  baseline  91 topics in doc/modules/; 35 modules undocumented (2026-08-01)
+  criterion  coverage script in the ordinary build reports zero uncovered modules
+
+item
+  id doc-5
+  track documentation
+  horizon mid
+  status open
+  baseline  every published docJar is empty (2026-08-01)
+  criterion  every published component has non-empty API documentation, published per release
+
+item
+  id doc-6
+  track documentation
+  horizon mid
+  status open
+  criterion  web/res/content/ contains no hand-maintained duplicate of any doc/ page
+
+item
+  id doc-7
+  track documentation
+  horizon long
+  status open
+  criterion  link check verifies each philosophy page is referenced from the topic guides of the modules embodying it
+
+item
+  id doc-8
+  track documentation
+  horizon long
+  status open
+  needs tool-2
+  needs tool-4
+  criterion  the from-nothing walkthrough is executed by an agent in CI and recorded per release
+
+item
+  id tool-1
+  track tooling
+  horizon near
+  status open
+  baseline  flame builds against 0.62.0; current release 0.64.0 (2026-08-01)
+  criterion  flame CI builds against every new release before it is announced
+
+item
+  id tool-2
+  track tooling
+  horizon near-mid
+  status open
+  baseline  fume does not exist; 3 suites disabled: cosmopolite, legerdemain, orthodoxy (2026-08-01)
+  criterion  fume runs the full suite in CI; grep -c 'enabled = false' build.mill == 0
+
+item
+  id tool-3
+  track tooling
+  horizon near-mid
+  status open
+  criterion  scripted LSP editor-session test passes in CI
+
+item
+  id tool-4
+  track tooling
+  horizon mid
+  status open
+  criterion  fury build builds Soundness from a clean checkout, attestation-equal to the Mill build
+
+item
+  id tool-5
+  track tooling
+  horizon mid
+  status open
+  criterion  scripted MCP session resolves an SN code, a module topic and a roadmap item status, in CI
+
+item
+  id tool-6
+  track tooling
+  horizon mid
+  status open
+  criterion  probably ships forAll-style generation with shrinking, or a philosophy page documents the axes/spread design
+
+item
+  id tool-7
+  track tooling
+  horizon long
+  status open
+  needs doc-5
+  criterion  fluence answers name, type and signature queries against the current release
+
+item
+  id tool-8
+  track tooling
+  horizon long
+  status open
+  criterion  a fume run can be watched live in a browser; the git-note report matches the stream
+
+item
+  id tool-9
+  track tooling
+  horizon long
+  status open
+  criterion  no ecosystem tool accepts any configuration format but TEL
+
+item
+  id dist-1
+  track distribution
+  horizon near
+  status open
+  baseline  no changelog; release notes live in pull-request bodies (2026-08-01)
+  criterion  changelog exists; release.sh fails when the released version has no entry
+
+item
+  id dist-2
+  track distribution
+  horizon near
+  status open
+  criterion  doc/standards/migration.md exists without a stub marker; CI rejects breaking-labelled PRs lacking conforming instructions
+
+item
+  id dist-3
+  track distribution
+  horizon near-mid
+  status open
+  criterion  the LIRA reference implementation round-trips a Soundness release byte-identically in a scripted test
+
+item
+  id dist-4
+  track distribution
+  horizon mid
+  status open
+  needs doc-5
+  criterion  versions are computed from the extracted API surface; an incompatible change forces the version it should
+
+item
+  id dist-5
+  track distribution
+  horizon mid
+  status open
+  needs tool-4
+  criterion  fury publish produces and publishes signed .lira files for a real release
+
+item
+  id dist-6
+  track distribution
+  horizon mid-long
+  status open
+  criterion  signature, namespace and transparency-log inclusion verified by a single shipped command
+
+item
+  id dist-7
+  track distribution
+  horizon mid
+  status open
+  needs dist-3
+  criterion  a release ships to Maven Central and LIRA, attested; make verify-attest covers both
+
+item
+  id dist-8
+  track distribution
+  horizon long
+  status open
+  needs dist-5
+  needs dist-6
+  needs dist-7
+  criterion  a fresh fury project builds and runs with the Maven resolver disabled
+
+item
+  id dist-9
+  track distribution
+  horizon long
+  status open
+  criterion  a scripted third-party verification with public data only passes for the latest release
+
+item
+  id brd-1
+  track breadth
+  horizon near
+  status open
+  criterion  JOSE module ships with tests, SN pages and a topic; round-trips RFC 7515/7516 example vectors
+
+item
+  id brd-2
+  track breadth
+  horizon near
+  status open
+  criterion  TOML module ships with tests, SN pages and a topic; passes the TOML compliance suite
+
+item
+  id brd-3
+  track breadth
+  horizon mid
+  status open
+  needs brd-1
+  criterion  WebAuthn module ships with tests, SN pages and a topic; scripted ceremony passes against a reference authenticator
+
+item
+  id brd-4
+  track breadth
+  horizon mid
+  status open
+  criterion  GraphQL module ships with tests, SN pages and a topic; passes the specification validation examples
+
+item
+  id brd-5
+  track breadth
+  horizon long
+  status open
+  criterion  QUIC/HTTP-3 module ships with tests, SN pages and a topic; interoperates with reference peers
+
+item
+  id brd-6
+  track breadth
+  horizon long
+  status open
+  criterion  IMAP module ships with tests, SN pages and a topic; scripted session passes against a reference server

--- a/doc/roadmap/status.tel
+++ b/doc/roadmap/status.tel
@@ -46,8 +46,8 @@ item
   track core
   horizon mid
   status open
-  baseline  235 files touch scala.Array or scala.IArray (2026-08-01)
-  criterion  allowlist enforced in the ordinary build; grep minus allowlist == 0
+  baseline  2244 while-do loops across 330 Scala files (2026-08-01)
+  criterion  no collection exposes a partial indexed apply (issue #1666); the indexing while-loop pattern is drained
 
 item
   id core-5
@@ -100,7 +100,7 @@ item
   track safety
   horizon long
   status open
-  criterion  build.mill consumes an upstream Scala release, or the rebase procedure and its measured cost are documented in rep/
+  criterion  CI consumes published artifacts from a mainline-Scala project; rep/ documents the rebase procedure and the cost of the two most recent rebases
 
 item
   id safety-6
@@ -148,6 +148,13 @@ item
   status open
   needs plat-4
   criterion  every exclusion reason in doc/compatibility.tsv is inherent; a reason-vocabulary check enforces it in CI
+
+item
+  id plat-6
+  track platforms
+  horizon mid
+  status open
+  criterion  the soundness.dev front-end ships as Soundness-compiled Scala.js with all web API access through generated typed facades, in the ordinary build
 
 item
   id api-1
@@ -324,6 +331,29 @@ item
   criterion  no ecosystem tool accepts any configuration format but TEL
 
 item
+  id tool-10
+  track tooling
+  horizon mid-long
+  status open
+  criterion  scripted DAP session (breakpoint, step, inspect with Soundness-rendered values) passes against a running application in CI
+
+item
+  id tool-11
+  track tooling
+  horizon mid
+  status open
+  needs tool-2
+  criterion  every CI run records coverage in a git note; one command reports the coverage delta between any two commits
+
+item
+  id tool-12
+  track tooling
+  horizon mid
+  status open
+  needs tool-2
+  criterion  every commit on main carries a benchmark git note; one command reports the benchmark delta between any two commits
+
+item
   id dist-1
   track distribution
   horizon near
@@ -374,7 +404,7 @@ item
   horizon mid
   status open
   needs dist-3
-  criterion  a release ships to Maven Central and LIRA, attested; make verify-attest covers both
+  criterion  a release ships to LIRA, attested; make verify-attest covers the published artifacts
 
 item
   id dist-8
@@ -384,7 +414,7 @@ item
   needs dist-5
   needs dist-6
   needs dist-7
-  criterion  a fresh fury project builds and runs with the Maven resolver disabled
+  criterion  the release script contains no Maven Central publishing step; a fresh fury project builds and runs with the Maven resolver disabled
 
 item
   id dist-9
@@ -418,19 +448,12 @@ item
 item
   id brd-4
   track breadth
-  horizon mid
-  status open
-  criterion  GraphQL module ships with tests, SN pages and a topic; passes the specification validation examples
-
-item
-  id brd-5
-  track breadth
   horizon long
   status open
   criterion  QUIC/HTTP-3 module ships with tests, SN pages and a topic; interoperates with reference peers
 
 item
-  id brd-6
+  id brd-5
   track breadth
   horizon long
   status open

--- a/doc/roadmap/tooling.md
+++ b/doc/roadmap/tooling.md
@@ -4,8 +4,9 @@ Soundness code should be written, built, tested, explored and debugged with tool
 its philosophy — total, honest, native-feeling — rather than through a Maven-era toolchain that
 predates every idea the platform embodies. The end-state is a developer, human or agent, who
 never leaves the ecosystem: flame for exploration, fury for building, fume for testing,
-fluence for finding APIs, the exegesis LSP server inside any editor, and the synesthesia MCP
-server giving agents the same access programmatically.
+fluence for finding APIs, the exegesis LSP server inside any editor, a debugger that speaks
+Soundness rather than Java, and the synesthesia MCP server giving agents the same access
+programmatically.
 
 The pieces are in different states, and the roadmap is honest about which. exegesis and
 synesthesia are working modules in this repository. flame exists as a separate, active project
@@ -113,3 +114,39 @@ Every ecosystem tool that needs configuration reads TEL, with stratiform as the 
 implementation. No tool in the ecosystem asks for YAML, JSON or HOCON configuration.
 
 Done when: no ecosystem tool's own configuration surface accepts any format but TEL.
+
+## tool-10: a debugger that speaks Soundness
+
+Horizon: mid → long
+
+Debugging a running application should feel native, not hosted: breakpoints, stepping and
+inspection through a Debug Adapter Protocol server, with inspected values rendered as their
+Soundness types — the same no-Java-encodings discipline `core-5` applies to traces, applied
+to live state.
+
+Done when: a scripted DAP session — set a breakpoint, step, inspect a value rendered in
+Soundness terms — passes against a running Soundness application in CI.
+
+## tool-11: coverage is tracked
+
+Horizon: mid
+Needs: tool-2
+
+probably already measures coverage; fume makes it a tracked property rather than a one-off
+report: unit-test coverage recorded for every commit, stored in git notes alongside the test
+reports, so the trend is queryable and a regression is visible at review time.
+
+Done when: every CI run records coverage in a git note, and a single command reports the
+coverage delta between any two commits.
+
+## tool-12: benchmarks on every commit
+
+Horizon: mid
+Needs: tool-2
+
+The benchmark suites run for every commit, with results stored in git notes under the same
+discipline as test reports and attestations, so performance history travels with the
+repository and regressions are caught when they land, not when users notice.
+
+Done when: every commit on the main branch carries a benchmark git note, and a single command
+reports the benchmark delta between any two commits.

--- a/doc/roadmap/tooling.md
+++ b/doc/roadmap/tooling.md
@@ -1,0 +1,115 @@
+# The Toolchain
+
+Soundness code should be written, built, tested, explored and debugged with tools that share
+its philosophy — total, honest, native-feeling — rather than through a Maven-era toolchain that
+predates every idea the platform embodies. The end-state is a developer, human or agent, who
+never leaves the ecosystem: flame for exploration, fury for building, fume for testing,
+fluence for finding APIs, the exegesis LSP server inside any editor, and the synesthesia MCP
+server giving agents the same access programmatically.
+
+The pieces are in different states, and the roadmap is honest about which. exegesis and
+synesthesia are working modules in this repository. flame exists as a separate, active project
+pinned to an older Soundness. fume is scoped but unwritten: a front-end and runner over the
+probably framework, which remains the library. fury and fluence do not exist as code. TEL — the
+configuration language the whole toolchain standardises on — is specified and implemented, with
+stratiform as its reference implementation. The bootstrap test for the entire track is fury
+building Soundness itself, attestation-equal to the Mill build it replaces.
+
+## tool-1: flame tracks current releases
+
+Horizon: near
+Baseline: flame builds against Soundness 0.62.0; the current release is 0.64.0 (measured 2026-08-01)
+
+A REPL that lags the platform cannot be the platform's front door. flame builds against each
+release as it happens, and staying current becomes a checked property rather than an intention.
+
+Done when: flame's CI builds it against every new Soundness release, and a release is not
+announced until that build is green.
+
+## tool-2: fume runs the suites
+
+Horizon: near → mid
+Baseline: fume does not exist; 3 test suites are disabled (measured 2026-08-01)
+
+fume is the testing tool over the probably framework: multiple report formats, live updates in
+the terminal, and results recorded as git notes alongside the existing attestation notes. Its
+first milestone is running this repository's own suites — all of them, including the three
+currently disabled.
+
+Done when: fume runs the full Soundness suite in CI and
+
+    grep -c 'enabled = false' build.mill    # 0
+
+## tool-3: the LSP server serves a real session
+
+Horizon: near → mid
+
+exegesis provides the LSP framework; the criterion is lived experience made mechanical: a
+scripted editor session — open, diagnose, complete, navigate — runs against a Soundness project
+in CI.
+
+Done when: the scripted editor-session test passes in CI.
+
+## tool-4: fury builds Soundness
+
+Horizon: mid
+
+The build tool is rebuilt, and the bootstrap is the criterion: `fury build` produces the same
+artifacts as the Mill build, verified by the same attestation input-digest discipline, on this
+repository — the hardest Scala build it will ever face.
+
+Done when: `fury build` builds Soundness from a clean checkout, attestation-equal to the Mill
+build.
+
+## tool-5: agents reach everything over MCP
+
+Horizon: mid
+
+synesthesia exposes the platform's knowledge to agents: module documentation, `SN-` error
+pages, roadmap status from `status.tel`, and migration instructions. An agent should never
+need to clone the repository to answer "what does SN-042 mean?"
+
+Done when: a scripted MCP session resolves an `SN-` code to its page, a module to its topic
+guide, and a roadmap item to its status, in CI.
+
+## tool-6: the property-testing question is settled
+
+Horizon: mid
+
+probably tests over axes and spreads rather than `forAll` and shrinking. Either that is the
+answer — in which case a philosophy page argues it — or generative testing with shrinking
+ships in probably. Either artifact closes the item; what is not acceptable is the question
+staying open by default.
+
+Done when: probably ships `forAll`-style generation with shrinking, or a philosophy page
+documents why axes and spreads are the design.
+
+## tool-7: fluence searches the APIs
+
+Horizon: long
+Needs: doc-5
+
+fluence makes the API surface searchable — by name, by type, by signature — over the extraction
+pipeline that `doc-5` builds.
+
+Done when: fluence answers name, type and signature queries against the current release's
+published API documentation.
+
+## tool-8: fume reports live to the web
+
+Horizon: long
+
+fume's second front-end: live test reporting over HTTP and WebSockets, the same data that
+drives the terminal renderer.
+
+Done when: a fume run can be watched live in a browser, and the recorded git-note report
+matches what was streamed.
+
+## tool-9: TEL everywhere
+
+Horizon: long
+
+Every ecosystem tool that needs configuration reads TEL, with stratiform as the reference
+implementation. No tool in the ecosystem asks for YAML, JSON or HOCON configuration.
+
+Done when: no ecosystem tool's own configuration surface accepts any format but TEL.


### PR DESCRIPTION
This adds a long-term roadmap for Soundness as a new documentation section, `doc/roadmap/`, defining the route to production-readiness as eight parallel tracks — the standard-library drain, capabilities and effects, platform parity, API coherence, documentation and learnability, the toolchain, distribution and release, and standards breadth — each phased across near/mid/long horizons. Every workstream item has a permanent identifier (on the same never-reuse discipline as `SN-` error codes), a dated measured baseline, and a completion criterion that is a runnable command or an observable fact; the index defines "the gate", a closed list of fifteen measurable criteria that constitute production-readiness, and a machine-readable item index is provided in TEL.

## Release notes

A new **roadmap** is now published under `doc/roadmap/`, describing the route to a production-ready Soundness:

- **[index](doc/roadmap/index.md)** — the guiding philosophy, how to read the roadmap, cross-track dependencies, and *the gate*: the fifteen measurable criteria that define production-readiness, ending with an agent taking a project from nothing to a deployed web application using only ecosystem tools and `doc/`.
- **Eight tracks**, each with measurable items: [core](doc/roadmap/core.md) (the standard-library drain, including total indexing per #1666), [safety](doc/roadmap/safety.md) (zero `caps.unsafe`, building on the freely modifiable Proscala compiler, bounded by mainline-Scala readability of published artifacts), [platforms](doc/roadmap/platforms.md) (JS/Native/WASI/Android parity and the browser as a first-class target with typed web APIs), [api](doc/roadmap/api.md) (one name, one meaning), [documentation](doc/roadmap/documentation.md), [tooling](doc/roadmap/tooling.md) (flame, fury, fume, fluence, LSP, MCP, a Soundness-native debugger, and coverage and benchmarks tracked per commit in git notes), [distribution](doc/roadmap/distribution.md) (migration-first stability and LIRA replacing Maven Central), and [breadth](doc/roadmap/breadth.md) (JOSE, TOML, WebAuthn, QUIC, IMAP).
- **[status.tel](doc/roadmap/status.tel)** — a machine-readable index of all 58 items, written in TEL, intended as the single source of roadmap status and to be served over MCP.

Every baseline in the roadmap was measured on 2026-08-01 and is reproducible by the command quoted alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)