### PR TITLE
Fix and gate the benchmark modules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,7 +8,28 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Run all tests: `make test`
 - Watch mode for development: `mill -w soundness.all`
 - Run single test: `mill module.test.run` (e.g., `mill abacist.test.run`)
+- Compile every benchmark module: `mill benches.compile` (see "Benchmarks" below)
 - Run the full CI test suite from a clean build and sign the result: `make attest` (see "CI workflow" below)
+
+## Benchmarks
+
+- Each library's benchmarks live in `lib/<name>/src/bench` and are declared as `object bench
+  extends Benchmarks(…)` in `build.mill`; the cross-format corpus is the top-level `bench` module
+  over `src/bench`, run with `make bench`.
+- **Benchmarks must keep compiling.** They are *not* in `soundness.all`, the `test` aggregate, or
+  `make attest`, so a library change that breaks one is otherwise invisible — that is exactly how
+  all 11 of them came to rot behind the opaque-collections migration. The `benches` aggregate
+  module exists to make them visible: `make build` runs `mill benches.compile`, so run `make
+  build` (not just `mill soundness.all`) after any change to a collection API, a core type's
+  surface, or a `Benchmarks(…)` module's dependencies.
+- A new benchmark module needs no registration: `benches` collects every `Benchmarks` child of
+  every library automatically. A `bench` object with no `src/bench` directory compiles vacuously
+  and proves nothing — `zeppelin.bench` is currently in that state.
+- Benchmarks compare Soundness against third-party rivals, so a bench file mixes two worlds. Keep
+  the rival side written as that library's own users would write it: mirror records declared with
+  the stdlib `List`/`Nil` (derivation macros in circe, Jsoniter and borer cannot see through
+  opaque `proscenium` types), rival monads using their own `flatMap` rather than Soundness's
+  `bind`, and conversions crossing back over the greppable `.stdlib` bridge at the boundary.
 
 ## Code Style
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ build:
 	./mill groupCheck.validate
 	python3 etc/check-given-uniqueness.py
 	./mill soundness.all
+	./mill benches.compile
 
 dev:
 	./mill -w soundness.all

--- a/build.mill
+++ b/build.mill
@@ -1015,6 +1015,10 @@ object breviloquence extends Library:
     )
   object test extends Tests(core, staged, sedentary.core, eucalyptus.core)
   object bench extends Benchmarks(core, quantitative.units):
+    // The benchmark sources annotate the `Array[Byte]^{}` payloads they hold, matching the
+    // capture-checked `core` they measure, so they need capture checking enabled too.
+    override def scalacOptions = Task:
+      settings.cc(super.scalacOptions())
     def mvnDeps = Seq(
       mvn"com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.18.2",
       mvn"io.bullet::borer-core:1.16.0"

--- a/build.mill
+++ b/build.mill
@@ -663,6 +663,19 @@ object bench extends BaseScalaModule:
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium")
 
+// The compile-only aggregate over every benchmark module: each library's `bench` plus the
+// cross-module `bench` corpus above. Benchmarks are not part of `soundness.all`, the `test`
+// aggregate or `make attest`, so nothing else notices when a library change stops them
+// compiling — which is how they came to rot behind the opaque-collections migration. `make
+// build` compiles this so that cannot happen silently again. It has no sources of its own;
+// depending on the modules is what compiles them.
+object benches extends Toolchain:
+  def scalaVersion = settings.scalaVersion
+  def scalacOptions = settings.scalaOptions
+  def sources = Task.Sources()
+  def moduleDeps: Seq[JavaModule] =
+    bench +: allLibraries.flatMap(_.moduleDirectChildren).collect { case b: Benchmarks => b }
+
 // The keyword-corpus analysis tool (`make keywords`): derives and checks the pattern data in
 // `prophesy.ScalaKeywords` by tokenizing the Soundness (and proscala) sources with harlequin.
 // A development-time tool, outside `lib/`, never published.

