### PR TITLE
Treat imports and lazy references as transparent in scala-tasty/1

### DIFF
--- a/lib/degustation/src/core/degustation.Atomizer.scala
+++ b/lib/degustation/src/core/degustation.Atomizer.scala
@@ -206,7 +206,17 @@ object Atomizer:
           encodeType(out, tpe.rhs, binders)
 
         case _ =>
-          throw Unencodable(s"type ${tpe.getClass.getName}")
+          // dotc's lazy placeholder for cyclically-referenced types (`LazyRef`) leaks
+          // through the reflection layer with no reflect-level extractor: dereference it
+          // and encode the underlying type, which is what consumers observe. The immediate
+          // underlying is always a proper type (typically a named reference), so this
+          // cannot recurse unboundedly.
+          if tpe.getClass.getName.nn.endsWith("LazyRef") then
+            val context = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+            val lazyRef = tpe.asInstanceOf[dotty.tools.dotc.core.Types.LazyRef]
+            encodeType(out, lazyRef.ref(using context).asInstanceOf[TypeRepr], binders)
+          else
+            throw Unencodable(s"type ${tpe.getClass.getName}")
 
     def denylisted(fullName: String): Boolean =
       val diagnostic = scala.collection.immutable.Set(
@@ -376,8 +386,17 @@ object Atomizer:
 
         case Block(statements, expression) =>
           tag(out, '{')
-          uvarint(out, statements.length.toLong)
-          statements.foreach(term)
+
+          // Imports and exports among a body's statements are purely lexical: every
+          // reference this encoding emits is already fully-qualified, so they carry no
+          // semantic content and fold into nothing, like positions.
+          val retained = statements.filter:
+            case _: Import => false
+            case _: Export => false
+            case _         => true
+
+          uvarint(out, retained.length.toLong)
+          retained.foreach(term)
           term(expression)
 
         case If(condition, positive, negative) =>

--- a/lib/degustation/src/test/degustation_test.scala
+++ b/lib/degustation/src/test/degustation_test.scala
@@ -206,6 +206,27 @@ object Tests extends Suite(m"Degustation Tests"):
       && before.keySet.filter(_ != inlineKey).forall { key => before(key) == grown(key) }
     . assert(identity)
 
+    test(m"an import inside an inline body is transparent"):
+      val plain: Text =
+        t"""|package lexical
+            |
+            |inline def compute(a: Int): Int =
+            |  val b = a + 1
+            |  b*2
+            |""".s.stripMargin.tt
+
+      val imported: Text =
+        t"""|package lexical
+            |
+            |inline def compute(a: Int): Int =
+            |  import scala.math.*
+            |  val b = a + 1
+            |  b*2
+            |""".s.stripMargin.tt
+
+      listing(plain).toMap == listing(imported).toMap
+    . assert(identity)
+
     test(m"an inline body references what it splices"):
       val source: Text =
         t"""|package refs


### PR DESCRIPTION
Building real modules (rudiments and contingency) as `.lira` files surfaced two constructs outside the `scala-tasty/1` discipline's strict vocabulary, both artifacts of compilation rather than API: import and export statements retained among an inline body's statements, and the compiler's `LazyRef` placeholders for cyclically-referenced types. Both are now transparent in the canonical encoding, with a test pinning that an import-only body change leaves atom values untouched.

## Release notes

The `scala-tasty/1` discipline in `degustation` now canonicalizes two further constructs encountered in real-world TASTy:

 - `import` and `export` statements within an `inline` or macro body fold into nothing, like positions: the encoding spells every reference fully-qualified, so lexical scoping conveniences carry no semantic content. Reformulating a body to use (or drop) a local import no longer changes its replaceable atom's value:

   ```scala
   inline def compute(a: Int): Int =
     import scala.math.*   // transparent: same atom value with or without
     val b = a + 1
     b*2
   ```

 - The compiler's lazy placeholders for cyclically-referenced types (`LazyRef`) are dereferenced before type encoding: the underlying type is what consumers observe; the placeholder is an artifact of completion order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
