### PR TITLE
Track compatibility for Java classfiles and TypeScript declarations

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1912,9 +1912,16 @@ object mandible extends Library:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
     def mvnDeps = Seq(mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}")
 
-  object test extends Tests(core, revolution.core, quantitative.units):
+  object lira extends Component(core, reliquary.core):
+    override def scalaJs = false // adapts the discipline to reliquary's JVM-only SPI
+    override def scalacOptions = Task:
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
+
+  object test extends Tests(core, lira, revolution.core, quantitative.units, anthology.`scala`,
+      anthology.java, hellenism.jvm):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions())
+    def mvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
 
 object locomotion extends Library:
   object core

--- a/build.mill
+++ b/build.mill
@@ -582,7 +582,7 @@ object soundness extends Toolchain:
     probably.coverage)
 
   object tool extends Bundle(anthology.core, decorum.plugin, degustation.core,
-    degustation.lira, harlequin.core, hellenism.core,
+    degustation.lira, mandible.lira, xenophile.lira, harlequin.core, hellenism.core,
     hyperbole.core, octogenarian.core, reliquary.core, revolution.core, umbrageous.plugin,
     anthology.java,
     harlequin.md, harlequin.ansi, austronesian.core, anthology.linker, anthology.link, anthology.nir,
@@ -2618,6 +2618,11 @@ object xenophile extends Library:
   object typescript extends Component(core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
+
+  object lira extends Component(typescript, reliquary.core):
+    override def scalaJs = false // adapts the discipline to reliquary's JVM-only SPI
+    override def scalacOptions = Task:
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // The platform-neutral C front end (the `Native` ecosystem type markers and the `CHeaderDialect`
   // header parser); shared by the JVM Panama backend and the Scala Native backend, so it carries no
   // platform runtime and cross-compiles to both.
@@ -2670,7 +2675,7 @@ object xenophile extends Library:
   // Every backend at once — which only typechecks because they now share the single `invoke` in
   // `core` rather than exporting one apiece into `soundness`.
   object test extends Tests(typescript, native, wit, webidl, wasm, kotlin, js, scalanative,
-      hellenism.core, harlequin.core):
+      lira, hellenism.core, harlequin.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions())
     // kotlin-stdlib is the Kotlin-classfile fixture: its `@Metadata`-annotated classes let the

--- a/lib/mandible/src/core/mandible.ClassSurface.scala
+++ b/lib/mandible/src/core/mandible.ClassSurface.scala
@@ -1,0 +1,175 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package mandible
+
+import java.lang.classfile as jlc
+import java.lang.classfile.attribute as jlca
+
+import anticipation.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+// The *declaration* surface of a classfile, as distinct from the bytecode surface `Classfile`
+// exposes. Everything a compiled consumer can bind to at link time is here — names, descriptors,
+// access flags, the supertype chain and the generic signatures a recompiling consumer reads back
+// — and nothing else is: `Code`, `SourceFile`, `LineNumberTable` and the annotation attributes
+// are all dropped, since none of them is linkage surface, and two builds of the same sources may
+// legitimately differ in all of them.
+object ClassSurface:
+  enum Kind:
+    case Method, Field
+
+  // A member reduced to what the JVM resolves against. `signature` is the generic signature
+  // attribute, kept because erasure discards the type arguments a consumer's *next* compile
+  // needs; `constant` is the `ConstantValue` a `static final` field may have had inlined into
+  // consumers already.
+  case class Member
+    ( kind:       Kind,
+      name:       Text,
+      descriptor: Text,
+      flags:      Int,
+      signature:  Optional[Text] = Unset,
+      exceptions: List[Text]     = Nil,
+      constant:   Optional[Text] = Unset ):
+
+    // The member's selector within its owning class; the atom key is the owner's name with this
+    // appended, so methods and fields of the same name never collide.
+    def selector: Text = kind match
+      case Kind.Method => t"#$name:$descriptor"
+      case Kind.Field  => t".$name:$descriptor"
+
+    def public: Boolean    = (flags & jlc.ClassFile.ACC_PUBLIC) != 0
+    def protect: Boolean   = (flags & jlc.ClassFile.ACC_PROTECTED) != 0
+    def priv: Boolean      = (flags & jlc.ClassFile.ACC_PRIVATE) != 0
+    def static: Boolean    = (flags & jlc.ClassFile.ACC_STATIC) != 0
+    def abstrakt: Boolean  = (flags & jlc.ClassFile.ACC_ABSTRACT) != 0
+    def bridge: Boolean    = (flags & jlc.ClassFile.ACC_BRIDGE) != 0
+    def synthetic: Boolean = (flags & jlc.ClassFile.ACC_SYNTHETIC) != 0
+
+    // Package-private and private members are not consumer surface: no consumer outside the
+    // runtime package can resolve against them, so they never become atoms.
+    def visible: Boolean = public || protect
+
+    // A `static final` field of primitive or `String` type whose value javac may already have
+    // copied into every consumer's constant pool (JLS 13.4.9). Its value is therefore
+    // *replaceable* surface, not rigid — see `ClassfileAtomizer`.
+    def inlinable: Boolean = kind == Kind.Field && static && constant.present
+
+  private def text(entry: jlc.constantpool.Utf8Entry): Text = entry.stringValue.nn.tt
+
+  private def signatureOf(attributes: List[jlc.Attribute[?]]): Optional[Text] =
+    attributes.stdlib.collectFirst:
+      case attribute: jlca.SignatureAttribute => attribute.signature.nn.stringValue.nn.tt
+
+    . getOrElse(Unset)
+
+  // The constant's *class* is folded alongside its value: `1` as an `Integer` and `"1"` as a
+  // `String` are different contracts, and their `toString` forms are not.
+  private def constantOf(attributes: List[jlc.Attribute[?]]): Optional[Text] =
+    attributes.stdlib.collectFirst:
+      case attribute: jlca.ConstantValueAttribute =>
+        val value = attribute.constant.nn.constantValue.nn
+        t"${value.getClass.nn.getName.nn.tt}:${value.toString.nn.tt}"
+
+    . getOrElse(Unset)
+
+  private def exceptionsOf(attributes: List[jlc.Attribute[?]]): List[Text] =
+    attributes.stdlib.collectFirst:
+      case attribute: jlca.ExceptionsAttribute =>
+        // Sorted: the `Exceptions` attribute's order is source order, which is not contractual.
+        List.from(attribute.exceptions.nn.to[List].stdlib.map(_.asInternalName.nn.tt).sorted)
+
+    . getOrElse(Nil)
+
+  def apply(data: scala.IArray[Byte]): ClassSurface =
+    val model = jlc.ClassFile.of().nn.parse(data.asInstanceOf[scala.Array[Byte]]).nn
+
+    val fields = model.fields.nn.to[List].map: field =>
+      val attributes = field.attributes.nn.to[List]
+
+      Member
+        ( Kind.Field,
+          text(field.fieldName.nn),
+          text(field.fieldType.nn),
+          field.flags.nn.flagsMask,
+          signatureOf(attributes),
+          Nil,
+          constantOf(attributes) )
+
+    val methods = model.methods.nn.to[List].map: method =>
+      val attributes = method.attributes.nn.to[List]
+
+      Member
+        ( Kind.Method,
+          text(method.methodName.nn),
+          text(method.methodType.nn),
+          method.flags.nn.flagsMask,
+          signatureOf(attributes),
+          exceptionsOf(attributes),
+          Unset )
+
+    // Members are sorted by selector: `java.lang.classfile` yields them in file order, and file
+    // order is an artifact of the compilation run, not of the interface (§11.2 requirement 3).
+    val members =
+      List.from((fields.stdlib ++ methods.stdlib).sortBy { member => member.selector.s })
+
+    ClassSurface
+      ( model.thisClass.nn.asInternalName.nn.tt,
+        model.flags.nn.flagsMask,
+        Optional(model.superclass.nn.orElse(null)).let(_.asInternalName.nn.tt),
+        List.from(model.interfaces.nn.to[List].stdlib.map(_.asInternalName.nn.tt).sorted),
+        signatureOf(model.attributes.nn.to[List]),
+        members )
+
+// The parsed declaration surface of one class. `name`, `superclass` and `interfaces` are JVM
+// internal names (`java/lang/String`), which is the form every reference in a classfile uses.
+case class ClassSurface
+  ( name:       Text,
+    flags:      Int,
+    superclass: Optional[Text],
+    interfaces: List[Text],
+    signature:  Optional[Text],
+    members:    List[ClassSurface.Member] ):
+
+  def public: Boolean    = (flags & jlc.ClassFile.ACC_PUBLIC) != 0
+  def interface: Boolean = (flags & jlc.ClassFile.ACC_INTERFACE) != 0
+  def isFinal: Boolean   = (flags & jlc.ClassFile.ACC_FINAL) != 0
+  def synthetic: Boolean = (flags & jlc.ClassFile.ACC_SYNTHETIC) != 0
+
+  // The supertypes named directly by this class, superclass first: the order the JVM's own
+  // resolution walks, and the order membership keying inherits members in.
+  def supertypes: List[Text] = superclass.lay(interfaces)(_ :: interfaces)
+
+  def member(selector: Text): Optional[ClassSurface.Member] =
+    members.stdlib.find { member => member.selector == selector }.getOrElse(Unset)

--- a/lib/mandible/src/core/mandible.ClassSurface.scala
+++ b/lib/mandible/src/core/mandible.ClassSurface.scala
@@ -104,6 +104,22 @@ object ClassSurface:
 
     . getOrElse(Unset)
 
+  // A nested class's own `access_flags` record the *outer* view — a `protected` member class has
+  // neither `ACC_PUBLIC` nor `ACC_PROTECTED` there — while its real accessibility lives in the
+  // `InnerClasses` entry describing itself. Reading it back is what stops a protected nested
+  // class from being silently treated as package-private and dropped from the interface.
+  private def innerFlagsOf(attributes: List[jlc.Attribute[?]], name: Text): Optional[Int] =
+    attributes.stdlib.collectFirst:
+      case attribute: jlca.InnerClassesAttribute => attribute
+
+    . flatMap: attribute =>
+        attribute.classes.nn.to[List].stdlib.find: info =>
+          info.innerClass.nn.asInternalName.nn.tt == name
+
+        . map(_.flagsMask)
+
+    . getOrElse(Unset)
+
   private def exceptionsOf(attributes: List[jlc.Attribute[?]]): List[Text] =
     attributes.stdlib.collectFirst:
       case attribute: jlca.ExceptionsAttribute =>
@@ -144,13 +160,17 @@ object ClassSurface:
     val members =
       List.from((fields.stdlib ++ methods.stdlib).sortBy { member => member.selector.s })
 
+    val name = model.thisClass.nn.asInternalName.nn.tt
+    val attributes = model.attributes.nn.to[List]
+
     ClassSurface
-      ( model.thisClass.nn.asInternalName.nn.tt,
+      ( name,
         model.flags.nn.flagsMask,
         Optional(model.superclass.nn.orElse(null)).let(_.asInternalName.nn.tt),
         List.from(model.interfaces.nn.to[List].stdlib.map(_.asInternalName.nn.tt).sorted),
-        signatureOf(model.attributes.nn.to[List]),
-        members )
+        signatureOf(attributes),
+        members,
+        innerFlagsOf(attributes, name) )
 
 // The parsed declaration surface of one class. `name`, `superclass` and `interfaces` are JVM
 // internal names (`java/lang/String`), which is the form every reference in a classfile uses.
@@ -160,12 +180,19 @@ case class ClassSurface
     superclass: Optional[Text],
     interfaces: List[Text],
     signature:  Optional[Text],
-    members:    List[ClassSurface.Member] ):
+    members:    List[ClassSurface.Member],
+    innerFlags: Optional[Int] = Unset ):
 
-  def public: Boolean    = (flags & jlc.ClassFile.ACC_PUBLIC) != 0
   def interface: Boolean = (flags & jlc.ClassFile.ACC_INTERFACE) != 0
   def isFinal: Boolean   = (flags & jlc.ClassFile.ACC_FINAL) != 0
   def synthetic: Boolean = (flags & jlc.ClassFile.ACC_SYNTHETIC) != 0
+
+  // Accessibility comes from the `InnerClasses` entry where there is one, since that is the only
+  // place a nested class's `protected` survives.
+  def access: Int = innerFlags.or(flags)
+
+  def visible: Boolean =
+    (access & (jlc.ClassFile.ACC_PUBLIC | jlc.ClassFile.ACC_PROTECTED)) != 0
 
   // The supertypes named directly by this class, superclass first: the order the JVM's own
   // resolution walks, and the order membership keying inherits members in.

--- a/lib/mandible/src/core/mandible.ClasspathIndex.scala
+++ b/lib/mandible/src/core/mandible.ClasspathIndex.scala
@@ -1,0 +1,105 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package mandible
+
+import java.net as jn
+
+import anticipation.*
+import gossamer.*
+import vacuous.*
+
+// Resolves a JVM internal class name to its declaration surface, over content held in memory
+// plus a classpath of textual entries. Membership keying (LIRA §11.2 requirement 4) has to walk
+// the supertype closure of every atomized class, and most of that closure lives in the
+// *dependencies*, not in the release being atomized — so the release's own classes are indexed
+// eagerly and everything else is resolved lazily through the classpath.
+object ClasspathIndex:
+  // A directory entry's URL must end in `/` for `URLClassLoader` to treat it as a directory;
+  // `File.toURI` appends one for a path that exists on disk, and a classpath entry that does not
+  // exist resolves nothing either way.
+  private def url(entry: Text): jn.URL = java.io.File(entry.s).toURI.nn.toURL.nn
+
+  def apply(local: Map[Text, ClassSurface], classpath: List[Text]): ClasspathIndex =
+    val urls: scala.Array[jn.URL | Null] =
+      scala.Array.from(classpath.stdlib.map(url(_)))
+
+    new ClasspathIndex
+      ( local,
+        jn.URLClassLoader(urls, ClassLoader.getPlatformClassLoader().nn) )
+
+class ClasspathIndex private (local: Map[Text, ClassSurface], classloader: jn.URLClassLoader):
+  // Resolution is memoized — and negative results are memoized too. A supertype walk revisits
+  // `java/lang/Object` once per atomized class, and a missing supertype is asked for exactly as
+  // often, so caching both is what keeps atomization linear in the release's size.
+  private val cache = scala.collection.mutable.HashMap[Text, Optional[ClassSurface]]()
+
+  // The classes carried by the release itself, which are the ones that get atomized. Held
+  // separately from the cache so `local` is never shadowed by a same-named class that happens to
+  // be earlier on the dependency classpath.
+  def own: List[Text] = List.from(local.stdlib.keys.toList.sortBy(_.s))
+
+  def apply(name: Text): Optional[ClassSurface] =
+    cache.getOrElseUpdate(name, resolve(name))
+
+  private def resolve(name: Text): Optional[ClassSurface] =
+    local.stdlib.get(name).map(Optional(_)).getOrElse:
+      Optional(classloader.getResourceAsStream(t"$name.class".s)).let: stream =>
+        // Same erasure: the bytes are read and never retained, so no freezing capability is
+        // needed to hand them to the parser.
+        try ClassSurface(stream.readAllBytes().nn.asInstanceOf[scala.IArray[Byte]])
+        finally stream.close()
+
+  // The transitive supertype closure of `name`, nearest first, excluding `name` itself. Classes
+  // that cannot be resolved are reported rather than skipped: an unresolvable supertype means
+  // the member set is *unknown*, and silently atomizing a smaller one would understate the
+  // interface.
+  def closure(name: Text): (List[Text], List[Text]) =
+    val seen = scala.collection.mutable.LinkedHashSet[Text]()
+    val missing = scala.collection.mutable.LinkedHashSet[Text]()
+
+    def recur(todo: List[Text]): Unit = todo match
+      case Nil => ()
+
+      case next :: rest =>
+        if seen.contains(next) || missing.contains(next) then recur(rest) else apply(next) match
+          case surface: ClassSurface =>
+            seen += next
+            recur(List.from(rest.stdlib ++ surface.supertypes.stdlib))
+
+          case _ =>
+            missing += next
+            recur(rest)
+
+    apply(name).let: surface => recur(surface.supertypes)
+
+    (List.from(seen.toList), List.from(missing.toList))

