### PR TITLE
Locate TEL schema-validation and decode errors again

### DIFF
--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -84,11 +84,33 @@ object Tel extends Tel2:
   =>  (TelOpenable[source]^{readable, writable}) =
     TelOpenable[source]()
 
+  // The source `Position` type located by `tel.locate(pointer)` and carried on a
+  // `Tel.Focus`. Defined canonically on `TelError` (where it also locates parse
+  // errors); aliased here for symmetry with `Json.Ast.Position` / `Yaml.Ast.Position`.
+  type Position = TelError.Position
+  val Position: TelError.Position.type = TelError.Position
+
   // The focus carried by `Tel#as[T]` for multi-error accrual: a keyword path
   // identifying the field being decoded (and, for parser-phase errors, an
-  // optional source position). Mirrors `Json.Focus` / `Yaml.Focus`.
+  // optional source position). Mirrors `Json.Focus` / `Yaml.Focus`. The
+  // `position` is populated lazily by `withPosition(tel)`, which delegates to
+  // `tel.locate(pointer)`, so a root parsed without position tracking (hence no
+  // `positionIndex`) leaves `position` Unset and the success path pays nothing.
   case class Focus(pointer: TelPath = TelPath.Root, position: Optional[TelError.Position] = Unset)
-  derives CanEqual
+  derives CanEqual:
+    def withPosition(tel: Tel): Focus = copy(position = tel.locate(pointer))
+
+  // Fill in a source `Position` for every focus accrued so far by locating its
+  // keyword path in `tel` — the counterpart of `Json#as`'s enrichment. A no-op
+  // unless the ambient `Foci` is a tracking one and `tel` was parsed under
+  // `parsing.trackPositions` (so carries a `positionIndex`); an unresolvable
+  // path — a member absent from the source — keeps its pointer and leaves the
+  // position Unset. An error registered outside every `focus` block has no
+  // focus at all and takes the root one, which renders as `#`, exactly as an
+  // absent focus did. Public because `Tel#as` is `inline` and expands into
+  // user modules, which may only reference public members.
+  def supplementPositions(tel: Tel)(using foci: Foci[Tel.Focus]): Unit =
+    foci.supplement(foci.length, _.let(_.withPosition(tel)).or(Tel.Focus()))
 
   extension (tel: Tel)
     def edited(revision: Revision): Tel raises MutationError = revision(tel)
@@ -998,6 +1020,12 @@ object Tel extends Tel2:
       val rootElements =
         applyConstraints(schema.document, Array.empty[Tel.Element], rootChildren, schema)
 
+      // Locate every focus accrued by the walk against the root. Validator
+      // errors (E310) are registered by the three-argument overload *after*
+      // this runs, so they keep the pointer their element supplies but no
+      // position.
+      Tel.supplementPositions(tel)
+
       Tel.Element.Node(keywordIndex = Unset, elementType = schema.document, children = rootElements)
 
     def assign(tel: Tel, schema: Tels, validators: Tel.Validator.Registry)
@@ -1286,26 +1314,35 @@ object Tel extends Tel2:
       while i < compounds.length do
         val compound = compounds(i)
 
-        // An unrecognised keyword is skipped (`IgnoreErroneousNode`): record it and
-        // emit no element, so remaining siblings are still validated.
-        km.get(compound.keyword) match
-          case Some(entry) =>
-            // §20.2 step 4c: all children of one member must form a single
-            // contiguous run; variants of one SelectRef share an ordinal and
-            // so interleave freely. Returning to an earlier member's run is
-            // E309, reported once per returned-to run; the child is still
-            // assigned.
-            if entry.ordinal != currentMember then
-              if currentMember >= 0 then seenMembers += currentMember
+        // Tag every error accrued for this compound (and its descendants) with
+        // its keyword path — mirroring the decode derivation's per-field `focus`
+        // — so that under a `validate[Tel.Focus]` boundary schema-validation
+        // errors carry a pointer (and, for a tracked root, a source position via
+        // `Focus.withPosition`) instead of the bare document root.
+        focus({
+          val base = prior.let(_.pointer).or(TelPath.Root)
+          Tel.Focus(base.prepend(compound.keyword))
+        }):
+          // An unrecognised keyword is skipped (`IgnoreErroneousNode`): record it and
+          // emit no element, so remaining siblings are still validated.
+          km.get(compound.keyword) match
+            case Some(entry) =>
+              // §20.2 step 4c: all children of one member must form a single
+              // contiguous run; variants of one SelectRef share an ordinal and
+              // so interleave freely. Returning to an earlier member's run is
+              // E309, reported once per returned-to run; the child is still
+              // assigned.
+              if entry.ordinal != currentMember then
+                if currentMember >= 0 then seenMembers += currentMember
 
