### PR TITLE
Implement resource/1, wire spanning, and sharpen two diagnostics

### DIFF
--- a/lib/reliquary/res/test/reliquary/lira.tel
+++ b/lib/reliquary/res/test/reliquary/lira.tel
@@ -2,8 +2,8 @@ tel 1.0
 
 # The `lira` manifest schema (LIRA specification §14: `jvm | sjsir | nir` universes, optional
 # numeric-only `version`, dependencies scoped by universe and integration or `build`-pinned,
-# sections keyed by universe and integration with `derivative` hashes, and ecosystem `profile`
-# claims). This document is the canonical mirror of the hand-encoded
+# sections keyed by universe and integration with `derivative` hashes, `resource` claims for the
+# resource/1 discipline, and ecosystem `profile` claims). This document is the canonical mirror of the hand-encoded
 # `LiraSchemas.lira`; reliquary's test suite asserts the two are structurally identical and pins
 # this document's schema signature.
 
@@ -17,6 +17,10 @@ record Tool
 record Api
   field discipline DisciplineId
   field atoms Hash
+
+record Resource
+  select ResourceMode
+  field path TreePath
 
 record Profile
   field id ProfileId
@@ -76,6 +80,9 @@ scalar DisciplineId
 scalar ProfileId
   validate profile-id
 
+scalar TreePath
+  validate tree-path
+
 scalar Guarantee
   validate guarantee
 
@@ -84,12 +91,18 @@ select Universe
   variant sjsir Flag
   variant nir Flag
 
+select ResourceMode
+  variant export Flag
+  variant track Flag
+  variant scan Flag
+
 document
   field module ModuleName
   field version Semver optional
   field lineage Hash repeatable
   field toolchain Tool repeatable
   field owns Namespace optional repeatable
+  field resource Resource optional repeatable
   field api Api repeatable
   field profile Profile optional repeatable
   field integration Integration optional repeatable

--- a/lib/reliquary/src/core/reliquary.Buildpath.scala
+++ b/lib/reliquary/src/core/reliquary.Buildpath.scala
@@ -124,9 +124,27 @@ case class Buildpath(releases: List[LiraManifest]):
     val chosen = releases.stdlib.sortBy(_.module.s).map: manifest =>
       candidates(manifest).find(satisfies(universe, manifest, _)) match
         case scala.Some(candidate) => (manifest.module, candidate)
-        case _                     => abort(LiraError(Reason.NoAssignment))
+
+        // Because the choices are independent, a failure is always one release's: there is no
+        // combination to report, only the module none of whose integrations hold.
+        case _ => abort(LiraError(Reason.NoAssignment(manifest.module)))
 
     Assignment(List.from(chosen))
+
+  // §13.2 satisfaction, plus §13.4 spanning: the required snapshot must appear in the candidate's
+  // lineage, or one of the snapshots the dependent has *proven* it spans must. A span is a
+  // publisher's recorded proof that its used-set is contained in that release's atom set, so a
+  // module that spans a dependency's major boundary resolves against either side of it without a
+  // variant compilation — which is the cheaper answer §9.5 tells producers to prefer.
+  //
+  // Spans are taken on trust here, because they are not decidable from one manifest: proving one
+  // requires atomizing the candidate's payload, so it is a publish-time check a registry makes
+  // across two releases (§16), not something buildpath validation can redo from manifests alone.
+  private def requirementMet(dependency: LiraManifest.Dependency, candidate: LiraManifest)
+  :   Boolean =
+
+    Lineage.contains(candidate.lineage, dependency.api)
+    || dependency.spans.stdlib.exists(Lineage.contains(candidate.lineage, _))
 
   // Whether one release's dependencies hold under one choice of its integration: rules 4 and 5,
   // as a predicate rather than a diagnosis. `audit` reports which rule failed and why.
@@ -137,7 +155,7 @@ case class Buildpath(releases: List[LiraManifest]):
       if !dependency.applies(universe, integration) then true else
         apply(dependency.module) match
           case candidate: LiraManifest =>
-            Lineage.contains(candidate.lineage, dependency.api)
+            requirementMet(dependency, candidate)
             && dependency.build.let(Blob.compare(_, candidate.payload.hash) == 0).or(true)
 
           case _ => false
@@ -162,6 +180,17 @@ case class Buildpath(releases: List[LiraManifest]):
           if one == two || one.startsWith(two + ".") || two.startsWith(one + ".")
           then abort(LiraError(Reason.NamespaceClash(left(1))))
 
+    // L126: `export` and `track` paths are pairwise disjoint across modules, so a classpath-style
+    // reference resolves to exactly one module. `scan` directories are exempt — cross-module
+    // aggregation under a shared directory is precisely their purpose.
+    val named = all.flatMap: manifest =>
+      manifest.resource.stdlib
+        . filter(_.mode != LiraManifest.ResourceMode.Scan)
+        . map: resource => (manifest.module, resource.path.text)
+
+    named.groupBy(_(1)).foreach: (path, group) =>
+      if group.map(_(0)).distinct.size > 1 then abort(LiraError(Reason.ResourceClash(path)))
+
   // Closure (L113) and satisfaction (L114) under one assignment, reporting the precise rule that
   // fails. `resolve` answers only whether *some* assignment works; this says why a given one does
   // not, which is what a diagnostic needs.
@@ -179,7 +208,7 @@ case class Buildpath(releases: List[LiraManifest]):
             case _ =>
               abort(LiraError(Reason.AbsentDependency(dependency.module)))
 
-          if !Lineage.contains(candidate.lineage, dependency.api)
+          if !requirementMet(dependency, candidate)
           then abort(LiraError(Reason.Unsatisfiable(dependency.module)))
 
           dependency.build.let: build =>

