### PR TITLE
Reach the stream, CSV and network-interface extensions through soundness

### DIFF
--- a/doc/modules/csv.md
+++ b/doc/modules/csv.md
@@ -48,8 +48,6 @@ the rows one at a time, parsed by the same reader, so a quoted cell spanning chu
 boundaries is handled exactly as it is in a materialized sheet:
 
 ```scala
-import caesura.rows
-
 source.rows.map(_[Text](t"name").or(t"?")).to(List)
 ```
 
@@ -163,11 +161,9 @@ t"z,9,note".read[Stat in Dsv]           // Stat(t"z", 9, t"note")
 t"a,1\nb,2".read[List[Stat] in Dsv]     // both records
 ```
 
-A stream yields records the same way, through `caesura.rowsOf`:
+A stream yields records the same way, through `rowsOf`:
 
 ```scala
-import caesura.rowsOf
-
 source.rowsOf[Stat].map(_.count).to(List)
 ```
 

--- a/doc/modules/network-addresses.md
+++ b/doc/modules/network-addresses.md
@@ -117,8 +117,6 @@ The machine's own network interfaces enumerate as typed values, each reporting w
 loopback, and each addressable by name:
 
 ```scala
-import urticose.NetworkInterface
-
 NetworkInterface.all()
 NetworkInterface.all().exists(_.loopback)
 ```

--- a/doc/modules/streams.md
+++ b/doc/modules/streams.md
@@ -124,10 +124,11 @@ stream.memoize                          // drain into one immutable value
 stream.sweep((storage, start, n) => …)  // drain, seeing each raw window
 ```
 
-`sweep` — and `fold`, its accumulating counterpart — expose the raw window rather than boxed
-elements, so a byte-level reduction runs over the array with no per-element cost. `take` and
-`drop` bound a stream without draining it, releasing the remainder of the upstream unread. These
-three are reached through `import zephyrine.{take, drop, fold}`.
+`sweep` — and `gather`, its accumulating counterpart — expose the raw window rather than boxed
+elements, so a byte-level reduction runs over the array with no per-element cost. `truncate` and
+`discard` bound a stream without draining it, releasing the remainder of the upstream unread; they
+count bytes or records, not collection elements, which is why they do not borrow the names `take`
+and `drop`.
 
 Where a pipeline ends in a *push* chain rather than a value, `pump` is the single point at which
 data crosses from the pull side to the push side:

--- a/lib/caesura/src/core/soundness_caesura_core.scala
+++ b/lib/caesura/src/core/soundness_caesura_core.scala
@@ -35,7 +35,7 @@ package soundness
 export
   caesura
   . { CellRef, Dsv, dsv, DsvError, DsvFormat, DsvRedesignation, dynamicDsvAccess, DynamicDsvEnabler,
-      Sheet, Spannable }
+      rows, rowsOf, Sheet, Spannable }
 
 package dsvFormats:
   export caesura.dsvFormats.{csvFormat, csvWithHeaderFormat, ssvFormat, ssvWithHeaderFormat,

--- a/lib/delicious/src/core/delicious.Markup.scala
+++ b/lib/delicious/src/core/delicious.Markup.scala
@@ -75,7 +75,7 @@ object Markup:
     def attr(name: Text): Optional[Text] =
       attrs.find(_(0) == name).optional.let(_(1))
 
-    val style = Style(attr(t"style"))
+    val rendition = Rendition(attr(t"style"))
 
     kind.s match
       case "type" =>
@@ -84,12 +84,12 @@ object Markup:
             Placeholder.decode(value).option
           })
 
-        Typed(attr(t"tasty"), placeholders, style, children)
+        Typed(attr(t"tasty"), placeholders, rendition, children)
 