-              if seenMembers.contains(entry.ordinal)
-              then recoverNode(Reason.MembersNonContiguous)(())
+                if seenMembers.contains(entry.ordinal)
+                then recoverNode(Reason.MembersNonContiguous)(())
 
-              currentMember = entry.ordinal
+                currentMember = entry.ordinal
 
-            results += assignCompound(compound, entry, schema, depth)
+              results += assignCompound(compound, entry, schema, depth)
 
-          case None => recoverNode(Reason.UnknownKeyword)(())
+            case None => recoverNode(Reason.UnknownKeyword)(())
 
         i += 1
 
@@ -1351,12 +1388,20 @@ object Tel extends Tel2:
 
         member match
           case f: Tels.Field =>
-            if requiredOf(f) && fillCount == 0 then resolveType(f.fieldType, schema) match
-              case s: Scalar => f.default match
-                case t: Text => results += Tel.Element.Value(flatStart, s, t)
-                case _       => recoverNode(Reason.RequiredMemberAbsent)(())
+            // A missing required member is reported under its own keyword path.
+            // It has no compound in the source, so `withPosition` leaves the
+            // position Unset (locate finds no node) — but the pointer still names
+            // the absent field.
+            if requiredOf(f) && fillCount == 0 then focus({
+              val base = prior.let(_.pointer).or(TelPath.Root)
+              Tel.Focus(base.prepend(f.keyword))
+            }):
+              resolveType(f.fieldType, schema) match
+                case s: Scalar => f.default match
+                  case t: Text => results += Tel.Element.Value(flatStart, s, t)
+                  case _       => recoverNode(Reason.RequiredMemberAbsent)(())
 
-              case _ => recoverNode(Reason.RequiredMemberAbsent)(())
+                case _ => recoverNode(Reason.RequiredMemberAbsent)(())
 
             // §20.2 step 5c; recovery reports the document invalid but
             // retains every occurrence.
@@ -1746,15 +1791,16 @@ object Tel extends Tel2:
   // Parse `bytes` into a `Tel` carrying a `PositionIndex`, so that
   // `tel.locate(pointer)` / `tel.locateKey(pointer)` resolve a node's keyword
   // path to its source `Position`, and accrued `Tel.Focus`es can be located via
-  // `withPosition`. Reached from the `read` / `load` givens only when
-  // `parsing.trackPositions` is in scope; otherwise the untracked `parse` runs
-  // and `positionIndex` is left Unset, so the throughput path is unaffected.
+  // `withPosition`. Reached from the `aggregable`, `aggregableIn` and `loadable`
+  // givens only when `parsing.trackPositions` is in scope; otherwise the
+  // untracked `parse` runs and `positionIndex` is left Unset, so the throughput
+  // path is unaffected.
   private def parseTracked(bytes: Data): Tel raises TelError =
     val (document, triples) = Tel.Parser.parseTracked(bytes)
     Tel(document, Optional(PositionIndex(buildIndex(document, triples))))
 
   // Parse `bytes` honouring the in-scope `Tracking` toggle (`parsing.trackPositions`).
-  private def parseTracking(bytes: Data)(using PositionTracking): Tel raises TelError =
+  private[stratiform] def parseTracking(bytes: Data)(using PositionTracking): Tel raises TelError =
     summon[PositionTracking] match
       case PositionTracking.On  => parseTracked(bytes)
       case PositionTracking.Off => parse(bytes)
@@ -1873,8 +1919,9 @@ object Tel extends Tel2:
   // pragma, line-endings) is *not* surfaced — use `.load[Tel]` to
   // recover those alongside the value. Per §6.1, single-document parsing
   // stops at the first document separator; content after it is ignored.
