### PR TITLE
Run the §19.2 positional atom phase in staged TEL parsers

### DIFF
--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -391,15 +391,12 @@ object Tel extends Tel2:
     // parser whose field values live in typed locals, whose keywords dispatch
     // through packed-`Long` literal comparisons, and whose record is built by
     // a direct constructor call — no `Array[Any]` buffer, no `Mirror`, no
-    // per-field boxing. Semantics (wire keywords, gathering, first-match-wins
-    // duplicates, defaults, absents, error foci) mirror `derived` exactly,
-    // EXCEPT that a staged record parser does not yet run the §19.2
-    // positional atom pre-pass (#1694): a record entry's own inline atoms
-    // are discarded, as all paths did before the fix. Use `derived` for
-    // documents that put field values in atom position. The generated
-    // instance's `shape()` is `Morphology.Any`. Requires a top-level or
-    // object-nested case class with a single parameter list — sums,
-    // method-local classes and other shapes use `derived`.
+    // per-field boxing. Semantics (wire keywords, §19.2 positional atom
+    // assignment, gathering, first-match-wins duplicates, defaults, absents,
+    // error foci) mirror `derived` exactly; the generated instance's
+    // `shape()` is `Morphology.Any`. Requires a top-level or object-nested
+    // case class with a single parameter list — sums, method-local classes
+    // and other shapes use `derived`.
     inline def staged[value]: value is Tel.Parsable =
       ${ stratiform.internal.stagedParsable[value]('{ adversaria.relabelling[value, Tel] }) }
 
@@ -564,6 +561,15 @@ object Tel extends Tel2:
     def missing[value](sentinel: value)(using Tactic[TelError]): value =
       raise(TelError(TelError.Reason.Absent)) yet sentinel
 
+    // A staged `Boolean` field's entry read, mirroring `booleanParsable`:
+    // flag semantics (§20) make a present entry with no atom the bare flag
+    // form, meaning `true`, while a present-but-unparseable atom is still
+    // `NotScalar`.
+    def flagEntry(reader: TelReader^): Boolean =
+      reader.boolean().lay:
+        if reader.primaryPresent then scalarFault(reader, t"Boolean", false) else true
+      . apply(identity)
+
     // A present entry whose atom was missing or unparseable: the byte-parsed
     // primitives' fault split — a missing atom is `Absent`, a
     // present-but-unparseable one `NotScalar` with the offending atom's text.
@@ -606,9 +612,109 @@ object Tel extends Tel2:
       (unwrap(parsing): @unchecked) match
         case gathering: Gathering => gathering.parseElement(reader, indent)
 
+    // One element of a repeatable field built from a positionally-assigned
+    // atom (§19.2): occurrences may split between inline atoms and later
+    // same-keyword children.
+    def parseAtomElement(parsing: Tel.Parsing, text: Text)(using Tactic[TelError]): Any =
+      (unwrap(parsing): @unchecked) match
+        case gathering: Gathering => gathering.parseAtomElement(text)
+
     def gathered[value](parsing: Tel.Parsing, elements: List[Any]): value =
       (unwrap(parsing): @unchecked) match
         case gathering: Gathering => gathering.gathered(elements).asInstanceOf[value]
+
+    // ── §19.2 positional assignment support for staged parsers ──
+    //
+    // Staged parsers are generated into user modules, so the atom phase is
+    // reached through public support points carrying neutral references, as
+    // the reader and field instances are. `positionalTable` is built once
+    // per generated instance (a lazy val); `positionalAssign` runs the atom
+    // phase for one entry line, and the two accessors read its per-field
+    // result by index — so generated code needs no collection API.
+
+    def positionalTable
+      ( keys:      Array[String]^{},
+        natures:   Array[Tel.Nature]^{},
+        instances: Array[Tel.Field | Null]^{},
+        fallbacks: Array[Any]^{} )
+    :   AnyRef =
+
+      val count = keys.length
+      val profiles = new scala.Array[Positional.Profile](count)
+      var index = 0
+
+      while index < count do
+        val instance = instances(index)
+
+        // A primitive field's nature is fixed by its type at expansion; an
+        // instance-backed field's comes from the instance itself.
+        val nature = if instance == null then natures(index) else instance.nature
+        val repeatable = instance != null && instance.repeatable
+        val optional = instance != null && instance.optional
+
+        // As in the derived engines: a Flag field is never required (its
+        // absence reads `false`), so the skip rule may pass over it.
+        profiles(index) =
+          Positional.Profile
+            ( Text(keys(index)),
+              nature,
+              repeatable,
+              required =
+                nature != Tel.Nature.Flag
+                && !(optional || fallbacks(index).asInstanceOf[Optional[Any]].present) )
+
+        index += 1
+
+      // The table and assignment travel as neutral carriers: both are fresh,
+      // self-contained arrays of pure data, so the rim cast is honest — the
+      // same discipline as `takeAtoms` and `Field.Adapter`.
+      profiles.asInstanceOf[AnyRef]
+
+    def positionalAssign(table: AnyRef, atoms: Array[Tel.Atom]^{})(using Tactic[TelError])
+    :   AnyRef =
+
+      val profiles = table.asInstanceOf[scala.Array[Positional.Profile]]
+      val assigned = Positional.assign(atoms, profiles.asInstanceOf[Array[Positional.Profile]^{}])
+      val result = new scala.Array[scala.Array[Text]](profiles.length)
+      var index = 0
+
+      while index < profiles.length do
+        val texts = assigned.readable(index).stdlib
+        val slot = new scala.Array[Text](texts.length)
+        var occurrence = 0
+        var rest = texts
+
+        while rest.nonEmpty do
+          slot(occurrence) = Positional.text(rest.head)
+          occurrence += 1
+          rest = rest.tail
+
+        result(index) = slot
+        index += 1
+
+      result.asInstanceOf[AnyRef]
+
+    def positionalCount(assignment: AnyRef, index: Int): Int =
+      assignment.asInstanceOf[scala.Array[scala.Array[Text]]](index).length
+
+    def positionalText(assignment: AnyRef, index: Int, occurrence: Int): Text =
+      assignment.asInstanceOf[scala.Array[scala.Array[Text]]](index)(occurrence)
+
+    // §20.2 step 5c from a staged parser: a non-repeatable field filled by a
+    // positional atom, then again by a same-keyword child.
+    def duplicateFill()(using Tactic[TelError]): Unit =
+      raise(TelError(TelError.Reason.NonRepeatableTooMany))
+
+    // The byte-parsed primitives' `parseAtom` semantics, for a staged
+    // parser's positionally-assigned atom: an unparseable value is
+    // `NotScalar` with the offending text, as on both other paths.
+    def atomInt(text: Text)(using Tactic[TelError]): Int =
+      val parsed = try Optional(text.s.toInt) catch case _: NumberFormatException => Unset
+      parsed.or(raise(TelError(TelError.Reason.NotScalar(text, t"Int"))) yet 0)
+
+    def atomLong(text: Text)(using Tactic[TelError]): Long =
+      val parsed = try Optional(text.s.toLong) catch case _: NumberFormatException => Unset
+      parsed.or(raise(TelError(TelError.Reason.NotScalar(text, t"Long"))) yet 0L)
 
     // Field instances travel wrapped in the `Field.Adapter`; the engine
     // looks through it for repeatability and element hooks.

--- a/lib/stratiform/src/core/stratiform.internal.scala
+++ b/lib/stratiform/src/core/stratiform.internal.scala
@@ -594,7 +594,9 @@ object internal:
         keys:        Expr[Array[String]^{}],
         instances:   Expr[Array[Tel.Field | Null]^{}],
         repeatables: Expr[Array[Boolean]^{}],
-        fallbacks:   Expr[Array[Any]^{}] )
+        fallbacks:   Expr[Array[Any]^{}],
+        table:       Expr[AnyRef],
+        lineAtoms:   Option[Expr[Array[Tel.Atom]^{}]] )
     :   Expr[value] =
 
       val owner = Symbol.spliceOwner