--- a/lib/mandible/src/lira/mandible.ClassfileAtomizer.scala
+++ b/lib/mandible/src/lira/mandible.ClassfileAtomizer.scala
@@ -1,0 +1,239 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package mandible
+
+import java.lang.classfile as jlc
+
+import anticipation.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+import vacuous.*
+
+// The atomization rules of `classfile/1`, over the declaration surface `ClassSurface` reads.
+// Shared, deliberately, by two consumers with opposite relationships to the snapshot: the
+// discipline, whose atoms *are* API identity, and the `jvm/1` profile, which compares the same
+// atom sets out of band precisely so that they are not (LIRA §11.6).
+//
+// Two rules govern every decision below. First, the encoding is a function of the *interface*,
+// never of the compilation run: file order, line tables, source names and the `Code` attribute
+// are absent, and every list is sorted unless its order is itself semantic. Second, where it is
+// unclear whether a property is linkage surface, it is folded in anyway: folding something
+// inessential can only over-report a change, which grades a needless major, while omitting
+// something essential under-reports a break, which is unsound.
+object ClassfileAtomizer:
+  val id: Text = t"classfile/1"
+
+  // The result of atomizing one release's classes. `unresolved` names supertypes that were not
+  // on the classpath: an unresolved supertype means an unknown member set, so the caller must
+  // fail rather than atomize the smaller set it can see.
+  case class Outcome(atoms: List[Atom], unresolved: List[Text])
+
+  // Flag subsets, in a fixed bit order, chosen per element kind because the JVM reuses bit
+  // values across kinds (`0x0040` is `ACC_BRIDGE` on a method and `ACC_VOLATILE` on a field).
+  // `ACC_SUPER`, `ACC_SYNCHRONIZED`, `ACC_NATIVE` and `ACC_STRICT` are excluded: none is
+  // resolvable surface, and all three of the latter vary with an implementation a consumer
+  // cannot observe through linkage.
+  private val classFlags: scala.List[Int] =
+    scala.List
+      ( jlc.ClassFile.ACC_PUBLIC, jlc.ClassFile.ACC_PROTECTED, jlc.ClassFile.ACC_FINAL,
+        jlc.ClassFile.ACC_INTERFACE, jlc.ClassFile.ACC_ABSTRACT, jlc.ClassFile.ACC_SYNTHETIC,
+        jlc.ClassFile.ACC_ANNOTATION, jlc.ClassFile.ACC_ENUM )
+
+  private val methodFlags: scala.List[Int] =
+    scala.List
+      ( jlc.ClassFile.ACC_PUBLIC, jlc.ClassFile.ACC_PRIVATE, jlc.ClassFile.ACC_PROTECTED,
+        jlc.ClassFile.ACC_STATIC, jlc.ClassFile.ACC_FINAL, jlc.ClassFile.ACC_BRIDGE,
+        jlc.ClassFile.ACC_VARARGS, jlc.ClassFile.ACC_ABSTRACT, jlc.ClassFile.ACC_SYNTHETIC )
+
+  private val fieldFlags: scala.List[Int] =
+    scala.List
+      ( jlc.ClassFile.ACC_PUBLIC, jlc.ClassFile.ACC_PRIVATE, jlc.ClassFile.ACC_PROTECTED,
+        jlc.ClassFile.ACC_STATIC, jlc.ClassFile.ACC_FINAL, jlc.ClassFile.ACC_VOLATILE,
+        jlc.ClassFile.ACC_TRANSIENT, jlc.ClassFile.ACC_SYNTHETIC, jlc.ClassFile.ACC_ENUM )
+
+  private def bits(mask: Int, flags: scala.List[Int]): Long =
+    flags.zipWithIndex.foldLeft(0L): (bits, pair) =>
+      if (mask & pair(0)) != 0 then bits | (1L << pair(1)) else bits
+
+  // --- canonical binary encoding ---------------------------------------------------------------
+  // The same tag-length-value scheme `tasty/1` uses (`tasty.md` §7): unsigned LEB128 lengths,
+  // length-prefixed UTF-8 strings, single-character constructor tags.
+
+  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+    var value = value0
+
+    while value >= 0x80L do
+      out.write(((value & 0x7f) | 0x80).toInt)
+      value >>>= 7
+
+    out.write(value.toInt)
+
+  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
+    val bytes = text.s.getBytes("UTF-8").nn
+    uvarint(out, bytes.length.toLong)
+    out.write(bytes)
+
+  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+
+  private def optional(out: java.io.ByteArrayOutputStream, value: Optional[Text]): Unit =
+    value.lay(tag(out, '0')):
+      text =>
+        tag(out, '1')
+        utf8(out, text)
+
+  private def texts(out: java.io.ByteArrayOutputStream, values: List[Text]): Unit =
+    uvarint(out, values.stdlib.length.toLong)
+    values.stdlib.foreach { value => utf8(out, value) }
+
+  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
+    val out = java.io.ByteArrayOutputStream()
+    encode(out)
+    LiraHash(LiraHash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+
+  // --- the presented member set -----------------------------------------------------------------
+
+  // Constructors are not inherited, and a class initializer is never resolvable surface.
+  private def inheritable(member: ClassSurface.Member): Boolean =
+    member.name != t"<init>" && member.name != t"<clinit>"
+
+  private def declarable(member: ClassSurface.Member): Boolean = member.name != t"<clinit>"
+
+  // Membership keying (§11.2 requirement 4): a JVM call site names the *receiver*, so the linkage
+  // surface of a type includes every member it presents, not merely those it declares. The
+  // presented set is this class's own visible members followed by those of its supertype closure,
+  // nearest first, with the first occurrence of each selector winning — which is exactly how an
+  // override, or a redeclaration that narrows nothing, shadows the inherited member.
+  private def presented(surface: ClassSurface, index: ClasspathIndex)
+  :   List[(ClassSurface.Member, Boolean)] =
+
+    val (closure, _) = index.closure(surface.name)
+    val seen = scala.collection.mutable.LinkedHashSet[Text]()
+    val result = scala.collection.mutable.ListBuffer[(ClassSurface.Member, Boolean)]()
+
+    surface.members.stdlib.foreach: member =>
+      if member.visible && declarable(member) && seen.add(member.selector)
+      then result += ((member, true))
+
+    closure.stdlib.foreach: name =>
+      index(name).let: parent =>
+        parent.members.stdlib.foreach: member =>
+          // A static member of an *interface* is not inherited by implementors (JLS 8.4.8), so it
+          // presents only on the interface that declares it.
+          val inherited = inheritable(member) && !(parent.interface && member.static)
+
+          if member.visible && inherited && seen.add(member.selector)
+          then result += ((member, false))
+
+    List.from(result.toList)
+
+  // --- atoms --------------------------------------------------------------------------------
+
+  private def memberAtom(owner: Text, member: ClassSurface.Member): Atom =
+    val flags = member.kind match
+      case ClassSurface.Kind.Method => bits(member.flags, methodFlags)
+      case ClassSurface.Kind.Field  => bits(member.flags, fieldFlags)
+
+    // The presenting owner is folded into the *value*, not merely the key. The snapshot (§12.1)
+    // hashes the set of *distinct* value hashes, so two membership atoms that differed only by
+    // key would collapse to one, and dropping a member from one of several presenting types
+    // would leave API identity unchanged — an under-report, and the one soundness trap
+    // membership keying introduces.
+    val encoding = hash: out =>
+      tag(out, if member.kind == ClassSurface.Kind.Method then 'M' else 'F')
+      utf8(out, owner)
+      utf8(out, member.name)
+      utf8(out, member.descriptor)
+      uvarint(out, flags)
+      optional(out, member.signature)
+      texts(out, member.exceptions)
+      optional(out, member.constant)
+
+    // A `static final` field of constant type may already have been copied into every consumer's
+    // constant pool (JLS 13.4.9), so its *value* is churn a recompile absorbs rather than a
+    // linkage contract: replaceable, with no references, exactly as `resource/1` tracks content.
+    val atomClass =
+      if member.inlinable then AtomClass.Replaceable else AtomClass.Rigid
+
+    Atom(t"$owner${member.selector}", atomClass, encoding)
+
+  private def classAtom
+    ( surface: ClassSurface, members: List[(ClassSurface.Member, Boolean)] )
+  :   Atom =
+
+    // Rule 5 of `tasty.md` §8, transposed: on a class open to subclassing, *adding* an abstract
+    // method breaks every existing implementor, so the abstract member set folds into the class's
+    // own atom and the addition grades major. On a final class nothing can implement it, the fold
+    // is empty, and the same addition is pure extension.
+    val abstracts =
+      if surface.isFinal then Nil else List.from:
+        members.stdlib.collect:
+          case (member, _) if member.abstrakt => member.selector
+
+        . sortBy(_.s)
+
+    val encoding = hash: out =>
+      tag(out, 'K')
+      utf8(out, surface.name)
+      uvarint(out, bits(surface.access, classFlags))
+      optional(out, surface.superclass)
+      // Interfaces keep no declaration order: the JVM resolves default methods by the class
+      // hierarchy, not by the order of the `interfaces` array, and `ClassSurface` sorts them.
+      texts(out, surface.interfaces)
+      optional(out, surface.signature)
+      texts(out, abstracts)
+
+    Atom(surface.name, AtomClass.Rigid, encoding)
+
+  // Atomizes the visible classes of one release. `classes` is the release's own content, keyed by
+  // JVM internal name; `classpath` locates the dependencies whose members present through it.
+  def atomize(classes: Map[Text, ClassSurface], classpath: List[Text]): Outcome =
+    val index = ClasspathIndex(classes, classpath)
+    val atoms = scala.collection.mutable.ListBuffer[Atom]()
+    val unresolved = scala.collection.mutable.LinkedHashSet[Text]()
+
+    index.own.stdlib.foreach: name =>
+      index(name).let: surface =>
+        // Synthetic classes — lambda holders, `package-info`, anonymous helpers — are not
+        // resolvable by name from any consumer's source, so they carry no interface of their own.
+        if surface.visible && !surface.synthetic then
+          val (_, missing) = index.closure(name)
+          unresolved ++= missing.stdlib
+
+          val members = presented(surface, index)
+          atoms += classAtom(surface, members)
+
+          members.stdlib.foreach: (member, _) =>
+            atoms += memberAtom(surface.name, member)
+
+    Outcome(List.from(atoms.toList), List.from(unresolved.toList))

--- a/lib/mandible/src/lira/mandible.ClassfileAtomizer.scala
+++ b/lib/mandible/src/lira/mandible.ClassfileAtomizer.scala
@@ -159,7 +159,20 @@ object ClassfileAtomizer:
 
   // --- atoms --------------------------------------------------------------------------------
 
-  private def memberAtom(owner: Text, member: ClassSurface.Member): Atom =
+  // Whether generic `Signature` attributes participate in the encoding.
+  //
+  // They are *not* linkage surface: the JVM ignores them entirely, resolving on descriptors
+  // alone. They are recompilation surface, which is why the discipline folds them anyway —
+  // over-reporting a change costs a needless major, and that is the safe direction for something
+  // whose atoms are API identity. The `jvm/1` profile has the opposite exposure: over-reporting
+  // there publishes `breaks linkage` for a release that breaks no linkage, which is a false
+  // claim rather than a conservative one. So the profile asks for the narrower view.
+  enum Fold:
+    case Full, Linkage
+
+    def signatures: Boolean = this == Full
+
+  private def memberAtom(owner: Text, member: ClassSurface.Member, fold: Fold): Atom =
     val flags = member.kind match
       case ClassSurface.Kind.Method => bits(member.flags, methodFlags)
       case ClassSurface.Kind.Field  => bits(member.flags, fieldFlags)
@@ -175,7 +188,7 @@ object ClassfileAtomizer:
       utf8(out, member.name)
       utf8(out, member.descriptor)
       uvarint(out, flags)
-      optional(out, member.signature)
+      if fold.signatures then optional(out, member.signature)
       texts(out, member.exceptions)
       optional(out, member.constant)
 
@@ -188,7 +201,7 @@ object ClassfileAtomizer:
     Atom(t"$owner${member.selector}", atomClass, encoding)
 
   private def classAtom
-    ( surface: ClassSurface, members: List[(ClassSurface.Member, Boolean)] )
+    ( surface: ClassSurface, members: List[(ClassSurface.Member, Boolean)], fold: Fold )
   :   Atom =
 
     // Rule 5 of `tasty.md` §8, transposed: on a class open to subclassing, *adding* an abstract
@@ -210,14 +223,16 @@ object ClassfileAtomizer:
       // Interfaces keep no declaration order: the JVM resolves default methods by the class
       // hierarchy, not by the order of the `interfaces` array, and `ClassSurface` sorts them.
       texts(out, surface.interfaces)
-      optional(out, surface.signature)
+      if fold.signatures then optional(out, surface.signature)
       texts(out, abstracts)
 
     Atom(surface.name, AtomClass.Rigid, encoding)
 
   // Atomizes the visible classes of one release. `classes` is the release's own content, keyed by
   // JVM internal name; `classpath` locates the dependencies whose members present through it.
-  def atomize(classes: Map[Text, ClassSurface], classpath: List[Text]): Outcome =
+  def atomize(classes: Map[Text, ClassSurface], classpath: List[Text], fold: Fold = Fold.Full)
+  :   Outcome =
+
     val index = ClasspathIndex(classes, classpath)
     val atoms = scala.collection.mutable.ListBuffer[Atom]()
     val unresolved = scala.collection.mutable.LinkedHashSet[Text]()
@@ -231,9 +246,9 @@ object ClassfileAtomizer:
           unresolved ++= missing.stdlib
 
           val members = presented(surface, index)
-          atoms += classAtom(surface, members)
+          atoms += classAtom(surface, members, fold)
 
           members.stdlib.foreach: (member, _) =>
-            atoms += memberAtom(surface.name, member)
+            atoms += memberAtom(surface.name, member, fold)
 
     Outcome(List.from(atoms.toList), List.from(unresolved.toList))

--- a/lib/mandible/src/lira/mandible.ClassfileDiscipline.scala
+++ b/lib/mandible/src/lira/mandible.ClassfileDiscipline.scala
@@ -30,8 +30,66 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package mandible
 
-export mandible.
-        {Bytecode, BytecodePalette, Classfile, ClassfileError, ClasspathIndex, ClassSurface,
-         disassemble}
+import anticipation.*
+import contingency.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+
+// The `classfile/1` discipline: the JVM's *linkage* contract, as atoms.
+//
+// Registering it is a deliberate choice with a cost, and the cost is the reason `tasty/1` holds
+// `.class` files atomless rather than doing this itself. Atoms feed the snapshot, and the
+// snapshot is API identity (§12.1), so folding bytecode surface into atoms means a release whose
+// source-level interface is untouched but whose bridge methods moved acquires a *different* API
+// identity — breaking dependency satisfaction (§13.2) for consumers who only ever recompile.
+// LIRA §11.6 records that trade-off and recommends the other side of it for an ecosystem whose
+// primary contract is recompilation: `JvmProfile` computes the same predicates from the same
+// atomizer without letting them near the snapshot. Register this discipline where linkage is the
+// primary contract; declare the `jvm/1` profile where it is not.
+//
+// Registry order is load-bearing (§11.2): `Discipline.Registry` claims by first match, and
+// `tasty/1` claims `.class` atomless, so this discipline must precede it —
+// `Discipline.Registry(List(ClassfileDiscipline, Tasty))`. In the other order it claims nothing.
+object ClassfileDiscipline extends Discipline:
+  def id: Text = ClassfileAtomizer.id
+
+  // Classfiles exist in the `jvm` universe alone; `sjsir` and `nir` have no counterpart to
+  // compare against, so the cross-section invariant (§9.6) is vacuous here and correctly so. A
+  // single-universe domain is exactly the case §11.2 requirement 1 exempts from it.
+  def domain: Discipline.Domain = Discipline.Domain.Universes(Set(t"jvm"))
+
+  // §11.2 requirement 4: a JVM call site names the receiver, not the declarer, so a type's
+  // linkage surface includes members it inherits. Declaration keying would be unsound for a
+  // discipline certifying linkage, and this one does certify it.
+  def keying: Discipline.Keying = Discipline.Keying.Membership
+
+  // Linkage only. Bytecode has erased the type arguments, variance and implicit specificity that
+  // decide whether a consumer's *next compile* succeeds, so this discipline cannot certify
+  // recompilation and must not claim it (§11.2 requirement 7). That level is `tasty/1`'s, and the
+  // two are independent in both directions (Appendix D.1).
+  def guarantees(universe: Text): Set[Discipline.Guarantee] = Set(Discipline.Guarantee.Linkage)
+
+  def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".class")
+
+  def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
+  :   Atomization raises DisciplineError =
+
+    val classes = content.stdlib.map: (path, data) =>
+      // Same erasure; the parser reads the bytes and retains nothing of them.
+      val surface = ClassSurface(data.asInstanceOf[scala.IArray[Byte]])
+      surface.name -> surface
+
+    . to(scala.collection.immutable.Map)
+
+    val outcome = ClassfileAtomizer.atomize(Map.of(classes), context.classpath)
+
+    // An unresolvable supertype is fatal, never skipped: its member set is unknown, so the
+    // presented set of everything below it is understated, and an understated interface is a
+    // compatibility claim made over content nobody read.
+    outcome.unresolved.stdlib.headOption.foreach: name =>
+      abort(DisciplineError(id, DisciplineError.Reason.Unresolved(name)))
+
+    Atomization.of(id, outcome.atoms)

--- a/lib/mandible/src/lira/mandible.JvmProfile.scala
+++ b/lib/mandible/src/lira/mandible.JvmProfile.scala
@@ -1,0 +1,147 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package mandible
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+import vacuous.*
+
+// The `jvm/1` ecosystem profile (LIRA Appendix D): the JVM's linkage predicates, checked against
+// the predecessor release and reported *separately* from the grade.
+//
+// It runs the same atomizer as `ClassfileDiscipline`, over the same content, and reaches the same
+// conclusions about what the bytecode contract does. The difference is entirely in where the
+// answer goes. The discipline's atoms enter the snapshot, and the snapshot is API identity, so a
+// release whose bridge methods merely moved would acquire a new identity and fail dependency
+// satisfaction for consumers who only recompile. The profile's findings enter the `breaks
+// linkage` record instead (§12.4), which is read by exactly the consumers a linkage break
+// affects — those pinned to prebuilt bytecode — and by nobody else.
+//
+// This is what Appendix D.1 means by the two levels diverging in both directions. A release can
+// be a clean minor by the core algebra and still fail these predicates; it can also break
+// recompilation, graded a major, while every predicate here passes.
+object JvmProfile extends EcosystemProfile:
+  def id: Text = t"jvm/1"
+
+  // Linkage alone. `tasty/1` certifies recompilation over the same release, and this profile
+  // adds no predicate about it: a profile adds guarantees, never subtracts them (L129).
+  def certifies: Set[Discipline.Guarantee] = Set(Discipline.Guarantee.Linkage)
+
+  private val universe: Text = t"jvm"
+
+  // The atoms `classfile/1` would produce for one release's `jvm` section, as a lookup by key.
+  // An absent section — a release that carries no `jvm` universe at all — has no linkage surface
+  // and yields nothing to compare.
+  private def surface(evidence: EcosystemProfile.Evidence)
+  :   Map[Text, Atom] raises DisciplineError =
+
+    evidence.section(universe).lay(Map.empty[Text, Atom]): section =>
+      val classes = section.content.stdlib.filter { pair => pair(0).text.s.endsWith(".class") }
+
+      if classes.isEmpty then Map.empty else
+        val surfaces = classes.map: (path, data) =>
+          // Same erasure; the parser reads the bytes and retains nothing of them.
+          val surface = ClassSurface(data.asInstanceOf[scala.IArray[Byte]])
+          surface.name -> surface
+
+        . to(scala.collection.immutable.Map)
+
+        val outcome =
+          ClassfileAtomizer.atomize
+            (Map.of(surfaces), section.classpath, ClassfileAtomizer.Fold.Linkage)
+
+        outcome.unresolved.stdlib.headOption.foreach: name =>
+          abort(DisciplineError(id, DisciplineError.Reason.Unresolved(name)))
+
+        Map.of(outcome.atoms.stdlib.map { atom => atom.key -> atom }.toMap)
+
+  def check(previous: EcosystemProfile.Evidence, next: EcosystemProfile.Evidence)
+  :   List[EcosystemProfile.Violation] raises DisciplineError =
+
+    val before = surface(previous)
+    val after = surface(next)
+    val violations = scala.collection.mutable.ListBuffer[EcosystemProfile.Violation]()
+
+    def violate(detail: Text): Unit =
+      violations += EcosystemProfile.Violation(Discipline.Guarantee.Linkage, detail)
+
+    before.stdlib.foreach: (key, atom) =>
+      after.stdlib.get(key) match
+        // D.2, predicates 1, 2 and 4 at once. A key is `owner#name:descriptor`, so a member that
+        // disappears, changes descriptor, or moves to a type that no longer presents it all show
+        // up here as a missing key — including the bridges and mixin forwarders a compiled
+        // consumer may have bound to, which is why the atomizer keeps them.
+        case scala.None => violate(t"$key is no longer presented")
+
+        case scala.Some(replacement) =>
+          // A rigid atom whose value moved is a member whose flags, descriptor, generic signature
+          // or throws clause changed under a name consumers still resolve. Narrowing
+          // accessibility is the case that matters most (D.2, predicate 4), and it lands here
+          // because access flags fold into the atom's value.
+          if atom.atomClass == AtomClass.Rigid
+          && LiraHash.text(atom.valueHash) != LiraHash.text(replacement.valueHash)
+          then violate(t"$key no longer has the shape compiled consumers resolved")
+
+    // D.2, predicate 5: the ecosystem's toolchain predicate (§13.3). TASTy readability is
+    // versioned and not universally backward-compatible, so a release must carry TASTy the
+    // consumer's compiler can read — a release that records no toolchain at all makes the claim
+    // uncheckable rather than false, and is reported as such.
+    next.manifest.let: manifest =>
+      if manifest.toolchain.stdlib.isEmpty
+      then violate(t"the release records no toolchain, so TASTy readability cannot be checked")
+
+    List.from(violations.toList)
+
+  // D.2, predicate 3: `static final` constant values that javac may already have inlined into
+  // consumers. These are *not* linkage violations — a changed constant leaves every descriptor
+  // resolvable — but a consumer holding the old value computes with it until it recompiles. The
+  // core algebra already says the right thing here (the atoms are replaceable, so the step is a
+  // minor and stale used-sets are marked, §13.4), and repeating it as a break would overstate
+  // the finding. They are surfaced separately, for reporting.
+  def constants(previous: EcosystemProfile.Evidence, next: EcosystemProfile.Evidence)
+  :   List[Text] raises DisciplineError =
+
+    val before = surface(previous)
+    val after = surface(next)
+
+    val changed = before.stdlib.collect:
+      case (key, atom) if atom.atomClass == AtomClass.Replaceable =>
+        after.stdlib.get(key).filter: replacement =>
+          LiraHash.text(replacement.valueHash) != LiraHash.text(atom.valueHash)
+
+        . map { _ => key }
+
+    List.from(changed.flatten.toList.sortBy(_.s))

