### PR TITLE
Fix the TEL benchmarks and restore Boolean's scalar mapping

### DIFF
--- a/lib/stratiform/src/bench/stratiform.Benchmarks.scala
+++ b/lib/stratiform/src/bench/stratiform.Benchmarks.scala
@@ -46,6 +46,7 @@ import hellenism.*, classloaders.threadContextClassloader
 import hieroglyph.*, charEncoders.utf8Encoder
 import probably.*
 import proscenium.*
+import proscenium.compat.*
 import quantitative.*
 import rudiments.*
 import sedentary.*

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -114,13 +114,19 @@ object Tel extends Tel2:
 
   // How a value of a codec's type occupies a compound line's atom positions,
   // approximating §20.2's member classification from Scala types alone
-  // (issue #1694): `Scalar` is atom-assignable and never skipped, `Flag`
-  // (Boolean) is atom-assignable when the atom text equals the keyword, and
-  // `Struct` (a nested record, sum, or map) can only be filled by a keyword
-  // child. The schema-less approximation diverges from §20.2 in documented
-  // ways: an all-singleton enum decodes through its text codec and so is
-  // `Scalar`, not Flag-shaped, and non-singleton sums are `Struct` even
-  // where a schema's all-Flag select would be atom-assignable.
+  // (issue #1694): `Scalar` is atom-assignable and never skipped, `Flag` is
+  // atom-assignable when the atom text equals the keyword, and `Struct` (a
+  // nested record, sum, or map) can only be filled by a keyword child.
+  //
+  // The schema-less approximation diverges from §20.2 in documented ways.
+  // No derived codec is `Flag`-natured: a §20 flag is keyword presence
+  // alone, whereas a Scala `Boolean` is a value, so it maps to `Scalar` and
+  // reads and writes an explicit `true`/`false` atom — the mapping the
+  // derived schema and BinTEL also use. A custom codec for a genuinely
+  // flag-shaped type may opt into `Flag`. Likewise an all-singleton enum
+  // decodes through its text codec and so is `Scalar`, and non-singleton
+  // sums are `Struct` even where a schema's all-Flag select would be
+  // atom-assignable.
   enum Nature:
     case Scalar, Flag, Struct
 
@@ -506,11 +512,7 @@ object Tel extends Tel2:
           override def optional: Boolean = true
 
           def parse(reader: TelReader^, indent: Int): value =
-            // A bare entry means `Unset` for most types, but a Flag-natured
-            // inner reads it as flag presence (`Optional[Boolean]` of
-            // `true`) — the AST `optionalDecodable`'s test exactly.
-            if reader.hasSubstance || field.nature == Tel.Nature.Flag
-            then field.parse(reader, indent)
+            if reader.hasSubstance then field.parse(reader, indent)
             else
               reader.skipEntry(indent)
               Unset
@@ -560,15 +562,6 @@ object Tel extends Tel2:
     // `absent()` semantics — raise and continue with the sentinel.
     def missing[value](sentinel: value)(using Tactic[TelError]): value =
       raise(TelError(TelError.Reason.Absent)) yet sentinel
-
-    // A staged `Boolean` field's entry read, mirroring `booleanParsable`:
-    // flag semantics (§20) make a present entry with no atom the bare flag
-    // form, meaning `true`, while a present-but-unparseable atom is still
-    // `NotScalar`.
-    def flagEntry(reader: TelReader^): Boolean =
-      reader.boolean().lay:
-        if reader.primaryPresent then scalarFault(reader, t"Boolean", false) else true
-      . apply(identity)
 
     // A present entry whose atom was missing or unparseable: the byte-parsed
     // primitives' fault split — a missing atom is `Absent`, a
@@ -715,6 +708,10 @@ object Tel extends Tel2:
     def atomLong(text: Text)(using Tactic[TelError]): Long =
       val parsed = try Optional(text.s.toLong) catch case _: NumberFormatException => Unset
       parsed.or(raise(TelError(TelError.Reason.NotScalar(text, t"Long"))) yet 0L)
