### PR TITLE
Compile against Proscala 3.9.0-RC4-p9: Spreadable instances, direct Duct attachment, capture-checking fixes

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -71,8 +71,8 @@ object settings:
   // (`SOUNDNESS_SCALA_RELEASE`) is a separate concept, though from `3.9.0-RC4-p1` on the two
   // coincide (earlier releases shipped jars built as e.g. `3.9.0-RC1-propensive`). Override the
   // coordinate with `SOUNDNESS_SCALA_VERSION`.
-  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC4-p8")
-  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC4-p8")
+  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC4-p9")
+  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC4-p9")
   // Empty by default → download `scalaRelease`. Set to a local `release` directory to use its
   // `release/lib` jars directly (fork-developer mode).
   val scalaHome = sys.env.getOrElse("SOUNDNESS_SCALA_HOME", "")

--- a/lib/delicious/src/core/delicious.Markup.scala
+++ b/lib/delicious/src/core/delicious.Markup.scala
@@ -137,10 +137,17 @@ object Markup:
 
       else if char == End then
         stack match
-          case top :: (rest @ (parent :: _)) =>
+          // Do not destructure the parent here (`case top :: (parent :: _)`):
+          // that binds two `Frame^`s drawn from the same stack, and the
+          // separation checker cannot prove them distinct. Finish with `top`,
+          // then reach the parent through `rest.head`, so only one frame is
+          // ever live. Were the two to alias, the old shape mutated a frame
+          // while reading it.
+          case top :: rest if rest.nonEmpty =>
             top.flush()
-            parent.children += typed(top.kind, top.attrs, top.children.to(List))
+            val node = typed(top.kind, top.attrs, top.children.to(List))
             stack = rest
+            rest.head.children += node
 
           case _ => // stray End at top level
 
@@ -155,10 +162,16 @@ object Markup:
     // splice the children of any unterminated markers into their parents
     while stack.tail.nonEmpty do
       stack match
-        case top :: (parent :: _) =>
+        // As above: one frame live at a time, parent reached via `rest.head`.
+        case top :: rest if rest.nonEmpty =>
           top.flush()
-          parent.children ++= top.children
-          stack = stack.tail
+          // `toList` copies into a fresh immutable list sharing nothing with the
+          // buffer, so the inferred `^{top.children}` is spurious; laundering it
+          // lets the orphans outlive `top`. Splicing them into the parent while
+          // they still captured `top.children` is what the checker refused.
+          val orphans = scala.caps.unsafe.unsafeAssumePure(top.children.toList)
+          stack = rest
+          rest.head.children ++= orphans
 
         case _ => ()
 

--- a/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
+++ b/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
@@ -132,10 +132,7 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
     Cloak.cleaner.register(this, { () => segment.fill(0.toByte); owned.close() })
 
   // Lends the key as a transient heap array, zeroed as soon as the operation completes.
-  // `result` is bounded by `Any^`, not left unbounded: the block returns a freshly
-  // allocated cipher buffer, whose capture set is a fresh root capability, and an
-  // unbounded type variable cannot be instantiated to a type that captures one.
-  private def withKey[result <: Any^](block: scala.Array[Byte] => result): result =
+  private def withKey[result](block: scala.Array[Byte] => result): result =
     val keyBytes = reload(keySegment, 32)
     try block(keyBytes) finally ju.Arrays.fill(keyBytes, 0.toByte)
 
@@ -144,7 +141,7 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
     random.nextBytes(nonce)
 
     val ciphertext = withKey: keyBytes =>
-      aes[scala.Array[Byte]](keyBytes, jc.Cipher.ENCRYPT_MODE, nonce)(_.doFinal(bytes).nn)
+      aes[scala.Array[Byte]^{}](keyBytes, jc.Cipher.ENCRYPT_MODE, nonce)(_.doFinal(bytes).nn)
 
     ju.Arrays.fill(bytes, 0.toByte)
 
@@ -154,7 +151,7 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
       new Secret:
         def uncloak[result](block: scala.Array[Byte] => result): result =
           val cleartext = withKey: keyBytes =>
-            aes[scala.Array[Byte]](keyBytes, jc.Cipher.DECRYPT_MODE, nonce)(_.doFinal(ciphertext).nn)
+            aes[scala.Array[Byte]^{}](keyBytes, jc.Cipher.DECRYPT_MODE, nonce)(_.doFinal(ciphertext).nn)
 
           try block(cleartext) finally ju.Arrays.fill(cleartext, 0.toByte)
 

--- a/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
+++ b/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
@@ -141,7 +141,7 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
     random.nextBytes(nonce)
 
     val ciphertext = withKey: keyBytes =>
-      aes[scala.Array[Byte]^{}](keyBytes, jc.Cipher.ENCRYPT_MODE, nonce)(_.doFinal(bytes).nn)
+      aes[scala.Array[Byte]](keyBytes, jc.Cipher.ENCRYPT_MODE, nonce)(_.doFinal(bytes).nn)
 
     ju.Arrays.fill(bytes, 0.toByte)
 
