### PR TITLE
Decode positional atoms in the TEL codecs and complete §20.2 conformance

### DIFF
--- a/lib/stratiform/src/core/stratiform.Mutation.scala
+++ b/lib/stratiform/src/core/stratiform.Mutation.scala
@@ -89,11 +89,15 @@ object Mutation:
   // `construct` algorithm: a scalar member with its present occurrences
   // (one occurrence models a non-repeatable member, several a repeatable
   // one, none an absent member that terminates the inline run), a flag
-  // member, or a ready-made compound child.
+  // member, a ready-made compound child, or `Break` — an absent member
+  // that contributes nothing but terminates the inline run (§22.2: an
+  // absent Scalar member ends the run, because the atom phase never skips
+  // a Scalar position).
   enum Member:
     case Value(keyword: Text, occurrences: List[Text])
     case Flag(keyword: Text)
     case Child(compound: Tel.Compound)
+    case Break
 
   enum Op:
     case UpdateAtom(pointer: Tel.Pointer, atomIndex: Int, text: Text)
@@ -1017,6 +1021,9 @@ object Mutation:
       case Member.Child(compound) =>
         inRun = false
         children += compound
+
+      case Member.Break =>
+        inRun = false
 
       case Member.Value(kw, occurrences) =>
         val os = occurrences.stdlib

--- a/lib/stratiform/src/core/stratiform.Mutation.scala
+++ b/lib/stratiform/src/core/stratiform.Mutation.scala
@@ -1046,8 +1046,10 @@ object Mutation:
     Tel.Compound(keyword, atoms, Unset, childBlocks)
 
   // §22.3 atom-form escalation: the first form in inline -> source ->
-  // literal whose §22.2 safety predicate the value satisfies.
-  private def chooseAtomForm(value: Text, sigil: Char): Tel.Atom =
+  // literal whose §22.2 safety predicate the value satisfies. Also used by
+  // the derived encoders (`Tel2.scalar`), so an encoded multi-line value
+  // reparses.
+  private[stratiform] def chooseAtomForm(value: Text, sigil: Char): Tel.Atom =
     if inlineSafe(value, sigil) then Tel.Atom.Inline(value, inlinePrecedingSpaces(value))
     else if sourceSafe(value) then Tel.Atom.Source(value)
     else Tel.Atom.Literal(literalDelimiter(value, t"---"), value)

--- a/lib/stratiform/src/core/stratiform.Positional.scala
+++ b/lib/stratiform/src/core/stratiform.Positional.scala
@@ -1,0 +1,131 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import proscenium.compat.*
+
+import anticipation.*
+import contingency.*
+
+// The schema-free §19.2/§20.2 atom phase shared by both derivation engines
+// (issue #1694). A derived product codec approximates the schema's member
+// classification from Scala types (`Tel.Nature`) and runs the same positional
+// assignment `Tel.Type.assign` performs against a real schema: atoms fill
+// members in declaration order, skipping only non-required members that
+// cannot take the atom.
+private[stratiform] object Positional:
+
+  // One field of a derived product, as the atom phase sees it. `required`
+  // is false for `Optional` fields and fields with a declared default,
+  // matching §20's effective-polarity model.
+  case class Profile
+    ( keyword:    Text,
+      nature:     Tel.Nature,
+      repeatable: Boolean,
+      required:   Boolean )
+
+  def text(atom: Tel.Atom): Text = atom match
+    case Tel.Atom.Inline(value, _)  => value
+    case Tel.Atom.Source(value)     => value
+    case Tel.Atom.Literal(_, value) => value
+
+  // §20.2 step 3 over a compound line's atoms (all three presentation
+  // forms): returns, per member, the atoms assigned to it, in order. Errors
+  // raise-and-continue through the ambient tactic, mirroring
+  // `Tel.Type.assignAtoms`: an unassignable atom is dropped and later atoms
+  // still assign.
+  def assign(atoms: Array[Tel.Atom]^{}, profiles: Array[Profile]^{})
+    ( using Tactic[TelError] )
+  :   Array[List[Tel.Atom]]^{} =
+
+    val assigned = new scala.Array[List[Tel.Atom]](profiles.length)
+    var slot = 0
+
+    while slot < profiles.length do
+      assigned(slot) = Nil
+      slot += 1
+
+    var position = 0
+    var index = 0
+
+    while index < atoms.length do
+      val value = text(atoms(index))
+
+      // Step 3a: advance past non-required members that cannot take this
+      // atom — Struct-natured ones, and Flag-natured ones whose keyword the
+      // atom's text does not match. A Scalar member is never skipped; a
+      // required member is never skipped.
+      var scanning = true
+
+      while scanning && position < profiles.length do
+        val profile = profiles(position)
+
+        val skippable =
+          !profile.required
+          && (profile.nature == Tel.Nature.Struct
+              || (profile.nature == Tel.Nature.Flag && value != profile.keyword))
+
+        if skippable then position += 1 else scanning = false
+
+      if position >= profiles.length then
+        // Step 3b: more atoms than assignable member positions (E302).
+        // Recovery drops the whole excess run, reported once.
+        raise(TelError(TelError.Reason.TooManyAtoms))
+        index = atoms.length
+      else
+        val profile = profiles(position)
+
+        profile.nature match
+          case Tel.Nature.Struct =>
+            // Step 3c: an atom at a required member only fillable by a
+            // keyword child (E303). The atom is dropped.
+            raise(TelError(TelError.Reason.AtomAtNonAssignablePos))
+
+          case Tel.Nature.Flag =>
+            if value == profile.keyword then
+              assigned(position) = assigned(position) :+ atoms(index)
+              if !profile.repeatable then position += 1
+            else
+              // Step 3d: a required Flag member's atom must match its
+              // keyword (E305). The atom is dropped.
+              raise(TelError(TelError.Reason.AtomFlagKeywordMismatch))
+
+          case Tel.Nature.Scalar =>
+            assigned(position) = assigned(position) :+ atoms(index)
+            // Step 3e: a repeatable member holds its position and consumes
+            // every remaining atom.
+            if !profile.repeatable then position += 1
+
+        index += 1
+
+    assigned.asInstanceOf[Array[List[Tel.Atom]]^{}]

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -112,17 +112,35 @@ object Tel extends Tel2:
       tel.as[topic]
       tel.asInstanceOf[Tel of topic from topic]
 
+  // How a value of a codec's type occupies a compound line's atom positions,
+  // approximating §20.2's member classification from Scala types alone
+  // (issue #1694): `Scalar` is atom-assignable and never skipped, `Flag`
+  // (Boolean) is atom-assignable when the atom text equals the keyword, and
+  // `Struct` (a nested record, sum, or map) can only be filled by a keyword
+  // child. The schema-less approximation diverges from §20.2 in documented
+  // ways: an all-singleton enum decodes through its text codec and so is
+  // `Scalar`, not Flag-shaped, and non-singleton sums are `Struct` even
+  // where a schema's all-Flag select would be atom-assignable.
+  enum Nature:
+    case Scalar, Flag, Struct
+
   object Encodable:
     // The shape is an explicit, nameable thunk (not by-name) so the instance's
     // capture set can name it: an honest result rather than a laundered-pure one.
     // Mirrors jacinta's `Json.Encodable.apply` (see rep/DECISIONS.md).
-    def apply[value](shape0: () => Morphology)(lambda: (value -> Tel)^)
+    def apply[value]
+      ( shape0:    () => Morphology,
+        nature0:   Tel.Nature = Tel.Nature.Struct,
+        optional0: Boolean = false )
+      ( lambda: (value -> Tel)^ )
     :   ((value is Tel.Encodable)^{shape0, lambda}) =
 
       new Tel.Encodable:
         type Self = value
         def encoded(value: value): Tel = lambda(value)
         def shape(): Morphology = shape0()
+        override def nature: Tel.Nature = nature0
+        override def optional: Boolean = optional0
 
   // A TEL encoder/decoder that also carries the format-neutral `Morphology` of exactly
   // what it reads/writes, so a fused `Encodable & Schematic` / `Decodable &
@@ -134,15 +152,29 @@ object Tel extends Tel2:
     type Form = Tel
     def shape(): Morphology
 
+    // The §20.2 member classification of this encoder's type — see
+    // `Tel.Nature`. Conservatively `Struct` unless overridden.
+    def nature: Tel.Nature = Tel.Nature.Struct
+
+    // True when a field of this type may be legitimately absent (an
+    // `Optional` wrapper), mirroring `Decodable.optional`.
+    def optional: Boolean = false
+
   object Decodable:
     // Explicit shape thunk, as in `Tel.Encodable.apply`.
-    def apply[value](shape0: () => Morphology)(decoder: (value is distillate.Decodable in Tel)^)
+    def apply[value]
+      ( shape0:    () => Morphology,
+        nature0:   Tel.Nature = Tel.Nature.Struct,
+        optional0: Boolean = false )
+      ( decoder: (value is distillate.Decodable in Tel)^ )
     :   ((value is Tel.Decodable)^{shape0, decoder}) =
 
       new Tel.Decodable:
         type Self = value
         def decoded(tel: Tel): value = decoder.decoded(tel)
         def shape(): Morphology = shape0()
+        override def nature: Tel.Nature = nature0
+        override def optional: Boolean = optional0
 
   trait Decodable extends distillate.Decodable:
     type Form = Tel
@@ -152,6 +184,23 @@ object Tel extends Tel2:
     // decoder gathers all same-keyword sibling compounds for such a field and hands
     // them here as a Document; other fields read a single matching compound.
     def repeatable: Boolean = false
+
+    // The §20.2 member classification of this decoder's type — see
+    // `Tel.Nature`. Drives the derived product decoder's positional atom
+    // pre-pass. Conservatively `Struct` (never atom-assignable) unless
+    // overridden.
+    def nature: Tel.Nature = Tel.Nature.Struct
+
+    // True when a field of this type may be legitimately absent (an
+    // `Optional` wrapper): with a declared default, this makes the field
+    // non-required for the §20.2 step 3a skip rule.
+    def optional: Boolean = false
+
+    // What a field of this type yields when no child compound carries its
+    // keyword — the AST counterpart of `Parsing.absent`. The default
+    // replicates the derivation's historical fallback: decode an empty node
+    // (primitives raise `Absent` from it).
+    def absent()(using Tactic[TelError]): Self = decoded(Tel.empty)
 
   // The shared substance of `Tel.Parsable` and `Tel.Field`, mirroring
   // jacinta's `Json.Parsing`. The two subtraits add nothing: they exist so
@@ -179,6 +228,26 @@ object Tel extends Tel2:
     // occurrence by the derived product parser — the direct counterpart of
     // `Tel.Decodable.repeatable`.
     def repeatable: Boolean = false
+
+    // The §20.2 member classification of this parser's type — see
+    // `Tel.Nature`. Drives the derived product parser's positional atom
+    // pre-pass. Conservatively `Struct` unless overridden.
+    def nature: Tel.Nature = Tel.Nature.Struct
+
+    // True when a field of this type may be legitimately absent (an
+    // `Optional` wrapper), mirroring `Tel.Decodable.optional`.
+    def optional: Boolean = false
+
+    // Parse one positionally-assigned atom as this field's value. Only
+    // meaningful for `Scalar`-natured instances; the default reports the
+    // §20.2 step 3c mismatch.
+    def parseAtom(text: Text)(using Tactic[TelError]): Self =
+      abort(TelError(TelError.Reason.AtomAtNonAssignablePos))
+
+    // The value of a `Flag`-natured field made present by a bare atom
+    // matching its keyword.
+    def parseFlag()(using Tactic[TelError]): Self =
+      abort(TelError(TelError.Reason.AtomAtNonAssignablePos))
 
     def parse(reader: TelReader^, indent: Int): Self
 
@@ -249,13 +318,20 @@ object Tel extends Tel2:
           type Self = value
           def shape(): Morphology = decodable.shape()
           override def repeatable: Boolean = true
+          override def nature: Tel.Nature = decodable.nature
+          override def optional: Boolean = decodable.optional
 
           def parse(reader: TelReader^, indent: Int): value =
             decodable.decoded(reader.value(indent))
 
           override def parse(reader: TelReader^): value = decodable.decoded(reader.document())
-          override def absent()(using Tactic[TelError]): value = decodable.decoded(Tel.empty)
+          override def absent()(using Tactic[TelError]): value = decodable.absent()
           def parseElement(reader: TelReader^, indent: Int): Any = reader.value(indent)
+
+          // A positional atom becomes a synthetic one-atom compound, exactly
+          // the element form `gathered` re-assembles into its document.
+          def parseAtomElement(text: Text)(using Tactic[TelError]): Any =
+            Tel.make(Tel.Compound(t"", Array.of(Tel.Atom.Inline(text, 1)), Unset, Array.empty))
 
           def gathered(elements: List[Any]): value =
             val compounds = Array.from:
@@ -268,12 +344,20 @@ object Tel extends Tel2:
         new Tel.Parsable:
           type Self = value
           def shape(): Morphology = decodable.shape()
+          override def nature: Tel.Nature = decodable.nature
+          override def optional: Boolean = decodable.optional
 
           def parse(reader: TelReader^, indent: Int): value =
             decodable.decoded(reader.value(indent))
 
           override def parse(reader: TelReader^): value = decodable.decoded(reader.document())
-          override def absent()(using Tactic[TelError]): value = decodable.decoded(Tel.empty)
+          override def absent()(using Tactic[TelError]): value = decodable.absent()
+
+          // The AST bridge for a positional atom: decode a synthetic
+          // one-atom compound, as the derived decoder hands one over.
+          override def parseAtom(text: Text)(using Tactic[TelError]): value =
+            decodable.decoded:
+              Tel.make(Tel.Compound(t"", Array.of(Tel.Atom.Inline(text, 1)), Unset, Array.empty))
 
     // The one-line opt-in to direct parsing for a structural type:
     // `given MyType is Tel.Parsable = Tel.Parsable.derived` — a
@@ -304,7 +388,11 @@ object Tel extends Tel2:
         override def parse(reader: TelReader^): value = field0.parse(reader)
         def shape(): Morphology = field0.shape()
         override def repeatable: Boolean = field0.repeatable
+        override def nature: Tel.Nature = field0.nature
+        override def optional: Boolean = field0.optional
         override def absent()(using Tactic[TelError]): value = field0.absent()
+        override def parseAtom(text: Text)(using Tactic[TelError]): value = field0.parseAtom(text)
+        override def parseFlag()(using Tactic[TelError]): value = field0.parseFlag()
 
     // The element-wise hooks of a repeatable (collection) parser. The
     // derived product parser gathers each same-keyword occurrence through
@@ -316,6 +404,12 @@ object Tel extends Tel2:
     private[stratiform] trait Gathering:
       self: Tel.Parsing^ =>
       def parseElement(reader: TelReader^, indent: Int): Any
+
+      // One element built from a positionally-assigned atom: §19.2 lets a
+      // repeatable member's occurrences split between inline atoms on the
+      // parent line and later same-keyword children.
+      def parseAtomElement(text: Text)(using Tactic[TelError]): Any
+
       def gathered(elements: List[Any]): Self
 
     // The synthetic document the AST derivation hands to a repeatable
@@ -340,8 +434,12 @@ object Tel extends Tel2:
           type Self = collection[element]
           def shape(): Morphology = Morphology.Arr(field.shape())
           override def repeatable: Boolean = true
+          override def nature: Tel.Nature = field.nature
+          override def optional: Boolean = true
 
           def parseElement(reader: TelReader^, indent: Int): Any = field.parse(reader, indent)
+
+          def parseAtomElement(text: Text)(using Tactic[TelError]): Any = field.parseAtom(text)
 
           def gathered(elements: List[Any]): collection[element] =
             val builder = factory.newBuilder
@@ -383,6 +481,8 @@ object Tel extends Tel2:
         new Tel.Parsable:
           type Self = value
           def shape(): Morphology = Morphology.Opt(field.shape())
+          override def nature: Tel.Nature = field.nature
+          override def optional: Boolean = true
 
           def parse(reader: TelReader^, indent: Int): value =
             if reader.hasSubstance then field.parse(reader, indent)
@@ -391,6 +491,11 @@ object Tel extends Tel2:
               Unset
 
           override def absent()(using Tactic[TelError]): value = Unset
+
+          override def parseAtom(text: Text)(using Tactic[TelError]): value =
+            field.parseAtom(text)
+
+          override def parseFlag()(using Tactic[TelError]): value = field.parseFlag()
 
     // Sentinel for the derived product parser's value buffer: a slot still
     // `AbsentSlot` after the entry loop had no matching keyword
@@ -642,7 +747,11 @@ object Tel extends Tel2:
       override def parse(reader: TelReader^): value = source.parse(reader)
       def shape(): Morphology = source.shape()
       override def repeatable: Boolean = source.repeatable
+      override def nature: Tel.Nature = source.nature
+      override def optional: Boolean = source.optional
       override def absent()(using Tactic[TelError]): value = source.absent()
+      override def parseAtom(text: Text)(using Tactic[TelError]): value = source.parseAtom(text)
+      override def parseFlag()(using Tactic[TelError]): value = source.parseFlag()
 
     def apply[value](parsing: (value is Tel.Parsing)^)
     :   ((value is Tel.Field)^{parsing}) =
@@ -1623,6 +1732,7 @@ object Tel extends Tel2:
     new Tel.Parsable:
       type Self = value
       def shape(): Morphology = shape0
+      override def nature: Tel.Nature = Tel.Nature.Scalar
 
       def parse(reader: TelReader^, indent: Int): value =
         reader.atom().lay(reader.fault(TelError.Reason.Absent) yet sentinel): atom =>