--- a/lib/breviloquence/src/bench/breviloquence.TimingMain.scala
+++ b/lib/breviloquence/src/bench/breviloquence.TimingMain.scala
@@ -34,6 +34,7 @@ package breviloquence
 
 import contingency.*, strategies.throwUnsafely
 import gossamer.t
+import proscenium.*
 
 object TimingMain:
   def time(label: String, payload: Array[Byte]^{}, iterations: Int)

--- a/lib/caesura/src/bench/caesura.Benchmarks.scala
+++ b/lib/caesura/src/bench/caesura.Benchmarks.scala
@@ -43,6 +43,7 @@ import gossamer.*
 import hellenism.*, classloaders.threadContextClassloader
 import probably.*
 import proscenium.*
+import rudiments.*
 import quantitative.*
 import sedentary.*
 import superlunary.embeddings.automatic

--- a/lib/jacinta/src/bench/jacinta.Benchmarks.scala
+++ b/lib/jacinta/src/bench/jacinta.Benchmarks.scala
@@ -68,11 +68,13 @@ case class BenchUsers(users: List[BenchUser])
 object BenchUsers:
   given parsable: BenchUsers is Json.Parsable = Json.Parsable.derived
 
-// Jsoniter's view of the same records, with `String` fields as a Jsoniter
-// user would declare them (`Text` is an opaque zero-cost wrapper over
-// `String`, so the two targets are materially identical).
+// Jsoniter's view of the same records, with `String` fields and a stdlib
+// `List` as a Jsoniter user would declare them (`Text` is an opaque zero-cost
+// wrapper over `String`, so the two targets are materially identical, and
+// `JsonCodecMaker` cannot see through the opaque `proscenium.List` to derive
+// a codec for it).
 case class JsoniterUser(id: Int, username: String, email: String, active: Boolean, role: String)
-case class JsoniterUsers(users: List[JsoniterUser])
+case class JsoniterUsers(users: scala.collection.immutable.List[JsoniterUser])
 
 enum JsonParser:
   case Merino, MerinoTracking, Jawn, Circe, Jsoniter, Jackson
@@ -150,10 +152,10 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
       while
         reader.key().lay(false): key =>
           if key == t"users" then
-            val builder = List.newBuilder[BenchUser]
+            val builder = scala.collection.immutable.List.newBuilder[BenchUser]
             reader.openArray()
             while reader.element() do builder += user()
-            users = builder.result()
+            users = List.of(builder.result())
           else reader.skipValue()
           true
       do ()
@@ -355,7 +357,7 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
           p = ws(p)
           if p >= limit || buffer(p) != '[' then bail()
           p += 1
-          val builder = List.newBuilder[BenchUser]
+          val builder = scala.collection.immutable.List.newBuilder[BenchUser]
           p = ws(p)
 
           if p < limit && buffer(p) == ']' then p += 1
@@ -411,7 +413,7 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
                 elements = false
               else bail()
 
-          users = builder.result()
+          users = List.of(builder.result())
         else bail()
 
       if !usersSeen then bail()

--- a/lib/locomotion/src/bench/locomotion.Benchmarks.scala
+++ b/lib/locomotion/src/bench/locomotion.Benchmarks.scala
@@ -188,7 +188,7 @@ object Benchmarks extends Suite(m"Locomotion Protobuf codec benchmarks"):
   // Corpus 5: a map with 50 string→string entries — exercises map-entry messages
   // (proto3 encodes maps as repeated key/value sub-messages).
   lazy val value5: Attributes =
-    Attributes((0 until 50).map(index => t"key$index" -> t"value$index").to[Map])
+    Attributes(Map.from((0 until 50).map(index => t"key$index" -> t"value$index")))
 
   // Corpus 6: a message nested five levels deep — stresses nested encode/decode.
   lazy val value6: Deep1 =

--- a/lib/locomotion/src/bench/locomotion_bench.scala
+++ b/lib/locomotion/src/bench/locomotion_bench.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import distillate.*
 import prepositional.*