@@ -151,7 +151,7 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
       new Secret:
         def uncloak[result](block: scala.Array[Byte] => result): result =
           val cleartext = withKey: keyBytes =>
-            aes[scala.Array[Byte]^{}](keyBytes, jc.Cipher.DECRYPT_MODE, nonce)(_.doFinal(ciphertext).nn)
+            aes[scala.Array[Byte]](keyBytes, jc.Cipher.DECRYPT_MODE, nonce)(_.doFinal(ciphertext).nn)
 
           try block(cleartext) finally ju.Arrays.fill(cleartext, 0.toByte)
 

--- a/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
+++ b/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
@@ -132,7 +132,10 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
     Cloak.cleaner.register(this, { () => segment.fill(0.toByte); owned.close() })
 
   // Lends the key as a transient heap array, zeroed as soon as the operation completes.
-  private def withKey[result](block: scala.Array[Byte] => result): result =
+  // `result` is bounded by `Any^`, not left unbounded: the block returns a freshly
+  // allocated cipher buffer, whose capture set is a fresh root capability, and an
+  // unbounded type variable cannot be instantiated to a type that captures one.
+  private def withKey[result <: Any^](block: scala.Array[Byte] => result): result =
     val keyBytes = reload(keySegment, 32)
     try block(keyBytes) finally ju.Arrays.fill(keyBytes, 0.toByte)
 
@@ -141,7 +144,7 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
     random.nextBytes(nonce)
 
     val ciphertext = withKey: keyBytes =>
-      aes[scala.Array[Byte]^{}](keyBytes, jc.Cipher.ENCRYPT_MODE, nonce)(_.doFinal(bytes).nn)
+      aes[scala.Array[Byte]](keyBytes, jc.Cipher.ENCRYPT_MODE, nonce)(_.doFinal(bytes).nn)
 
     ju.Arrays.fill(bytes, 0.toByte)
 
@@ -151,7 +154,7 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
       new Secret:
         def uncloak[result](block: scala.Array[Byte] => result): result =
           val cleartext = withKey: keyBytes =>
-            aes[scala.Array[Byte]^{}](keyBytes, jc.Cipher.DECRYPT_MODE, nonce)(_.doFinal(ciphertext).nn)
+            aes[scala.Array[Byte]](keyBytes, jc.Cipher.DECRYPT_MODE, nonce)(_.doFinal(ciphertext).nn)
 
           try block(cleartext) finally ju.Arrays.fill(cleartext, 0.toByte)
 

--- a/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
+++ b/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
@@ -141,7 +141,7 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
     random.nextBytes(nonce)
 
     val ciphertext = withKey: keyBytes =>
-      aes[scala.Array[Byte]](keyBytes, jc.Cipher.ENCRYPT_MODE, nonce)(_.doFinal(bytes).nn)
+      aes[scala.Array[Byte]^{}](keyBytes, jc.Cipher.ENCRYPT_MODE, nonce)(_.doFinal(bytes).nn)
 
     ju.Arrays.fill(bytes, 0.toByte)
 
@@ -151,7 +151,7 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
       new Secret:
         def uncloak[result](block: scala.Array[Byte] => result): result =
           val cleartext = withKey: keyBytes =>
-            aes[scala.Array[Byte]](keyBytes, jc.Cipher.DECRYPT_MODE, nonce)(_.doFinal(ciphertext).nn)
+            aes[scala.Array[Byte]^{}](keyBytes, jc.Cipher.DECRYPT_MODE, nonce)(_.doFinal(ciphertext).nn)
 
           try block(cleartext) finally ju.Arrays.fill(cleartext, 0.toByte)
 

--- a/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
@@ -106,7 +106,7 @@ extends Cipher, Encryption, Symmetric:
     val session = cipher.stream(transformation, key, iv)
     val finalise: Int => Unit = total => padding.verify(total, blockSize, mode.blockAligned)
 
-    stream.via(CipherDuct(session, iv, finalise)).asInstanceOf[(Stream[Data] over Credit)^]
+    stream.viaDuct(CipherDuct(session, iv, finalise)).asInstanceOf[(Stream[Data] over Credit)^]
 
   // Kernel-native streaming decryption. The leading IV block (for modes that
   // use one) is consumed off the stream before the session begins. NOTE: an
@@ -132,7 +132,7 @@ extends Cipher, Encryption, Symmetric:
     // The duct retains the ambient tactic, which the `consume` formal cannot see is not an
     // aliased writer.
     scala.caps.unsafe.unsafeAssumeSeparate:
-      stream.via(DecipherDuct(start, ivSize, tactic)).asInstanceOf[(Stream[Data] over Credit)^]
+      stream.viaDuct(DecipherDuct(start, ivSize, tactic)).asInstanceOf[(Stream[Data] over Credit)^]
 
   def decrypt(bytes: Data, key: Data): Data =
     val ivSize: Optional[Int] = if mode.usesIv then cipher.blockSize(transformation) else Unset

--- a/lib/enigmatic/src/core/enigmatic.Pem.scala
+++ b/lib/enigmatic/src/core/enigmatic.Pem.scala
@@ -144,7 +144,11 @@ object Pem:
               mitigate:
                 case SerializationError(_, _) => PemError(PemError.Reason.BadBase64)
 