@@ -1631,6 +1741,10 @@ object Tel extends Tel2:
 
       override def absent()(using Tactic[TelError]): value =
         raise(TelError(TelError.Reason.Absent)) yet sentinel
+
+      override def parseAtom(text: Text)(using Tactic[TelError]): value =
+        convert(text).or:
+          raise(TelError(TelError.Reason.NotScalar(text, expected))) yet sentinel
 
   given textParsable: Text is Tel.Parsable =
     primitiveParsable(Morphology.Str, t"Text", t""): atom => atom
@@ -1654,6 +1768,7 @@ object Tel extends Tel2:
     new Tel.Parsable:
       type Self = Int
       def shape(): Morphology = Morphology.Whole
+      override def nature: Tel.Nature = Tel.Nature.Scalar
 
       def parse(reader: TelReader^, indent: Int): Int =
         reader.int().lay(Parsable.scalarFault(reader, t"Int", 0))(identity)
@@ -1661,16 +1776,25 @@ object Tel extends Tel2:
       override def absent()(using Tactic[TelError]): Int =
         raise(TelError(TelError.Reason.Absent)) yet 0
 
+      override def parseAtom(text: Text)(using Tactic[TelError]): Int =
+        val parsed = try Optional(text.s.toInt) catch case _: NumberFormatException => Unset
+        parsed.or(raise(TelError(TelError.Reason.NotScalar(text, t"Int"))) yet 0)
+
   given longParsable: Long is Tel.Parsable =
     new Tel.Parsable:
       type Self = Long
       def shape(): Morphology = Morphology.Whole
+      override def nature: Tel.Nature = Tel.Nature.Scalar
 
       def parse(reader: TelReader^, indent: Int): Long =
         reader.long().lay(Parsable.scalarFault(reader, t"Long", 0L))(identity)
 
       override def absent()(using Tactic[TelError]): Long =
         raise(TelError(TelError.Reason.Absent)) yet 0L
+
+      override def parseAtom(text: Text)(using Tactic[TelError]): Long =
+        val parsed = try Optional(text.s.toLong) catch case _: NumberFormatException => Unset
+        parsed.or(raise(TelError(TelError.Reason.NotScalar(text, t"Long"))) yet 0L)
 
   given doubleParsable: Double is Tel.Parsable =
     primitiveParsable(Morphology.Real, t"Double", 0.0): atom =>
@@ -1680,12 +1804,19 @@ object Tel extends Tel2:
     new Tel.Parsable:
       type Self = Boolean
       def shape(): Morphology = Morphology.Bool
+      override def nature: Tel.Nature = Tel.Nature.Flag
 
       def parse(reader: TelReader^, indent: Int): Boolean =
         reader.boolean().lay(Parsable.scalarFault(reader, t"Boolean", false))(identity)
 
       override def absent()(using Tactic[TelError]): Boolean =
         raise(TelError(TelError.Reason.Absent)) yet false
+
+      override def parseAtom(text: Text)(using Tactic[TelError]): Boolean =
+        if text == t"true" then true else if text == t"false" then false
+        else raise(TelError(TelError.Reason.NotScalar(text, t"Boolean"))) yet false
+
+      override def parseFlag()(using Tactic[TelError]): Boolean = true
 
   // `Tel` reads itself directly through the AST bridge — the direct
   // counterpart of `telDecodable`.
@@ -1734,9 +1865,11 @@ object Tel extends Tel2:
     new Tel.Parsable:
       type Self = value
       def shape(): Morphology = Morphology.Str
+      override def nature: Tel.Nature = Tel.Nature.Scalar
       def parse(reader: TelReader^, indent: Int): value = codec.decoded(reader.atom().or(t""))
       override def parse(reader: TelReader^): value = codec.decoded(t"")
       override def absent()(using Tactic[TelError]): value = codec.decoded(t"")
+      override def parseAtom(text: Text)(using Tactic[TelError]): value = codec.decoded(text)
 
   // `source.read[List[Tel]]` / `read[Chain[Tel]]` for a multi-document source
   // (§6.1). `List[Tel]` parses every document eagerly; `Chain[Tel]` parses

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -1013,26 +1013,48 @@ object Tel extends Tel2:
             case Some(sd) => sd.variants.length
             case None     => 0
 
+      def indexOf(element: Tel.Element): Int = element match
+        case Tel.Element.Node(idx, _, _)  => idx.or(-1)
+        case Tel.Element.Value(idx, _, _) => idx
+
       var memberIdx = 0
       var flatStart = 0
 
       while memberIdx < parent.members.length do
-        val width = flatWidth(parent.members(memberIdx))
+        val member = parent.members(memberIdx)
+        val width = flatWidth(member)
 
-        parent.members(memberIdx) match
-          case f: Tels.Field if f.required != Polarity.Loose =>
-            val filled = results.exists:
-              case Tel.Element.Node(idx, _, _)  => idx == Optional(flatStart)
-              case Tel.Element.Value(idx, _, _) => idx == flatStart
+        // §20.2 step 5a: atoms and compound children assigned to the member
+        // count against the same budget. A member's elements all carry flat
+        // keyword indexes within its flat range.
+        val fillCount = results.count: element =>
+          val idx = indexOf(element)
+          idx >= flatStart && idx < flatStart + width
 
-            if !filled then resolveType(f.fieldType, schema) match
+        member match
+          case f: Tels.Field =>
+            if requiredOf(f) && fillCount == 0 then resolveType(f.fieldType, schema) match
               case s: Scalar => f.default match
                 case t: Text => results += Tel.Element.Value(flatStart, s, t)
                 case _       => recoverNode(Reason.RequiredMemberAbsent)(())
 
               case _ => recoverNode(Reason.RequiredMemberAbsent)(())
 
-          case _ => ()
+            // §20.2 step 5c; recovery reports the document invalid but
+            // retains every occurrence.
+            if !repeatableOf(f) && fillCount > 1
+            then recoverNode(Reason.NonRepeatableTooMany)(())
+
+          case s: SelectRef =>
+            // §20.2 step 5b: defaults exist only on Scalar Fields, so an
+            // absent required SelectRef is always E307.
+            if requiredOf(s) && fillCount == 0
+            then recoverNode(Reason.RequiredMemberAbsent)(())
+
+            if !repeatableOf(s) && fillCount > 1
+            then recoverNode(Reason.NonRepeatableTooMany)(())
+
+          case _: Exclude => ()
 
         flatStart += width
         memberIdx += 1

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -372,10 +372,14 @@ object Tel extends Tel2:
     // through packed-`Long` literal comparisons, and whose record is built by
     // a direct constructor call — no `Array[Any]` buffer, no `Mirror`, no
     // per-field boxing. Semantics (wire keywords, gathering, first-match-wins