--- a/lib/mandible/src/lira/soundness_mandible_lira.scala
+++ b/lib/mandible/src/lira/soundness_mandible_lira.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export mandible.{ClassfileAtomizer, ClassfileDiscipline}
+export mandible.{ClassfileAtomizer, ClassfileDiscipline, JvmProfile}

--- a/lib/mandible/src/lira/soundness_mandible_lira.scala
+++ b/lib/mandible/src/lira/soundness_mandible_lira.scala
@@ -32,6 +32,4 @@
                                                                                                   */
 package soundness
 
-export mandible.
-        {Bytecode, BytecodePalette, Classfile, ClassfileError, ClasspathIndex, ClassSurface,
-         disassemble}
+export mandible.{ClassfileAtomizer, ClassfileDiscipline}

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -32,14 +32,63 @@
                                                                                                   */
 package mandible
 
+import java.nio.file.{Files, Paths}
+
+import scala.jdk.CollectionConverters.IteratorHasAsScala
+
 import soundness.*
+import galilei.Linux.pathOnLinux
 
 import proscenium.compat.*
 
+import alphabets.hexLowerCase
 import classloaders.threadContextClassloader
+import logging.silentLogging
+import probates.cancelProbate
+import strategies.throwUnsafely
+import systems.javaSystem
+import temporaryDirectories.systemTemporaryDirectory
+import threading.platformThreading
 
 object Tests extends Suite(m"Mandible tests"):
+
+  // Java, not Scala, for the classfile fixtures: `classfile/1` is a contract over bytecode, and
+  // Java is the language whose surface maps onto bytecode without a compilation scheme in
+  // between — `static final` constants, `protected` members and bridge methods all say what they
+  // mean here.
+  val base: Text =
+    t"""|package fixture;
+        |public class Base {
+        |  public static final int CONSTANT = 7;
+        |  public int inherited() { return 1; }
+        |  protected int guarded() { return 2; }
+        |  private int hidden() { return 3; }
+        |}
+        |""".s.stripMargin.tt
+
+  val derived: Text =
+    t"""|package fixture;
+        |public class Derived extends Base {
+        |  public int own() { return 4; }
+        |}
+        |""".s.stripMargin.tt
+
+  val api: Text =
+    t"""|package fixture;
+        |public interface Api {
+        |  int one();
+        |}
+        |""".s.stripMargin.tt
+
+  // Fixture variants are made by editing the source text, so each test states exactly the one
+  // change whose grade it is asserting.
+  def edit(source: Text, from: Text, to: Text): Text = source.s.replace(from.s, to.s).nn.tt
+
+  def sources(base: Text, derived: Text, api: Text): Map[Text, Text] =
+    Map(t"fixture/Base.java" -> base, t"fixture/Derived.java" -> derived, t"fixture/Api.java" -> api)
+
   def run(): Unit =
+    classfileDisciplineTests()
     test(m"Locate a known method on a classfile"):
       val rewrite =
         Classfile[StackTrace].let(_.methods.stdlib.find(_.name == t"rewrite").getOrElse(Unset)).vouch
@@ -148,3 +197,144 @@ object Tests extends Suite(m"Mandible tests"):
 
       caller.linearize((_, _, _) => Unset, maxInstructions = 7).size
     . assert(_ == 7)