+import proscenium.*
 
 // The benchmark message schema. These types live at the top level of the package
 // (rather than nested in the `Benchmarks` object) so Wisteria derivation resolves

--- a/lib/panopticon/src/bench/panopticon.Benchmarks.scala
+++ b/lib/panopticon/src/bench/panopticon.Benchmarks.scala
@@ -44,6 +44,7 @@ import hellenism.*, classloaders.threadContextClassloader
 import probably.*
 import proscenium.*
 import quantitative.*
+import rudiments.*
 import sedentary.*
 import symbolism.*
 import temporaryDirectories.systemTemporaryDirectory

--- a/lib/polysyllabic/src/bench/polysyllabic.Benchmarks.scala
+++ b/lib/polysyllabic/src/bench/polysyllabic.Benchmarks.scala
@@ -45,6 +45,7 @@ import hellenism.*, classloaders.threadContextClassloader
 import hieroglyph.*, charDecoders.utf8Decoder, textMetrics.uniformMetric, textSanitizers.strictSanitizer
 import probably.*
 import proscenium.*
+import proscenium.compat.*
 import quantitative.*
 import sedentary.*
 import symbolism.*

--- a/lib/punctuation/src/bench/punctuation.Benchmarks.scala
+++ b/lib/punctuation/src/bench/punctuation.Benchmarks.scala
@@ -43,6 +43,7 @@ import hellenism.*, classloaders.threadContextClassloader
 import hieroglyph.*, charDecoders.utf8Decoder, textSanitizers.strictSanitizer
 import probably.*
 import proscenium.*
+import proscenium.compat.*
 import quantitative.*
 import sedentary.*
 import symbolism.*

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -51,6 +51,7 @@ import prepositional.*
 import probably.*
 import proscenium.*
 import quantitative.*
+import rudiments.*
 import sedentary.*
 import symbolism.*
 import temporaryDirectories.systemTemporaryDirectory
@@ -104,15 +105,23 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
   // comparison fair, so this deliberately stays a stdlib interop boundary.
   lazy val inputSeq: scala.collection.immutable.ArraySeq[Byte] =
     scala.collection.immutable.ArraySeq.unsafeWrapArray(inputArray)
+
+  // A window onto `input`. `Data` is a frozen `Array[Byte]`, which has no `slice` of its
+  // own, so this reads through the read-only view and re-freezes the result.
+  def slice(from: Int, until: Int): Data = Array.frozen(input.readable.slice(from, until))
   // The same 4 MB split into 64 KiB chunks, so aggregation/write loops iterate
   // (a single in-memory chunk would let `read[Data]` fold to an identity).
   lazy val inputChunks: Chain[Data] =
     Chain.from((0 until input.length by 65536).map: offset =>
-      input.slice(offset, (offset + 65536).min(input.length)))
+      slice(offset, (offset + 65536).min(input.length)))
+  // The same chunks as a stdlib `List`. The rival pipelines fold and map over the corpus with
+  // their own combinators, which need a stdlib collection; like `inputSeq` above, this is a
+  // deliberate interop boundary rather than a gap in `Chain`.
+  lazy val inputChunkList: scala.collection.immutable.List[Data] = inputChunks.stdlib.toList
   // The 4 MB split into four equal parts, one per source stream for fan-in.
   lazy val quarters: IndexedSeq[Data] =
     val q = input.length/4
-    IndexedSeq.tabulate(4)(i => input.slice(i*q, if i == 3 then input.length else (i + 1)*q))
+    IndexedSeq.tabulate(4)(i => slice(i*q, if i == 3 then input.length else (i + 1)*q))
 
   // ~4 MB of UTF-8 text with multi-byte characters, so the decode exercises the
   // cross-chunk continuation path in every library.
@@ -148,7 +157,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
 
   // ZIO's unsafe-run entry point, wrapping each ZIO benchmark's effect.
   def runZio[A](effect: zio.ZIO[Any, Throwable, A]): A =