-      case "sym"  => Symbolic(attr(t"name").or(t""), attr(t"full").or(t""), style, children)
-      case "name" => Named(attr(t"isType").let(_ == t"true").or(false), style, children)
-      case "code" => Code(style, children)
-      case _      => Spanned(kind, style, children)
+      case "sym"  => Symbolic(attr(t"name").or(t""), attr(t"full").or(t""), rendition, children)
+      case "name" => Named(attr(t"isType").let(_ == t"true").or(false), rendition, children)
+      case "code" => Code(rendition, children)
+      case _      => Spanned(kind, rendition, children)
 
   /** Parse a marked-up string into a tree, following the compiler's
    *  `DiagnosticMarkup.parse` semantics exactly: anything that does not form a
@@ -175,13 +175,13 @@ enum Markup:
   case Typed
         (tasty:        Optional[Text],
          placeholders: List[Placeholder],
-         style:        Style,
+         rendition:    Rendition,
          children:     List[Markup])
 
-  case Symbolic(name: Text, full: Text, style: Style, children: List[Markup])
-  case Named(isType: Boolean, style: Style, children: List[Markup])
-  case Code(style: Style, children: List[Markup])
-  case Spanned(kind: Text, style: Style, children: List[Markup])
+  case Symbolic(name: Text, full: Text, rendition: Rendition, children: List[Markup])
+  case Named(isType: Boolean, rendition: Rendition, children: List[Markup])
+  case Code(rendition: Rendition, children: List[Markup])
+  case Spanned(kind: Text, rendition: Rendition, children: List[Markup])
 
   def plain: Text = this match
     case Textual(text)               => text

--- a/lib/delicious/src/core/delicious.Rendition.scala
+++ b/lib/delicious/src/core/delicious.Rendition.scala
@@ -35,13 +35,16 @@ package delicious
 import anticipation.*
 import vacuous.*
 
-object Style:
-  def apply(text: Optional[Text]): Style = text.lay(Style.Default): text =>
+object Rendition:
+  def apply(text: Optional[Text]): Rendition = text.lay(Rendition.Default): text =>
     text.s match
       case "dcl"     => Declaration
       case "located" => Located
       case "full"    => Full
       case _         => Default
 
-enum Style:
+// The form a symbol reference is presented in — its declaration, its located
+// name, its full name, or the default — carried by every markup node. Not
+// visual styling, despite the `style` attribute it is parsed from.
+enum Rendition:
   case Default, Declaration, Located, Full

--- a/lib/delicious/src/core/soundness_delicious_core.scala
+++ b/lib/delicious/src/core/soundness_delicious_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export delicious.{Markup, Placeholder, PlaceholderKind, SemanticMessage, Style}
+export delicious.{Markup, Placeholder, PlaceholderKind, Rendition, SemanticMessage}

--- a/lib/delicious/src/test/delicious_test.scala
+++ b/lib/delicious/src/test/delicious_test.scala
@@ -86,21 +86,21 @@ object Tests extends Suite(m"Delicious Tests"):
       Markup.parse(t"method ${mark(t"sym", List(t"name" -> t"foo", t"full" -> t"example.foo"), t"foo")} here")
     . assert(_ == List
         ( Markup.Textual(t"method "),
-          Markup.Symbolic(t"foo", t"example.foo", Style.Default, List(Markup.Textual(t"foo"))),
+          Markup.Symbolic(t"foo", t"example.foo", Rendition.Default, List(Markup.Textual(t"foo"))),
           Markup.Textual(t" here") ))
 
     test(m"A name marker records whether it is a type name"):
       Markup.parse(mark(t"name", List(t"isType" -> t"true"), t"Elem"))
-    . assert(_ == List(Markup.Named(true, Style.Default, List(Markup.Textual(t"Elem")))))
+    . assert(_ == List(Markup.Named(true, Rendition.Default, List(Markup.Textual(t"Elem")))))
 
     test(m"An unknown marker kind falls back to a spanned node"):
       Markup.parse(mark(t"mystery", Nil, t"???"))
-    . assert(_ == List(Markup.Spanned(t"mystery", Style.Default, List(Markup.Textual(t"???")))))
+    . assert(_ == List(Markup.Spanned(t"mystery", Rendition.Default, List(Markup.Textual(t"???")))))
 
-    test(m"Styles decode from their wire names"):
+    test(m"Renditions decode from their wire names"):
       Markup.parse(mark(t"sym", List(t"name" -> t"foo", t"style" -> t"dcl"), t"def foo: Int"))
     . assert(_ == List
-        ( Markup.Symbolic(t"foo", t"", Style.Declaration, List(Markup.Textual(t"def foo: Int"))) ))
+        ( Markup.Symbolic(t"foo", t"", Rendition.Declaration, List(Markup.Textual(t"def foo: Int"))) ))
 
     test(m"Markers nest, and children keep their order"):
       val inner = mark(t"sym", List(t"name" -> t"foo"), t"foo")
@@ -108,15 +108,15 @@ object Tests extends Suite(m"Delicious Tests"):
     . assert(_ == List
         ( Markup.Named
             ( false,
-              Style.Default,
+              Rendition.Default,
               List
                 ( Markup.Textual(t"method "),
-                  Markup.Symbolic(t"foo", t"", Style.Default, List(Markup.Textual(t"foo"))) )) ))
+                  Markup.Symbolic(t"foo", t"", Rendition.Default, List(Markup.Textual(t"foo"))) )) ))
 
     test(m"Percent-encoded attribute values decode"):
       Markup.parse(mark(t"sym", List(t"name" -> t"%003ainit%003a"), t"constructor"))
     . assert(_ == List
-        ( Markup.Symbolic(t":init:", t"", Style.Default, List(Markup.Textual(t"constructor"))) ))
+        ( Markup.Symbolic(t":init:", t"", Rendition.Default, List(Markup.Textual(t"constructor"))) ))
 
     test(m"A stray start marker is dropped"):
       Markup.parse(t"broken ${Start} text")
@@ -146,7 +146,7 @@ object Tests extends Suite(m"Delicious Tests"):
         ( Markup.Typed
             ( t"QUJD",
               List(Placeholder(0, PlaceholderKind.LocalType, t"Foo", 1, Unset, t"Foo[Int]")),
-              Style.Default,
+              Rendition.Default,
               List(Markup.Textual(t"Foo[Int]")) ) ))
 
     test(m"A placeholder decodes its six fields"):
@@ -239,19 +239,19 @@ object Tests extends Suite(m"Delicious Tests"):
       given Imports = Imports.empty
 
       test(m"A pickled type payload reifies to a stenography rendering"):
-        reifier.syntax(Markup.Typed(stringPayload, Nil, Style.Default, Nil)).let(_.text)
+        reifier.syntax(Markup.Typed(stringPayload, Nil, Rendition.Default, Nil)).let(_.text)
       . assert(_ == t"java.lang.String")
 
       test(m"A placeholder payload reifies with its placeholder substituted"):
         val placeholder =
           Placeholder(0, PlaceholderKind.LocalType, t"Local", 0, t"Bad.scala:2", t"Bad.Local")
 
-        reifier.syntax(Markup.Typed(placeholderPayload, List(placeholder), Style.Default, Nil))
+        reifier.syntax(Markup.Typed(placeholderPayload, List(placeholder), Rendition.Default, Nil))
         . let(_.text)
       . assert(_ == t"scala.collection.immutable.List[Bad.Local]")
 
       test(m"An unpicklable payload degrades to Unset"):
-        reifier.syntax(Markup.Typed(t"bm90IHRhc3R5", Nil, Style.Default, Nil))
+        reifier.syntax(Markup.Typed(t"bm90IHRhc3R5", Nil, Rendition.Default, Nil))
       . assert(_ == Unset)
 
       test(m"A marked message renders types through stenography"):

--- a/lib/ethereal/src/core/ethereal.Installer.scala
+++ b/lib/ethereal/src/core/ethereal.Installer.scala
@@ -149,7 +149,7 @@ object Installer:
               val stream = file.stream
 
               if prefixSize > 0.b
-              then file.write(stream.take(prefixSize) #::: stream.discard(fileSize - jarSize))
+              then file.write(stream.take(prefixSize) #::: stream.drop(fileSize - jarSize))
               else file.write(stream)
 
             file.executable() = true

--- a/lib/probably/src/core/probably.AnsiRenderer.scala
+++ b/lib/probably/src/core/probably.AnsiRenderer.scala
@@ -388,17 +388,17 @@ private[probably] object AnsiRenderer:
 
   private def describeFailure(info: Optional[Verdict.Detail]): Text = info.lay(t"Test failed"):
     case Verdict.Detail.Throws(err) =>
-      Format.truncate(t"Threw ${err.component}.${err.className}: ${err.message.text}")
+      Format.abbreviate(t"Threw ${err.component}.${err.className}: ${err.message.text}")
 
     case Verdict.Detail.CheckThrows(err) =>
-      Format.truncate(t"Check threw ${err.component}.${err.className}: ${err.message.text}")
+      Format.abbreviate(t"Check threw ${err.component}.${err.className}: ${err.message.text}")
 
     case Verdict.Detail.Compare(expected, observed, _) =>
       val observed2 = observed.sub(t"\n", t" ")
-      Format.truncate(t"Expected: ${expected.sub(t"\n", t" ")}; observed: $observed2")
+      Format.abbreviate(t"Expected: ${expected.sub(t"\n", t" ")}; observed: $observed2")
 
     case Verdict.Detail.Message(text) =>
-      Format.truncate(text)
+      Format.abbreviate(text)
 
     case Verdict.Detail.Captures(_) =>
       t"Test failed"
@@ -512,8 +512,8 @@ private[probably] object AnsiRenderer:
 
         val message =
           if active.nil
-          then Format.truncate(t"Fatal error: $errorClass: $cause")
-          else Format.truncate(t"Fatal error in $activeNames: $errorClass: $cause")
+          then Format.abbreviate(t"Fatal error: $errorClass: $cause")
+          else Format.abbreviate(t"Fatal error in $activeNames: $errorClass: $cause")
 
         GithubActions.error(message = message, title = t"Fatal error")
         GithubActions.group(t"Fatal error stack trace")

--- a/lib/probably/src/core/probably.Format.scala
+++ b/lib/probably/src/core/probably.Format.scala
@@ -78,7 +78,7 @@ private[probably] object Format:
 
   val sparkBlocks: List[Text] = List(t"▁", t"▂", t"▃", t"▄", t"▅", t"▆", t"▇", t"█")
 
-  def truncate(text: Text, max: Int = 800): Text =
+  def abbreviate(text: Text, max: Int = 800): Text =
     if text.length <= max then text else t"${text.keep(max)}…"
 
   def statusWord(status: Report.Status): Text = status match

--- a/lib/probably/src/core/probably.TerseRenderer.scala
+++ b/lib/probably/src/core/probably.TerseRenderer.scala
@@ -193,28 +193,28 @@ private[probably] object TerseRenderer:
           detail match
             case Verdict.Detail.Throws(err) =>
               Out.println:
-                t"  threw ${err.component}.${err.className}: ${Format.truncate(err.message.text)}"
+                t"  threw ${err.component}.${err.className}: ${Format.abbreviate(err.message.text)}"
 
               err.crop(t"probably.Runner", t"run()").frames.stdlib.take(3).foreach: frame =>
                 Out.println(formatFrame(frame))
 
             case Verdict.Detail.CheckThrows(err) =>
-              val message = Format.truncate(err.message.text)
+              val message = Format.abbreviate(err.message.text)
               Out.println(t"  check threw ${err.component}.${err.className}: $message")
 
               err.crop(t"probably.Verdict#", t"apply()").frames.stdlib.take(3).foreach: frame =>
                 Out.println(formatFrame(frame))
 
             case Verdict.Detail.Compare(expected, observed, _) =>
-              Out.println(t"  expected: ${Format.truncate(expected.sub(t"\n", t" "))}")
-              Out.println(t"  observed: ${Format.truncate(observed.sub(t"\n", t" "))}")
+              Out.println(t"  expected: ${Format.abbreviate(expected.sub(t"\n", t" "))}")
+              Out.println(t"  observed: ${Format.abbreviate(observed.sub(t"\n", t" "))}")
 
             case Verdict.Detail.Message(text) =>
-              Out.println(t"  ${Format.truncate(text)}")
+              Out.println(t"  ${Format.abbreviate(text)}")
 
             case Verdict.Detail.Captures(captures) =>
               captures.stdlib.foreach: (expr, value) =>
-                Out.println(t"  $expr = ${Format.truncate(value)}")
+                Out.println(t"  $expr = ${Format.abbreviate(value)}")
 
         Out.println(t"")
 

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -601,17 +601,17 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         }
 
     // Chained example S: slice + transcode (no compression, 3-way), combining
-    // the `drop`/`take`/`fold` kernel operators with transcoding. `drop`/`take`
-    // are chunk-aware byte counts in all three libraries; the terminal count
-    // folds over whole windows.
+    // the `discard`/`truncate`/`gather` kernel operators with transcoding. The
+    // slice bounds are chunk-aware byte counts in all three libraries; the
+    // terminal count accumulates over whole windows.
     suite(m"Chained: drop -> transcode -> take -> count (4 MB)"):
-      bench(m"Soundness  drop.dec.enc.take.fold")
+      bench(m"Soundness  discard.dec.enc.truncate.gather")
         ( target = 1*Second, operationSize = textSize ):
         '{
-            turbulence.Benchmarks.textData.stream.drop(turbulence.Benchmarks.dropBytes)
+            turbulence.Benchmarks.textData.stream.discard(turbulence.Benchmarks.dropBytes)
             . via(summon[CharDecoder]).via(summon[CharEncoder])
-            . take(turbulence.Benchmarks.takeBytes)
-            . fold(0L)((total, _, _, count) => total + count)
+            . truncate(turbulence.Benchmarks.takeBytes)
+            . gather(0L)((total, _, _, count) => total + count)
         }
 
       bench(m"FS2  drop.utf8.take.count")(target = 1*Second, operationSize = textSize):

--- a/lib/turbulence/src/core/soundness_turbulence_core.scala
+++ b/lib/turbulence/src/core/soundness_turbulence_core.scala
@@ -35,7 +35,7 @@ package soundness
 export
   turbulence
   . { Aggregable, deduplicate,
-      defer, delineate, discard, Document, Documentary, Eof, Err, In, inputStream,
+      defer, delineate, Document, Documentary, drop, Eof, Err, In, inputStream,
       Io, Line, LineSeparation, load, Loadable, more, Out, read, Relay, shred, source,
       Confluence, Divergence, Readable, Sink, Stdio, Streamable, StreamError,
       StreamOutputStream, strict, take, Writable, writeTo, flow }

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -314,7 +314,7 @@ extension (obj: Chain.type)
 
 
 extension (stream: Chain[Data])
-  def discard(bytes: Bytes): Chain[Data] =
+  def drop(bytes: Bytes): Chain[Data] =
     def recur(stream: Chain[Data], count: Bytes): Chain[Data] = stream.flow(Chain()):
       if next.bytes < count
       then recur(more, count - next.bytes)

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -320,8 +320,10 @@ extension (stream: Chain[Data])
       then recur(more, count - next.bytes)
       else
         // hoisted: a fresh array built inside `#::`'s by-name operand (which would
-        // capture the enclosing context) could not escape it
-        val head: Data = next.drop(count.long.toInt).asInstanceOf[Data]
+        // capture the enclosing context) could not escape it. `slice` rather than
+        // `drop`: the sibling `drop` on `Chain[Data]` shadows `proscenium.compat`'s
+        // array version here.
+        val head: Data = next.slice(count.long.toInt, next.length).asInstanceOf[Data]
         head #:: more
 
     recur(stream, bytes)
@@ -379,7 +381,9 @@ extension (stream: Chain[Data])
         if next.bytes < count then
           val head: Data = next
           head #:: recur(more, count - next.bytes)
-        else Chain(next.take(count.long.toInt).asInstanceOf[Data])
+        // `slice`, not `take`: the sibling `take` on `Chain[Data]` shadows
+        // `proscenium.compat`'s array version here.
+        else Chain(next.slice(0, count.long.toInt).asInstanceOf[Data])
 
     recur(stream, bytes)
 

--- a/lib/urticose/src/core/soundness_urticose_core.scala
+++ b/lib/urticose/src/core/soundness_urticose_core.scala
@@ -34,10 +34,11 @@ package soundness
 
 export
   urticose
-  . { Remotable, EmailAddress, EmailAddressError, Endpoint, Host, Hostname, HostnameError,
-      Internet, internet, ip, IpAddressError, Localhost, LocalPart, mac, MacAddressError,
-      OfflineError, Online, online, Allocatable, Port, PortError, PortType, Protocolic, Quic, serve,
-      Service, subnet, Tcp, tcp, TcpPort, Udp, udp, UdpPort, via }
+  . { Remotable, DnsLabel, EmailAddress, EmailAddressError, Endpoint, Host, Hostname,
+      HostnameError, InterfaceAddress, Internet, internet, ip, IpAddressError, Ipv4, Ipv4Subnet,
+      Ipv6, Ipv6Subnet, Localhost, LocalPart, mac, MacAddress, MacAddressError, NetworkInterface,
+      NetworkInterfaceError, OfflineError, Online, online, Allocatable, Port, PortError, PortType,
+      Protocolic, Quic, serve, Service, subnet, Tcp, tcp, TcpPort, Udp, udp, UdpPort, via }
 
 package internetAccess:
   export urticose.internetAccess.{offline, online}

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -35,8 +35,8 @@ package soundness
 export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum,
     Duct, Ductile, Expanse, Malleable, Pace,
     Format, Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
-    Records, records, Regulation, Spring, Stream, Substrate, locate, locateKey, memoize, pump,
-    stream, streamOf, sweep, toProgression}
+    Records, records, Regulation, Spring, Stream, Substrate, chunks, discard, gather, locate,
+    locateKey, memoize, pump, stream, streamOf, sweep, toProgression, truncate}
 
 // Hand-written forwarders: the synthesized export forwarders for these dependent-typed
 // extensions lose the `ductile.Result`/`ductile.Operand` path refinements under capture

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -204,13 +204,14 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
 
     addressable.build(target)
 
-  // Drain the stream, threading an accumulator through each window: the
-  // window-level fold, the terminal counterpart to a pull chain. The operation
+  // Drain the stream, threading an accumulator through each window: `sweep`'s
+  // accumulating counterpart, the terminal end of a pull chain. The operation
   // receives the running state, the raw window storage, its start index and its
-  // element count; it must not retain the storage. Unlike an element-wise fold,
-  // this exposes the raw window, so a byte reduction runs over the array with no
-  // per-element boxing. (The `Stream[Data]` overload below types the window.)
-  def fold[state](initial: state)(operation: (state, AnyRef, Int, Int) => state)
+  // element count; it must not retain the storage. Unlike an element-wise fold
+  // over a collection, this exposes the raw window, so a byte reduction runs
+  // over the array with no per-element boxing. (The `Stream[Data]` overload
+  // below types the window.)
+  def gather[state](initial: state)(operation: (state, AnyRef, Int, Int) => state)
     (using buffering: Buffering)
   :   state =
 
@@ -230,12 +231,12 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
 
   // The first `count` elements, then end-of-stream. The remainder of the
   // upstream is released unread on `close`. (FS2 `take`, ZIO `ZStream.take`.)
-  def take(count: Long): (Stream[medium] over Credit)^ = takeStream(stream, count)
+  def truncate(count: Long): (Stream[medium] over Credit)^ = truncateStream(stream, count)
 
   // Skip the first `count` elements, then pass the rest through unchanged. The
   // skipped elements are pulled and discarded on the first `refill`. (FS2
   // `drop`, ZIO `ZStream.drop`.)
-  def drop(count: Long): (Stream[medium] over Credit)^ = dropStream(stream, count)
+  def discard(count: Long): (Stream[medium] over Credit)^ = discardStream(stream, count)
 
   // A single-consumer iterator of materialized chunks, one per refill: the
   // bridge by which stream content interleaves with other values (archive
@@ -276,7 +277,7 @@ extension [record](consume stream: (Stream[Array[record]^{}] over Credit)^)
   // it closes the stream when it reports exhaustion, so a consumer must drain it
   // (or close the stream by other means) to release the upstream. Per-record
   // combinators come free from the `Iterator` interface (and rudiments' `each`);
-  // window-level access for hot loops is `sweep`/`fold` above.
+  // window-level access for hot loops is `sweep`/`gather` above.
   def records(using Buffering): Iterator[record]^ = recordIterator(stream)
 
 // A pull endpoint lending a bounded view of a cursor: the next `length` elements
@@ -549,13 +550,13 @@ private def throughDuct[in, out, upTransport, downTransport]
         duct.close()
         stream.close()
 
-// `take`/`drop` wrappers, in helpers rather than inline in the extension for
-// the same reason as `throughDuct`: a local binding of the upstream would hide
-// it from the anonymous class, whereas the consumed parameter carries its
-// capture explicitly. Each delegates window access to the upstream (zero copy)
-// and only adjusts the element budget.
+// `truncate`/`discard` wrappers, in helpers rather than inline in the
+// extension for the same reason as `throughDuct`: a local binding of the
+// upstream would hide it from the anonymous class, whereas the consumed
+// parameter carries its capture explicitly. Each delegates window access to
+// the upstream (zero copy) and only adjusts the element budget.
 
-private def takeStream[medium](consume stream: (Stream[medium] over Credit)^, count: Long)
+private def truncateStream[medium](consume stream: (Stream[medium] over Credit)^, count: Long)
 :   (Stream[medium] over Credit)^ =
 
     new Stream[medium](using stream.addressable):
@@ -583,7 +584,7 @@ private def takeStream[medium](consume stream: (Stream[medium] over Credit)^, co
 
       override update def close(): Unit = stream.close()
 
-private def dropStream[medium](consume stream: (Stream[medium] over Credit)^, count: Long)
+private def discardStream[medium](consume stream: (Stream[medium] over Credit)^, count: Long)
 :   (Stream[medium] over Credit)^ =
 
     new Stream[medium](using stream.addressable):
@@ -602,9 +603,9 @@ private def dropStream[medium](consume stream: (Stream[medium] over Credit)^, co
         while pending > 0 && !ended do
           stream.refill(Credit(pending.min(Int.MaxValue.toLong))) match
             case available: Int =>
-              val discard = available.toLong.min(pending).toInt
-              stream.skip(discard)
-              pending -= discard
+              val skipped = available.toLong.min(pending).toInt
+              stream.skip(skipped)
+              pending -= skipped
 
             case _ => ended = true
 

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -36,11 +36,6 @@ import soundness.*
 
 import proscenium.compat.*
 
-// The kernel `Stream.take`/`drop` are shadowed here by turbulence's legacy
-// `Chain[Data]` `take`/`drop` arriving through the `soundness.*` wildcard;
-// the explicit imports restore the kernel versions under test.
-import zephyrine.{take, drop}
-
 import randomization.unseededRandomization
 
 import supervisors.globalSupervisor
@@ -875,45 +870,46 @@ object Tests extends Suite(m"Zephyrine tests"):
           Stream(Iterator(t"ab", t"cd", t"e")).memoize.s
         . assert(_ == "abcde")
 
-        test(m"take limits a stream to its first elements"):
-          small.stream.take(3).memoize.readable.to(List)
+        test(m"truncate limits a stream to its first elements"):
+          small.stream.truncate(3).memoize.readable.to(List)
         . assert(_ == List[Byte](1, 2, 3))
 
-        test(m"take across chunk boundaries"):
-          Stream(Iterator(Array.of[Byte](1, 2, 3), Array.of[Byte](4, 5, 6))).take(4).memoize.to[List]
+        test(m"truncate across chunk boundaries"):
+          Stream(Iterator(Array.of[Byte](1, 2, 3), Array.of[Byte](4, 5, 6)))
+          . truncate(4).memoize.to[List]
         . assert(_ == List[Byte](1, 2, 3, 4))
 
-        test(m"take of more than the stream holds yields the whole stream"):
-          small.stream.take(100).memoize.to[List]
+        test(m"truncate to more than the stream holds yields the whole stream"):
+          small.stream.truncate(100).memoize.to[List]
         . assert(_ == small.to[List])
 
-        test(m"take zero yields an empty stream"):
-          small.stream.take(0).memoize.to[List]
+        test(m"truncate to zero yields an empty stream"):
+          small.stream.truncate(0).memoize.to[List]
         . assert(_ == List())
 
-        test(m"drop skips a stream's first elements"):
-          small.stream.drop(2).memoize.to[List]
+        test(m"discard skips a stream's first elements"):
+          small.stream.discard(2).memoize.to[List]
         . assert(_ == List[Byte](3, 4, 5))
 
-        test(m"drop across chunk boundaries"):
-          Stream(Iterator(Array.of[Byte](1, 2, 3), Array.of[Byte](4, 5, 6))).drop(4).memoize.to[List]
+        test(m"discard across chunk boundaries"):
+          Stream(Iterator(Array.of[Byte](1, 2, 3), Array.of[Byte](4, 5, 6)))
+          . discard(4).memoize.to[List]
         . assert(_ == List[Byte](5, 6))
 
-        test(m"drop of more than the stream holds yields an empty stream"):
-          small.stream.drop(100).memoize.to[List]
+        test(m"discard of more than the stream holds yields an empty stream"):
+          small.stream.discard(100).memoize.to[List]
         . assert(_ == List())
 
-        test(m"take and drop compose to a slice"):
-          Stream(Data.fill(20)(_.toByte)).drop(5).take(5).memoize.to[List]
+        test(m"truncate and discard compose to a slice"):
+          Stream(Data.fill(20)(_.toByte)).discard(5).truncate(5).memoize.to[List]
         . assert(_ == List[Byte](5, 6, 7, 8, 9))
 
-        test(m"take composes with a duct"):
-          small.stream.take(3).via(Doubler()).memoize.to[List]
+        test(m"truncate composes with a duct"):
+          small.stream.truncate(3).via(Doubler()).memoize.to[List]
         . assert(_ == List[Byte](1, 1, 2, 2, 3, 3))
 
-        test(m"fold reduces over windows without boxing"):
-          import zephyrine.fold
-          bytes.stream.fold(0L): (total, storage, start, count) =>
+        test(m"gather reduces over windows without boxing"):
+          bytes.stream.gather(0L): (total, storage, start, count) =>
             val array = storage.asInstanceOf[scala.Array[Byte]]
             var sum = total
             var index = 0
@@ -963,8 +959,8 @@ object Tests extends Suite(m"Zephyrine tests"):
           rows.to[List]
         . assert(_ == List(Row(1), Row(2), Row(3)))
 
-        test(m"records composes with take"):
-          Stream(Iterator(Array.of(Row(1), Row(2)), Array.of(Row(3), Row(4)))).take(3).records
+        test(m"records composes with truncate"):
+          Stream(Iterator(Array.of(Row(1), Row(2)), Array.of(Row(3), Row(4)))).truncate(3).records
           . to(List)
         . assert(_ == List(Row(1), Row(2), Row(3)))
 


### PR DESCRIPTION
Three extensions defined in their modules' packages were missing from the `soundness` export lists, so `import soundness.*` did not reach them: the `Stream` slice and drain operators, `rows`/`rowsOf` on a character source, and `NetworkInterface`. Two of the stream operators could not simply be exported — `take` and `fold` were already held in the umbrella by turbulence and murmuration, and same-named top-level definitions there do not overload — so the kernel operators take names of their own, `truncate`, `discard` and `gather`, which better reflect that they count bytes or records rather than collection elements. Alongside them, `Style` had been exported by two modules at once; delicious's, which records the form a symbol reference is presented in rather than anything visual, becomes `Rendition`.

Stream slicing and window-level accumulation now reach you through the umbrella alone, under new names:

```scala
import soundness.*

stream.truncate(1024)                             // bound a stream
stream.discard(1024)                              // skip its first bytes
stream.gather(0L)((n, _, _, count) => n + count)  // accumulate per window
stream.chunks                                     // materialized chunks
```

`take` and `drop` still mean the collection operators; on a `Chain[Data]`, turbulence's byte-counted pair is now `take`/`drop`, where it was `take`/`discard`.

CSV row streams and the machine's network interfaces need no extra import:

```scala
source.rows.map(_[Text](t"name").or(t"?")).to(List)
source.rowsOf[Stat].map(_.count).to(List)
NetworkInterface.all().exists(_.loopback)
```

`NetworkInterface`'s own surface comes with it — `MacAddress`, `InterfaceAddress`, `Ipv4`/`Ipv6`, the subnet types and `DnsLabel` are all nameable now.

Renames to be aware of:

| Was | Is |
| --- | --- |
| `zephyrine`'s `Stream.take`/`drop`/`fold` | `truncate`/`discard`/`gather` |
| `turbulence`'s `Chain[Data].discard` | `drop` |
| `delicious.Style` | `Rendition` |
| `probably.Format.truncate` | `Format.abbreviate` |

Fixes #1671.
