### PR TITLE
Let an LSP proxy ask the server upstream questions of its own

### DIFF
--- a/doc/modules/lsp.md
+++ b/doc/modules/lsp.md
@@ -198,6 +198,32 @@ rewrite.outbound: (method, message) =>
 `Transit.Drop` swallows it, and `Transit.Answer` answers a request here, so that the server
 upstream never sees it.
 
+A proxy is not limited to what the editor asks. The session with the server upstream is in
+scope as `upstream` throughout the registration block, so a hook may ask a question of its
+own — typically for the project state only the server knows — and `rewrite.connected` runs
+once, on a task of its own, as soon as that session is open:
+
+```scala
+Lsp.proxy(Lsp.Server(sh"jdtls")):
+  val classpath: Promise[Json] = Promise()
+
+  rewrite.connected:
+    classpath.offer(upstream.execute(t"java.project.getClasspaths", arguments).or(Json()))
+
+  rewrite.inbound: (method, message) =>
+    if method == t"language/status" then async(refresh(classpath.await()))
+    Transit.Forward
+```
+
+Answers come back to the caller that asked for them, and never reach the editor: a response
+to a request the proxy made itself is routed to whoever awaits it, rather than relayed.
+
+Mind which thread each hook runs on. `rewrite.inbound` runs on the task that reads the
+server's messages — the task that would deliver the answer — so a request awaited there
+would wait forever, and must be made in an `async` block, as above. `rewrite.outbound` runs
+on the loop that reads the editor, which is not that task, so awaiting there is safe, though
+the editor waits with it. `rewrite.connected` has a task of its own and may await freely.
+
 ### Running the server
 
 `Lsp.listen` serves standard input until it is exhausted, so a server object supplies a

--- a/lib/exegesis/src/core/exegesis.Lsp.scala
+++ b/lib/exegesis/src/core/exegesis.Lsp.scala
@@ -1573,13 +1573,14 @@ object Lsp:
     case Streams(input: ji.InputStream, output: ji.OutputStream)
 
   // Serves an editor over the stdio transport while forwarding everything to a language server
-  // upstream, amending what the block registers on the lent proxy. See `LspProxy`.
-  def proxy(upstream: Server, observer: Observer = Observer.Silent)
-     ( register: (proxy: LspProxy^) ?=> Unit )
-     ( using Stdio^, Monitor, Probate, WorkingDirectory, Diagnostics )
+  // upstream, amending what the block registers on the lent proxy. The block may capture the
+  // monitor, which a hook needs to await an answer of its own; see `LspProxy`.
+  def proxy[capture^](upstream: Server, observer: Observer = Observer.Silent)
+     ( register: (proxy: LspProxy^) ?->{capture} Unit )
+     ( using Stdio^, Monitor^{capture}, Probate, WorkingDirectory, Diagnostics )
   :   Unit =
 
-    LspProxy.run(upstream, observer)(register)
+    LspProxy.run[capture](upstream, observer)(register)
 
   // Establishes a Language Server over the stdio transport. The block registers the server's
   // feature handlers on the lent registry; once it returns, the registry is consumed and frozen,

--- a/lib/exegesis/src/core/exegesis.LspProxy.scala
+++ b/lib/exegesis/src/core/exegesis.LspProxy.scala
@@ -60,7 +60,12 @@ import Lsp.*
 // Two layers of interception live here. The typed rewriters — `hover`, `capabilities`, and the
 // rest — are keyed by method and act on a decoded payload; the raw hooks act on whole messages,
 // including methods this library does not model. What neither covers is forwarded byte for byte.
-class LspProxy private[exegesis] () extends caps.ExclusiveCapability:
+//
+// The session with the server upstream comes in with the proxy, and goes back out through
+// `upstream`: a rewriter or a hook is registered before the session exists, but runs while it
+// does, so a proxy may ask the server something the editor never asked for.
+class LspProxy private[exegesis] (private[exegesis] val session: LspProxy.Upstream)
+extends caps.ExclusiveCapability:
   // The rewriters, by method: an erased rim like `LspRegistry`'s slots, for the same reason — a
   // function value in an invariant container freshens its capture set at every adaptation.
   @scala.caps.unsafe.untrackedCaptures
@@ -75,7 +80,33 @@ class LspProxy private[exegesis] () extends caps.ExclusiveCapability:
   @scala.caps.unsafe.untrackedCaptures
   var inbound0: AnyRef | Null = null
 