-    zio.Unsafe.unsafe:: unsafe ?=> zio.Runtime.default.unsafe.run(effect).getOrThrow()
+    zio.Unsafe.unsafe: (unsafe: zio.Unsafe) ?=>
+      zio.Runtime.default.unsafe.run(effect).getOrThrow()
   // A fixed-capacity `Buffering`, for the block-size sweep.
   def buffering(n: Int): Buffering = new Buffering:
     def capacity(substrate: Substrate): Int = n
@@ -205,7 +215,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             val comp = fs2.compression.Compression.forSync[cats.effect.IO]
             fs2.Stream.chunk(fs2.Chunk.array(turbulence.Benchmarks.gzippedInputArray))
             . covary[cats.effect.IO]
-            . through(comp.gunzip()).bind(_.content)
+            . through(comp.gunzip()).flatMap(_.content)
             . compile.count.unsafeRunSync()
         }
 
@@ -373,7 +383,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             import cats.effect.unsafe.implicits.global
             val comp = fs2.compression.Compression.forSync[cats.effect.IO]
             fs2.Stream.chunk(fs2.Chunk.array(turbulence.Benchmarks.inputArray)).covary[cats.effect.IO]
-            . through(comp.gzip()).through(comp.gunzip()).bind(_.content)
+            . through(comp.gzip()).through(comp.gunzip()).flatMap(_.content)
             . compile.count.unsafeRunSync()
         }
 
@@ -424,7 +434,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             import cats.effect.unsafe.implicits.global
             val comp = fs2.compression.Compression.forSync[cats.effect.IO]
             fs2.Stream.chunk(fs2.Chunk.array(turbulence.Benchmarks.gzippedTextArray)).covary[cats.effect.IO]
-            . through(comp.gunzip()).bind(_.content)
+            . through(comp.gunzip()).flatMap(_.content)
             . through(fs2.text.utf8.decode).map(_.length).compile.fold(0)(_ + _).unsafeRunSync()
         }
 
@@ -458,7 +468,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             . through(comp.gzip())
             . through(fs2.text.base64.encode)
             . through(fs2.text.base64.decode)
-            . through(comp.gunzip()).bind(_.content)
+            . through(comp.gunzip()).flatMap(_.content)
             . compile.count.unsafeRunSync()
         }
 
@@ -679,7 +689,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         '{
             turbulence.Benchmarks.aesKey.uncloak:
               Chain(turbulence.Benchmarks.input).encrypt(InitializationVector.random)
-              . map(_.length.toLong).sum
+              . fold(0L)(_ + _.length)
         }
 
       bench(m"JDK  javax.crypto.Cipher")(target = 1*Second, operationSize = size):
@@ -696,7 +706,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
     suite(m"Public read vs kernel memoize (4 MB)"):
       bench(m"Soundness  Stream.memoize (kernel)")
         ( target = 1*Second, operationSize = size ):
-        '{ turbulence.Benchmarks.inputChunks.iterator.stream.memoize.length }
+        '{ turbulence.Benchmarks.inputChunks.stdlib.iterator.stream.memoize.length }
 
       bench(m"Soundness  read[Data]")(target = 1*Second, operationSize = size):
         '{ turbulence.Benchmarks.inputChunks.read[Data].length }
@@ -830,9 +840,9 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         '{
             import cats.effect.unsafe.implicits.global
             import cats.effect.IO, cats.syntax.all.*
-            val program = fs2.concurrent.Channel.bounded[IO, fs2.Chunk[Byte]](8).bind: channel =>
+            val program = fs2.concurrent.Channel.bounded[IO, fs2.Chunk[Byte]](8).flatMap: channel =>
               val produce =
