### PR TITLE
Align reliquary and degustation with the LIRA specification

### DIFF
--- a/lib/degustation/src/core/degustation.Atomizer.scala
+++ b/lib/degustation/src/core/degustation.Atomizer.scala
@@ -36,7 +36,7 @@ import scala.quoted.Quotes
 
 import anticipation.*
 
-// The atomization rules of `scala-tasty/1`, applied over the compiler's reflection of unpickled
+// The atomization rules of `tasty/1`, applied over the compiler's reflection of unpickled
 // TASTy. The folding principle (LIRA §10.3) governs every decision here: declarations whose
 // addition cannot break consumers stand alone as atoms; fragments whose addition can break
 // consumers fold into their enclosing atom's value, so the entire compatibility check stays set

--- a/lib/degustation/src/core/degustation.ScalaAtom.scala
+++ b/lib/degustation/src/core/degustation.ScalaAtom.scala
@@ -40,7 +40,7 @@ enum ScalaReference:
   case Own(key: Text)
   case Foreign(key: Text)
 
-// One atom of the `scala-tasty/1` discipline, before hashing: the stable key, whether the atom
+// One atom of the `tasty/1` discipline, before hashing: the stable key, whether the atom
 // is replaceable (an inline or macro body) rather than rigid, the canonical encoding whose hash
 // is the atom's value, and the references collected from a replaceable body.
 case class ScalaAtom

--- a/lib/degustation/src/lira/degustation.Tasty.scala
+++ b/lib/degustation/src/lira/degustation.Tasty.scala
@@ -41,13 +41,25 @@ import rudiments.*
 
 import errorDiagnostics.emptyDiagnostics
 
-// The `scala-tasty/1` discipline, adapted to reliquary's SPI. It claims `.tasty` files — the
+// The `tasty/1` discipline, adapted to reliquary's SPI. It claims `.tasty` files — the
 // interface carrier shared by the `jvm`, `sjsir` and `nir` universes — for atomization, and
 // claims the derived binaries (`.class`, `.sjsir`, `.nir`) *atomless*: their interface is
 // exactly the TASTy's, so they contribute no atoms of their own and never fall through to
 // `opaque/1`, where every rebuild would register as a major event.
-object ScalaTasty extends Discipline:
-  def id: Text = t"scala-tasty/1"
+object Tasty extends Discipline:
+  def id: Text = t"tasty/1"
+
+  // TASTy is carried in every universe of the motivating ecosystem, so the domain is universal
+  // and the cross-section invariant (§9.6) binds all of them — which is what makes "one API on
+  // every platform" checkable. Keying is by declaration (`tasty.md` §6): a TASTy reference names
+  // the declaring symbol, so an inherited member need not be re-atomized under each type that
+  // presents it. Classfile-level linkage is the JVM ecosystem profile's, not this discipline's,
+  // so only the TASTy level is certified here.
+  def domain: Discipline.Domain = Discipline.Domain.Universal
+  def keying: Discipline.Keying = Discipline.Keying.Declaration
+
+  def guarantees(universe: Text): Set[Discipline.Guarantee] =
+    Set(Discipline.Guarantee.Linkage, Discipline.Guarantee.Recompilation)
 
   private val atomless: scala.List[String] = scala.List(".class", ".sjsir", ".nir")
 

--- a/lib/degustation/src/lira/soundness_degustation_lira.scala
+++ b/lib/degustation/src/lira/soundness_degustation_lira.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export degustation.ScalaTasty
+export degustation.Tasty

--- a/lib/degustation/src/test/degustation_test.scala
+++ b/lib/degustation/src/test/degustation_test.scala
@@ -294,9 +294,9 @@ object Tests extends Suite(m"Degustation Tests"):
       import reliquary.*
       val path = TreePath(t"fixture/Alpha.tasty")
 
-      (ScalaTasty.claims(path, Array.freeze(Array[Byte](0))),
-       ScalaTasty.claims(TreePath(t"fixture/Alpha.class"), Array.freeze(Array[Byte](0))),
-       ScalaTasty.claims(TreePath(t"readme.md"), Array.freeze(Array[Byte](0))))
+      (Tasty.claims(path, Array.freeze(Array[Byte](0))),
+       Tasty.claims(TreePath(t"fixture/Alpha.class"), Array.freeze(Array[Byte](0))),
+       Tasty.claims(TreePath(t"readme.md"), Array.freeze(Array[Byte](0))))
     . assert(_ == (true, true, false))
 
     test(m"a jvm-only lira assembles from a real compilation and verifies"):
@@ -307,7 +307,7 @@ object Tests extends Suite(m"Degustation Tests"):
         Compilation[Universe.Classfile](unsafely(out.s.tt.as[soundness.Path on Linux]), classpath)
 
       val input = LiraBundle.jvm(compilation)
-      val registry = Discipline.Registry(List(ScalaTasty))
+      val registry = Discipline.Registry(List(Tasty))
 
       val bytes = LiraAssembler.assemble
         ( t"fixture-core",
@@ -325,8 +325,8 @@ object Tests extends Suite(m"Degustation Tests"):
        lira.manifest.section.stdlib.map(_.universe),
        lira.manifest.section.stdlib.forall(_.derivative.present),
        report.atomizations.stdlib.map(_.discipline))
-    . assert(_ == (t"fixture-core", scala.List(t"scala-tasty/1"), scala.List(t"jvm"), true,
-        scala.List(t"scala-tasty/1")))
+    . assert(_ == (t"fixture-core", scala.List(t"tasty/1"), scala.List(t"jvm"), true,
+        scala.List(t"tasty/1")))
 
     val sjsJars = scala.List("scala3-library_sjs1.jar", "scalajs-scalalib_2.13.jar")
       . map(lib.resolve(_).nn)
@@ -352,7 +352,7 @@ object Tests extends Suite(m"Degustation Tests"):
         val sjsInput = LiraBundle.sjsir(Compilation[Universe.Sjsir]
           (unsafely(sjsOut.s.tt.as[soundness.Path on Linux]), sjsClasspath))
 
-        val registry = Discipline.Registry(List(ScalaTasty))
+        val registry = Discipline.Registry(List(Tasty))
 
         def contextClasspath(universe: Text): List[Text] =
           if universe == t"sjsir" then List.from(Text(sjsOut.s) :: sjsLibraryPaths)
@@ -363,15 +363,15 @@ object Tests extends Suite(m"Degustation Tests"):
             List(jvmInput, sjsInput),
             registry,
             toolchain = List(LiraBundle.tool[Universe.Classfile](t"3.9.0")),
-            classpath = contextClasspath(_) )
+            classpath = { input => contextClasspath(input.universe) } )
 
         val lira = Lira.read(bytes)
         val report = Verification.install(lira)
         val sjsSection = lira.manifest.section.stdlib.find(_.universe == t"sjsir")
 
         (lira.manifest.section.stdlib.map(_.universe),
-         report.materialized.stdlib.map(_(0)),
-         report.materialized.stdlib.find(_(0) == t"sjsir")
+         report.materialized.stdlib.map(_(0).universe),
+         report.materialized.stdlib.find(_(0).universe == t"sjsir")
            . map(_(1).entries.stdlib.exists(_.path.text.s.endsWith(".sjsir"))))
       . assert(_ == (scala.List(t"jvm", t"sjsir"), scala.List(t"jvm", t"sjsir"),
           scala.Some(true)))
@@ -387,10 +387,10 @@ object Tests extends Suite(m"Degustation Tests"):
 
       val binary = (TreePath(t"fixture/Alpha.class"), Array.freeze(Array[Byte](4)))
       val all = List.from(content.stdlib :+ binary)
-      val context = Discipline.Context(t"jvm", List.from(libraryPaths))
-      val atomization = ScalaTasty.atomize(all, context)
+      val context = Discipline.Context(t"jvm", classpath = List.from(libraryPaths))
+      val atomization = Tasty.atomize(all, context)
 
       (atomization.discipline,
        atomization.atoms.stdlib.exists(_.key.s.startsWith("fixture.Overloads.f(")),
        atomization.atoms.stdlib.exists(_.key.s.contains("Alpha.class")))
-    . assert(_ == (t"scala-tasty/1", true, false))
+    . assert(_ == (t"tasty/1", true, false))

--- a/lib/reliquary/res/test/reliquary/lira.tel
+++ b/lib/reliquary/res/test/reliquary/lira.tel
@@ -1,8 +1,9 @@
 tel 1.0
 
-# The `lira` manifest schema (LIRA specification §14, with the agreed amendments: `jvm | sjsir |
-# nir` universes, optional numeric-only `version`, per-universe and `build`-pinned dependencies,
-# and per-section `derivative` hashes). This document is the canonical mirror of the hand-encoded
+# The `lira` manifest schema (LIRA specification §14: `jvm | sjsir | nir` universes, optional
+# numeric-only `version`, dependencies scoped by universe and integration or `build`-pinned,
+# sections keyed by universe and integration with `derivative` hashes, and ecosystem `profile`
+# claims). This document is the canonical mirror of the hand-encoded
 # `LiraSchemas.lira`; reliquary's test suite asserts the two are structurally identical and pins
 # this document's schema signature.
 