-              . protect(body.toString.tt.deserialize[Base64])
+              // `[Data]` stated, not inferred: the conformance check on a macro expansion
+              // dealiases opaque types, and `Data` is a transparent alias over an opaque one.
+              // Inferred, the two sides of the check were spelled differently — `Data` against
+              // its own dealiasing, `scala.Array[Byte]` — and did not match.
+              . protect[Data](body.toString.tt.deserialize[Base64])
 
           case _ =>
             body.append(line.s)

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -580,13 +580,13 @@ extends caps.ExclusiveCapability:
 
     steps match
       case Filter.Step.Inflate :: rest =>
-        pipeline(rest, stream.via(pneumatic.Zlib.compression.decompressor()))
+        pipeline(rest, stream.viaDuct(pneumatic.Zlib.compression.decompressor()))
 
       case Filter.Step.Unlzw(earlyChange) :: rest =>
-        pipeline(rest, stream.via(pneumatic.Lzw.decompressor(earlyChange)))
+        pipeline(rest, stream.viaDuct(pneumatic.Lzw.decompressor(earlyChange)))
 
       case Filter.Step.Gather(transform) :: rest =>
-        pipeline(rest, stream.via(Gathering(transform)))
+        pipeline(rest, stream.viaDuct(Gathering(transform)))
 
       case _ =>
         stream

--- a/lib/gastronomy/src/core/gastronomy.Blake3.scala
+++ b/lib/gastronomy/src/core/gastronomy.Blake3.scala
@@ -160,11 +160,16 @@ object Blake3:
       val blockLen:           Int,
       val flags:              Int ):
 
-    def chainingValue(): scala.Array[Int] =
+    // Freshly allocated and copied into, so no writer can alias it: `^{}` is the
+    // whole story, which is what lets the hasher's stack own these values.
+    def chainingValue(): scala.Array[Int]^{} =
       val out = compress(inputChainingValue, blockWords, counter, blockLen, flags)
       val cv = new scala.Array[Int](8)
       System.arraycopy(out, 0, cv, 0, 8)
-      cv
+      // `cv` is allocated three lines above and never escapes, so no writer can
+      // alias it; capture checking cannot see that through `arraycopy`, so the
+      // freshness is asserted here, exactly as proscenium's `Array.of` does.
+      scala.caps.unsafe.unsafeAssumePure(cv)
 
     def rootOutputBytes(outLen: Int): Array[Byte]^{} =
       val result = Array[Byte](outLen)
@@ -200,7 +205,7 @@ object Blake3:
 
   private def parentCv
     ( leftCv: scala.Array[Int], rightCv: scala.Array[Int], keyWords: scala.Array[Int], flags: Int )
-  :   scala.Array[Int] =
+  :   scala.Array[Int]^{} =
 
     parentOutput(leftCv, rightCv, keyWords, flags).chainingValue()
 
@@ -256,18 +261,18 @@ object Blake3:
   private final class Hasher(keyWordsInit: scala.Array[Int], val flags: Int) extends caps.Mutable:
     private val keyWords: scala.Array[Int] = keyWordsInit.clone()
     private var chunkState: ChunkState^ = ChunkState(keyWords, 0L, flags)
-    private var cvStack: scala.Array[scala.Array[Int]]^ = new scala.Array[scala.Array[Int]](54)
+    private var cvStack: scala.Array[scala.Array[Int]^{}]^ = new scala.Array[scala.Array[Int]^{}](54)
     private var cvStackLen: Int = 0
 
-    private update def pushStack(cv: scala.Array[Int]): Unit =
+    private update def pushStack(cv: scala.Array[Int]^{}): Unit =
       cvStack(cvStackLen) = cv
       cvStackLen += 1
 
-    private update def popStack(): scala.Array[Int] =
+    private update def popStack(): scala.Array[Int]^{} =
       cvStackLen -= 1
       cvStack(cvStackLen)
 
-    private update def addChunkCv(initialCv: scala.Array[Int], initialTotal: Long): Unit =
+    private update def addChunkCv(initialCv: scala.Array[Int]^{}, initialTotal: Long): Unit =
       var cv = initialCv
       var totalChunks = initialTotal
 

--- a/lib/monotonous/src/core/monotonous.Alphabet.scala
+++ b/lib/monotonous/src/core/monotonous.Alphabet.scala
@@ -57,7 +57,7 @@ object Alphabet:
     31 - Integer.numberOfLeadingZeros(alphabet.chars.s.length)
 
   given serialization: [encoding <: Serialization]
-  =>  Ductile.Of[Alphabet[encoding], Data, Text, Credit, Credit] =
+  =>  Ductile.Instance[Alphabet[encoding], Data, Text, Credit, Credit] =
 
     // Sealed: a Ductile is a stateless stage descriptor; instantiation freshens its
     // type arguments under capture checking, which the seal discards.
@@ -177,7 +177,7 @@ object Alphabet:
             produced
 
   given deserialization: [encoding <: Serialization] => (tactic: Tactic[SerializationError])