-                turbulence.Benchmarks.inputChunks.foldLeft(IO.unit): (io, chunk) =>
+                turbulence.Benchmarks.inputChunkList.foldLeft(IO.unit): (io, chunk) =>
                   io *> channel.send(fs2.Chunk.array(chunk.asInstanceOf[scala.Array[Byte]])).void
                 *> channel.close.void
               produce.start *> channel.stream.compile.fold(0L)((acc, chunk) => acc + chunk.size)
@@ -845,7 +855,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               import zio.*, zio.stream.*
               val source =
                 ZStream.fromIterable
-                  (turbulence.Benchmarks.inputChunks.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
+                  (turbulence.Benchmarks.inputChunkList.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
               for
                 queue <- Queue.bounded[Take[Nothing, Chunk[Byte]]](8)
                 _     <- source.runIntoQueue(queue).fork
@@ -918,7 +928,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             turbulence.Benchmarks.runZio:
               import zio.*, zio.stream.*
               ZIO.scoped:
-                ZStream.fromChunk(Chunk.fromArray(turbulence.Benchmarks.inputArray)).broadcast(3, 16).bind: streams =>
+                ZStream.fromChunk(Chunk.fromArray(turbulence.Benchmarks.inputArray)).broadcast(3, 16).flatMap: streams =>
                   ZIO.foreachPar(streams)(_.runCount).map(_.sum)
         }
 
@@ -946,9 +956,9 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         '{
             import cats.effect.unsafe.implicits.global
             import cats.effect.IO
-            val program = fs2.concurrent.Channel.bounded[IO, fs2.Chunk[Byte]](8).bind: channel =>
+            val program = fs2.concurrent.Channel.bounded[IO, fs2.Chunk[Byte]](8).flatMap: channel =>
               val produce =
-                turbulence.Benchmarks.inputChunks.foldLeft(IO.unit): (io, chunk) =>
+                turbulence.Benchmarks.inputChunkList.foldLeft(IO.unit): (io, chunk) =>
                   io *> channel.send(fs2.Chunk.array(chunk.asInstanceOf[scala.Array[Byte]])).void
                 *> channel.close.void
               produce.start *> channel.stream.compile.fold(0L)((acc, chunk) => acc + chunk.size)
@@ -961,7 +971,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               import zio.*, zio.stream.*
               val source =
                 ZStream.fromIterable
-                  (turbulence.Benchmarks.inputChunks.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
+                  (turbulence.Benchmarks.inputChunkList.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
               for
                 queue <- Queue.bounded[Take[Nothing, Chunk[Byte]]](8)
                 _     <- source.runIntoQueue(queue).fork
@@ -993,9 +1003,9 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         '{
             import cats.effect.unsafe.implicits.global
             import cats.effect.IO
-            val program = fs2.concurrent.Channel.bounded[IO, fs2.Chunk[Byte]](8).bind: channel =>
+            val program = fs2.concurrent.Channel.bounded[IO, fs2.Chunk[Byte]](8).flatMap: channel =>
               val produce =
-                turbulence.Benchmarks.inputChunks.foldLeft(IO.unit): (io, chunk) =>
+                turbulence.Benchmarks.inputChunkList.foldLeft(IO.unit): (io, chunk) =>
                   io *> channel.send(fs2.Chunk.array(chunk.asInstanceOf[scala.Array[Byte]])).void
                 *> channel.close.void
               produce.start *> channel.stream.compile.fold(0L)((acc, chunk) => acc + chunk.size)
@@ -1008,7 +1018,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               import zio.*, zio.stream.*
               val source =
                 ZStream.fromIterable
-                  (turbulence.Benchmarks.inputChunks.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
+                  (turbulence.Benchmarks.inputChunkList.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
               for
                 queue <- Queue.bounded[Take[Nothing, Chunk[Byte]]](8)
                 _     <- source.runIntoQueue(queue).fork
@@ -1045,7 +1055,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             val comp = fs2.compression.Compression.forSync[cats.effect.IO]
             fs2.Stream.chunk(fs2.Chunk.array(turbulence.Benchmarks.gzippedInputArray))
             . covary[cats.effect.IO]
-            . through(comp.gunzip()).bind(_.content)
+            . through(comp.gunzip()).flatMap(_.content)
             . compile.count.unsafeRunSync()
         }
 
@@ -1119,9 +1129,9 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
           '{
               import cats.effect.unsafe.implicits.global
               import cats.effect.IO
-              val program = fs2.concurrent.Channel.bounded[IO, fs2.Chunk[Byte]](8).bind: channel =>
+              val program = fs2.concurrent.Channel.bounded[IO, fs2.Chunk[Byte]](8).flatMap: channel =>
                 val produce =
-                  turbulence.Benchmarks.inputChunks.foldLeft(IO.unit): (io, chunk) =>
+                  turbulence.Benchmarks.inputChunkList.foldLeft(IO.unit): (io, chunk) =>
                     io *> channel.send(fs2.Chunk.array(chunk.asInstanceOf[scala.Array[Byte]])).void
                   *> channel.close.void
                 produce.start *> channel.stream.compile.fold(0L)((acc, chunk) => acc + chunk.size)
@@ -1135,7 +1145,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
                 import zio.*, zio.stream.*
                 val source =
                   ZStream.fromIterable
-                    (turbulence.Benchmarks.inputChunks.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
+                    (turbulence.Benchmarks.inputChunkList.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
                 for
                   queue <- Queue.bounded[Take[Nothing, Chunk[Byte]]](8)
                   _     <- source.runIntoQueue(queue).fork

--- a/lib/zephyrine/src/bench/zephyrine.Benchmarks.scala
+++ b/lib/zephyrine/src/bench/zephyrine.Benchmarks.scala
@@ -42,6 +42,7 @@ import gossamer.*
 import hellenism.*, classloaders.threadContextClassloader
 import probably.*
 import proscenium.*
+import proscenium.compat.*
 import quantitative.*
 import rudiments.*
 import sedentary.*

--- a/src/bench/main/crossparse.Benchmarks.scala
+++ b/src/bench/main/crossparse.Benchmarks.scala
@@ -47,6 +47,7 @@ import locomotion.*
 import prepositional.*
 import probably.*
 import proscenium.*
+import proscenium.compat.*
 import quantitative.*
 import rudiments.*
 import sedentary.*
@@ -88,12 +89,16 @@ derives io.circe.derivation.ConfiguredDecoder
 case class JsoniterCustomer(id: Long, name: String, email: String, region: String)
 derives io.circe.derivation.ConfiguredDecoder
 
+// These two carry stdlib `List`s rather than the `proscenium.List` the rest of the file uses:
+// neither circe's `ConfiguredDecoder` derivation nor Jsoniter's `JsonCodecMaker` can see
+// through the opaque type, and a user of either library would declare them this way.
 case class JsoniterOrder
-  ( reference: String, customer: JsoniterCustomer, items: List[JsoniterLineItem],
+  ( reference: String, customer: JsoniterCustomer,
+    items: scala.collection.immutable.List[JsoniterLineItem],
     payment: JsoniterPayment, priority: Boolean, discount: Double )
 derives io.circe.derivation.ConfiguredDecoder
 
-case class JsoniterOrders(orders: List[JsoniterOrder])
+case class JsoniterOrders(orders: scala.collection.immutable.List[JsoniterOrder])
 derives io.circe.derivation.ConfiguredDecoder
 
 // The circe derivation reads this at each `derives` site above.
@@ -222,7 +227,10 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
   :   com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[JsoniterOrders] =
     com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make
       ( com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig
-          . withDiscriminatorFieldName(Some("kind"))
+          // `scala.Some`, not the `Some` from the proscenium prelude: `CodecMakerConfig` is
+          // read at expansion time, and only the stdlib one has a `FromExpr` the macro can
+          // extract the value through.
+          . withDiscriminatorFieldName(scala.Some("kind"))
           // The corpus writes the discriminator last, as Jacinta does.
           . withRequireDiscriminatorFirst(false) )
 
@@ -252,7 +260,8 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
                   order.customer.region.s ),
               order.items.map { item =>
                 JsoniterLineItem
-                  (item.sku.s, item.description.s, item.quantity, item.price, item.taxed) },
+                  (item.sku.s, item.description.s, item.quantity, item.price, item.taxed)
+              }.stdlib,
               order.payment match
                 case Payment.Card(number, expiry, secure) =>
                   JsoniterPayment.Card(number.s, expiry.s, secure)
@@ -260,7 +269,7 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
                 case Payment.Transfer(iban, reference) =>
                   JsoniterPayment.Transfer(iban.s, reference),
               order.priority,
-              order.discount ) } )
+              order.discount ) }.stdlib )
 
   def run(): Unit =
     println(s"Corpus sizes (bytes): JSON=${jsonText.s.length} TEL=${telText.s.length} "

--- a/src/bench/main/crossparse.matrix.scala
+++ b/src/bench/main/crossparse.matrix.scala
@@ -44,6 +44,7 @@ import locomotion.*
 import prepositional.*
 import probably.*
 import proscenium.*
+import proscenium.compat.*
 import quantitative.*
 import rudiments.*
 import sedentary.*

--- a/src/bench/main/crossparse.rivals.scala
+++ b/src/bench/main/crossparse.rivals.scala
@@ -40,6 +40,13 @@ import proscenium.*
 import rudiments.*
 import vacuous.*
 
+// The mirror records below are the rivals' own view of the corpus, and their derivation macros
+// (Jsoniter's `JsonCodecMaker`, borer's and circe's derivation) cannot see through the opaque
+// `proscenium.List` to build a codec for it. A user of those libraries would reach for the
+// stdlib `List` anyway, so this shadows the one `proscenium.*` brings into scope — keeping the
+// rival side of the comparison written exactly as its own users would write it.
+import scala.collection.immutable.{List, Nil}
+
 // ── Third-party baselines for the document matrix ───────────────────────
 // The best-in-class library for each format decodes the same corpus bytes
 // to `String`-field mirror records: Jsoniter (JSON, macro-generated
@@ -78,14 +85,19 @@ case class MDecimals(values: List[Double])
 
 // The expected mirror of each corpus, for the correctness gates.
 object mirrors:
+  // Each `map` below runs over the Soundness model's `proscenium.List` and lands in a mirror
+  // record's stdlib `List`, so the results cross back over the `stdlib` bridge.
+
   def config(value: Config): MConfig =
     MConfig
       ( MWebApp
           ( value.webApp.servlets.map: servlet =>
               MServlet
                 ( servlet.servletName.s, servlet.servletClass.s,
-                  servlet.params.map { param => MParam(param.key.s, param.value.s) } ),
-            value.webApp.mappings.map { mapping => MMapping(mapping.servletName.s, mapping.url.s) },
+                  servlet.params.map { param => MParam(param.key.s, param.value.s) }.stdlib )
+            . stdlib,
+            value.webApp.mappings.map { mapping => MMapping(mapping.servletName.s, mapping.url.s) }
+            . stdlib,
             MTaglib(value.webApp.taglib.uri.s, value.webApp.taglib.location.s) ) )
 
   def menu(value: MenuDoc): MMenuDoc =