--- a/lib/reliquary/src/core/reliquary.LiraError.scala
+++ b/lib/reliquary/src/core/reliquary.LiraError.scala
@@ -63,12 +63,15 @@ object LiraError:
     case BadSignature(signer: Text)           extends Reason(121)
     case UnknownAlgorithm(name: Text)         extends Reason(122)
     case UnknownKey(fingerprint: Text)        extends Reason(123)
+    case BadResource(detail: Text)            extends Reason(124)
+    case IneffectiveResource(path: Text)      extends Reason(125)
+    case ResourceClash(path: Text)            extends Reason(126)
     case InapplicableDiscipline(id: Text)     extends Reason(127)
     case ProfileViolated(id: Text, detail: Text) extends Reason(128)
     case ProfileWeakens(id: Text)             extends Reason(129)
     case UnrecordedBreak(id: Text, level: Text) extends Reason(130)
     case BadIntegration(detail: Text)         extends Reason(131)
-    case NoAssignment                         extends Reason(132)
+    case NoAssignment(module: Text)           extends Reason(132)
     case UnrealizedIntegration(id: Text)      extends Reason(133)
 
   given communicable: Reason is Communicable =
@@ -95,6 +98,12 @@ object LiraError:
     case Reason.BadSignature(signer)          => m"the signature by $signer does not verify"
     case Reason.UnknownAlgorithm(name)        => m"the signature algorithm $name is unknown"
     case Reason.UnknownKey(fingerprint)       => m"no key matches the fingerprint $fingerprint"
+    case Reason.BadResource(detail)           => m"the resource claims are ill-formed: $detail"
+
+    case Reason.IneffectiveResource(path) =>
+      m"the resource $path resolves to nothing, or to content another discipline claims"
+
+    case Reason.ResourceClash(path)           => m"the resource path $path is claimed twice"
 
     case Reason.InapplicableDiscipline(id) =>
       m"the discipline $id atomizes no universe this release carries"
@@ -106,7 +115,8 @@ object LiraError:
       m"the step does not preserve $level but the profile $id does not record it"
 
     case Reason.BadIntegration(detail)      => m"the integrations are ill-formed: $detail"
-    case Reason.NoAssignment                => m"no assignment of integrations validates"
+    case Reason.NoAssignment(module) =>
+      m"no integration of $module is satisfiable on this buildpath"
     case Reason.UnrealizedIntegration(id)   => m"the integration $id has no section"
 
 case class LiraError(reason: LiraError.Reason)(using Diagnostics)

--- a/lib/reliquary/src/core/reliquary.LiraManifest.scala
+++ b/lib/reliquary/src/core/reliquary.LiraManifest.scala
@@ -70,10 +70,10 @@ object LiraManifest:
   // One alternative dependency vector the release was built against (§9.5). `rank` orders the
   // canonical assignment (§13.3), lower first; a rank left unset sorts after every declared one,
   // so a publisher who ranks nothing gets declaration-order-independent, id-ordered resolution.
-  // `label` carries no authority (§14). It is one TEL atom, so it holds no whitespace: TEL
-  // splits unquoted values on whitespace, and a `String` field admits exactly one atom. Prose
-  // labels would need the field declared repeatable, or a literal-atom encoding (TEL §15); both
-  // are spec decisions rather than implementation ones, so the field stays a single token here.
+  // `label` is prose and carries no authority (§14). It is one atom even when it contains
+  // spaces: `render` separates it from its keyword by a hard-space run, which switches TEL into
+  // hard-space mode for the rest of the line (TEL §10.3), so the single spaces within it are
+  // content rather than phrase separators.
   case class Integration(id: Text, rank: Optional[Long] = Unset, label: Optional[Text] = Unset)
 
   case class Dependency
@@ -97,6 +97,28 @@ object LiraManifest:
         || integration.let { id => this.integration.stdlib.contains(id) }.or(false)
 
       universeApplies && integrationApplies
+
+  // How a declared resource participates in the algebra (§11.4). `Export` guarantees the name is
+  // present; `Track` additionally tracks the bytes as replaceable churn; `Scan` claims a whole
+  // directory atomless, so nothing under it is contractual.
+  enum ResourceMode:
+    case Export, Track, Scan
+
+    def keyword: Text = this match
+      case Export => t"export"
+      case Track  => t"track"
+      case Scan   => t"scan"
+
+  object ResourceMode:
+    def parse(keyword: Text): Optional[ResourceMode] = keyword.s match
+      case "export" => Export
+      case "track"  => Track
+      case "scan"   => Scan
+      case _        => Unset
+
+  // One resource claim (§11.4): an authorial statement, like `owns`, that parameterizes the
+  // `resource/1` discipline's claiming.
+  case class Resource(mode: ResourceMode, path: TreePath)
 
   case class Payload(compression: Text, length: Long, hash: Data)
   case class Signature(signer: Text, algorithm: Text, key: Data, value: Text)
@@ -186,6 +208,16 @@ object LiraManifest:
           uses        = field(fields, t"uses").let(hash(_)),
           spans       = List.from(repeated(fields, t"spans").map(hash(_))) )
 
+    val resource = top.filter(_.keyword == t"resource").map: compound =>
+      val mode = texts(compound) match
+        case scala.collection.immutable.Vector(mode) =>
+          ResourceMode.parse(mode).or(abort(bad(t"$mode is not a resource mode")))
+
+        case _ =>
+          abort(bad(t"a resource needs exactly one mode"))
+
+      Resource(mode, TreePath(required(children(compound), t"path")))
+
     val profile = top.filter(_.keyword == t"profile").map: compound =>
       val fields = children(compound)
 