-  =>  Ductile.Of[Alphabet[encoding], Text, Data, Credit, Credit] =
+  =>  Ductile.Instance[Alphabet[encoding], Text, Data, Credit, Credit] =
 
     // Sealed: see `serialization` above. The tactic is sealed here too — the duct
     // raises through the given's resolution-scoped tactic, which shares the

--- a/lib/pneumatic/src/core/pneumatic.Compression.scala
+++ b/lib/pneumatic/src/core/pneumatic.Compression.scala
@@ -45,10 +45,10 @@ trait Compression:
   // format's duct, and materialize one output chunk per refill — no staging
   // buffer, and byte-for-byte agreement with the stream and whole-value forms.
   def compress(stream: Chain[Data]): Chain[Data] =
-    Stream(stream.iterator).via(compressor()).toProgression
+    Stream(stream.iterator).viaDuct(compressor()).toProgression
 
   def decompress(stream: Chain[Data]): Chain[Data] =
-    Stream(stream.iterator).via(decompressor()).toProgression
+    Stream(stream.iterator).viaDuct(decompressor()).toProgression
 
   // Streaming stages for the same transformations, applied with
   // `stream.compress[Gzip]`/`stream.decompress[Gzip]` on a pull endpoint.

--- a/lib/pneumatic/src/core/pneumatic.Lzw.scala
+++ b/lib/pneumatic/src/core/pneumatic.Lzw.scala
@@ -44,15 +44,15 @@ import zephyrine.*
 // codes one table entry sooner — is the TIFF/PDF default, and what every known encoder
 // produces; the parameterized factories serve formats which state it explicitly.
 object Lzw:
-  def compressor(earlyChange: Boolean)(using Buffering): Duct[Data, Data] {
+  def compressor(earlyChange: Boolean)(using Buffering): (Duct[Data, Data] {
     type Transport = Credit
-    type Upstream = Credit } =
+    type Upstream = Credit })^ =
 
     LzwStage(LzwEncoder(earlyChange))
 
-  def decompressor(earlyChange: Boolean)(using Buffering): Duct[Data, Data] {
+  def decompressor(earlyChange: Boolean)(using Buffering): (Duct[Data, Data] {
     type Transport = Credit
-    type Upstream = Credit } =
+    type Upstream = Credit })^ =
 
     LzwStage(LzwDecoder(earlyChange))
 
@@ -63,15 +63,15 @@ object Lzw:
     drive(LzwDecoder(earlyChange), stream)
 
   given compression: Lzw is Compression:
-    def compressor()(using Buffering): Duct[Data, Data] {
+    def compressor()(using Buffering): (Duct[Data, Data] {
       type Transport = Credit
-      type Upstream = Credit } =
+      type Upstream = Credit })^ =
 
       LzwStage(LzwEncoder(true))
 
-    def decompressor()(using Buffering): Duct[Data, Data] {
+    def decompressor()(using Buffering): (Duct[Data, Data] {
       type Transport = Credit
-      type Upstream = Credit } =
+      type Upstream = Credit })^ =
 
       LzwStage(LzwDecoder(true))
 

--- a/lib/pneumatic/src/core/pneumatic_core.scala
+++ b/lib/pneumatic/src/core/pneumatic_core.scala
@@ -62,13 +62,13 @@ extension (consume stream: (Stream[Data] over Credit)^)
   def compress[format <: Compressor](using compression: format is Compression, buffering: Buffering)
   :   (Stream[Data] over Credit)^ =
 
-    stream.via(compression.compressor()).asInstanceOf[(Stream[Data] over Credit)^]
+    stream.viaDuct(compression.compressor()).asInstanceOf[(Stream[Data] over Credit)^]
 
   def decompress[format <: Compressor]
     ( using compression: format is Compression, buffering: Buffering )
   :   (Stream[Data] over Credit)^ =
 
-    stream.via(compression.decompressor()).asInstanceOf[(Stream[Data] over Credit)^]
+    stream.viaDuct(compression.decompressor()).asInstanceOf[(Stream[Data] over Credit)^]
 
 extension (stream: Chain[Data])
   def compress[compression <: Compressor: Compression]: Chain[Data] =

--- a/lib/probably/src/coverage/probably.Coverage.scala
+++ b/lib/probably/src/coverage/probably.Coverage.scala
@@ -52,8 +52,13 @@ object Coverage:
 
     if !dirFile.exists() then Coverage(dir, Array.of(), Set(), Set())
     else
+      // `listFiles` hands back a mutable array, which captures the root capability.
+      // Wrapping it in an `Option` instantiates that type variable with a capturing
+      // type, which capture checking refuses; consume the array where it is produced
+      // and let only the immutable list escape.
+      val listed = dirFile.listFiles
       val otherFiles =
-        Option(dirFile.listFiles).map(_.nn).map(_.iterator.map(_.nn).toList).getOrElse(Nil.stdlib)
+        if listed == null then Nil.stdlib else listed.nn.iterator.map(_.nn).toList
 
       val measurementFiles = otherFiles.filter(_.getName.nn.startsWith("scoverage.measurements"))
 