+  @scala.caps.unsafe.untrackedCaptures
+  var connected0: AnyRef | Null = null
+
 object LspProxy:
+  // The raw hooks' types, named because each is written three times — registered, read out of
+  // the erased rim, and applied — and must be spelled identically at all three.
+  private[exegesis] type OutboundHook = (Text, Json) => Transit
+  private[exegesis] type InboundHook = (Optional[Text], Json) => Transit
+
+  // The session a proxy holds with the server upstream, which `upstream` reads and `run` fills in.
+  // A cell, and a parameter of the proxy rather than a slot on it, for two reasons: the listener
+  // that carries messages to the hooks is built before the session exists — `Sessional#session`
+  // takes the listener, so the listener cannot take the connection — and `run` must not touch the
+  // proxy again once registration is over.
+  private[exegesis] class Upstream():
+    @scala.caps.unsafe.untrackedCaptures
+    var connection: LspConnection | Null = null
+
+    // Sealed on the way in and out, as the listener is: the connection is lent for the life of the
+    // session, and every hook that reads it here runs within it.
+    def open(connection: LspConnection^): Unit =
+      this.connection = caps.unsafe.unsafeAssumePure(connection)
+
+    def apply(): Optional[LspConnection] = connection match
+      case null                      => Unset
+      case connection: LspConnection => caps.unsafe.unsafeAssumePure(connection)
+
   // Runs the proxy: this process serves an editor over its own standard input and output while
   // holding a session with the server it forwards to.
   //
@@ -84,17 +115,22 @@ object LspProxy:
   // order, exactly as they would be without a proxy in the middle. Request ids pass through
   // unchanged, so a response returns under the id the editor chose; the id-to-method map exists
   // only so that a response can be given back its type on the way out.
-  def run
+  //
+  // The registration block is capture-polymorphic, and the monitor is declared to be among what it
+  // captures: a hook that asks the server something of its own needs the monitor to await the
+  // answer, and separation checking would otherwise see the block and this method aliasing it.
+  def run[capture^]
      ( upstream: Lsp.Server, observer: Lsp.Observer = Lsp.Observer.Silent )
-     ( register: (proxy: LspProxy^) ?=> Unit )
-     ( using stdio: Stdio^, monitor: Monitor, probate: Probate, working: WorkingDirectory,
+     ( register: (proxy: LspProxy^) ?->{capture} Unit )
+     ( using stdio: Stdio^, monitor: Monitor^{capture}, probate: Probate, working: WorkingDirectory,
              diagnostics: Diagnostics )
   :   Unit =
 
     import strategies.throwUnsafely
     import Json.jsonEncodableInText
 
-    val proxy: LspProxy^ = LspProxy()
+    val session: Upstream = Upstream()
+    val proxy: LspProxy^ = LspProxy(session)
     register(using proxy)
 
     // Registration is over, so the rules are read out once, here: everything below closes over
@@ -102,8 +138,12 @@ object LspProxy:
     // exists.
     val results: scm.HashMap[Text, AnyRef] = proxy.results
     val notices: scm.HashMap[Text, AnyRef] = proxy.notices
-    val inbound0: Optional[(Optional[Text], Json) => Transit] = inbound(proxy.inbound0)
-    val outbound0: Optional[(Text, Json) => Transit] = outbound(proxy.outbound0)
+    val inbound0: Optional[InboundHook] = inbound(proxy.inbound0)
+    val outbound0: Optional[OutboundHook] = outbound(proxy.outbound0)
+    // Nullable rather than `Optional`, and alone among the rules in that: a function in a
+    // container is capture-polymorphic, and the block is passed to a task rather than called here,
+    // which is one adaptation more than an `Optional` of it survives.
+    val connected0: (() => Unit) | Null = connected(proxy.connected0)
 
     // The method each in-flight request named, by the text of its id. An id is matched by its
     // encoded form because the protocol allows either a number or a string, and the proxy neither
@@ -124,31 +164,44 @@ object LspProxy:
     given listener: Lsp.Listener = caps.unsafe.unsafeAssumePure(new Lsp.Listener:
       override def intercept(json: Json): Boolean =
         val method: Optional[Text] = Lsp.method(json)
+        val id: Optional[Json] = Lsp.identifier(json)
 
         // A response is retyped by the method it answers, a notification by its own name.
         val answered: Optional[Text] =
-          if method.absent
-          then Lsp.identifier(json).let { id => pending.remove(id.encode).getOrElse(Unset) }
+          if method.absent then id.let { id => pending.remove(id.encode).getOrElse(Unset) }
           else Unset
 
-        val retyped: Json =
-          val typed: Json = answered.lay(json): method =>
-            rule(results.get(method)).lay(json)(rewriteResult(json, _))
+        // A response the proxy never forwarded a request for, answering under an id of the form
+        // `JsonRpc.call` mints, answers a request the proxy asked of its own accord. It is not the
+        // editor's to receive, so it is not intercepted: the session routes it to the caller
+        // awaiting it. The editor's ids cannot be confused with these, because a request that
+        // crossed this proxy was recorded in `pending` above.
+        if method.absent && answered.absent && id.let(token(_)).present then false else
+          val retyped: Json =
+            val typed: Json = answered.lay(json): method =>
+              rule(results.get(method)).lay(json)(rewriteResult(json, _))
 
-          method.lay(typed): method =>
-            rule(notices.get(method)).lay(typed)(rewriteParams(typed, _))
+            method.lay(typed): method =>
+              rule(notices.get(method)).lay(typed)(rewriteParams(typed, _))
 
-        inbound0.lay(downstream(retyped)): hook =>
-          hook(method.or(answered), retyped) match
-            case Transit.Forward       => downstream(retyped)
-            case Transit.Rewrite(json) => downstream(json)
-            case Transit.Drop          => ()
-            case Transit.Answer(_)     => ()
+          inbound0.lay(downstream(retyped)): hook =>
+            hook(method.or(answered), retyped) match
+              case Transit.Forward       => downstream(retyped)
+              case Transit.Rewrite(json) => downstream(json)
+              case Transit.Drop          => ()
+              case Transit.Answer(_)     => ()
 
-        true )
+          true )
 
     upstream.session: server ?=>
