### PR TITLE
Expose the LSP transport's traffic to an observer

### DIFF
--- a/doc/modules/lsp.md
+++ b/doc/modules/lsp.md
@@ -93,6 +93,26 @@ a server pushes diagnostics — errors and warnings — rather than waiting to b
 `client` also carries `showMessage` and `logMessage`, for notices shown to the user and
 lines written to the editor's log.
 
+### Observing the traffic
+
+A server's standard output is reserved for the wire protocol, so it cannot print a record
+of what it is exchanging. `Lsp.listen` takes an optional observer instead, which sees each
+message as the JSON body it was carried as — inbound before it is parsed, so a message
+that fails to decode is observed too, and outbound before it is framed:
+
+```scala
+  val observer = new Lsp.Observer:
+    def received(message: Text): Unit = log.put(t"recv $message")
+    def sent(message: Text): Unit = log.put(t"send $message")
+
+  Lsp.listen(t"Demo", t"0.1.0", observer):
+    ...
+```
+
+What the observer does with a message is the server's own concern: a debugging aid that
+streams it to a second process, a trace file, or nothing at all. Omitting the parameter
+observes nothing.
+
 ### Reporting errors
 
 A handler that cannot answer raises a typed fault, and continues:

--- a/lib/exegesis/doc/running.md
+++ b/lib/exegesis/doc/running.md
@@ -30,6 +30,26 @@ object MyServer:
 There is no capabilities record to write: registering `hover` is what advertises `hoverProvider` to the
 editor, and so on for every feature.
 