@@ -94,19 +106,22 @@ object mirrors:
           ( value.menu.id.s, value.menu.value.s,
             MPopup
               ( value.menu.popup.menuitems.map: item =>
-                  MMenuItem(item.value.s, item.onclick.s) ) ) )
+                  MMenuItem(item.value.s, item.onclick.s)
+                . stdlib ) ) )
 
   def users(value: Users): MUsers =
     MUsers
       ( value.users.map: user =>
-          MUser(user.id, user.username.s, user.email.s, user.active, user.role.s) )
+          MUser(user.id, user.username.s, user.email.s, user.active, user.role.s)
+        . stdlib )
 
   def logs(value: Logs): MLogs =
     MLogs
       ( value.logs.map: entry =>
           MLogEntry
             ( entry.timestamp, entry.level.s, entry.service.s, entry.requestId.s,
-              entry.userId, entry.message.s ) )
+              entry.userId, entry.message.s )
+        . stdlib )
 
   def transactions(value: Transactions): MTransactions =
     MTransactions
@@ -114,10 +129,11 @@ object mirrors:
           MTransaction
             ( transaction.from.s, transaction.to.s, transaction.valueWei.s,
               transaction.valueEth.s, transaction.gasPriceWei.s, transaction.gasUsed,
-              transaction.blockNumber, transaction.nonce, transaction.temperatureDelta ) )
+              transaction.blockNumber, transaction.nonce, transaction.temperatureDelta )
+        . stdlib )
 