-      LspTransport.pump(stdio.in.source[Data], observer): message =>
+      // The session is published before a single message crosses, so every hook that runs sees it.
+      session.open(server)
+
+      // On its own task, because it may await what it asks, and the loop below must not wait for
+      // it: an editor's first request arrives before a server has finished starting up.
+      val startup = if connected0 == null then null else async(connected0.nn())
+
+      try LspTransport.pump(stdio.in.source[Data], observer): message =>
         safely(message.as[Json]).let: json =>
           Lsp.method(json).let: method =>
             val id: Optional[Json] = Lsp.identifier(json)
@@ -166,6 +219,8 @@ object LspProxy:
                 // Answered here, so the server never sees the request and never answers it.
                 case Transit.Answer(result) =>
                   id.let { id => downstream(JsonRpc.Response("2.0", result, id).in[Json]) }
+
+      finally if startup != null then startup.nn.cancel()
 
   // The `result` member of a response, rewritten in place. A response carrying an `error` is left
   // alone: a fault is not a payload, and a rewriter typed for the payload could not read it.
@@ -214,19 +269,26 @@ object LspProxy:
         val lambda: Json => Json = value.asInstanceOf[LspRegistry.Slot[Json => Json]].value
         lambda
 
-  private def outbound(hook: AnyRef | Null): Optional[(Text, Json) => Transit] =
+  private def outbound(hook: AnyRef | Null): Optional[OutboundHook] =
     if hook == null then Unset else
-      val relay: (Text, Json) => Transit =
-        hook.asInstanceOf[LspRegistry.Slot[(Text, Json) => Transit]].value
+      val relay: OutboundHook = hook.asInstanceOf[LspRegistry.Slot[OutboundHook]].value
 
       relay
 
-  private def inbound(hook: AnyRef | Null): Optional[(Optional[Text], Json) => Transit] =
+  private def inbound(hook: AnyRef | Null): Optional[InboundHook] =
     if hook == null then Unset else
-      val relay: (Optional[Text], Json) => Transit =
-        hook.asInstanceOf[LspRegistry.Slot[(Optional[Text], Json) => Transit]].value
+      val relay: InboundHook = hook.asInstanceOf[LspRegistry.Slot[InboundHook]].value
 
       relay
+
+  private def connected(block: AnyRef | Null): (() => Unit) | Null =
+    if block == null then null else block.asInstanceOf[LspRegistry.Slot[() => Unit]].value
+
+  // The id of a message, if the peer chose a string for it: the form `JsonRpc.call` mints, and so
+  // the form a response to a request the proxy made itself comes back under.
+  private def token(id: Json): Optional[Text] =
+    import strategies.throwUnsafely
+    try id.as[Text] catch case _: Exception => Unset
 
 // The proxy's registration combinators, in a namespace of their own: `Lsp.hover` registers a
 // handler for a server this process implements, while `rewrite.hover` amends one a server upstream