--- a/lib/proscenium/src/core/proscenium.Array.scala
+++ b/lib/proscenium/src/core/proscenium.Array.scala
@@ -168,4 +168,9 @@ object Array:
     // surface, which exposes no write operations.
     inline def readable: scala.IArray[element] = array.asInstanceOf[scala.IArray[element]]
 
+  given arrayIsSpreadable: [element] => (Spreadable[Array[element]^{}] { type Out = scala.Array[element]^{} }) =
+    new Spreadable[Array[element]^{}]:
+      type Out = scala.Array[element]^{}
+      def spread(value: Array[element]^{}): scala.Array[element]^{} = value
+
 opaque type Array[element] = scala.Array[element]

--- a/lib/proscenium/src/core/proscenium.Chain.scala
+++ b/lib/proscenium/src/core/proscenium.Chain.scala
@@ -97,6 +97,11 @@ object Chain:
 // order, so the receiver is the HEAD; it rides on a given (a top-level name would clash with the
 // extractor object). The head is by-value (call sites hoist it), but the TAIL is by-name so the
 // stream stays lazy — `head #:: recur()` must not evaluate `recur()`.
+  given chainIsSpreadable: [element] => (Spreadable[Chain[element]] { type Out = sci.LazyList[element] }) =
+    new Spreadable[Chain[element]]:
+      type Out = sci.LazyList[element]
+      def spread(value: Chain[element]): sci.LazyList[element] = value
+
 given lazyCons: Object with
   extension [element](head: element)
     infix def #:: (tail: => Chain[element]): Chain[element] =

--- a/lib/proscenium/src/core/proscenium.List.scala
+++ b/lib/proscenium/src/core/proscenium.List.scala
@@ -85,6 +85,11 @@ val Nil: List[Nothing] = List.of(sci.Nil)
 // is the HEAD (the left operand). It cannot be a top-level extension (the name would clash
 // with the extractor object), so it rides on a given, whose extensions are candidates
 // wherever the given is visible — everywhere, via `-Yimports`.
+  given listIsSpreadable: [element] => (Spreadable[List[element]] { type Out = sci.List[element] }) =
+    new Spreadable[List[element]]:
+      type Out = sci.List[element]
+      def spread(value: List[element]): sci.List[element] = value
+
 given consConstructor: Object with
   extension [element](head: element)
     infix def :: (tail: List[element]): List[element] =

--- a/lib/proscenium/src/core/proscenium.Sequence.scala
+++ b/lib/proscenium/src/core/proscenium.Sequence.scala
@@ -67,4 +67,9 @@ object Sequence:
   extension [element](sequence: Sequence[element])
     inline def stdlib: sci.Vector[element] = sequence.asInstanceOf[sci.Vector[element]]
 
+  given sequenceIsSpreadable: [element] => (Spreadable[Sequence[element]] { type Out = sci.Vector[element] }) =
+    new Spreadable[Sequence[element]]:
+      type Out = sci.Vector[element]
+      def spread(value: Sequence[element]): sci.Vector[element] = value
+
 opaque type Sequence[+element] = sci.Vector[element]

--- a/lib/turbulence/src/core/turbulence.LineSeparation.scala
+++ b/lib/turbulence/src/core/turbulence.LineSeparation.scala
@@ -57,7 +57,7 @@ object LineSeparation:
   //
   // A separator-free input grows `partial` without bound — the inherent
   // exposure of any line reader; cap upstream if the input is adversarial.
-  given lines: Ductile.Of[LineSeparation, Text, Array[Text]^{}, Credit, Credit] =
+  given lines: Ductile.Instance[LineSeparation, Text, Array[Text]^{}, Credit, Credit] =
     new Ductile:
       type Self = LineSeparation
       type Operand = Text

--- a/lib/wisteria/src/core/wisteria.internal.scala
+++ b/lib/wisteria/src/core/wisteria.internal.scala
@@ -1040,4 +1040,9 @@ object internal:
           case Nil       => selection
           case arguments => selection.appliedToTypes(arguments)
 
-    . map(_.asExprOf[field]).getOrElse('{Unset})
+    // Ascribed, not bare: the macro's declared result is `Optional[field]`, and a bare
+    // `'{Unset}` expands with the singleton type `Unset.type`. The conformance check on a
+    // macro expansion dealiases opaque types on both sides, but only reaches them through a
+    // `TypeRef`; a singleton hides `Unset`'s underlying type, so the expansion no longer
+    // conformed to the dealiased `Optional[field]`.
+    . map(_.asExprOf[field]).getOrElse('{Unset: Optional[field]})

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -36,7 +36,8 @@ export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum,
     Duct, Ductile, Expanse, Malleable, Pace,
     Format, Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
     Records, records, Regulation, Spring, Stream, Substrate, chunks, discard, gather, locate,
-    locateKey, memoize, pump, stream, streamOf, sweep, toProgression, truncate}
+    locateKey, memoize, pump, stream, streamOf, sweep, toProgression, truncate,
+    viaDuct, acceptingDuct}
 
 // Hand-written forwarders: the synthesized export forwarders for these dependent-typed
 // extensions lose the `ductile.Result`/`ductile.Operand` path refinements under capture