@@ -244,6 +276,7 @@ object LiraManifest:
         lineage     = List.from(repeated(top, t"lineage").map(hash(_))),
         toolchain   = List.from(toolchain),
         owns        = List.from(repeated(top, t"owns")),
+        resource    = List.from(resource),
         api         = List.from(api),
         profile     = List.from(profile),
         integration = List.from(integration),
@@ -263,6 +296,7 @@ case class LiraManifest
     lineage:     List[Data],
     toolchain:   List[LiraManifest.Tool]         = List(),
     owns:        List[Text]                      = List(),
+    resource:    List[LiraManifest.Resource]     = List(),
     api:         List[LiraManifest.Api],
     profile:     List[LiraManifest.Profile]      = List(),
     integration: List[LiraManifest.Integration]  = List(),
@@ -298,6 +332,10 @@ case class LiraManifest
 
     owns.stdlib.foreach: space => lines += s"owns $space"
 
+    resource.stdlib.foreach: resource =>
+      lines += s"resource ${resource.mode.keyword}"
+      lines += s"  path ${resource.path.text}"
+
     api.stdlib.foreach: api =>
       lines += "api"
       lines += s"  discipline ${api.discipline}"
@@ -312,7 +350,9 @@ case class LiraManifest
       lines += "integration"
       lines += s"  id ${integration.id}"
       integration.rank.let: rank => lines += s"  rank $rank"
-      integration.label.let: label => lines += s"  label $label"
+      // Two spaces, not one: the hard-space run makes the whole remainder of the line one atom
+      // (TEL §10.3), which is what lets a label contain spaces.
+      integration.label.let: label => lines += s"  label  $label"
 
     dependency.stdlib.foreach: dependency =>
       lines += "dependency"

--- a/lib/reliquary/src/core/reliquary.LiraSchemas.scala
+++ b/lib/reliquary/src/core/reliquary.LiraSchemas.scala
@@ -89,6 +89,7 @@ object LiraSchemas:
   private val profileId:    Type = Reference(t"ProfileId")
   private val guarantee:    Type = Reference(t"Guarantee")
   private val string:       Type = Reference(t"String")
+  private val treePath:     Type = Reference(t"TreePath")
 
   private val hashScalar: ScalarDefinition = scalar("Hash", "base-256-hash")
 
@@ -109,6 +110,7 @@ object LiraSchemas:
         field("lineage", hash, repeatable = Loose),
         field("toolchain", Reference(t"Tool"), repeatable = Loose),
         field("owns", namespace, required = Loose, repeatable = Loose),
+        field("resource", Reference(t"Resource"), required = Loose, repeatable = Loose),
         field("api", Reference(t"Api"), repeatable = Loose),
         field("profile", Reference(t"Profile"), required = Loose, repeatable = Loose),
         field("integration", Reference(t"Integration"), required = Loose, repeatable = Loose),
@@ -129,6 +131,10 @@ object LiraSchemas:
       record("Api",
         field("discipline", disciplineId),
         field("atoms", hash)),