-    // duplicates, defaults, absents, error foci) mirror `derived` exactly;
-    // the generated instance's `shape()` is `Morphology.Any`. Requires a
-    // top-level or object-nested case class with a single parameter list —
-    // sums, method-local classes and other shapes use `derived`.
+    // duplicates, defaults, absents, error foci) mirror `derived` exactly,
+    // EXCEPT that a staged record parser does not yet run the §19.2
+    // positional atom pre-pass (#1694): a record entry's own inline atoms
+    // are discarded, as all paths did before the fix. Use `derived` for
+    // documents that put field values in atom position. The generated
+    // instance's `shape()` is `Morphology.Any`. Requires a top-level or
+    // object-nested case class with a single parameter list — sums,
+    // method-local classes and other shapes use `derived`.
     inline def staged[value]: value is Tel.Parsable =
       ${ stratiform.internal.stagedParsable[value]('{ adversaria.relabelling[value, Tel] }) }
 

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -485,7 +485,11 @@ object Tel extends Tel2:
           override def optional: Boolean = true
 
           def parse(reader: TelReader^, indent: Int): value =
-            if reader.hasSubstance then field.parse(reader, indent)
+            // A bare entry means `Unset` for most types, but a Flag-natured
+            // inner reads it as flag presence (`Optional[Boolean]` of
+            // `true`) — the AST `optionalDecodable`'s test exactly.
+            if reader.hasSubstance || field.nature == Tel.Nature.Flag
+            then field.parse(reader, indent)
             else
               reader.skipEntry(indent)
               Unset
@@ -606,6 +610,18 @@ object Tel extends Tel2:
         private lazy val fields: Array[(String, Tel.Parsing, Any)]^{} = fields0()
         private lazy val keys: Array[String]^{} = fields.map(_(0))
 
+        // Per-field positional profiles for the §19.2 atom pre-pass,
+        // computed from the same table as the keyword dispatch.
+        private lazy val profiles: Array[Positional.Profile]^{} =
+          fields.map: (key, parsing, fallback) =>
+            val actual = unwrap(parsing)
+
+            Positional.Profile
+              ( Text(key),
+                actual.nature,
+                actual.repeatable,
+                required = !(actual.optional || fallback.asInstanceOf[Optional[Any]].present) )
+
         def shape(): Morphology =
           val entries: List[(Text, Morphology)] =
             fields.map { (key, parser, _) => (Text(key), parser.shape()) }.to[List]
@@ -626,18 +642,23 @@ object Tel extends Tel2:
           -1
 
         // The value of a record field is its children, one level deeper than
-        // its own entry line.
+        // its own entry line — after the entry line's own atoms fill fields
+        // positionally (§19.2).
         def parse(reader: TelReader^, indent: Int): derivation =
-          reader.finishLine()
-          parseFields(reader, indent + 1)
+          parseFields(reader, indent + 1, reader.lineAtoms())
 
-        // A whole document's fields sit at indent zero.
-        override def parse(reader: TelReader^): derivation = parseFields(reader, 0)
+        // A whole document's fields sit at indent zero; the root carries no
+        // atoms (§20.2).
+        override def parse(reader: TelReader^): derivation =
+          parseFields(reader, 0, Array.empty)
 
-        private def parseFields(reader: TelReader^, indent: Int): derivation =
+        private def parseFields(reader: TelReader^, indent: Int, atoms: Array[Tel.Atom]^{})
+        :   derivation =
+
           val entries = fields
           val count = entries.length
           val values = new scala.Array[Any](count)
+          val atomFilled = new scala.Array[Boolean](count)
           var index = 0
 
           while index < count do
@@ -647,6 +668,43 @@ object Tel extends Tel2:
           // With the inert default `Foci`, per-field `focus` wrapping would
           // observably do nothing, so the hot loop skips it.
           val focused = foci.active
+
+          // §19.2 positional pre-pass (issue #1694): the entry line's atoms
+          // fill fields in declaration order before the keyword loop, so a
+          // repeatable field's later same-keyword children append after them
+          // (§18.3 step 4 — atoms precede children).
+          if atoms.length > 0 then
+            val assigned = Positional.assign(atoms, profiles)(using tactic)
+            var slot = 0
+
+            while slot < assigned.length do
+              val slotAtoms = assigned(slot).stdlib
+
+              if slotAtoms.nonEmpty then
+                val parsing = unwrap(entries(slot)(1))
+
+                inline def positioned[result](inline block: => result): result =
+                  if focused then focus(descend(prior, Text(keys(slot))))(block) else block
+
+                parsing match
+                  case gathering: Gathering if parsing.repeatable =>
+                    val buffer = scala.collection.mutable.ListBuffer.empty[Any]
+
+                    slotAtoms.foreach: atom =>
+                      buffer += positioned(gathering.parseAtomElement(Positional.text(atom)))
+
+                    values(slot) = buffer
+
+                  case _ =>
+                    atomFilled(slot) = true
+
+                    values(slot) =
+                      if parsing.nature == Tel.Nature.Flag
+                      then positioned(parsing.parseFlag())
+                      else positioned(parsing.parseAtom(Positional.text(slotAtoms.head)))
+
+              slot += 1
+
           var next: Optional[Text] = reader.keyword(indent)
 
           while next.present do
@@ -677,9 +735,14 @@ object Tel extends Tel2:
 
                 case _ =>
                   // A non-repeatable field keeps its first occurrence — the
-                  // AST's `field()` semantics — and skips the rest.
-                  if !(values(found).asInstanceOf[AnyRef] eq AbsentSlot)
-                  then reader.skipEntry(indent)
+                  // AST's `field()` semantics — and skips the rest. When the
+                  // first fill came from a positional atom, the duplicate is
+                  // §20.2 step 5c's E308 (the atom wins).
+                  if !(values(found).asInstanceOf[AnyRef] eq AbsentSlot) then
+                    if atomFilled(found)
+                    then raise(TelError(TelError.Reason.NonRepeatableTooMany))(using tactic)
+
+                    reader.skipEntry(indent)
                   else values(found) =
                     if focused
                     then focus(descend(prior, Text(keys(found)))):
@@ -1807,10 +1870,14 @@ object Tel extends Tel2:
       override def nature: Tel.Nature = Tel.Nature.Flag
 
       def parse(reader: TelReader^, indent: Int): Boolean =
-        reader.boolean().lay(Parsable.scalarFault(reader, t"Boolean", false))(identity)
+        // Flag semantics (§20): a present entry with no atom is the bare
+        // flag form, meaning `true`; a present-but-unparseable atom is
+        // still `NotScalar`, exactly as on the AST path.
+        reader.boolean().lay(
+          if reader.primaryPresent then Parsable.scalarFault(reader, t"Boolean", false) else true
+        )(identity)
 
-      override def absent()(using Tactic[TelError]): Boolean =
-        raise(TelError(TelError.Reason.Absent)) yet false
+      override def absent()(using Tactic[TelError]): Boolean = false
 
       override def parseAtom(text: Text)(using Tactic[TelError]): Boolean =
         if text == t"true" then true else if text == t"false" then false
@@ -5286,6 +5353,47 @@ object Tel extends Tel2:
       if (tabulated || extraAtom.present) && !head.eof && !head.separator && !head.blank &&
         head.indentLevels > indent
       then errorAt(directOverIndentReason, head.startLine, 1)
+
+    // As `directFinishLine`, but capturing the entry line's atoms — including
+    // the source/literal continuation, which §14/§15 append to the atom
+    // sequence — for the derived record parser's §19.2 positional pre-pass.
+    private[stratiform] update def directFinishLineAtoms()(using Tactic[TelError])
+    :   Array[Tel.Atom]^{} =
+
+      val spaces = directEntrySpaces
+      val indent = directEntryIndent
+      val tabulated = directTabulation.present
+
+      // A record entry is usually a bare `keyword` line: nothing to scan.
+      val bare = inHold:
+        if more && (peek == LF || peek == CR) then
+          consumeLineEnding()
+          compoundLineRemark = Unset
+          true
+        else false
+
+      val atomsStart = atomScratchIx
+      if !bare then parseCompoundLineRest(directEntryLine)
+      prevContentLeadingSpaces = spaces
+      prevLineWasBoundary = false
+      fillHead()
+
+      val extraAtom: Optional[Tel.Atom] =
+        if tabulated then Unset else parseSourceOrLiteralAtomIfPresent(spaces)
+
+      extraAtom match
+        case atom: Tel.Atom => pushAtom(atom)
+        case _              => ()
+
+      val atoms = takeAtoms(atomScratchIx - atomsStart)
+
+      // As in `directFinishLine`: after a source/literal atom or on a
+      // tabulated row, a deeper line is over-indented.
+      if (tabulated || extraAtom.present) && !head.eof && !head.separator && !head.blank &&
+        head.indentLevels > indent
+      then errorAt(directOverIndentReason, head.startLine, 1)
+
+      atoms
 
     // Skip the whole entry — line remainder, continuation and subtree —
     // discarding it. Used for unknown keywords and duplicate non-repeatable

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -803,6 +803,43 @@ object Tel extends Tel2:
 
         case _: Exclude => false
 
+    private def selectDefinitionOf(select: SelectRef, schema: Tels)
+    :   SelectDefinition raises TelError =
+
+      schema.selects.find(_.name == select.reference).getOrElse:
+        abort(TelError(Reason.UnresolvedReference))
+
+    // Effective polarity per §20: `required` unless declared `Loose`.
+    private def requiredOf(member: Member): Boolean = member match
+      case f: Tels.Field => f.required != Polarity.Loose
+      case s: SelectRef  => s.required != Polarity.Loose
+      case _: Exclude    => false
+
+    private def repeatableOf(member: Member): Boolean = member match
+      case f: Tels.Field => f.repeatable == Polarity.Loose
+      case s: SelectRef  => s.repeatable == Polarity.Loose
+      case _: Exclude    => false
+
+    // Flag-shaped per §20.2 step 3a: a Field resolving to Flag, or a
+    // SelectRef all of whose variants resolve to Flag.
+    private def flagShaped(member: Member, schema: Tels): Boolean raises TelError =
+      member match
+        case f: Tels.Field =>
+          resolveType(f.fieldType, schema) match
+            case Flag => true
+            case _    => false
+
+        case s: SelectRef => atomAssignable(s, schema)
+        case _: Exclude   => false
+
+    private def keywordMatches(member: Member, text: Text, schema: Tels)
+    :   Boolean raises TelError =
+
+      member match
+        case f: Tels.Field => f.keyword == text
+        case s: SelectRef  => selectDefinitionOf(s, schema).variants.exists(_.keyword == text)
+        case _: Exclude    => false
+
     // Track both the member position (`pos` in parent.members) and the
     // running flat keyword index (`flatPos`) — Tel.Element.keywordIndex
     // uses flat positions per BinTEL §5.
@@ -810,7 +847,7 @@ object Tel extends Tel2:
       ( atoms:  Array[Tel.Atom]^{},
        parent: Struct,
        schema: Tels )
-    :   Array[Tel.Element]^{} raises TelError =
+    :   Array[Tel.Element]^{} raises TelError tracks Tel.Focus =
 
       val results = scala.collection.mutable.ArrayBuffer.empty[Tel.Element]
       var pos = 0
@@ -832,12 +869,39 @@ object Tel extends Tel2:
           case Tel.Atom.Source(t)     => t
           case Tel.Atom.Literal(_, t) => t
 
-        var consumed = false
+        // §20.2 step 3a: advance past non-required members that cannot take
+        // this atom — those that are not atom-assignable, or are Flag-shaped
+        // with a keyword the atom's text does not match. A Scalar member is
+        // never skipped; a required member is never skipped.
+        var scanning = true
 
-        while !consumed && pos < parent.members.length do
-          if !atomAssignable(parent.members(pos), schema) then
-            flatPos += flatWidthOf(parent.members(pos))
+        while scanning && pos < parent.members.length do
+          val member = parent.members(pos)
+
+          val skippable = member match
+            case _: Exclude => true
+
+            case _ =>
+              !requiredOf(member)
+              && (!atomAssignable(member, schema)
+                  || (flagShaped(member, schema) && !keywordMatches(member, atomText, schema)))
+
+          if skippable then
+            flatPos += flatWidthOf(member)
             pos += 1
+          else scanning = false
+
+        if pos >= parent.members.length then
+          // §20.2 step 3b: more atoms than assignable member positions.
+          // Recovery drops the whole excess run, reported once.
+          recoverNode(Reason.TooManyAtoms)(())
+          i = atoms.length
+        else
+          if !atomAssignable(parent.members(pos), schema) then
+            // §20.2 step 3c: an atom arrived at a required member that can
+            // only be filled by compound children. Recovery drops the atom;
+            // the member may still be filled by a child.
+            recoverNode(Reason.AtomAtNonAssignablePos)(())
           else
             parent.members(pos) match
               case f: Tels.Field =>
@@ -849,23 +913,22 @@ object Tel extends Tel2:
                       flatPos += 1
                       pos += 1
 
-                    consumed = true
-
                   case Flag =>
                     if atomText == f.keyword then
                       results += Tel.Element.Node(flatPos, Flag, Array.empty)
-                      flatPos += 1
-                      pos += 1
-                      consumed = true
-                    else
-                      flatPos += 1
-                      pos += 1
 
-                  case _ => abort(TelError(Reason.AtomAtNonAssignablePos))
+                      if f.repeatable != Polarity.Loose then
+                        flatPos += 1
+                        pos += 1
+                    else
+                      // §20.2 step 3d: a required Flag member's atom must
+                      // match its keyword. Recovery drops the atom.
+                      recoverNode(Reason.AtomFlagKeywordMismatch)(())
+
+                  case _ => () // unreachable behind `atomAssignable`
 
               case s: SelectRef =>
-                val selectDef = schema.selects.find(_.name == s.reference).getOrElse:
-                  abort(TelError(Reason.UnresolvedReference))
+                val selectDef = selectDefinitionOf(s, schema)
 
                 selectDef.variants.readable.zipWithIndex.find(_._1.keyword == atomText) match
                   case Some((_, variantOffset)) =>
@@ -875,18 +938,14 @@ object Tel extends Tel2:
                       flatPos += selectDef.variants.length
                       pos += 1
 
-                    consumed = true
-
                   case None =>
-                    flatPos += selectDef.variants.length
-                    pos += 1
+                    // §20.2 step 3d: no variant keyword matches the atom at a
+                    // required all-Flag SelectRef. Recovery drops the atom.
+                    recoverNode(Reason.AtomVariantUnmatched)(())
 
-              case _ =>
-                flatPos += flatWidthOf(parent.members(pos))
-                pos += 1
+              case _: Exclude => () // consumed by the skip scan
 
-        if !consumed then abort(TelError(Reason.AtomFlagKeywordMismatch))
-        i += 1
+          i += 1
 
       Array.from(results)
 

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -160,6 +160,26 @@ object Tel extends Tel2:
     // `Optional` wrapper), mirroring `Decodable.optional`.
     def optional: Boolean = false
 
+    // The §22.2 canonical child form of a value — for derived products, the
+    // compound carrying its leading inline atom run (`Mutation.construct`);
+    // identical to `encoded` unless overridden. This is the embedding form
+    // a canonicalizing parent uses for its nested values.
+    def constructed(value: Self): Tel = encoded(value)
+
+    // The §22.2 canonical presentation rooted as a document (the root
+    // carries no atoms, §20.2): for derived products, the member fields as
+    // top-level children whose own nested records carry inline runs.
+    // Identical to `constructed` unless overridden.
+    def canonicalized(value: Self): Tel = constructed(value)
+
+  // The §22.2 canonical presentation of a value: `.encode` keeps the fully
+  // keyword-child wire form (which typed navigation and the optics rely on);
+  // this opt-in rendering puts leading scalar and flag fields of each nested
+  // record in atom position per §22.2 `construct`. Both forms decode to the
+  // same value (§19.1).
+  def canonical[value](value: value)(using encodable: value is Tel.Encodable): Tel =
+    encodable.canonicalized(value)
+
   object Decodable:
     // Explicit shape thunk, as in `Tel.Encodable.apply`.
     def apply[value]
@@ -615,7 +635,10 @@ object Tel extends Tel2:
         private lazy val keys: Array[String]^{} = fields.map(_(0))
 
         // Per-field positional profiles for the §19.2 atom pre-pass,
-        // computed from the same table as the keyword dispatch.
+        // computed from the same table as the keyword dispatch. A Flag
+        // field is never required: its absence parses `false`, so the skip
+        // rule may pass over it — which the canonical encoder relies on
+        // when it elides a false flag from a run.
         private lazy val profiles: Array[Positional.Profile]^{} =
           fields.map: (key, parsing, fallback) =>
             val actual = unwrap(parsing)
@@ -624,7 +647,8 @@ object Tel extends Tel2:
               ( Text(key),
                 actual.nature,
                 actual.repeatable,
-                required = !(actual.optional || fallback.asInstanceOf[Optional[Any]].present) )
+                required = actual.nature != Tel.Nature.Flag
+                           && !(actual.optional || fallback.asInstanceOf[Optional[Any]].present) )
 
         def shape(): Morphology =
           val entries: List[(Text, Morphology)] =

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -659,6 +659,14 @@ object Tel extends Tel2:
   trait Field extends Parsing
 
   // Type assignment algorithm per §20.2 of the TEL specification.
+  //
+  // Document-conformance violations (E301-E311) go through `recoverNode` and
+  // so record-and-continue under an accrual boundary, per §19.5; schema
+  // errors (E210/E218) abort, because a malformed schema offers no document-
+  // level recovery. Out of scope here: §20.1 schema-validity checking (E2xx
+  // beyond reference resolution), tabulation-aware column assignment, and
+  // diagnostic spans — a TelError raised during assignment carries no
+  // position.
   object Type:
     import TelError.Reason
     import Tels.*

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -1035,6 +1035,15 @@ object Tel extends Tel2:
           Tel.Element.Node(entry.memberIndex, s, allElements)
 
         case s: Scalar =>
+          // §20.2 step 1: a Scalar-typed compound is a leaf with at most one
+          // atom (of any presentation form) and no compound children. Extra
+          // atoms are E302 and children are E301; recovery keeps the first
+          // atom and ignores the children.
+          if compound.atoms.length > 1 then recoverNode(Reason.TooManyAtoms)(())
+
+          if compound.children.exists(_.compounds.nonEmpty)
+          then recoverNode(Reason.NonStructCompound)(())
+
           val text = compound.atoms.headOption.map:
             case Tel.Atom.Inline(t, _)  => t
             case Tel.Atom.Source(t)     => t

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -737,18 +737,22 @@ object Tel extends Tel2:
         case other => other
 
     private case class KeywordEntry
-      ( memberIndex: Int,
-        entryType:   Type,
-        member:      Member,
-        variant:     Optional[Variant] = Unset )
+      ( flatIndex: Int,
+        ordinal:   Int,
+        entryType: Type,
+        member:    Member,
+        variant:   Optional[Variant] = Unset )
 
-    // Builds a map from keyword Text → KeywordEntry where `memberIndex`
+    // Builds a map from keyword Text → KeywordEntry where `flatIndex`
     // is the **flat keyword index** per BinTEL §5: each Field
     // contributes 1 entry, each SelectRef contributes 1 entry per
     // variant in the referenced SelectDefinition. The flat index
     // identifies the unique keyword position in the parent's flat-
     // keyword sequence — used as the `keywordIndex` of every
-    // Tel.Element produced from this parent.
+    // Tel.Element produced from this parent. `ordinal` is the member
+    // index in `parent.members`: all variants of one SelectRef share
+    // it, which is what lets them interleave under the §20.2 step 4c
+    // contiguity rule.
     private def keywordMap(parent: Struct, schema: Tels)
     :   Map[Text, KeywordEntry] raises TelError =
 
@@ -759,7 +763,7 @@ object Tel extends Tel2:
       while idx < parent.members.length do
         parent.members(idx) match
           case f: Tels.Field =>
-            builder(f.keyword) = KeywordEntry(flatIdx, f.fieldType, f)
+            builder(f.keyword) = KeywordEntry(flatIdx, idx, f.fieldType, f)
             flatIdx += 1
 
           case s: SelectRef =>
@@ -772,7 +776,7 @@ object Tel extends Tel2:
               val variant = selectDef.variants(v)
 
               builder(variant.keyword) =
-                KeywordEntry(flatIdx + v, variant.variantType, s, Optional(variant))
+                KeywordEntry(flatIdx + v, idx, variant.variantType, s, Optional(variant))
 
               v += 1
 
@@ -957,6 +961,8 @@ object Tel extends Tel2:
 
       val km = keywordMap(parent, schema)
       val results = scala.collection.mutable.ArrayBuffer.empty[Tel.Element]
+      var currentMember = -1
+      val seenMembers = scala.collection.mutable.HashSet.empty[Int]
       var i = 0
 
       while i < compounds.length do
@@ -965,8 +971,23 @@ object Tel extends Tel2:
         // An unrecognised keyword is skipped (`IgnoreErroneousNode`): record it and
         // emit no element, so remaining siblings are still validated.
         km.get(compound.keyword) match
-          case Some(entry) => results += assignCompound(compound, entry, schema)
-          case None        => recoverNode(Reason.UnknownKeyword)(())
+          case Some(entry) =>
+            // §20.2 step 4c: all children of one member must form a single
+            // contiguous run; variants of one SelectRef share an ordinal and
+            // so interleave freely. Returning to an earlier member's run is
+            // E309, reported once per returned-to run; the child is still
+            // assigned.
+            if entry.ordinal != currentMember then
+              if currentMember >= 0 then seenMembers += currentMember
+
+              if seenMembers.contains(entry.ordinal)
+              then recoverNode(Reason.MembersNonContiguous)(())
+
+              currentMember = entry.ordinal
+
+            results += assignCompound(compound, entry, schema)
+
+          case None => recoverNode(Reason.UnknownKeyword)(())
 
         i += 1
 
@@ -1032,7 +1053,7 @@ object Tel extends Tel2:
           val childCompounds: Array[Tel.Compound]^{} = compound.children.bind(_.compounds)
           val childElements = assignChildren(childCompounds, s, schema)
           val allElements = applyConstraints(s, atomElements, childElements, schema)
-          Tel.Element.Node(entry.memberIndex, s, allElements)
+          Tel.Element.Node(entry.flatIndex, s, allElements)
 
         case s: Scalar =>
           // §20.2 step 1: a Scalar-typed compound is a leaf with at most one
@@ -1051,17 +1072,17 @@ object Tel extends Tel2:
 
           .getOrElse(t"")
 
-          Tel.Element.Value(entry.memberIndex, s, text)
+          Tel.Element.Value(entry.flatIndex, s, text)
 
         case Flag =>
           if compound.atoms.nonEmpty || compound.children.nonEmpty then
             recoverNode(Reason.FlagWithContent)(())
 
-          Tel.Element.Node(entry.memberIndex, Flag, Array.empty)
+          Tel.Element.Node(entry.flatIndex, Flag, Array.empty)
 
         case _: Reference =>
           recoverNode(Reason.UnresolvedReference):
-            Tel.Element.Node(entry.memberIndex, Flag, Array.empty)
+            Tel.Element.Node(entry.flatIndex, Flag, Array.empty)
 
   // Validator infrastructure per §21 of the TEL specification.
   object Validator:

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -674,9 +674,15 @@ object Tel extends Tel2:
 
       raise(TelError(reason)) yet continuation
 
+    // §20.2 RECOMMENDED defence against pathologically deep documents: type
+    // assignment fail-stops beyond this many levels of compound nesting. It
+    // carries no E-code because it is a property of the implementation, not
+    // of the document.
+    private val nestingLimit = 256
+
     def assign(tel: Tel, schema: Tels): Tel.Element raises TelError tracks Tel.Focus =
       val compounds: Array[Tel.Compound]^{} = tel.subtree.children.bind(_.compounds)
-      val rootChildren = assignChildren(compounds, schema.document, schema)
+      val rootChildren = assignChildren(compounds, schema.document, schema, 1)
 
       val rootElements =
         applyConstraints(schema.document, Array.empty[Tel.Element], rootChildren, schema)
@@ -956,7 +962,8 @@ object Tel extends Tel2:
     private def assignChildren
       ( compounds: Array[Tel.Compound]^{},
        parent:    Struct,
-       schema:    Tels )
+       schema:    Tels,
+       depth:     Int )
     :   Array[Tel.Element]^{} raises TelError tracks Tel.Focus =
 
       val km = keywordMap(parent, schema)
@@ -985,7 +992,7 @@ object Tel extends Tel2:
 
               currentMember = entry.ordinal
 
-            results += assignCompound(compound, entry, schema)
+            results += assignCompound(compound, entry, schema, depth)
 
           case None => recoverNode(Reason.UnknownKeyword)(())
 
@@ -1064,8 +1071,11 @@ object Tel extends Tel2:
     private def assignCompound
       ( compound: Tel.Compound,
        entry:    KeywordEntry,
-       schema:   Tels )
+       schema:   Tels,
+       depth:    Int )
     :   Tel.Element raises TelError tracks Tel.Focus =
+
+      if depth > nestingLimit then abort(TelError(Reason.NestingLimitExceeded))
 
       val resolved = resolveType(entry.entryType, schema)
 
@@ -1073,7 +1083,7 @@ object Tel extends Tel2:
         case s: Struct =>
           val atomElements = assignAtoms(compound.atoms, s, schema)
           val childCompounds: Array[Tel.Compound]^{} = compound.children.bind(_.compounds)
-          val childElements = assignChildren(childCompounds, s, schema)
+          val childElements = assignChildren(childCompounds, s, schema, depth + 1)
           val allElements = applyConstraints(s, atomElements, childElements, schema)
           Tel.Element.Node(entry.flatIndex, s, allElements)
 

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -4872,12 +4872,78 @@ object Tel extends Tel2:
       val extraAtom: Optional[Tel.Atom] =
         if tabulated then Unset else parseSourceOrLiteralAtomIfPresent(spaces)
 
+      // §14/§15 append the source/literal atom to the atom sequence: when the
+      // line itself carried no inline atom, it is the entry's first atom and
+      // supplies the primary.
+      if !directPrimaryPresent then extraAtom match
+        case Tel.Atom.Source(text)     => capturePrimaryFromText(text.s)
+        case Tel.Atom.Literal(_, text) => capturePrimaryFromText(text.s)
+        case _                         => ()
+
       // Mirror `directCompound`: children are parsed (and here discarded) only
       // when no source/literal atom and no tabulation intervened; otherwise a
       // following deeper line is over-indented and fails with the same reason.
       if !tabulated && extraAtom.absent then parseChildren(indent)
       else if !head.eof && !head.separator && !head.blank && head.indentLevels > indent
       then errorAt(directOverIndentReason, head.startLine, 1)
+
+    // Parses an optional `-` and one to eighteen digits — exactly the
+    // spellings `parseArenaLong` accepts — or Unset.
+    private def parsedTextLong(text: String): Optional[Long] =
+      val negative = text.startsWith("-")
+      val start = if negative then 1 else 0
+      val digits = text.length - start
+
+      if digits < 1 || digits > 18 then Unset else
+        var index = start
+        var accumulator = 0L
+        var ok = true
+
+        while ok && index < text.length do
+          val ch = text.charAt(index)
+
+          if ch < '0' || ch > '9' then ok = false else
+            accumulator = accumulator*10 + (ch - '0')
+            index += 1
+
+        if ok then Optional(if negative then -accumulator else accumulator) else Unset
+
+    // Capture the primary slot from a source/literal atom's text, mirroring
+    // `parseCompoundLineRest`'s per-mode capture of the first inline atom.
+    private update def capturePrimaryFromText(value: String): Unit =
+      directPrimaryPresent = true
+      directPrimaryOk = false
+      directPrimaryText = null
+
+      directPrimaryMode match
+        case PrimaryLong =>
+          parsedTextLong(value) match
+            case parsed: Long =>
+              directPrimaryLongVal = parsed
+              directPrimaryOk = true
+
+            case _ => directPrimaryText = value
+
+        case PrimaryInt =>
+          parsedTextLong(value) match
+            case parsed: Long
+                 if parsed >= Int.MinValue && parsed <= Int.MaxValue =>
+              directPrimaryLongVal = parsed
+              directPrimaryOk = true
+
+            case _ => directPrimaryText = value
+
+        case PrimaryBoolean =>
+          if value == "true" then
+            directPrimaryBoolVal = true
+            directPrimaryOk = true
+          else if value == "false" then
+            directPrimaryBoolVal = false
+            directPrimaryOk = true
+          else directPrimaryText = value
+
+        case _ =>
+          directPrimaryText = value
 
     // The leaf fast path, entered with the cursor right after the keyword:
     // handles the dominant data shapes — a bare `keyword` line, and
