### PR TITLE
Unify xenophile's five foreign-call backends behind one invoke

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2626,8 +2626,8 @@ object xenophile extends Library:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // The Scala Native materializer: lowers a C `Foreign` navigation to a `dlsym`+`CFuncPtr` call.
   // Compiled for the JVM (where the macro runs) and cross-compiled for native (where downstream
-  // callers link it). Its `invoke` extension collides by design with `wasm`/`js` (they target
-  // different platforms), so — like `js` — it is not bundled into the `test` module.
+  // callers link it). It is the second of the two backends the `Native` ecosystem's `Emission`
+  // names; a build gets this one or `native`, never both.
   object scalanative extends Component(core, cffi):
     override def scalaJs = false // a Scala Native materializer; no JS relevance
     override def scalaNative = true // but it is, of course, the native materializer itself
@@ -2656,14 +2656,14 @@ object xenophile extends Library:
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // The JavaScript materializer: emits Scala.js dynamic calls for WebIDL/TypeScript navigations.
-  // The `invoke` extension it exports collides by design with `wasm`'s (they target different
-  // Scala.js link outputs), so it is not bundled into the `test` module alongside `wasm`.
   object js extends Component(core, hypotenuse.core, anticipation.codec, distillate.core,
     gossamer.core, prepositional.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium")
-  object test extends Tests(typescript, native, wit, webidl, wasm, kotlin, hellenism.core,
-      harlequin.core):
+  // Every backend at once — which only typechecks because they now share the single `invoke` in
+  // `core` rather than exporting one apiece into `soundness`.
+  object test extends Tests(typescript, native, wit, webidl, wasm, kotlin, js, scalanative,
+      hellenism.core, harlequin.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions())
     // kotlin-stdlib is the Kotlin-classfile fixture: its `@Metadata`-annotated classes let the

--- a/lib/xenophile/src/cffi/xenophile.Native.scala
+++ b/lib/xenophile/src/cffi/xenophile.Native.scala
@@ -71,3 +71,9 @@ object Native:
 
 trait Native extends Ecosystem:
   type Grammar = CHeaderDialect.type
+
+  // Two backends, one per target platform: `xenophile.native` lowers to a Panama downcall on the
+  // JVM, `xenophile.scalanative` to a `dlsym`/`CFuncPtr` call on Scala Native. A build depends on
+  // one or the other — never both — so naming both here lets the same source compile either way,
+  // which is what `enigmatic.openssl` relies on.
+  type Emission = "xenophile.PanamaInvoke" | "xenophile.NativeInvoke"

--- a/lib/xenophile/src/core/soundness_xenophile_core.scala
+++ b/lib/xenophile/src/core/soundness_xenophile_core.scala
@@ -32,4 +32,5 @@
                                                                                                   */
 package soundness
 
-export xenophile.{Dialect, Ecosystem, Foreign, Interface, Interoperable, Prototype}
+export xenophile.{invoke, Dialect, Ecosystem, Foreign, Interface, Interoperable, Materializer,
+    Prototype}

--- a/lib/xenophile/src/core/xenophile.Ecosystem.scala
+++ b/lib/xenophile/src/core/xenophile.Ecosystem.scala
@@ -37,3 +37,17 @@ package xenophile
 // ecosystem.
 trait Ecosystem:
   type Grammar <: Dialect
+
+  // The `Materializer` objects that can emit a call in this ecosystem, named by fully-qualified
+  // class name — as literal types, and as a union where a language has more than one backend.
+  //
+  // Names, not singleton types like `Grammar`, because an ecosystem must not depend on the module
+  // that materializes it: `xenophile.wasm` already depends on `xenophile.wit`, so `Wit` naming
+  // `WasmInvoke` as a type would close a cycle. A name costs the compiler's checking, which is
+  // why `materializerFor` reports a missing one precisely.
+  //
+  // A union is how the C ecosystem carries its two backends, which differ by *target platform*
+  // rather than by ecosystem. The build picks between them by which module it depends on — only
+  // one is ever on a real classpath, and `enigmatic.openssl` compiles one unchanged source both
+  // ways on exactly that basis — so `materializerFor` takes the first candidate it can load.
+  type Emission

--- a/lib/xenophile/src/core/xenophile.Materializer.scala
+++ b/lib/xenophile/src/core/xenophile.Materializer.scala
@@ -32,8 +32,17 @@
                                                                                                   */
 package xenophile
 
-// The `invoke` terminal for call sites that import `xenophile.*` rather than `soundness.*`
-// (the same extension is exported to the `soundness` package alongside `ForeignLibrary`).
-extension (foreign: Foreign)
-  inline def invoke[result]: result =
-    ${PanamaInvoke.invoke[result]('foreign)}
+import scala.quoted.*
+
+// The terminal step of a foreign call: turning a navigation into the tree that performs it. The
+// steps before it — peeling the navigation apart, and checking it against the ecosystem's
+// definitions — are shared, and live in `Xenophile.navigation`.
+//
+// There is one implementation per backend: `PanamaInvoke` (a JVM Panama downcall), `NativeInvoke`
+// (a Scala Native `dlsym`/`CFuncPtr` call), `WasmInvoke` (a Wasm Component Model import),
+// `JsInvoke` (a Scala.js dynamic call) and `KotlinInvoke` (a direct JVM call). Each ecosystem
+// names the ones that serve it in its `Emission` member, and `core` loads whichever the build put
+// on the classpath reflectively — so it depends on none of them, and the single `invoke`
+// extension can live here rather than being duplicated once per backend.
+trait Materializer:
+  def materialize[result: Type](self: Expr[Foreign])(using Quotes): Expr[result]

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -69,6 +69,142 @@ object Xenophile:
     catch case _: Throwable =>
       halt(m"xenophile: could not load the grammar for the foreign source language")
 
+  // Resolves the emission backend for a source language by reading the `Emission` member of its
+  // `Ecosystem` — the fully-qualified names of `Materializer` objects — and loading the first that
+  // is on the classpath. The reflective step is `dialectFor`'s, and for the same reason: `core`
+  // must reach a backend it cannot depend on. Only the name differs, because a *type* would make
+  // the ecosystem depend on the backend, and `xenophile.wasm` already depends on `xenophile.wit`.
+  //
+  // "The first that is on the classpath" is what makes the choice the build's. The C ecosystem
+  // names two — Panama for the JVM, `CFuncPtr` for Scala Native — and no real classpath carries
+  // both: `enigmatic.openssl` compiles one unchanged source both ways purely by swapping
+  // `xenophile.native` for `xenophile.scalanative` in its `nativeModuleDeps`.
+  private def materializerFor(using quotes: Quotes)(origin: quotes.reflect.TypeRepr): Materializer =
+    import quotes.reflect.*
+
+    val emission = origin.typeSymbol.typeMember("Emission")
+
+    if !emission.exists
+    then halt(m"xenophile: the source language names no materializer (it defines no `Emission`)")
+
+    // A union of candidates flattens to a list; a single candidate is a list of one.
+    def candidates(repr: TypeRepr): Seq[Text] = repr.dealias match
+      case OrType(left, right)                => candidates(left) ++ candidates(right)
+      case ConstantType(StringConstant(name)) => Seq(name.tt)
+
+      case _ =>
+        halt(m"xenophile: the source language's `Emission` is not a materializer's name")
+
+    val names = origin.memberType(emission) match
+      case TypeBounds(_, hi) => candidates(hi)
+      case other             => candidates(other)
+
+    // The singleton of a named object is the static `MODULE$` field of its `$`-suffixed module
+    // class. A candidate that is simply absent is skipped — that is the other platform's backend,
+    // which this build did not depend on.
+    def load(name: Text): Optional[Materializer] =
+      try
+        val module = Class.forName(name.s+"$").nn
+        module.getField("MODULE$").nn.get(null).nn.asInstanceOf[Materializer]
+      catch case _: Throwable => Unset
+
+    var found: Optional[Materializer] = Unset
+
+    names.foreach: name =>
+      if found.absent then found = load(name)
+
+    found.or:
+      halt(m"xenophile: no materializer for this foreign source language is on the classpath")
+
+  // The single terminal for every ecosystem: let the backend the build selected emit the call.
+  def invoke[result: Type](self: Expr[Foreign]): Macro[result] =
+    val (_, origin) = receiver(self)
+    materializerFor(origin).materialize[result](self)
+
+  // Peels a navigation apart into the foreign type it selected from, the member it reached, the
+  // receiver's own tree (which WIT resource methods thread as a handle) and the operand trees.
+  //
+  // Until the five backends were unified this was copied verbatim into each of them, and three
+  // divergences had already crept in: Kotlin rejected the bare selection the others accepted, and
+  // Wasm lacked the others' plain string-literal fallback. This takes the lenient reading of each.
+  private[xenophile] def navigation(using quotes: Quotes)(self: Expr[Foreign])
+  :   (Text, Text, quotes.reflect.Term, Seq[quotes.reflect.Term]) =
+
+    import quotes.reflect.*
+
+    // The navigation expands to `Foreign.make(<AST>).asInstanceOf[…]`, and reaching a materializer
+    // through further `inline` definitions (an inline given publishing a deferred import, say)
+    // nests it in `Inlined`/`Typed` layers that `underlyingArgument` cannot fold away. So the AST
+    // is recovered by term-level stripping rather than by quote-pattern matching.
+    def strip(term: Term): Term = term match
+      case Inlined(_, _, body)                        => strip(body)
+      case Typed(expr, _)                             => strip(expr)
+      case Block(Nil, expr)                           => strip(expr)
+      case TypeApply(Select(expr, "asInstanceOf"), _) => strip(expr)
+      case _                                          => term
+
+    def stringOf(term: Term): Text = strip(term).absolve match
+      case Literal(StringConstant(string)) => string.tt
+
+    // `.tt` desugars to `tt("…")`; recover the string from the operand, or from a bare literal.
+    def literal(term: Term): Text = strip(term).absolve match
+      case Apply(Ident("tt"), Seq(argument)) => stringOf(argument)
+      case other                             => stringOf(other)
+
+    def notCall: Nothing =
+      halt(m"xenophile: `invoke` expects a foreign function invocation, `interface.function(…)`")
+
+    val expression = strip(self.asTerm.underlyingArgument).absolve match
+      case Apply(Select(_, "make"), Seq(argument)) => strip(argument)
+      case _                                       => notCall
+
+    // The elements of the `Expr.ofList`-built argument list of an `Expression.Apply`.
+    def argumentList(term: Term): Seq[Term] = strip(term) match
+      case Apply(_, Seq(varargs)) => strip(varargs) match
+        case Repeated(elements, _) => elements.map(strip)
+        case _                     => Seq()
+
+      case _ =>
+        Seq()
+
+    // Either an applied call — `Expression.Apply(select, arguments)`, whose companion `apply`
+    // takes two arguments — or the bare selection of a zero-parameter function
+    // (`Expression.Select`, whose companion `apply` takes three): `interface.function.invoke[R]`.
+    // The latter is preferred inside `inline` definitions, where re-inlining an empty-varargs
+    // application trips path-dependent type avoidance.
+    val (selectNode, argumentTerms) = expression match
+      case Apply(Select(_, "apply"), Seq(node, args)) => (strip(node), argumentList(args))
+      case _                                          => (expression, Seq())
+
+    selectNode.absolve match
+      case Apply(Select(_, "apply"), Seq(receiver, member, owner)) =>
+        (literal(owner), literal(member), strip(receiver), argumentTerms)
+
+      case _ =>
+        notCall
+
+  // The Scala value wrapped by the `Foreign.converter` `Conversion` in a navigation operand: a
+  // converted argument, or (for WIT) a resource-handle receiver.
+  private[xenophile] def convertedValue(using quotes: Quotes)(term: quotes.reflect.Term)
+  :   quotes.reflect.Term =
+
+    import quotes.reflect.*
+    var found: Optional[Term] = Unset
+
+    val traverser = new TreeTraverser:
+      override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match
+        case Apply(Select(qualifier, "apply"), Seq(value))
+        if qualifier.tpe <:< TypeRepr.of[Conversion[Nothing, Foreign]] =>
+          if found.absent then found = value
+
+        case _ =>
+          traverseTreeChildren(tree)(owner)
+
+    traverser.traverseTree(term)(Symbol.spliceOwner)
+
+    found.or:
+      halt(m"xenophile: a foreign operand must be a Scala value with an `Interoperable` instance")
+
   // Reads the definitions resource at `path` and parses it with the grammar for `origin`.
   // Parsed definitions are cached by resource path for the lifetime of a compilation run, so that
   // navigating a chain like `foo.bar.qux` parses each resource only once instead of per access.

--- a/lib/xenophile/src/core/xenophile_core.scala
+++ b/lib/xenophile/src/core/xenophile_core.scala
@@ -32,10 +32,19 @@
                                                                                                   */
 package xenophile
 
-// The `invoke` terminal (re-exported to the `soundness` package alongside `NativeInvoke`).
-// Plain `inline` (not `transparent`): the return type is fixed by the type argument, and
-// non-transparency defers the macro so the `scala.scalanative.*` call only materializes at the
-// downstream (Native-linked) call site.
+// The one terminal for every ecosystem and every target platform. Which backend emits the call —
+// Panama, Scala Native, Wasm, JS or Kotlin — follows from the receiver's `Origin` and the
+// `Materialization` the build put on the classpath, so this module depends on none of them and
+// exactly one `invoke` reaches the `soundness` umbrella. (It used to be five, one per backend,
+// which `import soundness.*` resolved by classpath order.)
+//
+// Must be applied directly to an inline navigation chain — e.g.
+// `Foreign["random", Wit].\`get-random-u64\`().invoke[U64]` — not to a value bound to a `val`.
+//
+// Plain `inline`, not `transparent`: the result type is fully determined by the type argument in
+// all five backends, and non-transparency defers the macro when `invoke` appears inside another
+// `inline` definition, so a library can publish an inline given whose call only materializes at
+// the downstream (Wasm-, JS- or Native-linked) call site — where the platform runtime is on the
+// classpath.
 extension (foreign: Foreign)
-  inline def invoke[result]: result =
-    ${NativeInvoke.invoke[result]('foreign)}
+  inline def invoke[result]: result = ${Xenophile.invoke[result]('foreign)}

--- a/lib/xenophile/src/js/soundness_xenophile_js.scala
+++ b/lib/xenophile/src/js/soundness_xenophile_js.scala
@@ -33,12 +33,3 @@
 package soundness
 
 export xenophile.{Js, JsInvoke}
-
-// Materializes a fully-applied JavaScript `Foreign` navigation into a real Scala.js dynamic call.
-// Must be applied directly to an inline navigation chain — e.g.
-// `Foreign["Math", Typescript].random().invoke[F64]` — not to a value bound to a `val`. It mirrors
-// the `Wasm` module's `invoke`; the two target different Scala.js link outputs (JS vs the Wasm
-// Component Model) and are never on the same application's classpath.
-extension (foreign: xenophile.Foreign)
-  transparent inline def invoke[result]: result =
-    ${xenophile.JsInvoke.invoke[result]('foreign)}

--- a/lib/xenophile/src/js/xenophile.JsInvoke.scala
+++ b/lib/xenophile/src/js/xenophile.JsInvoke.scala
@@ -50,8 +50,8 @@ import prepositional.*
 //
 // Like `WasmInvoke`, this v1 materializes nullary method calls (`receiver.method()`); argument
 // marshalling through `Encodable in Js` is a follow-up, tracked alongside the `Wasm` form's.
-object JsInvoke:
-  def invoke[result: Type](self: Expr[Foreign])(using quotes: Quotes): Expr[result] =
+object JsInvoke extends Materializer:
+  def materialize[result: Type](self: Expr[Foreign])(using quotes: Quotes): Expr[result] =
     import quotes.reflect.*
 
     // The `js.Dynamic` interop entry points, resolved from the downstream Scala.js library. Named
@@ -62,26 +62,6 @@ object JsInvoke:
     val applyDynamic = dynamic.methodMember("applyDynamic").head
     // A concrete `js.Any` tree for the empty varargs element (an inferred one fails to resolve).
     val jsAnyTree = TypeTree.ref(Symbol.requiredClass("scala.scalajs.js.Any"))
-
-    // The navigation the `invoke` is applied to expands to `Foreign.make(<AST>).asInstanceOf[…]`,
-    // itself wrapped in `Inlined`/`Typed` layers (the inline `applyDynamic` leaves a `Foreign_this`
-    // binding, so `underlyingArgument` cannot fold the `Inlined` away). Rather than quote-match
-    // through those layers, we peel them at tree level and read the `Foreign.Expression` AST the
-    // navigation macros built directly. (`.tt` desugars to a plain `tt("…")` application.)
-    def strip(term: Term): Term = term match
-      case Inlined(_, _, body)                        => strip(body)
-      case Typed(expr, _)                             => strip(expr)
-      case Block(Nil, expr)                           => strip(expr)
-      case TypeApply(Select(expr, "asInstanceOf"), _) => strip(expr)
-      case _                                          => term
-
-    // `.tt` desugars to `tt("…")`; recover the string from the operand (or a bare string literal).
-    def stringOf(term: Term): Text = strip(term).absolve match
-      case Literal(StringConstant(string)) => string.tt
-
-    def literal(term: Term): Text = strip(term).absolve match
-      case Apply(Ident("tt"), List(argument)) => stringOf(argument)
-      case other                              => stringOf(other)
 
     // `receiver.selectDynamic("name")`, yielding another `js.Dynamic`.
     def select(receiver: Term, name: Text): Term =
@@ -100,24 +80,10 @@ object JsInvoke:
         ( Apply(Select(receiver, applyDynamic), List(Literal(StringConstant(method.s)))),
           List(arguments) )
 
-    def notCall: Nothing = halt(m"xenophile: `invoke` expects a call, `receiver.method()`")
-
-    // Peel to the `Foreign.make(<AST>)` application; take its argument — the expression AST.
-    val expression = strip(self.asTerm.underlyingArgument).absolve match
-      case Apply(Select(_, "make"), List(argument)) => strip(argument)
-      case _                                        => notCall
-
-    // Like `WasmInvoke`, the `owner` recorded on the `Select` names the type the method belongs to;
-    // for a global JavaScript object (`Math`, `crypto`, …) that is the global property to read, so
-    // the call is `global.<owner>.<method>()`. AST: `Apply(Select(_, member, owner), _)`
-    // (`Apply.apply` has two arguments; the nested `Select.apply` has three).
-    val selectNode = expression match
-      case Apply(Select(_, "apply"), List(node, _)) => strip(node)
-      case _                                        => notCall
-
-    val (owner, function) = selectNode.absolve match
-      case Apply(Select(_, "apply"), List(_, member, owner)) => (literal(owner), literal(member))
-      case _                                                 => notCall
+    // The owner recorded on the navigation's `Select` names the type the method belongs to; for a
+    // global JavaScript object (`Math`, `crypto`, …) that is the global property to read, so the
+    // call is `global.<owner>.<method>()`.
+    val (owner, function, _, _) = Xenophile.navigation(self)
 
     val call = applyNullary(select(Ref(globalMethod), owner), function)
 

--- a/lib/xenophile/src/kotlin/soundness_xenophile_kotlin.scala
+++ b/lib/xenophile/src/kotlin/soundness_xenophile_kotlin.scala
@@ -33,4 +33,4 @@
 package soundness
 
 export xenophile.{companion, enumEntry, make, singleton, Facade, Kotlin, KotlinDialect,
-    KotlinFacade, KotlinInvoke, KotlinRuntime, kotlinInvocation}
+    KotlinFacade, KotlinInvoke, KotlinRuntime}

--- a/lib/xenophile/src/kotlin/xenophile.Kotlin.scala
+++ b/lib/xenophile/src/kotlin/xenophile.Kotlin.scala
@@ -86,3 +86,4 @@ object Kotlin:
 
 trait Kotlin extends Ecosystem:
   type Grammar = KotlinDialect.type
+  type Emission = "xenophile.KotlinInvoke"

--- a/lib/xenophile/src/kotlin/xenophile.KotlinInvoke.scala
+++ b/lib/xenophile/src/kotlin/xenophile.KotlinInvoke.scala
@@ -48,67 +48,13 @@ import vacuous.*
 // downstream compile classpath, so this module needs no dependency on the Kotlin libraries it
 // calls into. This v1 materializes calls to top-level (static) functions; instance receivers
 // and properties follow.
-object KotlinInvoke:
-  def invoke[result: Type](self: Expr[Foreign])(using quotes: Quotes): Expr[result] =
+object KotlinInvoke extends Materializer:
+  def materialize[result: Type](self: Expr[Foreign])(using quotes: Quotes): Expr[result] =
     import quotes.reflect.*
 
-    def strip(term: Term): Term = term match
-      case Inlined(_, _, body)                        => strip(body)
-      case Typed(expr, _)                             => strip(expr)
-      case Block(Nil, expr)                           => strip(expr)
-      case TypeApply(Select(expr, "asInstanceOf"), _) => strip(expr)
-      case _                                          => term
+    val (owner, function, _, argumentTerms) = Xenophile.navigation(self)
 
-    def stringOf(term: Term): Text = strip(term).absolve match
-      case Literal(StringConstant(string)) => string.tt
-
-    def literal(term: Term): Text = strip(term).absolve match
-      case Apply(Ident("tt"), List(argument)) => stringOf(argument)
-      case other                              => stringOf(other)
-
-    def notCall: Nothing =
-      halt(m"xenophile: `invoke` expects a Kotlin function invocation, `facade.function(…)`")
-
-    val expression = strip(self.asTerm.underlyingArgument).absolve match
-      case Apply(Select(_, "make"), List(argument)) => strip(argument)
-      case _                                        => notCall
-
-    def argumentList(term: Term): List[Term] = strip(term) match
-      case Apply(_, List(varargs)) => strip(varargs).absolve match
-        case Repeated(elements, _) => elements.map(strip)
-        case _                     => Nil
-
-      case _ =>
-        Nil
-
-    val (selectNode, argumentTerms) = expression match
-      case Apply(Select(_, "apply"), List(node, args)) => (strip(node), argumentList(args))
-      case _                                           => notCall
-
-    val (owner, function) = selectNode.absolve match
-      case Apply(Select(_, "apply"), List(_, member, owner)) => (literal(owner), literal(member))
-      case _                                                 => notCall
-
-    // The Scala value wrapped by the `Foreign.converter` `Conversion` in an argument operand,
-    // recovered by traversal, as in `PanamaInvoke`.
-    def convertedValue(term: Term): Term =
-      var found: Optional[Term] = Unset
-
-      val traverser = new TreeTraverser:
-        override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match
-          case Apply(Select(qualifier, "apply"), List(value))
-          if qualifier.tpe <:< TypeRepr.of[Conversion[Nothing, Foreign]] =>
-            if found.absent then found = value
-
-          case _ =>
-            traverseTreeChildren(tree)(owner)
-
-      traverser.traverseTree(term)(Symbol.spliceOwner)
-
-      found.or:
-        halt(m"xenophile: a Kotlin argument must be a Scala value with an `Interoperable`")
-
-    val argumentValues = argumentTerms.map(convertedValue)
+    val argumentValues = argumentTerms.to(List).map(Xenophile.convertedValue)
 
     // The parameter segment of a JVM method descriptor, split into one entry per parameter.
     def descriptorParameters(descriptor: Text): List[Text] =
@@ -180,10 +126,3 @@ object KotlinInvoke:
     val call = Apply(Select(Ref(module), method), arguments)
 
     TypeApply(Select.unique(call, "asInstanceOf"), List(TypeTree.of[result])).asExprOf[result]
-
-// The `invoke` terminal for Kotlin navigations. Deliberately housed in its own object rather
-// than exported loose: other ecosystems' materializers (Wasm, JS) export `invoke` extensions
-// too, so a named import — `import kotlinInvocation.invoke` — disambiguates where they coexist.
-object kotlinInvocation:
-  extension (foreign: Foreign)
-    transparent inline def invoke[result]: result = ${KotlinInvoke.invoke[result]('foreign)}

--- a/lib/xenophile/src/native/soundness_xenophile_native.scala
+++ b/lib/xenophile/src/native/soundness_xenophile_native.scala
@@ -32,8 +32,9 @@
                                                                                                   */
 package soundness
 
-// `invoke` materializes a fully-applied C `Foreign` navigation into a Panama downcall (see
-// `PanamaInvoke`); it is the JVM analogue of the `scalanative` module's `invoke` — the two lower
-// the identical navigation for different platforms and are never on the same application's
-// classpath.
-export xenophile.{ForeignBuffer, ForeignLibrary, PanamaInvoke, invoke}
+// `PanamaInvoke` is the backend the C ecosystem's `Emission` names first: it lowers a
+// fully-applied C `Foreign` navigation into a Panama downcall for the single `invoke` in
+// `xenophile.core`. It is the JVM analogue of the `scalanative` module's `NativeInvoke` — the two
+// lower the identical navigation for different platforms, and a build gets whichever of the two
+// modules it depends on.
+export xenophile.{ForeignBuffer, ForeignLibrary, PanamaInvoke}

--- a/lib/xenophile/src/native/xenophile.PanamaInvoke.scala
+++ b/lib/xenophile/src/native/xenophile.PanamaInvoke.scala
@@ -56,70 +56,14 @@ import vacuous.*
 // expects), a `string` argument (`Text`) is copied into a confined per-call `Arena`, and a
 // `pointer` argument (any other `T*`) travels as its raw address via `MemorySegment.ofAddress`.
 // A `string` result is read back out of native memory; a pointer result becomes an `Address`.
-object PanamaInvoke:
-  def invoke[result: Type](self: Expr[Foreign])(using quotes: Quotes): Expr[result] =
+object PanamaInvoke extends Materializer:
+  def materialize[result: Type](self: Expr[Foreign])(using quotes: Quotes): Expr[result] =
     import quotes.reflect.*
 
     // The receiver carries the source language (`Origin`) in its refined type; the C function it
-    // was reached through is recovered from the `Foreign.Expression` the navigation built —
-    // term-level stripping, as in `NativeInvoke`/`WasmInvoke`/`JsInvoke`.
+    // was reached through is peeled out of the navigation tree by the shared recovery in `core`.
     val (_, origin) = Xenophile.receiver(self)
-
-    def strip(term: Term): Term = term match
-      case Inlined(_, _, body)                        => strip(body)
-      case Typed(expr, _)                             => strip(expr)
-      case Block(Nil, expr)                           => strip(expr)
-      case TypeApply(Select(expr, "asInstanceOf"), _) => strip(expr)
-      case _                                          => term
-
-    def stringOf(term: Term): Text = strip(term).absolve match
-      case Literal(StringConstant(string)) => string.tt
-
-    def literal(term: Term): Text = strip(term).absolve match
-      case Apply(Ident("tt"), List(argument)) => stringOf(argument)
-      case other                              => stringOf(other)
-
-    def notCall: Nothing =
-      halt(m"xenophile: `invoke` expects a foreign function invocation, `interface.function()`")
-
-    val expression = strip(self.asTerm.underlyingArgument).absolve match
-      case Apply(Select(_, "make"), List(argument)) => strip(argument)
-      case _                                        => notCall
-
-    def argumentList(term: Term): List[Term] = strip(term) match
-      case Apply(_, List(varargs)) => strip(varargs).absolve match
-        case Repeated(elements, _) => elements.map(strip)
-        case _                     => Nil
-
-      case _ =>
-        Nil
-
-    val (selectNode, argumentTerms) = expression match
-      case Apply(Select(_, "apply"), List(node, args)) => (strip(node), argumentList(args))
-      case _                                           => (expression, Nil)
-
-    val (owner, function) = selectNode.absolve match
-      case Apply(Select(_, "apply"), List(_, member, owner)) => (literal(owner), literal(member))
-      case _                                                 => notCall
-
-    // The Scala value wrapped by the `Foreign.converter` `Conversion` in an argument operand,
-    // recovered by traversal, as in `NativeInvoke`.
-    def convertedValue(term: Term): Term =
-      var found: Optional[Term] = Unset
-
-      val traverser = new TreeTraverser:
-        override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match
-          case Apply(Select(qualifier, "apply"), List(value))
-          if qualifier.tpe <:< TypeRepr.of[Conversion[Nothing, Foreign]] =>
-            if found.absent then found = value
-
-          case _ =>
-            traverseTreeChildren(tree)(owner)
-
-      traverser.traverseTree(term)(Symbol.spliceOwner)
-
-      found.or:
-        halt(m"xenophile: a foreign argument must be a Scala value with an `Interoperable`")
+    val (owner, function, _, argumentTerms) = Xenophile.navigation(self)
 
     // Validate the call against the parsed C header and read its parameter and result types.
     val allDefinitions = Xenophile.definitions(origin, Xenophile.locusOf(origin))
@@ -168,8 +112,8 @@ object PanamaInvoke:
     // is copied into `arena` (absent unless some parameter needs it); any other pointer travels
     // as a zero-length segment of its raw address.
     def marshalled(arena: Optional[Expr[Arena]]): List[Expr[AnyRef]] =
-      argumentTerms.zip(parameterTypes).map: (term, paramType) =>
-        val value = convertedValue(term).asExpr
+      argumentTerms.to(List).zip(parameterTypes).map: (term, paramType) =>
+        val value = Xenophile.convertedValue(term).asExpr
 
         paramType match
           case Foreign.Type.Named(t"string") =>

--- a/lib/xenophile/src/scalanative/soundness_xenophile_scalanative.scala
+++ b/lib/xenophile/src/scalanative/soundness_xenophile_scalanative.scala
@@ -32,10 +32,9 @@
                                                                                                   */
 package soundness
 
-// `invoke` materializes a fully-applied C `Foreign` navigation into a real Scala Native call,
-// resolving the symbol with `dlsym` and invoking it through a `CFuncPtr`. Must be applied
-// directly to an inline navigation chain — e.g. `Foreign["library", Native].random().invoke[Int]`
-// — not to a value bound to a `val`. It is the Scala Native analogue of `PanamaInvoke` (the JVM
-// Panama materializer); the two lower the identical navigation for different platforms and are
-// never on the same application's classpath.
-export xenophile.{NativeInvoke, invoke}
+// `NativeInvoke` is the C ecosystem's Scala Native backend: it lowers a fully-applied C `Foreign`
+// navigation into a real Scala Native call, resolving the symbol with `dlsym` and invoking it
+// through a `CFuncPtr`, for the single `invoke` in `xenophile.core`. It is the analogue of the
+// `native` module's `PanamaInvoke` — the two lower the identical navigation for different
+// platforms, and a build gets whichever of the two modules it depends on.
+export xenophile.NativeInvoke

--- a/lib/xenophile/src/scalanative/xenophile.NativeInvoke.scala
+++ b/lib/xenophile/src/scalanative/xenophile.NativeInvoke.scala
@@ -58,8 +58,8 @@ import vacuous.*
 // argument, recovered from the `Foreign.converter` `Conversion` the navigation applied, is passed
 // to a `CFuncPtr` of the matching arity, with `Text` arguments marshalled to a `CString` in a
 // `Zone` and a `Text` result read back with `fromCString`. General pointers/structs are next.
-object NativeInvoke:
-  def invoke[result: Type](self: Expr[Foreign])(using quotes: Quotes): Expr[result] =
+object NativeInvoke extends Materializer:
+  def materialize[result: Type](self: Expr[Foreign])(using quotes: Quotes): Expr[result] =
     import quotes.reflect.*
 
     // The native runtime entry points, resolved from the downstream `nativelib`/`posixlib` so this
@@ -79,69 +79,7 @@ object NativeInvoke:
     // was reached through is recovered from the `Foreign.Expression` the navigation built.
     val (_, origin) = Xenophile.receiver(self)
 
-    // The navigation expands to `Foreign.make(<AST>).asInstanceOf[…]`, nested in `Inlined`/`Typed`
-    // layers `underlyingArgument` cannot fold away; recover the AST by term-level stripping, as in
-    // `WasmInvoke`/`JsInvoke`.
-    def strip(term: Term): Term = term match
-      case Inlined(_, _, body)                        => strip(body)
-      case Typed(expr, _)                             => strip(expr)
-      case Block(Nil, expr)                           => strip(expr)
-      case TypeApply(Select(expr, "asInstanceOf"), _) => strip(expr)
-      case _                                          => term
-
-    def stringOf(term: Term): Text = strip(term).absolve match
-      case Literal(StringConstant(string)) => string.tt
-
-    def literal(term: Term): Text = strip(term).absolve match
-      case Apply(Ident("tt"), sci.List(argument)) => stringOf(argument)
-      case other                              => stringOf(other)
-
-    def notCall: Nothing =
-      halt(m"xenophile: `invoke` expects a foreign function invocation, `interface.function()`")
-
-    // Peel to `Foreign.make(<AST>)`; take its argument — the navigation expression AST.
-    val expression = strip(self.asTerm.underlyingArgument).absolve match
-      case Apply(Select(_, "make"), sci.List(argument)) => strip(argument)
-      case _                                        => notCall
-
-    // The argument operands the navigation applied (`Expression.Apply`'s argument list); an empty
-    // list for the bare selection of a zero-parameter function (`Expression.Select`, preferred
-    // inside `inline` definitions).
-    def argumentList(term: Term): List[Term] = strip(term) match
-      case Apply(_, sci.List(varargs)) => strip(varargs).absolve match
-        case Repeated(elements, _) => elements.map(strip)
-        case _                     => Nil
-
-      case _ =>
-        Nil
-
-    val (selectNode, argumentTerms) = expression match
-      case Apply(Select(_, "apply"), sci.List(node, args)) => (strip(node), argumentList(args))
-      case _                                           => (expression, Nil)
-
-    val (owner, function) = selectNode.absolve match
-      case Apply(Select(_, "apply"), List(_, member, owner)) => (literal(owner), literal(member))
-      case _                                                 => notCall
-
-    // The Scala value wrapped by the `Foreign.converter` `Conversion` in an argument operand — the
-    // argument of the conversion's `apply` (`argTree` emits `arg.expr`, where `arg` is that
-    // converted value). Recovered by traversal, as in `WasmInvoke`.
-    def convertedValue(term: Term): Term =
-      var found: Optional[Term] = Unset
-
-      val traverser = new TreeTraverser:
-        override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match
-          case Apply(Select(qualifier, "apply"), List(value))
-          if qualifier.tpe <:< TypeRepr.of[Conversion[Nothing, Foreign]] =>
-            if found.absent then found = value
-
-          case _ =>
-            traverseTreeChildren(tree)(owner)
-
-      traverser.traverseTree(term)(Symbol.spliceOwner)
-
-      found.or:
-        halt(m"xenophile: a foreign argument must be a Scala value with an `Interoperable`")
+    val (owner, function, _, argumentTerms) = Xenophile.navigation(self)
 
     // Validate the call against the parsed C header and read its parameter and result types.
     val allDefinitions = Xenophile.definitions(origin, Xenophile.locusOf(origin))
@@ -255,9 +193,9 @@ object NativeInvoke:
     // `fromRawPtr(castLongToRawPtr(_))`. A `string` result is read back with `fromCString`, and a
     // pointer result lowered to its raw address with `castRawPtrToLong(toRawPtr(_))`.
     def invocation(zone: Optional[Term]): Term =
-      val callArgs = argumentTerms.zip(paramInfo).map: (term, info) =>
+      val callArgs = argumentTerms.to(List).zip(paramInfo).map: (term, info) =>
         val (tpe, kind) = info
-        val value = convertedValue(term)
+        val value = Xenophile.convertedValue(term)
 
         kind match
           case Kind.Str =>

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -64,8 +64,6 @@ given webIdlDom: WebIdlDomSource = Interface[WebIdlDom](cp"/xenophile/dom.idl")
 object Tests extends Suite(m"Xenophile tests"):
   def run(): Unit =
     suite(m"Kotlin ecosystem"):
-      import kotlinInvocation.invoke
-
       test(m"a top-level Kotlin function call materializes as a direct JVM call"):
         Foreign["kotlin.internal.ProgressionUtilKt", Kotlin]
         . getProgressionLastElement(1, 10, 2)
@@ -475,6 +473,14 @@ object Tests extends Suite(m"Xenophile tests"):
         val text = arena.allocateFrom("hello, world").nn
         libc.handle(t"strlen").invokeWithArguments(text).nn.asInstanceOf[Long]
       . assert(_ == 12L)
+
+      // The bare `invoke`, on a module that also depends on the Wasm, JS, Kotlin and Scala Native
+      // backends: it resolves to Panama because the `Native` ecosystem names both C backends and
+      // only `PanamaInvoke` is on this classpath. Before the backends shared one `invoke`, this
+      // could not be written here at all.
+      test(m"FFM: `invoke` materializes a C call as a Panama downcall"):
+        library.abs(-5).invoke[Int]
+      . assert(_ == 5)
 
       test(m"a C struct field has the field's foreign type"):
         val point: Foreign of "Point" from Native = Foreign["Point", Native]

--- a/lib/xenophile/src/typescript/xenophile.Typescript.scala
+++ b/lib/xenophile/src/typescript/xenophile.Typescript.scala
@@ -76,3 +76,4 @@ object Typescript:
 
 trait Typescript extends Ecosystem:
   type Grammar = TypescriptDialect.type
+  type Emission = "xenophile.JsInvoke"

--- a/lib/xenophile/src/wasm/soundness_xenophile_wasm.scala
+++ b/lib/xenophile/src/wasm/soundness_xenophile_wasm.scala
@@ -34,17 +34,6 @@ package soundness
 
 export xenophile.{Wasm, WasmInvoke, WitCase, WitError, WitHandle, WitVariant}
 
-// Materializes a fully-applied WIT `Foreign` invocation into a real Wasm Component Model import
-// call. Must be applied directly to an inline navigation chain — e.g.
-// `Foreign["random", Wit].\`get-random-u64\`().invoke[U64]` — not to a value bound to a `val`.
-// Plain `inline` (not `transparent`): the return type is fully determined by the type argument,
-// and non-transparency defers the macro when `invoke` appears inside another `inline` definition,
-// so a library can publish an inline given whose import call only materializes at the downstream
-// (Wasm-linked) call site — where `scala.scalajs.wit.witImportCall` is on the classpath.
-extension (foreign: xenophile.Foreign)
-  inline def invoke[result]: result =
-    ${xenophile.WasmInvoke.invoke[result]('foreign)}
-
 // Releases a WIT resource handle, emitting its `[resource-drop]` Component Model import. Like
 // `invoke`, plain `inline` so the import materializes at the downstream (Wasm-linked) call site.
 extension (handle: xenophile.WitHandle)

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -53,85 +53,15 @@ import vacuous.*
 // scala-wasm compiler). Unlike querencia's runtime `Javascript.serialize`, this runs at compile
 // time, so it is a macro that deconstructs the inline navigation (the `invoke` extension in the
 // module's package object must be applied directly to an inline chain — not to a `val`).
-object WasmInvoke:
-  def invoke[result: Type](self: Expr[Foreign])(using quotes: Quotes): Expr[result] =
+object WasmInvoke extends Materializer:
+  def materialize[result: Type](self: Expr[Foreign])(using quotes: Quotes): Expr[result] =
     import quotes.reflect.*
 
     // The receiver carries the source language (`Origin`) in its refined type; the WIT function it
     // was reached through is recovered from the `Foreign.Expression` the navigation built.
     val (_, origin) = Xenophile.receiver(self)
 
-    // The navigation expands to `Foreign.make(<AST>).asInstanceOf[…]`, and reaching this macro
-    // through further `inline` definitions (e.g. an inline given publishing a deferred import)
-    // nests it in `Inlined`/`Typed` layers that `underlyingArgument` cannot fold away. So the AST
-    // is recovered by term-level stripping, as in `JsInvoke`, rather than quote-pattern matching.
-    def strip(term: Term): Term = term match
-      case Inlined(_, _, body)                        => strip(body)
-      case Typed(expr, _)                             => strip(expr)
-      case Block(Nil, expr)                           => strip(expr)
-      case TypeApply(Select(expr, "asInstanceOf"), _) => strip(expr)
-      case _                                          => term
-
-    // `.tt` desugars to `tt("…")`; recover the string from the operand (or a bare string literal).
-    def stringOf(term: Term): Text = strip(term).absolve match
-      case Literal(StringConstant(string)) => string.tt
-
-    def literal(term: Term): Text = strip(term).absolve match
-      case Apply(Ident("tt"), sci.List(argument)) => stringOf(argument)
-
-    def notCall: Nothing =
-      halt(m"xenophile: `invoke` expects a foreign function invocation, `interface.function(args)`")
-
-    val expression = strip(self.asTerm.underlyingArgument).absolve match
-      case Apply(Select(_, "make"), sci.List(argument)) => strip(argument)
-      case _                                        => notCall
-
-    // The elements of the `Expr.ofList`-built argument list of an `Expression.Apply`.
-    def argumentList(term: Term): sci.List[Term] = strip(term) match
-      case Apply(_, sci.List(varargs)) => strip(varargs) match
-        case Repeated(elements, _) => elements.map(strip)
-        case _                     => sci.Nil
-
-      case _ =>
-        sci.Nil
-
-    // The Scala value wrapped by the `Foreign.converter` `Conversion` in a navigation operand (a
-    // converted argument, or a `WitHandle` receiver): the argument of the conversion's `apply`.
-    def convertedValue(term: Term): Term =
-      var found: Optional[Term] = Unset
-
-      val traverser = new TreeTraverser:
-        override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match
-          case Apply(Select(qualifier, "apply"), sci.List(value))
-          if qualifier.tpe <:< TypeRepr.of[Conversion[Nothing, Foreign]] =>
-            if found.absent then found = value
-
-          case _ =>
-            traverseTreeChildren(tree)(owner)
-
-      traverser.traverseTree(term)(Symbol.spliceOwner)
-
-      found.or:
-        halt(m"xenophile: a foreign operand must be a Scala value with an `Interoperable` instance")
-
-    // Either an applied call — `Expression.Apply(select, args)`, whose companion `apply` takes two
-    // arguments — or the bare selection of a zero-parameter WIT function (`Expression.Select`,
-    // whose companion `apply` takes three): `interface.function.invoke[R]`. The latter is
-    // preferred inside `inline` definitions, where re-inlining an empty-varargs application trips
-    // path-dependent type avoidance.
-    val (selectNode, argumentTerms) = expression match
-      case Apply(Select(_, "apply"), sci.List(node, arguments)) =>
-        (strip(node), argumentList(arguments))
-
-      case _ =>
-        (expression, sci.Nil)
-
-    val (receiverNode, owner, function) = selectNode.absolve match
-      case Apply(Select(_, "apply"), sci.List(receiver, member, owner)) =>
-        (strip(receiver), literal(owner), literal(member))
-
-      case _ =>
-        notCall
+    val (owner, function, receiverNode, argumentTerms) = Xenophile.navigation(self)
 
     // Look up the function's module id (e.g. `wasi:random/random@0.2.0`) from the definitions.
     val allDefinitions = Xenophile.definitions(origin, Xenophile.locusOf(origin))
@@ -745,8 +675,9 @@ object WasmInvoke:
             (carrier, encoded)
 
     val argumentPairs: List[Term] =
-      argumentTerms.zip(parameterTypes).flatMap: (argument, parameter) =>
-        val (carrierRepr, encoded) = encodedArgument(convertedValue(argument), parameter)
+      argumentTerms.to(sci.List).zip(parameterTypes).flatMap: (argument, parameter) =>
+        val (carrierRepr, encoded) =
+          encodedArgument(Xenophile.convertedValue(argument), parameter)
 
         val slot =
           Apply

--- a/lib/xenophile/src/webidl/xenophile.WebIdl.scala
+++ b/lib/xenophile/src/webidl/xenophile.WebIdl.scala
@@ -93,3 +93,4 @@ object WebIdl:
 
 trait WebIdl extends Ecosystem:
   type Grammar = WebIdlDialect.type
+  type Emission = "xenophile.JsInvoke"

--- a/lib/xenophile/src/wit/xenophile.Wit.scala
+++ b/lib/xenophile/src/wit/xenophile.Wit.scala
@@ -85,3 +85,4 @@ object Wit:
 
 trait Wit extends Ecosystem:
   type Grammar = WitDialect.type
+  type Emission = "xenophile.WasmInvoke"


### PR DESCRIPTION
Xenophile's five foreign-call backends each published their own top-level `invoke` extension method, so a wildcard `import soundness.*` resolved the name by classpath order and silently dropped the rest — the Kotlin backend had to be quarantined in a `kotlinInvocation` object to be reachable at all, every WASI backend pinned the one it wanted with a named import, and the xenophile test module could not depend on the JS and Scala Native backends. `invoke` now lives once in `xenophile.core`, which also owns the navigation-peeling step the five macros had each copied verbatim; a backend implements the new `Materializer` interface and an ecosystem names the backends that serve it, so the build chooses which one materializes a call by which module it depends on.

## Release notes

`invoke` is now a single extension method exported from `xenophile.core`, rather than one per backend. Existing code is unaffected — the same call sites compile to the same downcall, import, or dynamic call as before:

```scala
Foreign["random", Wit].`get-random-u64`().invoke[U64]
Foreign["library", Native].abs(-5).invoke[Int]
```

Three things change for users:

- **`kotlinInvocation` is gone.** Kotlin navigations use the ordinary `invoke`:

  ```scala
  // before
  import kotlinInvocation.invoke
  Foreign["kotlin.internal.ProgressionUtilKt", Kotlin].getProgressionLastElement(1, 10, 2).invoke[Int]

  // after
  Foreign["kotlin.internal.ProgressionUtilKt", Kotlin].getProgressionLastElement(1, 10, 2).invoke[Int]
  ```

- **`import soundness.invoke` is no longer needed** to disambiguate; a plain `import soundness.*` reaches the single definition. The named import still compiles.

- **A missing backend now says so.** Calling `invoke` for an ecosystem whose materializer is not on the classpath reports *"no materializer for this foreign source language is on the classpath"* instead of failing to find `invoke`.

A custom `Ecosystem` must now name its backend in an `Emission` member, as a fully-qualified class name:

```scala
trait Wit extends Ecosystem:
  type Grammar = WitDialect.type
  type Emission = "xenophile.WasmInvoke"
```

The C ecosystem names both of its backends, `"xenophile.PanamaInvoke" | "xenophile.NativeInvoke"`, and `core` loads whichever the build put on the classpath. That is what lets one source compile to a Panama downcall on the JVM and a `CFuncPtr` call on Scala Native purely by swapping `xenophile.native` for `xenophile.scalanative`, as `enigmatic.openssl` does.