+
+      record("Resource",
+        selectRef("ResourceMode"),
+        field("path", treePath)),
 
       record("Profile",
         field("id", profileId),
@@ -174,12 +180,18 @@ object LiraSchemas:
       scalar("Natural", "natural"),
       scalar("DisciplineId", "discipline-id"),
       scalar("ProfileId", "profile-id"),
+      scalar("TreePath", "tree-path"),
       scalar("Guarantee", "guarantee")),
     selects  = Array.of(
       select("Universe",
         variant("jvm"),
         variant("sjsir"),
-        variant("nir"))))
+        variant("nir")),
+
+      select("ResourceMode",
+        variant("export"),
+        variant("track"),
+        variant("scan"))))
 
   val tree: Tels = Tels(
     name     = t"lira-tree",
@@ -248,7 +260,7 @@ object LiraSchemas:
   // The BASE-256 schema signatures of the five canonical documents, pinned as golden values (the
   // test suite recomputes each from its `res/test/reliquary/*.tel` mirror and checks agreement).
   // A conforming document of each schema carries its signature on the pragma line.
-  val liraSignature:  Text = t"ẋḣẀΦḤȐYeû0VǓңңќỵ0ẃẈşȑĺЖȐAÞjìẓȧƟḋh"
+  val liraSignature:  Text = t"ψñŻṛγeẙðẁƏơǣǿÐẇӂàfơẃẇḢAῘΔӮžSẙӜύYç"
   val treeSignature:  Text = t"ǨẙơẗỵclϋẁЫĥᾸMôĮẍOώżӯάǢЗĆӸkҚțȐωǢέӫ"
   val atomsSignature: Text = t"2ӪççÃ5AḟǑXϋƤzᾱĺHϕЂẌǒEẂẁĮί9ḀẘΊÐιЪp"
   val usesSignature:  Text = t"şşCȧOӖGҐΪḍḋjΊӁῚƟȐЌĥέȦЬƜδĻĘ1Ȑḟ6ӟÔḍ"

--- a/lib/reliquary/src/core/reliquary.ResourceDiscipline.scala
+++ b/lib/reliquary/src/core/reliquary.ResourceDiscipline.scala
@@ -34,91 +34,81 @@ package reliquary
 
 import anticipation.*
 import contingency.*
-import prepositional.*
+import gossamer.*
 import rudiments.*
 import vacuous.*
 
-object Discipline:
-  // What a compiler-based discipline needs beyond the content itself: which section is being
-  // atomized — its universe and, where the release offers alternative dependency vectors (§9.5),
-  // its integration — and the dependency classpath materialized from the buildpath (entries as
-  // textual paths, so the core stays platform-light). The classpath is a property of the
-  // integration, which is why atomization is per-section and not per-universe.
-  case class Context
-    ( universe:    Text,
-      integration: Optional[Text] = Unset,
-      classpath:   List[Text]     = List() )
+import LiraManifest.{Resource, ResourceMode}
 
-  // The universes a discipline atomizes at all (§11.2, requirement 1). A universal discipline
-  // atomizes whatever universe it is given; a universe-specific one names its universes, and the
-  // cross-section invariant (§9.6) is vacuous outside them. Claiming nothing in a universe
-  // outside the domain is not the same as claiming content atomless.
-  enum Domain:
-    case Universal
-    case Universes(names: Set[Text])
+// The normative `resource/1` discipline (§11.4): non-code content addressed by classpath-style
+// name, whose *name* may be part of a module's contract even where its bytes are not. It is the
+// one registered discipline whose claiming takes input beyond the tree itself — the manifest's
+// `resource` records, an authorial claim like `owns` — which is unproblematic because
+// atomization only ever runs where the manifest is in hand (§16, step 4).
+//
+// In the claiming order it follows every language discipline and precedes the `opaque/1`
+// fallback, so an item under a scanned directory that a language discipline claims goes to that
+// discipline, and only the remainder are atomless.
+case class ResourceDiscipline(resources: List[Resource]) extends Discipline:
+  def id: Text = t"resource/1"
 
-    def covers(universe: Text): Boolean = this match
-      case Universal        => true
-      case Universes(names) => names.stdlib.contains(universe)
+  // Universal: resources are content, not a representation of one universe. Keys are paths, so
+  // keying is by declaration in the only sense available. Rigid resource atoms certify presence
+  // at both levels — a name that resolves keeps resolving — and nothing about content, since
+  // resource bytes are behavior and no discipline certifies that (§18).
+  def domain: Discipline.Domain = Discipline.Domain.Universal
+  def keying: Discipline.Keying = Discipline.Keying.Declaration
 
-  // Whether an atom's key names the type that *declares* a member, or every type that *presents*
-  // it after inheritance (§11.2, requirement 4). Declaration keying is sound exactly where every
-  // reference a certified consumer can make resolves through the declaring type.
-  enum Keying:
-    case Declaration, Membership
+  def guarantees(universe: Text): Set[Discipline.Guarantee] =
+    Set(Discipline.Guarantee.Linkage, Discipline.Guarantee.Recompilation)
 
-  // What a discipline's rigid atoms certify (§11.2 requirement 7, §11.5). Behavior is not a
-  // certifiable level and so has no case here: no hash scheme certifies it (§18).
-  enum Guarantee:
-    case Linkage, Recompilation
+  private def named(mode: ResourceMode): List[TreePath] =
+    List.from(resources.stdlib.filter(_.mode == mode).map(_.path))
 
-  // An ordered set of disciplines. Content is claimed by the first discipline whose `claims`
-  // accepts it; anything left unclaimed falls to `opaque/1` (§11.3), so nothing in a LIRA file
-  // is ever outside the compatibility algebra. A discipline out of its domain claims nothing,
-  // ahead of any question of what it would have claimed.
-  // The claiming order of §11.4 is structural rather than a convention the caller must remember:
-  // language disciplines first, then `resource/1` over the manifest's claims, then the
-  // `opaque/1` fallback. So an item under a scanned directory that a language discipline claims
-  // goes to that discipline, and only the remainder are atomless.
-  class Registry(disciplines: List[Discipline], resources: List[LiraManifest.Resource] = List()):
-    // The language disciplines alone, without the two the registry supplies itself.
-    def declared: List[Discipline] = disciplines
+  def exports: List[TreePath] = named(ResourceMode.Export)
+  def tracked: List[TreePath] = named(ResourceMode.Track)
+  def scanned: List[TreePath] = named(ResourceMode.Scan)
 
-    def all: List[Discipline] =
-      List.from(disciplines.stdlib :+ ResourceDiscipline(resources) :+ OpaqueDiscipline)
+  // A scan claims every item whose path has the declared directory plus `/` as a prefix. The
+  // directory itself is not an item, and a scanned directory may be empty in any or all
+  // universes.
+  def underScan(path: TreePath): Boolean =
+    scanned.stdlib.exists: directory => path.text.s.startsWith(directory.text.s + "/")
 
-    def atomize(content: List[(TreePath, Data)], context: Context)
-    :   List[Atomization] raises DisciplineError =
-
-      var remaining = content.stdlib
-
-      val results = all.stdlib.map: discipline =>
-        val (claimed, rest) =
-          if !discipline.domain.covers(context.universe) then (scala.Nil, remaining)
-          else remaining.partition: (path, data) => discipline.claims(path, data)
-
-        remaining = rest
-        (discipline, claimed)
-
-      List.from:
-        results.filter { (_, claimed) => !claimed.isEmpty }.map: (discipline, claimed) =>
-          discipline.atomize(List.from(claimed), context)
-
-// A named, versioned canonicalization procedure (§11): the single language-specific plug-in
-// point of the format. Atomization must be a pure function of the content's semantic model —
-// independent of file ordering, timestamps, tool versions and fresh names — and obey the
-// folding principle (§10.3).
-trait Discipline:
-  def id: Text
-  def claims(path: TreePath, data: Data): Boolean
-
-  // The three declarative requirements of §11.2. `domain` scopes the cross-section invariant
-  // (§9.6) and decides L127; `keying` and `guarantees` are contracts a discipline states and
-  // this core takes on trust — neither is checkable by machine, and both change what a reader
-  // may conclude from a grade (§12.4).
-  def domain: Discipline.Domain
-  def keying: Discipline.Keying
-  def guarantees(universe: Text): Set[Discipline.Guarantee]
+  def claims(path: TreePath, data: Data): Boolean =
+    exports.stdlib.exists(_.text == path.text)
+    || tracked.stdlib.exists(_.text == path.text)
+    || underScan(path)
 
   def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
-  :   Atomization raises DisciplineError
+  :   Atomization raises DisciplineError =
+
+    val atoms = content.stdlib.flatMap: (path, data) =>
+      if exports.stdlib.exists(_.text == path.text) then
+        // The value hashes the path alone, so the atom asserts presence and not content: bytes
+        // may differ per universe while L108 still requires the name in every one of them.
+        scala.List(Atom(path.text, AtomClass.Rigid, LiraHash(LiraHash.Domain.Atom(id), path.bytes)))
+      else if tracked.stdlib.exists(_.text == path.text) then
+        // Content-hashed and replaceable: an edit is replaceable churn, a minor event that marks
+        // consumers whose used-sets contain the atom as stale (§13.4). Resources create no
+        // linkage, so replaceability soundness is trivial and the reference list is empty.
+        scala.List(Atom(path.text, AtomClass.Replaceable, LiraHash(LiraHash.Domain.Atom(id), data)))
+      else scala.List()  // claimed by a scan: atomless
+
+    Atomization.of(id, List.from(atoms))
+
+object ResourceDiscipline:
+  // L124: declarations must be well-formed — no path declared twice, and no `export` or `track`
+  // path lying under a declared `scan` directory — so §11.2's partition has a single claimant by
+  // construction.
+  def check(resources: List[Resource]): Unit raises LiraError =
+    val discipline = ResourceDiscipline(resources)
+    val paths = resources.stdlib.map(_.path.text)
+
+    paths.groupBy(identity).foreach: (path, group) =>
+      if group.size > 1
+      then abort(LiraError(LiraError.Reason.BadResource(t"$path is declared twice")))
+
+    (discipline.exports.stdlib ++ discipline.tracked.stdlib).foreach: path =>
+      if discipline.underScan(path)
+      then abort(LiraError(LiraError.Reason.BadResource(t"${path.text} lies under a scan")))

--- a/lib/reliquary/src/core/reliquary.Verification.scala
+++ b/lib/reliquary/src/core/reliquary.Verification.scala
@@ -93,6 +93,7 @@ object Verification:
   def install(lira: Lira): Report raises LiraError =
     val manifest = lira.manifest
     integrations(manifest)
+    ResourceDiscipline.check(manifest.resource)
 
     // Steps 1–2: decompress within the declared length, verify the payload hash, and re-derive
     // every blob identity while checking stream order (L102–L105).

--- a/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
+++ b/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
@@ -66,6 +66,7 @@ object LiraAssembler:
       owns:        List[Text]                    = List(),
       profile:     List[LiraManifest.Profile]     = List(),
       integration: List[LiraManifest.Integration] = List(),
+      resource:    List[LiraManifest.Resource]    = List(),
       dependency:  List[LiraManifest.Dependency]  = List(),
       delta:       Optional[LiraDelta]            = Unset,
       classpath:   SectionInput => List[Text]     = { _ => List() },
@@ -85,15 +86,42 @@ object LiraAssembler:
     // (discipline, key, class, value hash), for the release to present one API on every universe
     // and under every integration (L108). The classpath is a property of the section, since it
     // is exactly what distinguishes one integration from another.
+    // L124 before anything else: an ill-formed set of claims makes the partition ambiguous, so
+    // there is nothing sensible to atomize.
+    ResourceDiscipline.check(resource)
+
+    val registry = Discipline.Registry(disciplines.declared, resource)
+
     val atomized = inputs.map: input =>
       val context = Discipline.Context(input.universe, input.integration, classpath(input))
-      (input.universe, disciplines.atomize(input.content, context))
+      (input.universe, registry.atomize(input.content, context))
+
+    // L125: an `export` or `track` declaration must be effective — a declared path that resolves
+    // to no item in any section, or that some other discipline claims, is an assembly-time
+    // error. A presence guarantee over nothing, or over content whose contract another
+    // discipline already carries, is never what the author meant.
+    val resourceDiscipline = ResourceDiscipline(resource)
+
+    (resourceDiscipline.exports.stdlib ++ resourceDiscipline.tracked.stdlib).foreach: path =>
+      val present = inputs.exists: input =>
+        input.content.stdlib.exists: pair => pair(0).text == path.text
+
+      if !present
+      then abort(LiraError(Reason.IneffectiveResource(path.text)))
+
+      val claimedByOther = disciplines.declared.stdlib.exists: discipline =>
+        inputs.exists: input =>
+          input.content.stdlib.exists: pair =>
+            pair(0).text == path.text && discipline.claims(pair(0), pair(1))
+
+      if claimedByOther
+      then abort(LiraError(Reason.IneffectiveResource(path.text)))
 
     // L127: a declared discipline must atomize some universe this release carries. An
     // atomization of nothing is not a claim about anything.
     val universes = inputs.map(_.universe).toSet
 
-    disciplines.all.stdlib.foreach: discipline =>
+    registry.all.stdlib.foreach: discipline =>
       if !universes.exists(discipline.domain.covers)
       then abort(LiraError(Reason.InapplicableDiscipline(discipline.id)))
 
@@ -160,6 +188,7 @@ object LiraAssembler:
           lineage     = fullLineage,
           toolchain   = toolchain,
           owns        = owns,
+          resource    = resource,
           api         = api,
           profile     = profile,
           integration = integration,

--- a/lib/reliquary/src/test/reliquary_test.scala
+++ b/lib/reliquary/src/test/reliquary_test.scala
@@ -724,6 +724,149 @@ object Tests extends Suite(m"Reliquary Tests"):
         report.materialized.stdlib.map { pair => pair(0).universe }
       . assert(_ == scala.List(t"jvm", t"sjsir"))
 
+      test(m"resource/1 atomizes exports by name and tracks content"):
+        import LiraManifest.{Resource, ResourceMode}
+        val claims = List(
+          Resource(ResourceMode.Export, TreePath(t"r/exported.conf")),
+          Resource(ResourceMode.Track, TreePath(t"r/tracked.json")),
+          Resource(ResourceMode.Scan, TreePath(t"r/plugins")))
+
+        val registry = Discipline.Registry(List(), claims)
+
+        def atoms(exportBytes: Text, trackBytes: Text) =
+          registry.atomize(List(
+            (TreePath(t"r/exported.conf"), encode(exportBytes)),
+            (TreePath(t"r/tracked.json"), encode(trackBytes)),
+            (TreePath(t"r/plugins/one.txt"), encode(t"scanned"))),
+            Discipline.Context(t"jvm"))
+
+        val one = atoms(t"alpha", t"schema-v1")
+        val two = atoms(t"beta", t"schema-v1")
+        val three = atoms(t"alpha", t"schema-v2")
+
+        def summary(list: List[Atomization]) =
+          list.stdlib.flatMap: atomization =>
+            atomization.atoms.stdlib.map: atom =>
+              (atom.key, atom.atomClass, LiraHash.text(atom.valueHash))
+
+        // The scanned item is claimed atomless, so only two atoms exist; the export's hash is a
+        // function of the name alone, so changing its bytes changes nothing; the tracked atom is
+        // replaceable and its hash follows its content.
+        (summary(one).map(_(0)), summary(one).map(_(1)),
+         summary(one) == summary(two), summary(one) == summary(three))
+      . assert(_ == (scala.List(t"r/exported.conf", t"r/tracked.json"),
+          scala.List(AtomClass.Rigid, AtomClass.Replaceable), true, false))
+
+      test(m"a resource path declared twice is L124"):
+        import LiraManifest.{Resource, ResourceMode}
+
+        capture[LiraError](ResourceDiscipline.check(List(
+          Resource(ResourceMode.Export, TreePath(t"r/a.conf")),
+          Resource(ResourceMode.Track, TreePath(t"r/a.conf"))))).reason match
+
+          case LiraError.Reason.BadResource(_) => true
+          case _                               => false
+      . assert(identity)
+
+      test(m"an export under a scanned directory is L124"):
+        import LiraManifest.{Resource, ResourceMode}
+
+        capture[LiraError](ResourceDiscipline.check(List(
+          Resource(ResourceMode.Scan, TreePath(t"r/plugins")),
+          Resource(ResourceMode.Export, TreePath(t"r/plugins/one.txt"))))).reason match
+
+          case LiraError.Reason.BadResource(_) => true
+          case _                               => false
+      . assert(identity)
+
+      test(m"a scanned directory may be empty and claims only what lies under it"):
+        import LiraManifest.{Resource, ResourceMode}
+        val discipline = ResourceDiscipline(List(
+          Resource(ResourceMode.Scan, TreePath(t"r/plugins"))))
+
+        val data = encode(t"x")
+
+        (discipline.claims(TreePath(t"r/plugins/a.txt"), data),
+         discipline.claims(TreePath(t"r/plugins"), data),
+         discipline.claims(TreePath(t"r/pluginsx/a.txt"), data))
+      . assert(_ == (true, false, false))
+
+      test(m"an assembled release carries its resource atoms and round-trips"):
+        import LiraManifest.{Resource, ResourceMode}
+        val claims = List(
+          Resource(ResourceMode.Export, TreePath(t"r/exported.conf")),
+          Resource(ResourceMode.Scan, TreePath(t"r/plugins")))
+
+        val content = List(
+          (TreePath(t"a/A.class"), classA),
+          (TreePath(t"r/exported.conf"), encode(t"config")),
+          (TreePath(t"r/plugins/one.txt"), encode(t"plugin")))
+
+        val bytes = LiraAssembler.assemble(t"example-core",
+          List(LiraAssembler.SectionInput(t"jvm", content)),
+          Discipline.Registry(List()),
+          toolchain = List(LiraManifest.Tool(t"scala", t"3.9.0")),
+          resource = claims)
+
+        val back = Lira.read(bytes)
+        val report = Verification.install(back)
+
+        val resourceAtoms = report.atomizations.stdlib
+          . filter(_.discipline == t"resource/1")
+          . flatMap(_.atoms.stdlib.map(_.key))
+
+        // The scanned item is atomless and the classfile falls to opaque/1, so resource/1
+        // contributes exactly the one exported name.
+        (back.manifest.resource.stdlib.map(_.mode),
+         resourceAtoms,
+         back.manifest.render == Lira.read(bytes).manifest.render)
+      . assert(_ == (scala.List(LiraManifest.ResourceMode.Export, LiraManifest.ResourceMode.Scan),
+          scala.List(t"r/exported.conf"), true))
+
+      test(m"an export resolving to no item is L125"):
+        import LiraManifest.{Resource, ResourceMode}
+
+        val claims = List(Resource(ResourceMode.Export, TreePath(t"r/absent.conf")))
+
+        capture[LiraError]:
+          LiraAssembler.assemble(t"example-core",
+            List(LiraAssembler.SectionInput(t"jvm", List((TreePath(t"a/A.class"), classA)))),
+            Discipline.Registry(List()),
+            toolchain = List(LiraManifest.Tool(t"scala", t"3.9.0")),
+            resource = claims)
+
+        . reason
+      . assert(_ == LiraError.Reason.IneffectiveResource(t"r/absent.conf"))
+
+      test(m"an export another discipline claims is L125"):
+        import LiraManifest.{Resource, ResourceMode}
+
+        object Greedy extends Discipline:
+          def id: Text = t"greedy/1"
+          def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".conf")
+          def domain: Discipline.Domain = Discipline.Domain.Universal
+          def keying: Discipline.Keying = Discipline.Keying.Declaration
+
+          def guarantees(universe: Text): Set[Discipline.Guarantee] =
+            Set(Discipline.Guarantee.Recompilation)
+
+          def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
+          :   Atomization raises DisciplineError =
+            Atomization.of(id, List())
+
+        val claims = List(Resource(ResourceMode.Export, TreePath(t"r/taken.conf")))
+
+        capture[LiraError]:
+          LiraAssembler.assemble(t"example-core",
+            List(LiraAssembler.SectionInput(t"jvm",
+              List((TreePath(t"r/taken.conf"), encode(t"config"))))),
+            Discipline.Registry(List(Greedy)),
+            toolchain = List(LiraManifest.Tool(t"scala", t"3.9.0")),
+            resource = claims)
+
+        . reason
+      . assert(_ == LiraError.Reason.IneffectiveResource(t"r/taken.conf"))
+
       test(m"a manifest with profiles and integrations round-trips through its rendering"):
         val rootTree = LiraTree.of(List(TreeEntry(TreePath(t"a/A.class"), blob(classA))))
         val altTree = LiraTree.of(List(TreeEntry(TreePath(t"a/A.class"), blob(sjsirA))))