+
+    def atomBoolean(text: Text)(using Tactic[TelError]): Boolean =
+      if text == t"true" then true else if text == t"false" then false
+      else raise(TelError(TelError.Reason.NotScalar(text, t"Boolean"))) yet false
 
     // Field instances travel wrapped in the `Field.Adapter`; the engine
     // looks through it for repeatability and element hooks.
@@ -2001,23 +1998,16 @@ object Tel extends Tel2:
     new Tel.Parsable:
       type Self = Boolean
       def shape(): Morphology = Morphology.Bool
-      override def nature: Tel.Nature = Tel.Nature.Flag
+      override def nature: Tel.Nature = Tel.Nature.Scalar
 
       def parse(reader: TelReader^, indent: Int): Boolean =
-        // Flag semantics (§20): a present entry with no atom is the bare
-        // flag form, meaning `true`; a present-but-unparseable atom is
-        // still `NotScalar`, exactly as on the AST path.
-        reader.boolean().lay(
-          if reader.primaryPresent then Parsable.scalarFault(reader, t"Boolean", false) else true
-        )(identity)
+        reader.boolean().lay(Parsable.scalarFault(reader, t"Boolean", false))(identity)
 
-      override def absent()(using Tactic[TelError]): Boolean = false
+      override def absent()(using Tactic[TelError]): Boolean =
+        raise(TelError(TelError.Reason.Absent)) yet false
 
       override def parseAtom(text: Text)(using Tactic[TelError]): Boolean =
-        if text == t"true" then true else if text == t"false" then false
-        else raise(TelError(TelError.Reason.NotScalar(text, t"Boolean"))) yet false
-
-      override def parseFlag()(using Tactic[TelError]): Boolean = true
+        Parsable.atomBoolean(text)
 
   // `Tel` reads itself directly through the AST bridge — the direct
   // counterpart of `telDecodable`.

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -440,23 +440,7 @@ trait Tel2 extends Tel3:
               val encoded = contextual.encode(fieldValue)
               val keyword = renames.at(label).or(Tel.camelToKebab(label.s))
 
-              // Flag encoding (§20): `true` is the bare keyword and a plain
-              // `false` flag is omitted, since decoding reads absence as
-              // false. An `Optional[Boolean]`'s `false` stays explicit, so
-              // Unset / true / false remain distinguishable (omitted / bare
-              // keyword / `keyword false`); its Unset encodes an empty
-              // document and emits nothing below.
-              if contextual.nature == Tel.Nature.Flag then
-                encoded.subtree match
-                  case c: Tel.Compound =>
-                    if encoded.primaryAtom == t"true"
-                    then compounds += Tel.Compound(keyword, Array.empty, Unset, Array.empty)
-                    else if encoded.primaryAtom == t"false" && !contextual.optional
-                    then ()
-                    else compounds += c.copy(keyword = keyword)
-
-                  case _ => ()
-              else encoded.subtree match
+              encoded.subtree match
                 case c: Tel.Compound =>
                   compounds += c.copy(keyword = keyword)
 
@@ -476,7 +460,6 @@ trait Tel2 extends Tel3:
         :   scala.collection.immutable.List[Mutation.Member] =
 
           val members = scala.collection.mutable.ListBuffer.empty[Mutation.Member]
-          val elidedFlags = scala.collection.mutable.HashSet.empty[Text]
 
           fields(value): [field] =>
             fieldValue =>
@@ -484,32 +467,20 @@ trait Tel2 extends Tel3:
 
               contextual.nature match
                 case Tel.Nature.Flag =>
+                  // No derived codec is flag-natured (a Scala `Boolean` is a
+                  // value, §20 flags are keyword presence), but a custom one
+                  // may be: `true` is the bare keyword, `false` is elided.
                   val encoded = contextual.encode(fieldValue)
 