+
+  def classfileDisciplineTests(): Unit =
+    import reliquary.*
+
+    // Compiles the fixtures and returns the emitted classfiles as discipline content, plus the
+    // output directory to use as the atomization classpath.
+    def compile(base: Text, derived: Text, api: Text) =
+      // The compilation runs inside `supervise`, but the classfile bytes are read outside it:
+      // `Data` is a frozen-array capability, and returning one out of the supervisor's scope
+      // freshens its capture set past what the enclosing method can admit.
+      val out: Text = supervise:
+        val directory: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
+        Files.createDirectories(Paths.get(directory.encode.s))
+        Javac(Nil)(LocalClasspath())(sources(base, derived, api), directory).complete()
+
+        directory.encode
+
+      val root = Paths.get(out.s).nn
+
+      val content = Files.walk(root).nn.iterator.nn.asScala
+        . to(scala.List)
+        . filter { path => path.toString.endsWith(".class") }
+        . sortBy(_.toString)
+        . map: path =>
+            val name = Text(root.relativize(path).nn.toString)
+            (TreePath(name), Array.unsafeFrozen(Files.readAllBytes(path).nn))
+
+      (List.from(content), out)
+
+    def atomize(base: Text, derived: Text, api: Text): Atomization =
+      val (content, out) = compile(base, derived, api)
+      ClassfileDiscipline.atomize(content, Discipline.Context(t"jvm", classpath = List(out)))
+
+    def listing(atomization: Atomization): scala.List[(Text, Text)] =
+      atomization.atoms.stdlib
+      . map { atom => (atom.key, atom.valueHash.serialize[Hex]) }
+      . sortBy(_(0).s)
+
+    val baseline = atomize(base, derived, api)
+    val keys = listing(baseline).map(_(0).s).toSet
+
+    test(m"a compiled fixture yields a nonempty atom listing"):
+      baseline.atoms.stdlib.size
+    . assert(_ > 0)
+
+    test(m"each compiled class yields a class atom"):
+      (keys.contains("fixture/Base"), keys.contains("fixture/Derived"), keys.contains("fixture/Api"))
+    . assert(_ == (true, true, true))
+
+    test(m"a declared method yields a member atom keyed by its owner"):
+      keys.contains("fixture/Base#inherited:()I")
+    . assert(identity)
+
+    test(m"membership keying presents an inherited method under the subclass"):
+      keys.contains("fixture/Derived#inherited:()I")
+    . assert(identity)
+
+    test(m"membership keying presents an inherited protected method too"):
+      keys.contains("fixture/Derived#guarded:()I")
+    . assert(identity)
+
+    test(m"a private method is not consumer surface and yields no atom"):
+      keys.exists(_.contains("hidden"))
+    . assert(_ == false)
+
+    test(m"a constructor is not inherited by the subclass"):
+      keys.contains("fixture/Derived#<init>:()V") && !keys.contains("fixture/Derived#Base:()V")
+    . assert(identity)
+
+    test(m"an inherited member's atom differs in value from the declared one"):
+      val table = listing(baseline).toMap
+      table.get(t"fixture/Base#inherited:()I") != table.get(t"fixture/Derived#inherited:()I")
+    . assert(identity)
+
+    // A constant presents through the subclass too, and javac will have inlined `Derived.CONSTANT`
+    // into consumers just as readily as `Base.CONSTANT`, so both are replaceable.
+    test(m"a static final constant is replaceable wherever it presents"):
+      baseline.replaceable.stdlib.map(_.key.s).toSet
+    . assert(_ == Set("fixture/Base.CONSTANT:I", "fixture/Derived.CONSTANT:I"))
+
+    test(m"atomization is deterministic across separate compilations"):
+      listing(atomize(base, derived, api)) == listing(atomize(base, derived, api))
+    . assert(identity)
+
+    // The §12.3 grades, computed over real bytecode.
+
+    def grade(base2: Text, derived2: Text, api2: Text): Grade =
+      Grade.between(List(baseline), List(atomize(base2, derived2, api2)))
+
+    test(m"an unchanged release grades as a patch"):
+      grade(base, derived, api)
+    . assert(_ == Grade.Patch)
+
+    test(m"adding a concrete method grades as a minor"):
+      val added = t"public int added() { return 9; }\n  public int inherited"
+      grade(edit(base, t"public int inherited", added), derived, api)
+    . assert(_ == Grade.Minor)
+
+    test(m"changing a static final constant's value grades as a minor"):
+      grade(edit(base, t"CONSTANT = 7", t"CONSTANT = 8"), derived, api)
+    . assert(_ == Grade.Minor)
+
+    test(m"removing a protected method grades as a major"):
+      grade(edit(base, t"protected int guarded() { return 2; }", t""), derived, api)
+    . assert(_ == Grade.Major)
+
+    test(m"narrowing a method's accessibility grades as a major"):
+      grade(edit(base, t"protected int guarded", t"private int guarded"), derived, api)
+    . assert(_ == Grade.Major)
+
+    test(m"adding an abstract method to an open interface grades as a major"):
+      grade(base, derived, edit(api, t"int one();", t"int one();\n  int two();"))
+    . assert(_ == Grade.Major)
+
+    // Registry ordering (§11.2): `tasty/1` claims `.class` atomless, and the registry claims by
+    // first match, so a registry that lists it first leaves `classfile/1` nothing to atomize.
+
+    test(m"the discipline claims classfiles and nothing else"):
+      val data = Array.freeze(Array[Byte](0))
+
+      (ClassfileDiscipline.claims(TreePath(t"fixture/Base.class"), data),
+       ClassfileDiscipline.claims(TreePath(t"fixture/Base.tasty"), data),
+       ClassfileDiscipline.claims(TreePath(t"readme.md"), data))
+    . assert(_ == (true, false, false))
+
+    test(m"the discipline claims nothing outside the jvm universe"):
+      val (content, out) = compile(base, derived, api)
+      val registry = Discipline.Registry(List(ClassfileDiscipline))
+      val context = Discipline.Context(t"sjsir", classpath = List(out))
+
+      registry.atomize(content, context).stdlib.map(_.discipline)
+    . assert(_ == scala.List(t"opaque/1"))
+
+    test(m"a registry listing the discipline first atomizes the classfiles"):
+      val (content, out) = compile(base, derived, api)
+      val registry = Discipline.Registry(List(ClassfileDiscipline))
+      val context = Discipline.Context(t"jvm", classpath = List(out))
+
+      registry.atomize(content, context).stdlib.map: atomization =>
+        (atomization.discipline, atomization.atoms.stdlib.size > 0)
+    . assert(_ == scala.List((t"classfile/1", true)))

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -80,15 +80,27 @@ object Tests extends Suite(m"Mandible tests"):
         |}
         |""".s.stripMargin.tt
 
+  val holder: Text =
+    t"""|package fixture;
+        |public class Holder<T> {
+        |  public Object get() { return null; }
+        |}
+        |""".s.stripMargin.tt
+
   // Fixture variants are made by editing the source text, so each test states exactly the one
   // change whose grade it is asserting.
   def edit(source: Text, from: Text, to: Text): Text = source.s.replace(from.s, to.s).nn.tt
 
-  def sources(base: Text, derived: Text, api: Text): Map[Text, Text] =
-    Map(t"fixture/Base.java" -> base, t"fixture/Derived.java" -> derived, t"fixture/Api.java" -> api)
+  def sources(base: Text, derived: Text, api: Text, holder: Text = holder): Map[Text, Text] =
+    Map
+      ( t"fixture/Base.java"    -> base,
+        t"fixture/Derived.java" -> derived,
+        t"fixture/Api.java"     -> api,
+        t"fixture/Holder.java"  -> holder )
 
   def run(): Unit =
     classfileDisciplineTests()
+    jvmProfileTests()
     test(m"Locate a known method on a classfile"):
       val rewrite =
         Classfile[StackTrace].let(_.methods.stdlib.find(_.name == t"rewrite").getOrElse(Unset)).vouch
@@ -203,14 +215,14 @@ object Tests extends Suite(m"Mandible tests"):
 
     // Compiles the fixtures and returns the emitted classfiles as discipline content, plus the
     // output directory to use as the atomization classpath.
-    def compile(base: Text, derived: Text, api: Text) =
+    def compile(base: Text, derived: Text, api: Text, holder: Text = holder) =
       // The compilation runs inside `supervise`, but the classfile bytes are read outside it:
       // `Data` is a frozen-array capability, and returning one out of the supervisor's scope
       // freshens its capture set past what the enclosing method can admit.
       val out: Text = supervise:
         val directory: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
         Files.createDirectories(Paths.get(directory.encode.s))
-        Javac(Nil)(LocalClasspath())(sources(base, derived, api), directory).complete()
+        Javac(Nil)(LocalClasspath())(sources(base, derived, api, holder), directory).complete()
 
         directory.encode
 
@@ -226,8 +238,8 @@ object Tests extends Suite(m"Mandible tests"):
 
       (List.from(content), out)
 
-    def atomize(base: Text, derived: Text, api: Text): Atomization =
-      val (content, out) = compile(base, derived, api)
+    def atomize(base: Text, derived: Text, api: Text, holder: Text = holder): Atomization =
+      val (content, out) = compile(base, derived, api, holder)
       ClassfileDiscipline.atomize(content, Discipline.Context(t"jvm", classpath = List(out)))
 
     def listing(atomization: Atomization): scala.List[(Text, Text)] =
@@ -338,3 +350,119 @@ object Tests extends Suite(m"Mandible tests"):
       registry.atomize(content, context).stdlib.map: atomization =>
         (atomization.discipline, atomization.atoms.stdlib.size > 0)
     . assert(_ == scala.List((t"classfile/1", true)))
+
+  def jvmProfileTests(): Unit =
+    import reliquary.*
+
+    def compile(base: Text, derived: Text, api: Text, holder: Text = holder) =
+      val out: Text = supervise:
+        val directory: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
+        Files.createDirectories(Paths.get(directory.encode.s))
+        Javac(Nil)(LocalClasspath())(sources(base, derived, api, holder), directory).complete()
+
+        directory.encode
+
+      val root = Paths.get(out.s).nn
+
+      val content = Files.walk(root).nn.iterator.nn.asScala
+        . to(scala.List)
+        . filter { path => path.toString.endsWith(".class") }
+        . sortBy(_.toString)
+        . map: path =>
+            val name = Text(root.relativize(path).nn.toString)
+            (TreePath(name), Array.unsafeFrozen(Files.readAllBytes(path).nn))
+
+      (List.from(content), out)
+
+    def evidence(base: Text, derived: Text, api: Text, holder: Text = holder) =
+      val (content, out) = compile(base, derived, api, holder)
+
+      EcosystemProfile.Evidence
+        (List(EcosystemProfile.Section(t"jvm", content, classpath = List(out))))
+
+    def atomize(base: Text, derived: Text, api: Text, holder: Text = holder): Atomization =
+      val (content, out) = compile(base, derived, api, holder)
+      ClassfileDiscipline.atomize(content, Discipline.Context(t"jvm", classpath = List(out)))
+
+    val before = evidence(base, derived, api)
+
+    def violations(base2: Text, derived2: Text, api2: Text): scala.List[Text] =
+      JvmProfile.check(before, evidence(base2, derived2, api2)).stdlib.map(_.detail)
+
+    test(m"the profile certifies linkage and nothing else"):
+      (JvmProfile.id, JvmProfile.certifies)
+    . assert(_ == (t"jvm/1", Set(Discipline.Guarantee.Linkage)))
+
+    test(m"an unchanged release violates no linkage predicate"):
+      violations(base, derived, api)
+    . assert(_.isEmpty)
+
+    test(m"adding a concrete method violates no linkage predicate"):
+      val added = t"public int added() { return 9; }\n  public int inherited"
+      violations(edit(base, t"public int inherited", added), derived, api)
+    . assert(_.isEmpty)
+
+    test(m"removing a presented method is a linkage violation"):
+      violations(edit(base, t"protected int guarded() { return 2; }", t""), derived, api)
+    . assert: details =>
+        details.exists(_.s.startsWith("fixture/Base#guarded:()I"))
+          && details.exists(_.s.startsWith("fixture/Derived#guarded:()I"))
+
+    test(m"narrowing accessibility is a linkage violation"):
+      violations(edit(base, t"protected int guarded", t"private int guarded"), derived, api)
+    . assert(_.nonEmpty)
+
+    test(m"changing a method's return type is a linkage violation"):
+      violations(edit(base, t"public int inherited() { return 1; }",
+          t"public long inherited() { return 1; }"), derived, api)
+    . assert(_.nonEmpty)
+
+    test(m"a changed constant is reported apart from the linkage predicates"):
+      val changed = edit(base, t"CONSTANT = 7", t"CONSTANT = 8")
+
+      (violations(changed, derived, api),
+       JvmProfile.constants(before, evidence(changed, derived, api)).stdlib)
+    . assert(_ == (scala.List(),
+        scala.List(t"fixture/Base.CONSTANT:I", t"fixture/Derived.CONSTANT:I")))
+
+    // Appendix D.1's second bullet, made executable: a change can break recompilation while
+    // leaving linkage untouched. Tightening a class's type-parameter bound rewrites its generic
+    // `Signature` attribute and fails every consumer's next compile, but erasure is unchanged, so
+    // every descriptor a compiled consumer resolves is byte-identical. The discipline grades it a
+    // major; the profile — which reads the linkage-only fold — finds nothing to report. Both are
+    // right, which is exactly why the two levels are recorded separately.
+    test(m"a recompilation break with no linkage break is graded but not reported"):
+      val bounded = edit(holder, t"class Holder<T>", t"class Holder<T extends Number>")
+
+      (Grade.between(List(atomize(base, derived, api)), List(atomize(base, derived, api, bounded))),
+       JvmProfile.check(before, evidence(base, derived, api, bounded)).stdlib)
+    . assert(_ == (Grade.Major, scala.List()))
+
+    // The audit (L128/L130) is what turns a finding into a verdict about the release.
+
+    test(m"an unrecorded linkage break is rejected"):
+      val registry = EcosystemProfile.Registry(List(JvmProfile))
+      val declared = List(LiraManifest.Profile(t"jvm/1"))
+      val after = evidence(edit(base, t"protected int guarded() { return 2; }", t""), derived, api)
+
+      import errorDiagnostics.stackTracesDiagnostics
+      capture[LiraError](EcosystemProfile.audit(registry, declared, before, after)).reason
+    . assert(_ == LiraError.Reason.UnrecordedBreak(t"jvm/1", t"linkage"))
+
+    test(m"a recorded linkage break is accepted"):
+      val registry = EcosystemProfile.Registry(List(JvmProfile))
+
+      val declared =
+        List(LiraManifest.Profile(t"jvm/1", List(LiraManifest.Guarantee.Linkage)))
+
+      val after = evidence(edit(base, t"protected int guarded() { return 2; }", t""), derived, api)
+
+      EcosystemProfile.audit(registry, declared, before, after).stdlib
+    . assert(_ == scala.List())
+
+    test(m"a declared profile with no implementation is reported, not rejected"):
+      val registry = EcosystemProfile.Registry(List(JvmProfile))
+      val declared = List(LiraManifest.Profile(t"unknown/1"))
+
+      EcosystemProfile.audit(registry, declared, before, before).stdlib
+    . assert(_ == scala.List(t"unknown/1"))

--- a/lib/reliquary/src/core/reliquary.EcosystemProfile.scala
+++ b/lib/reliquary/src/core/reliquary.EcosystemProfile.scala
@@ -1,0 +1,142 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package reliquary
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+import LiraError.Reason
+
+object EcosystemProfile:
+  // One section's content, in the form a profile predicate reads it. The same shape a discipline
+  // is handed, because a profile that checks structural invariants over a universe's content
+  // (§11.6, clause 2) needs exactly what a discipline over that universe would need.
+  case class Section
+    ( universe:    Text,
+      content:     List[(TreePath, Data)],
+      integration: Optional[Text] = Unset,
+      classpath:   List[Text]     = List() )
+
+  // Everything a profile may examine about *one* release. Unlike a discipline, whose atomization
+  // is a function of one release's content alone, profile predicates are diachronic: they compare
+  // a release against its predecessor. That difference is the whole reason this is a separate
+  // SPI and not another `Discipline`.
+  case class Evidence
+    ( sections: List[Section],
+      manifest: Optional[LiraManifest] = Unset ):
+
+    def section(universe: Text): Optional[Section] =
+      sections.stdlib.find { section => section.universe == universe }.getOrElse(Unset)
+
+  // A predicate failure, at the guarantee level it breaks. A profile reports what it found; the
+  // audit below decides whether the release accounted for it.
+  case class Violation(level: Discipline.Guarantee, detail: Text)
+
+  class Registry(profiles: List[EcosystemProfile]):
+    def all: List[EcosystemProfile] = profiles
+
+    def apply(id: Text): Optional[EcosystemProfile] =
+      profiles.stdlib.find { profile => profile.id == id }.getOrElse(Unset)
+
+  // L128 and L130, the two rules that make a `profile` record a claim rather than decoration.
+  //
+  // A release declares the profiles it satisfies and, per §12.4, the guarantee levels this step
+  // *breaks*. Checking is therefore not a matter of computing the `breaks` list — the author
+  // states it — but of confirming that it accounts for what the predicates actually found:
+  //
+  //   - a violation at a level the profile certifies, which the release does not record, is
+  //     **L130**: the step does not preserve the level and says nothing about it;
+  //   - a violation at a level the profile does not certify at all is **L128**: the profile
+  //     claims a predicate it does not enforce, which is a broken profile, not a broken release.
+  //
+  // A declared profile with no implementation in the registry is *not* an error. It is a gap in
+  // the checking tool, not a defect in the release, and `unchecked` names them so a caller that
+  // must not proceed on unverified claims — a registry, per §16 — can refuse.
+  def audit
+    ( registry: Registry,
+      declared: List[LiraManifest.Profile],
+      previous: Evidence,
+      next:     Evidence )
+  :   List[Text] raises LiraError raises DisciplineError =
+
+    val unchecked = scala.collection.mutable.ListBuffer[Text]()
+
+    declared.stdlib.foreach: record =>
+      registry(record.id) match
+        case profile: EcosystemProfile =>
+          val recorded = record.breaks.stdlib.map(guarantee(_)).toSet
+
+          profile.check(previous, next).stdlib.foreach: violation =>
+            if !profile.certifies.stdlib.contains(violation.level)
+            then abort(LiraError(Reason.ProfileViolated(record.id, violation.detail)))
+
+            if !recorded.contains(violation.level)
+            then abort(LiraError(Reason.UnrecordedBreak(record.id, keyword(violation.level))))
+
+        case _ => unchecked += record.id
+
+    List.from(unchecked.toList)
+
+  // Both vocabularies omit `behavior` for the same reason — no hash scheme certifies it (§11.5,
+  // §18) — so the mapping is total in both directions.
+  private def guarantee(level: LiraManifest.Guarantee): Discipline.Guarantee = level match
+    case LiraManifest.Guarantee.Linkage       => Discipline.Guarantee.Linkage
+    case LiraManifest.Guarantee.Recompilation => Discipline.Guarantee.Recompilation
+
+  private def keyword(level: Discipline.Guarantee): Text = level match
+    case Discipline.Guarantee.Linkage       => t"linkage"
+    case Discipline.Guarantee.Recompilation => t"recompilation"
+
+// A named, versioned set of predicates an ecosystem imposes in addition to those of the core
+// specification (§11.6). Profiles add predicates and add guarantees; they never subtract (L129),
+// so a file the core rejects is rejected under every profile.
+//
+// The alternative to a profile is a universe-specific discipline, and §11.6 explains why it is
+// the wrong default: atoms feed the snapshot, and the snapshot is API identity, so folding an
+// ecosystem's linkage surface into atoms means a release whose source interface is unchanged but
+// whose bridge methods moved acquires a new identity and breaks dependency satisfaction for
+// every consumer — including those who only ever recompile. A profile keeps the snapshot at the
+// recompilation level, where it is the useful identity, and records linkage breakage separately,
+// where it can be acted on by the consumers it actually affects.
+trait EcosystemProfile:
+  def id: Text
+
+  // The levels this profile's predicates cover (§11.6, clause 3) — typically levels the
+  // release's disciplines do *not* certify, which is the point of having a profile at all.
+  def certifies: Set[Discipline.Guarantee]
+
+  def check(previous: EcosystemProfile.Evidence, next: EcosystemProfile.Evidence)
+  :   List[EcosystemProfile.Violation] raises DisciplineError

--- a/lib/reliquary/src/core/reliquary.Verification.scala
+++ b/lib/reliquary/src/core/reliquary.Verification.scala
@@ -148,3 +148,24 @@ object Verification:
       else List(LiraAdvisory.UnreferencedBlobs(unreferenced))
 
     Report(store, atomizations, List.from(materialized), advisories)
+
+  // Step 4's sibling for profiles (§11.6, L128/L130). `install` stays language-blind, exactly as
+  // it does for re-atomization and lineage-step grading, and this recovers the per-section
+  // content a profile's predicates read — which the report holds only as tree entries and blob
+  // hashes. `classpath` supplies the materialized dependency vector per (universe, integration)
+  // cell, since a profile checking a universe's structure needs the same view a discipline had.
+  def evidence
+    ( manifest:  LiraManifest,
+      report:    Report,
+      classpath: (Text, Optional[Text]) => List[Text] = { (_, _) => List() } )
+  :   EcosystemProfile.Evidence raises LiraError =
+
+    val sections = report.materialized.stdlib.map: (section, tree) =>
+      val content = tree.entries.map: entry =>
+        (entry.path, report.blobstore.resolve(entry.blob))
+
+      EcosystemProfile.Section
+        (section.universe, content, section.integration, classpath(section.universe,
+            section.integration))
+
+    EcosystemProfile.Evidence(List.from(sections), manifest)

--- a/lib/reliquary/src/core/soundness_reliquary_core.scala
+++ b/lib/reliquary/src/core/soundness_reliquary_core.scala
@@ -33,7 +33,8 @@
 package soundness
 
 export reliquary.{Atom, AtomClass, Atomization, AtomReference, AtomsBlob, Blob, BlobStream,
-    Blobstore, Buildpath, Discipline, DisciplineError, Grade, Lineage, Lira, LiraAdvisory,
+    Blobstore, Buildpath, Discipline, DisciplineError, EcosystemProfile, Grade, Lineage, Lira,
+    LiraAdvisory,
     LiraDelta, LiraError, LiraHash, LiraManifest, LiraPayload, LiraSchemas, LiraTree,
     LiraUniverse, LiraValidators, ManifestSigning, OpaqueDiscipline, Overlay, Publication,
     Replacement, Section, Snapshot, TreeEntry, TreePath, UsesBlob, Verification, Versioning}

--- a/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
+++ b/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
@@ -69,6 +69,8 @@ object LiraAssembler:
       resource:    List[LiraManifest.Resource]    = List(),
       dependency:  List[LiraManifest.Dependency]  = List(),
       delta:       Optional[LiraDelta]            = Unset,
+      profiles:    EcosystemProfile.Registry      = EcosystemProfile.Registry(List()),
+      predecessor: Optional[EcosystemProfile.Evidence] = Unset,
       classpath:   SectionInput => List[Text]     = { _ => List() },
       sign:        LiraManifest => LiraManifest  = identity(_) )
   :   Data raises LiraError raises DisciplineError =
@@ -95,6 +97,14 @@ object LiraAssembler:
     val atomized = inputs.map: input =>
       val context = Discipline.Context(input.universe, input.integration, classpath(input))
       (input.universe, registry.atomize(input.content, context))
+
+    // The same per-section view a discipline is given, for the profile predicates below. Built
+    // here so that a profile checking structural invariants over a universe's content (§11.6,
+    // clause 2) sees exactly what the disciplines saw, including the integration's classpath.
+    val profileSections = List.from:
+      inputs.map: input =>
+        EcosystemProfile.Section
+          (input.universe, input.content, input.integration, classpath(input))
 
     // L125: an `export` or `track` declaration must be effective — a declared path that resolves
     // to no item in any section, or that some other discipline claims, is an assembly-time
@@ -201,6 +211,15 @@ object LiraAssembler:
     // The producer never emits a file a consumer would reject: L131/L133 are decidable from the
     // manifest, so they are checked here rather than discovered at install time.
     Verification.integrations(manifest)
+
+    // L128/L130. Profile predicates are diachronic, so they can only run where the caller has the
+    // predecessor's content in hand; with no predecessor there is no step to check, which is the
+    // ordinary case for the first release of a lineage. The audit runs against the assembled
+    // manifest because a profile may impose predicates over `toolchain` records (§13.3), and it
+    // runs before signing, so nothing unverified is ever signed.
+    predecessor.let: previous =>
+      val evidence = EcosystemProfile.Evidence(profileSections, manifest)
+      EcosystemProfile.audit(profiles, profile, previous, evidence)
 
     val blobs = contentBlobs ++ builtSections.map(_(1)) ++ atomsBlobs ++ deltaBlob.option.toList
 

--- a/lib/xenophile/src/lira/soundness_xenophile_lira.scala
+++ b/lib/xenophile/src/lira/soundness_xenophile_lira.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export xenophile.{DtsAtomizer, DtsDiscipline}

--- a/lib/xenophile/src/lira/xenophile.DtsAtomizer.scala
+++ b/lib/xenophile/src/lira/xenophile.DtsAtomizer.scala
@@ -1,0 +1,352 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import anticipation.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+import vacuous.*
+
+// The atomization rules of `dts/1`.
+//
+// The folding principle (LIRA §10.3) decides the shape: a declaration whose *addition* cannot
+// break a consumer stands alone as an atom, and everything whose addition can break one folds
+// into the enclosing atom's value, so the whole compatibility check stays set arithmetic.
+//
+// TypeScript makes that decision sharper than most languages, because a type is both something to
+// call and something to implement. Adding a member to an interface cannot break a consumer who
+// only *calls* it, and always breaks one who *implements* it — so members are atoms of their own
+// (the addition is a minor for callers) and the sorted member-key list also folds into the
+// interface's own atom (the same addition is a major for implementors). This mirrors rule 5 of
+// `tasty.md` §8, where an open template folds its abstract members for exactly this reason;
+// every TypeScript interface is open in that sense, since structural typing needs no declaration
+// of intent to implement one.
+object DtsAtomizer:
+  val id: Text = t"dts/1"
+
+  // --- canonical binary encoding ---------------------------------------------------------------
+
+  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+    var value = value0
+
+    while value >= 0x80L do
+      out.write(((value & 0x7f) | 0x80).toInt)
+      value >>>= 7
+
+    out.write(value.toInt)
+
+  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
+    val bytes = text.s.getBytes("UTF-8").nn
+    uvarint(out, bytes.length.toLong)
+    out.write(bytes)
+
+  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+
+  private def flag(out: java.io.ByteArrayOutputStream, value: Boolean): Unit =
+    out.write(if value then 1 else 0)
+
+  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
+    val out = java.io.ByteArrayOutputStream()
+    encode(out)
+    LiraHash(LiraHash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+
+  // --- types -----------------------------------------------------------------------------------
+
+  // Type parameters encode as de Bruijn indices, so a binder's *name* never enters a hash:
+  // renaming `T` to `U` throughout a declaration changes nothing a consumer can observe, and
+  // must therefore change no atom. `binders` holds the enclosing binder scopes, innermost last.
+  private def encode
+    ( out:     java.io.ByteArrayOutputStream,
+      typed:   TypescriptType,
+      binders: scala.List[scala.List[Text]] )
+  :   Unit =
+
+    def index(name: Text): Optional[(Int, Int)] =
+      val depths = binders.reverse.zipWithIndex
+
+      depths.collectFirst:
+        case (names, depth) if names.contains(name) => (depth, names.indexOf(name))
+
+      . getOrElse(Unset)
+
+    typed match
+      case TypescriptType.Named(name, arguments) =>
+        index(name) match
+          case position: (Int, Int) =>
+            tag(out, 'P')
+            uvarint(out, position(0).toLong)
+            uvarint(out, position(1).toLong)
+
+          case _ =>
+            tag(out, 'N')
+            utf8(out, name)
+
+        uvarint(out, arguments.stdlib.length.toLong)
+        arguments.stdlib.foreach { argument => encode(out, argument, binders) }
+
+      case TypescriptType.Literal(value, kind) =>
+        tag(out, 'L')
+        // The kind is folded alongside the value: `"1"` and `1` are different types whose source
+        // forms differ only by quoting, which the lexer removed.
+        uvarint(out, kind.ordinal.toLong)
+        utf8(out, value)
+
+      // Unions and intersections are set-like — `A | B` and `B | A` are the same type — so their
+      // members sort. Everything below whose order is semantic keeps declaration order.
+      case TypescriptType.Union(members) =>
+        tag(out, '|')
+        sorted(out, members, binders)
+
+      case TypescriptType.Intersection(members) =>
+        tag(out, '&')
+        sorted(out, members, binders)
+
+      case TypescriptType.Tuple(members, _) =>
+        // A tuple's element order is its meaning; its element *labels* are documentation and
+        // never distinguish two types, so they are not folded.
+        tag(out, 'T')
+        uvarint(out, members.stdlib.length.toLong)
+        members.stdlib.foreach { member => encode(out, member, binders) }
+
+      case TypescriptType.Array(element) =>
+        tag(out, 'A')
+        encode(out, element, binders)
+
+      case TypescriptType.Object(members) =>
+        tag(out, 'O')
+        val ordered = members.stdlib.sortBy { member => member.selector.s }
+        uvarint(out, ordered.length.toLong)
+        ordered.foreach { member => encodeMember(out, member, binders) }
+
+      case TypescriptType.Keyof(target) =>
+        tag(out, 'K')
+        encode(out, target, binders)
+
+      case TypescriptType.Typeof(target) =>
+        tag(out, 'Y')
+        utf8(out, target)
+
+      case TypescriptType.Indexed(target, key) =>
+        tag(out, 'X')
+        encode(out, target, binders)
+        encode(out, key, binders)
+
+      case TypescriptType.Predicate(parameter, target) =>
+        // The narrowed type is the contract; which parameter it narrows is positional, and the
+        // parameter's name is not consumer surface.
+        tag(out, '?')
+        encode(out, target, binders)
+
+      case TypescriptType.Function(parameters, result, typed, construct) =>
+        tag(out, if construct then 'C' else 'F')
+        val names = typed.stdlib.map(_.name)
+        val inner = binders :+ names
+
+        uvarint(out, typed.stdlib.length.toLong)
+
+        typed.stdlib.foreach: parameter =>
+          // A bound and a default are contract: a caller may rely on the default, and a bound
+          // decides which arguments are legal.
+          parameter.bound.lay(tag(out, '0')) { bound => tag(out, '1'); encode(out, bound, inner) }
+
+          parameter.default.lay(tag(out, '0')): default =>
+            tag(out, '1')
+            encode(out, default, inner)
+
+        uvarint(out, parameters.stdlib.length.toLong)
+
+        parameters.stdlib.foreach: parameter =>
+          // Parameter *names* are not folded — TypeScript call sites are positional — but
+          // optionality and rest-ness decide which calls are legal, so both are.
+          flag(out, parameter.optional)
+          flag(out, parameter.rest)
+          parameter.typed.lay(tag(out, '0')) { value => tag(out, '1'); encode(out, value, inner) }
+
+        encode(out, result, inner)
+
+  private def sorted
+    ( out:     java.io.ByteArrayOutputStream,
+      members: List[TypescriptType],
+      binders: scala.List[scala.List[Text]] )
+  :   Unit =
+
+    val encodings = members.stdlib.map: member =>
+      val buffer = java.io.ByteArrayOutputStream()
+      encode(buffer, member, binders)
+      // An immutable view: the sort's comparator would otherwise capture the mutable arrays
+      // exclusively, which capture checking rejects.
+      val bytes: scala.Array[Byte] = buffer.toByteArray().nn
+      // An immutable, unsigned view: the comparator would otherwise capture the mutable arrays
+      // exclusively, which capture checking rejects, and signed bytes would sort wrongly.
+      scala.Vector.tabulate(bytes.length) { index => bytes(index) & 0xff }
+
+    uvarint(out, encodings.length.toLong)
+
+    encodings.sortWith { (left, right) => compare(left, right) < 0 }.foreach: encoding =>
+      uvarint(out, encoding.length.toLong)
+      encoding.foreach { byte => out.write(byte) }
+
+  // Sorting by encoded bytes, rather than by rendered text, keeps the order a property of the
+  // structure: two types that encode identically must sort adjacently whatever they were called.
+  private def compare(left: scala.Vector[Int], right: scala.Vector[Int]): Int =
+    val shared = left.length.min(right.length)
+    var index = 0
+    var result = 0
+
+    while result == 0 && index < shared do
+      result = left(index) - right(index)
+      index += 1
+
+    if result != 0 then result else left.length - right.length
+
+  private def encodeMember
+    ( out:     java.io.ByteArrayOutputStream,
+      member:  TypescriptMember,
+      binders: scala.List[scala.List[Text]] )
+  :   Unit =
+
+    utf8(out, member.selector)
+    uvarint(out, member.kind.ordinal.toLong)
+    uvarint(out, member.visibility.ordinal.toLong)
+    flag(out, member.static)
+    flag(out, member.readonly)
+    flag(out, member.optional)
+    flag(out, member.isAbstract)
+
+    // Overload signatures keep declaration order: TypeScript resolves a call against them in
+    // order, so reordering them changes which one a given call selects.
+    uvarint(out, member.signatures.stdlib.length.toLong)
+    member.signatures.stdlib.foreach { signature => encode(out, signature, binders) }
+
+  // --- atoms -----------------------------------------------------------------------------------
+
+  private def binderNames(typed: List[TypescriptType.Parameter]): scala.List[Text] =
+    typed.stdlib.map(_.name)
+
+  def atomize(declaration: TypescriptDeclaration): List[Atom] =
+    val key = declaration.key
+    val atoms = scala.collection.mutable.ListBuffer[Atom]()
+
+    val members = declaration.declaredMembers.stdlib.filter(_.visible)
+    val binders = scala.List(binderNames(typeParameters(declaration)))
+
+    // Members are atoms of their own, so adding one is a minor for a consumer who only calls it.
+    members.foreach: member =>
+      val encoding = hash: out =>
+        tag(out, 'M')
+        utf8(out, key)
+        encodeMember(out, member, binders)
+
+      atoms += Atom(t"$key#${member.selector}", AtomClass.Rigid, encoding)
+
+    val encoding = hash: out =>
+      declaration match
+        case TypescriptDeclaration.Interface(_, _, typed, extending, _, _) =>
+          tag(out, 'I')
+          utf8(out, key)
+          parameters(out, typed, binders)
+          // Heritage keeps declaration order, which decides how conflicting inherited members
+          // resolve.
+          uvarint(out, extending.stdlib.length.toLong)
+          extending.stdlib.foreach { base => encode(out, base, binders) }
+
+        case TypescriptDeclaration.Class(_, _, typed, extending, implements, _, isAbstract, _) =>
+          tag(out, 'C')
+          utf8(out, key)
+          parameters(out, typed, binders)
+          flag(out, isAbstract)
+          extending.lay(tag(out, '0')) { base => tag(out, '1'); encode(out, base, binders) }
+          uvarint(out, implements.stdlib.length.toLong)
+          implements.stdlib.foreach { base => encode(out, base, binders) }
+
+        case TypescriptDeclaration.Alias(_, _, typed, target, _) =>
+          tag(out, 'A')
+          utf8(out, key)
+          parameters(out, typed, binders)
+          encode(out, target, binders)
+
+        case TypescriptDeclaration.Enumeration(_, _, members, constant, _) =>
+          tag(out, 'E')
+          utf8(out, key)
+          // A `const enum` is inlined into consumers at *their* compile time, so its values are
+          // a materially stronger commitment than an ordinary enum's; the flag folds so that a
+          // change of kind is never invisible.
+          flag(out, constant)
+          uvarint(out, members.stdlib.length.toLong)
+
+          members.stdlib.foreach: (name, value) =>
+            utf8(out, name)
+            value.lay(tag(out, '0')) { text => tag(out, '1'); utf8(out, text) }
+
+        case TypescriptDeclaration.Function(_, _, signatures, _) =>
+          tag(out, 'F')
+          utf8(out, key)
+          uvarint(out, signatures.stdlib.length.toLong)
+          signatures.stdlib.foreach { signature => encode(out, signature, binders) }
+
+        case TypescriptDeclaration.Variable(_, _, typed, constant, _) =>
+          tag(out, 'V')
+          utf8(out, key)
+          flag(out, constant)
+          typed.lay(tag(out, '0')) { value => tag(out, '1'); encode(out, value, binders) }
+
+      // The sorted member-key list, folded into the declaration's own atom. This is what makes
+      // adding a member a *major* for implementors while it remains a minor for callers — the
+      // one place where a single change is honestly two different events.
+      val keys = members.map(_.selector).sortBy(_.s)
+      uvarint(out, keys.length.toLong)
+      keys.foreach { selector => utf8(out, selector) }
+
+    atoms += Atom(key, AtomClass.Rigid, encoding)
+
+    List.from(atoms.toList)
+
+  private def parameters
+    ( out:     java.io.ByteArrayOutputStream,
+      typed:   List[TypescriptType.Parameter],
+      binders: scala.List[scala.List[Text]] )
+  :   Unit =
+
+    uvarint(out, typed.stdlib.length.toLong)
+
+    typed.stdlib.foreach: parameter =>
+      parameter.bound.lay(tag(out, '0')) { bound => tag(out, '1'); encode(out, bound, binders) }
+      parameter.default.lay(tag(out, '0')) { value => tag(out, '1'); encode(out, value, binders) }
+
+  private def typeParameters(declaration: TypescriptDeclaration): List[TypescriptType.Parameter] =
+    declaration match
+      case TypescriptDeclaration.Interface(_, _, typed, _, _, _)   => typed
+      case TypescriptDeclaration.Class(_, _, typed, _, _, _, _, _) => typed
+      case TypescriptDeclaration.Alias(_, _, typed, _, _)          => typed
+      case _                                                       => Nil

--- a/lib/xenophile/src/lira/xenophile.DtsDiscipline.scala
+++ b/lib/xenophile/src/lira/xenophile.DtsDiscipline.scala
@@ -1,0 +1,96 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+import vacuous.*
+
+import fulminate.*
+
+import errorDiagnostics.emptyDiagnostics
+
+// The `dts/1` discipline: the declared TypeScript surface of a release, as atoms.
+//
+// Named for the carrier, not the language (§11.1). A `.d.ts` file is the declaration surface a
+// TypeScript consumer compiles against, whatever produced the JavaScript beneath it — hand-written
+// JavaScript, TypeScript, or a compiler targeting neither.
+object DtsDiscipline extends Discipline:
+  def id: Text = t"dts/1"
+
+  // Universal, for want of a universe to name. The base schema's universes are `jvm`, `sjsir` and
+  // `nir` (§9.4 reserves `js` for a future schema layer), and §11.3 already admits foreign
+  // JavaScript content in any section under `opaque/1` — so there is nothing narrower to scope to
+  // that would not simply exclude the discipline from every release that exists. Universality has
+  // a second effect worth having: it brings `.d.ts` under the cross-section invariant (§9.6), and
+  // a declared TypeScript surface that differed per universe would be a defect, not a feature.
+  def domain: Discipline.Domain = Discipline.Domain.Universal
+
+  // TypeScript references name the declaring interface, class or alias, and structural
+  // assignability is checked against that declaration rather than resolved through a receiver at
+  // a call site. Declaration keying is sound exactly where that holds (§11.2 requirement 4), and
+  // it holds here because this discipline certifies recompilation only.
+  def keying: Discipline.Keying = Discipline.Keying.Declaration
+
+  // Recompilation alone. `.d.ts` declarations are erased before anything runs: there is no late
+  // linking for them to protect, so certifying linkage would be a claim about a mechanism that
+  // does not exist (§11.2 requirement 7).
+  def guarantees(universe: Text): Set[Discipline.Guarantee] =
+    Set(Discipline.Guarantee.Recompilation)
+
+  def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".d.ts")
+
+  def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
+  :   Atomization raises DisciplineError =
+
+    val atoms = scala.collection.mutable.ListBuffer[Atom]()
+
+    content.stdlib.foreach: (path, data) =>
+      val source = Text(String(Array.unsafeJvm(data), "UTF-8"))
+
+      val declarations =
+        mitigate:
+          case TypescriptError(reason) =>
+            DisciplineError(id, DisciplineError.Reason.Malformed(t"${path.text}: $reason"))
+
+        . protect(TypescriptParser.parse(source))
+
+      // A declaration a consumer of the module cannot name is not part of its contract. In a
+      // module that is the unexported declarations; in a global script there are none.
+      declarations.stdlib.filter(_.exported).foreach: declaration =>
+        atoms ++= DtsAtomizer.atomize(declaration).stdlib
+
+    Atomization.of(id, List.from(atoms.toList))

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -789,3 +789,172 @@ object Tests extends Suite(m"Xenophile tests"):
         completionsAt(t"${header}val foo = Foreign[\"Foo\", Typescript]\nval x = foo.bar.qu")
         . map(_.name)
       . assert(_ == List(t"qux"))
+
+    typescriptParserTests()
+
+  def typescriptParserTests(): Unit =
+    import strategies.throwUnsafely
+
+    def declarations(source: Text): List[TypescriptDeclaration] = TypescriptParser.parse(source)
+
+    def names(source: Text): scala.List[Text] = declarations(source).stdlib.map(_.key)
+
+    def members(source: Text): scala.List[Text] =
+      declarations(source).stdlib.flatMap(_.declaredMembers.stdlib).map(_.selector)
+
+    // Every construct below was dropped whole, or silently misread, by the grammar this
+    // replaced; each test names the shape rather than the mechanism.
+
+    test(m"a generic interface is read, not dropped"):
+      names(t"interface Box<T> { value: T; }")
+    . assert(_ == scala.List(t"Box"))
+
+    test(m"an interface's extends clause is recorded"):
+      declarations(t"interface A { x: number; }\ninterface B extends A { y: number; }").stdlib
+      . collect { case interface: TypescriptDeclaration.Interface => interface }
+      . flatMap(_.extending.stdlib.map(_.text))
+    . assert(_ == scala.List(t"A"))
+
+    test(m"a type alias is a declaration"):
+      names(t"type Id = string | number;")
+    . assert(_ == scala.List(t"Id"))
+
+    test(m"a class, an enum, a function and a const are declarations"):
+      names(t"""|declare class C { m(): void; }
+                |declare enum E { A, B }
+                |declare function f(x: number): string;
+                |declare const k: number;
+                |""".s.stripMargin.tt)
+    . assert(_ == scala.List(t"C", t"E", t"f", t"k"))
+
+    test(m"a namespace qualifies the declarations it encloses"):
+      names(t"declare namespace a { namespace b { interface X { y: number; } } }")
+    . assert(_ == scala.List(t"a.b.X"))
+
+    test(m"only exported declarations are exported in a module"):
+      declarations(t"export interface A { x: number; }\ninterface B { y: number; }").stdlib
+      . map { declaration => (declaration.key, declaration.exported) }
+    . assert(_ == scala.List((t"A", true), (t"B", false)))
+
+    test(m"every top-level declaration is exported in a global script"):
+      declarations(t"interface A { x: number; }").stdlib.map(_.exported)
+    . assert(_ == scala.List(true))
+
+    test(m"a comment does not start a declaration"):
+      names(t"// interface Ghost { x: number; }\ninterface Real { x: number; }")
+    . assert(_ == scala.List(t"Real"))
+
+    test(m"a block comment is skipped entirely"):
+      names(t"/* interface Ghost {\n x: number; } */\ninterface Real { x: number; }")
+    . assert(_ == scala.List(t"Real"))
+
+    test(m"an index signature is a member of its own kind"):
+      members(t"interface A { [key: string]: number; }")
+    . assert(_ == scala.List(t"[]"))
+
+    test(m"a call signature and a construct signature are distinct members"):
+      members(t"interface A { (x: number): string; new (y: string): A; }")
+    . assert(_ == scala.List(t"()", t"new()"))
+
+    test(m"a getter and a setter do not collide with a property"):
+      members(t"interface A { get x(): number; set x(value: number); }")
+    . assert(_ == scala.List(t"get x", t"set x"))
+
+    test(m"overloads accumulate under one member rather than overwriting"):
+      declarations(t"interface A { f(x: number): string; f(x: string): number; }").stdlib
+      . flatMap(_.declaredMembers.stdlib).map(_.signatures.stdlib.length)
+    . assert(_ == scala.List(2))
+
+    test(m"an inline object type does not terminate the enclosing interface"):
+      members(t"interface A { config: { host: string; port: number }; after: number; }")
+    . assert(_ == scala.List(t"config", t"after"))
+
+    test(m"a function type is read as a function, not as a stray parenthesis"):
+      declarations(t"interface A { handler: (event: string) => void; }").stdlib
+      . flatMap(_.declaredMembers.stdlib).flatMap(_.signatures.stdlib).map(_.text)
+    . assert(_ == scala.List(t"(event: string) => void"))
+
+    test(m"an intersection is not truncated to its first member"):
+      declarations(t"type T = A & B;").stdlib
+      . collect { case alias: TypescriptDeclaration.Alias => alias.target.text }
+    . assert(_ == scala.List(t"A & B"))
+
+    test(m"a tuple type is read"):
+      declarations(t"type T = [string, number];").stdlib
+      . collect { case alias: TypescriptDeclaration.Alias => alias.target.text }
+    . assert(_ == scala.List(t"[string, number]"))
+
+    test(m"a string literal type keeps its value and is not confused with a name"):
+      declarations(t"""type T = "a" | "b";""").stdlib
+      . collect { case alias: TypescriptDeclaration.Alias => alias.target.text }
+    . assert(_ == scala.List(t"a | b"))
+
+    test(m"a negative numeric literal type keeps its sign"):
+      declarations(t"type T = -1;").stdlib
+      . collect { case alias: TypescriptDeclaration.Alias => alias.target.text }
+    . assert(_ == scala.List(t"-1"))
+
+    test(m"a nested array type is read to the right depth"):
+      declarations(t"type T = string[][];").stdlib
+      . collect { case alias: TypescriptDeclaration.Alias => alias.target.text }
+    . assert(_ == scala.List(t"string[][]"))
+
+    test(m"a type predicate is read"):
+      declarations(t"declare function isFoo(x: unknown): x is Foo;").stdlib
+      . collect { case function: TypescriptDeclaration.Function => function }
+      . flatMap(_.signatures.stdlib).map(_.text)
+    . assert(_ == scala.List(t"(x: unknown) => x is Foo"))
+
+    test(m"a rest parameter is marked as such"):
+      declarations(t"declare function f(...args: string[]): void;").stdlib
+      . collect { case function: TypescriptDeclaration.Function => function }
+      . flatMap(_.signatures.stdlib)
+      . collect { case TypescriptType.Function(parameters, _, _, _) => parameters.stdlib.map(_.rest) }
+    . assert(_ == scala.List(scala.List(true)))
+
+    // Constructs outside the grammar are refused, never approximated. This is the property the
+    // discipline depends on: a declaration file read as a smaller contract than it declares
+    // would make every claim computed from it unsound.
+
+    def refuses(source: Text): Optional[TypescriptError.Reason] =
+      import errorDiagnostics.stackTracesDiagnostics
+      capture[TypescriptError](TypescriptParser.parse(source)).reason
+
+    test(m"a conditional type is refused"):
+      refuses(t"type T<A> = A extends string ? number : boolean;")
+    . assert(_ == TypescriptError.Reason.Unsupported(t"a conditional type"))
+
+    test(m"a template literal type is refused"):
+      refuses(t"type T = `a${'$'}{B}c`;")
+    . assert(_ == TypescriptError.Reason.Unsupported(t"a template literal type"))
+
+    test(m"an infer binder is refused"):
+      refuses(t"type T<A> = Array<infer B>;")
+    . assert(_ == TypescriptError.Reason.Unsupported(t"an `infer` binder"))
+
+    test(m"an unterminated string literal is a syntax error"):
+      refuses(t"""type T = "unterminated;""").let:
+        case TypescriptError.Reason.Syntax(_, _) => true
+        case _                                   => false
+    . assert(_ == true)
+
+    test(m"a duplicated class declaration is refused"):
+      refuses(t"declare class A {}\ndeclare class A {}")
+    . assert(_ == TypescriptError.Reason.Duplicate(t"A"))
+
+    test(m"interfaces merge, so a repeated interface name is accepted"):
+      names(t"interface A { x: number; }\ninterface A { y: number; }")
+    . assert(_ == scala.List(t"A", t"A"))
+
+    // The dialect projection, which the foreign-function macro reads.
+
+    test(m"the dialect resolves a member inherited through extends"):
+      TypescriptDialect.parse(t"interface A { x: number; }\ninterface B extends A { y: number; }")
+      . at(t"B").lay(scala.Nil) { members => members.stdlib.keys.toList }
+      . sortBy(_.s)
+    . assert(_ == scala.List(t"x", t"y"))
+
+    test(m"the dialect reads a generic interface the old grammar dropped"):
+      TypescriptDialect.parse(t"interface Box<T> { value: T; }")
+      . at(t"Box").lay(scala.Nil) { members => members.stdlib.keys.toList }
+    . assert(_ == scala.List(t"value"))

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -791,6 +791,7 @@ object Tests extends Suite(m"Xenophile tests"):
       . assert(_ == List(t"qux"))
 
     typescriptParserTests()