@@ -744,7 +887,7 @@ object Tests extends Suite(m"Reliquary Tests"):
               breaks = List(LiraManifest.Guarantee.Linkage))),
           integration = List(
             LiraManifest.Integration(t"new", rank = 0L),
-            LiraManifest.Integration(t"old", rank = 1L, label = t"rudiments-7.x")),
+            LiraManifest.Integration(t"old", rank = 1L, label = t"built against the rudiments 0.x line")),
           dependency  = List(LiraManifest.Dependency(t"beta",
               blob(encode(t"snapshot")), integration = List(t"old"))),
           section     = List(
@@ -763,9 +906,11 @@ object Tests extends Suite(m"Reliquary Tests"):
          back.profile.stdlib.head.breaks.stdlib.head,
          back.integration.stdlib.map(_.id),
          back.section.stdlib.map(_.integration.or(t"-")),
-         back.dependency.stdlib.head.integration.stdlib)
+         back.dependency.stdlib.head.integration.stdlib,
+         back.integration.stdlib(1).label.or(t"-"))
       . assert(_ == (true, LiraManifest.Guarantee.Linkage, scala.List(t"new", t"old"),
-          scala.List(t"new", t"old"), scala.List(t"old")))
+          scala.List(t"new", t"old"), scala.List(t"old"),
+          t"built against the rudiments 0.x line"))
 
       test(m"two sections sharing a universe and integration are L131"):
         val tree = LiraTree.of(List(TreeEntry(TreePath(t"a/A.class"), blob(classA))))