@@ -17,18 +18,28 @@ record Api
   field discipline DisciplineId
   field atoms Hash
 
+record Profile
+  field id ProfileId
+  field breaks Guarantee optional repeatable
+
+record Integration
+  field id Identifier
+  field rank Natural optional
+  field label String optional
+
 record Dependency
   field module ModuleName
   field api Hash
   field version Semver optional
   field build Hash optional
   field universe Identifier optional repeatable
+  field integration Identifier optional repeatable
   field uses Hash optional
   field spans Hash optional repeatable
 
 record Section
   select Universe
-  field against Hash optional repeatable
+  field integration Identifier optional
   field tree Hash
   field delete String optional repeatable
   field derivative Hash optional
@@ -62,6 +73,12 @@ scalar Natural
 scalar DisciplineId
   validate discipline-id
 
+scalar ProfileId
+  validate profile-id
+
+scalar Guarantee
+  validate guarantee
+
 select Universe
   variant jvm Flag
   variant sjsir Flag
@@ -74,6 +91,8 @@ document
   field toolchain Tool repeatable
   field owns Namespace optional repeatable
   field api Api repeatable
+  field profile Profile optional repeatable
+  field integration Integration optional repeatable
   field dependency Dependency optional repeatable
   field delta Hash optional
   field section Section repeatable

--- a/lib/reliquary/src/core/reliquary.Buildpath.scala
+++ b/lib/reliquary/src/core/reliquary.Buildpath.scala
@@ -69,34 +69,87 @@ object Buildpath:
       val expected = s"${version.major}.${manifest.lineage.stdlib.size - 1}.${version.patch}"
       abort(LiraError(Reason.VersionProjection(Text(expected))))
 
+// An assignment (§13.3): one integration per release, under which a buildpath's validity is
+// decided. A release declaring no integrations maps to `Unset`, its single implicit one.
+case class Assignment(choices: List[(Text, Optional[Text])]):
+  def apply(module: Text): Optional[Text] =
+    choices.stdlib.find(_(0) == module).map(_(1)).getOrElse(Unset)
+
 // A set of releases intended for joint use (§13). It is unordered — the coherence rules make
 // ordering irrelevant — and every rule here is decidable from manifests alone, without reading
-// any payload. Closure and satisfaction are evaluated per requested universe, since a
-// dependency may be scoped to the universes whose implementations need it.
+// any payload. Closure and satisfaction are evaluated per requested universe and per the
+// integration the assignment chose, since a dependency may be scoped to either axis.
 case class Buildpath(releases: List[LiraManifest]):
 
   def apply(module: Text): Optional[LiraManifest] =
     releases.stdlib.find(_.module == module).getOrElse(Unset)
 
   // The lira#1 reverse lookup: given the hash of a canonical derivative artifact (a classpath
-  // JAR), find the release one of whose sections declares it.
-  def byDerivative(hash: Data): Optional[LiraManifest] =
-    def declares(manifest: LiraManifest): Boolean =
-      manifest.section.stdlib.exists: section =>
-        section.derivative.let { declared => Blob.compare(declared, hash) == 0 }.or(false)
+  // JAR), find the release and the section declaring it — the section, not just the release,
+  // because a derivative belongs to one (universe, integration) cell, so the hash identifies
+  // which integration the artifact is (§13.6).
+  def byDerivative(hash: Data): Optional[(LiraManifest, Section)] =
+    val found = releases.stdlib.flatMap: manifest =>
+      manifest.section.stdlib.collect:
+        case section if section.derivative.let(Blob.compare(_, hash) == 0).or(false) =>
+          (manifest, section)
 
-    releases.stdlib.find(declares).getOrElse(Unset)
+    found.headOption.getOrElse(Unset)
 
-  // §13.3 validity for one universe. Diamond dependencies resolve by construction: requirements
-  // on two snapshots of one module are jointly satisfiable iff some lineage contains both.
-  def validate(universe: Text): List[LiraAdvisory] raises LiraError =
+  // The integrations a release offers, in canonical order (§13.3): ascending `rank`, then
+  // ascending `id`. A release declaring none offers exactly one, its implicit `Unset`. An
+  // unranked integration sorts after every ranked one rather than at zero, so that leaving
+  // `rank` off never silently promotes an alternative above the publisher's preferred build.
+  def candidates(manifest: LiraManifest): scala.List[Optional[Text]] =
+    if manifest.integration.stdlib.isEmpty then scala.List(Unset) else
+      manifest.integration.stdlib.sortBy: integration =>
+        (integration.rank.or(Long.MaxValue), integration.id.s)
+
+      . map { integration => integration.id }.toList
+
+  // §13.3: valid for a universe iff *some* assignment makes it so.
+  //
+  // The search collapses. A buildpath is a *fixed* set of releases, and every rule an assignment
+  // can affect — closure (4) and satisfaction (5) — is a property of one release together with
+  // its own choice: which release provides a module is decided by the buildpath, never by an
+  // integration. So the choices are independent, and the canonical assignment is found by taking,
+  // for each release, the first of its candidates whose own dependencies hold. There is no
+  // backtracking and no combinatorial blow-up, and the result is canonical by construction
+  // because `candidates` is already in (rank, id) order.
+  //
+  // Coupling would appear only in a resolver that also chose *which* releases to include, since
+  // an integration can then pull a module in; that is dependency resolution proper, and it is
+  // outside §13.3, which audits a buildpath it is handed.
+  def resolve(universe: Text): Assignment raises LiraError =
+    val chosen = releases.stdlib.sortBy(_.module.s).map: manifest =>
+      candidates(manifest).find(satisfies(universe, manifest, _)) match
+        case scala.Some(candidate) => (manifest.module, candidate)
+        case _                     => abort(LiraError(Reason.NoAssignment))
+
+    Assignment(List.from(chosen))
+
+  // Whether one release's dependencies hold under one choice of its integration: rules 4 and 5,
+  // as a predicate rather than a diagnosis. `audit` reports which rule failed and why.
+  private def satisfies(universe: Text, manifest: LiraManifest, integration: Optional[Text])
+  :   Boolean =
+
+    manifest.dependency.stdlib.forall: dependency =>
+      if !dependency.applies(universe, integration) then true else
+        apply(dependency.module) match
+          case candidate: LiraManifest =>
+            Lineage.contains(candidate.lineage, dependency.api)
+            && dependency.build.let(Blob.compare(_, candidate.payload.hash) == 0).or(true)
+
+          case _ => false
+
+  // §13.3 structural rules, which no assignment can affect: at most one release per module
+  // (L111) and pairwise-disjoint `owns` claims (L112).
+  private def structural(): Unit raises LiraError =
     val all = releases.stdlib
 
-    // L111: at most one release per module.
     all.groupBy(_.module).foreach: (module, group) =>
       if group.size > 1 then abort(LiraError(Reason.DuplicateModule(module)))
 
-    // L112: `owns` claims pairwise disjoint; a namespace and any dotted extension of it clash.
     val claims = all.flatMap: manifest =>
       manifest.owns.stdlib.map: namespace => (manifest.module, namespace)
 
@@ -109,23 +162,23 @@ case class Buildpath(releases: List[LiraManifest]):
           if one == two || one.startsWith(two + ".") || two.startsWith(one + ".")
           then abort(LiraError(Reason.NamespaceClash(left(1))))
 
+  // Closure (L113) and satisfaction (L114) under one assignment, reporting the precise rule that
+  // fails. `resolve` answers only whether *some* assignment works; this says why a given one does
+  // not, which is what a diagnostic needs.
+  private def audit(universe: Text, assignment: Assignment)
+  :   List[LiraAdvisory] raises LiraError =
+
     val advisories = scala.collection.mutable.ArrayBuffer[LiraAdvisory]()
 
-    all.foreach: manifest =>
+    releases.stdlib.foreach: manifest =>
       manifest.dependency.stdlib.foreach: dependency =>
-        val applies =
-          dependency.universe.stdlib.isEmpty || dependency.universe.stdlib.contains(universe)
-
-        if applies then
-          // L113: closure — the dependency must be present.
+        if dependency.applies(universe, assignment(manifest.module)) then
           val candidate = apply(dependency.module) match
             case candidate: LiraManifest => candidate
 
             case _ =>
               abort(LiraError(Reason.AbsentDependency(dependency.module)))
 
-          // L114: satisfaction — the required snapshot must appear in the candidate's lineage,
-          // and a development-time build pin must match the candidate's implementation identity.
           if !Lineage.contains(candidate.lineage, dependency.api)
           then abort(LiraError(Reason.Unsatisfiable(dependency.module)))
 
@@ -139,3 +192,22 @@ case class Buildpath(releases: List[LiraManifest]):
               if hint != actual then advisories += LiraAdvisory.VersionMismatch(hint, actual)
 
     List.from(advisories)