@@ -5027,9 +5093,10 @@ object Tel extends Tel2:
                     directPrimaryText = sliceText(atomStart)
                     finish()
 
-    // The entry's primary atom as text — the first inline atom's, or Unset when
-    // the line carries none (a source/literal atom never supplies it), mirroring
-    // `Tel#primaryAtom`. Backs the `Text`/text-codec primitive readers.
+    // The entry's primary atom as text — the first atom's, of any presentation
+    // form (a source/literal atom supplies it when the line itself carries no
+    // inline atom), mirroring `Tel#primaryAtom`. Backs the `Text`/text-codec
+    // primitive readers.
     private[stratiform] update def directAtomText()(using Tactic[TelError]): Optional[Text] =
       consumeDirectEntry(PrimaryText)
       val captured = directPrimaryText
@@ -5103,10 +5170,10 @@ object Tel extends Tel2:
     private[stratiform] update def directDocument()(using Tactic[TelError]): Tel =
       Tel.make(Tel.Document(Unset, Unset, lineEndings, parseChildren(-1)))
 
-    // Peek whether the current entry has substance — an inline atom on its
-    // line, or a child compound beneath it — the exact test the AST's
-    // `optionalDecodable` performs (a source/literal atom is not an inline
-    // atom and contributes none). The entry is parsed in full under a mark
+    // Peek whether the current entry has substance — an atom of any
+    // presentation form (§14/§15 append source/literal atoms to the atom
+    // sequence), or a child compound beneath it — the exact test the AST's
+    // `optionalDecodable` performs. The entry is parsed in full under a mark
     // and then rewound, restoring every piece of parser state the parse
     // touched, so the caller can still consume the entry either way.
     private[stratiform] update def directEntrySubstance()(using Tactic[TelError]): Boolean = inHold:
@@ -5129,14 +5196,8 @@ object Tel extends Tel2:
 
       val compound = directCompound(directEntryIndent)
 
-      var hasInlineAtom = false
-      var index = 0
-
-      while index < compound.atoms.length do
-        if compound.atoms(index).isInstanceOf[Tel.Atom.Inline] then hasInlineAtom = true
-        index += 1
-
-      val substance = hasInlineAtom || compound.children.exists(_.compounds.length > 0)
+      val substance =
+        compound.atoms.length > 0 || compound.children.exists(_.compounds.length > 0)
 
       syncTo()
       cursor.cue(mk)
@@ -5211,15 +5272,29 @@ extends scala.Dynamic, Documentary, Topical, Original:
     case c: Tel.Compound  => c.keyword
     case _: Tel.Document  => t""
 
-  // Flat list of inline atom texts attached to this node. For the document
-  // root this is always empty since the root has no atoms.
+  // Flat list of atom texts attached to this node, in atom order: inline
+  // atoms first, then the source or literal atom if one follows the line
+  // (§14/§15 append it to the same atom sequence). For the document root
+  // this is always empty since the root has no atoms.
   def atomTexts: Array[Text]^{} = subtree match
-    case c: Tel.Compound => Array.frozen(c.atoms.readable.collect { case Tel.Atom.Inline(text, _) => text })
+    case c: Tel.Compound =>
+      Array.frozen:
+        c.atoms.readable.map:
+          case Tel.Atom.Inline(text, _)  => text
+          case Tel.Atom.Source(text)     => text
+          case Tel.Atom.Literal(_, text) => text
+
     case _: Tel.Document => Array.empty
 
-  // First inline atom text or empty string if none. Used by primitive
-  // Decodable instances which interpret a compound's first atom as its
-  // scalar value.
+  // The node's atoms in presentation order (all three forms); empty for the
+  // document root.
+  private[stratiform] def atoms: Array[Tel.Atom]^{} = subtree match
+    case c: Tel.Compound => c.atoms
+    case _: Tel.Document => Array.empty
+
+  // First atom text (of any presentation form) or empty string if none.
+  // Used by primitive Decodable instances which interpret a compound's
+  // first atom as its scalar value.
   def primaryAtom: Text =
     if atomTexts.isEmpty then t"" else atomTexts(0)
 

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -280,11 +280,15 @@ trait Tel2 extends Tel3:
       lazy val profiles: Array[Positional.Profile]^{} =
         contexts[derivation]():
           [field] => context =>
+            // A Flag field is never required: its absence decodes `false`,
+            // so the skip rule may pass over it — which the canonical
+            // encoder relies on when it elides a false flag from a run.
             Positional.Profile
               ( renames.at(label).or(Tel.camelToKebab(label.s)),
                 context.nature,
                 context.repeatable,
-                required = !(context.optional || default[Optional[field]].present) )
+                required = context.nature != Tel.Nature.Flag
+                           && !(context.optional || default[Optional[field]].present) )
 
       // The object `Morphology` is built from the field decoders' own shapes (a single
       // inlined `contexts` traversal — kept here, not factored out, so it does not
@@ -414,19 +418,22 @@ trait Tel2 extends Tel3:
     inline def conjunction[derivation <: Product: ProductReflection]
     :   derivation is Tel.Encodable =
 
-      Tel.Encodable({ () =>
-        val fields: List[(Text, Morphology)] =
-          contexts[derivation](): [field] => context => (label, context.shape())
-          . toList // direct shim, not `to[List]`: inline re-elaboration freshens the array
+      // `@name[Tel]` / bare `@name` renames: field name -> keyword, used
+      // verbatim; an unannotated field falls back to its camel→kebab form.
+      lazy val renames: Map[Text, Text] = relabelling[derivation, Tel]
 
-        Morphology.Obj(fields, fields.collect { case (label, shape) if !shape.optional => label })
-      }):
-        value =>
+      new Tel.Encodable:
+        type Self = derivation
+
+        def shape(): Morphology =
+          val fields: List[(Text, Morphology)] =
+            contexts[derivation](): [field] => context => (label, context.shape())
+            . toList // direct shim, not `to[List]`: inline re-elaboration freshens the array
+
+          Morphology.Obj(fields, fields.collect { case (label, shape) if !shape.optional => label })
+
+        def encoded(value: derivation): Tel =
           val compounds = scala.collection.mutable.ArrayBuffer.empty[Tel.Compound]
-
-          // `@name[Tel]` / bare `@name` renames: field name -> keyword, used
-          // verbatim; an unannotated field falls back to its camel→kebab form.
-          val renames: Map[Text, Text] = relabelling[derivation, Tel]
 
           fields(value): [field] =>
             fieldValue =>
@@ -463,6 +470,106 @@ trait Tel2 extends Tel3:
 
           Tel.compound(t"", Array.empty, Array.from(compounds))
 
+        // The §22.2 member description of a value, in field order — the
+        // input to `Mutation.construct` for the canonical forms below.
+        private def membersOf(value: derivation)
+        :   scala.collection.immutable.List[Mutation.Member] =
+
+          val members = scala.collection.mutable.ListBuffer.empty[Mutation.Member]
+          val elidedFlags = scala.collection.mutable.HashSet.empty[Text]
+
+          fields(value): [field] =>
+            fieldValue =>
+              val keyword: Text = renames.at(label).or(Tel.camelToKebab(label.s))
+
+              contextual.nature match
+                case Tel.Nature.Flag =>
+                  val encoded = contextual.encode(fieldValue)
+
+                  encoded.subtree match
+                    case c: Tel.Compound =>
+                      if encoded.primaryAtom == t"true"
+                      then members += Mutation.Member.Flag(keyword)
+                      else if encoded.primaryAtom == t"false" && !contextual.optional
+                      then elidedFlags += keyword
+                      else members += Mutation.Member.Child(c.copy(keyword = keyword))
+
+                    case _ => elidedFlags += keyword
+
+                case Tel.Nature.Scalar =>
+                  val encoded = contextual.encode(fieldValue)
+
+                  encoded.subtree match
+                    case c: Tel.Compound =>
+                      val text = encoded.primaryAtom
+
+                      // A value colliding with a preceding elided flag's
+                      // keyword would set that flag on re-decode; the child
+                      // form sidesteps the collision.
+                      if elidedFlags.contains(text)
+                      then members += Mutation.Member.Child:
+                        Tel.Compound(keyword, c.atoms, Unset, Array.empty)
+                      else members += Mutation.Member.Value(keyword, List(text))
+
+                    case d: Tel.Document =>
+                      // A repeatable scalar field: all occurrences inline or
+                      // none (§22.2). A single occurrence still terminates
+                      // the run — a repeatable member holds its atom
+                      // position and would consume any atom that followed —
+                      // so it takes the child form. An empty collection (or
+                      // Unset Optional) contributes nothing but breaks the
+                      // run, exactly like an absent Scalar member.
+                      val children = d.children.bind(_.compounds)
+
+                      if children.length == 0 then members += Mutation.Member.Break
+                      else if children.length == 1
+                      then members += Mutation.Member.Child(children(0).copy(keyword = keyword))
+                      else
+                        var collision = false
+                        val texts = scala.collection.mutable.ListBuffer.empty[Text]
+
+                        children.each: child =>
+                          val text =
+                            if child.atoms.length == 0 then t""
+                            else Positional.text(child.atoms(0))
+
+                          if elidedFlags.contains(text) then collision = true
+                          texts += text
+
+                        if collision then children.each: child =>
+                          members += Mutation.Member.Child(child.copy(keyword = keyword))
+                        else members += Mutation.Member.Value(keyword, List.of(texts.toList))
+
+                case Tel.Nature.Struct =>
+                  val encoded = contextual.constructed(fieldValue)
+
+                  encoded.subtree match
+                    case c: Tel.Compound =>
+                      members += Mutation.Member.Child(c.copy(keyword = keyword))
+
+                    case d: Tel.Document =>
+                      val children = d.children.bind(_.compounds)
+
+                      if children.length == 0 then members += Mutation.Member.Break
+                      else children.each: child =>
+                        members += Mutation.Member.Child(child.copy(keyword = keyword))
+
+          members.toList
+
+        // The canonical child form: this record's compound with its §22.2
+        // leading inline run, for embedding under a keyword.
+        override def constructed(value: derivation): Tel =
+          Tel.make(Mutation.construct(t"", List.of(membersOf(value)), '#'))
+
+        // The canonical document form: the root carries no atoms (§20.2),
+        // so a leading `Break` suppresses the root's own run while nested
+        // records keep theirs.
+        override def canonicalized(value: derivation): Tel =
+          val compound =
+            Mutation.construct(t"", List.of(Mutation.Member.Break :: membersOf(value)), '#')
+
+          Tel.make(Tel.Document(Unset, Unset, Tel.LineEndings.Lf, compound.children))
+
     inline def disjunction[derivation: SumReflection]: derivation is Tel.Encodable =
       // A sum encodes as a document whose single child compound is the chosen variant,
       // keyed by the variant's (kebab-cased) name with the variant's fields as its own
@@ -471,13 +578,30 @@ trait Tel2 extends Tel3:
       // round-trips identically to the same document parsed from text. The codec-carried
       // shape stays permissive (`Any`); the precise select schema comes from the standalone
       // `Schematic` / `Tels.tels`.
-      Tel.Encodable(() => Morphology.Any):
-        value =>
+      new Tel.Encodable:
+        type Self = derivation
+        def shape(): Morphology = Morphology.Any
+
+        def encoded(value: derivation): Tel =
           variant(value): [variant <: derivation] =>
             v =>
               val keyword: Text = Tel.camelToKebab(label.s)
 
               contextual.encode(v).subtree match
+                case compound: Tel.Compound =>
+                  Tel.compound(t"", Array.empty, Array.of(compound.copy(keyword = keyword)))
+
+                case other =>
+                  Tel.make(other)
+
+        // The canonical child form: the chosen variant in its own §22.2
+        // construct form, so a record variant carries its inline run.
+        override def constructed(value: derivation): Tel =
+          variant(value): [variant <: derivation] =>
+            v =>
+              val keyword: Text = Tel.camelToKebab(label.s)
+
+              contextual.constructed(v).subtree match
                 case compound: Tel.Compound =>
                   Tel.compound(t"", Array.empty, Array.of(compound.copy(keyword = keyword)))
 
@@ -574,6 +698,9 @@ trait Tel2 extends Tel3:
       def encoded(opt: value): Tel =
         opt.let(_.asInstanceOf[inner]).lay(emptyDocument)(encodable.encoded(_))
 
+      override def constructed(opt: value): Tel =
+        opt.let(_.asInstanceOf[inner]).lay(emptyDocument)(encodable.constructed(_))
+
   given optionalDecodable: [inner <: value, value >: Unset.type: Mandatable to inner]
   =>  Tactic[TelError]
   =>  ( decodable0: -> (inner is Tel.Decodable) )
@@ -604,18 +731,41 @@ trait Tel2 extends Tel3:
   // Re-keys an encoded value's compound (or wraps a document) under `keyword`.
   given listEncodable: [list <: List, element] => (encodable: -> (element is Tel.Encodable))
   =>  list[element] is Tel.Encodable =
-    Tel.Encodable(() => Morphology.Arr(encodable.shape())): values =>
-      collectionDocument(values.stdlib)(using encodable)
+    new Tel.Encodable:
+      type Self = list[element]
+      def shape(): Morphology = Morphology.Arr(encodable.shape())
+      override def nature: Tel.Nature = encodable.nature
+      override def optional: Boolean = true
+      def encoded(values: list[element]): Tel = collectionDocument(values.stdlib)(using encodable)
+
+      override def constructed(values: list[element]): Tel =
+        constructedDocument(values.stdlib)(using encodable)
 
   given setEncodable: [set <: Set, element] => (encodable: -> (element is Tel.Encodable))
   =>  set[element] is Tel.Encodable =
-    Tel.Encodable(() => Morphology.Arr(encodable.shape())): values =>
-      collectionDocument(values.stdlib)(using encodable)
+    new Tel.Encodable:
+      type Self = set[element]
+      def shape(): Morphology = Morphology.Arr(encodable.shape())
+      override def nature: Tel.Nature = encodable.nature
+      override def optional: Boolean = true
+      def encoded(values: set[element]): Tel = collectionDocument(values.stdlib)(using encodable)
+
+      override def constructed(values: set[element]): Tel =
+        constructedDocument(values.stdlib)(using encodable)
 
   given seriesEncodable: [sequence <: Sequence, element] => (encodable: -> (element is Tel.Encodable))
   =>  sequence[element] is Tel.Encodable =