-  def ints(value: Ints): MInts = MInts(value.values)
-  def decimals(value: Decimals): MDecimals = MDecimals(value.values)
+  def ints(value: Ints): MInts = MInts(value.values.stdlib)
+  def decimals(value: Decimals): MDecimals = MDecimals(value.values.stdlib)
 
 // The Jsoniter codecs: one macro-generated codec per document root.
 object jsoniterCodecs:


### PR DESCRIPTION
Ten of the eighteen benchmark modules did not compile, `make bench`'s own cross-format corpus among them. Nothing compiles the benchmarks — they sit outside `soundness.all`, the `test` aggregate and `make attest` — so a library change that breaks one is invisible, and they had been broken since the opaque-collections flip without anyone noticing. This fixes all ten and adds a `benches` aggregate that `make build` compiles, so the next one cannot rot silently. (#1709 fixed the eleventh, stratiform's, while this was in preparation; that fix is upstream and the duplicate dropped out on rebase.)

## Release notes

**Benchmarks compile again.** `mill benches.compile` compiles every benchmark module — each library's `bench` plus the cross-format corpus — and `make build` now runs it. A new benchmark needs no registration: the aggregate collects every `Benchmarks` module automatically.

Most of the breakage was the opaque-collections flip never reaching `src/bench`: missing `rudiments.*` (for `map`/`foreach`/`each`/`fold`) and `proscenium.compat.*` (for the stdlib-shaped `apply`/`length`/`iterator`) imports, and model files declaring their `List` without the `proscenium` import their benchmark body had.