+
+  // §13.3 validity for one universe, with the assignment that establishes it. Diamond
+  // dependencies resolve by construction: requirements on two snapshots of one module are
+  // jointly satisfiable iff some lineage contains both.
+  //
+  // Where no release declares an integration the assignment is unique, so the search is skipped
+  // entirely and the rules read exactly as they did before integrations existed — including the
+  // diagnostics, which name the failing dependency rather than reporting that no assignment
+  // exists.
+  def resolved(universe: Text): (Assignment, List[LiraAdvisory]) raises LiraError =
+    structural()
+
+    val assignment =
+      if releases.stdlib.forall(_.integration.stdlib.isEmpty) then Assignment(List())
+      else resolve(universe)
+
+    (assignment, audit(universe, assignment))
+
+  def validate(universe: Text): List[LiraAdvisory] raises LiraError = resolved(universe)(1)

--- a/lib/reliquary/src/core/reliquary.Discipline.scala
+++ b/lib/reliquary/src/core/reliquary.Discipline.scala
@@ -34,25 +34,61 @@ package reliquary
 
 import anticipation.*
 import contingency.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
 
 object Discipline:
-  // What a compiler-based discipline needs beyond the content itself: which universe is being
-  // atomized, and the dependency classpath materialized from the buildpath (entries as textual
-  // paths, so the core stays platform-light).
-  case class Context(universe: Text, classpath: List[Text] = List())
+  // What a compiler-based discipline needs beyond the content itself: which section is being
+  // atomized — its universe and, where the release offers alternative dependency vectors (§9.5),
+  // its integration — and the dependency classpath materialized from the buildpath (entries as
+  // textual paths, so the core stays platform-light). The classpath is a property of the
+  // integration, which is why atomization is per-section and not per-universe.
+  case class Context
+    ( universe:    Text,
+      integration: Optional[Text] = Unset,
+      classpath:   List[Text]     = List() )
+
+  // The universes a discipline atomizes at all (§11.2, requirement 1). A universal discipline
+  // atomizes whatever universe it is given; a universe-specific one names its universes, and the
+  // cross-section invariant (§9.6) is vacuous outside them. Claiming nothing in a universe
+  // outside the domain is not the same as claiming content atomless.
+  enum Domain:
+    case Universal
+    case Universes(names: Set[Text])
+
+    def covers(universe: Text): Boolean = this match
+      case Universal        => true
+      case Universes(names) => names.stdlib.contains(universe)
+
+  // Whether an atom's key names the type that *declares* a member, or every type that *presents*
+  // it after inheritance (§11.2, requirement 4). Declaration keying is sound exactly where every
+  // reference a certified consumer can make resolves through the declaring type.
+  enum Keying:
+    case Declaration, Membership
+
+  // What a discipline's rigid atoms certify (§11.2 requirement 7, §11.5). Behavior is not a
+  // certifiable level and so has no case here: no hash scheme certifies it (§18).
+  enum Guarantee:
+    case Linkage, Recompilation
 
   // An ordered set of disciplines. Content is claimed by the first discipline whose `claims`
   // accepts it; anything left unclaimed falls to `opaque/1` (§11.3), so nothing in a LIRA file
-  // is ever outside the compatibility algebra.
+  // is ever outside the compatibility algebra. A discipline out of its domain claims nothing,
+  // ahead of any question of what it would have claimed.
   class Registry(disciplines: List[Discipline]):
+    def all: List[Discipline] = List.from(disciplines.stdlib :+ OpaqueDiscipline)
+
     def atomize(content: List[(TreePath, Data)], context: Context)
     :   List[Atomization] raises DisciplineError =
 
-      val all = disciplines.stdlib :+ OpaqueDiscipline
       var remaining = content.stdlib
 
-      val results = all.map: discipline =>
-        val (claimed, rest) = remaining.partition: (path, data) => discipline.claims(path, data)
+      val results = all.stdlib.map: discipline =>
+        val (claimed, rest) =
+          if !discipline.domain.covers(context.universe) then (scala.Nil, remaining)
+          else remaining.partition: (path, data) => discipline.claims(path, data)
+
         remaining = rest
         (discipline, claimed)
 
@@ -67,6 +103,14 @@ object Discipline:
 trait Discipline:
   def id: Text
   def claims(path: TreePath, data: Data): Boolean
+
+  // The three declarative requirements of §11.2. `domain` scopes the cross-section invariant
+  // (§9.6) and decides L127; `keying` and `guarantees` are contracts a discipline states and
+  // this core takes on trust — neither is checkable by machine, and both change what a reader
+  // may conclude from a grade (§12.4).
+  def domain: Discipline.Domain
+  def keying: Discipline.Keying
+  def guarantees(universe: Text): Set[Discipline.Guarantee]
 
   def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
   :   Atomization raises DisciplineError

--- a/lib/reliquary/src/core/reliquary.LiraError.scala
+++ b/lib/reliquary/src/core/reliquary.LiraError.scala
@@ -63,6 +63,13 @@ object LiraError:
     case BadSignature(signer: Text)           extends Reason(121)
     case UnknownAlgorithm(name: Text)         extends Reason(122)
     case UnknownKey(fingerprint: Text)        extends Reason(123)
+    case InapplicableDiscipline(id: Text)     extends Reason(127)
+    case ProfileViolated(id: Text, detail: Text) extends Reason(128)
+    case ProfileWeakens(id: Text)             extends Reason(129)
+    case UnrecordedBreak(id: Text, level: Text) extends Reason(130)
+    case BadIntegration(detail: Text)         extends Reason(131)
+    case NoAssignment                         extends Reason(132)
+    case UnrealizedIntegration(id: Text)      extends Reason(133)
 
   given communicable: Reason is Communicable =
     case Reason.InvalidManifest(detail)       => m"the manifest is invalid: $detail"
@@ -72,7 +79,7 @@ object LiraError:
     case Reason.PayloadHash                   => m"the payload hash is not its declared value"
     case Reason.InvalidTree(detail)           => m"a tree metadata blob is invalid: $detail"
     case Reason.OverlayNotMinimal(path)       => m"the overlay is not minimal at $path"
-    case Reason.ApiDivergence(detail)         => m"the universes differ in API: $detail"
+    case Reason.ApiDivergence(detail)         => m"the sections differ in API: $detail"
     case Reason.LineageMismatch               => m"the last lineage entry is not this snapshot"
     case Reason.UngradedSuccessor             => m"the release is not a patch or minor successor"
     case Reason.DuplicateModule(module)       => m"the buildpath contains $module more than once"
@@ -88,6 +95,19 @@ object LiraError:
     case Reason.BadSignature(signer)          => m"the signature by $signer does not verify"
     case Reason.UnknownAlgorithm(name)        => m"the signature algorithm $name is unknown"
     case Reason.UnknownKey(fingerprint)       => m"no key matches the fingerprint $fingerprint"
+
+    case Reason.InapplicableDiscipline(id) =>
+      m"the discipline $id atomizes no universe this release carries"
+
+    case Reason.ProfileViolated(id, detail) => m"the profile $id is violated: $detail"
+    case Reason.ProfileWeakens(id)          => m"the profile $id weakens a core requirement"
+
+    case Reason.UnrecordedBreak(id, level) =>
+      m"the step does not preserve $level but the profile $id does not record it"
+
+    case Reason.BadIntegration(detail)      => m"the integrations are ill-formed: $detail"
+    case Reason.NoAssignment                => m"no assignment of integrations validates"
+    case Reason.UnrealizedIntegration(id)   => m"the integration $id has no section"
 
 case class LiraError(reason: LiraError.Reason)(using Diagnostics)
 extends Error(640, reason.number)(m"the LIRA operation failed because $reason")

--- a/lib/reliquary/src/core/reliquary.LiraManifest.scala
+++ b/lib/reliquary/src/core/reliquary.LiraManifest.scala
@@ -46,14 +46,57 @@ object LiraManifest:
   case class Tool(name: Text, version: Text, flag: List[Text] = List())
   case class Api(discipline: Text, atoms: Data)
 
+  // The guarantee levels of §11.5 that can be claimed or broken. Behavior is absent by design:
+  // no hash scheme certifies it (§18), so it is not expressible in a `breaks` field.
+  enum Guarantee:
+    case Linkage, Recompilation
+
+    def keyword: Text = this match
+      case Linkage       => t"linkage"
+      case Recompilation => t"recompilation"
+
+  object Guarantee:
+    def parse(keyword: Text): Optional[Guarantee] = keyword.s match
+      case "linkage"       => Linkage
+      case "recompilation" => Recompilation
+      case _               => Unset
+
+  // An ecosystem profile this release claims to satisfy (§11.6), with the guarantee levels its
+  // lineage step did not preserve (§12.4). `breaks` being empty means the step preserved every
+  // level the profile certifies — the whole value of the record is that its absence means
+  // something, so a level not preserved and not listed is invalid (L130).
+  case class Profile(id: Text, breaks: List[Guarantee] = List())
+
+  // One alternative dependency vector the release was built against (§9.5). `rank` orders the
+  // canonical assignment (§13.3), lower first; a rank left unset sorts after every declared one,
+  // so a publisher who ranks nothing gets declaration-order-independent, id-ordered resolution.
+  // `label` carries no authority (§14). It is one TEL atom, so it holds no whitespace: TEL
+  // splits unquoted values on whitespace, and a `String` field admits exactly one atom. Prose
+  // labels would need the field declared repeatable, or a literal-atom encoding (TEL §15); both
+  // are spec decisions rather than implementation ones, so the field stays a single token here.
+  case class Integration(id: Text, rank: Optional[Long] = Unset, label: Optional[Text] = Unset)
+
   case class Dependency