@@ -605,6 +607,12 @@ object internal:
 
       val seens = List.range(0, arity).map: index =>
         Symbol.newVal(owner, "seen"+index, TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+
+      // Whether a field's slot was filled by a positionally-assigned atom
+      // rather than a keyword child — a later same-keyword child then fills
+      // a non-repeatable member twice (§20.2 step 5c).
+      val atomFilleds = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "atom"+index, TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
 
       // Occurrence buffers for the fields that may gather (repeatable
       // instances), allocated lazily on the first occurrence.
@@ -617,6 +625,9 @@ object internal:
 
       val seenDefs = List.range(0, arity).map: index =>
         ValDef(seens(index), Some(Literal(BooleanConstant(false))))
+
+      val atomFilledDefs = List.range(0, arity).map: index =>
+        ValDef(atomFilleds(index), Some(Literal(BooleanConstant(false))))
 
       val bufferDefs = List.range(0, arity).flatMap: index =>
         buffers(index).map: symbol => ValDef(symbol, Some('{ null }.asTerm))
@@ -633,7 +644,13 @@ object internal:
         def firstWins(read: Term): Term =
           If
             ( Ref(seens(index)),
-              '{ $reader.skipEntry($indent) }.asTerm,
+              Block
+                ( List
+                    ( If
+                        ( Ref(atomFilleds(index)),
+                          '{ Tel.Parsable.duplicateFill()(using $tactic) }.asTerm,
+                          unit ) ),
+                  '{ $reader.skipEntry($indent) }.asTerm ),
               Block
                 ( List
                     ( Assign(Ref(slots(index)), read),
@@ -660,9 +677,7 @@ object internal:
               case BooleanK =>
                 firstWins:
                   '{
-                    Tel.Parsable.focusing($foci, $keyText):
-                      $reader.boolean()
-                      . lay(Tel.Parsable.scalarFault($reader, t"Boolean", false))(identity)
+                    Tel.Parsable.focusing($foci, $keyText)(Tel.Parsable.flagEntry($reader))
                   }.asTerm
 
               case TextK =>
@@ -720,6 +735,121 @@ object internal:
         CaseDef(Literal(IntConstant(index)), None, rhs)
 
       val fallthrough = CaseDef(Wildcard(), None, '{ $reader.skipEntry($indent) }.asTerm)
+
+      // The §19.2 atom phase over the entry line's own atoms, run before the
+      // keyword loop so a repeatable field's atoms precede its same-keyword
+      // children (§18.3 step 4). Generated only for the entry form — the
+      // document root carries no atoms (§20.2) — and guarded at runtime, so
+      // the dominant atomless shape pays a single length test.
+      val prepass: List[Statement] = lineAtoms.toList.map: atoms =>
+        val assignment =
+          Symbol.newVal(owner, "positional", TypeRepr.of[AnyRef], Flags.EmptyFlags, Symbol.noSymbol)
+
+        val assignmentExpr = Ref(assignment).asExprOf[AnyRef]
+
+        val deliveries: List[Statement] = List.range(0, arity).map: index =>
+          val keyText: Expr[Text] = '{ $keys(${Expr(index)}).tt }
+          val count: Expr[Int] = '{ Tel.Parsable.positionalCount($assignmentExpr, ${Expr(index)}) }
+
+          val first: Expr[Text] =
+            '{ Tel.Parsable.positionalText($assignmentExpr, ${Expr(index)}, 0) }
+
+          // A slot filled from an atom is `seen`, so the keyword loop's
+          // first-wins step skips a later same-keyword child (and reports
+          // the duplicate fill).
+          def fill(value: Term): Term =
+            Block
+              ( List
+                  ( Assign(Ref(slots(index)), value),
+                    Assign(Ref(seens(index)), Literal(BooleanConstant(true))),
+                    Assign(Ref(atomFilleds(index)), Literal(BooleanConstant(true))) ),
+                unit )
+
+          val deliver: Term = fieldTypes(index).asType match
+            case '[fieldType] =>
+              kinds(index) match
+                case IntK =>
+                  fill:
+                    '{
+                      Tel.Parsable.focusing($foci, $keyText):
+                        Tel.Parsable.atomInt($first)(using $tactic)
+                    }.asTerm
+
+                case LongK =>
+                  fill:
+                    '{
+                      Tel.Parsable.focusing($foci, $keyText):
+                        Tel.Parsable.atomLong($first)(using $tactic)
+                    }.asTerm
+
+                // A Flag-natured field's assigned atom is its keyword, and
+                // means presence.
+                case BooleanK => fill(Literal(BooleanConstant(true)))
+
+                case TextK => fill(first.asTerm)
+
+                case StringK => fill('{ $first.s }.asTerm)
+
+                case InstanceK =>
+                  val bufferRef = Ref(buffers(index).get)
+
+                  val bufferExpr =
+                    bufferRef.asExprOf[scala.collection.mutable.ListBuffer[Any] | Null]
+
+                  val ensure: Term =
+                    If
+                      ( '{ $bufferExpr == null }.asTerm,
+                        Assign
+                          ( bufferRef,
+                            '{ scala.collection.mutable.ListBuffer.empty[Any] }.asTerm ),
+                        unit )
+
+                  // §19.2: a repeatable member takes every atom assigned to
+                  // it, each becoming one gathered occurrence.
+                  val gather: Term =
+                    '{
+                      var occurrence = 0
+
+                      while occurrence < $count do
+                        $bufferExpr.asInstanceOf[scala.collection.mutable.ListBuffer[Any]].addOne
+                          ( Tel.Parsable.focusing($foci, $keyText):
+                              Tel.Parsable.parseAtomElement
+                                ( $instances(${Expr(index)}).asInstanceOf[Tel.Parsing],
+                                  Tel.Parsable.positionalText
+                                    ( $assignmentExpr, ${Expr(index)}, occurrence ) )
+                                ( using $tactic ) )
+
+                        occurrence += 1
+                    }.asTerm
+
+                  val single: Term =
+                    fill:
+                      '{
+                        val instance =
+                          $instances(${Expr(index)}).asInstanceOf[fieldType is Tel.Field]
+
+                        Tel.Parsable.focusing($foci, $keyText):
+                          if instance.nature == Tel.Nature.Flag
+                          then instance.parseFlag()(using $tactic)
+                          else instance.parseAtom($first)(using $tactic)
+                      }.asTerm
+
+                  If
+                    ( '{ $repeatables(${Expr(index)}) }.asTerm,
+                      Block(List(ensure), gather),
+                      single )
+
+          If('{ $count > 0 }.asTerm, deliver, unit)
+
+        If
+          ( '{ $atoms.length > 0 }.asTerm,
+            Block
+              ( ValDef
+                  ( assignment,
+                    Some('{ Tel.Parsable.positionalAssign($table, $atoms)(using $tactic) }.asTerm) )
+                :: deliveries,
+                unit ),
+            unit )
 
       // The keyword loop. With literal keywords, each step compares the
       // packed word against the wire keywords as immediate constants,
@@ -782,8 +912,8 @@ object internal:
               case TextK    => '{ Tel.Parsable.missing[Text](t"")(using $tactic) }.asExprOf[fieldType]
               case StringK  => '{ Tel.Parsable.missing[String]("")(using $tactic) }.asExprOf[fieldType]
 
-              case BooleanK =>
-                '{ Tel.Parsable.missing[Boolean](false)(using $tactic) }.asExprOf[fieldType]
+              // A Flag field's absence is `false`, not an error (§20).
+              case BooleanK => '{ false }.asExprOf[fieldType]
 
             val resolveAbsent: Term =
               Assign
@@ -835,7 +965,9 @@ object internal:
 
         Apply(applied, slots.map { slot => Ref(slot) })
 
-      Block(slotDefs ::: seenDefs ::: bufferDefs ::: loop ::: absents, construct)
+      Block
+        ( slotDefs ::: seenDefs ::: atomFilledDefs ::: bufferDefs ::: prepass ::: loop ::: absents,
+          construct )
       . asExprOf[value]
 
     def summonOrAbort[required: Type](role: String): Expr[required] =
@@ -847,6 +979,14 @@ object internal:
     val nameExprs = fieldNames.map { name => Expr(name) }
     val instanceExprs = List.range(0, arity).map(summonField)
     val fallbackExprs = List.range(0, arity).map(declaredDefault)
+
+    // A primitive field's §20.2 nature is fixed by its type here; an
+    // instance-backed field's is read from the instance when the positional
+    // table is built, so its entry is only a placeholder.
+    val natureExprs: List[Expr[Tel.Nature]] = kinds.map:
+      case BooleanK  => '{ Tel.Nature.Flag }
+      case InstanceK => '{ Tel.Nature.Struct }
+      case _         => '{ Tel.Nature.Scalar }
 
     '{
       // Sealed per the codec-thunk pattern, like the derived instances: the
@@ -867,22 +1007,32 @@ object internal:
 
         lazy val fallbacks: Array[Any]^{} = Array.of[Any](${Varargs(fallbackExprs)}*)
 
+        lazy val natures: Array[Tel.Nature]^{} = Array.of[Tel.Nature](${Varargs(natureExprs)}*)
+
+        // The §19.2 profile table: one per generated instance, built on
+        // first use so recursive self-references stay deferred, like the
+        // instance array it reads.
+        lazy val table: AnyRef =
+          Tel.Parsable.positionalTable(keys, natures, instances, fallbacks)
+
         new Tel.Parsable:
           type Self = value
           def shape(): Morphology = Morphology.Any
 
           def parse(reader: TelReader^, indent: Int): value =
-            reader.finishLine()
+            val atoms = reader.lineAtoms()
             ${
               body
                 ( '{reader}, '{indent + 1}, '{foci}, '{tactic}, '{keys}, '{instances},
-                  '{repeatables}, '{fallbacks} )
+                  '{repeatables}, '{fallbacks}, '{table}, Some('{atoms}) )
             }
 
+          // The document root carries no atoms (§20.2), so the whole-input
+          // form generates no positional pre-pass at all.
           override def parse(reader: TelReader^): value =
             ${
               body
                 ( '{reader}, '{0}, '{foci}, '{tactic}, '{keys}, '{instances},
-                  '{repeatables}, '{fallbacks} )
+                  '{repeatables}, '{fallbacks}, '{table}, None )
             }
     }

--- a/lib/stratiform/src/test/stratiform.PositionalTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionalTests.scala
@@ -211,6 +211,78 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
         value.encode.show.s.tt.read[PNote in Tel] == value
       . assert(identity)
 
+    suite(m"Positional atom decoding (§19.2, staged path)"):
+      given PRecipient is Tel.Parsable = Tel.Parsable.staged
+      given PDelivery is Tel.Parsable = Tel.Parsable.staged
+      given PFlagItem is Tel.Parsable = Tel.Parsable.staged
+      given PHolder is Tel.Parsable = Tel.Parsable.staged
+      given PLog is Tel.Parsable = Tel.Parsable.staged
+      given PLogBook is Tel.Parsable = Tel.Parsable.staged
+      given PFlags is Tel.Parsable = Tel.Parsable.staged
+      given PPair is Tel.Parsable = Tel.Parsable.staged
+      given PPairBox is Tel.Parsable = Tel.Parsable.staged
+      given PNote is Tel.Parsable = Tel.Parsable.staged
+
+      // The acceptance criterion for staged generation: the staged read must
+      // equal the AST-path read, for the same input.
+      inline def parity[value](tel: Text)(using value is Tel.Parsable, value is Tel.Decodable)
+      :   Boolean =
+        tel.read[value in Tel] == tel.read[Tel].as[value]
+
+      test(m"inline atoms assign positionally, equally on both paths (#1699)"):
+        val doc = t"recipient  Acme Corporation\n  address  1 Acme Way\n"
+        (doc.read[PDelivery in Tel], parity[PDelivery](doc))
+      . assert(_ == (PDelivery(PRecipient(t"Acme Corporation", t"1 Acme Way")), true))
+
+      test(m"the worked example parses staged, equally on both paths"):
+        val doc = t"item a xyz\n"
+        (doc.read[PHolder in Tel], parity[PHolder](doc))
+      . assert(_ == (PHolder(PFlagItem(true, Unset, t"xyz")), true))
+
+      test(m"a repeatable field consumes the rest, equally on both paths"):
+        val doc = t"log lbl 1 2 3\n"
+        (doc.read[PLogBook in Tel], parity[PLogBook](doc))
+      . assert(_ == (PLogBook(PLog(t"lbl", List(1, 2, 3))), true))
+
+      test(m"repeatable occurrences split atoms/children, equally on both paths"):
+        val doc = t"log lbl 1\n  values 2\n"
+        (doc.read[PLogBook in Tel], parity[PLogBook](doc))
+      . assert(_ == (PLogBook(PLog(t"lbl", List(1, 2))), true))
+
+      test(m"bare and absent flags parse staged, equally on both paths"):
+        val doc = t"active\n"
+        (doc.read[PFlags in Tel], parity[PFlags](doc))
+      . assert(_ == (PFlags(true, Unset), true))
+
+      test(m"a bare optional flag parses as present true, equally on both paths"):
+        val doc = t"active\nverbose\n"
+        (doc.read[PFlags in Tel], parity[PFlags](doc))
+      . assert(_ == (PFlags(true, true), true))
+
+      test(m"optional scalars fill per §20.8, equally on both paths"):
+        val doc = t"pair hello\n  second world\n"
+        (doc.read[PPairBox in Tel], parity[PPairBox](doc))
+      . assert(_ == (PPairBox(PPair(t"hello", t"world")), true))
+
+      test(m"a source atom supplies a staged scalar field"):
+        val doc = t"body\n    line one\n    line two\n"
+        (doc.read[PNote in Tel], parity[PNote](doc))
+      . assert(_ == (PNote(t"line one\nline two"), true))
+
+      test(m"an atom plus a same-keyword child raises E308 on the staged path"):
+        capture[TelError](t"log lbl\n  label dup\n".read[PLogBook in Tel]).reason
+      . assert(_ == TelError.Reason.NonRepeatableTooMany)
+
+      test(m"excess atoms raise E302 on the staged path"):
+        capture[TelError](t"item a xyz extra\n".read[PHolder in Tel]).reason
+      . assert(_ == TelError.Reason.TooManyAtoms)
+
+      test(m"an unparseable positional atom raises NotScalar"):
+        capture[TelError](t"log lbl notanumber\n".read[PLogBook in Tel]).reason match
+          case TelError.Reason.NotScalar(_, expected) => expected
+          case _                                      => t"?"
+      . assert(_ == t"Int")
+
     suite(m"Canonical construction (§22.2)"):
       given canonicalRecipient: (PRecipient is Tel.Parsable) = Tel.Parsable.derived
       given canonicalDelivery: (PDelivery is Tel.Parsable) = Tel.Parsable.derived


### PR DESCRIPTION
Staged TEL parsers now implement §19.2 positional atom assignment, closing the last gap left by #1694: a record entry's own inline atoms fill fields positionally, exactly as they already do for `Tel.Parsable.derived` and the AST path, so all three decoding routes agree on the same document.

Closes #1699.

## Positional atoms in staged parsers

`Tel.Parsable.staged` previously discarded a record entry's atoms, so a positional-form document decoded with those fields absent — diverging from `Tel.Parsable.derived` for the same type:

```scala
case class Recipient(name: Text, address: Optional[Text])
case class Delivery(recipient: Optional[Recipient])

given Recipient is Tel.Parsable = Tel.Parsable.staged
given Delivery is Tel.Parsable = Tel.Parsable.staged
```

```tel
recipient  Acme Corporation
  address  1 Acme Way
```

`read[Delivery in Tel]` now produces `Recipient(t"Acme Corporation", t"1 Acme Way")`; previously `name` decoded as absent. The generated parser captures the entry line's atoms and runs the same atom phase before its keyword loop, delivering each assignment into the typed slot it belongs to: primitive fields parse the atom text inline, instance-backed fields go through `parseAtom`/`parseFlag`, and a repeatable field's atoms seed its gather buffer ahead of any later same-keyword children (§18.3 step 4). A slot filled from an atom reports E308 if a same-keyword child follows, and the skip, overflow and mismatch diagnostics (E302, E303, E305) come from the shared algorithm, so a staged parser reports them identically.

Boolean fields also pick up the flag semantics the other two paths gained: a bare keyword entry reads `true` and an absent field `false`.

The document form is unaffected — the root carries no atoms (§20.2), so no pre-pass is generated for it at all — and a record entry with no atoms costs a single length test, keeping the staged parser's allocation-free shape for the dominant keyword-child form.

## Testing

The staged path now runs the full positional fixture set from the derived and AST suites, asserting on each that the staged read equals the AST-path read — the existing acceptance criterion for staged generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