-                  encoded.subtree match
-                    case c: Tel.Compound =>
-                      if encoded.primaryAtom == t"true"
-                      then members += Mutation.Member.Flag(keyword)
-                      else if encoded.primaryAtom == t"false" && !contextual.optional
-                      then elidedFlags += keyword
-                      else members += Mutation.Member.Child(c.copy(keyword = keyword))
-
-                    case _ => elidedFlags += keyword
+                  if encoded.primaryAtom == t"true" then members += Mutation.Member.Flag(keyword)
+                  else members += Mutation.Member.Break
 
                 case Tel.Nature.Scalar =>
                   val encoded = contextual.encode(fieldValue)
 
                   encoded.subtree match
                     case c: Tel.Compound =>
-                      val text = encoded.primaryAtom
-
-                      // A value colliding with a preceding elided flag's
-                      // keyword would set that flag on re-decode; the child
-                      // form sidesteps the collision.
-                      if elidedFlags.contains(text)
-                      then members += Mutation.Member.Child:
-                        Tel.Compound(keyword, c.atoms, Unset, Array.empty)
-                      else members += Mutation.Member.Value(keyword, List(text))
+                      members += Mutation.Member.Value(keyword, List(encoded.primaryAtom))
 
                     case d: Tel.Document =>
                       // A repeatable scalar field: all occurrences inline or
@@ -525,20 +496,14 @@ trait Tel2 extends Tel3:
                       else if children.length == 1
                       then members += Mutation.Member.Child(children(0).copy(keyword = keyword))
                       else
-                        var collision = false
                         val texts = scala.collection.mutable.ListBuffer.empty[Text]
 
                         children.each: child =>
-                          val text =
-                            if child.atoms.length == 0 then t""
-                            else Positional.text(child.atoms(0))
+                          texts +=
+                            ( if child.atoms.length == 0 then t""
+                              else Positional.text(child.atoms(0)) )
 
-                          if elidedFlags.contains(text) then collision = true
-                          texts += text
-
-                        if collision then children.each: child =>
-                          members += Mutation.Member.Child(child.copy(keyword = keyword))
-                        else members += Mutation.Member.Value(keyword, List.of(texts.toList))
+                        members += Mutation.Member.Value(keyword, List.of(texts.toList))
 
                 case Tel.Nature.Struct =>
                   val encoded = contextual.constructed(fieldValue)
@@ -641,23 +606,18 @@ trait Tel2 extends Tel3:
       primitiveFault(tel, t"Double", 0.0): atom =>
         try atom.s.toDouble catch case _: NumberFormatException => Unset
 
-  // Flag semantics (§20): a present, keyword-bearing compound with no atom
-  // is the bare flag form, meaning `true`; an absent field decodes `false`
-  // via `absent()`. The explicit `true`/`false` atom forms stay readable.
+  // A Scala `Boolean` is a value, not a TEL flag (§20 flags are keyword
+  // presence alone), so it reads and writes the explicit `true`/`false` atom
+  // — the mapping every layer agrees on, from the derived schema through
+  // BinTEL. A codec may opt into `Tel.Nature.Flag` for a genuinely
+  // flag-shaped type.
   given booleanDecodable: (tactic: Tactic[TelError]) => ((Boolean is Tel.Decodable)^{tactic}) =
-    new Tel.Decodable:
-      type Self = Boolean
-      def shape(): Morphology = Morphology.Bool
-      override def nature: Tel.Nature = Tel.Nature.Flag
-      override def absent()(using Tactic[TelError]): Boolean = false
-
-      def decoded(tel: Tel): Boolean =
-        if tel.atomTexts.isEmpty && bareCompound(tel) then true
-        else primitiveFault(tel, t"Boolean", false): atom =>
-          atom.s match
-            case "true"  => true
-            case "false" => false
-            case _       => Unset
+    Tel.Decodable(() => Morphology.Bool, Tel.Nature.Scalar): tel =>
+      primitiveFault(tel, t"Boolean", false): atom =>
+        atom.s match
+          case "true"  => true
+          case "false" => false
+          case _       => Unset
 
   given telDecodable: Tel is Tel.Decodable = Tel.Decodable(() => Morphology.Any)(identity(_))
 