-    ( module:   Text,
-      api:      Data,
-      version:  Optional[Semver] = Unset,
-      build:    Optional[Data]   = Unset,
-      universe: List[Text]       = List(),
-      uses:     Optional[Data]   = Unset,
-      spans:    List[Data]       = List() )
+    ( module:      Text,
+      api:         Data,
+      version:     Optional[Semver] = Unset,
+      build:       Optional[Data]   = Unset,
+      universe:    List[Text]       = List(),
+      integration: List[Text]       = List(),
+      uses:        Optional[Data]   = Unset,
+      spans:       List[Data]       = List() ):
+
+    // §13.2: the two scopes are independent and conjunctive. An empty list on either axis means
+    // "every value of that axis", which is how a dependency common to all of them is declared
+    // once and unscoped.
+    def applies(universe: Text, integration: Optional[Text]): Boolean =
+      val universeApplies = this.universe.stdlib.isEmpty || this.universe.stdlib.contains(universe)
+
+      val integrationApplies =
+        this.integration.stdlib.isEmpty
+        || integration.let { id => this.integration.stdlib.contains(id) }.or(false)
+
+      universeApplies && integrationApplies
 
   case class Payload(compression: Text, length: Long, hash: Data)
   case class Signature(signer: Text, algorithm: Text, key: Data, value: Text)
@@ -134,13 +177,30 @@ object LiraManifest:
       val fields = children(compound)
 
       Dependency
-        ( module   = required(fields, t"module"),
-          api      = hash(required(fields, t"api")),
-          version  = field(fields, t"version").let(semver(_)),
-          build    = field(fields, t"build").let(hash(_)),
-          universe = List.from(repeated(fields, t"universe")),
-          uses     = field(fields, t"uses").let(hash(_)),
-          spans    = List.from(repeated(fields, t"spans").map(hash(_))) )
+        ( module      = required(fields, t"module"),
+          api         = hash(required(fields, t"api")),
+          version     = field(fields, t"version").let(semver(_)),
+          build       = field(fields, t"build").let(hash(_)),
+          universe    = List.from(repeated(fields, t"universe")),
+          integration = List.from(repeated(fields, t"integration")),
+          uses        = field(fields, t"uses").let(hash(_)),
+          spans       = List.from(repeated(fields, t"spans").map(hash(_))) )
+
+    val profile = top.filter(_.keyword == t"profile").map: compound =>
+      val fields = children(compound)
+
+      val breaks = repeated(fields, t"breaks").map: keyword =>
+        Guarantee.parse(keyword).or(abort(bad(t"$keyword is not a guarantee level")))
+
+      Profile(required(fields, t"id"), List.from(breaks))
+
+    val integration = top.filter(_.keyword == t"integration").map: compound =>
+      val fields = children(compound)
+
+      Integration
+        ( id    = required(fields, t"id"),
+          rank  = field(fields, t"rank").let { text => text.s.toLong },
+          label = field(fields, t"label") )
 
     val section = top.filter(_.keyword == t"section").map: compound =>
       val universe = texts(compound) match
@@ -152,11 +212,11 @@ object LiraManifest:
       val fields = children(compound)
 
       Section
-        ( universe   = universe,
-          tree       = hash(required(fields, t"tree")),
-          delete     = List.from(repeated(fields, t"delete").map(TreePath(_))),
-          against    = List.from(repeated(fields, t"against").map(hash(_))),
-          derivative = field(fields, t"derivative").let(hash(_)) )
+        ( universe    = universe,
+          integration = field(fields, t"integration"),
+          tree        = hash(required(fields, t"tree")),
+          delete      = List.from(repeated(fields, t"delete").map(TreePath(_))),
+          derivative  = field(fields, t"derivative").let(hash(_)) )
 
     val payload = top.filter(_.keyword == t"payload").toList match
       case scala.List(compound) =>
@@ -179,34 +239,38 @@ object LiraManifest:
           required(fields, t"value") )
 
     LiraManifest
-      ( module     = required(top, t"module"),
-        version    = field(top, t"version").let(semver(_)),
-        lineage    = List.from(repeated(top, t"lineage").map(hash(_))),
-        toolchain  = List.from(toolchain),
-        owns       = List.from(repeated(top, t"owns")),
-        api        = List.from(api),
-        dependency = List.from(dependency),
-        delta      = field(top, t"delta").let(hash(_)),
-        section    = List.from(section),
-        payload    = payload,
-        signature  = List.from(signature) )
+      ( module      = required(top, t"module"),
+        version     = field(top, t"version").let(semver(_)),
+        lineage     = List.from(repeated(top, t"lineage").map(hash(_))),
+        toolchain   = List.from(toolchain),
+        owns        = List.from(repeated(top, t"owns")),
+        api         = List.from(api),
+        profile     = List.from(profile),
+        integration = List.from(integration),
+        dependency  = List.from(dependency),
+        delta       = field(top, t"delta").let(hash(_)),
+        section     = List.from(section),
+        payload     = payload,
+        signature   = List.from(signature) )
 
 // The typed view of a `.lira` manifest (§14). Decoding always retains the parsed `Tel` alongside
 // (in `Lira`): signing and reserialization operate on the TEL semantic model; this class is the
 // ergonomic projection. A manifest without a `version` is a development release, identified
 // purely by its hashes and unpublishable until a version is assigned.
 case class LiraManifest
-  ( module:     Text,
-    version:    Optional[Semver]                 = Unset,
-    lineage:    List[Data],
-    toolchain:  List[LiraManifest.Tool]          = List(),
-    owns:       List[Text]                       = List(),
-    api:        List[LiraManifest.Api],
-    dependency: List[LiraManifest.Dependency]    = List(),
-    delta:      Optional[Data]                   = Unset,
-    section:    List[Section],
-    payload:    LiraManifest.Payload,
-    signature:  List[LiraManifest.Signature]     = List() ):
+  ( module:      Text,
+    version:     Optional[Semver]                = Unset,
+    lineage:     List[Data],
+    toolchain:   List[LiraManifest.Tool]         = List(),
+    owns:        List[Text]                      = List(),
+    api:         List[LiraManifest.Api],
+    profile:     List[LiraManifest.Profile]      = List(),
+    integration: List[LiraManifest.Integration]  = List(),
+    dependency:  List[LiraManifest.Dependency]   = List(),
+    delta:       Optional[Data]                  = Unset,
+    section:     List[Section],
+    payload:     LiraManifest.Payload,
+    signature:   List[LiraManifest.Signature]    = List() ):
 
   // The root section is the first (§9.1); overlays materialize against it.
   def root: Optional[Section] = if section.stdlib.isEmpty then Unset else section.stdlib.head
@@ -239,6 +303,17 @@ case class LiraManifest
       lines += s"  discipline ${api.discipline}"
       lines += s"  atoms ${LiraHash.text(api.atoms)}"
 
+    profile.stdlib.foreach: profile =>
+      lines += "profile"
+      lines += s"  id ${profile.id}"
+      profile.breaks.stdlib.foreach: level => lines += s"  breaks ${level.keyword}"
+
+    integration.stdlib.foreach: integration =>
+      lines += "integration"
+      lines += s"  id ${integration.id}"
+      integration.rank.let: rank => lines += s"  rank $rank"
+      integration.label.let: label => lines += s"  label $label"
+
     dependency.stdlib.foreach: dependency =>
       lines += "dependency"
       lines += s"  module ${dependency.module}"
@@ -249,6 +324,10 @@ case class LiraManifest
 
       dependency.build.let: build => lines += s"  build ${LiraHash.text(build)}"
       dependency.universe.stdlib.foreach: universe => lines += s"  universe $universe"
+
+      dependency.integration.stdlib.foreach: integration =>
+        lines += s"  integration $integration"
+
       dependency.uses.let: uses => lines += s"  uses ${LiraHash.text(uses)}"
       dependency.spans.stdlib.foreach: spans => lines += s"  spans ${LiraHash.text(spans)}"
 
@@ -256,7 +335,7 @@ case class LiraManifest
 
     section.stdlib.foreach: section =>
       lines += s"section ${section.universe}"
-      section.against.stdlib.foreach: hash => lines += s"  against ${LiraHash.text(hash)}"
+      section.integration.let: id => lines += s"  integration $id"
       lines += s"  tree ${LiraHash.text(section.tree)}"
       section.delete.stdlib.foreach: path => lines += s"  delete ${path.text}"
       section.derivative.let: hash => lines += s"  derivative ${LiraHash.text(hash)}"