-    Tel.Encodable(() => Morphology.Arr(encodable.shape())): values =>
-      collectionDocument(values.stdlib)(using encodable)
+    new Tel.Encodable:
+      type Self = sequence[element]
+      def shape(): Morphology = Morphology.Arr(encodable.shape())
+      override def nature: Tel.Nature = encodable.nature
+      override def optional: Boolean = true
+
+      def encoded(values: sequence[element]): Tel =
+        collectionDocument(values.stdlib)(using encodable)
+
+      override def constructed(values: sequence[element]): Tel =
+        constructedDocument(values.stdlib)(using encodable)
 
   given collectionDecodable: [collection <: Iterable, element]
   =>  ( factory:   Factory[element, collection[element]],

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -332,7 +332,13 @@ trait Tel2 extends Tel3:
           provide[Foci[Tel.Focus]]:
             provide[Tactic[TelError]]:
               provide[Tactic[VariantError]]:
-                val variant: Tel = Tel.make(telVal.childCompounds.head)
+                val compounds = telVal.childCompounds
+
+                // A sum position with no child compound carries no variant to
+                // dispatch on: a decode-layer absence, not a crash.
+                if compounds.nil then abort(TelError(TelError.Reason.Absent))
+
+                val variant: Tel = Tel.make(compounds.head)
                 val variantKeyword: Text = labels.at(variant.keyword).or(variant.keyword)
 
                 delegate(variantKeyword): [variant <: derivation] =>

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -433,7 +433,23 @@ trait Tel2 extends Tel3:
               val encoded = contextual.encode(fieldValue)
               val keyword = renames.at(label).or(Tel.camelToKebab(label.s))
 
-              encoded.subtree match
+              // Flag encoding (§20): `true` is the bare keyword and a plain
+              // `false` flag is omitted, since decoding reads absence as
+              // false. An `Optional[Boolean]`'s `false` stays explicit, so
+              // Unset / true / false remain distinguishable (omitted / bare
+              // keyword / `keyword false`); its Unset encodes an empty
+              // document and emits nothing below.
+              if contextual.nature == Tel.Nature.Flag then
+                encoded.subtree match
+                  case c: Tel.Compound =>
+                    if encoded.primaryAtom == t"true"
+                    then compounds += Tel.Compound(keyword, Array.empty, Unset, Array.empty)
+                    else if encoded.primaryAtom == t"false" && !contextual.optional
+                    then ()
+                    else compounds += c.copy(keyword = keyword)
+
+                  case _ => ()
+              else encoded.subtree match
                 case c: Tel.Compound =>
                   compounds += c.copy(keyword = keyword)
 
@@ -737,8 +753,14 @@ trait Tel2 extends Tel3:
 
   // Helpers used by encoders to construct Tel values.
 
+  // The §22.3 atom-form escalation (inline -> source -> literal) keeps every
+  // encoded value reparseable — a multi-line or space-edged Text can never be
+  // an inline atom. The default `#` sigil is assumed, matching the documents
+  // the encoder produces (it never emits a pragma overriding it). An empty
+  // text stays an empty inline atom: presentationally it serializes as no
+  // atom, but the value level distinguishes present-empty from absent.
   def scalar(text: Text): Tel =
-    Tel.make(Tel.Compound(t"", Array.of(Tel.Atom.Inline(text, 1)), Unset, Array.empty))
+    Tel.make(Tel.Compound(t"", Array.of(Mutation.chooseAtomForm(text, '#')), Unset, Array.empty))
 
   def compound
     ( keyword: Text, atoms: Array[Tel.Atom]^{}, compounds: Array[Tel.Compound]^{} )

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -147,13 +147,14 @@ trait Tel2 extends Tel3:
 
   inline given decodable: [value] => value is Tel.Decodable = summonFrom:
     case given (`value` is Decodable in Text) =>
-      Tel.Decodable(() => Morphology.Str)(provide[Tactic[TelError]](_.primaryAtom.as[value]))
+      Tel.Decodable(() => Morphology.Str, Tel.Nature.Scalar):
+        provide[Tactic[TelError]](_.primaryAtom.as[value])
 
     case given Reflection[`value`] => DecodableDerivation.derived
 
   inline given encodable: [value] => value is Tel.Encodable = summonFrom:
     case given (`value` is Encodable in Text) =>
-      Tel.Encodable(() => Morphology.Str): v => Tel.scalar(v.encode)
+      Tel.Encodable(() => Morphology.Str, Tel.Nature.Scalar): v => Tel.scalar(v.encode)
 
     case given Reflection[`value`] => EncodableDerivation.derived
 
@@ -407,28 +408,30 @@ trait Tel2 extends Tel3:
   // the atom text rather than a JSON AST.
 
   given textDecodable: (tactic: Tactic[TelError]) => ((Text is Tel.Decodable)^{tactic}) =
-    Tel.Decodable(() => Morphology.Str): tel => primitiveFault(tel, t"Text", t""): atom => atom
+    Tel.Decodable(() => Morphology.Str, Tel.Nature.Scalar): tel =>
+      primitiveFault(tel, t"Text", t""): atom => atom
 
   given stringDecodable: (tactic: Tactic[TelError]) => ((String is Tel.Decodable)^{tactic}) =
-    Tel.Decodable(() => Morphology.Str): tel => primitiveFault(tel, t"String", ""): atom => atom.s
+    Tel.Decodable(() => Morphology.Str, Tel.Nature.Scalar): tel =>
+      primitiveFault(tel, t"String", ""): atom => atom.s
 
   given intDecodable: (tactic: Tactic[TelError]) => ((Int is Tel.Decodable)^{tactic}) =
-    Tel.Decodable(() => Morphology.Whole): tel =>
+    Tel.Decodable(() => Morphology.Whole, Tel.Nature.Scalar): tel =>
       primitiveFault(tel, t"Int", 0): atom =>
         try atom.s.toInt catch case _: NumberFormatException => Unset
 
   given longDecodable: (tactic: Tactic[TelError]) => ((Long is Tel.Decodable)^{tactic}) =
-    Tel.Decodable(() => Morphology.Whole): tel =>
+    Tel.Decodable(() => Morphology.Whole, Tel.Nature.Scalar): tel =>
       primitiveFault(tel, t"Long", 0L): atom =>
         try atom.s.toLong catch case _: NumberFormatException => Unset
 
   given doubleDecodable: (tactic: Tactic[TelError]) => ((Double is Tel.Decodable)^{tactic}) =
-    Tel.Decodable(() => Morphology.Real): tel =>
+    Tel.Decodable(() => Morphology.Real, Tel.Nature.Scalar): tel =>
       primitiveFault(tel, t"Double", 0.0): atom =>
         try atom.s.toDouble catch case _: NumberFormatException => Unset
 
   given booleanDecodable: (tactic: Tactic[TelError]) => ((Boolean is Tel.Decodable)^{tactic}) =
-    Tel.Decodable(() => Morphology.Bool): tel =>
+    Tel.Decodable(() => Morphology.Bool, Tel.Nature.Flag): tel =>
       primitiveFault(tel, t"Boolean", false): atom =>
         atom.s match
           case "true"  => true
@@ -438,22 +441,22 @@ trait Tel2 extends Tel3:
   given telDecodable: Tel is Tel.Decodable = Tel.Decodable(() => Morphology.Any)(identity(_))
 
   given textEncodable: Text is Tel.Encodable =
-    Tel.Encodable(() => Morphology.Str): text => Tel.scalar(text)
+    Tel.Encodable(() => Morphology.Str, Tel.Nature.Scalar): text => Tel.scalar(text)
 
   given stringEncodable: String is Tel.Encodable =
-    Tel.Encodable(() => Morphology.Str): s => Tel.scalar(Text(s))
+    Tel.Encodable(() => Morphology.Str, Tel.Nature.Scalar): s => Tel.scalar(Text(s))
 
   given intEncodable: Int is Tel.Encodable =
-    Tel.Encodable(() => Morphology.Whole): i => Tel.scalar(Text(i.toString))
+    Tel.Encodable(() => Morphology.Whole, Tel.Nature.Scalar): i => Tel.scalar(Text(i.toString))
 
   given longEncodable: Long is Tel.Encodable =
-    Tel.Encodable(() => Morphology.Whole): l => Tel.scalar(Text(l.toString))
+    Tel.Encodable(() => Morphology.Whole, Tel.Nature.Scalar): l => Tel.scalar(Text(l.toString))
 
   given doubleEncodable: Double is Tel.Encodable =
-    Tel.Encodable(() => Morphology.Real): d => Tel.scalar(Text(d.toString))
+    Tel.Encodable(() => Morphology.Real, Tel.Nature.Scalar): d => Tel.scalar(Text(d.toString))
 
   given booleanEncodable: Boolean is Tel.Encodable =
-    Tel.Encodable(() => Morphology.Bool): b => Tel.scalar(Text(b.toString))
+    Tel.Encodable(() => Morphology.Bool, Tel.Nature.Flag): b => Tel.scalar(Text(b.toString))
 
   given telEncodable: Tel is Tel.Encodable = Tel.Encodable(() => Morphology.Any)(identity(_))
 
@@ -465,15 +468,29 @@ trait Tel2 extends Tel3:
   given optionalEncodable: [inner <: value, value >: Unset.type: Mandatable to inner]
   =>  ( encodable: inner is Tel.Encodable )
   =>  value is Tel.Encodable =
-    Tel.Encodable(() => Morphology.Opt(encodable.shape())): opt =>
-      opt.let(_.asInstanceOf[inner]).lay(emptyDocument)(_.encode)
+    new Tel.Encodable:
+      type Self = value
+      def shape(): Morphology = Morphology.Opt(encodable.shape())
+      override def nature: Tel.Nature = encodable.nature
+      override def optional: Boolean = true
+
+      def encoded(opt: value): Tel =
+        opt.let(_.asInstanceOf[inner]).lay(emptyDocument)(encodable.encoded(_))
 
   given optionalDecodable: [inner <: value, value >: Unset.type: Mandatable to inner]
   =>  Tactic[TelError]
-  =>  ( decodable: -> (inner is Tel.Decodable) )
+  =>  ( decodable0: -> (inner is Tel.Decodable) )
   =>  value is Tel.Decodable =
-    Tel.Decodable(() => Morphology.Opt(decodable.shape())): telVal =>
-      if telVal.childCompounds.nil && telVal.atomTexts.nil then Unset else decodable.decoded(telVal)
+    new Tel.Decodable:
+      type Self = value
+      def shape(): Morphology = Morphology.Opt(decodable0.shape())
+      override def nature: Tel.Nature = decodable0.nature
+      override def optional: Boolean = true
+      override def absent()(using Tactic[TelError]): value = Unset
+
+      def decoded(telVal: Tel): value =
+        if telVal.childCompounds.nil && telVal.atomTexts.nil then Unset
+        else decodable0.decoded(telVal)
 
   // Collection support (aligned with `#1291`) — a `List`/`Set` encodes to a
   // Document-rooted Tel whose children are the elements' compounds; the product
@@ -508,6 +525,8 @@ trait Tel2 extends Tel3:
       type Self = collection[element]
       def shape(): Morphology = Morphology.Arr(element0.shape())
       override def repeatable: Boolean = true
+      override def nature: Tel.Nature = element0.nature
+      override def optional: Boolean = true
 
       def decoded(telVal: Tel): collection[element] =
         val builder = factory.newBuilder
@@ -534,6 +553,8 @@ trait Tel2 extends Tel3:
       type Self = list[element]
       def shape(): Morphology = Morphology.Arr(element0.shape())
       override def repeatable: Boolean = true
+      override def nature: Tel.Nature = element0.nature
+      override def optional: Boolean = true
 
       def decoded(telVal: Tel): list[element] =
         val builder = scala.collection.immutable.List.newBuilder[element]
@@ -556,6 +577,8 @@ trait Tel2 extends Tel3:
       type Self = set[element]
       def shape(): Morphology = Morphology.Arr(element0.shape())
       override def repeatable: Boolean = true
+      override def nature: Tel.Nature = element0.nature
+      override def optional: Boolean = true
 
       def decoded(telVal: Tel): set[element] =
         val builder = scala.collection.immutable.Set.newBuilder[element]
@@ -578,6 +601,8 @@ trait Tel2 extends Tel3:
       type Self = sequence[element]
       def shape(): Morphology = Morphology.Arr(element0.shape())
       override def repeatable: Boolean = true
+      override def nature: Tel.Nature = element0.nature
+      override def optional: Boolean = true
 
       def decoded(telVal: Tel): sequence[element] =
         val builder = Vector.newBuilder[element]

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -66,6 +66,14 @@ import wisteria.*
 // list contains one Compound per field, keyed by the field's label.
 // Decoding inverts these mappings.
 
+// A present entry with a keyword and no children — the node form under which
+// a bare compound line reaches a scalar or flag decoder. The keywordless
+// empty `Tel` (the historical absent-field fallback, and `Tel.empty`) is
+// excluded, so absence keeps raising `Absent`.
+private[stratiform] def bareCompound(tel: Tel): Boolean = tel.subtree match
+  case c: Tel.Compound => c.keyword != t"" && tel.childCompounds.nil
+  case _               => false
+
 // Register a decode error and continue with `sentinel` instead of aborting, so
 // that sibling fields of a product can each accrue their own error under a
 // `validate[Tel.Focus]` boundary. A field with no atom (the empty `Tel` handed
@@ -264,6 +272,20 @@ trait Tel2 extends Tel3:
     inline def conjunction[derivation <: Product: ProductReflection]
     :   derivation is Tel.Decodable =
 
+      // `@name[Tel]` / bare `@name` renames and the per-field positional
+      // profiles are per-derivation constants, hoisted out of the decode
+      // call (lazily, so recursive types tie their knot).
+      lazy val renames: Map[Text, Text] = relabelling[derivation, Tel]
+
+      lazy val profiles: Array[Positional.Profile]^{} =
+        contexts[derivation]():
+          [field] => context =>
+            Positional.Profile
+              ( renames.at(label).or(Tel.camelToKebab(label.s)),
+                context.nature,
+                context.repeatable,
+                required = !(context.optional || default[Optional[field]].present) )
+
       // The object `Morphology` is built from the field decoders' own shapes (a single
       // inlined `contexts` traversal — kept here, not factored out, so it does not
       // perturb the `build` traversal), keeping a fused `Decodable & Schematic`
@@ -278,13 +300,22 @@ trait Tel2 extends Tel3:
         telVal =>
           provide[Foci[Tel.Focus]]:
             provide[Tactic[TelError]]:
-              // `@name[Tel]` / bare `@name` renames: field name -> keyword, used
-              // verbatim; an unannotated field falls back to its camel→kebab form.
-              val renames: Map[Text, Text] = relabelling[derivation, Tel]
+              // §19.2 positional pre-pass (issue #1694): the compound's own
+              // atoms fill fields in declaration order, per the schema-free
+              // §20.2 step 3. The dominant wire form has no atoms and skips
+              // the pass entirely.
+              val atoms = telVal.atoms
+
+              val assigned: Array[List[Tel.Atom]]^{} =
+                if atoms.length == 0 then Array.empty else Positional.assign(atoms, profiles)
 
               build[derivation]: [field] =>
                 ctx =>
                   val keyword: Text = renames.at(label).or(Tel.camelToKebab(label.s))
+
+                  val positional: scala.collection.immutable.List[Tel.Atom] =
+                    if assigned.length == 0 then scala.collection.immutable.Nil
+                    else assigned(index).stdlib
 
                   // Tag every error registered while decoding this field with its
                   // keyword path, so that under a `validate[Tel.Focus]` boundary the
@@ -296,10 +327,29 @@ trait Tel2 extends Tel3:
                   }):
                     // A `List`/`Set` field (`ctx.repeatable`) is encoded as repeated
                     // keyword compounds, so gather them all into a Document for the
-                    // collection decoder. Every other field — scalar, nested product,
-                    // `Optional`, `Map` (a single `entries` compound) — reads one match.
+                    // collection decoder — positionally-assigned atoms first, since
+                    // atoms precede children (§18.3 step 4). Every other field —
+                    // scalar, nested product, `Optional`, `Map` (a single `entries`
+                    // compound) — reads one match.
                     if ctx.repeatable then
-                      val compounds = telVal.childCompounds.filter(_.keyword == keyword)
+                      val compounds =
+                        if positional.isEmpty
+                        then telVal.childCompounds.filter(_.keyword == keyword)
+                        else
+                          val buffer = scala.collection.mutable.ArrayBuffer.empty[Tel.Compound]
+
+                          // A flag's atom is its keyword, meaning presence: it
+                          // becomes a bare compound, not an atom-bearing one.
+                          positional.foreach: atom =>
+                            buffer +=
+                              ( if ctx.nature == Tel.Nature.Flag
+                                then Tel.Compound(keyword, Array.empty, Unset, Array.empty)
+                                else Tel.Compound(keyword, Array.of(atom), Unset, Array.empty) )
+
+                          telVal.childCompounds.each: compound =>
+                            if compound.keyword == keyword then buffer += compound
+
+                          Array.from(buffer)
 
                       ctx.decoded:
                         Tel.make
@@ -309,8 +359,23 @@ trait Tel2 extends Tel3:
                     else
                       val match0 = telVal.field(keyword)
 
-                      if match0.absent then default.or(ctx.decoded(Tel.empty))
-                      else ctx.decoded(match0.vouch)
+                      if positional.isEmpty then
+                        if match0.absent then default.or(ctx.absent())
+                        else ctx.decoded(match0.vouch)
+                      else
+                        // §20.2 step 5c: an inline atom plus a same-keyword
+                        // child fills a non-repeatable member twice (E308).
+                        // The atom wins — atoms precede children.
+                        if match0.present
+                        then raise(TelError(TelError.Reason.NonRepeatableTooMany))
+
+                        ctx.decoded:
+                          Tel.make:
+                            // A flag's atom is its keyword, meaning presence:
+                            // it becomes a bare compound.
+                            if ctx.nature == Tel.Nature.Flag
+                            then Tel.Compound(keyword, Array.empty, Unset, Array.empty)
+                            else Tel.Compound(keyword, Array.of(positional.head), Unset, Array.empty)
 
     inline def disjunction[derivation: SumReflection]: derivation is Tel.Decodable =
       // A sum is a document whose single child compound is the chosen variant, keyed by
@@ -407,13 +472,19 @@ trait Tel2 extends Tel3:
   // atom. These mirror jacinta.Json's primitive decoders but go through
   // the atom text rather than a JSON AST.
 
+  // A present, keyword-bearing compound with no atom is the empty string
+  // (§18.3/§20.2 step 1: a Scalar's value is its atom of any form, or the
+  // empty string if it has none); a keywordless empty node — the historical
+  // absent-field fallback — still raises `Absent`.
   given textDecodable: (tactic: Tactic[TelError]) => ((Text is Tel.Decodable)^{tactic}) =
     Tel.Decodable(() => Morphology.Str, Tel.Nature.Scalar): tel =>
-      primitiveFault(tel, t"Text", t""): atom => atom
+      if tel.atomTexts.isEmpty && bareCompound(tel) then t""
+      else primitiveFault(tel, t"Text", t""): atom => atom
 
   given stringDecodable: (tactic: Tactic[TelError]) => ((String is Tel.Decodable)^{tactic}) =
     Tel.Decodable(() => Morphology.Str, Tel.Nature.Scalar): tel =>
-      primitiveFault(tel, t"String", ""): atom => atom.s
+      if tel.atomTexts.isEmpty && bareCompound(tel) then ""
+      else primitiveFault(tel, t"String", ""): atom => atom.s
 
   given intDecodable: (tactic: Tactic[TelError]) => ((Int is Tel.Decodable)^{tactic}) =
     Tel.Decodable(() => Morphology.Whole, Tel.Nature.Scalar): tel =>
@@ -430,13 +501,23 @@ trait Tel2 extends Tel3:
       primitiveFault(tel, t"Double", 0.0): atom =>
         try atom.s.toDouble catch case _: NumberFormatException => Unset
 
+  // Flag semantics (§20): a present, keyword-bearing compound with no atom
+  // is the bare flag form, meaning `true`; an absent field decodes `false`
+  // via `absent()`. The explicit `true`/`false` atom forms stay readable.
   given booleanDecodable: (tactic: Tactic[TelError]) => ((Boolean is Tel.Decodable)^{tactic}) =