--- a/lib/zephyrine/src/core/zephyrine.Duct.scala
+++ b/lib/zephyrine/src/core/zephyrine.Duct.scala
@@ -38,8 +38,8 @@ import prepositional.*
 import vacuous.*
 
 // A synchronous transformation stage, attachable to either end of a pipeline:
-// `stream.via(duct)` yields a differently-typed `Stream`, and
-// `intake.accepting(duct)` yields a differently-typed `Intake` — the same
+// `stream.viaDuct(duct)` yields a differently-typed `Stream`, and
+// `intake.acceptingDuct(duct)` yields a differently-typed `Intake` — the same
 // `Duct` instance serves both, since `translate` converts demand whichever
 // direction it is reported.
 //
@@ -75,7 +75,7 @@ object Duct:
   // backing directly when the medium exposes one, else one copy in) until the
   // input is consumed, output windows accumulate into the medium's builder,
   // and `flush` drains the duct's terminal state. This is the whole-value
-  // counterpart of `stream.via(duct)`: one transformation, two drivers.
+  // counterpart of `stream.viaDuct(duct)`: one transformation, two drivers.
   def feed[in, out](value: in, consume duct: (Duct[in, out])^)(using buffering: Buffering): out =
     val length = duct.input.length(value)
 

--- a/lib/zephyrine/src/core/zephyrine.Ductile.scala
+++ b/lib/zephyrine/src/core/zephyrine.Ductile.scala
@@ -48,45 +48,20 @@ import vacuous.*
 // `intake.accepting(stage)`. Instances are typed
 // `X is Ductile by In to Out over Transport`, with `Upstream` (the demand
 // type the stage presents to its upstream) as a further member, `Credit` in
-// almost all cases. A `Duct` is trivially its own descriptor, so raw ducts
-// compose with the same `through`/`accepting` calls.
+// almost all cases. A `Duct` is *not* a descriptor and has no instance here:
+// it is already the stage a descriptor would build, so it attaches directly
+// with `stream.viaDuct(duct)` or `intake.acceptingDuct(duct)`.
 object Ductile:
   // The fully-determined type of a `Ductile` instance for `stage`, naming all
   // five type members positionally.
-  type Of[stage, in, out, transport, upstream] =
+  type Instance[stage, in, out, transport, upstream] =
     (stage is Ductile by in to out over transport) { type Upstream = upstream }
-
-  given duct: [in, out, transport, upstream,
-        stage <: (Duct[in, out] { type Transport = transport; type Upstream = upstream })^]
-  =>  Of[stage, in, out, transport, upstream] =
-
-    // The identity instance: the cast bridges the capture-decorated inferred member types
-    // against the declared alias (bare `stage` under a stateful bound reads as `.rd`).
-    (new Ductile:
-      type Self = stage
-      type Operand = in
-      type Result = out
-      type Transport = transport
-      type Upstream = upstream
-
-      def duct(consume stage0: stage^)(using Buffering)
-      :   (Duct[in, out] { type Transport = transport; type Upstream = upstream })^ =
-
-        // consumed pass-through: ownership moves from caller to result (the admission
-        // gap for direct returns is bridged by the erasure cast)
-        stage0.asInstanceOf[(Duct[in, out] { type Transport = transport; type Upstream = upstream })^]
-    ).asInstanceOf[Ductile {
-      type Self = stage^{caps.any.rd}
-      type Operand = in
-      type Result = out
-      type Transport = transport
-      type Upstream = upstream }]
 
   // Character decoding as a pipeline stage. Bytes are staged internally (so
   // multi-byte characters split across refills are carried, and `step`
   // always consumes what it is offered), and malformed input is substituted
   // through the decoder's `TextSanitizer`, exactly as `CharDecoder.decoded`.
-  given charDecoder: Of[CharDecoder, Data, Text, Credit, Credit] =
+  given charDecoder: Instance[CharDecoder, Data, Text, Credit, Credit] =
     new Ductile:
       type Self = CharDecoder
       type Operand = Data
@@ -347,7 +322,7 @@ object Ductile:
   // Character encoding as a pipeline stage. Malformed input (a split
   // surrogate pair at end-of-stream) and unmappable characters are replaced,
   // mirroring the replacement semantics of `CharEncoder.encoded`.
-  given charEncoder: Of[CharEncoder, Text, Data, Credit, Credit] =
+  given charEncoder: Instance[CharEncoder, Text, Data, Credit, Credit] =
     new Ductile:
       type Self = CharEncoder
       type Operand = Text

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -125,6 +125,20 @@ extension [in, transport](consume stream: (Stream[in] over transport)^)
     throughDuct[in, ductile.Result, transport, ductile.Transport]
       (ductile.duct(stage), stream)
 