@@ -1009,6 +1154,7 @@ object Tests extends Suite(m"Reliquary Tests"):
         ( module:       Text,
           lineage:      List[Data],
           owns:         List[Text]                     = List(),
+          resources:    List[LiraManifest.Resource]    = List(),
           deps:         List[LiraManifest.Dependency]  = List(),
           version:      Optional[Semver]               = Unset,
           section:      List[Section]                  = List(),
@@ -1020,6 +1166,7 @@ object Tests extends Suite(m"Reliquary Tests"):
             version     = version,
             lineage     = lineage,
             owns        = owns,
+            resource    = resources,
             api         = List(),
             integration = integrations,
             dependency  = deps,
@@ -1051,6 +1198,28 @@ object Tests extends Suite(m"Reliquary Tests"):
         val path = Buildpath(List(
           stub(t"alpha", List(snapOne), owns = List(t"gossamer")),
           stub(t"beta", List(snapTwo), owns = List(t"gossamers"))))
+
+        path.validate(t"jvm").stdlib.size
+      . assert(_ == 0)
+
+      test(m"an export path claimed by two modules is L126"):
+        import LiraManifest.{Resource, ResourceMode}
+        val claim = List(Resource(ResourceMode.Export, TreePath(t"r/shared.conf")))
+
+        val path = Buildpath(List(
+          stub(t"alpha", List(snapOne), resources = claim),
+          stub(t"beta", List(snapTwo), resources = claim)))
+
+        capture[LiraError](path.validate(t"jvm")).reason
+      . assert(_ == LiraError.Reason.ResourceClash(t"r/shared.conf"))
+
+      test(m"a scanned directory shared by two modules is exempt from L126"):
+        import LiraManifest.{Resource, ResourceMode}
+        val claim = List(Resource(ResourceMode.Scan, TreePath(t"r/plugins")))
+
+        val path = Buildpath(List(
+          stub(t"alpha", List(snapOne), resources = claim),
+          stub(t"beta", List(snapTwo), resources = claim)))
 
         path.validate(t"jvm").stdlib.size
       . assert(_ == 0)
@@ -1139,7 +1308,7 @@ object Tests extends Suite(m"Reliquary Tests"):
           deps = List(LiraManifest.Dependency(t"beta", snapOne, integration = List(t"only"))))
 
         capture[LiraError](Buildpath(List(alpha, provider)).resolved(t"jvm")).reason