+    dtsDisciplineTests()
 
   def typescriptParserTests(): Unit =
     import strategies.throwUnsafely
@@ -958,3 +959,124 @@ object Tests extends Suite(m"Xenophile tests"):
       TypescriptDialect.parse(t"interface Box<T> { value: T; }")
       . at(t"Box").lay(scala.Nil) { members => members.stdlib.keys.toList }
     . assert(_ == scala.List(t"value"))
+
+  def dtsDisciplineTests(): Unit =
+    import reliquary.*
+    import alphabets.hexLowerCase
+    import strategies.throwUnsafely
+
+    def content(source: Text): List[(TreePath, Data)] =
+      List((TreePath(t"types/index.d.ts"), Array.unsafeFrozen(source.s.getBytes("UTF-8").nn)))
+
+    def atomize(source: Text): Atomization =
+      DtsDiscipline.atomize(content(source), Discipline.Context(t"jvm"))
+
+    def keys(source: Text): scala.List[Text] =
+      atomize(source).atoms.stdlib.map(_.key).sortBy(_.s)
+
+    def grade(before: Text, after: Text): Grade =
+      Grade.between(List(atomize(before)), List(atomize(after)))
+
+    val baseline: Text =
+      t"""|export interface Client {
+          |  send(message: string): void;
+          |  readonly id: string;
+          |}
+          |export type Handle = string | number;
+          |export declare function connect(url: string): Client;
+          |""".s.stripMargin.tt
+
+    test(m"the discipline claims declaration files and nothing else"):
+      val data = Array.freeze(Array[Byte](0))
+
+      (DtsDiscipline.claims(TreePath(t"types/index.d.ts"), data),
+       DtsDiscipline.claims(TreePath(t"lib/index.js"), data),
+       DtsDiscipline.claims(TreePath(t"readme.md"), data))
+    . assert(_ == (true, false, false))
+
+    test(m"the discipline certifies recompilation and not linkage"):
+      (DtsDiscipline.id, DtsDiscipline.guarantees(t"jvm"), DtsDiscipline.keying)
+    . assert(_ == (t"dts/1", Set(Discipline.Guarantee.Recompilation),
+        Discipline.Keying.Declaration))
+
+    test(m"each exported declaration and each member yields an atom"):
+      keys(baseline)
+    . assert(_ == scala.List(t"Client", t"Client#id", t"Client#send", t"Handle", t"connect"))
+
+    test(m"an unexported declaration is not part of the contract"):
+      keys(t"export interface A { x: number; }\ninterface Hidden { y: number; }")
+    . assert(_ == scala.List(t"A", t"A#x"))
+
+    test(m"atomization is deterministic"):
+      def once(): scala.List[(Text, Text)] =
+        atomize(baseline).atoms.stdlib
+        . map { atom => (atom.key, atom.valueHash.serialize[Hex]) }
+        . sortBy(_(0).s)
+
+      once() == once()
+    . assert(identity)
+
+    test(m"renaming a type parameter changes nothing"):
+      grade(t"export interface Box<T> { value: T; }", t"export interface Box<U> { value: U; }")
+    . assert(_ == Grade.Patch)
+
+    test(m"reordering the members of a union changes nothing"):
+      grade(t"export type T = A | B;", t"export type T = B | A;")
+    . assert(_ == Grade.Patch)
+
+    test(m"reordering the elements of a tuple is a major change"):
+      grade(t"export type T = [A, B];", t"export type T = [B, A];")
+    . assert(_ == Grade.Major)
+
+    // The one change that is honestly two events: adding a member is pure extension for a
+    // consumer who calls the interface, and a break for one who implements it. The member's own
+    // atom records the first; the fold of member keys into the interface's atom records the
+    // second, and the second is what the grade reports.
+    test(m"adding an interface member is a major change for implementors"):
+      grade(t"export interface A { x: number; }", t"export interface A { x: number; y: number; }")
+    . assert(_ == Grade.Major)
+
+    test(m"the added member is nonetheless an atom of its own"):
+      keys(t"export interface A { x: number; y: number; }")
+    . assert(_ == scala.List(t"A", t"A#x", t"A#y"))
+
+    test(m"adding a whole interface is a minor change"):
+      grade(t"export interface A { x: number; }",
+          t"export interface A { x: number; }\nexport interface B { y: number; }")
+    . assert(_ == Grade.Minor)
+
+    test(m"removing a member is a major change"):
+      grade(t"export interface A { x: number; y: number; }", t"export interface A { x: number; }")
+    . assert(_ == Grade.Major)
+
+    test(m"making a member optional is a major change"):
+      grade(t"export interface A { x: number; }", t"export interface A { x?: number; }")
+    . assert(_ == Grade.Major)
+
+    test(m"adding an overload is a major change"):
+      grade(t"export interface A { f(x: number): void; }",
+          t"export interface A { f(x: number): void; f(x: string): void; }")
+    . assert(_ == Grade.Major)
+
+    test(m"changing a declaration's namespace changes its key"):
+      keys(t"export declare namespace a { interface X { y: number; } }")
+    . assert(_ == scala.List(t"a.X", t"a.X#y"))
+
+    test(m"an unreadable declaration file is an atomization error"):
+      import errorDiagnostics.stackTracesDiagnostics
+
+      capture[DisciplineError]:
+        DtsDiscipline.atomize(content(t"export type T<A> = A extends string ? 1 : 2;"),
+            Discipline.Context(t"jvm"))
+
+      . reason
+    . assert:
+        case DisciplineError.Reason.Malformed(_) => true
+        case _                                   => false
+
+    test(m"the registry falls back to opaque for content the discipline does not claim"):
+      val registry = Discipline.Registry(List(DtsDiscipline))
+      val js = List((TreePath(t"lib/index.js"), Array.freeze(Array[Byte](1))))
+
+      registry.atomize(js, Discipline.Context(t"jvm")).stdlib.map(_.discipline)
+    . assert(_ == scala.List(t"opaque/1"))