-  given aggregable: (tactic: Tactic[TelError]) => ((Tel is Aggregable by Data)^{tactic}) =
-    source => parse(concatenate(source))
+  given aggregable: (tactic: Tactic[TelError], tracking: PositionTracking)
+  =>  ((Tel is Aggregable by Data)^{tactic}) =
+    source => parseTracking(concatenate(source))
 
   // Direct parsing: when the value knows how to consume compound entries
   // itself, the document's AST is never materialized. Declared here (not in
@@ -2077,7 +2124,7 @@ object Tel extends Tel2:
   // `text.load[Tel]` for any Chain[Text] source: concatenates the
   // chunks, UTF-8 encodes, parses, and pairs the resulting Tel with a
   // `Tel.Metadata` carrying the document's prologue.
-  given loadable: (tactic: Tactic[TelError], buffering: Buffering)
+  given loadable: (tactic: Tactic[TelError], buffering: Buffering, tracking: PositionTracking)
   =>  ((Tel is Loadable by Text)^{tactic}) = stream =>
     // The whole document materializes once (the parser is whole-input), but the
     // Text stream is transcoded to UTF-8 through the encoder duct and memoized
@@ -2090,9 +2137,18 @@ object Tel extends Tel2:
       . asInstanceOf[(zephyrine.Stream[Data] over zephyrine.Credit)^]
       . memoize
 
-    val doc = Tel.Parser.parse(bytes)
-    val meta = Tel.Metadata(doc.interpreterDirective, doc.pragma, doc.lineEndings)
-    turbulence.Document(Tel(doc): Tel, meta)
+    // The metadata comes off the parsed `Tel`'s own subtree rather than from a
+    // second, untracked `Tel.Parser.parse`, so that under `parsing.trackPositions`
+    // the loaded document keeps its `positionIndex`.
+    val tel = parseTracking(bytes)
+
+    tel.subtree match
+      case doc: Tel.Document =>
+        turbulence.Document
+         ( tel, Tel.Metadata(doc.interpreterDirective, doc.pragma, doc.lineEndings) )
+
+      case _ =>
+        turbulence.Document(tel, Tel.Metadata(Unset, Unset, Tel.LineEndings.Lf))
 
   // Renders a document's presentation back to text, reversing the presentation parser. The whole
   // line-based serialization lives in this instance so that `.show` is the single route to TEL
@@ -5595,8 +5651,18 @@ extends scala.Dynamic, Documentary, Topical, Original:
   type Self = Tel
   type Metadata = Tel.Metadata
 
+  // Decode, then locate every focus the decoders accrued against this root —
+  // the per-field pointers are built by the derivation and by
+  // `Parsable.focusing`; `supplementPositions` supplies their source positions
+  // when this document was parsed under `parsing.trackPositions`. (jacinta
+  // routes the same enrichment through `distillate.Decodable.position`, which
+  // needs a `Locus`-fixing mixin and a lowest-priority adapter given; here the
+  // focus type is already fixed by the `tracks Tel.Focus` clause, so the
+  // enrichment is called directly.)
   inline def as[value: Decodable in Tel]: value raises TelError tracks Tel.Focus =
-    value.decoded(this)
+    val result = value.decoded(this)
+    Tel.supplementPositions(this)
+    result
 
   // Total field access used by the schema-typed navigation macros and by
   // internal optics: an empty `Tel` for a missing field, never raising.

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -227,9 +227,10 @@ trait Tel2 extends Tel3:
   // at runtime. Lives at this priority so `object Tel`'s direct-parsing
   // `aggregableParsed` wins whenever the value has a `Tel.Parsable`; when it
   // does not (all pre-`Parsable` code), this resolves exactly as before.
-  given aggregableIn: [value: distillate.Decodable in Tel] => (tactic: Tactic[TelError])
+  given aggregableIn: [value: distillate.Decodable in Tel]
+  =>  (tactic: Tactic[TelError], tracking: zephyrine.PositionTracking)
   =>  (((value in Tel) is Aggregable by Data)^{tactic}) =
-    source => Tel.parse(Tel.concatenate(source)).as[value].asInstanceOf[value in Tel]
+    source => Tel.parseTracking(Tel.concatenate(source)).as[value].asInstanceOf[value in Tel]
 
   object ParsableDerivation extends Derivable[Tel.Field]:
     inline def conjunction[derivation <: Product: ProductReflection]