-      . assert(_ == LiraError.Reason.NoAssignment)
+      . assert(_ == LiraError.Reason.NoAssignment(t"alpha"))
 
       test(m"a release declaring no integration assigns the implicit one"):
         Buildpath(List(stub(t"alpha", List(snapOne)))).resolved(t"jvm")(0)(t"alpha").absent
@@ -1152,6 +1321,40 @@ object Tests extends Suite(m"Reliquary Tests"):
 
         Buildpath(List(needy, provider)).validate(t"jvm").stdlib.size
       . assert(_ == 0)
+
+      test(m"a recorded span satisfies a requirement outside the lineage"):
+        // beta's lineage carries only snapTwo, so alpha's snapOne requirement fails on lineage
+        // membership; the recorded span across the major boundary carries it (§13.4).
+        val provider = stub(t"beta", List(snapTwo))
+
+        val needy = stub(t"alpha", List(snapOne),
+          deps = List(LiraManifest.Dependency(t"beta", snapOne, spans = List(snapTwo))))
+
+        Buildpath(List(needy, provider)).validate(t"jvm").stdlib.size
+      . assert(_ == 0)
+
+      test(m"a span naming a snapshot the candidate does not carry is still L114"):
+        val provider = stub(t"beta", List(snapTwo))
+        val other = LiraHash(LiraHash.Domain.Snapshot, encode(t"three"))
+
+        val needy = stub(t"alpha", List(snapOne),
+          deps = List(LiraManifest.Dependency(t"beta", snapOne, spans = List(other))))
+
+        capture[LiraError](Buildpath(List(needy, provider)).validate(t"jvm")).reason match
+          case LiraError.Reason.Unsatisfiable(_) => true
+          case _                                 => false
+      . assert(identity)
+
+      test(m"a span lets an integration resolve that lineage membership would reject"):
+        val provider = stub(t"beta", List(snapTwo))
+
+        val alpha = stub(t"alpha", List(snapOne),
+          integrations = List(LiraManifest.Integration(t"spanned", rank = 0L)),
+          deps = List(LiraManifest.Dependency(t"beta", snapOne, integration = List(t"spanned"),
+              spans = List(snapTwo))))
+
+        Buildpath(List(alpha, provider)).resolved(t"jvm")(0)(t"alpha")
+      . assert(_ == t"spanned")
 
       test(m"a requirement outside the lineage is L114"):
         val provider = stub(t"beta", List(snapTwo))