--- a/lib/xenophile/src/typescript/xenophile.TypescriptDeclaration.scala
+++ b/lib/xenophile/src/typescript/xenophile.TypescriptDeclaration.scala
@@ -30,8 +30,92 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.
-        {Typescript, TypescriptDeclaration, TypescriptDialect, TypescriptError, TypescriptMember,
-         TypescriptParser, TypescriptType}
+import anticipation.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+object TypescriptDeclaration:
+  // A declaration's namespace path, outermost first: `declare namespace a { namespace b { … } }`
+  // gives an inner declaration the scope `a.b`. Two declarations of the same name in different
+  // namespaces are different contracts, so the scope is part of every key.
+  type Scope = List[Text]
+
+  extension (scope: Scope)
+    def qualify(name: Text): Text =
+      if scope.stdlib.isEmpty then name else t"${scope.join(t".")}.$name"
+
+// What every declaration has in common. Declared abstractly here rather than as methods on the
+// enum, so that each case's own parameters implement them: an enum whose cases redeclare a
+// member of the enum body would need an `override` on every parameter.
+sealed trait Declared:
+  def name: Text
+  def scope: TypescriptDeclaration.Scope
+  def exported: Boolean
+
+// A top-level declaration of a `.d.ts` file.
+//
+// `exported` records whether the declaration is reachable by a consumer of the module: in a
+// module (a file with any top-level `import`/`export`), only exported declarations are; in a
+// legacy global script every top-level declaration is. Resolving that distinction is the
+// parser's job, so by the time a declaration reaches a discipline the flag means what it says.
+enum TypescriptDeclaration extends Declared:
+  case Interface
+    ( name:     Text,
+      scope:    TypescriptDeclaration.Scope,
+      typed:    List[TypescriptType.Parameter],
+      extending: List[TypescriptType],
+      members:  List[TypescriptMember],
+      exported: Boolean )
+
+  case Class
+    ( name:       Text,
+      scope:      TypescriptDeclaration.Scope,
+      typed:      List[TypescriptType.Parameter],
+      extending:  Optional[TypescriptType],
+      implements: List[TypescriptType],
+      members:    List[TypescriptMember],
+      isAbstract: Boolean,
+      exported:   Boolean )
+
+  case Alias
+    ( name:     Text,
+      scope:    TypescriptDeclaration.Scope,
+      typed:    List[TypescriptType.Parameter],
+      target:   TypescriptType,
+      exported: Boolean )
+
+  // An enum's members are its contract, and a `const enum` is inlined into consumers at *their*
+  // compile time, which is a materially different guarantee — so the flag is carried, not
+  // discarded.
+  case Enumeration
+    ( name:     Text,
+      scope:    TypescriptDeclaration.Scope,
+      members:  List[(Text, Optional[Text])],
+      constant: Boolean,
+      exported: Boolean )
+
+  case Function
+    ( name:       Text,
+      scope:      TypescriptDeclaration.Scope,
+      signatures: List[TypescriptType],
+      exported:   Boolean )
+
+  case Variable
+    ( name:     Text,
+      scope:    TypescriptDeclaration.Scope,
+      typed:    Optional[TypescriptType],
+      constant: Boolean,
+      exported: Boolean )
+
+  // The members a declaration presents. Named apart from the `members` parameter that two of the
+  // cases carry, which an enum-level method of the same name would collide with.
+  def declaredMembers: List[TypescriptMember] = this match
+    case Interface(_, _, _, _, members, _)   => members
+    case Class(_, _, _, _, _, members, _, _) => members
+    case _                                   => Nil
+
+  import TypescriptDeclaration.qualify
+  def key: Text = scope.qualify(name)

--- a/lib/xenophile/src/typescript/xenophile.TypescriptDialect.scala
+++ b/lib/xenophile/src/typescript/xenophile.TypescriptDialect.scala
@@ -32,169 +32,119 @@
                                                                                                   */
 package xenophile
 
-import proscenium.compat.*
-
 import anticipation.*
+import contingency.*
 import gossamer.*
 import rudiments.*
 import vacuous.*
 
-// A minimal grammar for TypeScript declaration files: enough to read `interface` blocks of fields
-// (`name: Type;`) and methods (`name(p: T, …): Type;`). It does not interpret the rest of the
-// language — unrecognised tokens between members are skipped.
+// The `Dialect` adapter over `TypescriptParser`: it projects the parsed declarations onto the
+// `Foreign` model the foreign-function macro reads.
+//
+// The projection is lossy by design — `Foreign.Type` describes only what a call site needs to
+// marshal — but the *parse* is not, which is the difference from the grammar this replaced.
+// Generic interfaces and `extends` clauses used to be dropped whole, so a member declared on a
+// base interface surfaced to the user as "has no member"; they are now resolved.
 object TypescriptDialect extends Dialect:
-  def parse(source: Text): Map[Text, Map[Text, Prototype]] = interfaces(tokenize(source.s), Map())
 
-  // Splits the source into identifier and single-character punctuation tokens, discarding
-  // whitespace; this is all the lexical structure the interface grammar needs.
-  private def punctuation(char: Char): Boolean =
-    char == '{' || char == '}' || char == '(' || char == ')' || char == ':' || char == ',' ||
-      char == ';' || char == '[' || char == ']' || char == '?' || char == '|' || char == '<' ||
-      char == '>'
+  // `Dialect.parse` is total: it cannot report an error, and the macro that calls it reports
+  // "the foreign type is not defined" from the empty result. A discipline computing a
+  // compatibility claim must never take that path — it calls `TypescriptParser.parse` directly,
+  // where an unreadable declaration is an error rather than an absent contract.
+  def parse(source: Text): Map[Text, Map[Text, Prototype]] =
+    safely(project(TypescriptParser.parse(source))).or(Map())
 
-  private def tokenize(source: String): List[String] =
-    def recur(index: Int, current: String, tokens: scala.collection.immutable.List[String])
-    :   scala.collection.immutable.List[String] =
-
-      if index >= source.length
-      then (if current.isEmpty then tokens else current :: tokens).reverse
-      else
-        val char = source.charAt(index)
-
-        if char.isLetterOrDigit || char == '_' then recur(index + 1, current + char, tokens)
-        else
-          val flushed = if current.isEmpty then tokens else current :: tokens
-
-          if punctuation(char) then recur(index + 1, "", char.toString :: flushed)
-          else recur(index + 1, "", flushed)
-
-    List.of(recur(0, "", Nil.stdlib))
-
-  private def interfaces(tokens: List[String], acc: Map[Text, Map[Text, Prototype]])
+  private def project(declarations: List[TypescriptDeclaration])
   :   Map[Text, Map[Text, Prototype]] =
 
-    tokens match
-      case "interface" :: name :: "{" :: rest =>
-        val (members, rest2) = membersOf(rest, Map())
-        interfaces(rest2, acc.updated(name.tt, members))
+    val byName = scala.collection.mutable.LinkedHashMap[Text, TypescriptDeclaration]()
 
-      case _ :: rest =>
-        interfaces(rest, acc)
+    declarations.stdlib.foreach: declaration =>
+      declaration match
+        case _: TypescriptDeclaration.Interface => byName.put(declaration.key, declaration)
+        case _: TypescriptDeclaration.Class     => byName.put(declaration.key, declaration)
+        case _                                  => ()
 
-      case Nil =>
-        acc
+    // Inherited members are resolved against the declarations of this same file. A base named by
+    // a declaration this file does not carry contributes nothing — the file is the whole world
+    // the macro has — but it never removes what is declared here.
+    def members(key: Text, seen: scala.collection.immutable.Set[Text])
+    :   scala.collection.immutable.Map[Text, Prototype] =
 
-  // Parses a type expression into a `Foreign.Type`: `T[]` and `T?` as suffixed named types, `A | B`
-  // as a union (with `| null` / `| undefined` collapsing to an optional), and `Name<args>` as a
-  // generic application.
-  private def typeOf(tokens: List[String]): (Foreign.Type, List[String]) =
-    val (first, rest0) = atom(tokens)
+      if seen.contains(key) then scala.collection.immutable.Map() else
+        byName.get(key) match
+          case scala.None => scala.collection.immutable.Map()
 
-    def union(todo: List[String], acc: List[Foreign.Type]): (List[Foreign.Type], List[String]) =
-      todo match
-        case "|" :: more =>
-          val (next, rest) = atom(more)
-          union(rest, next :: acc)
+          case scala.Some(declaration) =>
+            val bases = declaration match
+              case TypescriptDeclaration.Interface(_, _, _, extending, _, _) => extending.stdlib
 
-        case _ =>
-          (acc.reverse, todo)
+              case TypescriptDeclaration.Class(_, _, _, extending, implements, _, _, _) =>
+                extending.option.toList ++ implements.stdlib
 
-    val (members, rest) = union(rest0, List(first))
-    val result = if members.length == 1 then members.head else Foreign.Type.Union(members)
+              case _ => scala.Nil
 
-    (result, rest)
+            val inherited = bases.foldLeft(scala.collection.immutable.Map[Text, Prototype]()):
+              (accumulated, base) =>
+                base match
+                  case TypescriptType.Named(name, _) => accumulated ++ members(name, seen + key)
+                  case _                             => accumulated
 
-  // Parses a single (non-union) type. `T[]` is read as `Array<T>` (one array representation), and
-  // `null`/`undefined` are canonicalised to `undefined` (the absent value in a union).
-  private def atom(tokens: List[String]): (Foreign.Type, List[String]) = tokens match
-    case name :: "<" :: more =>
-      val (args, rest) = arguments(more, Nil)
-      (Foreign.Type.Applied(name.tt, args), rest)
+            declaration.declaredMembers.stdlib.foldLeft(inherited): (accumulated, member) =>
+              prototype(member).lay(accumulated): value =>
+                accumulated.updated(member.name, value)
 
-    case name :: "[" :: "]" :: more =>
-      (Foreign.Type.Applied(t"Array", List(Foreign.Type.Named(name.tt))), more)
+    Map.of(byName.keys.toList.map { key => key -> Map.of(members(key, scala.collection.immutable.Set())) }.toMap)
 
-    case ("null" | "undefined") :: more =>
-      (Foreign.Type.Named(t"undefined"), more)
+  // Index, call and construct signatures have no name a `Foreign` member selection could use,
+  // and a private member is not the consumer's to call.
+  private def prototype(member: TypescriptMember): Optional[Prototype] =
+    if !member.visible then Unset else member.kind match
+      case TypescriptMember.Kind.Call | TypescriptMember.Kind.Construct
+         | TypescriptMember.Kind.Index => Unset
 
-    case name :: more =>
-      (Foreign.Type.Named(name.tt), more)
+      case TypescriptMember.Kind.Property | TypescriptMember.Kind.Getter =>
+        member.signatures.stdlib.headOption.map: signature =>
+          val result = signature match
+            case TypescriptType.Function(_, result, _, _) => foreign(result)
+            case other                                    => foreign(other)
 
-    case Nil =>
-      (Foreign.Type.Named(t""), Nil)
+          Prototype(Unset, if member.optional then optional(result) else result)
 
-  private def arguments(tokens: List[String], acc: List[Foreign.Type])
-  :   (List[Foreign.Type], List[String]) =
+        . getOrElse(Unset)
 
-    tokens match
-      case ">" :: rest =>
-        (acc.reverse, rest)
+      case TypescriptMember.Kind.Method | TypescriptMember.Kind.Setter =>
+        // The first declared signature wins where a member is overloaded: `Prototype` records one
+        // arity, and TypeScript resolves against the signatures in order.
+        member.signatures.stdlib.headOption.map: signature =>
+          signature match
+            case TypescriptType.Function(parameters, result, _, _) =>
+              val arguments = parameters.map: parameter =>
+                val typed = parameter.typed.lay(Foreign.Type.Named(t"any"))(foreign(_))
+                if parameter.optional then optional(typed) else typed
 
-      case _ =>
-        val (arg, rest) = typeOf(tokens)
+              Prototype(arguments, foreign(result))
 
-        rest match
-          case "," :: more => arguments(more, arg :: acc)
-          case ">" :: more => (List.of((arg :: acc).reverse), more)
-          case _           => arguments(rest, acc)
+            case other => Prototype(Unset, foreign(other))
 
-  private def membersOf(tokens: List[String], acc: Map[Text, Prototype])
-  :   (Map[Text, Prototype], List[String]) =
+        . getOrElse(Unset)
 
-    tokens match
-      case "}" :: rest =>
-        (acc, rest)
-
-      case name :: "(" :: rest =>
-        val (parameters, rest2) = params(rest, Nil)
-
-        rest2 match
-          case ":" :: rest3 =>
-            val (result, rest4) = typeOf(rest3)
-            membersOf(semicolon(rest4), acc.updated(name.tt, Prototype(parameters, result)))
-
-          case _ =>
-            (acc, rest2)
-
-      case name :: "?" :: ":" :: rest =>
-        val (result, rest2) = typeOf(rest)
-        membersOf(semicolon(rest2), acc.updated(name.tt, Prototype(Unset, optional(result))))
-
-      case name :: ":" :: rest =>
-        val (result, rest2) = typeOf(rest)
-        membersOf(semicolon(rest2), acc.updated(name.tt, Prototype(Unset, result)))
-
-      case _ :: rest =>
-        membersOf(rest, acc)
-
-      case Nil =>
-        (acc, Nil)
-
-  // An optional member `x?: T` is `T | undefined`.
   private def optional(foreign: Foreign.Type): Foreign.Type =
     Foreign.Type.Union(List(foreign, Foreign.Type.Named(t"undefined")))
 
-  // Reads parameter declarations up to the closing `)`, keeping only each parameter's type.
-  private def params(tokens: List[String], acc: List[Foreign.Type])
-  :   (List[Foreign.Type], List[String]) =
+  // The projection onto `Foreign.Type`. Constructs the foreign model cannot express are rendered
+  // to a named type carrying their source shape, so they remain distinguishable from one another
+  // and from anything that *is* expressible — they simply will not marshal.
+  private def foreign(typed: TypescriptType): Foreign.Type = typed match
+    case TypescriptType.Named(t"null" | t"undefined", _) => Foreign.Type.Named(t"undefined")
+    case TypescriptType.Named(name, Nil)                 => Foreign.Type.Named(name)
 
-    tokens match
-      case ")" :: rest =>
-        (acc.reverse, rest)
+    case TypescriptType.Named(name, arguments) =>
+      Foreign.Type.Applied(name, arguments.map(foreign(_)))
 
-      case name :: ":" :: rest =>
-        val (kind, rest2) = typeOf(rest)
+    case TypescriptType.Array(element) =>
+      Foreign.Type.Applied(t"Array", List(foreign(element)))
 
-        rest2 match
-          case "," :: more => params(more, kind :: acc)
-          case _           => params(rest2, kind :: acc)
-
-      case _ :: rest =>
-        params(rest, acc)
-
-      case Nil =>
-        (acc.reverse, Nil)
-
-  private def semicolon(tokens: List[String]): List[String] = tokens match
-    case ";" :: rest => rest
-    case _           => tokens
+    case TypescriptType.Union(members)     => Foreign.Type.Union(members.map(foreign(_)))
+    case TypescriptType.Literal(value, _)  => Foreign.Type.Named(value)
+    case other                             => Foreign.Type.Named(other.text)

--- a/lib/xenophile/src/typescript/xenophile.TypescriptError.scala
+++ b/lib/xenophile/src/typescript/xenophile.TypescriptError.scala
@@ -30,8 +30,27 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.
-        {Typescript, TypescriptDeclaration, TypescriptDialect, TypescriptError, TypescriptMember,
-         TypescriptParser, TypescriptType}
+import anticipation.*
+import fulminate.*
+
+object TypescriptError:
+  enum Reason(val number: Int) extends Clarification:
+    case Syntax(detail: Text, near: Text)  extends Reason(1)
+    case Unsupported(construct: Text)      extends Reason(2)
+    case Duplicate(name: Text)             extends Reason(3)
+
+  given communicable: Reason is Communicable =
+    case Reason.Syntax(detail, near) => m"$detail, near $near"
+    case Reason.Unsupported(construct) =>
+      m"the construct $construct is outside the grammar this parser accepts"
+
+    case Reason.Duplicate(name) => m"the declaration $name appears twice in the same scope"
+
+// A `.d.ts` source could not be read. `Unsupported` is deliberately an error and not a silent
+// skip: a declaration file is a contract, and a parser that quietly drops what it does not
+// recognise reports a smaller contract than the file declares — which would make any
+// compatibility claim computed from it unsound.
+case class TypescriptError(reason: TypescriptError.Reason)(using Diagnostics)
+extends Error(643, reason.number)(m"the TypeScript declarations could not be read because $reason")

--- a/lib/xenophile/src/typescript/xenophile.TypescriptMember.scala
+++ b/lib/xenophile/src/typescript/xenophile.TypescriptMember.scala
@@ -30,8 +30,48 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.
-        {Typescript, TypescriptDeclaration, TypescriptDialect, TypescriptError, TypescriptMember,
-         TypescriptParser, TypescriptType}
+import anticipation.*
+import gossamer.*
+import vacuous.*
+
+object TypescriptMember:
+  // What the member *is*, which decides how a consumer may address it. A property and a method of
+  // the same name are different contracts even when their types agree, and a call signature is
+  // addressable only by invoking the enclosing type.
+  enum Kind:
+    case Property, Method, Getter, Setter, Call, Construct, Index
+
+  enum Visibility:
+    case Public, Protected, Private
+
+// One member of an interface, class or inline object type.
+//
+// Overloads are *not* merged: TypeScript resolves a call against the declared signatures in
+// order, so a member holds the list it was declared with and the order is semantic.
+case class TypescriptMember
+  ( name:       Text,
+    kind:       TypescriptMember.Kind,
+    signatures: List[TypescriptType],
+    visibility: TypescriptMember.Visibility = TypescriptMember.Visibility.Public,
+    static:     Boolean = false,
+    readonly:   Boolean = false,
+    optional:   Boolean = false,
+    isAbstract: Boolean = false ):
+
+  // The key a member is addressed by within its owning declaration. Getters and setters share a
+  // name with a property but are distinct contracts, and index and call signatures have no name
+  // of their own, so each kind contributes its own selector shape.
+  def selector: Text = kind match
+    case TypescriptMember.Kind.Property  => name
+    case TypescriptMember.Kind.Method    => name
+    case TypescriptMember.Kind.Getter    => t"get $name"
+    case TypescriptMember.Kind.Setter    => t"set $name"
+    case TypescriptMember.Kind.Call      => t"()"
+    case TypescriptMember.Kind.Construct => t"new()"
+    case TypescriptMember.Kind.Index     => t"[]"
+
+  // A `private` member is not part of any consumer's contract, and a TypeScript consumer cannot
+  // name it. `protected` is, since a subclass may.
+  def visible: Boolean = visibility != TypescriptMember.Visibility.Private

--- a/lib/xenophile/src/typescript/xenophile.TypescriptParser.scala
+++ b/lib/xenophile/src/typescript/xenophile.TypescriptParser.scala
@@ -231,7 +231,7 @@ object TypescriptParser:
     def declarations(): List[TypescriptDeclaration] raises TypescriptError =
       val module = moduleForm
       val result = scala.collection.mutable.ListBuffer[TypescriptDeclaration]()