@@ -677,7 +637,7 @@ trait Tel2 extends Tel3:
     Tel.Encodable(() => Morphology.Real, Tel.Nature.Scalar): d => Tel.scalar(Text(d.toString))
 
   given booleanEncodable: Boolean is Tel.Encodable =
-    Tel.Encodable(() => Morphology.Bool, Tel.Nature.Flag): b => Tel.scalar(Text(b.toString))
+    Tel.Encodable(() => Morphology.Bool, Tel.Nature.Scalar): b => Tel.scalar(Text(b.toString))
 
   given telEncodable: Tel is Tel.Encodable = Tel.Encodable(() => Morphology.Any)(identity(_))
 
@@ -713,11 +673,7 @@ trait Tel2 extends Tel3:
       override def absent()(using Tactic[TelError]): value = Unset
 
       def decoded(telVal: Tel): value =
-        // A bare entry means `Unset` for most types, but a Flag-natured
-        // inner reads it as flag presence (`Optional[Boolean]` of `true`).
-        if telVal.childCompounds.nil && telVal.atomTexts.nil
-           && decodable0.nature != Tel.Nature.Flag
-        then Unset
+        if telVal.childCompounds.nil && telVal.atomTexts.nil then Unset
         else decodable0.decoded(telVal)
 
   // Collection support (aligned with `#1291`) — a `List`/`Set` encodes to a

--- a/lib/stratiform/src/core/stratiform.internal.scala
+++ b/lib/stratiform/src/core/stratiform.internal.scala
@@ -677,7 +677,9 @@ object internal:
               case BooleanK =>
                 firstWins:
                   '{
-                    Tel.Parsable.focusing($foci, $keyText)(Tel.Parsable.flagEntry($reader))
+                    Tel.Parsable.focusing($foci, $keyText):
+                      $reader.boolean()
+                      . lay(Tel.Parsable.scalarFault($reader, t"Boolean", false))(identity)
                   }.asTerm
 
               case TextK =>
@@ -782,9 +784,12 @@ object internal:
                         Tel.Parsable.atomLong($first)(using $tactic)
                     }.asTerm
 
-                // A Flag-natured field's assigned atom is its keyword, and
-                // means presence.
-                case BooleanK => fill(Literal(BooleanConstant(true)))
+                case BooleanK =>
+                  fill:
+                    '{
+                      Tel.Parsable.focusing($foci, $keyText):
+                        Tel.Parsable.atomBoolean($first)(using $tactic)
+                    }.asTerm
 
                 case TextK => fill(first.asTerm)
 
@@ -912,8 +917,8 @@ object internal:
               case TextK    => '{ Tel.Parsable.missing[Text](t"")(using $tactic) }.asExprOf[fieldType]
               case StringK  => '{ Tel.Parsable.missing[String]("")(using $tactic) }.asExprOf[fieldType]
 
-              // A Flag field's absence is `false`, not an error (§20).
-              case BooleanK => '{ false }.asExprOf[fieldType]
+              case BooleanK =>
+                '{ Tel.Parsable.missing[Boolean](false)(using $tactic) }.asExprOf[fieldType]
 
             val resolveAbsent: Term =
               Assign

