### PR TITLE
Rebase the ZIP64 locator when a JAR is appended to a launcher stub

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1421,7 +1421,7 @@ object polysyllabic extends Library:
   object bench extends Benchmarks(core, escritoire.core, hellenism.core, quantitative.units)
 
 object ethereal extends Library:
-  object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, coaxial.jvm, quantitative.units, telekinesis.jvm, urticose.url, gastronomy.core):
+  object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, coaxial.jvm, quantitative.units, telekinesis.jvm, urticose.url, gastronomy.core, zeppelin.core):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))

--- a/lib/ethereal/src/core/ethereal.Assembler.scala
+++ b/lib/ethereal/src/core/ethereal.Assembler.scala
@@ -48,6 +48,9 @@ import prepositional.*
 import rudiments.*
 import serpentine.*
 import turbulence.*
+import zeppelin.*
+
+import errorDiagnostics.emptyDiagnostics
 
 import filesystemOptions.createNonexistentParents.enabled
 import filesystemOptions.dereferenceSymlinks.enabled
@@ -154,6 +157,11 @@ object Assembler:
       if !isWindows then output.executable() = true
       safely(mute[ExecEvent](sh"codesign --sign - --force $output".exec[Exit]()))
 
+    // Measured from the file rather than taken as `patched.length`: on macOS `codesign` has just
+    // rewritten the stub, adding a signature blob, so the prefix the JAR is about to sit behind is
+    // longer than the bytes `patch` returned.
+    val prefixSize: Bytes = output.size()
+
     // Two sequential opens rather than one nested inside the other's lambda (the inner
     // open's evidence would mint fresh roots inside the outer handle's loan that cannot
     // unify with it), and a direct append-mode open rather than `Eof` (whose two-evidence
@@ -161,5 +169,16 @@ object Assembler:
     // so nothing reads the closed handle.
     val chunks = jarFile.open[File]()(List.from(file.reader().stdlib))
     output.open[File](Write, OpenFlag.Create, OpenFlag.Append)(file.write(Chain.from(chunks.stdlib)))
+
+    // Appending the JAR to the stub shifts every byte of it by the stub's length. ZIP offsets are
+    // relative, so a reader recovers that shift by itself — except for the ZIP64 locator's pointer,
+    // which is physical, and which only exists at all once the JAR holds more than 0xffff entries.
+    // Left stale, the JVM declines to open the executable and the daemon dies mute (#1680).
+    mitigate:
+      case ZipError(_) =>
+        AssemblyError(m"The appended JAR's ZIP64 metadata could not be rebased")
+
+    . protect:
+        Zipfile.rebase(output, prefixSize.long)
 
     if !isWindows then output.executable() = true

--- a/lib/ethereal/src/core/ethereal.Installer.scala
+++ b/lib/ethereal/src/core/ethereal.Installer.scala
@@ -52,6 +52,7 @@ import spectacular.*
 import symbolism.*
 import turbulence.*
 import vacuous.*
+import zeppelin.*
 
 import filesystemOptions.createNonexistentParents.enabled
 import filesystemOptions.deleteRecursively.enabled
@@ -122,6 +123,7 @@ object Installer:
       case NameError(_, _, _)   => InstallError(InstallError.Reason.Io)
       case ExecError(_, _, _)   => InstallError(InstallError.Reason.Io)
       case StreamError(_)       => InstallError(InstallError.Reason.Io)
+      case ZipError(_)          => InstallError(InstallError.Reason.Io)
 
     . protect:
         val command: Text = service.script