@@ -343,12 +405,18 @@ object rewrite:
     proxy.notices(method) = LspRegistry.Slot[Json => Json](lambda)
 
   // The whole-message hooks: every message the editor sends, and every message the server sends
-  // back, with the chance to forward it, amend it, drop it, or answer it here.
-  transparent inline def outbound(inline hook: (Text, Json) => Transit)(using proxy: LspProxy^)
+  // back, with the chance to forward it, amend it, drop it, or answer it here. Each may also ask
+  // the server something of its own, through `upstream` — mind which thread the hook runs on, as
+  // `upstream` documents.
+  transparent inline def outbound(inline hook: LspProxy.OutboundHook)(using proxy: LspProxy^)
   :   Unit =
-    proxy.outbound0 = LspRegistry.Slot[(Text, Json) => Transit](hook)
+    proxy.outbound0 = LspRegistry.Slot[LspProxy.OutboundHook](hook)
 
-  transparent inline def inbound(inline hook: (Optional[Text], Json) => Transit)
-     ( using proxy: LspProxy^ )
-  :   Unit =
-    proxy.inbound0 = LspRegistry.Slot[(Optional[Text], Json) => Transit](hook)
+  transparent inline def inbound(inline hook: LspProxy.InboundHook)(using proxy: LspProxy^): Unit =
+    proxy.inbound0 = LspRegistry.Slot[LspProxy.InboundHook](hook)
+
+  // Run once, on a task of its own, as soon as the proxy has a session with the server upstream:
+  // the place for what a proxy must ask before it can amend anything, and the only hook free to
+  // await an answer.
+  transparent inline def connected(inline block: => Unit)(using proxy: LspProxy^): Unit =
+    proxy.connected0 = LspRegistry.Slot[() => Unit](() => block)

--- a/lib/exegesis/src/core/exegesis_core.scala
+++ b/lib/exegesis/src/core/exegesis_core.scala
@@ -30,7 +30,23 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package exegesis
 
-export exegesis.{Lsp, LspClient, LspConnection, LspDispatch, LspError, LspProxy, LspRegistry,
-    LspSessional, rewrite, upstream}
+import fulminate.*
+import rudiments.*
+import vacuous.*
+
+// The session a proxy holds with the server upstream: what a proxy uses to ask the server
+// something the editor never asked for. In scope wherever the proxy is — inside the raw hooks
+// `rewrite.outbound` and `rewrite.inbound`, inside a `rewrite.connected` block, and inside the
+// typed rewriters — but not before the session exists, which is why it is a method and not a
+// value: registration itself runs before the proxy has a server to talk to.
+//
+// A hook runs on the thread that delivered the message it is amending, so how a request may be
+// made depends on which hook makes it. `rewrite.inbound` runs on the task reading the server's
+// messages — the same task that would deliver the response — so a request awaited there would
+// wait forever, and must be made in an `async` block. `rewrite.outbound` runs on the loop reading
+// the editor, which is not that task, so awaiting there is safe, though it holds up the editor
+// until the server answers. `rewrite.connected` has a task of its own and may await freely.
+def upstream(using proxy: LspProxy^): LspConnection =
+  proxy.session().or(panic(m"the proxy has no session with a server upstream yet"))

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -209,6 +209,13 @@ object LoopbackFixture:
 object ProxyFixture:
   import Lsp.*
 
+  // The command a `workspace/executeCommand` request names, or nothing for any other message.
+  // Decoded in a `try` rather than with `safely`, here and below: a decodable cannot thread the
+  // boundary tactic under separation checking.
+  def commandName(message: Json): Text =
+    import dynamicJsonAccess.enabled
+    try Lsp.params(message).command.as[Text] catch case _: Exception => t""
+
   def connect[result](using listener: Lsp.Listener^)
      ( lambda: (session: LspConnection^) ?=> result )
   :   result =
@@ -221,6 +228,9 @@ object ProxyFixture:
     val proxyIn: ji.PipedInputStream = ji.PipedInputStream(toProxy, 65536)
     val fromProxy: ji.PipedOutputStream = ji.PipedOutputStream()
     val proxyOut: ji.PipedInputStream = ji.PipedInputStream(fromProxy, 65536)