--- a/lib/stratiform/src/test/stratiform.EquivalenceTests.scala
+++ b/lib/stratiform/src/test/stratiform.EquivalenceTests.scala
@@ -153,33 +153,26 @@ object EquivalenceTests extends Suite(m"Stratiform schema/codec equivalence test
         (schemaReasons, codecReason)
       . assert(_ == (Set(TelError.Reason.TooManyAtoms), TelError.Reason.TooManyAtoms))
 
-    suite(m"Codec/assign equivalence (flags, hand-built schema)"):
-      // The schema derivation does not yet model Boolean fields as Flag
-      // members, so the flag fixture pairs the codecs against a hand-built
-      // schema with true Flag members.
-      val flagsSchema = Tels(
-        name     = t"flags",
-        document = Tels.Struct(
-          members = Array.of(
-            Tels.Field(Tels.Polarity.Loose, Tels.Polarity.Implicit, t"active", Tels.Flag, Unset),
-            Tels.Field(Tels.Polarity.Loose, Tels.Polarity.Implicit, t"verbose", Tels.Flag, Unset)),
-          validators = Array.empty),
-        layers   = Array.empty,
-        sigil    = Unset,
-        records  = Array.empty,
-        scalars  = Array.empty,
-        selects  = Array.empty)
-
-      test(m"a bare flag agrees across codecs and type assignment"):
-        val doc = t"active\n"
-        val decoded = doc.read[Tel].as[PFlags] == PFlags(true, Unset)
-        val issues = validateAssign(doc.read[Tel], flagsSchema).items.length
-        val oracle = scalars(Tel.Type.assign(doc.read[Tel], flagsSchema))
-        (decoded, issues, oracle)
-      . assert(_ == (true, 0, scala.collection.immutable.List(("#/0", "+"))))
-
-      test(m"the encoded flag form validates against the flag schema"):
+    suite(m"Encoded values validate against their derived schema"):
+      // The invariant the benchmarks caught breaking: whatever the encoder
+      // writes for a field must satisfy the schema derived from the same
+      // type. A Boolean is a scalar member on both sides — an encoder that
+      // elided or bare-keyworded it would fail its own schema with E307 or
+      // E311.
+      test(m"a Boolean field's encoding validates and decodes back"):
         val encoded = PFlags(true, Unset).encode
-        val issues = validateAssign(encoded, flagsSchema).items.length
+        val issues = validateAssign(encoded, Tels.tels[PFlags](t"flags")).items.length
         (encoded.as[PFlags], issues)
       . assert(_ == (PFlags(true, Unset), 0))
+
+      test(m"a false Boolean's encoding validates against the derived schema"):
+        val encoded = PFlags(false, false).encode
+        val issues = validateAssign(encoded, Tels.tels[PFlags](t"flags")).items.length
+        (encoded.as[PFlags], issues)
+      . assert(_ == (PFlags(false, false), 0))
+
+      test(m"a record of scalars, collections and nested records validates"):
+        val value = PDelivery(PRecipient(t"Acme Corporation", t"1 Acme Way"))
+        val issues = validateAssign(value.encode, Tels.tels[PDelivery](t"delivery")).items.length
+        (value.encode.as[PDelivery], issues)
+      . assert(_ == (PDelivery(PRecipient(t"Acme Corporation", t"1 Acme Way")), 0))

--- a/lib/stratiform/src/test/stratiform.PositionalTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionalTests.scala
@@ -46,8 +46,8 @@ import Tel.given
 // atoms (§20.2).
 case class PRecipient(name: Text, address: Optional[Text]) derives CanEqual
 case class PDelivery(recipient: Optional[PRecipient]) derives CanEqual
-case class PFlagItem(a: Boolean, b: Optional[Boolean], c: Text) derives CanEqual
-case class PHolder(item: PFlagItem) derives CanEqual
+case class PTriple(one: Text, two: Optional[Text]) derives CanEqual
+case class PHolder(item: PTriple) derives CanEqual
 case class PLog(label: Text, values: List[Int]) derives CanEqual
 case class PLogBook(log: PLog) derives CanEqual
 case class PFlags(active: Boolean, verbose: Optional[Boolean]) derives CanEqual
@@ -70,9 +70,9 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
         positional.read[Tel].as[PDelivery] == explicit.read[Tel].as[PDelivery]
       . assert(identity)
 
-      test(m"an atom skips an optional flag and fills the scalar (worked example)"):
+      test(m"consecutive atoms fill consecutive scalar members"):
         t"item a xyz\n".read[Tel].as[PHolder]
-      . assert(_ == PHolder(PFlagItem(true, Unset, t"xyz")))
+      . assert(_ == PHolder(PTriple(t"a", t"xyz")))
 
       test(m"a repeatable field consumes every remaining atom"):
         t"log lbl 1 2 3\n".read[Tel].as[PLogBook]
@@ -82,13 +82,16 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
         t"log lbl 1\n  values 2\n".read[Tel].as[PLogBook]
       . assert(_ == PLogBook(PLog(t"lbl", List(1, 2))))
 
-      test(m"a bare flag keyword decodes true and an absent flag false"):
-        t"active\n".read[Tel].as[PFlags]
-      . assert(_ == PFlags(true, Unset))
+      // A Scala `Boolean` is a value, not a §20 flag: it reads and writes an
+      // explicit `true`/`false` atom, the mapping the derived schema and
+      // BinTEL also use.
+      test(m"a Boolean field reads its explicit atom"):
+        t"active true\nverbose false\n".read[Tel].as[PFlags]
+      . assert(_ == PFlags(true, false))
 
-      test(m"a bare optional flag decodes as present true"):
-        t"active\nverbose\n".read[Tel].as[PFlags]
-      . assert(_ == PFlags(true, true))
+      test(m"an absent Optional Boolean reads as Unset"):
+        t"active false\n".read[Tel].as[PFlags]
+      . assert(_ == PFlags(false, Unset))
 
       test(m"only the first optional scalar fills positionally (§20.8)"):
         t"pair hello\n".read[Tel].as[PPairBox]
@@ -103,13 +106,13 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
       . assert(_ == TelError.Reason.NonRepeatableTooMany)
 
       test(m"excess atoms raise E302"):
-        capture[TelError](t"item a xyz extra\n".read[Tel].as[PHolder]).reason
+        capture[TelError](t"item a b c\n".read[Tel].as[PHolder]).reason
       . assert(_ == TelError.Reason.TooManyAtoms)
 
     suite(m"Positional atom decoding (§19.2, direct path)"):
       given PRecipient is Tel.Parsable = Tel.Parsable.derived
       given PDelivery is Tel.Parsable = Tel.Parsable.derived
-      given PFlagItem is Tel.Parsable = Tel.Parsable.derived
+      given PTriple is Tel.Parsable = Tel.Parsable.derived
       given PHolder is Tel.Parsable = Tel.Parsable.derived
       given PLog is Tel.Parsable = Tel.Parsable.derived
       given PLogBook is Tel.Parsable = Tel.Parsable.derived
@@ -127,10 +130,10 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
         (doc.read[PDelivery in Tel], parity[PDelivery](doc))
       . assert(_ == (PDelivery(PRecipient(t"Acme Corporation", t"1 Acme Way")), true))
 
-      test(m"the worked example parses directly, equally on both paths"):
+      test(m"consecutive atoms fill consecutive members, equally on both paths"):
         val doc = t"item a xyz\n"
         (doc.read[PHolder in Tel], parity[PHolder](doc))
-      . assert(_ == (PHolder(PFlagItem(true, Unset, t"xyz")), true))
+      . assert(_ == (PHolder(PTriple(t"a", t"xyz")), true))
 
       test(m"a repeatable field consumes the rest, equally on both paths"):
         val doc = t"log lbl 1 2 3\n"
@@ -142,15 +145,10 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
         (doc.read[PLogBook in Tel], parity[PLogBook](doc))
       . assert(_ == (PLogBook(PLog(t"lbl", List(1, 2))), true))
 
-      test(m"bare and absent flags parse directly, equally on both paths"):
-        val doc = t"active\n"
+      test(m"Boolean fields read explicit atoms, equally on both paths"):
+        val doc = t"active true\nverbose false\n"
         (doc.read[PFlags in Tel], parity[PFlags](doc))
-      . assert(_ == (PFlags(true, Unset), true))
-
-      test(m"a bare optional flag parses as present true, equally on both paths"):
-        val doc = t"active\nverbose\n"
-        (doc.read[PFlags in Tel], parity[PFlags](doc))
-      . assert(_ == (PFlags(true, true), true))
+      . assert(_ == (PFlags(true, false), true))
 
       test(m"optional scalars fill per §20.8, equally on both paths"):
         val doc = t"pair hello\n  second world\n"
@@ -162,7 +160,7 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
       . assert(_ == TelError.Reason.NonRepeatableTooMany)
 
       test(m"excess atoms raise E302 on the direct path"):
-        capture[TelError](t"item a xyz extra\n".read[PHolder in Tel]).reason
+        capture[TelError](t"item a b c\n".read[PHolder in Tel]).reason
       . assert(_ == TelError.Reason.TooManyAtoms)
 
     suite(m"Encoder atom forms and flags (§22.3)"):
@@ -185,18 +183,21 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
         (value.encode.show.s.tt.read[Tel].as[PNote] == value, literalForm)
       . assert(_ == (true, true))
 
-      test(m"a true flag encodes as the bare keyword"):
+      // A Boolean encodes as its explicit atom, and an absent `Optional`
+      // contributes no compound — the form the derived schema and BinTEL
+      // both expect.
+      test(m"a Boolean encodes as an explicit true/false atom"):
         val doc = PFlags(true, Unset).encode
         (doc.childCompounds.readable.length, doc.childCompounds.readable.head.keyword,
          doc.childCompounds.readable.head.atoms.length)
-      . assert(_ == (1, t"active", 0))
+      . assert(_ == (1, t"active", 1))
 
-      test(m"a false flag is omitted and an optional false stays explicit"):
+      test(m"a false Boolean is written, not omitted"):
         val doc = PFlags(false, false).encode
-        (doc.childCompounds.readable.length, doc.childCompounds.readable.head.keyword)
-      . assert(_ == (1, t"verbose"))
+        (doc.childCompounds.readable.length, doc.field(t"active").vouch.primaryAtom)
+      . assert(_ == (2, t"false"))
 
-      test(m"every flag combination round-trips through serialized text"):
+      test(m"every Boolean combination round-trips through serialized text"):
         val values = List
          ( PFlags(true, Unset), PFlags(false, Unset), PFlags(true, true),
            PFlags(false, false), PFlags(true, false), PFlags(false, true) )
@@ -214,7 +215,7 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
     suite(m"Positional atom decoding (§19.2, staged path)"):
       given PRecipient is Tel.Parsable = Tel.Parsable.staged
       given PDelivery is Tel.Parsable = Tel.Parsable.staged
-      given PFlagItem is Tel.Parsable = Tel.Parsable.staged
+      given PTriple is Tel.Parsable = Tel.Parsable.staged
       given PHolder is Tel.Parsable = Tel.Parsable.staged
       given PLog is Tel.Parsable = Tel.Parsable.staged
       given PLogBook is Tel.Parsable = Tel.Parsable.staged
@@ -234,10 +235,10 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
         (doc.read[PDelivery in Tel], parity[PDelivery](doc))
       . assert(_ == (PDelivery(PRecipient(t"Acme Corporation", t"1 Acme Way")), true))
 
-      test(m"the worked example parses staged, equally on both paths"):
+      test(m"consecutive atoms fill consecutive members, equally on both paths"):
         val doc = t"item a xyz\n"
         (doc.read[PHolder in Tel], parity[PHolder](doc))
-      . assert(_ == (PHolder(PFlagItem(true, Unset, t"xyz")), true))
+      . assert(_ == (PHolder(PTriple(t"a", t"xyz")), true))
 
       test(m"a repeatable field consumes the rest, equally on both paths"):
         val doc = t"log lbl 1 2 3\n"
@@ -249,15 +250,10 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
         (doc.read[PLogBook in Tel], parity[PLogBook](doc))
       . assert(_ == (PLogBook(PLog(t"lbl", List(1, 2))), true))
 
-      test(m"bare and absent flags parse staged, equally on both paths"):
-        val doc = t"active\n"
+      test(m"Boolean fields read explicit atoms, equally on both paths"):
+        val doc = t"active true\nverbose false\n"
         (doc.read[PFlags in Tel], parity[PFlags](doc))
-      . assert(_ == (PFlags(true, Unset), true))
-
-      test(m"a bare optional flag parses as present true, equally on both paths"):
-        val doc = t"active\nverbose\n"
-        (doc.read[PFlags in Tel], parity[PFlags](doc))
-      . assert(_ == (PFlags(true, true), true))
+      . assert(_ == (PFlags(true, false), true))
 
       test(m"optional scalars fill per §20.8, equally on both paths"):
         val doc = t"pair hello\n  second world\n"
@@ -274,7 +270,7 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
       . assert(_ == TelError.Reason.NonRepeatableTooMany)
 
       test(m"excess atoms raise E302 on the staged path"):
-        capture[TelError](t"item a xyz extra\n".read[PHolder in Tel]).reason
+        capture[TelError](t"item a b c\n".read[PHolder in Tel]).reason
       . assert(_ == TelError.Reason.TooManyAtoms)
 
       test(m"an unparseable positional atom raises NotScalar"):
@@ -327,20 +323,16 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
          reparses(PPairBox(PPair(Unset, t"x"))))
       . assert(_ == (0, true))
 