-    Tel.Decodable(() => Morphology.Bool, Tel.Nature.Flag): tel =>
-      primitiveFault(tel, t"Boolean", false): atom =>
-        atom.s match
-          case "true"  => true
-          case "false" => false
-          case _       => Unset
+    new Tel.Decodable:
+      type Self = Boolean
+      def shape(): Morphology = Morphology.Bool
+      override def nature: Tel.Nature = Tel.Nature.Flag
+      override def absent()(using Tactic[TelError]): Boolean = false
+
+      def decoded(tel: Tel): Boolean =
+        if tel.atomTexts.isEmpty && bareCompound(tel) then true
+        else primitiveFault(tel, t"Boolean", false): atom =>
+          atom.s match
+            case "true"  => true
+            case "false" => false
+            case _       => Unset
 
   given telDecodable: Tel is Tel.Decodable = Tel.Decodable(() => Morphology.Any)(identity(_))
 
@@ -489,7 +570,11 @@ trait Tel2 extends Tel3:
       override def absent()(using Tactic[TelError]): value = Unset
 
       def decoded(telVal: Tel): value =
-        if telVal.childCompounds.nil && telVal.atomTexts.nil then Unset
+        // A bare entry means `Unset` for most types, but a Flag-natured
+        // inner reads it as flag presence (`Optional[Boolean]` of `true`).
+        if telVal.childCompounds.nil && telVal.atomTexts.nil
+           && decodable0.nature != Tel.Nature.Flag
+        then Unset
         else decodable0.decoded(telVal)
 
   // Collection support (aligned with `#1291`) — a `List`/`Set` encodes to a
@@ -632,14 +717,20 @@ trait Tel2 extends Tel3:
 
       Tel.compound(t"", Array.empty, entries)
 
-  given mapDecodable: [key: Tel.Decodable, value: Tel.Decodable] => Tactic[TelError]
-  =>  Map[key, value] is Tel.Decodable =
-    Tel.Decodable(() => Morphology.Dict(key.shape(), value.shape())): telVal =>
+  given mapDecodable: [key, value]
+  =>  ( keyCodec:   key is Tel.Decodable,
+        valueCodec: value is Tel.Decodable,
+        tactic:     Tactic[TelError] )
+  =>  ((Map[key, value] is Tel.Decodable)^{tactic}) =
+    Tel.Decodable(() => Morphology.Dict(keyCodec.shape(), valueCodec.shape())): telVal =>
       var accumulator = Map.empty[key, value]
 
       for entry <- telVal.fields(t"entries") do
-        val k = key.decoded(entry.field(t"key").or(Tel.empty))
-        val v = value.decoded(entry.field(t"value").or(Tel.empty))
+        // A missing `key`/`value` child routes through `absent()` rather
+        // than decoding an empty node, so flag-natured values report their
+        // absent form (`false`) instead of misreading emptiness.
+        val k = entry.field(t"key").lay(keyCodec.absent())(keyCodec.decoded(_))
+        val v = entry.field(t"value").lay(valueCodec.absent())(valueCodec.decoded(_))
         accumulator = accumulator.updated(k, v)
 
       accumulator

--- a/lib/stratiform/src/core/stratiform.TelError.scala
+++ b/lib/stratiform/src/core/stratiform.TelError.scala
@@ -192,6 +192,9 @@ object TelError:
       case NotScalar(value, expected) =>
         m"the value $value could not be parsed as $expected"
 
+      case NestingLimitExceeded =>
+        m"the document nesting exceeds the supported limit of 256"
+
     // The §19.5 recovery strategy for a parse/validation reason, or `Unset` for a
     // decode reason (E4xx), which accrues through `Foci` rather than the parser's
     // recovery model.
@@ -235,8 +238,9 @@ object TelError:
         | ValidatorRejected | FlagWithContent =>
         Recovery.IgnoreErroneousNode
 
-      // E4xx decode reasons have no parser-level recovery.
-      case Absent | NotScalar(_, _) =>
+      // E4xx decode reasons and implementation-reserved resource errors have
+      // no parser-level recovery.
+      case Absent | NotScalar(_, _) | NestingLimitExceeded =>
         Unset
 
   enum Reason(val number: Int) extends Clarification:
@@ -302,6 +306,10 @@ object TelError:
     // recovery model, so they carry no `Recovery` strategy.
     case Absent                                 extends Reason(401)
     case NotScalar(value: Text, expected: Text) extends Reason(402)
+
+    // Implementation-reserved (§20.2 assigns no TEL error code): resource
+    // limits that are properties of the implementation, not the document.
+    case NestingLimitExceeded                   extends Reason(501)
 
 case class TelError(reason: TelError.Reason, position: Optional[TelError.Position] = Unset)
   ( using Diagnostics )

--- a/lib/stratiform/src/core/stratiform.TelReader.scala
+++ b/lib/stratiform/src/core/stratiform.TelReader.scala
@@ -143,6 +143,10 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // deeper — the step before a nested record's field loop.
   update def finishLine(): Unit = parser.directFinishLine()(using errorTactic)
 
+  // As `finishLine`, but returning the entry line's atoms (all presentation
+  // forms) for the derived record parser's §19.2 positional pre-pass.
+  update def lineAtoms(): Array[Tel.Atom]^{} = parser.directFinishLineAtoms()(using errorTactic)
+
   // Skips the entry entirely: unknown keywords, and duplicate occurrences
   // of a non-repeatable field (the AST's first-match-wins semantics).
   update def skipEntry(indent: Int): Unit = parser.directSkipEntry(indent)(using errorTactic)

--- a/lib/stratiform/src/core/stratiform_core.scala
+++ b/lib/stratiform/src/core/stratiform_core.scala
@@ -78,6 +78,23 @@ private[stratiform] def collectionDocument[value]
   Tel(Tel.Document(Unset, Unset, Tel.LineEndings.Lf,
       Array.of(Tel.Block(Array.empty, Unset, compounds, 0))))
 
+// As `collectionDocument`, but embedding each element in its §22.2 canonical child form
+// (`constructed`), so nested records keep their inline runs under `Tel.canonical`.
+private[stratiform] def constructedDocument[value]
+    (values: Iterable[value])(using encodable: value is Tel.Encodable)
+:   Tel =
+
+  val compounds: Array[Tel.Compound]^{} = Array.from:
+    values.flatMap: element =>
+      encodable.constructed(element).subtree match
+        case compound: Tel.Compound => List(compound).stdlib
+
+        case document: Tel.Document =>
+          document.children.flatMap(_.compounds).toSeq
+
+  Tel(Tel.Document(Unset, Unset, Tel.LineEndings.Lf,
+      Array.of(Tel.Block(Array.empty, Unset, compounds, 0))))
+
 // Re-keys a replacement compound to the original child's keyword (so a positional optic update
 // preserves field identity).
 private[stratiform] def rewrap(original: Tel.Compound, replacement: Tel): Tel.Compound =

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -113,6 +113,53 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
     scalars  = Array.empty,
     selects  = Array.empty)
 
+  // An optional `item` record member (one required scalar) beside a required
+  // `name` scalar: an atom-phase defect inside `item` must accrue alongside
+  // the missing-member defect at the root rather than aborting.
+  private val atomAccrualSchema: Tels = Tels(
+    name     = t"atoms",
+    document = Tels.Struct(
+      members = Array.of(
+        Tels.Field
+         ( Tels.Polarity.Loose, Tels.Polarity.Implicit,
+           t"item", Tels.Reference(t"Item"), Unset ),
+        Tels.Field
+         ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+           t"name", Tels.Scalar(Array.of(t"string")), Unset )),
+      validators = Array.empty),
+    layers   = Array.empty,
+    sigil    = Unset,
+    records  = Array.of(Tels.RecordDefinition(
+      t"Item",
+      Array.of(Tels.Field
+       ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+         t"only", Tels.Scalar(Array.of(t"string")), Unset )),
+      Array.empty)),
+    scalars  = Array.empty,
+    selects  = Array.empty)
+
+  // Like `atomAccrualSchema`, but `Item` carries a single required Flag: a
+  // mismatched atom is E305 and the flag then also reports absent (E307).
+  private val flagAccrualSchema: Tels = Tels(
+    name     = t"flags",
+    document = Tels.Struct(
+      members = Array.of(
+        Tels.Field
+         ( Tels.Polarity.Loose, Tels.Polarity.Implicit,
+           t"item", Tels.Reference(t"Item"), Unset ),
+        Tels.Field
+         ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+           t"name", Tels.Scalar(Array.of(t"string")), Unset )),
+      validators = Array.empty),
+    layers   = Array.empty,
+    sigil    = Unset,
+    records  = Array.of(Tels.RecordDefinition(
+      t"Item",
+      Array.of(Tels.Field(Tels.Polarity.Implicit, Tels.Polarity.Implicit, t"a", Tels.Flag, Unset)),
+      Array.empty)),
+    scalars  = Array.empty,
+    selects  = Array.empty)
+
   def run(): Unit =
     suite(m"Single-error decoding (sanity)"):
       test(m"Fully-valid record: no errors accrued"):
@@ -204,6 +251,25 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
         validateAssign(doc, optionalFieldSchema).items.all:
           case (_, err) => err.reason == TelError.Reason.UnknownKeyword
       . assert(identity)
+
+    suite(m"Type-assignment accrual (atom phase and constraints)"):
+      test(m"An excess atom and a missing member accrue together"):
+        val doc = t"item x y\n".read[Tel]
+        validateAssign(doc, atomAccrualSchema).items.map(_(1).reason).to[Set]
+      . assert(_ == Set(TelError.Reason.TooManyAtoms, TelError.Reason.RequiredMemberAbsent))
+
+      test(m"A mismatched flag atom accrues E305 and the flag reports absent"):
+        val doc = t"item xyz\nname n\n".read[Tel]
+        validateAssign(doc, flagAccrualSchema).items.map(_(1).reason).to[Set]
+      . assert: reasons =>
+          reasons == Set
+           ( TelError.Reason.AtomFlagKeywordMismatch,
+             TelError.Reason.RequiredMemberAbsent )
+
+      test(m"A duplicated non-repeatable member accrues a single E308"):
+        val doc = t"name Alice\nname Bob\nemail e\n".read[Tel]
+        validateAssign(doc, twoRequiredSchema).items.map(_(1).reason).to[Set]
+      . assert(_ == Set(TelError.Reason.NonRepeatableTooMany))
 
     suite(m"Parser-recovery accrual (E1xx)"):
       test(m"Two trailing-space lines accrue two errors"):

--- a/lib/stratiform/src/test/stratiform.EquivalenceTests.scala
+++ b/lib/stratiform/src/test/stratiform.EquivalenceTests.scala
@@ -1,0 +1,180 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import soundness.*
+
+import proscenium.compat.*
+
+import strategies.throwUnsafely
+import errorDiagnostics.stackTracesDiagnostics
+import charEncoders.utf8Encoder
+import Tel.given
+
+// The differential property issue #1694 proposes: for a document and a schema
+// derived from the corresponding Scala type, decoding through the codecs must
+// agree with decoding through `Tel.Type.assign` — a divergence between the
+// two layers is caught even when both "succeed", by projecting the semantic
+// element tree and comparing it against a hand-written oracle.
+object EquivalenceTests extends Suite(m"Stratiform schema/codec equivalence tests"):
+
+  case class Issues(items: List[(Text, TelError)] = Nil)(using Diagnostics)
+  extends Error(m"${items.length} validation issues"):
+    def +(focus: Text, error: TelError): Issues = Issues(items :+ (focus, error))
+
+  private def validateAssign(tel: Tel, schema: Tels): Issues =
+    validate[Tel.Focus](Issues()):
+      case error: TelError =>
+        // Explicit: `Tel.given` is in scope, whose blanket Tel encodable
+        // would otherwise beat `TelPath`'s text form under `.encode`.
+        accrual + (prior.let { focus => TelPath.encodable.encoded(focus.pointer) }.or(t"#"), error)
+    . protect(Tel.Type.assign(tel, schema))
+
+  // Projects the semantic tree to (path-of-flat-keyword-indexes, text) pairs
+  // in depth-first order; a Flag node projects as "+". This is the oracle the
+  // decoded value's fields are checked against.
+  private def scalars(element: Tel.Element): scala.collection.immutable.List[(String, String)] =
+    val buffer = scala.collection.mutable.ListBuffer.empty[(String, String)]
+
+    def recur(element: Tel.Element, prefix: String): Unit = element match
+      case Tel.Element.Value(idx, _, text) => buffer += ((prefix + "/" + idx, text.s))
+
+      case Tel.Element.Node(idx, Tels.Flag, _) =>
+        buffer += ((prefix + "/" + idx.or(-1), "+"))
+
+      case Tel.Element.Node(idx, _, children) =>
+        val next = idx.lay(prefix)(prefix + "/" + _)
+        var i = 0
+
+        while i < children.length do
+          recur(children.readable(i), next)
+          i += 1
+
+    recur(element, "#")
+    buffer.toList
+
+  // The full equivalence check for one fixture: both codec paths produce
+  // `expected`; type assignment against `schema` accrues nothing and its
+  // scalar projection matches `oracle`; and the encoded form of `expected`
+  // decodes back and validates cleanly too.
+  private inline def equivalent[value](document: Text, schema: Tels, expected: value,
+      oracle: scala.collection.immutable.List[(String, String)])
+    ( using value is Tel.Parsable, value is Tel.Decodable, value is Tel.Encodable )
+  :   Boolean =
+
+    val parsed  = document.read[Tel]
+    val encoded = expected.encode
+
+    document.read[Tel].as[value] == expected
+    && document.read[value in Tel] == expected
+    && validateAssign(parsed, schema).items.length == 0
+    && scalars(Tel.Type.assign(parsed, schema)) == oracle
+    && encoded.as[value] == expected
+    && validateAssign(encoded, schema).items.length == 0
+
+  def run(): Unit =
+    suite(m"Codec/assign equivalence (positive)"):
+      given PRecipient is Tel.Parsable = Tel.Parsable.derived
+      given PDelivery is Tel.Parsable = Tel.Parsable.derived
+      given PLog is Tel.Parsable = Tel.Parsable.derived
+      given PLogBook is Tel.Parsable = Tel.Parsable.derived
+      given PNote is Tel.Parsable = Tel.Parsable.derived
+
+      test(m"positional atoms agree across codecs and type assignment (#1694)"):
+        equivalent[PDelivery]
+         ( t"recipient  Acme Corporation\n  address  1 Acme Way\n",
+           Tels.tels[PDelivery](t"delivery"),
+           PDelivery(PRecipient(t"Acme Corporation", t"1 Acme Way")),
+           scala.collection.immutable.List
+            ( ("#/0/0", "Acme Corporation"),
+              ("#/0/1", "1 Acme Way") ) )
+      . assert(identity)
+
+      test(m"a repeatable split between atoms and children agrees"):
+        equivalent[PLogBook]
+         ( t"log lbl 1\n  values 2\n",
+           Tels.tels[PLogBook](t"logbook"),
+           PLogBook(PLog(t"lbl", List(1, 2))),
+           scala.collection.immutable.List
+            ( ("#/0/0", "lbl"),
+              ("#/0/1", "1"),
+              ("#/0/1", "2") ) )
+      . assert(identity)
+
+      test(m"a source atom agrees across codecs and type assignment"):
+        equivalent[PNote]
+         ( t"body\n    line one\n    line two\n",
+           Tels.tels[PNote](t"note"),
+           PNote(t"line one\nline two"),
+           scala.collection.immutable.List(("#/0", "line one\nline two")) )
+      . assert(identity)
+
+    suite(m"Codec/assign equivalence (negative)"):
+      test(m"both layers reject an atom overflow with E302"):
+        val doc = t"recipient a b c\n"
+        val schema = Tels.tels[PDelivery](t"delivery")
+        val schemaReasons = validateAssign(doc.read[Tel], schema).items.map(_(1).reason).to[Set]
+        val codecReason = capture[TelError](doc.read[Tel].as[PDelivery]).reason
+        (schemaReasons, codecReason)
+      . assert(_ == (Set(TelError.Reason.TooManyAtoms), TelError.Reason.TooManyAtoms))
+
+    suite(m"Codec/assign equivalence (flags, hand-built schema)"):
+      // The schema derivation does not yet model Boolean fields as Flag
+      // members, so the flag fixture pairs the codecs against a hand-built
+      // schema with true Flag members.
+      val flagsSchema = Tels(
+        name     = t"flags",
+        document = Tels.Struct(
+          members = Array.of(
+            Tels.Field(Tels.Polarity.Loose, Tels.Polarity.Implicit, t"active", Tels.Flag, Unset),
+            Tels.Field(Tels.Polarity.Loose, Tels.Polarity.Implicit, t"verbose", Tels.Flag, Unset)),
+          validators = Array.empty),
+        layers   = Array.empty,
+        sigil    = Unset,
+        records  = Array.empty,
+        scalars  = Array.empty,
+        selects  = Array.empty)
+
+      test(m"a bare flag agrees across codecs and type assignment"):
+        val doc = t"active\n"
+        val decoded = doc.read[Tel].as[PFlags] == PFlags(true, Unset)
+        val issues = validateAssign(doc.read[Tel], flagsSchema).items.length
+        val oracle = scalars(Tel.Type.assign(doc.read[Tel], flagsSchema))
+        (decoded, issues, oracle)
+      . assert(_ == (true, 0, scala.collection.immutable.List(("#/0", "+"))))
+
+      test(m"the encoded flag form validates against the flag schema"):
+        val encoded = PFlags(true, Unset).encode
+        val issues = validateAssign(encoded, flagsSchema).items.length
+        (encoded.as[PFlags], issues)
+      . assert(_ == (PFlags(true, Unset), 0))

--- a/lib/stratiform/src/test/stratiform.EquivalenceTests.scala
+++ b/lib/stratiform/src/test/stratiform.EquivalenceTests.scala
@@ -131,6 +131,11 @@ object EquivalenceTests extends Suite(m"Stratiform schema/codec equivalence test
               ("#/0/1", "2") ) )
       . assert(identity)
 