--- a/lib/reliquary/src/core/reliquary.LiraSchemas.scala
+++ b/lib/reliquary/src/core/reliquary.LiraSchemas.scala
@@ -43,11 +43,13 @@ import vacuous.*
 // canonical `.tel` document (at `res/test/reliquary/`) verbatim; the test suite asserts the two
 // stay in agreement and pins each schema's signature as a golden value.
 //
-// The schemas encode the LIRA specification's §14 with the agreed amendments: universes are
-// `jvm | sjsir | nir`; a `Section` may carry a `derivative` hash (its canonical derived JAR); a
-// `version` is optional (a release without one is a development release) and strictly numeric;
-// and a `Dependency` may be scoped to particular universes, or pinned to an exact `build` during
-// development.
+// The schemas encode the LIRA specification's §14: universes are `jvm | sjsir | nir`; a
+// `Section` is keyed by universe and integration (§9.5) and may carry a `derivative` hash (its
+// canonical derived JAR); a `version` is optional (a release without one is a development
+// release) and strictly numeric; a `Dependency` may be scoped to particular universes or
+// integrations, or pinned to an exact `build` during development; and a `Profile` records the
+// ecosystem predicates a release claims, with the guarantee levels its last step did not
+// preserve (§11.6, §12.4).
 object LiraSchemas:
   import Tels.{Field, Polarity, RecordDefinition, Reference, ScalarDefinition, SelectDefinition,
       SelectRef, Struct, Type, Variant}
@@ -84,6 +86,8 @@ object LiraSchemas:
   private val natural:      Type = Reference(t"Natural")
   private val disciplineId: Type = Reference(t"DisciplineId")
   private val identifier:   Type = Reference(t"Identifier")
+  private val profileId:    Type = Reference(t"ProfileId")
+  private val guarantee:    Type = Reference(t"Guarantee")
   private val string:       Type = Reference(t"String")
 
   private val hashScalar: ScalarDefinition = scalar("Hash", "base-256-hash")
@@ -106,6 +110,8 @@ object LiraSchemas:
         field("toolchain", Reference(t"Tool"), repeatable = Loose),
         field("owns", namespace, required = Loose, repeatable = Loose),
         field("api", Reference(t"Api"), repeatable = Loose),
+        field("profile", Reference(t"Profile"), required = Loose, repeatable = Loose),
+        field("integration", Reference(t"Integration"), required = Loose, repeatable = Loose),
         field("dependency", Reference(t"Dependency"), required = Loose, repeatable = Loose),
         field("delta", hash, required = Loose),
         field("section", Reference(t"Section"), repeatable = Loose),
@@ -124,18 +130,28 @@ object LiraSchemas:
         field("discipline", disciplineId),
         field("atoms", hash)),
 
+      record("Profile",
+        field("id", profileId),
+        field("breaks", guarantee, required = Loose, repeatable = Loose)),
+
+      record("Integration",
+        field("id", identifier),
+        field("rank", natural, required = Loose),
+        field("label", string, required = Loose)),
+
       record("Dependency",
         field("module", moduleName),
         field("api", hash),
         field("version", semver, required = Loose),
         field("build", hash, required = Loose),
         field("universe", identifier, required = Loose, repeatable = Loose),
+        field("integration", identifier, required = Loose, repeatable = Loose),
         field("uses", hash, required = Loose),
         field("spans", hash, required = Loose, repeatable = Loose)),
 
       record("Section",
         selectRef("Universe"),
-        field("against", hash, required = Loose, repeatable = Loose),
+        field("integration", identifier, required = Loose),
         field("tree", hash),
         field("delete", string, required = Loose, repeatable = Loose),
         field("derivative", hash, required = Loose)),
@@ -156,7 +172,9 @@ object LiraSchemas:
       scalar("Namespace", "namespace"),
       scalar("Semver", "semver"),
       scalar("Natural", "natural"),