The rest was the rival side of each comparison, which is a different problem — a benchmark file mixes two worlds:

```scala
// The rival's mirror records use the stdlib List: neither circe's derivation
// nor Jsoniter's JsonCodecMaker can see through an opaque proscenium.List,
// and a user of those libraries would declare them this way.
case class JsoniterOrders(orders: scala.collection.immutable.List[JsoniterOrder])
```

A sweep had also renamed `flatMap` to `bind` on `IO`, `ZIO` and `fs2.Stream`, where `bind` is not a method at all; those are back to their own `flatMap`, and conversions cross the greppable `.stdlib` bridge at the boundary. `CodecMakerConfig` takes `scala.Some` — only the stdlib one has a `FromExpr` the macro can read through at expansion time.

Also: turbulence's ZIO entry point no longer parses in the `Unsafe.unsafe:: unsafe ?=>` form; `Data` gains a `slice` helper (it is a frozen `Array[Byte]` with no `slice` of its own); and `breviloquence.bench` gains capture checking to match the `core` it measures.

Two things worth knowing:

- The gate is `make build`, not `make attest`. The benchmarks pull zio, fs2, kyo, circe, jsoniter, borer, protobuf, aalto and snakeyaml from Maven Central, and putting that on the path of every attestation costs more than the gap it closes. A broken benchmark can still merge; it is caught at the next full local build.
- `zeppelin.bench` has no `src/bench` directory, so it compiles vacuously and passes the new gate while proving nothing. Left as-is and documented rather than silently counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)