+  // Pull-composition with a duct directly. A `Duct` *is* a pipeline stage, not a
+  // description of one, so it needs no `Ductile` instance to be attached: the duct
+  // type already states its operand, result and both transports. Going through the
+  // typeclass instead would mean instantiating `Ductile` at the duct's own type,
+  // which capture checking cannot express — the identity instance's `Self` and the
+  // type argument `via` infers differ only in whether they are boxed.
+  def viaDuct[out, downTransport]
+    ( consume duct:
+        (Duct[in, out] { type Transport = downTransport; type Upstream = transport })^ )
+    ( using Buffering )
+  :   (Stream[out] over downTransport)^ =
+
+    throughDuct[in, out, transport, downTransport](duct, stream)
+
   // The pump loop connecting a pull-chain to a push-chain, on the calling
   // thread: poll the intake's demand, refill with it, transfer the window.
   // This is the only place data crosses from the pull side to the push side
@@ -161,8 +175,17 @@ extension [out, transport](consume intake: (Intake[out] over transport)^)
   :   (Intake[ductile.Operand] over ductile.Upstream)^ =
 
     // See `throughDuct` above.
-    acceptingDuct[ductile.Operand, out, ductile.Upstream, transport]
+    intakeThroughDuct[ductile.Operand, out, ductile.Upstream, transport]
       (ductile.duct(stage), intake)
+
+  // Push-composition with a duct directly; see `viaDuct` above.
+  def acceptingDuct[in, upTransport]
+    ( consume duct:
+        (Duct[in, out] { type Transport = transport; type Upstream = upTransport })^ )
+    ( using Buffering )
+  :   (Intake[in] over upTransport)^ =
+
+    intakeThroughDuct[in, out, upTransport, transport](duct, intake)
 
 
 // ─── terminal operations and explicit replay ───────────────────────────────────────────