--- a/lib/stratiform/src/core/stratiform.TelError.scala
+++ b/lib/stratiform/src/core/stratiform.TelError.scala
@@ -49,11 +49,13 @@ object TelError:
   // offending line in the source. `column = 1` refers to the first
   // character of the line (including any leading spaces). Parse errors
   // that pre-date the document body (e.g. `BomPresent` at offset 0)
-  // report `(1, 1)`. Post-parse / validation errors leave `position`
-  // `Unset` unless resolved against a tracked document's `PositionIndex`
-  // (see `Tel.parseTracked` / `Tel.Focus.withPosition`).
+  // report `(1, 1)`. Post-parse / validation errors always leave the
+  // `TelError`'s own `position` Unset: their coordinates are carried on the
+  // accrued `Tel.Focus` instead, filled in from a tracked document's
+  // `PositionIndex` by `Tel.supplementPositions` / `Tel.Focus.withPosition`.
   //
-  // This is also the `Positionable` `Result` for `tel.locate(pointer)`, so it
+  // Aliased as `Tel.Position`. This is also the `Positionable` `Result` for
+  // `tel.locate(pointer)`, so it
   // extends zephyrine's `Format.Position` — `line`/`column` stay 1-based here
   // while the uniform, public `span` is 0-based (mirrors `Json.Ast.Position` /
   // `Yaml.Ast.Position`). `length` is the length in characters of the located

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -370,6 +370,14 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
         . to[Set]
       . assert(_ == Set(("#/name", false), ("#/email", false)))
 
+      // The excess atom is read by `assignAtoms`, deep inside `assignCompound`,
+      // so this proves the per-compound focus covers a compound's whole subtree
+      // and not just the keyword-dispatch step — the issue's `e302.tel` case.
+      test(m"An excess atom is located at the enclosing compound"):
+        assignPositions(t"item x y\nname n\n", atomAccrualSchema).items
+        . map { case (pointer, position) => (pointer.s, position.let(_.line).or(-1)) }.to[Set]
+      . assert(_ == Set(("#/item", 1)))
+
       // E308 is a property of a member's whole run, not of one node, so it is
       // raised outside every `focus` block: the entry has no focus at all and
       // takes the root one. `supplementPositions` must tolerate that rather

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -69,6 +69,39 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
     . protect(Tel.Type.assign(tel, schema))
 
+  case class Located(items: List[(Text, Optional[TelError.Position])] = Nil)(using Diagnostics)
+  extends Error(m"${items.length} located issues"):
+    def +(pointer: Text, position: Optional[TelError.Position]): Located =
+      Located(items :+ (pointer, position))
+
+  // Validate a *tracked* document against `schema`, capturing each error's
+  // keyword-path pointer alongside the source `Position` filled in by
+  // `Tel.supplementPositions` at the end of `Tel.Type.assign`.
+  private def assignPositions(text: Text, schema: Tels): Located =
+    import parsing.trackPositions
+    val tel = text.read[Tel]
+
+    validate[Tel.Focus](Located()):
+      case error: TelError =>
+        accrual + (prior.let(_.pointer.encode).or(t"#"),
+                   prior.lay(Unset: Optional[TelError.Position])(_.position))
+    . protect(Tel.Type.assign(tel, schema))
+
+  // The decode-path counterpart: `Tel#as` locates its per-field foci against
+  // the same tracked root. Inline for the same reason as `validateTel`.
+  private inline def decodePositions[result](text: Text)
+                                    (inline decode: Tel => result raises TelError tracks Tel.Focus)
+  :   Located =
+    import parsing.trackPositions
+    val tel = text.read[Tel]
+
+    Validate[Located, [r] =>> r raises TelError, Tel.Focus]
+      ( Located(),
+        { case error: TelError =>
+            accrual + (prior.let(_.pointer.encode).or(t"#"),
+                       prior.lay(Unset: Optional[TelError.Position])(_.position)) } )
+    . protect(decode(tel))
+
   // Parse a document under an accrual boundary: recoverable parse defects
   // (§19.5) accrue rather than aborting on the first, because `read[Tel]` parses
   // through the installed `TrackTactic`.
@@ -312,3 +345,47 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
            ( TelError.Reason.BadVersion,
              TelError.Reason.OverIndentation,
              TelError.Reason.TrailingSpaces )