-      block(Nil, module, result, top = true)
+      block(Nil, module, result, ambient = false)
 
       val seen = scala.collection.mutable.HashSet[Text]()
 
@@ -249,23 +249,26 @@ object TypescriptParser:
 
       List.from(result.toList)
 
+    // `ambient` marks a namespace body, where every declaration is exported implicitly: an
+    // ambient namespace has no notion of a private member, so its contents are as reachable as
+    // the namespace itself.
     private def block
-      ( scope:  TypescriptDeclaration.Scope,
-        module: Boolean,
-        into:   scala.collection.mutable.ListBuffer[TypescriptDeclaration],
-        top:    Boolean )
+      ( scope:   TypescriptDeclaration.Scope,
+        module:  Boolean,
+        into:    scala.collection.mutable.ListBuffer[TypescriptDeclaration],
+        ambient: Boolean )
     :   Unit raises TypescriptError =
 
       while peek().present && !at(t"}") do
-        if at(t"}") then () else declaration(scope, module, into, top)
+        if at(t"}") then () else declaration(scope, module, into, ambient)
 
       ()
 
     private def declaration
-      ( scope:  TypescriptDeclaration.Scope,
-        module: Boolean,
-        into:   scala.collection.mutable.ListBuffer[TypescriptDeclaration],
-        top:    Boolean )
+      ( scope:   TypescriptDeclaration.Scope,
+        module:  Boolean,
+        into:    scala.collection.mutable.ListBuffer[TypescriptDeclaration],
+        ambient: Boolean )
     :   Unit raises TypescriptError =
 
       if skip(t";") then ()
@@ -279,13 +282,13 @@ object TypescriptParser:
         if exported && (at(t"default") || at(t"=") || at(t"{") || at(t"*")) then skipStatement()
         else
           skip(t"declare")
-          declared(scope, module, into, top, exported || !module)
+          declared(scope, module, into, ambient, exported || ambient || !module)
 
     private def declared
       ( scope:   TypescriptDeclaration.Scope,
         module:  Boolean,
         into:    scala.collection.mutable.ListBuffer[TypescriptDeclaration],
-        top:     Boolean,
+        ambient: Boolean,
         visible: Boolean )
     :   Unit raises TypescriptError =
 
@@ -293,7 +296,9 @@ object TypescriptParser:
         val keyword = identifier()
         val name = if keyword == t"global" then t"global" else identifier()
         expect(t"{")
-        block(List.from(scope.stdlib :+ name), module, into, top = false)
+        // The namespace's own visibility becomes its contents': an unexported namespace exports
+        // nothing, however its members are written.
+        block(List.from(scope.stdlib :+ name), module, into, ambient = visible)
         expect(t"}")
       else if at(t"interface") then into += interfaceDeclaration(scope, visible)
       else if at(t"class") || at(t"abstract") then into += classDeclaration(scope, visible)

--- a/lib/xenophile/src/typescript/xenophile.TypescriptParser.scala
+++ b/lib/xenophile/src/typescript/xenophile.TypescriptParser.scala
@@ -1,0 +1,770 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+import TypescriptError.Reason
+
+// A parser for TypeScript declaration files.
+//
+// It is a *declaration* parser, not a TypeScript compiler: it reads the shapes a `.d.ts` file may
+// contain and nothing about expressions or statements, which such a file does not have. Within
+// that scope it is total in the only sense that matters — every construct is either understood or
+// rejected. The previous grammar here skipped what it did not recognise, which quietly turned a
+// generic or `extends`-bearing interface into no interface at all; for a foreign-function facade
+// that produced a confusing "no such member" later, and for a compatibility discipline it would
+// have produced an unsound claim.
+//
+// Constructs deliberately outside the grammar — conditional types, mapped types, template literal
+// types, `infer`, decorators — raise `Unsupported` rather than being approximated.
+object TypescriptParser:
+
+  enum Token:
+    case Word(text: Text)
+    case Str(text: Text)
+    case Num(text: Text)
+    case Punct(text: Text)
+
+    def show: Text = this match
+      case Word(text)  => text
+      case Str(text)   => t"'$text'"
+      case Num(text)   => text
+      case Punct(text) => text
+
+  // Multi-character punctuation, longest first, so `=>` never lexes as `=` then `>`, and `...`
+  // never as three dots.
+  private val operators: scala.List[String] =
+    scala.List("...", "=>", "?.", "??", "<=", ">=", "===", "!==", "==", "!=", "&&", "||")
+
+  private val singles: String = "{}()[]<>:;,.?|&=+-*/!#@"
+
+  def lex(source: Text): List[Token] raises TypescriptError =
+    val text = source.s
+    val tokens = scala.collection.mutable.ListBuffer[Token]()
+    var index = 0
+
+    def word(start: Int): Int =
+      var end = start
+      while end < text.length && (text.charAt(end).isLetterOrDigit || text.charAt(end) == '_'
+          || text.charAt(end) == '$') do end += 1
+
+      tokens += Token.Word(text.substring(start, end).nn.tt)
+      end
+
+    def number(start: Int): Int =
+      var end = start
+      while end < text.length && (text.charAt(end).isDigit || text.charAt(end) == '.'
+          || text.charAt(end) == 'x' || text.charAt(end) == 'e'
+          || (text.charAt(end) >= 'a' && text.charAt(end) <= 'f')
+          || (text.charAt(end) >= 'A' && text.charAt(end) <= 'F')) do end += 1
+
+      tokens += Token.Num(text.substring(start, end).nn.tt)
+      end
+
+    // A string literal's *value* is the token, so `"a"` and `'a'` — the same literal type written
+    // two ways — lex identically and cannot differ in any encoding computed from these tokens.
+    def string(start: Int, quote: Char): Int raises TypescriptError =
+      val builder = StringBuilder()
+      var end = start + 1
+
+      while end < text.length && text.charAt(end) != quote do
+        if text.charAt(end) == '\\' && end + 1 < text.length then
+          builder.append(text.charAt(end + 1))
+          end += 2
+        else
+          builder.append(text.charAt(end))
+          end += 1
+
+      if end >= text.length
+      then abort(TypescriptError(Reason.Syntax(t"the string literal is unterminated", t"$quote")))
+
+      tokens += Token.Str(builder.toString.tt)
+      end + 1
+
+    while index < text.length do
+      val char = text.charAt(index)
+
+      if char.isWhitespace then index += 1
+      else if char == '/' && index + 1 < text.length && text.charAt(index + 1) == '/' then
+        while index < text.length && text.charAt(index) != '\n' do index += 1
+      else if char == '/' && index + 1 < text.length && text.charAt(index + 1) == '*' then
+        index += 2
+        while index + 1 < text.length
+        && !(text.charAt(index) == '*' && text.charAt(index + 1) == '/') do index += 1
+        index = (index + 2).min(text.length)
+      else if char == '`' then
+        abort(TypescriptError(Reason.Unsupported(t"a template literal type")))
+      else if char == '"' || char == '\'' then index = string(index, char)
+      else if char.isDigit then index = number(index)
+      else if char.isLetter || char == '_' || char == '$' then index = word(index)
+      else
+        val operator = operators.find: operator =>
+          text.regionMatches(index, operator, 0, operator.length)
+
+        operator match
+          case scala.Some(operator) =>
+            tokens += Token.Punct(operator.tt)
+            index += operator.length
+
+          case scala.None =>
+            if singles.indexOf(char.toInt) >= 0 then
+              tokens += Token.Punct(char.toString.tt)
+              index += 1
+            else abort(TypescriptError(Reason.Syntax(t"unexpected character", char.toString.tt)))
+
+    List.from(tokens.toList)
+
+  def parse(source: Text): List[TypescriptDeclaration] raises TypescriptError =
+    Cursor(lex(source)).declarations()
+
+  // A mutable cursor over the token stream. Declaration grammars are almost entirely
+  // single-token-lookahead, and threading an index through forty mutually recursive functions
+  // obscures the grammar without making it any more correct.
+  private class Cursor(tokens: List[Token]):
+    private val items: scala.collection.immutable.Vector[Token] = tokens.stdlib.toVector
+
+    // The cursor is a plain `Int` into an immutable vector, so it captures nothing; the
+    // annotation says so, rather than making the whole parser a tracked capability.
+    @scala.caps.unsafe.untrackedCaptures private var position: Int = 0
+
+    def peek(ahead: Int = 0): Optional[Token] =
+      if position + ahead < items.length then items(position + ahead) else Unset
+
+    def next(): Optional[Token] =
+      val token = peek()
+      position += 1
+      token
+
+    def here: Text = peek().lay(t"the end of the file")(_.show)
+
+    def word: Optional[Text] = peek() match
+      case Token.Word(text) => text
+      case _                => Unset
+
+    def punct: Optional[Text] = peek() match
+      case Token.Punct(text) => text
+      case _                 => Unset
+
+    def at(text: Text): Boolean = word == text || punct == text
+
+    // Lookahead by token text, without constructing an `Optional` to compare against: the
+    // comparison would search for a `CanEqual` over the `Unset | Token` union.
+    def ahead(offset: Int, text: Text): Boolean = peek(offset) match
+      case Token.Word(value)  => value == text
+      case Token.Punct(value) => value == text
+      case _                  => false
+
+    def skip(text: Text): Boolean = if at(text) then { position += 1; true } else false
+
+    def expect(text: Text): Unit raises TypescriptError =
+      if !skip(text)
+      then abort(TypescriptError(Reason.Syntax(t"expected $text", here)))
+
+    def identifier(): Text raises TypescriptError = next() match
+      case Token.Word(text) => text
+      case Token.Str(text)  => text
+      case Token.Num(text)  => text
+      case _ => abort(TypescriptError(Reason.Syntax(t"expected a name", here)))
+
+    // Consumes a `;` or `,` separator where the grammar permits either, and tolerates its
+    // absence: a newline terminates a member in TypeScript, and the lexer has discarded newlines.
+    def separator(): Unit =
+      skip(t";")
+      skip(t",")
+      ()
+
+    // --- declarations ------------------------------------------------------------------------
+
+    // A file with any top-level `import` or `export` is a *module*, in which only exported
+    // declarations are reachable by a consumer; otherwise it is a global script, in which every
+    // top-level declaration is. The distinction is settled by scanning the whole token stream
+    // once, because an `export` at the end of a file retroactively determines the status of a
+    // declaration at the top.
+    private def moduleForm: Boolean =
+      var found = false
+      var index = 0
+
+      while !found && index < items.length do
+        items(index) match
+          case Token.Word(text) => found = text == t"export" || text == t"import"
+          case _                => ()
+
+        index += 1
+
+      found
+
+    def declarations(): List[TypescriptDeclaration] raises TypescriptError =
+      val module = moduleForm
+      val result = scala.collection.mutable.ListBuffer[TypescriptDeclaration]()
+      block(Nil, module, result, top = true)
+
+      val seen = scala.collection.mutable.HashSet[Text]()
+
+      // Interfaces and namespaces merge in TypeScript; classes, aliases and enums do not. A
+      // repeated non-mergeable name is a source error, not something to resolve by last-wins.
+      def mergeable(declaration: TypescriptDeclaration): Boolean = declaration match
+        case _: TypescriptDeclaration.Interface => true
+        case _: TypescriptDeclaration.Function  => true
+        case _                                  => false
+
+      result.toList.foreach: declaration =>
+        val key = declaration.key
+        if !mergeable(declaration) && !seen.add(key)
+        then abort(TypescriptError(Reason.Duplicate(key)))
+
+      List.from(result.toList)
+
+    private def block
+      ( scope:  TypescriptDeclaration.Scope,
+        module: Boolean,
+        into:   scala.collection.mutable.ListBuffer[TypescriptDeclaration],
+        top:    Boolean )
+    :   Unit raises TypescriptError =
+
+      while peek().present && !at(t"}") do
+        if at(t"}") then () else declaration(scope, module, into, top)
+
+      ()
+
+    private def declaration
+      ( scope:  TypescriptDeclaration.Scope,
+        module: Boolean,
+        into:   scala.collection.mutable.ListBuffer[TypescriptDeclaration],
+        top:    Boolean )
+    :   Unit raises TypescriptError =
+
+      if skip(t";") then ()
+      else if at(t"import") then skipStatement()
+      else if at(t"@") then abort(TypescriptError(Reason.Unsupported(t"a decorator")))
+      else
+        val exported = skip(t"export")
+
+        // `export default …`, `export = …` and `export { … }` re-export existing names; they
+        // change nothing about the declarations themselves, which are parsed where they stand.
+        if exported && (at(t"default") || at(t"=") || at(t"{") || at(t"*")) then skipStatement()
+        else
+          skip(t"declare")
+          declared(scope, module, into, top, exported || !module)
+
+    private def declared
+      ( scope:   TypescriptDeclaration.Scope,
+        module:  Boolean,
+        into:    scala.collection.mutable.ListBuffer[TypescriptDeclaration],
+        top:     Boolean,
+        visible: Boolean )
+    :   Unit raises TypescriptError =
+
+      if at(t"namespace") || at(t"module") || at(t"global") then
+        val keyword = identifier()
+        val name = if keyword == t"global" then t"global" else identifier()
+        expect(t"{")
+        block(List.from(scope.stdlib :+ name), module, into, top = false)
+        expect(t"}")
+      else if at(t"interface") then into += interfaceDeclaration(scope, visible)
+      else if at(t"class") || at(t"abstract") then into += classDeclaration(scope, visible)
+      else if at(t"type") then into += aliasDeclaration(scope, visible)
+      else if at(t"enum") || at(t"const") && ahead(1, t"enum")
+      then into += enumDeclaration(scope, visible)
+      else if at(t"function") then into += functionDeclaration(scope, visible)
+      else if at(t"const") || at(t"let") || at(t"var") then into += variableDeclaration(scope, visible)
+      else abort(TypescriptError(Reason.Unsupported(t"a top-level ${here} declaration")))
+
+    // `import` and re-export forms are recorded by their absence: they bind no new contract of
+    // their own, so the parser advances past them to the statement terminator.
+    private def skipStatement(): Unit =
+      var depth = 0
+
+      while peek().present && !(depth == 0 && (at(t";") || at(t"}"))) do
+        if at(t"{") then depth += 1
+        if at(t"}") then depth -= 1
+        next()
+
+      skip(t";")
+      ()
+
+    private def interfaceDeclaration(scope: TypescriptDeclaration.Scope, exported: Boolean)
+    :   TypescriptDeclaration raises TypescriptError =
+
+      expect(t"interface")
+      val name = identifier()
+      val typed = typeParameters()
+      val extending = if skip(t"extends") then typeList() else Nil
+      expect(t"{")
+      val members = memberList()
+      expect(t"}")
+
+      TypescriptDeclaration.Interface(name, scope, typed, extending, members, exported)
+
+    private def classDeclaration(scope: TypescriptDeclaration.Scope, exported: Boolean)
+    :   TypescriptDeclaration raises TypescriptError =
+
+      val isAbstract = skip(t"abstract")
+      expect(t"class")
+      val name = identifier()
+      val typed = typeParameters()
+      val extending: Optional[TypescriptType] = if skip(t"extends") then typeExpression() else Unset
+      val implements = if skip(t"implements") then typeList() else Nil
+      expect(t"{")
+      val members = memberList()
+      expect(t"}")
+
+      TypescriptDeclaration.Class
+        (name, scope, typed, extending, implements, members, isAbstract, exported)
+
+    private def aliasDeclaration(scope: TypescriptDeclaration.Scope, exported: Boolean)
+    :   TypescriptDeclaration raises TypescriptError =
+
+      expect(t"type")
+      val name = identifier()
+      val typed = typeParameters()
+      expect(t"=")
+      val target = typeExpression()
+      separator()
+
+      TypescriptDeclaration.Alias(name, scope, typed, target, exported)
+
+    private def enumDeclaration(scope: TypescriptDeclaration.Scope, exported: Boolean)
+    :   TypescriptDeclaration raises TypescriptError =
+
+      val constant = skip(t"const")
+      expect(t"enum")
+      val name = identifier()
+      expect(t"{")
+      val members = scala.collection.mutable.ListBuffer[(Text, Optional[Text])]()
+
+      while !at(t"}") && peek().present do
+        val member = identifier()
+        val value: Optional[Text] = if skip(t"=") then identifier() else Unset
+        members += ((member, value))
+        separator()
+
+      expect(t"}")
+
+      TypescriptDeclaration.Enumeration(name, scope, List.from(members.toList), constant, exported)
+
+    private def functionDeclaration(scope: TypescriptDeclaration.Scope, exported: Boolean)
+    :   TypescriptDeclaration raises TypescriptError =
+
+      expect(t"function")
+      val name = identifier()
+      val typed = typeParameters()
+      val parameters = parameterList()
+      val result = if skip(t":") then typeExpression() else TypescriptType.Named(t"void")
+      separator()
+
+      TypescriptDeclaration.Function
+        (name, scope, List(TypescriptType.Function(parameters, result, typed)), exported)
+
+    private def variableDeclaration(scope: TypescriptDeclaration.Scope, exported: Boolean)
+    :   TypescriptDeclaration raises TypescriptError =
+
+      val constant = at(t"const")
+      next()
+      val name = identifier()
+      val typed: Optional[TypescriptType] = if skip(t":") then typeExpression() else Unset
+      separator()
+
+      TypescriptDeclaration.Variable(name, scope, typed, constant, exported)
+
+    // --- members -----------------------------------------------------------------------------
+
+    private def memberList(): List[TypescriptMember] raises TypescriptError =
+      val members = scala.collection.mutable.ListBuffer[TypescriptMember]()
+
+      while !at(t"}") && peek().present do
+        member().let { value => members += value }
+        separator()
+
+      // Overload groups are folded here rather than in the grammar: consecutive signatures under
+      // one name and kind are one member with several signatures, in declaration order, because
+      // that order is what TypeScript's overload resolution reads.
+      val merged = scala.collection.mutable.LinkedHashMap[Text, TypescriptMember]()
+
+      members.toList.foreach: member =>
+        val selector = member.selector
+
+        merged.get(selector) match
+          case scala.Some(existing) =>
+            val signatures: List[TypescriptType] =
+              List.from(existing.signatures.stdlib ++ member.signatures.stdlib)
+
+            merged.put(selector, existing.copy(signatures = signatures))
+
+          case scala.None => merged.put(selector, member)
+
+      List.from(merged.values.toList)
+
+    private def member(): Optional[TypescriptMember] raises TypescriptError =
+      if skip(t";") then Unset
+      else if at(t"@") then abort(TypescriptError(Reason.Unsupported(t"a decorator")))
+      else declaredMember()
+
+    private def declaredMember(): TypescriptMember raises TypescriptError =
+      var visibility = TypescriptMember.Visibility.Public
+      var static = false
+      var readonly = false
+      var isAbstract = false
+
+      var scanning = true
+
+      while scanning do
+        if at(t"public") then { next(); visibility = TypescriptMember.Visibility.Public }
+        else if at(t"protected") then { next(); visibility = TypescriptMember.Visibility.Protected }
+        else if at(t"private") then { next(); visibility = TypescriptMember.Visibility.Private }
+        else if at(t"static") then { next(); static = true }
+        else if at(t"abstract") then { next(); isAbstract = true }
+        // `readonly` is only a modifier when something follows it that can be named; `readonly`
+        // as a member name is legal TypeScript.
+        else if at(t"readonly") && !(ahead(1, t":")
+            || ahead(1, t"?")
+            || ahead(1, t"(")) then { next(); readonly = true }
+        else scanning = false
+
+      // A call signature `(…): T`, or a generic one `<T>(…): U`.
+      if at(t"(") || at(t"<") then
+        val typed = typeParameters()
+        val parameters = parameterList()
+        val result = if skip(t":") then typeExpression() else TypescriptType.Named(t"any")
+
+        TypescriptMember
+          ( t"", TypescriptMember.Kind.Call,
+            List(TypescriptType.Function(parameters, result, typed)),
+            visibility, static, readonly )
+
+      // A construct signature `new (…): T`.
+      else if at(t"new") && (ahead(1, t"(") || peek(1)
+          == Optional(Token.Punct(t"<"))) then
+        next()
+        val typed = typeParameters()
+        val parameters = parameterList()
+        val result = if skip(t":") then typeExpression() else TypescriptType.Named(t"any")
+
+        TypescriptMember
+          ( t"", TypescriptMember.Kind.Construct,
+            List(TypescriptType.Function(parameters, result, typed, construct = true)),
+            visibility, static, readonly )
+
+      // An index signature `[key: string]: T`. Distinguished from a computed property name
+      // (`[Symbol.iterator]()`) by the `:` after the key.
+      else if at(t"[") && ahead(2, t":") then
+        expect(t"[")
+        val key = identifier()
+        expect(t":")
+        val keyType = typeExpression()
+        expect(t"]")
+        expect(t":")
+        val value = typeExpression()
+
+        TypescriptMember
+          ( key, TypescriptMember.Kind.Index,
+            List(TypescriptType.Function(List(TypescriptType.Argument(key, keyType)), value)),
+            visibility, static, readonly )
+
+      else if at(t"[") then abort(TypescriptError(Reason.Unsupported(t"a computed property name")))
+      else
+        val getter = at(t"get") && !(ahead(1, t":")
+            || ahead(1, t"("))
+
+        val setter = at(t"set") && !(ahead(1, t":")
+            || ahead(1, t"("))
+
+        if getter || setter then next()
+
+        val name = identifier()
+        val optional = skip(t"?")
+
+        if at(t"(") || at(t"<") then
+          val typed = typeParameters()
+          val parameters = parameterList()
+          val result = if skip(t":") then typeExpression() else TypescriptType.Named(t"any")
+
+          val kind =
+            if getter then TypescriptMember.Kind.Getter
+            else if setter then TypescriptMember.Kind.Setter
+            else TypescriptMember.Kind.Method
+
+          TypescriptMember
+            ( name, kind, List(TypescriptType.Function(parameters, result, typed)), visibility,
+              static, readonly, optional, isAbstract )
+        else
+          val typed = if skip(t":") then typeExpression() else TypescriptType.Named(t"any")
+
+          TypescriptMember
+            ( name, TypescriptMember.Kind.Property, List(typed), visibility, static, readonly,
+              optional, isAbstract )
+
+    // --- types -------------------------------------------------------------------------------
+
+    private def typeParameters(): List[TypescriptType.Parameter] raises TypescriptError =
+      if !skip(t"<") then Nil else
+        val parameters = scala.collection.mutable.ListBuffer[TypescriptType.Parameter]()
+
+        while !at(t">") && peek().present do
+          if at(t"infer") then abort(TypescriptError(Reason.Unsupported(t"an `infer` binder")))
+          val name = identifier()
+          val bound: Optional[TypescriptType] = if skip(t"extends") then typeExpression() else Unset
+          val default: Optional[TypescriptType] = if skip(t"=") then typeExpression() else Unset
+          parameters += TypescriptType.Parameter(name, bound, default)
+          skip(t",")
+
+        expect(t">")
+        List.from(parameters.toList)
+
+    private def typeArguments(): List[TypescriptType] raises TypescriptError =
+      if !skip(t"<") then Nil else
+        val arguments = scala.collection.mutable.ListBuffer[TypescriptType]()
+
+        while !at(t">") && peek().present do
+          arguments += typeExpression()
+          skip(t",")
+
+        expect(t">")
+        List.from(arguments.toList)
+
+    private def typeList(): List[TypescriptType] raises TypescriptError =
+      val types = scala.collection.mutable.ListBuffer[TypescriptType]()
+      types += typeExpression()
+      while skip(t",") do types += typeExpression()
+
+      List.from(types.toList)
+
+    private def parameterList(): List[TypescriptType.Argument] raises TypescriptError =
+      expect(t"(")
+      val parameters = scala.collection.mutable.ListBuffer[TypescriptType.Argument]()
+
+      while !at(t")") && peek().present do
+        val rest = skip(t"...")
+        // Parameter modifiers (`public readonly x: T`) appear in constructor parameter
+        // properties; they declare a member, but the parameter's own contract is its type.
+        skip(t"public")
+        skip(t"protected")
+        skip(t"private")
+        skip(t"readonly")
+        val name = identifier()
+        val optional = skip(t"?")
+        val typed: Optional[TypescriptType] = if skip(t":") then typeExpression() else Unset
+        // A default value makes a parameter optional; the value itself is behaviour, not
+        // contract, so it is consumed and discarded.
+        if skip(t"=") then skipDefault()
+        parameters += TypescriptType.Argument(name, typed, optional, rest)
+        skip(t",")
+
+      expect(t")")
+      List.from(parameters.toList)
+
+    private def skipDefault(): Unit =
+      var depth = 0
+
+      while peek().present && !(depth == 0 && (at(t",") || at(t")"))) do
+        if at(t"(") || at(t"[") || at(t"{") then depth += 1
+        if at(t")") || at(t"]") || at(t"}") then depth -= 1
+        next()
+
+      ()
+
+    def typeExpression(): TypescriptType raises TypescriptError =
+      // A leading `|` or `&` is legal and purely cosmetic.
+      skip(t"|")
+      skip(t"&")
+
+      val first = intersection()
+
+      if !at(t"|") then first else
+        val members = scala.collection.mutable.ListBuffer[TypescriptType]()
+        members += first
+        while skip(t"|") do members += intersection()
+
+        TypescriptType.Union(List.from(members.toList))
+
+    private def intersection(): TypescriptType raises TypescriptError =
+      val first = suffixed()
+
+      if !at(t"&") then first else
+        val members = scala.collection.mutable.ListBuffer[TypescriptType]()
+        members += first
+        while skip(t"&") do members += suffixed()
+
+        TypescriptType.Intersection(List.from(members.toList))
+
+    // `T[]`, `T[][]` and `T[K]` all suffix a primary type, and they chain.
+    private def suffixed(): TypescriptType raises TypescriptError =
+      var result = primary()
+
+      while at(t"[") do
+        expect(t"[")
+
+        if skip(t"]") then result = TypescriptType.Array(result)
+        else
+          val index = typeExpression()
+          expect(t"]")
+          result = TypescriptType.Indexed(result, index)
+
+      if skip(t"is") then
+        result match
+          case TypescriptType.Named(name, Nil) =>
+            TypescriptType.Predicate(name, typeExpression())
+
+          case _ =>
+            abort(TypescriptError(Reason.Syntax(t"a type predicate needs a parameter name", here)))
+      else result
+
+    private def primary(): TypescriptType raises TypescriptError =
+      if at(t"(") then
+        // Either a parenthesised type or a function type. They are distinguished only by what
+        // follows the closing parenthesis, and `(a: T)` is not a valid type on its own, so the
+        // parser reads the parenthesised form as a parameter list first and rewinds if no `=>`
+        // follows.
+        val mark = position
+
+        val function: Optional[TypescriptType] =
+          try
+            val parameters = parameterList()
+            if skip(t"=>") then TypescriptType.Function(parameters, typeExpression()) else Unset
+          catch case _: Exception => Unset
+
+        function match
+          case function: TypescriptType => function
+
+          case _ =>
+            position = mark
+            expect(t"(")
+            val inner = typeExpression()
+            expect(t")")
+            inner
+
+      else if at(t"<") then
+        val typed = typeParameters()
+        val parameters = parameterList()
+        expect(t"=>")
+
+        TypescriptType.Function(parameters, typeExpression(), typed)
+
+      else if at(t"new") then
+        next()
+        val typed = typeParameters()
+        val parameters = parameterList()
+        expect(t"=>")
+
+        TypescriptType.Function(parameters, typeExpression(), typed, construct = true)
+
+      else if at(t"{") then
+        expect(t"{")
+        val members = memberList()
+        expect(t"}")
+
+        TypescriptType.Object(members)
+
+      else if at(t"[") then
+        expect(t"[")
+        val members = scala.collection.mutable.ListBuffer[TypescriptType]()
+        val names = scala.collection.mutable.ListBuffer[Optional[Text]]()
+
+        while !at(t"]") && peek().present do
+          skip(t"...")
+          skip(t"readonly")
+
+          // A labelled tuple element (`[first: A, second: B]`) names a position; the name is
+          // documentation to TypeScript, so it is kept but never distinguishes a type.
+          val label: Optional[Text] =
+            if ahead(1, t":") then
+              val name = identifier()
+              expect(t":")
+              name
+            else Unset
+
+          names += label
+          members += typeExpression()
+          skip(t"?")
+          skip(t",")
+
+        expect(t"]")
+
+        TypescriptType.Tuple(List.from(members.toList), List.from(names.toList))
+
+      else if at(t"keyof") then
+        next()
+        TypescriptType.Keyof(primary())
+
+      else if at(t"typeof") then
+        next()
+        TypescriptType.Typeof(qualifiedName())
+
+      else if at(t"infer") then abort(TypescriptError(Reason.Unsupported(t"an `infer` binder")))
+      else if at(t"asserts") then
+        abort(TypescriptError(Reason.Unsupported(t"an assertion signature")))
+      else if at(t"unique") then abort(TypescriptError(Reason.Unsupported(t"a `unique symbol`")))
+      else peek() match
+        case Token.Str(value)  => { next(); TypescriptType.Literal(value,
+            TypescriptType.LiteralKind.String) }
+
+        case Token.Num(value)  => { next(); TypescriptType.Literal(value,
+            TypescriptType.LiteralKind.Number) }
+
+        case Token.Punct(t"-") =>
+          next()
+
+          peek() match
+            case Token.Num(value) =>
+              next()
+              TypescriptType.Literal(t"-$value", TypescriptType.LiteralKind.Number)
+
+            case _ => abort(TypescriptError(Reason.Syntax(t"expected a number", here)))
+
+        case Token.Word(word) if word == t"true" || word == t"false" =>
+          next()
+          TypescriptType.Literal(word, TypescriptType.LiteralKind.Boolean)
+
+        case Token.Word(_) =>
+          val name = qualifiedName()
+          val arguments = typeArguments()
+          val named = TypescriptType.Named(name, arguments)
+
+          // A conditional type is recognised here, where its `extends` follows a type rather
+          // than a declaration name, and rejected rather than approximated.
+          if at(t"extends")
+          then abort(TypescriptError(Reason.Unsupported(t"a conditional type")))
+          else named
+
+        case _ => abort(TypescriptError(Reason.Syntax(t"expected a type", here)))
+
+    private def qualifiedName(): Text raises TypescriptError =
+      val parts = scala.collection.mutable.ListBuffer[Text]()
+      parts += identifier()
+      while skip(t".") do parts += identifier()
+
+      parts.toList.map(_.s).mkString(".").tt