+#### Observing the traffic
+
+`Lsp.listen` takes an optional `Lsp.Observer`, which sees every message crossing the transport — inbound before
+it is parsed, outbound before it is framed — as the JSON body, without the `Content-Length` header. This is how
+a server exposes a log of its own traffic, which it cannot simply print: standard output is reserved for the
+wire protocol.
+
+```scala
+  val observer = new Lsp.Observer:
+    def received(message: Text): Unit = log.put(t"recv $message")
+    def sent(message: Text): Unit = log.put(t"send $message")
+
+  Lsp.listen(t"my-server", t"1.0", observer):
+    hover:
+      Hover(MarkupContent(value = t"Hello from my server."))
+```
+
+A message that fails to parse is observed too, since the observer runs before decoding. Omitting the parameter
+observes nothing, at no cost.
+
 #### Fast startup as a daemon
 
 The `cli` entry point runs the server through [Ethereal](https://github.com/propensive/ethereal), so it starts

--- a/lib/exegesis/src/core/exegesis.Lsp.scala
+++ b/lib/exegesis/src/core/exegesis.Lsp.scala
@@ -1297,6 +1297,21 @@ object Lsp:
     import strategies.throwUnsafely
     try json.as[JsonRpc.Request].id catch case _: Exception => Unset
 
+  // An observer of the raw traffic crossing the transport, for a server that exposes a log of the
+  // messages it exchanges. Each message is reported as the text that was read from — or framed
+  // onto — the wire, before parsing, so a malformed message is observed too. Both methods are
+  // abstract: a concrete default would oblige every implementation to write `override`, which
+  // costs more than the one-line no-op it saves.
+  object Observer:
+    // The default: a server that does not expose its traffic pays nothing for the hook.
+    object Silent extends Observer:
+      def received(message: Text): Unit = ()
+      def sent(message: Text): Unit = ()
+
+  trait Observer:
+    def received(message: Text): Unit
+    def sent(message: Text): Unit
+
   // Establishes a Language Server over the stdio transport. The block registers the server's
   // feature handlers on the lent registry; once it returns, the registry is consumed and frozen,
   // the server's capabilities are derived from what was registered, and the loop serves
@@ -1304,8 +1319,9 @@ object Lsp:
   // asynchronous writer drains the outgoing channel (request responses and server-initiated
   // notifications alike) and frames each message onto standard output, so writes never
   // interleave. Everything stateful — registry, session, dispatcher — is local to this call:
-  // nothing capability-carrying is ever stored in an application-lifetime object.
-  def listen(name: Text, version: Optional[Text] = Unset)
+  // nothing capability-carrying is ever stored in an application-lifetime object. `observer`, if
+  // given, sees every message in both directions as it crosses the transport.
+  def listen(name: Text, version: Optional[Text] = Unset, observer: Observer^ = Observer.Silent)
     ( register: (registry: LspRegistry^) ?=> Unit )
     ( using Stdio^, Monitor, Probate )
   :   Unit =
@@ -1324,17 +1340,24 @@ object Lsp:
     // take a capability-typed splice.
     val dispatch: Json => Optional[Json] = LspDispatch(caps.unsafe.unsafeAssumePure(session))
 
-    // The writer drains the channel and frames each message onto stdout.
+    // The writer drains the channel and frames each message onto stdout. The observer sees the
+    // encoded body, not the framing, so both directions read alike in a log.
     val writer: Task[Unit] = async:
       session.outgoing.stdlib.iterator.each: json =>
-        val payload: Data = json.encode.in[Data]
+        val body: Text = json.encode
+        observer.sent(body)
+        val payload: Data = body.in[Data]
         summon[Stdio].write(t"Content-Length: ${payload.length}\r\n\r\n".in[Data])
         summon[Stdio].write(payload)
         summon[Stdio].out.flush()
 
     summon[Stdio].in.source[Data].toProgression.stdlib.iterator.frames[ContentLength].each:
       frame =>
-        safely(frame.utf8.as[Json]).lay(session.put(JsonRpc.failure(-32700, t"Parse error"))):
+        // Observed before parsing, so a message that fails to decode is logged as it arrived.
+        val message: Text = frame.utf8
+        observer.received(message)
+
+        safely(message.as[Json]).lay(session.put(JsonRpc.failure(-32700, t"Parse error"))):
           json =>
             val response: Optional[Json] =
               try dispatch(json) catch

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -32,10 +32,17 @@
                                                                                                   */
 package exegesis
 
+import scala.collection.mutable as scm
+
+import java.io as ji
+import java.util.concurrent as juc
+
 import soundness.*
 
 import charEncoders.utf8Encoder
+import probates.awaitProbate
 import strategies.throwUnsafely
+import threading.virtualThreading
 
 // Kept as a top-level object (its own class) rather than nested in `Tests` so the LSP codecs the
 // dispatcher inlines do not add to the `Tests` class, which would otherwise exceed the JVM
@@ -94,6 +101,48 @@ object TestServer:
 
   // Dispatch plus the session's fault-aware conclusion, as `Lsp.listen` performs it.
   def roundtrip(json: Json): Optional[Json] = session.conclude(json, dispatch(json))
+
+// Drives `Lsp.listen` end-to-end over an in-memory transport, capturing what an `Lsp.Observer`
+// sees. Top-level for the same reason as `TestServer`: `listen` inlines the LSP codecs, which
+// would otherwise count against the `Tests` class's size.
+object TrafficFixture:
+  import Lsp.*
+
+  val request: Text =
+    t"""{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"capabilities":{}}}"""
+
+  // Every message the observer saw, as (direction, body) pairs in the order they were observed.
+  lazy val observed: List[(Text, Text)] =
+    val log: scm.ArrayBuffer[(Text, Text)] = scm.ArrayBuffer()
+
+    // Released once the response has been observed. The reader loop cancels the writer when
+    // standard input runs dry, so an input that ended with the request could interrupt the
+    // writer before it drained the response; instead the stream stays open until `sent` fires.
+    val answered: juc.CountDownLatch = juc.CountDownLatch(1)
+
+    val observer = new Observer:
+      def received(message: Text): Unit = log.synchronized(log.append((t"recv", message)))
+
+      def sent(message: Text): Unit =
+        log.synchronized(log.append((t"send", message)))
+        answered.countDown()
+
+    val framed: Text = t"Content-Length: ${request.in[Data].readable.length}\r\n\r\n"+request
+
+    val in: ji.InputStream = new ji.ByteArrayInputStream(framed.s.getBytes("UTF-8").nn):
+      override def read(array: scala.Array[Byte] | Null, offset: Int, length: Int): Int =
+        val count = super.read(array, offset, length)
+        if count == -1 then answered.await(10, juc.TimeUnit.SECONDS)
+        count
+
+    val out: ji.ByteArrayOutputStream = ji.ByteArrayOutputStream()
+    given Stdio = Stdio(ji.PrintStream(out, true), null, in, termcapDefinitions.basicTermcap)
+
+    supervise:
+      Lsp.listen(t"Test", t"1.0", observer):
+        hover(Hover(MarkupContent(value = document.text)))
+
+    List.from(log.synchronized(log.toList))
 
 object Tests extends Suite(m"Exegesis Tests"):
   import Lsp.*
@@ -294,5 +343,20 @@ object Tests extends Suite(m"Exegesis Tests"):
         TestServer.roundtrip(request)
         TestServer.session.outgoing.stdlib.iterator.next().as[JsonRpc.Request].method
       . assert(_ == t"window/logMessage")
+
+    suite(m"Traffic observation"):
+      val traffic: List[(Text, Text)] = TrafficFixture.observed
+
+      test(m"the observer sees one message in each direction"):
+        traffic.stdlib.map(_._1).mkString(",")
+      . assert(_ == "recv,send")
+
+      test(m"an inbound message is observed as its body, without the framing"):
+        traffic.stdlib.head._2
+      . assert(_ == TrafficFixture.request)
+
+      test(m"an outbound message is observed as the response to the request"):
+        traffic.stdlib.last._2.as[Json].as[JsonRpc.Response].id.vouch.as[Int]
+      . assert(_ == 0)
 
     CaptureTests()


### PR DESCRIPTION
## Why

A language server's standard output is reserved for the wire protocol, so a server that wants to expose a log of the messages it exchanges — a debugging aid an editor integration needs — has nowhere to write it. `Lsp.listen` gave it no way to see the traffic at all: `LspSession`, `LspDispatch` and `session.outgoing` are all `private[exegesis]`.

This came out of migrating the [TEL language server](https://github.com/propensive/tel) to the new registration-based API: its `tel lsp --log` subcommand worked by overriding `LspServer.serve()`, which #1703 removed.

## What

`Lsp.listen` takes an optional `Lsp.Observer`, called with each message as the JSON body it was carried as:

- **inbound before it is parsed**, so a message that fails to decode is observed too;
- **outbound before it is framed**, so both directions read alike — no `Content-Length` header either way.

The default, `Observer.Silent`, observes nothing. Both trait methods are abstract: a concrete default would oblige every implementation to write `override`, which costs more than the one-line no-op it saves.

The module still compiles under separation checking — the observer is captured by the writer's `async` block with no further annotation needed.

## Tests

Three new tests drive `Lsp.listen` **end-to-end over an in-memory transport**, which nothing covered before (the existing fixture drives the dispatcher directly). Standard input is held open until the response has been observed: the reader loop cancels the writer when input runs dry, so an input ending with the request could otherwise interrupt the writer before it drained the response.

`make test.exegesis` — 31 passed, 0 failed (was 28).

## Docs

`doc/modules/lsp.md` gains an "Observing the traffic" section; `lib/exegesis/doc/running.md` the matching subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)