+
+    suite(m"Located schema-validation errors (LSP diagnostics)"):
+      test(m"Unknown-keyword errors carry their keyword pointer"):
+        assignPositions(t"foo a\nbar b\n", optionalFieldSchema).items.map(_(0).s).to[Set]
+      . assert(_ == Set("#/foo", "#/bar"))
+
+      test(m"Unknown-keyword errors are located at the offending compound"):
+        assignPositions(t"foo a\nbar b\n", optionalFieldSchema).items.map(_(1)).to[Set]
+      . assert(_ == Set(Optional(Tel.Position(1, 1, length = Optional(3))),
+                        Optional(Tel.Position(2, 1, length = Optional(3)))))
+
+      test(m"An unlocated (untracked) validation still accrues without a position"):
+        val tel = t"foo a\n".read[Tel]
+
+        validate[Tel.Focus](Issues()):
+          case error: TelError => accrual + (prior.lay(t"")(_.position.lay(t"")(_.describe)), error)
+        . protect(Tel.Type.assign(tel, optionalFieldSchema))
+        . items.map(_(0).s).to[Set]
+      . assert(_ == Set(""))
+
+      test(m"Missing required members carry a pointer but no source position"):
+        assignPositions(t"", twoRequiredSchema).items.map { case (p, pos) => (p.s, pos.present) }
+        . to[Set]
+      . assert(_ == Set(("#/name", false), ("#/email", false)))
+
+      // E308 is a property of a member's whole run, not of one node, so it is
+      // raised outside every `focus` block: the entry has no focus at all and
+      // takes the root one. `supplementPositions` must tolerate that rather
+      // than `vouch` on it.
+      test(m"A run-level E308 accrues at the root without panicking"):
+        assignPositions(t"name Alice\nname Bob\nemail e\n", twoRequiredSchema).items
+        . map { case (p, pos) => (p.s, pos.present) }.to[Set]
+      . assert(_ == Set(("#", false)))
+
+    suite(m"Located decode errors"):
+      test(m"A malformed field's focus names the field"):
+        decodePositions(t"name Alice\nage notanumber\nemail e\n")(_.as[APerson])
+        . items.map(_(0).s).to[Set]
+      . assert(_ == Set("#/age"))
+
+      test(m"A malformed field is located at its compound"):
+        decodePositions(t"name Alice\nage notanumber\nemail e\n")(_.as[APerson])
+        . items.map(_(1)).to[Set]
+      . assert(_ == Set(Optional(Tel.Position(2, 1, length = Optional(3)))))