@@ -613,7 +636,7 @@ private def discardStream[medium](consume stream: (Stream[medium] over Credit)^,
 
       override update def close(): Unit = stream.close()
 
-private def acceptingDuct[in, out, upTransport, downTransport]
+private def intakeThroughDuct[in, out, upTransport, downTransport]
   ( consume duct:
       (Duct[in, out] { type Transport = downTransport; type Upstream = upTransport })^,
     consume intake: (Intake[out] over downTransport)^ )

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -598,7 +598,7 @@ object Tests extends Suite(m"Zephyrine tests"):
 
         test(m"through doubles each byte"):
           val gather = Gather()
-          small.stream.via(Doubler()).pump(gather)
+          small.stream.viaDuct(Doubler()).pump(gather)
           scala.caps.unsafe.unsafeAssumeSeparate(gather.data).to[List]
         . assert(_ == (small.to[List]: List[Byte]).flatMap { byte => proscenium.List(byte, byte) })
 
@@ -606,19 +606,19 @@ object Tests extends Suite(m"Zephyrine tests"):
           val recorder = Recorder(small.stream)
           val gather = Gather()
           gather.credit = 10
-          scala.caps.unsafe.unsafeAssumeSeparate(recorder.via(Doubler()).pump(gather))
+          scala.caps.unsafe.unsafeAssumeSeparate(recorder.viaDuct(Doubler()).pump(gather))
           recorder.demands.last
         . assert(_ == 5L)
 
         test(m"accepting reports translated demand"):
           val gather = Gather()
           gather.credit = 10
-          gather.accepting(Doubler()).demand.count
+          gather.acceptingDuct(Doubler()).demand.count
         . assert(_ == 5L)
 
         test(m"accepting transforms pushed data"):
           val gather = Gather()
-          val intake = gather.accepting(Doubler())
+          val intake = gather.acceptingDuct(Doubler())
           intake.put(small)
           intake.finish()
           scala.caps.unsafe.unsafeAssumeSeparate(gather.data).to[List]
@@ -626,7 +626,7 @@ object Tests extends Suite(m"Zephyrine tests"):
 
         test(m"duct flush emits terminal state on finish"):
           val gather = Gather()
-          val intake = gather.accepting(Trailer())
+          val intake = gather.acceptingDuct(Trailer())
           intake.put(Array.of[Byte](1, 2))
           intake.finish()
           scala.caps.unsafe.unsafeAssumeSeparate(gather.data).readable.to(List)
@@ -634,7 +634,7 @@ object Tests extends Suite(m"Zephyrine tests"):
 
         test(m"duct flush emits terminal state at end of a pulled stream"):
           val gather = Gather()
-          Stream(Array.of[Byte](1, 2)).via(Trailer()).pump(gather)
+          Stream(Array.of[Byte](1, 2)).viaDuct(Trailer()).pump(gather)
           scala.caps.unsafe.unsafeAssumeSeparate(gather.data).to[List]
         . assert(_ == List[Byte](1, 2, 99))
 
@@ -863,7 +863,7 @@ object Tests extends Suite(m"Zephyrine tests"):
         . assert(_ == List())
 
         test(m"memoize reassembles a transformed pipeline"):
-          small.stream.via(Doubler()).memoize.to[List]
+          small.stream.viaDuct(Doubler()).memoize.to[List]
         . assert(_ == (small.to[List]: List[Byte]).flatMap { byte => proscenium.List(byte, byte) })
 
         test(m"memoize drains a text stream into a single text value"):
@@ -905,7 +905,7 @@ object Tests extends Suite(m"Zephyrine tests"):
         . assert(_ == List[Byte](5, 6, 7, 8, 9))
 
         test(m"truncate composes with a duct"):
-          small.stream.truncate(3).via(Doubler()).memoize.to[List]
+          small.stream.truncate(3).viaDuct(Doubler()).memoize.to[List]
         . assert(_ == List[Byte](1, 1, 2, 2, 3, 3))
 
         test(m"gather reduces over windows without boxing"):


### PR DESCRIPTION
Migrates Soundness onto the Proscala 3.9 stream as released in `3.9.0-RC4-p9`,
whose `spreadable` patch replaces the `spliceopaque` behaviour this code
currently relies on. Also carries the capture-checking fixes 3.10's stricter
rules exposed, since they hold on 3.9 too.

Verified: **10608 passed, 0 failed** (of 10614; the 5 `aspire-failed` are the
suite's expected failures), plus the 9 `wasm-e2e` scenarios, from a clean
`make attest` on this branch rebased onto `6483980da9`, against the published
`3.9.0-RC4-p9` downloaded from Maven with `SOUNDNESS_SCALA_HOME` unset — the
same path CI takes.

## Why the compiler pin moves

`build.mill` goes from `3.9.0-RC4-p8` to `p9`. This is not incidental: p8
carries `spliceopaque`, which pierced *any* opaque alias over a `Seq`/`Array` at
a vararg splice; p9 replaces it with `spreadable`, where a library grants
permission explicitly. The `Spreadable` instances below cannot compile against
p8, so the pin and the source changes have to land together.

## Spreading, by permission

`proscenium`'s `List`, `Array`, `Chain` and `Sequence` each gain a `Spreadable`
instance in its companion, written where the alias is transparent so it is the
identity and costs nothing at run time. The `Array` instance is keyed on the
frozen form:

```scala
given arrayIsSpreadable: [element]
    => (Spreadable[Array[element]^{}] { type Out = scala.Array[element]^{} }) = ...
```

A capture-carrying collection cannot instantiate the typeclass's type parameter,
and should not be spread — freeze it first.

## A `Duct` attaches directly

`viaDuct`/`acceptingDuct` replace the identity `Ductile` given for a raw `Duct`.
A `Duct` *is* a pipeline stage, not a description of one, so it needs no
descriptor typeclass; routing it through the typeclass meant instantiating
`Ductile` at the duct's own type, which capture checking cannot express — the
identity instance's `Self` and the type argument `via` infers differ only in
whether they are boxed, and boxing is not writable in source.

Removing the given removes a whole-instance `asInstanceOf` and a `consume`
pass-through cast. It also surfaced a real mis-declaration those casts had been
hiding: `pneumatic.Lzw`'s four duct factories declared `Duct[Data, Data] {...}`
with no `^`, claiming a stateful duct captures nothing, where `Xz` and `Brotli`
both declare `(Duct[Data, Data] {...})^`. The identity given accepted a
read-only duct and cast it; `viaDuct` does not, so the declaration is now
honest.

Call sites migrated in `pneumatic`, `enigmatic`, `facsimile` and zephyrine's
tests. Every `via`/`accepting` call that passes a *descriptor* — `CharDecoder`,
`Alphabet`, `LineSeparation` — is untouched.

`Ductile.Of` is renamed to `Ductile.Instance`: a name that only reads correctly
in one context is not a name.

## Capture-checking fixes

- `delicious.Markup` — one frame live at a time, instead of a nested
  destructuring that kept two.
- `probably.Coverage` — the directory array no longer escapes into an `Option`.
- `gastronomy.Blake3` — chaining values are frozen (`Array[Int]^{}`), so the
  stack holds no live capabilities.

## Macro expansions stated precisely

- `wisteria.internal.getDefault` — the fallback expansion was a bare `'{Unset}`,
  typed as the singleton `Unset.type`, while the macro's declared result is
  `Optional[field]`. The conformance check on a macro expansion dealiases opaque
  types but only reaches them through a `TypeRef`, so a singleton hid `Unset`'s
  underlying type. Now ascribed to what the macro promises.
- `enigmatic.Pem` — `protect`'s type argument is stated. Inferred, the two sides
  of that check were spelt differently: `anticipation.Data`, a transparent alias
  over an opaque one, against its own dealiasing `scala.Array[Byte]`.

## Scope

This makes Soundness build on the **3.9** stream. It does **not** complete the
3.10 stream: `bitumen`, `enigmatic` and `hallucination` still fail there, all
capture-set identity mismatches on freshly allocated or opaque-aliased arrays —
a frozen `Array[Byte]^{}` acquiring a fresh `^{any.rd}` per occurrence, which no
source spelling suppresses. Those are unrelated to the changes here and are left
for separate work.

Two commits in this branch are a change and its revert (`withKey`'s bound). They
are kept rather than squashed because the revert records something worth
knowing: freezing the cipher buffer fixes 3.10 but breaks 3.9.

Developed with LLM assistance (Claude, Anthropic); every claim above was checked
against a built compiler rather than assumed.