--- a/lib/xenophile/src/typescript/xenophile.TypescriptType.scala
+++ b/lib/xenophile/src/typescript/xenophile.TypescriptType.scala
@@ -30,8 +30,89 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.
-        {Typescript, TypescriptDeclaration, TypescriptDialect, TypescriptError, TypescriptMember,
-         TypescriptParser, TypescriptType}
+import anticipation.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+object TypescriptType:
+  // A literal type's kind, kept apart from its text because `"1"` and `1` are different types
+  // whose source forms differ only in quoting, which the lexer has already removed.
+  enum LiteralKind:
+    case String, Number, Boolean
+
+  // A type parameter's binder: its bound (`T extends U`) and its default (`T = U`). The name is
+  // carried for diagnostics and for resolving references within the binder's scope; a canonical
+  // encoding is expected to replace it with a positional index.
+  case class Parameter(name: Text, bound: Optional[TypescriptType], default: Optional[TypescriptType])
+
+  // A value parameter of a function, method or constructor. `rest` marks `...args: T[]`, whose
+  // arity is unbounded, and `optional` marks `a?: T`, which callers may omit — both change what
+  // call sites are legal, so both are part of the contract.
+  case class Argument
+    ( name:     Text,
+      typed:    Optional[TypescriptType],
+      optional: Boolean = false,
+      rest:     Boolean = false )
+
+// A TypeScript type expression.
+//
+// The vocabulary is deliberately closed: `TypescriptParser` raises rather than guessing when it
+// meets a construct not represented here, so a `.d.ts` file using one is rejected loudly instead
+// of being read as a smaller interface than it declares. That property is what lets a discipline
+// atomize these values at all (LIRA §11.2 requirement 3).
+enum TypescriptType:
+  case Named(name: Text, arguments: List[TypescriptType] = Nil)
+  case Literal(value: Text, kind: TypescriptType.LiteralKind)
+  case Union(members: List[TypescriptType])
+  case Intersection(members: List[TypescriptType])
+  case Tuple(members: List[TypescriptType], names: List[Optional[Text]] = Nil)
+  case Array(element: TypescriptType)
+  case Object(members: List[TypescriptMember])
+  case Keyof(target: TypescriptType)
+  case Typeof(target: Text)
+  case Indexed(target: TypescriptType, index: TypescriptType)
+  case Predicate(parameter: Text, target: TypescriptType)
+
+  case Function
+    ( parameters: List[TypescriptType.Argument],
+      result:     TypescriptType,
+      typed:      List[TypescriptType.Parameter] = Nil,
+      construct:  Boolean = false )
+
+  // A stable rendering, used in diagnostics. It is *not* the canonical encoding: the encoding a
+  // discipline hashes is structural and binder-name-free, and lives with the discipline.
+  //
+  // Rendering runs over the `stdlib` view rather than the opaque collections' `map`/`join`. An
+  // extension method applied under a still-uninstantiated type variable is the shape that trips
+  // the compiler's `wildApprox` assertion (scala/scala3#24824), and a recursive renderer over a
+  // generic collection reaches it reliably.
+  def text: Text =
+    def render(types: List[TypescriptType], separator: String): String =
+      types.stdlib.map { typed => typed.text.s }.mkString(separator)
+
+    val rendered: String = this match
+      case Named(name, Nil)       => name.s
+      case Literal(value, _)      => value.s
+      case Union(members)         => render(members, " | ")
+      case Intersection(members)  => render(members, " & ")
+      case Array(element)         => element.text.s+"[]"
+      case Keyof(target)          => "keyof "+target.text.s
+      case Typeof(target)         => "typeof "+target.s
+      case Named(name, arguments) => name.s+"<"+render(arguments, ", ")+">"
+      case Tuple(members, _)      => "["+render(members, ", ")+"]"
+      case Indexed(target, index) => target.text.s+"["+index.text.s+"]"
+      case Predicate(name, target) => name.s+" is "+target.text.s
+
+      case Object(members) =>
+        "{ "+members.stdlib.map { member => member.name.s }.mkString("; ")+" }"
+
+      case Function(parameters, result, _, construct) =>
+        val arguments = parameters.stdlib.map: parameter =>
+          parameter.name.s+": "+parameter.typed.lay("any") { value => value.text.s }
+
+        (if construct then "new " else "")+"("+arguments.mkString(", ")+") => "+result.text.s
+
+    rendered.tt


### PR DESCRIPTION
LIRA's compatibility algebra has until now had one language-specific
plug-in for Soundness: `tasty/1`, which certifies recompilation and
deliberately holds `.class` files atomless. That leaves two gaps. Nothing
detects a release that is a clean minor at the source level and breaks
every consumer holding prebuilt bytecode, and TypeScript declarations fall
to `opaque/1`, where the whole file is one atom over its bytes and every
rebuild is a major event. This change adds `classfile/1` for the JVM's
linkage contract, the `jvm/1` ecosystem profile that checks the same
predicates without fusing them into API identity, and `dts/1` for
TypeScript declaration files — the last of which rests on a rewritten
`.d.ts` parser that refuses what it cannot read instead of skipping it.

## `classfile/1`: the JVM linkage contract as atoms

A new discipline in `mandible` atomizes the declaration surface of Java
classfiles. It keys by **membership** rather than by declaration, because a
JVM call site names the receiver: `Derived` presents `inherited()` whether
or not it declares it, so both get atoms.

```scala
val registry = Discipline.Registry(List(ClassfileDiscipline, Tasty))
```

Registry order is load-bearing. `tasty/1` claims `.class` files atomless
and claiming is first-match, so `classfile/1` must come first; in the other
order it silently atomizes nothing.

It certifies **linkage only**. Bytecode has erased the type arguments,
variance and implicit specificity that decide whether a consumer's next
compile succeeds — that level remains `tasty/1`'s.

## `jvm/1`: linkage without fusing it into API identity

Registering `classfile/1` has a cost that LIRA §11.6 warns about: atoms
feed the snapshot, and the snapshot is API identity, so a release whose
bridge methods merely moved acquires a new identity and stops satisfying
consumers who only ever recompile.

The new `EcosystemProfile` SPI gives the other option. `jvm/1` runs the
same predicates over the same content, out of band, and records what it
finds in `breaks linkage` — read by the consumers a linkage break actually
affects, and by nobody else.

```scala
LiraAssembler.assemble
  ( module,
    sections,
    disciplines = Discipline.Registry(List(Tasty)),
    profile     = List(LiraManifest.Profile(t"jvm/1")),
    profiles    = EcosystemProfile.Registry(List(JvmProfile)),
    predecessor = previousRelease )
```

The `breaks` list stays an authorial claim: the audit confirms it accounts
for what the predicates found (L130) rather than computing it. A declared
profile with no implementation is reported, not rejected — that is a gap in
the checking tool, not a defect in the release.

Choose one instrument or the other: register `classfile/1` where linkage is
the primary contract, and declare `jvm/1` where recompilation is.

## `dts/1`: TypeScript declaration files

```scala
val registry = Discipline.Registry(List(DtsDiscipline))
```

`dts/1` claims `**/*.d.ts` and certifies recompilation — declarations are
erased before anything runs, so there is no late linking for them to
protect.

Adding a member to an interface is two events at once, and the discipline
records both. It cannot break a consumer who *calls* the interface, and
always breaks one who *implements* it — and structural typing means
implementors cannot be enumerated. So each member is an atom of its own,
and the sorted member-key list also folds into the interface's atom. The
grade reports the major.

Renaming a type parameter changes no atom (binders encode as de Bruijn
indices) and reordering a union changes no atom (unions sort), while
reordering a tuple or adding an overload is a major.

## A real `.d.ts` parser

`dts/1` needed a parser that cannot lose anything, so the minimal grammar
behind `xenophile`'s TypeScript FFI has been replaced. The old one silently
dropped whatever it did not recognise, which was not marginal: a generic
interface, or one with an `extends` clause, vanished whole; an inline
object type terminated the enclosing interface early; comments were not
lexed, so the word `interface` inside one started a bogus parse.

The new parser understands classes, type aliases, enums, functions,
namespaces, overloads, index and call signatures, function and tuple types,
intersections and literal types, and it **refuses** conditional types,
mapped types, template literals and `infer` rather than approximating them.

This is a straight improvement for existing `Foreign` users, who need
change nothing: generic and inherited members now resolve where they
previously reported "has no member".

```typescript
interface Base { id: string; }
interface Client<T> extends Base { send(message: T): void; }
```

Both `id` and `send` are now visible on `Client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