-      scalar("DisciplineId", "discipline-id")),
+      scalar("DisciplineId", "discipline-id"),
+      scalar("ProfileId", "profile-id"),
+      scalar("Guarantee", "guarantee")),
     selects  = Array.of(
       select("Universe",
         variant("jvm"),
@@ -230,7 +248,7 @@ object LiraSchemas:
   // The BASE-256 schema signatures of the five canonical documents, pinned as golden values (the
   // test suite recomputes each from its `res/test/reliquary/*.tel` mirror and checks agreement).
   // A conforming document of each schema carries its signature on the pragma line.
-  val liraSignature:  Text = t"1Ϊð8ƨẉǽhῘĝοΊơḠơǓĺШḤγàӯǽmẗṽFíǽĝӝӖЭ"
+  val liraSignature:  Text = t"ẋḣẀΦḤȐYeû0VǓңңќỵ0ẃẈşȑĺЖȐAÞjìẓȧƟḋh"
   val treeSignature:  Text = t"ǨẙơẗỵclϋẁЫĥᾸMôĮẍOώżӯάǢЗĆӸkҚțȐωǢέӫ"
   val atomsSignature: Text = t"2ӪççÃ5AḟǑXϋƤzᾱĺHϕЂẌǒEẂẁĮί9ḀẘΊÐιЪp"
   val usesSignature:  Text = t"şşCȧOӖGҐΪḍḋjΊӁῚƟȐЌĥέȦЬƜδĻĘ1Ȑḟ6ӟÔḍ"

--- a/lib/reliquary/src/core/reliquary.LiraValidators.scala
+++ b/lib/reliquary/src/core/reliquary.LiraValidators.scala
@@ -46,7 +46,9 @@ import vacuous.*
 //  - `namespace`:      dotted package-style segments (letters, digits, `_`; no leading digit)
 //  - `semver`:         exactly `major.minor.patch`, each a natural; no prerelease/build suffixes
 //  - `natural`:        a decimal natural with no superfluous leading zero
-//  - `discipline-id`:  `<kebab-name>/<positive integer>`, e.g. `scala-tasty/1`
+//  - `discipline-id`:  `<kebab-name>/<positive integer>`, e.g. `tasty/1`
+//  - `profile-id`:     the same grammar as a discipline (§11.6), e.g. `jvm/1`
+//  - `guarantee`:      `linkage` or `recompilation` (§11.5; behavior is not certifiable)
 //  - `tree-path`:      relative `/`-separated path; no empty, `.` or `..` segments
 //  - `atom-class`:     `rigid` or `replaceable`
 object LiraValidators:
@@ -62,6 +64,8 @@ object LiraValidators:
           case "semver"        => semver(value)
           case "natural"       => natural(value)
           case "discipline-id" => disciplineId(value)
+          case "profile-id"    => profileId(value)
+          case "guarantee"     => guarantee(value)
           case "tree-path"     => treePath(value)
           case "atom-class"    => atomClass(value)
           case _               => unknown(method)
@@ -137,6 +141,21 @@ object LiraValidators:
     if parts.length != 2 || !kebab(parts(0).nn) || !naturalNumber(parts(1)) || parts(1) == "0"
     then fail(t"a discipline is identified as `<name>/<positive integer>`", (0, value.s.length))
     else Response.Valid
+
+  // §11.6: a profile is identified on the same terms as a discipline, and must likewise bump its
+  // version on any change to a predicate.
+  private def profileId(value: Text): Response =
+    val parts = value.s.split("/", -1).nn
+
+    if parts.length != 2 || !kebab(parts(0).nn) || !naturalNumber(parts(1)) || parts(1) == "0"
+    then fail(t"a profile is identified as `<name>/<positive integer>`", (0, value.s.length))
+    else Response.Valid
+
+  // §11.5 names three guarantee levels, but only two can be claimed or broken: behavior is not
+  // certified by any hash scheme, so it is not expressible in a `breaks` field.
+  private def guarantee(value: Text): Response =
+    if value.s == "linkage" || value.s == "recompilation" then Response.Valid
+    else fail(t"a guarantee level is `linkage` or `recompilation`", (0, value.s.length))
 
   private def treePath(value: Text): Response =
     val s = value.s

--- a/lib/reliquary/src/core/reliquary.OpaqueDiscipline.scala
+++ b/lib/reliquary/src/core/reliquary.OpaqueDiscipline.scala
@@ -45,6 +45,15 @@ object OpaqueDiscipline extends Discipline:
   def id: Text = t"opaque/1"
   def claims(path: TreePath, data: Data): Boolean = true
 
+  // Universal by necessity: it is the fallback, so it must be able to claim content in any
+  // universe. Keys are paths, so keying is by declaration in the only sense available to it.
+  // It certifies both levels trivially, admitting no change at all below the major grade.
+  def domain: Discipline.Domain = Discipline.Domain.Universal
+  def keying: Discipline.Keying = Discipline.Keying.Declaration
+
+  def guarantees(universe: Text): Set[Discipline.Guarantee] =
+    Set(Discipline.Guarantee.Linkage, Discipline.Guarantee.Recompilation)
+
   def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
   :   Atomization raises DisciplineError =
 

--- a/lib/reliquary/src/core/reliquary.Section.scala
+++ b/lib/reliquary/src/core/reliquary.Section.scala
@@ -35,14 +35,20 @@ package reliquary
 import anticipation.*
 import vacuous.*
 
-// One compiled view of a release (§9): a universe keyword (kept textual so sections of unknown,
-// layered universes survive as opaque data), the tree blob's hash, the overlay-delete list, the
-// variant dependency snapshots (§9.5), and the canonical derivative artifact's hash (§13.6).
+// One compiled view of a release (§9), keyed by universe and integration: a universe keyword
+// (kept textual so sections of unknown, layered universes survive as opaque data), the
+// integration realized (§9.5; absent where the release declares none, which is the single
+// implicit integration), the tree blob's hash, the overlay-delete list, and the canonical
+// derivative artifact's hash (§13.6).
 case class Section
-  ( universe:   Text,
-    tree:       Data,
-    delete:     List[TreePath]  = List(),
-    against:    List[Data]      = List(),
-    derivative: Optional[Data]  = Unset ):
+  ( universe:    Text,
+    integration: Optional[Text] = Unset,
+    tree:        Data,
+    delete:      List[TreePath] = List(),
+    derivative:  Optional[Data] = Unset ):
 
   def known: Optional[LiraUniverse] = LiraUniverse.parse(universe)
+
+  // The key that must be unique within a release (L131), and by which a consumer selects a
+  // section once an assignment has chosen an integration (§13.5).
+  def key: (Text, Optional[Text]) = (universe, integration)

--- a/lib/reliquary/src/core/reliquary.Verification.scala
+++ b/lib/reliquary/src/core/reliquary.Verification.scala
@@ -34,7 +34,11 @@ package reliquary
 
 import anticipation.*
 import contingency.*
+import gossamer.*
+import rudiments.*
 import vacuous.*
+
+import LiraError.Reason
 
 // Verification is re-execution of the construction, bottom-up (§16). `install` performs the
 // language-blind steps every consumer runs: payload decompression and hashing (1), blob-stream
@@ -43,14 +47,52 @@ import vacuous.*
 // separately: the first two need disciplines and the predecessor, the last needs key material.
 object Verification:
 
+  // `materialized` is keyed by the whole section, not by universe alone: a release offering
+  // alternative dependency vectors (§9.5) has one entry per (universe, integration) cell.
   case class Report
     ( blobstore:     Blobstore,
       atomizations:  List[Atomization],
-      materialized:  List[(Text, LiraTree)],
-      advisories:    List[LiraAdvisory] )
+      materialized:  List[(Section, LiraTree)],
+      advisories:    List[LiraAdvisory] ):
+
+    def tree(universe: Text, integration: Optional[Text]): Optional[LiraTree] =
+      materialized.stdlib.find: pair =>
+        pair(0).universe == universe && pair(0).integration.option == integration.option
+
+      . map(_(1)).getOrElse(Unset)
+
+  // L131/L133: the integration declarations must be well-formed — ids unique, every section's
+  // integration declared, no two sections sharing a (universe, integration) key — and every
+  // declared integration must be realized by at least one section. Decidable from the manifest
+  // alone, so every consumer checks it, not just a registry.
+  def integrations(manifest: LiraManifest): Unit raises LiraError =
+    val declared = manifest.integration.stdlib.map(_.id)
+
+    declared.groupBy(identity).foreach: (id, group) =>
+      if group.size > 1
+      then abort(LiraError(Reason.BadIntegration(t"the integration $id is declared twice")))
+
+    manifest.section.stdlib.foreach: section =>
+      section.integration.let: id =>
+        if !declared.contains(id)
+        then abort(LiraError(Reason.BadIntegration(t"the section names undeclared $id")))
+
+      if section.integration.absent && !declared.isEmpty
+      then abort(LiraError(Reason.BadIntegration(t"a section names no integration")))
+
+    manifest.section.stdlib.groupBy(_.key).foreach: (key, group) =>
+      if group.size > 1
+      then abort(LiraError(Reason.BadIntegration(t"two sections share universe ${key(0)}")))
+
+    declared.foreach: id =>
+      val realized = manifest.section.stdlib.exists: section =>
+        section.integration.let(_ == id).or(false)
+
+      if !realized then abort(LiraError(Reason.UnrealizedIntegration(id)))
 
   def install(lira: Lira): Report raises LiraError =
     val manifest = lira.manifest
+    integrations(manifest)
 
     // Steps 1–2: decompress within the declared length, verify the payload hash, and re-derive
     // every blob identity while checking stream order (L102–L105).
@@ -91,9 +133,9 @@ object Verification:
         val known = trees.tail.filter: pair => pair(0).known.present
 
         val results = known.map: pair =>
-          (pair(0).universe, Overlay.materialize(rootTree, pair(0).delete, pair(1)))
+          (pair(0), Overlay.materialize(rootTree, pair(0).delete, pair(1)))
 
-        (rootSection.universe, rootTree) :: results.toList
+        (rootSection, rootTree) :: results.toList
 
     // Step 5: the snapshot recomputed from the atom listings must equal the last lineage entry.
     Lineage.check(manifest.lineage, Snapshot(atomizations))

--- a/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
+++ b/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
@@ -43,13 +43,18 @@ import vacuous.*
 import LiraError.Reason
 import errorDiagnostics.emptyDiagnostics
 
-// The language-blind producer: given one body of content per universe — the first is the root —
-// it atomizes every universe under the discipline registry, enforces the cross-universe API
+// The language-blind producer: given one body of content per section — the first is the root —
+// it atomizes every section under the discipline registry, enforces the cross-section API
 // invariant (L108), computes minimal overlays, derivative hashes, the snapshot and lineage, and
 // assembles the complete `.lira` file. Everything here is deterministic for fixed inputs.
 object LiraAssembler:
 
-  case class SectionInput(universe: Text, content: List[(TreePath, Data)])
+  // One cell of the (universe × integration) matrix (§9.5). `integration` is absent where the
+  // release declares none, which is its single implicit integration.
+  case class SectionInput
+    ( universe:    Text,
+      content:     List[(TreePath, Data)],
+      integration: Optional[Text] = Unset )
 
   def assemble
     ( module:      Text,
@@ -59,9 +64,11 @@ object LiraAssembler:
       lineage:     List[Data]                    = List(),
       toolchain:   List[LiraManifest.Tool]       = List(),
       owns:        List[Text]                    = List(),
-      dependency:  List[LiraManifest.Dependency] = List(),
-      delta:       Optional[LiraDelta]           = Unset,
-      classpath:   Text => List[Text]            = { _ => List() },
+      profile:     List[LiraManifest.Profile]     = List(),
+      integration: List[LiraManifest.Integration] = List(),
+      dependency:  List[LiraManifest.Dependency]  = List(),
+      delta:       Optional[LiraDelta]            = Unset,
+      classpath:   SectionInput => List[Text]     = { _ => List() },
       sign:        LiraManifest => LiraManifest  = identity(_) )
   :   Data raises LiraError raises DisciplineError =
 
@@ -74,11 +81,21 @@ object LiraAssembler:
       LiraTree.of:
         input.content.map: pair => TreeEntry(pair(0), LiraHash(LiraHash.Domain.Blob, pair(1)))
 
-    // Each universe's content is atomized independently; the atom sets must be identical, as
-    // (discipline, key, class, value hash), for the release to present one API (L108).
+    // Each section's content is atomized independently; the atom sets must be identical, as
+    // (discipline, key, class, value hash), for the release to present one API on every universe
+    // and under every integration (L108). The classpath is a property of the section, since it
+    // is exactly what distinguishes one integration from another.
     val atomized = inputs.map: input =>
-      val context = Discipline.Context(input.universe, classpath(input.universe))
+      val context = Discipline.Context(input.universe, input.integration, classpath(input))
       (input.universe, disciplines.atomize(input.content, context))
+
+    // L127: a declared discipline must atomize some universe this release carries. An
+    // atomization of nothing is not a claim about anything.
+    val universes = inputs.map(_.universe).toSet
+
+    disciplines.all.stdlib.foreach: discipline =>
+      if !universes.exists(discipline.domain.covers)
+      then abort(LiraError(Reason.InapplicableDiscipline(discipline.id)))
 
     def summary(atomizations: List[Atomization])
     :   scala.collection.immutable.Set[(Text, Text, AtomClass, Text)] =
@@ -123,10 +140,11 @@ object LiraAssembler:
 
       val section =
         Section
-          ( universe   = input.universe,
-            tree       = LiraHash(LiraHash.Domain.Blob, tree.encode),
-            delete     = delete,
-            derivative = Derivative.hash(target, store) )
+          ( universe    = input.universe,
+            integration = input.integration,
+            tree        = LiraHash(LiraHash.Domain.Blob, tree.encode),
+            delete      = delete,
+            derivative  = Derivative.hash(target, store) )
 
       (section, tree.encode)
 
@@ -137,17 +155,23 @@ object LiraAssembler:
 
     val manifest =
       LiraManifest
-        ( module     = module,
-          version    = version,
-          lineage    = fullLineage,
-          toolchain  = toolchain,
-          owns       = owns,
-          api        = api,
-          dependency = dependency,
-          delta      = deltaBlob.let { data => LiraHash(LiraHash.Domain.Blob, data) },
-          section    = List.from(builtSections.map(_(0))),
-          payload    = LiraManifest.Payload(t"brotli", 0L, LiraHash(LiraHash.Domain.Blob,
+        ( module      = module,
+          version     = version,
+          lineage     = fullLineage,
+          toolchain   = toolchain,
+          owns        = owns,
+          api         = api,
+          profile     = profile,
+          integration = integration,
+          dependency  = dependency,
+          delta       = deltaBlob.let { data => LiraHash(LiraHash.Domain.Blob, data) },
+          section     = List.from(builtSections.map(_(0))),
+          payload     = LiraManifest.Payload(t"brotli", 0L, LiraHash(LiraHash.Domain.Blob,
               Array.freeze(Array[Byte](0)))) )
+
+    // The producer never emits a file a consumer would reject: L131/L133 are decidable from the
+    // manifest, so they are checked here rather than discovered at install time.
+    Verification.integrations(manifest)
 
     val blobs = contentBlobs ++ builtSections.map(_(1)) ++ atomsBlobs ++ deltaBlob.option.toList
 

--- a/lib/reliquary/src/derive/reliquary.Materializer.scala
+++ b/lib/reliquary/src/derive/reliquary.Materializer.scala
@@ -42,6 +42,7 @@ import monotonous.*
 import prepositional.*
 import rudiments.*
 import serpentine.*
+import vacuous.*
 import turbulence.*
 
 import LiraError.Reason
@@ -58,18 +59,25 @@ object Materializer:
   def classpath(liras: List[Lira], universe: Text, cache: Path on Linux)
   :   LocalClasspath raises LiraError raises IoError raises StreamError =
 
-    Buildpath(liras.map(_.manifest)).validate(universe)
+    val (assignment, _) = Buildpath(liras.map(_.manifest)).resolved(universe)
 
     val jars = liras.stdlib.map: lira =>
       val identity = lira.manifest.payload.hash.serialize[Hex]
-      // The segments are a hex digest and `<universe>.jar`, admissible on any filesystem.
-      val target = unsafely((cache / identity / t"$universe.jar").on[Linux])
+      val integration = assignment(lira.manifest.module)
+
+      // The cache slot is per (release, universe, integration): integrations share a payload
+      // hash by definition, so keying on universe alone would let the first one materialized
+      // stand in for every other one, permanently.
+      val slot = integration.let { id => t"$universe.$id.jar" }.or(t"$universe.jar")
+
+      // The segments are a hex digest and a filename, admissible on any filesystem.
+      val target = unsafely((cache / identity / slot).on[Linux])
 
       if !target.existent() then
         val report = Verification.install(lira)
 
-        val tree = report.materialized.stdlib.find(_(0) == universe) match
-          case scala.Some(pair) => pair(1)
+        val tree = report.tree(universe, integration) match
+          case tree: LiraTree => tree
 
           case _ =>
             abort(LiraError(Reason.InvalidManifest(t"the release has no $universe section")))

--- a/lib/reliquary/src/test/reliquary_test.scala
+++ b/lib/reliquary/src/test/reliquary_test.scala
@@ -465,6 +465,11 @@ object Tests extends Suite(m"Reliquary Tests"):
       object Special extends Discipline:
         def id: Text = t"special/1"
         def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".special")
+        def domain: Discipline.Domain = Discipline.Domain.Universal
+        def keying: Discipline.Keying = Discipline.Keying.Declaration
+
+        def guarantees(universe: Text): Set[Discipline.Guarantee] =
+          Set(Discipline.Guarantee.Recompilation)
 
         def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
         :   Atomization raises DisciplineError =
@@ -716,8 +721,97 @@ object Tests extends Suite(m"Reliquary Tests"):
     suite(m"Container and verification"):
       test(m"an assembled lira reads back and verifies"):
         val report = Verification.install(Lira.read(makeLira()))
-        report.materialized.stdlib.map { pair => pair(0) }
+        report.materialized.stdlib.map { pair => pair(0).universe }
       . assert(_ == scala.List(t"jvm", t"sjsir"))
+
+      test(m"a manifest with profiles and integrations round-trips through its rendering"):
+        val rootTree = LiraTree.of(List(TreeEntry(TreePath(t"a/A.class"), blob(classA))))
+        val altTree = LiraTree.of(List(TreeEntry(TreePath(t"a/A.class"), blob(sjsirA))))
+
+        val context = Discipline.Context(t"jvm")
+        val atomizations = Discipline.Registry(List()).atomize(
+          List((TreePath(t"a/A.class"), classA)), context)
+
+        val atomsData = AtomsBlob.encode(atomizations.stdlib.head)
+
+        val manifest = LiraManifest(
+          module      = t"example-core",
+          version     = revolution.Semver(0, 1, 0),
+          lineage     = List(Snapshot(atomizations)),
+          toolchain   = List(LiraManifest.Tool(t"scala", t"3.9.0")),
+          api         = List(LiraManifest.Api(t"opaque/1", blob(atomsData))),
+          profile     = List(LiraManifest.Profile(t"jvm/1",
+              breaks = List(LiraManifest.Guarantee.Linkage))),
+          integration = List(
+            LiraManifest.Integration(t"new", rank = 0L),
+            LiraManifest.Integration(t"old", rank = 1L, label = t"rudiments-7.x")),
+          dependency  = List(LiraManifest.Dependency(t"beta",
+              blob(encode(t"snapshot")), integration = List(t"old"))),
+          section     = List(
+            Section(t"jvm", integration = t"new", tree = blob(rootTree.encode)),
+            Section(t"jvm", integration = t"old", tree = blob(altTree.encode))),
+          payload     = LiraManifest.Payload(t"brotli", 0L, blob(encode(t""))))
+
+        val data = Lira.assemble(manifest,
+          List(classA, sjsirA, rootTree.encode, altTree.encode, atomsData))
+
+        val back = Lira.read(data).manifest
+
+        // Assembly fills in the payload length and hash, so the round-trip property is that a
+        // re-read renders identically, not that it matches the pre-assembly stub.
+        (Lira.read(data).manifest.render == back.render,
+         back.profile.stdlib.head.breaks.stdlib.head,
+         back.integration.stdlib.map(_.id),
+         back.section.stdlib.map(_.integration.or(t"-")),
+         back.dependency.stdlib.head.integration.stdlib)
+      . assert(_ == (true, LiraManifest.Guarantee.Linkage, scala.List(t"new", t"old"),
+          scala.List(t"new", t"old"), scala.List(t"old")))
+
+      test(m"two sections sharing a universe and integration are L131"):
+        val tree = LiraTree.of(List(TreeEntry(TreePath(t"a/A.class"), blob(classA))))
+
+        val manifest = LiraManifest(
+          module      = t"example-core",
+          lineage     = List(Snapshot(List())),
+          api         = List(),
+          integration = List(LiraManifest.Integration(t"one")),
+          section     = List(
+            Section(t"jvm", integration = t"one", tree = blob(tree.encode)),
+            Section(t"jvm", integration = t"one", tree = blob(tree.encode))),
+          payload     = LiraManifest.Payload(t"brotli", 0L, blob(encode(t""))))
+
+        capture[LiraError](Verification.integrations(manifest)).reason match
+          case LiraError.Reason.BadIntegration(_) => true
+          case _                                  => false
+      . assert(identity)
+
+      test(m"a section naming an undeclared integration is L131"):
+        val manifest = LiraManifest(
+          module      = t"example-core",
+          lineage     = List(Snapshot(List())),
+          api         = List(),
+          integration = List(LiraManifest.Integration(t"one")),
+          section     = List(Section(t"jvm", integration = t"other",
+              tree = blob(encode(t"tree")))),
+          payload     = LiraManifest.Payload(t"brotli", 0L, blob(encode(t""))))
+
+        capture[LiraError](Verification.integrations(manifest)).reason match
+          case LiraError.Reason.BadIntegration(_) => true
+          case _                                  => false
+      . assert(identity)
+
+      test(m"a declared integration with no section is L133"):
+        val manifest = LiraManifest(
+          module      = t"example-core",
+          lineage     = List(Snapshot(List())),
+          api         = List(),
+          integration = List(LiraManifest.Integration(t"one"), LiraManifest.Integration(t"two")),
+          section     = List(Section(t"jvm", integration = t"one",
+              tree = blob(encode(t"tree")))),
+          payload     = LiraManifest.Payload(t"brotli", 0L, blob(encode(t""))))
+
+        capture[LiraError](Verification.integrations(manifest)).reason
+      . assert(_ == LiraError.Reason.UnrealizedIntegration(t"two"))
 
       test(m"assembly is byte-deterministic"):
         makeLira().serialize[Hex] == makeLira().serialize[Hex]
@@ -739,7 +833,7 @@ object Tests extends Suite(m"Reliquary Tests"):
 
       test(m"the sjsir overlay materializes without the deleted classfile"):
         val report = Verification.install(Lira.read(makeLira()))
-        val sjsir = report.materialized.stdlib.find { pair => pair(0) == t"sjsir" }
+        val sjsir = report.materialized.stdlib.find { pair => pair(0).universe == t"sjsir" }
 
         sjsir.map { pair => pair(1).entries.map(_.path.text).stdlib }
       . assert(_ == scala.Some(scala.List(t"a/A.sjsir", t"a/A.tasty")))
@@ -912,23 +1006,25 @@ object Tests extends Suite(m"Reliquary Tests"):
         LiraManifest.Payload(t"brotli", 1L, blob(encode(seed)))
 
       def stub
-        ( module:  Text,
-          lineage: List[Data],
-          owns:    List[Text]                    = List(),
-          deps:    List[LiraManifest.Dependency] = List(),
-          version: Optional[Semver]              = Unset,
-          section: List[Section]                 = List() )
+        ( module:       Text,
+          lineage:      List[Data],
+          owns:         List[Text]                     = List(),
+          deps:         List[LiraManifest.Dependency]  = List(),
+          version:      Optional[Semver]               = Unset,
+          section:      List[Section]                  = List(),
+          integrations: List[LiraManifest.Integration] = List() )
       :   LiraManifest =
 
         LiraManifest
-          ( module     = module,
-            version    = version,
-            lineage    = lineage,
-            owns       = owns,
-            api        = List(),
-            dependency = deps,
-            section    = section,
-            payload    = payloadStub(module) )
+          ( module      = module,
+            version     = version,
+            lineage     = lineage,
+            owns        = owns,
+            api         = List(),
+            integration = integrations,
+            dependency  = deps,
+            section     = section,
+            payload     = payloadStub(module) )
 
       val snapOne = LiraHash(LiraHash.Domain.Snapshot, encode(t"one"))
       val snapTwo = LiraHash(LiraHash.Domain.Snapshot, encode(t"two"))
@@ -981,6 +1077,73 @@ object Tests extends Suite(m"Reliquary Tests"):
 
         (jvm, nir)
       . assert(_ == (0, true))
+
+      test(m"an integration-scoped dependency binds only its integration"):
+        val dependency = LiraManifest.Dependency(t"missing", snapTwo, integration = List(t"two"))
+        val one = LiraManifest.Integration(t"one", rank = 0L)
+        val two = LiraManifest.Integration(t"two", rank = 1L)
+
+        val needy = stub(t"alpha", List(snapOne), deps = List(dependency),
+          integrations = List(one, two))
+
+        // The `two` integration needs an absent module, so only `one` yields a valid
+        // assignment — closure decides the choice, with no new rule (§13.3).
+        Buildpath(List(needy)).resolved(t"jvm")(0)(t"alpha")
+      . assert(_ == t"one")
+
+      test(m"the canonical assignment prefers the lower rank"):
+        val alpha = stub(t"alpha", List(snapOne), integrations = List(
+          LiraManifest.Integration(t"slow", rank = 7L),
+          LiraManifest.Integration(t"fast", rank = 2L)))
+
+        Buildpath(List(alpha)).resolved(t"jvm")(0)(t"alpha")
+      . assert(_ == t"fast")
+
+      test(m"an unranked integration sorts after every ranked one"):
+        val alpha = stub(t"alpha", List(snapOne), integrations = List(
+          LiraManifest.Integration(t"anon"),
+          LiraManifest.Integration(t"ranked", rank = 9L)))
+
+        Buildpath(List(alpha)).resolved(t"jvm")(0)(t"alpha")
+      . assert(_ == t"ranked")
+
+      test(m"equal ranks break the tie on id"):
+        val alpha = stub(t"alpha", List(snapOne), integrations = List(
+          LiraManifest.Integration(t"zeta", rank = 1L),
+          LiraManifest.Integration(t"beta", rank = 1L)))
+
+        Buildpath(List(alpha)).resolved(t"jvm")(0)(t"alpha")
+      . assert(_ == t"beta")
+
+      test(m"an integration whose dependency is unsatisfiable is not chosen"):
+        // `old` requires a snapshot the present release of beta does not carry; `new` requires
+        // one it does. Rule 5, not rule 1, is what rejects the wrong assignment here.
+        val provider = stub(t"beta", List(snapTwo))
+
+        val alpha = stub(t"alpha", List(snapOne),
+          integrations = List(
+            LiraManifest.Integration(t"old", rank = 0L),
+            LiraManifest.Integration(t"new", rank = 1L)),
+          deps = List(
+            LiraManifest.Dependency(t"beta", snapOne, integration = List(t"old")),
+            LiraManifest.Dependency(t"beta", snapTwo, integration = List(t"new"))))
+
+        Buildpath(List(alpha, provider)).resolved(t"jvm")(0)(t"alpha")
+      . assert(_ == t"new")
+
+      test(m"no satisfiable integration is L132"):
+        val provider = stub(t"beta", List(snapTwo))
+
+        val alpha = stub(t"alpha", List(snapOne),
+          integrations = List(LiraManifest.Integration(t"only", rank = 0L)),
+          deps = List(LiraManifest.Dependency(t"beta", snapOne, integration = List(t"only"))))
+
+        capture[LiraError](Buildpath(List(alpha, provider)).resolved(t"jvm")).reason
+      . assert(_ == LiraError.Reason.NoAssignment)
+
+      test(m"a release declaring no integration assigns the implicit one"):
+        Buildpath(List(stub(t"alpha", List(snapOne)))).resolved(t"jvm")(0)(t"alpha").absent
+      . assert(identity)
 
       test(m"lineage membership satisfies a requirement"):
         val provider = stub(t"beta", List(snapOne, snapTwo))
@@ -1043,7 +1206,7 @@ object Tests extends Suite(m"Reliquary Tests"):
           Section(t"jvm", tree = blob(encode(t"tree")), derivative = derivative)))
 
         val path = Buildpath(List(holder, stub(t"beta", List(snapTwo))))
-        path.byDerivative(derivative).let(_.module).or(t"absent")
+        path.byDerivative(derivative).let(_(0).module).or(t"absent")
       . assert(_ == t"alpha")
 
       test(m"a development release is unpublishable (L117)"):


### PR DESCRIPTION
Implements the mechanisms merged into the lira specification: carrier-based discipline naming, the extended discipline SPI, ecosystem profiles, and integrations.

**Naming.** `degustation.ScalaTasty` becomes `degustation.Tasty` and its id `tasty/1`, per §11.1's rule that a discipline is named for the interface carrier rather than the producing language. Because `id` feeds the atom hash domain, this changes every atom hash the discipline produces — correct as a version bump, and no golden value pinned one.

**Discipline SPI.** §11.2 grew from four requirements to seven, so the trait gains `domain`, `keying` and `guarantees`. `Registry.atomize` now claims nothing in a universe outside a discipline's domain, ahead of any question of what it would have claimed, and the assembler rejects a declared discipline that atomizes no universe the release carries (L127).

**Profiles.** `Profile` records with `breaks` levels, `ProfileId` and `Guarantee` scalars and their validators, and the `profile` document field. `Guarantee` has no behavior case: no hash scheme certifies it, so it is not expressible in a `breaks` field.

**Integrations.** Sections are keyed by universe *and* integration; dependencies are scoped to integrations exactly as they were already scoped to universes, the two axes conjunctive. The inert `against` field is removed. L131/L133 well-formedness is checked by every consumer at install and by the producer before it emits, since both are decidable from the manifest alone. Downstream: `Verification.Report.materialized` is keyed by section rather than universe text; the derivative cache path carries the integration, since integrations share a payload hash and would otherwise collide on one slot forever; and `byDerivative` returns the matching section, so a bare JAR identifies which integration it is.

**One finding worth recording.** §13.3 frames assignment as a search that is "in the general case an intractable one". Implementing it showed that is not so for the rule set as specified: a buildpath is a fixed set of releases, and every rule an assignment can affect turns on one release together with its own choice — which release provides a module is decided by the buildpath, not by any integration. The choices are therefore independent, and the canonical assignment is a per-release first fit, linear in the total number of integrations, with no backtracking. Coupling would appear only in a resolver that also chose which releases to include, which is dependency resolution proper and outside §13.3. `Buildpath.resolve` implements the decomposition and its comment records why; the spec text overstates the cost.

The `lira` schema changes, so `liraSignature` is re-pinned and `res/test/reliquary/lira.tel` moves in lockstep. Integration `label` is one TEL atom and so holds no whitespace; prose labels need the field declared repeatable or a literal-atom encoding, which is a spec decision.

reliquary 150 -> 161 tests, degustation 19, all passing.

<!--
Single summary paragraph below: plain prose, user-facing voice, no headings or
bullets. This is the changelog blurb for the release.
-->


<!--
Below the blank line, write release notes in Markdown addressed to users of
the library. Include short code examples if they help illustrate the change.
This is the user-facing release note for the change.
-->