### PR DESCRIPTION
Four loose ends left over from the LIRA specification alignment, each self-contained. Attested locally (`verify-attest: OK`, 9 wasm-e2e scenarios); reliquary 161 → 173 tests, degustation 19, all passing.

## `resource/1` (§11.4)

The discipline was normative with no implementation at all — it predated the integrations work.

`ResourceDiscipline` is parameterized by the manifest's `resource` records: the one registered discipline whose claiming takes input beyond the tree, which is unproblematic because atomization only ever runs where the manifest is in hand.

- **`export`** yields a rigid atom keyed *and valued* by the path, so it asserts presence and not content. L108 then does something rather elegant for free: it requires the name in every section while letting the bytes differ per universe.
- **`track`** yields a replaceable atom over the bytes, so an edit is replaceable churn that marks consumers stale.
- **`scan`** claims a whole directory atomless.

§11.4's claiming order is now structural rather than a convention callers must remember: `Registry.all` is language disciplines, then `resource/1`, then the `opaque/1` fallback. L124 (well-formedness) is checked at install and before assembly; L125 (effectiveness) in the assembler, the only place holding both the trees and the registry; L126 (resource disjointness) as buildpath rule 3, with `scan` directories exempt since cross-module aggregation is their purpose.

## Spanning (§13.4)

`dependency.spans` was decoded, rendered and in the schema, but read by nothing — so the mechanism §9.5 tells producers to *prefer over integrations* was the one that wasn't wired up. A requirement is now satisfied when the required snapshot is in the candidate's lineage **or** one of the recorded spans is.

Spans are taken on trust at validation time, and the comment says why rather than leaving it implicit: proving one requires atomizing the candidate's payload, so it is a publish-time check a registry makes across two releases, not something buildpath validation can redo from manifests alone.

## Integration `label`

It can hold spaces after all — my earlier conclusion was wrong. `render` now separates it from its keyword by a hard-space run, which switches TEL into hard-space mode for the rest of the line (TEL §10.3), making the whole remainder one atom. No schema change needed. The comment asserting the opposite is corrected, and the test round-trips a real prose label.

## `NoAssignment` names the release

Because the integration choices are independent, a failure is always one release's — there is never a combination to report. The error now carries the module none of whose integrations hold, which is what lets lira#5 raise §13.3's diagnostic obligation from SHOULD to MUST.

## Incidental

- The `lira` schema gains `Resource`, `ResourceMode` and the `TreePath` scalar, so `liraSignature` is re-pinned and `res/test/reliquary/lira.tel` moves with it.
- Noticed while testing: `LiraAssembler.assemble` defaults `toolchain` to empty, which produces a manifest failing its own schema, since `toolchain` is required. Caller error rather than a bug, but a required field with a permissive default is a trap worth closing separately.
- Profile predicate checking remains unimplementable until `jvm/1` has a normative companion spec; the manifest surface and error codes are in place waiting on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)