+      test(m"the canonical form validates against the derived schema"):
+        val doc = Tel.canonical(PDelivery(PRecipient(t"Acme Corporation", t"1 Acme Way")))
+        validateAssign(doc, Tels.tels[PDelivery](t"delivery")).items.length
+      . assert(_ == 0)
+
       test(m"a source atom agrees across codecs and type assignment"):
         equivalent[PNote]
          ( t"body\n    line one\n    line two\n",

--- a/lib/stratiform/src/test/stratiform.PositionalTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionalTests.scala
@@ -101,3 +101,62 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
       test(m"excess atoms raise E302"):
         capture[TelError](t"item a xyz extra\n".read[Tel].as[PHolder]).reason
       . assert(_ == TelError.Reason.TooManyAtoms)
+
+    suite(m"Positional atom decoding (§19.2, direct path)"):
+      given PRecipient is Tel.Parsable = Tel.Parsable.derived
+      given PDelivery is Tel.Parsable = Tel.Parsable.derived
+      given PFlagItem is Tel.Parsable = Tel.Parsable.derived
+      given PHolder is Tel.Parsable = Tel.Parsable.derived
+      given PLog is Tel.Parsable = Tel.Parsable.derived
+      given PLogBook is Tel.Parsable = Tel.Parsable.derived
+      given PFlags is Tel.Parsable = Tel.Parsable.derived
+      given PPair is Tel.Parsable = Tel.Parsable.derived
+      given PPairBox is Tel.Parsable = Tel.Parsable.derived
+
+      // The acceptance criterion: the direct read equals the AST-path read.
+      inline def parity[value](tel: Text)(using value is Tel.Parsable, value is Tel.Decodable)
+      :   Boolean =
+        tel.read[value in Tel] == tel.read[Tel].as[value]
+
+      test(m"inline atoms assign positionally, equally on both paths (#1694)"):
+        val doc = t"recipient  Acme Corporation\n  address  1 Acme Way\n"
+        (doc.read[PDelivery in Tel], parity[PDelivery](doc))
+      . assert(_ == (PDelivery(PRecipient(t"Acme Corporation", t"1 Acme Way")), true))
+
+      test(m"the worked example parses directly, equally on both paths"):
+        val doc = t"item a xyz\n"
+        (doc.read[PHolder in Tel], parity[PHolder](doc))
+      . assert(_ == (PHolder(PFlagItem(true, Unset, t"xyz")), true))
+
+      test(m"a repeatable field consumes the rest, equally on both paths"):
+        val doc = t"log lbl 1 2 3\n"
+        (doc.read[PLogBook in Tel], parity[PLogBook](doc))
+      . assert(_ == (PLogBook(PLog(t"lbl", List(1, 2, 3))), true))
+
+      test(m"repeatable occurrences split atoms/children, equally on both paths"):
+        val doc = t"log lbl 1\n  values 2\n"
+        (doc.read[PLogBook in Tel], parity[PLogBook](doc))
+      . assert(_ == (PLogBook(PLog(t"lbl", List(1, 2))), true))
+
+      test(m"bare and absent flags parse directly, equally on both paths"):
+        val doc = t"active\n"
+        (doc.read[PFlags in Tel], parity[PFlags](doc))
+      . assert(_ == (PFlags(true, Unset), true))
+
+      test(m"a bare optional flag parses as present true, equally on both paths"):
+        val doc = t"active\nverbose\n"
+        (doc.read[PFlags in Tel], parity[PFlags](doc))
+      . assert(_ == (PFlags(true, true), true))
+
+      test(m"optional scalars fill per §20.8, equally on both paths"):
+        val doc = t"pair hello\n  second world\n"
+        (doc.read[PPairBox in Tel], parity[PPairBox](doc))
+      . assert(_ == (PPairBox(PPair(t"hello", t"world")), true))
+
+      test(m"an atom plus a same-keyword child raises E308 on the direct path"):
+        capture[TelError](t"log lbl\n  label dup\n".read[PLogBook in Tel]).reason
+      . assert(_ == TelError.Reason.NonRepeatableTooMany)
+
+      test(m"excess atoms raise E302 on the direct path"):
+        capture[TelError](t"item a xyz extra\n".read[PHolder in Tel]).reason
+      . assert(_ == TelError.Reason.TooManyAtoms)

--- a/lib/stratiform/src/test/stratiform.PositionalTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionalTests.scala
@@ -54,6 +54,8 @@ case class PFlags(active: Boolean, verbose: Optional[Boolean]) derives CanEqual
 case class PPair(first: Optional[Text], second: Optional[Text]) derives CanEqual
 case class PPairBox(pair: PPair) derives CanEqual
 case class PNote(body: Text) derives CanEqual
+case class PGuard(flag: Boolean, word: Text) derives CanEqual
+case class PGuardBox(item: PGuard) derives CanEqual
 
 object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
   def run(): Unit =
@@ -208,3 +210,65 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
         val value = PNote(t"line one\nline two")
         value.encode.show.s.tt.read[PNote in Tel] == value
       . assert(identity)
+
+    suite(m"Canonical construction (§22.2)"):
+      given canonicalRecipient: (PRecipient is Tel.Parsable) = Tel.Parsable.derived
+      given canonicalDelivery: (PDelivery is Tel.Parsable) = Tel.Parsable.derived
+      given canonicalLog: (PLog is Tel.Parsable) = Tel.Parsable.derived
+      given canonicalLogBook: (PLogBook is Tel.Parsable) = Tel.Parsable.derived
+      given canonicalPair: (PPair is Tel.Parsable) = Tel.Parsable.derived
+      given canonicalPairBox: (PPairBox is Tel.Parsable) = Tel.Parsable.derived
+      given canonicalGuard: (PGuard is Tel.Parsable) = Tel.Parsable.derived
+      given canonicalGuardBox: (PGuardBox is Tel.Parsable) = Tel.Parsable.derived
+
+      // The canonical text must reparse to the same value on both paths.
+      inline def reparses[value](value0: value)
+        (using value is Tel.Encodable, value is Tel.Decodable, value is Tel.Parsable)
+      :   Boolean =
+        val printed = Tel.canonical(value0).show.s.tt
+        printed.read[Tel].as[value] == value0 && printed.read[value in Tel] == value0
+
+      test(m"a nested record's leading scalars go inline"):
+        Tel.canonical(PDelivery(PRecipient(t"Acme", t"HQ")))
+          .childCompounds.readable.head.atoms.length
+      . assert(_ == 2)
+
+      test(m"the canonical form reparses to the value on both paths"):
+        reparses(PDelivery(PRecipient(t"Acme Corporation", t"1 Acme Way")))
+      . assert(identity)
+
+      test(m"a repeatable's occurrences all go inline and reparse"):
+        val doc = Tel.canonical(PLogBook(PLog(t"lbl", List(1, 2, 3))))
+        (doc.childCompounds.readable.head.atoms.length,
+         reparses(PLogBook(PLog(t"lbl", List(1, 2, 3)))))
+      . assert(_ == (4, true))
+
+      test(m"a single-occurrence repeatable takes the child form"):
+        val doc = Tel.canonical(PLogBook(PLog(t"lbl", List(7))))
+        (doc.childCompounds.readable.head.atoms.length,
+         reparses(PLogBook(PLog(t"lbl", List(7)))))
+      . assert(_ == (1, true))
+
+      test(m"an absent optional scalar terminates the inline run"):
+        val doc = Tel.canonical(PPairBox(PPair(Unset, t"x")))
+        (doc.childCompounds.readable.head.atoms.length,
+         reparses(PPairBox(PPair(Unset, t"x"))))
+      . assert(_ == (0, true))
+
+      test(m"an elided false flag lets the run continue and skip on decode"):
+        val doc = Tel.canonical(PGuardBox(PGuard(false, t"hello")))
+        (doc.childCompounds.readable.head.atoms.length,
+         reparses(PGuardBox(PGuard(false, t"hello"))))
+      . assert(_ == (1, true))
+
+      test(m"a true flag joins the run as its keyword"):
+        val doc = Tel.canonical(PGuardBox(PGuard(true, t"hello")))
+        (doc.childCompounds.readable.head.atoms.length,
+         reparses(PGuardBox(PGuard(true, t"hello"))))
+      . assert(_ == (2, true))
+
+      test(m"a value colliding with an elided flag keyword takes child form"):
+        val doc = Tel.canonical(PGuardBox(PGuard(false, t"flag")))
+        (doc.childCompounds.readable.head.atoms.length,
+         reparses(PGuardBox(PGuard(false, t"flag"))))
+      . assert(_ == (0, true))

--- a/lib/stratiform/src/test/stratiform.PositionalTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionalTests.scala
@@ -39,6 +39,7 @@ import proscenium.compat.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import charEncoders.utf8Encoder
+import Tel.given
 
 // Positional-assignment fixtures (§19.2, issue #1694). The positional cases
 // nest the record one level down, because the document root never carries
@@ -52,6 +53,7 @@ case class PLogBook(log: PLog) derives CanEqual
 case class PFlags(active: Boolean, verbose: Optional[Boolean]) derives CanEqual
 case class PPair(first: Optional[Text], second: Optional[Text]) derives CanEqual
 case class PPairBox(pair: PPair) derives CanEqual
+case class PNote(body: Text) derives CanEqual
 
 object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
   def run(): Unit =
@@ -160,3 +162,49 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
       test(m"excess atoms raise E302 on the direct path"):
         capture[TelError](t"item a xyz extra\n".read[PHolder in Tel]).reason
       . assert(_ == TelError.Reason.TooManyAtoms)
+
+    suite(m"Encoder atom forms and flags (§22.3)"):
+      given PNote is Tel.Parsable = Tel.Parsable.derived
+      given PFlags2: (PFlags is Tel.Parsable) = Tel.Parsable.derived
+
+      test(m"a multi-line Text encodes as a source atom and reparses"):
+        val value = PNote(t"line one\nline two")
+        val sourceForm =
+          value.encode.childCompounds.readable.head.atoms(0).isInstanceOf[Tel.Atom.Source]
+
+        (value.encode.show.s.tt.read[Tel].as[PNote] == value, sourceForm)
+      . assert(_ == (true, true))
+
+      test(m"an unsafe payload escalates to a literal atom and reparses"):
+        val value = PNote(t"para one\n\npara two")
+        val literalForm =
+          value.encode.childCompounds.readable.head.atoms(0).isInstanceOf[Tel.Atom.Literal]
+
+        (value.encode.show.s.tt.read[Tel].as[PNote] == value, literalForm)
+      . assert(_ == (true, true))
+
+      test(m"a true flag encodes as the bare keyword"):
+        val doc = PFlags(true, Unset).encode
+        (doc.childCompounds.readable.length, doc.childCompounds.readable.head.keyword,
+         doc.childCompounds.readable.head.atoms.length)
+      . assert(_ == (1, t"active", 0))
+
+      test(m"a false flag is omitted and an optional false stays explicit"):
+        val doc = PFlags(false, false).encode
+        (doc.childCompounds.readable.length, doc.childCompounds.readable.head.keyword)
+      . assert(_ == (1, t"verbose"))
+
+      test(m"every flag combination round-trips through serialized text"):
+        val values = List
+         ( PFlags(true, Unset), PFlags(false, Unset), PFlags(true, true),
+           PFlags(false, false), PFlags(true, false), PFlags(false, true) )
+
+        values.all: value =>
+          val printed = value.encode.show.s.tt
+          printed.read[Tel].as[PFlags] == value && printed.read[PFlags in Tel] == value
+      . assert(identity)
+
+      test(m"a multi-line Text round-trips on the direct path too"):
+        val value = PNote(t"line one\nline two")
+        value.encode.show.s.tt.read[PNote in Tel] == value
+      . assert(identity)

--- a/lib/stratiform/src/test/stratiform.PositionalTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionalTests.scala
@@ -1,0 +1,103 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import soundness.*
+
+import proscenium.compat.*
+
+import strategies.throwUnsafely
+import errorDiagnostics.stackTracesDiagnostics
+import charEncoders.utf8Encoder
+
+// Positional-assignment fixtures (§19.2, issue #1694). The positional cases
+// nest the record one level down, because the document root never carries
+// atoms (§20.2).
+case class PRecipient(name: Text, address: Optional[Text]) derives CanEqual
+case class PDelivery(recipient: Optional[PRecipient]) derives CanEqual
+case class PFlagItem(a: Boolean, b: Optional[Boolean], c: Text) derives CanEqual
+case class PHolder(item: PFlagItem) derives CanEqual
+case class PLog(label: Text, values: List[Int]) derives CanEqual
+case class PLogBook(log: PLog) derives CanEqual
+case class PFlags(active: Boolean, verbose: Optional[Boolean]) derives CanEqual
+case class PPair(first: Optional[Text], second: Optional[Text]) derives CanEqual
+case class PPairBox(pair: PPair) derives CanEqual
+
+object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
+  def run(): Unit =
+    suite(m"Positional atom decoding (§19.2, AST path)"):
+      test(m"inline atoms assign positionally to record fields (#1694)"):
+        t"recipient  Acme Corporation\n  address  1 Acme Way\n".read[Tel].as[PDelivery]
+      . assert(_ == PDelivery(PRecipient(t"Acme Corporation", t"1 Acme Way")))
+
+      test(m"keyword-child form decodes identically to the positional form"):
+        val positional = t"recipient  Acme Corporation\n  address  1 Acme Way\n"
+        val explicit   = t"recipient\n  name  Acme Corporation\n  address  1 Acme Way\n"
+        positional.read[Tel].as[PDelivery] == explicit.read[Tel].as[PDelivery]
+      . assert(identity)
+
+      test(m"an atom skips an optional flag and fills the scalar (worked example)"):
+        t"item a xyz\n".read[Tel].as[PHolder]
+      . assert(_ == PHolder(PFlagItem(true, Unset, t"xyz")))
+
+      test(m"a repeatable field consumes every remaining atom"):
+        t"log lbl 1 2 3\n".read[Tel].as[PLogBook]
+      . assert(_ == PLogBook(PLog(t"lbl", List(1, 2, 3))))
+
+      test(m"repeatable occurrences split between atoms and children"):
+        t"log lbl 1\n  values 2\n".read[Tel].as[PLogBook]
+      . assert(_ == PLogBook(PLog(t"lbl", List(1, 2))))
+
+      test(m"a bare flag keyword decodes true and an absent flag false"):
+        t"active\n".read[Tel].as[PFlags]
+      . assert(_ == PFlags(true, Unset))
+
+      test(m"a bare optional flag decodes as present true"):
+        t"active\nverbose\n".read[Tel].as[PFlags]
+      . assert(_ == PFlags(true, true))
+
+      test(m"only the first optional scalar fills positionally (§20.8)"):
+        t"pair hello\n".read[Tel].as[PPairBox]
+      . assert(_ == PPairBox(PPair(t"hello", Unset)))
+
+      test(m"a second optional scalar arrives as an explicit child"):
+        t"pair hello\n  second world\n".read[Tel].as[PPairBox]
+      . assert(_ == PPairBox(PPair(t"hello", t"world")))
+
+      test(m"an atom plus a same-keyword child raises E308"):
+        capture[TelError](t"log lbl\n  label dup\n".read[Tel].as[PLogBook]).reason
+      . assert(_ == TelError.Reason.NonRepeatableTooMany)
+
+      test(m"excess atoms raise E302"):
+        capture[TelError](t"item a xyz extra\n".read[Tel].as[PHolder]).reason
+      . assert(_ == TelError.Reason.TooManyAtoms)

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -2849,6 +2849,7 @@ object Tests extends Suite(m"Stratiform Tests"):
     RecordsTests()
     VerifyTests()
     AccrualTests()
+    PositionalTests()
 
     suite(m"BinTEL direct parsing (BintelInlinable)"):
       given (Tests.Person is Bintel.Parsable) = BintelInlinable.parsable[Tests.Person]

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -2850,6 +2850,7 @@ object Tests extends Suite(m"Stratiform Tests"):
     VerifyTests()
     AccrualTests()
     PositionalTests()
+    EquivalenceTests()
 
     suite(m"BinTEL direct parsing (BintelInlinable)"):
       given (Tests.Person is Bintel.Parsable) = BintelInlinable.parsable[Tests.Person]

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -944,6 +944,23 @@ object Tests extends Suite(m"Stratiform Tests"):
           case _                                => -1
       . assert(_ == 3)
 
+      test(m"non-repeatable member filled twice raises E308"):
+        val doc = t"name Alice\nname Bob\n".read[Tel]
+        capture[TelError](Tel.Type.assign(doc, personSchema)).reason
+      . assert(_ == TelError.Reason.NonRepeatableTooMany)
+
+      test(m"repeatable member filled three times is accepted"):
+        val doc = t"a x\na y\na z\nb w\n".read[Tel]
+        Tel.Type.assign(doc, contiguitySchema) match
+          case Tel.Element.Node(_, _, children) => children.readable.length
+          case _                                => -1
+      . assert(_ == 4)
+
+      test(m"absent required SelectRef raises E307"):
+        val doc = t"\n".read[Tel]
+        capture[TelError](Tel.Type.assign(doc, statusSchema)).reason
+      . assert(_ == TelError.Reason.RequiredMemberAbsent)
+
     suite(m"Atom phase (§20.2 step 3)"):
       // Wraps the record under test as the single root member `item`: the
       // document root never carries atoms (§20.2), so the atom phase is
@@ -1065,6 +1082,15 @@ object Tests extends Suite(m"Stratiform Tests"):
 
         capture[TelError](Tel.Type.assign(t"item xyz\n".read[Tel], schema)).reason
       . assert(_ == TelError.Reason.AtomFlagKeywordMismatch)
+
+      test(m"atom plus child for a non-repeatable member raises E308"):
+        val schema = itemSchema(Array.of(
+          Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+             t"only", Tels.Scalar(Array.of(t"string")), Unset )))
+
+        capture[TelError](Tel.Type.assign(t"item x\n  only y\n".read[Tel], schema)).reason
+      . assert(_ == TelError.Reason.NonRepeatableTooMany)
 
     suite(m"Schema default-field"):
       // Like `personSchema`, but the required `name` field carries a default,

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -415,6 +415,26 @@ object Tests extends Suite(m"Stratiform Tests"):
         (doc.read[Tests.OptField in Tel], parity[Tests.OptField](doc))
       . assert(_ == (Tests.OptField(1, t"hello"), true))
 