--- a/lib/stratiform/src/test/stratiform.PositionTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionTests.scala
@@ -1,0 +1,126 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import soundness.*
+
+import charEncoders.utf8Encoder
+import parsing.trackPositions
+import strategies.throwUnsafely
+
+object PositionTests extends Suite(m"Stratiform position-index tests"):
+
+  // A compound's keyword position: 1-based line/column with the keyword's
+  // character length (mirrors `jacinta.PositionTests.at`).
+  private def at(line: Int, column: Int, length: Int): Tel.Position =
+    Tel.Position(line, column, length = Optional(length))
+
+  def run(): Unit =
+    suite(m"Top-level compounds"):
+      test(m"Locate the document root"):
+        t"greeting hello\n".read[Tel].locate(TelPath(Nil))
+      . assert(_ == at(1, 1, 0))
+
+      test(m"Locate a top-level compound by keyword"):
+        t"greeting hello\n".read[Tel].locate(TelPath(List(t"greeting")))
+      . assert(_ == at(1, 1, 8))
+
+      test(m"Locate the second of two top-level compounds"):
+        t"first a\nsecond b\n".read[Tel].locate(TelPath(List(t"second")))
+      . assert(_ == at(2, 1, 6))
+
+      test(m"An unknown keyword returns Unset"):
+        t"greeting hello\n".read[Tel].locate(TelPath(List(t"absent")))
+      . assert(_ == Unset)
+
+    suite(m"Nested compounds"):
+      test(m"Locate a child compound"):
+        t"person\n  name Alice\n  age 30\n".read[Tel]
+        . locate(TelPath(List(t"person", t"name")))
+      . assert(_ == at(2, 3, 4))
+
+      test(m"Locate a sibling child on a later line"):
+        t"person\n  name Alice\n  age 30\n".read[Tel]
+        . locate(TelPath(List(t"person", t"age")))
+      . assert(_ == at(3, 3, 3))
+
+      test(m"Locate a grandchild compound"):
+        t"a\n  b\n    c hello\n".read[Tel].locate(TelPath(List(t"a", t"b", t"c")))
+      . assert(_ == at(3, 5, 1))
+
+      test(m"A missing intermediate segment returns Unset"):
+        t"person\n  name Alice\n".read[Tel].locate(TelPath(List(t"person", t"absent")))
+      . assert(_ == Unset)
+
+    suite(m"Column tracks indentation"):
+      test(m"A top-level keyword is at column 1"):
+        t"root\n  child value\n".read[Tel].locate(TelPath(List(t"root"))).let(_.column)
+      . assert(_ == 1)
+
+      test(m"A one-level-deep keyword is at column 3"):
+        t"root\n  child value\n".read[Tel]
+        . locate(TelPath(List(t"root", t"child"))).let(_.column)
+      . assert(_ == 3)
+
+      test(m"A one-level-deep keyword is on the second line"):
+        t"root\n  child value\n".read[Tel]
+        . locate(TelPath(List(t"root", t"child"))).let(_.line)
+      . assert(_ == 2)
+
+    suite(m"Tracking mode"):
+      test(m"`import parsing.trackPositions` records a position index"):
+        t"greeting hello\n".read[Tel].positionIndex.absent
+      . assert(_ == false)
+
+      test(m"Without the import, the position index is Unset"):
+        given PositionTracking = PositionTracking.Off
+        t"greeting hello\n".read[Tel].positionIndex
+      . assert(_ == Unset)
+
+      test(m"Locating in an untracked document returns Unset"):
+        given PositionTracking = PositionTracking.Off
+        t"greeting hello\n".read[Tel].locate(TelPath(List(t"greeting")))
+      . assert(_ == Unset)
+
+    suite(m"Span derivation"):
+      test(m"a position's span carries its line as a 0-based ordinal"):
+        at(2, 8, 3).span.startLine.vouch
+      . assert(_ == 1.z)
+
+      test(m"a position's span carries its column as a 0-based ordinal"):
+        at(2, 8, 3).span.startColumn.vouch
+      . assert(_ == 7.z)
+
+      test(m"a position's span carries its length"):
+        at(2, 8, 3).span.length.vouch
+      . assert(_ == 3)

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -2850,6 +2850,7 @@ object Tests extends Suite(m"Stratiform Tests"):
     VerifyTests()
     AccrualTests()
     PositionalTests()
+    PositionTests()
     EquivalenceTests()
 
     suite(m"BinTEL direct parsing (BintelInlinable)"):


### PR DESCRIPTION
#1498's capture-checking rollout incidentally deleted the position machinery that #1473 had added to stratiform, so every `Tel.Type.assign` error — the whole §20.2 family — accrued with an empty `Tel.Focus` and could only be reported at the document root. The enrichment is restored as a single shared `Tel.supplementPositions`, the §20.2 walk scopes each compound's assignment to its own focus again, and `PositionTracking` is re-threaded through the `read`/`load` givens; without that last part `parseTracking` had no caller at all, so `parsing.trackPositions` had no effect on TEL and restoring the enrichment alone would have changed nothing. `Tel#as` gets the same treatment, so decode errors are located too.

## Release notes

Under `import parsing.trackPositions`, TEL validation and decoding errors accrued through a `validate[Tel.Focus]` boundary now carry both the keyword path of the offending compound and its source position — enough for precise editor diagnostics, where previously every diagnostic landed on line 1.

```scala
import parsing.trackPositions

val tel = source.read[Tel]

validate[Tel.Focus](Diagnostics()):
  case error: TelError =>
    accrual + (prior.let(_.pointer.encode).or(t"#"), prior.let(_.position))
. protect(Tel.Type.assign(tel, schema))
```

An unknown keyword on line 2 now reports `#/bar` at line 2, column 1; a missing required member reports its own keyword path with no position, since it has no compound in the source.

The `Tel.Position` alias for `TelError.Position` is available again, and `Tel.Focus.withPosition(tel)` resolves a focus's pointer against a position-tracked document.

Fixes #1705

🤖 Generated with [Claude Code](https://claude.com/claude-code)