-      test(m"an elided false flag lets the run continue and skip on decode"):
+      // A Boolean is a scalar member, so it joins the inline run as its
+      // explicit `true`/`false` atom.
+      test(m"a false Boolean joins the inline run as its atom"):
         val doc = Tel.canonical(PGuardBox(PGuard(false, t"hello")))
         (doc.childCompounds.readable.head.atoms.length,
          reparses(PGuardBox(PGuard(false, t"hello"))))
-      . assert(_ == (1, true))
+      . assert(_ == (2, true))
 
-      test(m"a true flag joins the run as its keyword"):
+      test(m"a true Boolean joins the inline run as its atom"):
         val doc = Tel.canonical(PGuardBox(PGuard(true, t"hello")))
         (doc.childCompounds.readable.head.atoms.length,
          reparses(PGuardBox(PGuard(true, t"hello"))))
       . assert(_ == (2, true))
-
-      test(m"a value colliding with an elided flag keyword takes child form"):
-        val doc = Tel.canonical(PGuardBox(PGuard(false, t"flag")))
-        (doc.childCompounds.readable.head.atoms.length,
-         reparses(PGuardBox(PGuard(false, t"flag"))))
-      . assert(_ == (0, true))


### PR DESCRIPTION
The TEL benchmark module compiles and runs again, and a cross-layer regression it uncovered — a `Boolean` field encoding into a form that fails the schema derived from its own type — is fixed by mapping Boolean back to a scalar atom everywhere.