+      test(m"A source atom supplies a scalar field, equally on both paths"):
+        val doc = t"name\n    Alice\n    Smith\nage 30\n"
+        (doc.read[Tests.Person in Tel], parity[Tests.Person](doc))
+      . assert(_ == (Tests.Person(t"Alice\nSmith", 30), true))
+
+      test(m"A literal atom supplies a scalar field, equally on both paths"):
+        val doc = t"name\n      ---\nAlice  Smith\n      ---\nage 30\n"
+        (doc.read[Tests.Person in Tel], parity[Tests.Person](doc))
+      . assert(_ == (Tests.Person(t"Alice  Smith", 30), true))
+
+      test(m"A source atom supplies a numeric field, equally on both paths"):
+        val doc = t"name Amy\nage\n    30\n"
+        (doc.read[Tests.Person in Tel], parity[Tests.Person](doc))
+      . assert(_ == (Tests.Person(t"Amy", 30), true))
+
+      test(m"A source atom gives an Optional field substance, equally on both paths"):
+        val doc = t"x 1\nnote\n    hello there\n"
+        (doc.read[Tests.OptField in Tel], parity[Tests.OptField](doc))
+      . assert(_ == (Tests.OptField(1, t"hello there"), true))
+
       test(m"Unknown keywords are skipped, including their child subtrees"):
         t"name Amy\nextra one two\n  deep 1\n  deeper\n    x 9\nage 50\n"
         . read[Tests.Person in Tel]

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -961,6 +961,52 @@ object Tests extends Suite(m"Stratiform Tests"):
         capture[TelError](Tel.Type.assign(doc, statusSchema)).reason
       . assert(_ == TelError.Reason.RequiredMemberAbsent)
 
+      // A self-referential schema describing arbitrarily deep nesting, for
+      // the §20.2 recursion-depth limit.
+      val treeSchema = Tels(
+        name     = t"tree",
+        document = Tels.Struct(
+          members = Array.of(Tels.Field
+           ( Tels.Polarity.Loose, Tels.Polarity.Implicit,
+             t"node", Tels.Reference(t"Node"), Unset )),
+          validators = Array.empty),
+        layers   = Array.empty,
+        sigil    = Unset,
+        records  = Array.of(Tels.RecordDefinition(
+          t"Node",
+          Array.of(Tels.Field
+           ( Tels.Polarity.Loose, Tels.Polarity.Implicit,
+             t"node", Tels.Reference(t"Node"), Unset )),
+          Array.empty)),
+        scalars  = Array.empty,
+        selects  = Array.empty)
+
+      def deepDocument(levels: Int): Tel =
+        val sb = new java.lang.StringBuilder
+        var n = 0
+
+        while n < levels do
+          var s = 0
+
+          while s < n*2 do
+            sb.append(' ')
+            s += 1
+
+          sb.append("node\n")
+          n += 1
+
+        sb.toString.tt.read[Tel]
+
+      test(m"nesting beyond 256 levels fail-stops type assignment"):
+        capture[TelError](Tel.Type.assign(deepDocument(300), treeSchema)).reason
+      . assert(_ == TelError.Reason.NestingLimitExceeded)
+
+      test(m"nesting within the depth limit assigns"):
+        Tel.Type.assign(deepDocument(10), treeSchema) match
+          case Tel.Element.Node(_, _, children) => children.readable.length
+          case _                                => -1
+      . assert(_ == 1)
+
     suite(m"Atom phase (§20.2 step 3)"):
       // Wraps the record under test as the single root member `item`: the
       // document root never carries atoms (§20.2), so the atom phase is

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -303,6 +303,10 @@ object Tests extends Suite(m"Stratiform Tests"):
         shape.encode.as[Tests.Shape2]
       . assert(_ == Tests.Shape2.Dot)
 
+      test(m"decoding a sum from an empty node raises Absent, not a crash"):
+        capture[TelError](t"\n".read[Tel].as[Tests.Shape2]).reason
+      . assert(_ == TelError.Reason.Absent)
+
       val tree =
         Tests.Tree(t"root", List(Tests.Tree(t"a", Nil),
             Tests.Tree(t"b", List(Tests.Tree(t"c", Nil)))))

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -871,6 +871,128 @@ object Tests extends Suite(m"Stratiform Tests"):
         capture[TelError](Tel.Type.assign(doc, statusSchema)).reason
       . assert(_ == TelError.Reason.UnknownKeyword)
 
+    suite(m"Atom phase (§20.2 step 3)"):
+      // Wraps the record under test as the single root member `item`: the
+      // document root never carries atoms (§20.2), so the atom phase is
+      // exercised one level down.
+      def itemSchema
+        ( members: Array[Tels.Member],
+          selects: Array[Tels.SelectDefinition] = Array.empty )
+      :   Tels =
+
+        Tels(
+          name     = t"test",
+          document = Tels.Struct(
+            members = Array.of(Tels.Field
+             ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+               t"item", Tels.Reference(t"Item"), Unset )),
+            validators = Array.empty),
+          layers   = Array.empty,
+          sigil    = Unset,
+          records  = Array.of(Tels.RecordDefinition(t"Item", members, Array.empty)),
+          scalars  = Array.empty,
+          selects  = selects)
+
+      // Projects the `item` node's children to (keywordIndex, text) pairs,
+      // with flags carrying empty text.
+      def project(root: Tel.Element) = root match
+        case Tel.Element.Node(_, _, children) if children.readable.length == 1 =>
+          children.readable(0) match
+            case Tel.Element.Node(_, _, inner) =>
+              inner.readable.collect:
+                case Tel.Element.Value(idx, _, text) => (idx, text)
+                case Tel.Element.Node(idx, _, _)     => (idx.or(-1), t"")
+              .toList
+
+            case _ => Nil
+
+        case _ => Nil
+
+      test(m"atom skips optional flag and fills scalar (worked example)"):
+        val schema = itemSchema(Array.of(
+          Tels.Field(Tels.Polarity.Implicit, Tels.Polarity.Implicit, t"a", Tels.Flag, Unset),
+          Tels.Field(Tels.Polarity.Loose, Tels.Polarity.Implicit, t"b", Tels.Flag, Unset),
+          Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+             t"c", Tels.Scalar(Array.of(t"string")), Unset )))
+
+        project(Tel.Type.assign(t"item a xyz\n".read[Tel], schema))
+      . assert(_ == List((0, t""), (2, t"xyz")))
+
+      test(m"repeatable scalar consumes every remaining atom"):
+        val schema = itemSchema(Array.of(
+          Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+             t"label", Tels.Scalar(Array.of(t"string")), Unset ),
+          Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Loose,
+             t"values", Tels.Scalar(Array.of(t"string")), Unset )))
+
+        project(Tel.Type.assign(t"item lbl 1 2 3\n".read[Tel], schema))
+      . assert(_ == List((0, t"lbl"), (1, t"1"), (1, t"2"), (1, t"3")))
+
+      test(m"optional scalar is never skipped (§20.8)"):
+        val schema = itemSchema(Array.of(
+          Tels.Field
+           ( Tels.Polarity.Loose, Tels.Polarity.Implicit,
+             t"first", Tels.Scalar(Array.of(t"string")), Unset ),
+          Tels.Field
+           ( Tels.Polarity.Loose, Tels.Polarity.Implicit,
+             t"second", Tels.Scalar(Array.of(t"string")), Unset )))
+
+        project(Tel.Type.assign(t"item hello\n".read[Tel], schema))
+      . assert(_ == List((0, t"hello")))
+
+      test(m"source atom participates in positional assignment"):
+        val schema = itemSchema(Array.of(
+          Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+             t"body", Tels.Scalar(Array.of(t"string")), Unset )))
+
+        project(Tel.Type.assign(t"item\n    payload\n".read[Tel], schema))
+      . assert(_ == List((0, t"payload")))
+
+      test(m"excess atoms raise E302"):
+        val schema = itemSchema(Array.of(
+          Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+             t"only", Tels.Scalar(Array.of(t"string")), Unset )))
+
+        capture[TelError](Tel.Type.assign(t"item x y\n".read[Tel], schema)).reason
+      . assert(_ == TelError.Reason.TooManyAtoms)
+
+      test(m"atom at required struct-typed member raises E303"):
+        val schema = itemSchema(Array.of(
+          Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+             t"address", Tels.Struct(Array.empty, Array.empty), Unset )))
+
+        capture[TelError](Tel.Type.assign(t"item x\n".read[Tel], schema)).reason
+      . assert(_ == TelError.Reason.AtomAtNonAssignablePos)
+
+      test(m"unmatched variant at required SelectRef raises E304"):
+        val schema = itemSchema(
+          Array.of(Tels.SelectRef
+           ( required   = Tels.Polarity.Implicit,
+             repeatable = Tels.Polarity.Implicit,
+             reference  = t"Status" )),
+          selects = Array.of(Tels.SelectDefinition(
+            name     = t"Status",
+            variants = Array.of(
+              Tels.Variant(t"active",   Tels.Flag),
+              Tels.Variant(t"archived", Tels.Flag)),
+            validators = Array.empty)))
+
+        capture[TelError](Tel.Type.assign(t"item pending\n".read[Tel], schema)).reason
+      . assert(_ == TelError.Reason.AtomVariantUnmatched)
+
+      test(m"mismatched atom at required flag raises E305"):
+        val schema = itemSchema(Array.of(
+          Tels.Field(Tels.Polarity.Implicit, Tels.Polarity.Implicit, t"a", Tels.Flag, Unset)))
+
+        capture[TelError](Tel.Type.assign(t"item xyz\n".read[Tel], schema)).reason
+      . assert(_ == TelError.Reason.AtomFlagKeywordMismatch)
+
     suite(m"Schema default-field"):
       // Like `personSchema`, but the required `name` field carries a default,
       // so a document omitting it is filled with the default rather than

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -886,6 +886,64 @@ object Tests extends Suite(m"Stratiform Tests"):
         capture[TelError](Tel.Type.assign(doc, statusSchema)).reason
       . assert(_ == TelError.Reason.FlagWithContent)
 
+      // Two repeatable scalar members, for the §20.2 step 4c contiguity rule.
+      val contiguitySchema = Tels(
+        name     = t"doc",
+        document = Tels.Struct(
+          members = Array.of(
+            Tels.Field
+             ( Tels.Polarity.Implicit, Tels.Polarity.Loose,
+               t"a", Tels.Scalar(Array.of(t"string")), Unset ),
+            Tels.Field
+             ( Tels.Polarity.Implicit, Tels.Polarity.Loose,
+               t"b", Tels.Scalar(Array.of(t"string")), Unset )),
+          validators = Array.empty),
+        layers   = Array.empty,
+        sigil    = Unset,
+        records  = Array.empty,
+        scalars  = Array.empty,
+        selects  = Array.empty)
+
+      test(m"non-contiguous member children raise E309"):
+        val doc = t"a x\na y\nb z\na w\n".read[Tel]
+        capture[TelError](Tel.Type.assign(doc, contiguitySchema)).reason
+      . assert(_ == TelError.Reason.MembersNonContiguous)
+
+      test(m"contiguous runs of repeatable members do not raise E309"):
+        val doc = t"a x\na y\nb z\n".read[Tel]
+        Tel.Type.assign(doc, contiguitySchema) match
+          case Tel.Element.Node(_, _, children) => children.readable.length
+          case _                                => -1
+      . assert(_ == 3)
+
+      // A repeatable all-Flag SelectRef: its variants share a member index,
+      // so they interleave freely without E309.
+      val repeatableStatusSchema = Tels(
+        name     = t"status",
+        document = Tels.Struct(
+          members = Array.of(Tels.SelectRef
+           ( required   = Tels.Polarity.Implicit,
+             repeatable = Tels.Polarity.Loose,
+             reference  = t"Status" )),
+          validators = Array.empty),
+        layers   = Array.empty,
+        sigil    = Unset,
+        records  = Array.empty,
+        scalars  = Array.empty,
+        selects  = Array.of(Tels.SelectDefinition(
+          name     = t"Status",
+          variants = Array.of(
+            Tels.Variant(t"active",   Tels.Flag),
+            Tels.Variant(t"archived", Tels.Flag)),
+          validators = Array.empty)))
+
+      test(m"interleaved variants of one SelectRef do not raise E309"):
+        val doc = t"active\narchived\nactive\n".read[Tel]
+        Tel.Type.assign(doc, repeatableStatusSchema) match
+          case Tel.Element.Node(_, _, children) => children.readable.length
+          case _                                => -1
+      . assert(_ == 3)
+
     suite(m"Atom phase (§20.2 step 3)"):
       // Wraps the record under test as the single root member `item`: the
       // document root never carries atoms (§20.2), so the atom phase is

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -871,6 +871,21 @@ object Tests extends Suite(m"Stratiform Tests"):
         capture[TelError](Tel.Type.assign(doc, statusSchema)).reason
       . assert(_ == TelError.Reason.UnknownKeyword)
 
+      test(m"scalar compound with two atoms raises E302"):
+        val doc = t"name Alice Bob\n".read[Tel]
+        capture[TelError](Tel.Type.assign(doc, personSchema)).reason
+      . assert(_ == TelError.Reason.TooManyAtoms)
+
+      test(m"scalar compound with a child raises E301"):
+        val doc = t"name Alice\n  extra x\n".read[Tel]
+        capture[TelError](Tel.Type.assign(doc, personSchema)).reason
+      . assert(_ == TelError.Reason.NonStructCompound)
+
+      test(m"flag compound with an atom raises E311"):
+        val doc = t"active foo\n".read[Tel]
+        capture[TelError](Tel.Type.assign(doc, statusSchema)).reason
+      . assert(_ == TelError.Reason.FlagWithContent)
+
     suite(m"Atom phase (§20.2 step 3)"):
       // Wraps the record under test as the single root member `item`: the
       // document root never carries atoms (§20.2), so the atom phase is


### PR DESCRIPTION
The Wisteria-derived TEL codecs now implement §19.2 positional atom assignment (fixing #1694), together with the rest of the omissions a three-way audit of the specification, the schema-typed `Tel.Type.assign` path and the codecs turned up: source and literal atoms decode as scalar values on both paths, `Boolean` fields gain flag semantics, the encoder escalates unsafe values to source or literal atom form so every encoded document reparses, type assignment raises the previously-unraised E301–E305, E308 and E309 diagnostics with required-aware skip rules and a recursion-depth limit, and a differential test harness keeps the two decoding layers in agreement.

## Positional atom assignment (#1694)

A compound's inline atoms are assigned to record fields positionally, in declaration order, on both decode paths — matching what the schema-typed layer always accepted:

```scala
case class Recipient(name: Text, address: Optional[Text])
case class Delivery(recipient: Optional[Recipient])
```

```tel
recipient  Acme Corporation
  address  1 Acme Way
```

`read[Delivery in Tel]` and `read[Tel].as[Delivery]` now both produce `Recipient(t"Acme Corporation", t"1 Acme Way")`; previously `name` decoded as absent. The skip rules approximate §20.2 from Scala types: nested records never take atoms, optional flags are skipped when the atom doesn't match their keyword, scalars are never skipped, and a collection field consumes every remaining atom on the line (its occurrences may split between inline atoms and later same-keyword children). Tabulated rows decode their column values through the same pre-pass.

## Source and literal atoms; flags

Multi-line values (§14 source atoms and §15 literal atoms) now decode as scalar field values on both paths, and count towards `Optional` presence. `Boolean` fields follow flag semantics: a bare keyword decodes `true`, absence decodes `false`, and `Optional[Boolean]` keeps `Unset`/`true`/`false` distinguishable. Sums no longer crash on an empty node (they raise `Absent`).

## Encoding

`Tel2.scalar` escalates values through inline → source → literal atom forms, so a `Text` containing a newline — previously emitted as an unparseable inline atom — round-trips through serialized text. Booleans encode in flag form. A new opt-in `Tel.canonical(value)` renders the §22.2 canonical presentation, with each nested record's leading scalars and flags as an inline run on its keyword line; `.encode` keeps the fully keyword-child wire form that typed navigation relies on. Both forms decode identically (§19.1).

## Type assignment conformance

`Tel.Type.assign` now raises E301/E302/E303/E304/E305 at their §20.2 trigger points (all record-and-continue under accrual per §19.5), enforces the E309 member-contiguity rule and the E308 multiplicity rule (atoms and children counted against one budget), checks required `SelectRef`s for absence, honours `required` in the atom-phase skip rules, and fail-stops beyond 256 levels of nesting per §20.2's recommended limit.

## Testing

A differential harness decodes fixture documents through both codec paths and through `Tel.Type.assign` with a schema derived from the same type, comparing all three against a hand-written oracle — the equivalence property that would have caught both this and the earlier source-atom gap. Staged parsers (`Tel.Parsable.staged`) do not yet run the positional pre-pass; this is documented and tracked as #1699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