+
+    // What the proxy learned from the server before the editor asked it anything.
+    val startup: Promise[Json] = Promise()
 
     supervise:
       async:
@@ -242,6 +252,8 @@ object ProxyFixture:
           complete():
             CompletionList(items = List(CompletionItem(label = t"upstream")))
 
+          command(t"test.classpath")(t"a.jar".in[Json])
+
       async:
         given stdio: Stdio =
           Stdio(ji.PrintStream(fromProxy, true), null, proxyIn, termcapDefinitions.basicTermcap)
@@ -252,6 +264,30 @@ object ProxyFixture:
             hover.copy(contents = MarkupContent(value = t"[${hover.contents.value}]"))
 
           rewrite.diagnostics(_.map(_.copy(message = t"proxied")))
+
+          // Asked as soon as the proxy has a server to ask, and kept for whoever wants it.
+          rewrite.connected:
+            val classpath: Json =
+              try upstream.execute(t"test.classpath").or(t"none".in[Json])
+              catch case _: Exception => t"none".in[Json]
+
+            startup.offer(classpath)
+
+          // Two commands the server upstream knows nothing about, answered by the proxy out of
+          // what it asked the server itself: one asked here and now, one asked at startup.
+          rewrite.outbound: (method, message) =>
+            val name: Text = ProxyFixture.commandName(message)
+
+            if name == t"proxy.now" then
+              val classpath: Json =
+                try upstream.execute(t"test.classpath").or(t"none".in[Json])
+                catch case _: Exception => t"none".in[Json]
+
+              Transit.Answer(classpath)
+
+            else if name == t"proxy.startup"
+            then Transit.Answer(safely(startup.await()).or(t"none".in[Json]))
+            else Transit.Forward
 
       Lsp.Server.streams(proxyOut, toProxy).session: connection ?=>
         lambda
@@ -565,6 +601,22 @@ object Tests extends Suite(m"Exegesis Tests"):
         record.notes.stdlib.map(_.s)
 
       . assert(_ == List("diagnostics:file:///a.scala:proxied"))
+
+      test(m"a hook asks the server upstream a question of its own"):
+        ProxyFixture.connect: server ?=>
+          server.initialize()
+          server.initialized()
+          server.execute(t"proxy.now").let(_.as[Text])
+
+      . assert(_ == t"a.jar")
+
+      test(m"a proxy asks the server a question as soon as it connects"):
+        ProxyFixture.connect: server ?=>
+          server.initialize()
+          server.initialized()
+          server.execute(t"proxy.startup").let(_.as[Text])
+
+      . assert(_ == t"a.jar")
 
       test(m"an unregistered method passes through untouched"):
         ProxyFixture.connect: server ?=>


### PR DESCRIPTION
An `Lsp.proxy` can now initiate an exchange with the server it forwards to, rather than only amending the traffic the editor starts. The session with the server upstream is in scope as `upstream` throughout the registration block, a new `rewrite.connected` block runs once on its own task as soon as that session opens, and a response to a request the proxy made itself is routed to the caller awaiting it instead of being relayed to an editor that never asked for it.

A proxy often needs project state that only the language server knows — the resolved classpath, say — which no message from the editor will ever carry. The session is now in scope as `upstream` for every rewriter and hook, and `rewrite.connected` runs once, on a task of its own, as soon as the proxy has a server to ask:

```scala
Lsp.proxy(Lsp.Server(sh"jdtls")):
  val classpath: Promise[Json] = Promise()

  rewrite.connected:
    classpath.offer(upstream.execute(t"java.project.getClasspaths", arguments).or(Json()))

  rewrite.inbound: (method, message) =>
    if method == t"language/status" then async(refresh(classpath.await()))
    Transit.Forward
```

Answers come back to whoever asked for them: a response whose id the proxy never forwarded is left to the session to route, so it reaches the awaiting caller and never reaches the editor.

Mind which thread each hook runs on. `rewrite.inbound` runs on the task reading the server's messages — the task that would deliver the answer — so a request awaited there would wait forever, and must be made in an `async` block, as above. `rewrite.outbound` runs on the loop reading the editor, so awaiting there is safe, though the editor waits with it. `rewrite.connected` has a task of its own and may await freely.

Existing proxies need no change: the registration block's signature gained a capture-set parameter so that a hook may capture the ambient monitor to await an answer, which is source-compatible with blocks that don't.

Closes #1717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