## The benchmark module

`stratiform.Benchmarks` indexes a `List` to pick a customer region but never imported `proscenium.compat.*`, so `apply` resolved against a `quantitative` unit extension and the module stopped compiling after the opaque-collections flip. The sibling test files already import the shims. `stratiform.bench` is outside `soundness.all`, so neither `make attest` nor CI was exercising it.

## Boolean is a scalar, not a flag

With the module compiling again, the benchmarks failed at runtime with E307: they encode a corpus with `Boolean` fields, run `Tel.Type.assign` against the schema derived from the same types, and BinTEL round-trip it. #1701 had made the text encoder write Booleans in flag form — bare keyword for `true`, elided for `false` — while schema derivation and BinTEL both still model a Boolean field as a required scalar, so an encoded record no longer validated against its own derived schema.

A §20 flag is keyword presence alone, whereas a Scala `Boolean` is a value; equating them was the error. `Boolean` is `Nature.Scalar` again and reads and writes an explicit `true`/`false` atom on the AST, direct and staged paths, with absence reported as `Absent` like any other required scalar:

```tel
active   true
verbose  false
```

`Tel.Nature.Flag` and the atom phase's flag rules remain — they implement §20.2 faithfully, and a custom codec for a genuinely flag-shaped type can opt in — but no derived instance produces them. Making flags first-class would need coordinated changes to schema derivation, `BintelInlinable` and the BinTEL wire format; that is deliberately not attempted here.

The §19.2 positional atom assignment, source and literal atom decoding, and the type-assignment conformance work from #1701 and #1708 are all unaffected.

## Testing

A new equivalence test pins the invariant that broke: what the encoder writes for a value must validate, with no accrued errors, against the schema derived from the same type. That is the check that would have caught this without the benchmarks — the previous flag fixtures used a hand-built schema and so could not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