@@ -151,6 +153,12 @@ object Installer:
               if prefixSize > 0.b
               then file.write(stream.take(prefixSize) #::: stream.drop(fileSize - jarSize))
               else file.write(stream)
+
+            // Excising the embedded payload from between the stub and the JAR moves the JAR
+            // earlier by exactly the payload's size, which invalidates the JAR's ZIP64 locator —
+            // the one physical offset the format records. See `Zipfile.rebase` and #1680.
+            if prefixSize > 0.b && payloadSize > 0.b
+            then Zipfile.rebase(service.executable, -payloadSize.long)
 
             file.executable() = true
             Result.Installed(command, file.encode)

--- a/lib/ethereal/src/runner/src/launch.rs
+++ b/lib/ethereal/src/runner/src/launch.rs
@@ -68,6 +68,7 @@ pub fn launch(
         Err(e) => {
             crate::debug!("launch: spawn failed: {}", e);
             crate::state::abort(fail_file);
+            crate::state::report_failure(base_dir, name, &format!("it could not be spawned ({e})"));
             std::process::exit(1);
         }
     };
@@ -89,6 +90,7 @@ pub fn launch(
         if matches!(child.try_wait(), Ok(Some(_))) && !crate::state::socket_ready(socket_file) {
             crate::debug!("launch: daemon exited during startup, aborting");
             crate::state::abort(fail_file);
+            crate::state::report_failure(base_dir, name, "it exited during startup");
             crate::state::backout(fail_file, pid_file, name);
             std::process::exit(1);
         }
@@ -105,6 +107,9 @@ pub fn launch(
     if !crate::state::socket_ready(socket_file) {
         crate::debug!("launch: socket never appeared, aborting");
         crate::state::abort(fail_file);
+        let seconds = STARTUP_POLL.as_millis()*u128::from(STARTUP_MAX_ATTEMPTS)/1000;
+        let reason = format!("it did not bind its socket within {seconds}s");
+        crate::state::report_failure(base_dir, name, &reason);
         crate::state::backout(fail_file, pid_file, name);
         std::process::exit(1);
     }

--- a/lib/ethereal/src/runner/src/main.rs
+++ b/lib/ethereal/src/runner/src/main.rs
@@ -100,6 +100,8 @@ fn main() {
                 if !state::await_socket(&socket_file, 40) {
                     debug!("main: socket did not appear");
                     state::abort(&fail_file);
+                    let reason = "another launcher held the startup lock but bound no socket";
+                    state::report_failure(&base_dir, &name, reason);
                     state::backout(&fail_file, &pid_file, &name);
                     std::process::exit(1);
                 }
@@ -110,6 +112,7 @@ fn main() {
 
     if !state::socket_alive(&socket_file) {
         debug!("main: socket not alive, exiting STARTUP_FAILURE");
+        state::report_failure(&base_dir, &name, "its socket does not accept connections");
         std::process::exit(STARTUP_FAILURE_EXIT_CODE);
     }
     debug!("main: socket is alive");

--- a/lib/ethereal/src/runner/src/state.rs
+++ b/lib/ethereal/src/runner/src/state.rs
@@ -91,6 +91,31 @@ pub fn abort(fail_file: &Path) {
     let _ = File::create(fail_file);
 }
 
+const LOG_TAIL_LINES: usize = 20;
+
+// Every startup failure below used to exit silently: `backout`'s message can only fire while the
+// pid file is empty, and `launch` writes the wrapper's pid into it before any of the polling
+// failure paths run, so nothing was ever printed. Meanwhile the JVM's own account of what went
+// wrong sat unread in `daemon.log`. That is how a JAR the JVM would not open (#1680) presented
+// itself as a flake. An *empty* log is itself a diagnosis, so say so rather than staying quiet.
+pub fn report_failure(base_dir: &Path, name: &str, reason: &str) {
+    eprintln!("\nThe {name} daemon failed to start: {reason}.");
+    eprintln!("Its state directory is {}", base_dir.display());
+    let log = base_dir.join("daemon.log");
+
+    match fs::read_to_string(&log) {
+        Ok(text) if !text.trim().is_empty() => {
+            eprintln!("The last output in {} was:", log.display());
+            let lines: Vec<&str> = text.lines().collect();
+            for line in lines.iter().skip(lines.len().saturating_sub(LOG_TAIL_LINES)) {
+                eprintln!("  {line}");
+            }
+        }
+        Ok(_) => eprintln!("{} is empty: the JVM died before it could say why.", log.display()),
+        Err(_) => eprintln!("{} could not be read.", log.display()),
+    }
+}
+
 pub fn backout(fail_file: &Path, pid_file: &Path, name: &str) {
     let metadata = match fs::metadata(fail_file) {
         Ok(metadata) => metadata,

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -35,6 +35,7 @@ package ethereal
 import java.lang as jl
 import java.io as ji
 import java.util.concurrent as juc
+import java.util.zip as juz
 
 import soundness.*
 
@@ -725,6 +726,55 @@ object Tests extends Suite(m"Ethereal Tests"):
 
       safely(sh"pkill $selfuName".exec[Exit]())
       sh"rm -rf $selfuStateDir $selfuDataDir".exec[Unit]()
+
+      // A JAR of more than 0xffff entries carries ZIP64 end-of-central-directory records, whose
+      // locator holds the format's one physical offset. Appending such a JAR to a runner stub
+      // moves it, and a stale locator makes the JVM refuse to open the executable at all — a
+      // daemon that dies before it can say anything (#1680). The stub is a fake one carrying the
+      // ETHRCFG marker, as ziggurat's tests use; nothing here executes it. The `macos` label is
+      // deliberate: it makes `assemble` codesign the stub, which grows it, so the prefix the JAR
+      // sits behind is longer than the patched bytes — the delta must be measured from the file.
+      suite(m"Assembling a launcher around a ZIP64 JAR"):
+        val assemblyDir: Path on Linux = temporaryDirectory[Path on Linux]/Uuid().show
+        sh"mkdir -p $assemblyDir".exec[Unit]()
+
+        val stub: Data =
+          Array.unsafeFrozen
+            ( scala.Array.fill(64)(0.toByte)
+              ++ Assembler.MagicMarker
+              ++ scala.Array.fill(64 + Assembler.PublicKeyLength)(0.toByte) )
+
+        val publicKey: Data = Array.fill(Assembler.PublicKeyLength)(0.toByte)
+        val entryCount = 66000
+
+        def assembled(entries: Int): Path on Linux =
+          val jar: Path on Linux = assemblyDir/t"app$entries.jar"
+          val output: Path on Linux = assemblyDir/t"launcher$entries"
+
+          val contents: List[Zip.Entry] =
+            List.from((0 until entries).map: index =>
+              Zip.Entry(unsafely(t"e$index".as[Path on Zip]), Array.empty[Byte]))
+
+          Zipfile.write(jar)(contents.stdlib)
+
+          Assembler.assemble
+            (stub, jar, output, t"macos-arm64", 1L, 21, 24, false, publicKey)
+
+          output
+
+        def jdkEntryCount(path: Path on Linux): Int =
+          val zip = juz.ZipFile(ji.File(path.encode.s))
+          try zip.size() finally zip.close()
+
+        test(m"the JVM reads every entry of a ZIP64 launcher"):
+          jdkEntryCount(assembled(entryCount))
+        . assert(_ == entryCount)
+
+        test(m"a launcher below the ZIP64 threshold still reads"):
+          jdkEntryCount(assembled(16))
+        . assert(_ == 16)
+
+        sh"rm -rf $assemblyDir".exec[Unit]()
 
       val brokenStateDir: Path on Local =
         Xdg.runtimeDir[Path on Local].or(Xdg.stateHome[Path on Local]) / t"brokn"

--- a/lib/zeppelin/src/core/zeppelin.Zipfile.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zipfile.scala
@@ -86,6 +86,42 @@ object Zipfile:
 
   def read(data: Data): Zipfile raises ZipError = parse(DataSource(data))
 
+  // Every offset a ZIP archive records is central-directory-relative: a reader derives the shift
+  // from the difference between the recorded and the physical position of the central directory,
+  // which is why an archive concatenated onto a binary prefix still reads. The ZIP64 locator's
+  // pointer to the ZIP64 end-of-central-directory record is the sole exception — it is a physical
+  // file offset — so prepending a prefix (or excising bytes from one, as a self-installing
+  // executable does) invalidates exactly that field. This reader tolerates it by falling back to
+  // the record's physical position, but the JDK's follows it blindly and then declines to open the
+  // archive at all, with no diagnostic. `rebase` shifts the pointer by `delta`; an archive with no
+  // ZIP64 locator — anything under 0xffff entries, which is nearly everything — is left untouched.
+  def rebase[path: Abstractable across Paths to Text](path: path, delta: Long)
+  :   Unit raises ZipError =
+
+    val filename: Text = path.generic
+    val source = FileSource(filename)
+    val (_, _, eocdOffset) = findEocd(source)
+
+    if eocdOffset >= 20 then
+      val locator = source.read(eocdOffset - 20, 20)
+
+      if Zip.u32(locator, 0) == (Zip.zip64LocatorSig.toLong & 0xffffffffL) then
+        val rebased = Zip.u64(locator, 8) + delta
+
+        if rebased < 0 || rebased + 56 > source.size
+        then raise(ZipError(ZipError.Reason.Zip64Error))
+        else
+          val update: Data = Data.build(8): array =>
+            Zip.putU64(array, 0, rebased)
+
+          val channel =
+            jnc.FileChannel.open(jnf.Path.of(filename.s), jnf.StandardOpenOption.WRITE).nn
+
+          try
+            val buffer = jn.ByteBuffer.wrap(update.asInstanceOf[scala.Array[Byte]]).nn
+            while buffer.hasRemaining do channel.write(buffer, eocdOffset - 12 + buffer.position)
+          finally channel.close()
+
   private def checkDuplicates(entries: Iterable[Zip.Entry]): Unit raises ZipError =
     val seen = scala.collection.mutable.HashSet[Text]()
 
@@ -142,7 +178,10 @@ object Zipfile:
 
         Array.unsafeFrozen(buffer.array.nn)
 
-  private[zeppelin] def parse(source: Expanse): Zipfile raises ZipError =
+  // The end-of-central-directory trailer is the archive's last record, but a comment of up to
+  // 0xffff bytes may follow it, so it is found by scanning back for its signature. Returns the
+  // window scanned, the trailer's index within it, and its absolute offset in the archive.
+  private def findEocd(source: Expanse): (Data, Int, Long) raises ZipError =
     val size = source.size
     if size < 22 then raise(ZipError(ZipError.Reason.MissingEocd))
 
@@ -154,7 +193,11 @@ object Zipfile:
     while i >= 0 && Zip.u32(window, i) != Zip.eocdSig.toLong do i -= 1
     if i < 0 then raise(ZipError(ZipError.Reason.MissingEocd))
 
-    val eocdOffset = windowStart + i
+    (window, i, windowStart + i)
+
+  private[zeppelin] def parse(source: Expanse): Zipfile raises ZipError =
+    val size = source.size
+    val (window, i, eocdOffset) = findEocd(source)
     var entryCount = Zip.u16(window, i + 10).toLong
     var cdSize = Zip.u32(window, i + 12)
     var cdOffset = Zip.u32(window, i + 16)

--- a/lib/zeppelin/src/test/zeppelin_test.scala
+++ b/lib/zeppelin/src/test/zeppelin_test.scala
@@ -440,6 +440,52 @@ object Tests extends Suite(m"Zeppelin tests"):
         Zipfile.read(path).entries.stdlib.length
       . assert(_ == 66000)
 
+      // Concatenation, rather than `Zipfile.write(…, prefix)`: an Ethereal launcher is built by
+      // appending an already-linked JAR to a runner binary, which leaves the ZIP64 locator's
+      // pointer — the format's one physical offset — pointing into the prefix. See
+      // `Zipfile.rebase`.
+      val stub: Data = Array.tabulate(1024)(i => (i*11).toByte)
+
+      def concatenate(name: Text, prefix: Data, archive: Data): Path on Linux =
+        val path = workDir/name
+        val out = ji.FileOutputStream(ji.File(path.encode.s))
+
+        try
+          out.write(Array.unsafeJvm(prefix))
+          out.write(Array.unsafeJvm(archive))
+        finally out.close()
+
+        path
+
+      test(m"a stale ZIP64 locator stops the JDK opening a concatenated archive"):
+        val stale = concatenate(t"zip64-stale.zip", stub, bytesOf(path))
+        try jdkNames(stale).length catch case exception: Exception => -1
+      . assert(_ == -1)
+
+      test(m"the native reader tolerates a stale ZIP64 locator"):
+        val stale = concatenate(t"zip64-stale2.zip", stub, bytesOf(path))
+        Zipfile.read(stale).entries.stdlib.length
+      . assert(_ == 66000)
+
+      test(m"rebasing a concatenated ZIP64 archive restores the JDK reader"):
+        val rebased = concatenate(t"zip64-rebased.zip", stub, bytesOf(path))
+        Zipfile.rebase(rebased, stub.length)
+        jdkNames(rebased).length
+      . assert(_ == 66000)
+
+      test(m"a rebased archive still reads natively, prefix and all"):
+        val rebased = concatenate(t"zip64-rebased2.zip", stub, bytesOf(path))
+        Zipfile.rebase(rebased, stub.length)
+        Zipfile.read(rebased).prefix.lay(0)(_.length)
+      . assert(_ == 1024)
+
+      test(m"rebasing an archive with no ZIP64 locator changes nothing"):
+        val plain = writeZip(t"rebase-noop.zip", entry(t"a.txt", t"alpha"))
+        val before = bytesOf(plain).to[List]
+        Zipfile.rebase(plain, 1024)
+        bytesOf(plain).to[List] == before
+      . assert(_ == true)
+
     suite(m"Binary prefix"):
       val prefix: Data = Array.tabulate(64)(i => (i*7).toByte)
 


### PR DESCRIPTION
Ethereal's daemon would not start when the application JAR it was launched from held more than about 66,000 entries: the launcher exited without a word, the state directory held nothing but an empty log, and the client died parsing an empty PID. The cause was in the ZIP format's one physical offset. Every other offset a ZIP records is relative to the central directory, which is why appending an archive to a runner binary works at all — a reader recovers the shift by itself — but the ZIP64 locator's pointer to the ZIP64 end-of-central-directory record is a file offset, and it only exists once an archive passes 65,535 entries. Left stale by the append, it sent the JVM into the middle of the runner binary, and the JVM then declined to open the executable at all. Zeppelin gains a `Zipfile.rebase` to shift that pointer, Ethereal's assembler and installer call it whenever they move a JAR, and the runner's five silent startup-failure paths now report what happened and quote the daemon's log.

## Zeppelin: `Zipfile.rebase`

Shifts an archive's ZIP64 locator pointer after data has been prepended to, or excised from, its prefix. Archives with no ZIP64 locator — anything under 65,535 entries — are left untouched.

```scala
// A self-extracting executable: a stub, then the archive appended at EOF.
stub.append(archive)
Zipfile.rebase(executable, stub.size)
```

Zeppelin's own reader already tolerated a stale locator by falling back to the record's physical position, so archives it produced round-tripped through it and looked correct; it is `java.util.zip` (and so `java -jar`) that refuses them.

## Ethereal

`Assembler.assemble` now rebases the JAR it appends to the runner stub, so a launcher built from a large application JAR starts. The shift is measured from the file rather than from the patched stub bytes, because on macOS `codesign` rewrites the stub in between and grows it by the size of the signature blob.

`Installer` applies the same shift in the opposite direction: self-installing removes the embedded payload from between the stub and the JAR, which moves the JAR earlier by exactly the payload's size.

## Ethereal's launcher

Every startup failure previously exited with no output at all. The message that was meant to cover this could only fire while the pid file was empty, and the launcher writes the wrapper's pid into it before any of the polling failure paths run — so nothing was ever printed, while the JVM's own account of the failure sat unread in `daemon.log`. Each failure path now names the daemon and its state directory and quotes the tail of that log:

```
The hello daemon failed to start: it did not bind its socket within 10s.
Its state directory is /home/user/.local/state/hello
The last output in /home/user/.local/state/hello/daemon.log was:
  Error: An unexpected error occurred while trying to open file /home/user/.local/bin/hello
```

An empty log is itself a diagnosis, and is reported as one. These changes are in the Rust runner, so they reach users with the next `runners-` release.

Closes #1680.

### Still open

`ziggurat`'s `EmbedAll` and `Download` deliveries concatenate stub and JAR inside a polyglot shell launcher at unpack time, where no rebase is possible; they remain broken above 65,535 entries. Padding every patched stub to a common length would let the packager pre-rebase the single embedded JAR by that constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)