### PR TITLE
Give TEL error locations an extent, not just a point

### DIFF
--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -44,6 +44,7 @@ import scala.language.dynamics
 import anticipation.*
 import aperture.*
 import contingency.*
+import denominative.{Span, z}
 import distillate.*
 import gossamer.*
 import prepositional.*
@@ -91,26 +92,26 @@ object Tel extends Tel2:
   val Position: TelError.Position.type = TelError.Position
 
   // The focus carried by `Tel#as[T]` for multi-error accrual: a keyword path
-  // identifying the field being decoded (and, for parser-phase errors, an
-  // optional source position). Mirrors `Json.Focus` / `Yaml.Focus`. The
-  // `position` is populated lazily by `withPosition(tel)`, which delegates to
+  // identifying the field being decoded (and, for located errors, the source
+  // `Span` of the compound's keyword). Mirrors `Json.Focus` / `Yaml.Focus`. The
+  // `span` is populated lazily by `withSpan(tel)`, which delegates to
   // `tel.locate(pointer)`, so a root parsed without position tracking (hence no
-  // `positionIndex`) leaves `position` Unset and the success path pays nothing.
-  case class Focus(pointer: TelPath = TelPath.Root, position: Optional[TelError.Position] = Unset)
+  // `positionIndex`) leaves `span` empty and the success path pays nothing.
+  case class Focus(pointer: TelPath = TelPath.Root, span: Span = Span.empty)
   derives CanEqual:
-    def withPosition(tel: Tel): Focus = copy(position = tel.locate(pointer))
+    def withSpan(tel: Tel): Focus = copy(span = tel.locate(pointer).lay(Span.empty)(_.span))
 
-  // Fill in a source `Position` for every focus accrued so far by locating its
+  // Fill in a source `Span` for every focus accrued so far by locating its
   // keyword path in `tel` — the counterpart of `Json#as`'s enrichment. A no-op
   // unless the ambient `Foci` is a tracking one and `tel` was parsed under
   // `parsing.trackPositions` (so carries a `positionIndex`); an unresolvable
   // path — a member absent from the source — keeps its pointer and leaves the
-  // position Unset. An error registered outside every `focus` block has no
+  // span empty. An error registered outside every `focus` block has no
   // focus at all and takes the root one, which renders as `#`, exactly as an
   // absent focus did. Public because `Tel#as` is `inline` and expands into
   // user modules, which may only reference public members.
   def supplementPositions(tel: Tel)(using foci: Foci[Tel.Focus]): Unit =
-    foci.supplement(foci.length, _.let(_.withPosition(tel)).or(Tel.Focus()))
+    foci.supplement(foci.length, _.let(_.withSpan(tel)).or(Tel.Focus()))
 
   extension (tel: Tel)
     def edited(revision: Revision): Tel raises MutationError = revision(tel)
@@ -3131,16 +3132,23 @@ object Tel extends Tel2:
 
       col
 
-    private update def errorHere(reason: Reason): (Tactic[TelError]^) ?->{this} Nothing =
+    // Every error carries a `Span` covering the offending text: `length` is the
+    // extent, in characters, of the token being read. Sites that know the token
+    // they rejected (a keyword, a pragma phrase, a hard-space run, a literal's
+    // delimiter, an indent) pass it; the rest fall back to the single character
+    // at the reported column.
+    private update def errorHere(reason: Reason, length: Int = 1)
+    :   (Tactic[TelError]^) ?->{this} Nothing =
+
       val column = columnForCurrentBytePos()
-      abort(TelError(reason, TelError.Position(lineNo, column)))
+      abort(TelError(reason, TelError.spanAt(lineNo, column, length)))
 
     // Direct line-number variant: callers pass the 1-indexed source line of
     // the offending location and its column.
-    private update def errorAt(reason: Reason, line: Int, column: Int)
+    private update def errorAt(reason: Reason, line: Int, column: Int, length: Int = 1)
     :   (Tactic[TelError]^) ?->{this} Nothing =
 
-      abort(TelError(reason, TelError.Position(line, column)))
+      abort(TelError(reason, TelError.spanAt(line, column, length)))
 
     // Recoverable-error variants of `errorHere`/`errorAt`. They `raise` the error
     // (rather than `abort`) and continue with `continuation`, which realises the
@@ -3150,19 +3158,20 @@ object Tel extends Tel2:
     // continues, so a document with several recoverable defects reports them all.
     // The continuation MUST advance the cursor past the offending input (or the
     // surrounding flow must), otherwise an enclosing scan loop would not progress.
-    private update inline def recoverHere[T](reason: Reason)(continuation: => T)
-      ( using Tactic[TelError]^ )
-    :   T =
-
-      raise(TelError(reason, TelError.Position(lineNo, columnForCurrentBytePos())))
-      continuation
-
-    private update inline def recoverAt[T](reason: Reason, line: Int, column: Int)
+    private update inline def recoverHere[T](reason: Reason, length: Int = 1)
       ( continuation: => T )
       ( using Tactic[TelError]^ )
     :   T =
 
-      raise(TelError(reason, TelError.Position(line, column)))
+      raise(TelError(reason, TelError.spanAt(lineNo, columnForCurrentBytePos(), length)))
+      continuation
+
+    private update inline def recoverAt[T](reason: Reason, line: Int, column: Int, length: Int = 1)
+      ( continuation: => T )
+      ( using Tactic[TelError]^ )
+    :   T =
+
+      raise(TelError(reason, TelError.spanAt(line, column, length)))
       continuation
 
     // ── Mark / hold plumbing ──────────────────────────────────────────────────
@@ -3499,7 +3508,9 @@ object Tel extends Tel2:
             syncTo()
             val pragmaEndAbs = cursor.position.n0
 
-            if pragmaEndAbs > 4096 then recoverAt(Reason.PragmaTooLong, pragmaLine, 1)(())
+            // The whole pragma line is the offending text, and it has now been read.
+            if pragmaEndAbs > 4096
+            then recoverAt(Reason.PragmaTooLong, pragmaLine, 1, payload.length)(())
 
             consumeLineEnding()
             prevLineWasBoundary = true
@@ -3599,17 +3610,21 @@ object Tel extends Tel2:
     private update def parsePragmaContent(content: String, line: Int)
     :   (Tactic[TelError]^) ?->{this} Tel.Pragma =
 
-      val parts = splitPragmaPhrases(content)
+      val (parts, offsets) = splitPragmaPhrases(content)
 
       // §19.5 RestartFromPragma: a non-`tel` head is recorded but parsing continues.
-      if parts.head != "tel" then recoverAt(Reason.PragmaNotFirst, line, 1)(())
+      if parts.head != "tel"
+      then recoverAt(Reason.PragmaNotFirst, line, offsets.head + 1, parts.head.length)(())
 
       val version =
-        if parts.length >= 2 then parseVersion(parts(1), line) else (1, 0)
+        if parts.length >= 2 then parseVersion(parts(1), line, offsets(1) + 1) else (1, 0)
 
       // §19.5 IgnoreExtraPragmaAtoms: only parts 2 and 3 are read below, so excess
-      // atoms are already ignored once the error is recorded.
-      if parts.length > 4 then recoverAt(Reason.ExtraPragmaContent, line, 1)(())
+      // atoms are already ignored once the error is recorded. The span runs from the
+      // first excess atom to the end of the line.
+      if parts.length > 4
+      then recoverAt(Reason.ExtraPragmaContent, line, offsets(4) + 1, content.length - offsets(4))
+        ( () )
 
       val schemaText: Optional[Text] =
         if parts.length >= 3 then
@@ -3627,7 +3642,7 @@ object Tel extends Tel2:
 
           // §19.5 IgnoreSchemaId: a malformed schema identifier is dropped (Unset).
           if !isUrl && !isBase256
-          then recoverAt(Reason.BadSchemaIdentifier, line, 1)(Unset)
+          then recoverAt(Reason.BadSchemaIdentifier, line, offsets(2) + 1, s.length)(Unset)
           else Text(s): Optional[Text]
         else
           Unset
@@ -3636,7 +3651,7 @@ object Tel extends Tel2:
         if parts.length >= 4 && parts(3).length == 1 then
           val c = parts(3).charAt(0)
           // §19.5 UseDefaultSigil: an invalid sigil is dropped, keeping the default.
-          if c.isLetterOrDigit then recoverAt(Reason.BadSigil, line, 1)(Unset)
+          if c.isLetterOrDigit then recoverAt(Reason.BadSigil, line, offsets(3) + 1, 1)(Unset)
           else
             sigil = c.toByte
             c: Optional[Char]
@@ -3645,28 +3660,39 @@ object Tel extends Tel2:
 
       Tel.Pragma(version, schemaText, pragmaSigil)
 
-    private update def parseVersion(s: String, line: Int)
+    // `column` is the 1-indexed column of the version phrase within the pragma
+    // line, so a malformed version is spanned at the phrase itself.
+    private update def parseVersion(s: String, line: Int, column: Int)
     :   (Tactic[TelError]^) ?->{this} (Int, Int) =
 
       // §19.5 IgnoreVersion: a malformed version falls back to (0, 0) so the rest
       // of the document is still parsed (and its defects accrued).
       val dot = s.indexOf('.')
 
-      if dot <= 0 || dot == s.length - 1 then recoverAt(Reason.BadVersion, line, 1)((0, 0))
+      if dot <= 0 || dot == s.length - 1
+      then recoverAt(Reason.BadVersion, line, column, s.length)((0, 0))
       else
         try
           val major = s.substring(0, dot).toInt
           val minor = s.substring(dot + 1).toInt
 
-          if major < 0 || minor < 0 then recoverAt(Reason.BadVersion, line, 1)((0, 0))
+          if major < 0 || minor < 0
+          then recoverAt(Reason.BadVersion, line, column, s.length)((0, 0))
           else (major, minor)
 
-        catch case _: NumberFormatException => recoverAt(Reason.BadVersion, line, 1)((0, 0))
+        catch case _: NumberFormatException =>
+          recoverAt(Reason.BadVersion, line, column, s.length)((0, 0))
 
-    private update def splitPragmaPhrases(content: String): List[String] =
+    // Splits a pragma line into its phrases, pairing each with its 0-based
+    // character offset within the line so that an error in one phrase — a bad
+    // version, sigil or schema identifier — is spanned at that phrase rather
+    // than at the start of the line.
+    private update def splitPragmaPhrases(content: String): (List[String], List[Int]) =
       val parts = scala.collection.mutable.ListBuffer.empty[String]
+      val offsets = scala.collection.mutable.ListBuffer.empty[Int]
       val builder = new StringBuilder()
       var i = 0
+      var start = 0
       var hardSpaceMode = false
 
       while i < content.length do
@@ -3678,18 +3704,31 @@ object Tel extends Tel2:
           val runLength = j - i
 
           if !hardSpaceMode && runLength == 1 then
-            if builder.nonEmpty then { parts += builder.toString; builder.clear() }
+            if builder.nonEmpty then
+              parts += builder.toString
+              offsets += start
+              builder.clear()
+
             i += 1
           else
             if !hardSpaceMode then hardSpaceMode = true
-            if builder.nonEmpty then { parts += builder.toString; builder.clear() }
+
+            if builder.nonEmpty then
+              parts += builder.toString
+              offsets += start
+              builder.clear()
+
             i = j
         else
+          if builder.isEmpty then start = i
           builder.append(ch)
           i += 1
 
-      if builder.nonEmpty then parts += builder.toString
-      List.of(parts.toList)
+      if builder.nonEmpty then
+        parts += builder.toString
+        offsets += start
+
+      (List.of(parts.toList), List.of(offsets.toList))
 
     // ── Margin determination ─────────────────────────────────────────────────
 
@@ -3820,7 +3859,8 @@ object Tel extends Tel2:
       . or:
         // §19.5 ShallowerIndent: round an odd indent down to the nearer level. The
         // leading spaces are already consumed, so returning a level cannot stall.
-        recoverAt(Reason.OddIndentation, line, 1)(rel / 2)
+        // The offending text is the line's indent run.
+        recoverAt(Reason.OddIndentation, line, 1, spaces)(rel / 2)
 
     // ── Line-head fill ───────────────────────────────────────────────────────
 
@@ -3866,7 +3906,9 @@ object Tel extends Tel2:
 
         head.indentLevels =
           // §19.5 AdjustMargin: a line indented less than the margin sits at level 0.
-          if rel < 0 then recoverAt(Reason.LessThanMargin, head.startLine, 1)(0)
+          // The indent run itself is the offending text (at least one character, so
+          // an unindented line under a positive margin still has a visible span).
+          if rel < 0 then recoverAt(Reason.LessThanMargin, head.startLine, 1, spaces.max(1))(0)
           else if rel % 2 == 0 then rel / 2
           else recoverOddIndent(spaces, head.startLine)
 
@@ -3899,6 +3941,7 @@ object Tel extends Tel2:
         while !head.eof && !head.separator && head.indentLevels >= expected do
           if head.indentLevels > expected then
             val line   = head.startLine
+            val indent = head.leadingSpaces
             val lastIx = blockScratchIx - 1
 
             val reason =
@@ -3910,7 +3953,7 @@ object Tel extends Tel2:
                 else if last.tabulation.present || last.compounds.nil then Reason.ChildOfNonCompound
                 else Reason.OverIndentation
 
-            recoverAt(reason, line, 1)(())
+            recoverAt(reason, line, 1, indent.max(1))(())
             head.indentLevels = expected
 
           parseBlock(expected)  // pushes one block onto scratchBlocks; consumes ≥1 line
@@ -3938,7 +3981,7 @@ object Tel extends Tel2:
         // §19.5 AttachComment: record the misplacement but attach the comment.
         if !prevLineWasBoundary && prevContentLeadingSpaces >= 0 &&
           prevContentLeadingSpaces >= margin + indent * 2
-        then recoverAt(Reason.CommentNotPreceded, head.startLine, 1)(())
+        then recoverAt(Reason.CommentNotPreceded, head.startLine, head.leadingSpaces + 1, 1)(())
 
         val text = parseCommentLine()
         pushComment(Tel.Comment(text))
@@ -4354,8 +4397,10 @@ object Tel extends Tel2:
 
                   // §19.5 SuppressColumnAlignment: record but keep scanning (the
                   // loop self-advances and the row is re-read by parseCompoundLine).
+                  // The over-wide column value is the offending text.
                   if phraseWidth > colMax then
-                    recoverAt(Reason.ColumnValueTooWide, lineNumber, phraseStart + 1)(())
+                    recoverAt(Reason.ColumnValueTooWide, lineNumber, phraseStart + 1, phraseWidth)
+                      ( () )
 
                 var foundIdx = -1
                 var k = 1
@@ -4364,9 +4409,11 @@ object Tel extends Tel2:
                   if markers(k) == col then foundIdx = k
                   k += 1
 
-                // §19.5 SuppressColumnAlignment: record but keep scanning.
+                // §19.5 SuppressColumnAlignment: record but keep scanning. The
+                // misaligned hard-space run — from where it began to where it ended,
+                // which is not a marker offset — is the offending text.
                 if foundIdx < 0 then
-                  recoverAt(Reason.HardSpaceWrongPosition, lineNumber, col + 1)(())
+                  recoverAt(Reason.HardSpaceWrongPosition, lineNumber, runStart + 1, runLen)(())
 
                 columnIdx = foundIdx
                 phraseStart = col
@@ -4397,13 +4444,15 @@ object Tel extends Tel2:
         // §10.4 / §11.1: at most one source / literal atom per compound. §19.5
         // IgnoreDuplicateAtom: record the duplicate but consume (and discard) it so
         // the cursor advances past it and parsing continues.
+        // The duplicate's own indent is all that has been read of it when the error
+        // is raised, so the span covers the line up to its first content byte.
         if first.present && !head.eof && !head.blank then
           if head.leadingSpaces == literalIndent then
-            recoverAt(Reason.DuplicateLiteral, head.startLine, 1):
+            recoverAt(Reason.DuplicateLiteral, head.startLine, 1, literalIndent):
               parseLiteralAtom(literalIndent)
               ()
           else if head.leadingSpaces == sourceIndent then
-            recoverAt(Reason.DuplicateSource, head.startLine, 1):
+            recoverAt(Reason.DuplicateSource, head.startLine, 1, sourceIndent):
               parseSourceAtom(sourceIndent)
               ()
 
@@ -4561,7 +4610,15 @@ object Tel extends Tel2:
       while !done do
         // §19.5 PayloadToEof: an unterminated literal ends at EOF rather than
         // aborting, so the rest of the document can still be parsed and accrued.
-        if !more then done = recoverAt(Reason.UnclosedLiteral, openingLine, 1)(true)
+        // The unclosed literal is reported at its opening delimiter, which is the
+        // text a caller must fix (by matching it on a closing line).
+        if !more
+        then done = recoverAt
+                     ( Reason.UnclosedLiteral,
+                       openingLine,
+                       literalIndent + 1,
+                       delimiter.length )
+                     ( true )
         // Read a line. Inside the literal payload, line endings are not
         // subject to the document's LF/CRLF mode (per §15 the payload is
         // verbatim, with CRLF normalised to LF). One hold per payload line so
@@ -4599,7 +4656,8 @@ object Tel extends Tel2:
             // PayloadToEof: an unterminated final line ends the payload at EOF.
             if !more then
               sb.append(raw)
-              recoverAt(Reason.UnclosedLiteral, openingLine, 1)(true)
+              recoverAt(Reason.UnclosedLiteral, openingLine, literalIndent + 1, delimiter.length)
+                ( true )
             else
               advance()  // consume LF
               lineNo += 1
@@ -4634,7 +4692,7 @@ object Tel extends Tel2:
       // §19.5 RestartFromPragma: record the misplaced pragma but parse the line as
       // an ordinary compound (the keyword is already read; the rest follows).
       if mayBeMisplacedPragma && keyword == t"tel" then
-        recoverAt(Reason.PragmaNotFirst, lineNumber, 1)(())
+        recoverAt(Reason.PragmaNotFirst, lineNumber, 1, keyword.s.length)(())
 
       hasConsumedNonBlankLine = true
       parseCompoundLineRest(lineNumber)
@@ -4793,8 +4851,16 @@ object Tel extends Tel2:
       // consumed at least the keyword.)
       // §19.5 StripTrailing: the keyword/atoms already exclude the trailing space,
       // so recording the error and continuing yields the stripped line.
+      // The trailing run itself is the offending text: walk back over it (still
+      // inside the hold, so those bytes are resident) to span exactly the spaces.
       if remark.absent && more && (peek == LF || peek == CR) && pos > 0 && bytes(pos - 1) == SP
-      then recoverAt(Reason.TrailingSpaces, lineNumber, head.leadingSpaces + 1)(())
+      then
+        var back = pos
+        while back > 0 && bytes(back - 1) == SP do back -= 1
+        val trailing = pos - back
+
+        recoverAt(Reason.TrailingSpaces, lineNumber, columnForCurrentBytePos() - trailing, trailing)
+          ( () )
 
       consumeLineEnding()
       compoundLineRemark  = remark
@@ -5099,7 +5165,7 @@ object Tel extends Tel2:
         else if head.indentLevels < indent then
           done = true
         else if head.indentLevels > indent then
-          errorAt(directOverIndentReason, head.startLine, 1)
+          errorAt(directOverIndentReason, head.startLine, 1, head.leadingSpaces.max(1))
         // Both comment and tabulation lines open with the sigil, so a
         // compound line — the overwhelmingly common step — skips both
         // classifiers (and their hold ceremony) on one byte test.
@@ -5108,7 +5174,7 @@ object Tel extends Tel2:
           // consuming a comment line.
           if !prevLineWasBoundary && prevContentLeadingSpaces >= 0 &&
             prevContentLeadingSpaces >= margin + indent*2
-          then recoverAt(Reason.CommentNotPreceded, head.startLine, 1)(())
+          then recoverAt(Reason.CommentNotPreceded, head.startLine, head.leadingSpaces + 1, 1)(())
 
           directTabulation = Unset
           directGroup = DirectComments
@@ -5142,7 +5208,7 @@ object Tel extends Tel2:
 
               // E102 / §19.5 RestartFromPragma, as in `parseCompoundLine`.
               if mayBeMisplacedPragma && keyword == t"tel" then
-                recoverAt(Reason.PragmaNotFirst, directEntryLine, 1)(())
+                recoverAt(Reason.PragmaNotFirst, directEntryLine, 1, keyword.s.length)(())
 
               directEntryKeyword = keyword
               directEntryKeywordLazy = false
@@ -5151,7 +5217,7 @@ object Tel extends Tel2:
 
               // The same E102 check against the packed form of `tel`.
               if mayBeMisplacedPragma && directKeywordLen == 3 && directKeywordLow == 0x6C6574L
-              then recoverAt(Reason.PragmaNotFirst, directEntryLine, 1)(())
+              then recoverAt(Reason.PragmaNotFirst, directEntryLine, 1, directKeywordLen)(())
 
             hasConsumedNonBlankLine = true
 
@@ -5219,7 +5285,7 @@ object Tel extends Tel2:
       // would fail on it, so fail here with the same classification.
       if (tabulated || extraAtom.present) && !head.eof && !head.separator && !head.blank &&
         head.indentLevels > indent
-      then errorAt(directOverIndentReason, head.startLine, 1)
+      then errorAt(directOverIndentReason, head.startLine, 1, head.leadingSpaces.max(1))
 
       val atoms = takeAtoms(atomScratchIx - atomsStart)
       Tel.Compound(keyword, atoms, remark, children)
@@ -5265,7 +5331,7 @@ object Tel extends Tel2:
       // following deeper line is over-indented and fails with the same reason.
       if !tabulated && extraAtom.absent then parseChildren(indent)
       else if !head.eof && !head.separator && !head.blank && head.indentLevels > indent
-      then errorAt(directOverIndentReason, head.startLine, 1)
+      then errorAt(directOverIndentReason, head.startLine, 1, head.leadingSpaces.max(1))
 
     // Parses an optional `-` and one to eighteen digits — exactly the
     // spellings `parseArenaLong` accepts — or Unset.
@@ -5532,7 +5598,7 @@ object Tel extends Tel2:
       // the same way rather than letting the nested field loop consume it.
       if (tabulated || extraAtom.present) && !head.eof && !head.separator && !head.blank &&
         head.indentLevels > indent
-      then errorAt(directOverIndentReason, head.startLine, 1)
+      then errorAt(directOverIndentReason, head.startLine, 1, head.leadingSpaces.max(1))
 
     // As `directFinishLine`, but capturing the entry line's atoms — including
     // the source/literal continuation, which §14/§15 append to the atom
@@ -5571,7 +5637,7 @@ object Tel extends Tel2:
       // tabulated row, a deeper line is over-indented.
       if (tabulated || extraAtom.present) && !head.eof && !head.separator && !head.blank &&
         head.indentLevels > indent
-      then errorAt(directOverIndentReason, head.startLine, 1)
+      then errorAt(directOverIndentReason, head.startLine, 1, head.leadingSpaces.max(1))
 
       atoms
 

--- a/lib/stratiform/src/core/stratiform.TelError.scala
+++ b/lib/stratiform/src/core/stratiform.TelError.scala
@@ -44,15 +44,37 @@ object TelError:
     given communicable: Position is Communicable =
       position => m"line ${position.line}, column ${position.column}"
 
+  // Render a `Line`-mode `Span` — the location carried by a `TelError` — in the
+  // parser's own 1-indexed terms. A span wider than one character names its
+  // extent too, so a diagnostic reads "line 2, columns 5-8".
+  def describe(span: Span): Text =
+    val line   = span.startLine.lay(1)(_.n1)
+    val column = span.startColumn.lay(1)(_.n1)
+    val length = span.length.or(0)
+
+    if length > 1 then Text("line "+line+", columns "+column+"-"+(column + length - 1))
+    else Text("line "+line+", column "+column)
+
+  // The `Line`-mode `Span` for a token of `length` characters starting at the
+  // parser's 1-indexed `line`/`column`. `Span`'s own coordinates are 0-based, and
+  // its `Line` mode packs the column and length into 19 bits each (the line into
+  // 23), so each is clamped rather than allowed to wrap: a span into the far
+  // reaches of an implausibly long line saturates instead of pointing elsewhere.
+  def spanAt(line: Int, column: Int, length: Int): Span =
+    Span.line
+     ( (line - 1).max(0).min(0x7fffff).z,
+       (column - 1).max(0).min(0x7ffff).z,
+       length.max(0).min(0x7ffff) )
+
   // 1-indexed source position attached to a `TelError` raised by the
   // TEL parser, so a caller capturing the error can point at the
   // offending line in the source. `column = 1` refers to the first
   // character of the line (including any leading spaces). Parse errors
   // that pre-date the document body (e.g. `BomPresent` at offset 0)
   // report `(1, 1)`. Post-parse / validation errors always leave the
-  // `TelError`'s own `position` Unset: their coordinates are carried on the
+  // `TelError`'s own `span` empty: their coordinates are carried on the
   // accrued `Tel.Focus` instead, filled in from a tracked document's
-  // `PositionIndex` by `Tel.supplementPositions` / `Tel.Focus.withPosition`.
+  // `PositionIndex` by `Tel.supplementPositions` / `Tel.Focus.withSpan`.
   //
   // Aliased as `Tel.Position`. This is also the `Positionable` `Result` for
   // `tel.locate(pointer)`, so it
@@ -313,14 +335,14 @@ object TelError:
     // limits that are properties of the implementation, not the document.
     case NestingLimitExceeded                   extends Reason(501)
 
-case class TelError(reason: TelError.Reason, position: Optional[TelError.Position] = Unset)
-  ( using Diagnostics )
+// `span` locates the offending text in the source: a `Line`-mode `Span` giving
+// the 0-based line and column at which it starts and its extent in characters,
+// so a caller can highlight the token itself and not merely the line. It is
+// empty (`Span.empty` is in-band, so no `Optional` boxing) for post-parse and
+// validation errors, whose coordinates apply to AST nodes rather than source
+// bytes and are carried on the accrued `Tel.Focus`.
+case class TelError(reason: TelError.Reason, span: Span = Span.empty)(using Diagnostics)
 extends Error
   ( 605, reason.number )
-  ( position.let: p =>
-      m"the TEL document is invalid at $p because $reason"
-
-    . or(m"the TEL document is invalid because $reason") ):
-
-  // The internal 1-indexed position rendered as a uniform 0-based `Span`.
-  def span: Span = position.lay(Span.empty)(_.span)
+  ( if span.vacant then m"the TEL document is invalid because $reason"
+    else m"the TEL document is invalid at ${TelError.describe(span)} because $reason" )

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -69,13 +69,12 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
     . protect(Tel.Type.assign(tel, schema))
 
-  case class Located(items: List[(Text, Optional[TelError.Position])] = Nil)(using Diagnostics)
+  case class Located(items: List[(Text, Span)] = Nil)(using Diagnostics)
   extends Error(m"${items.length} located issues"):
-    def +(pointer: Text, position: Optional[TelError.Position]): Located =
-      Located(items :+ (pointer, position))
+    def +(pointer: Text, span: Span): Located = Located(items :+ (pointer, span))
 
   // Validate a *tracked* document against `schema`, capturing each error's
-  // keyword-path pointer alongside the source `Position` filled in by
+  // keyword-path pointer alongside the source `Span` filled in by
   // `Tel.supplementPositions` at the end of `Tel.Type.assign`.
   private def assignPositions(text: Text, schema: Tels): Located =
     import parsing.trackPositions
@@ -83,8 +82,7 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
 
     validate[Tel.Focus](Located()):
       case error: TelError =>
-        accrual + (prior.let(_.pointer.encode).or(t"#"),
-                   prior.lay(Unset: Optional[TelError.Position])(_.position))
+        accrual + (prior.let(_.pointer.encode).or(t"#"), prior.lay(Span.empty)(_.span))
     . protect(Tel.Type.assign(tel, schema))
 
   // The decode-path counterpart: `Tel#as` locates its per-field foci against
@@ -99,7 +97,7 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
       ( Located(),
         { case error: TelError =>
             accrual + (prior.let(_.pointer.encode).or(t"#"),
-                       prior.lay(Unset: Optional[TelError.Position])(_.position)) } )
+                       prior.lay(Span.empty)(_.span)) } )
     . protect(decode(tel))
 
   // Parse a document under an accrual boundary: recoverable parse defects
@@ -353,20 +351,21 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
 
       test(m"Unknown-keyword errors are located at the offending compound"):
         assignPositions(t"foo a\nbar b\n", optionalFieldSchema).items.map(_(1)).to[Set]
-      . assert(_ == Set(Optional(Tel.Position(1, 1, length = Optional(3))),
-                        Optional(Tel.Position(2, 1, length = Optional(3)))))
+      . assert(_ == Set(TelError.spanAt(1, 1, 3), TelError.spanAt(2, 1, 3)))
 
       test(m"An unlocated (untracked) validation still accrues without a position"):
         val tel = t"foo a\n".read[Tel]
 
         validate[Tel.Focus](Issues()):
-          case error: TelError => accrual + (prior.lay(t"")(_.position.lay(t"")(_.describe)), error)
+          case error: TelError =>
+            accrual + (prior.lay(t"")(f => if f.span.vacant then t"" else TelError.describe(f.span)),
+                       error)
         . protect(Tel.Type.assign(tel, optionalFieldSchema))
         . items.map(_(0).s).to[Set]
       . assert(_ == Set(""))
 
-      test(m"Missing required members carry a pointer but no source position"):
-        assignPositions(t"", twoRequiredSchema).items.map { case (p, pos) => (p.s, pos.present) }
+      test(m"Missing required members carry a pointer but no source span"):
+        assignPositions(t"", twoRequiredSchema).items.map { case (p, span) => (p.s, span.exists) }
         . to[Set]
       . assert(_ == Set(("#/name", false), ("#/email", false)))
 
@@ -375,7 +374,7 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
       // and not just the keyword-dispatch step — the issue's `e302.tel` case.
       test(m"An excess atom is located at the enclosing compound"):
         assignPositions(t"item x y\nname n\n", atomAccrualSchema).items
-        . map { case (pointer, position) => (pointer.s, position.let(_.line).or(-1)) }.to[Set]
+        . map { case (pointer, span) => (pointer.s, span.startLine.lay(-1)(_.n1)) }.to[Set]
       . assert(_ == Set(("#/item", 1)))
 
       // E308 is a property of a member's whole run, not of one node, so it is
@@ -384,7 +383,7 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
       // than `vouch` on it.
       test(m"A run-level E308 accrues at the root without panicking"):
         assignPositions(t"name Alice\nname Bob\nemail e\n", twoRequiredSchema).items
-        . map { case (p, pos) => (p.s, pos.present) }.to[Set]
+        . map { case (p, span) => (p.s, span.exists) }.to[Set]
       . assert(_ == Set(("#", false)))
 
     suite(m"Located decode errors"):
@@ -396,4 +395,4 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
       test(m"A malformed field is located at its compound"):
         decodePositions(t"name Alice\nage notanumber\nemail e\n")(_.as[APerson])
         . items.map(_(1)).to[Set]
-      . assert(_ == Set(Optional(Tel.Position(2, 1, length = Optional(3)))))
+      . assert(_ == Set(TelError.spanAt(2, 1, 3)))

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -780,33 +780,51 @@ object Tests extends Suite(m"Stratiform Tests"):
         capture[TelError](t"parent\n child Alice\n".read[Tel]).reason
       . assert(_ == TelError.Reason.OddIndentation)
 
-    suite(m"Error line/column positions"):
-      // Parse-time errors carry an `Optional[TelError.Position]` so
-      // callers can point at the offending line in the source. Validation
-      // (post-parse) errors leave `position` Unset because they apply to
-      // AST nodes rather than source bytes.
+    suite(m"Error spans"):
+      // Parse-time errors carry a `Span` covering the offending text, so callers
+      // can highlight it (not merely the line) in the source. Validation
+      // (post-parse) errors leave the span empty because they apply to AST nodes
+      // rather than source bytes. `Span`'s coordinates are 0-based.
 
       test(m"BOM error is at line 1, column 1"):
-        capture[TelError](t"﻿tel 1.0\n".read[Tel]).position
-      . assert(_ == TelError.Position(1, 1))
+        capture[TelError](t"﻿tel 1.0\n".read[Tel]).span
+      . assert(_ == TelError.spanAt(1, 1, 1))
 
       test(m"OddIndentation error reports the offending line"):
-        capture[TelError](t"parent\n child Alice\n".read[Tel]).position.let(_.line)
-      . assert(_ == 2)
+        capture[TelError](t"parent\n child Alice\n".read[Tel]).span.startLine
+      . assert(_ == 1.z)
 
-      test(m"BadVersion error reports the pragma line"):
-        capture[TelError](t"tel notaversion\n".read[Tel]).position.let(_.line)
+      test(m"OddIndentation error spans the odd indent"):
+        capture[TelError](t"parent\n child Alice\n".read[Tel]).span.length
       . assert(_ == 1)
 
+      test(m"BadVersion error reports the pragma line"):
+        capture[TelError](t"tel notaversion\n".read[Tel]).span.startLine
+      . assert(_ == 0.z)
+
+      test(m"BadVersion error spans the malformed version phrase"):
+        val span = capture[TelError](t"tel notaversion\n".read[Tel]).span
+        (span.startColumn.vouch.n1, span.length.vouch)
+      . assert(_ == (5, 11))
+
       test(m"PragmaNotFirst error reports the misplaced pragma's line"):
-        capture[TelError](t"foo bar\ntel 1.0\nbaz\n".read[Tel]).position.let(_.line)
-      . assert(_ == 2)
+        capture[TelError](t"foo bar\ntel 1.0\nbaz\n".read[Tel]).span.startLine
+      . assert(_ == 1.z)
+
+      test(m"PragmaNotFirst error spans the `tel` keyword"):
+        capture[TelError](t"foo bar\ntel 1.0\nbaz\n".read[Tel]).span.length
+      . assert(_ == 3)
 
       test(m"TrailingSpaces error reports the offending line"):
-        capture[TelError](t"good\nbad   \n".read[Tel]).position.let(_.line)
-      . assert(_ == 2)
+        capture[TelError](t"good\nbad   \n".read[Tel]).span.startLine
+      . assert(_ == 1.z)
 
-      test(m"Validation error (Type.assign) leaves position Unset"):
+      test(m"TrailingSpaces error spans exactly the trailing spaces"):
+        val span = capture[TelError](t"good\nbad   \n".read[Tel]).span
+        (span.startColumn.vouch.n1, span.length.vouch)
+      . assert(_ == (4, 3))
+
+      test(m"Validation error (Type.assign) leaves the span empty"):
         val schema = Tels(
           name     = t"person",
           document = Tels.Struct(
@@ -821,8 +839,8 @@ object Tests extends Suite(m"Stratiform Tests"):
           scalars  = Array.empty,
           selects  = Array.empty)
         val doc = t"age 30\n".read[Tel]
-        capture[TelError](Tel.Type.assign(doc, schema)).position
-      . assert(_ == Unset)
+        capture[TelError](Tel.Type.assign(doc, schema)).span
+      . assert(_ == Span.empty)
 
     suite(m"Type assignment"):
       // A small hand-built schema for a `person` document with required


### PR DESCRIPTION
TEL's parse and validation errors were located at a single line and column, which is enough to name the offending line but not to highlight the offending text. This replaces the line/column pair on `TelError` and `Tel.Focus` with a denominative `Span`, and walks the parser's error sites so that each one reports the extent of the text it actually rejected.

### Release notes

`TelError` now carries a `span: Span` in place of `position: Optional[TelError.Position]`, and `Tel.Focus` likewise carries `span: Span` (its `withPosition` method is now `withSpan`). A `Span` gives the start line, start column and length of the offending text, so a diagnostic can underline it:

```scala
val error = capture[TelError](t"tel notaversion\n".read[Tel])
error.span.startLine   // 0.z
error.span.startColumn // 4.z  — the version phrase, not the line start
error.span.length      // 11
```

`Span.empty` signals "no source location" in-band, so post-parse and validation errors — whose coordinates belong to AST nodes rather than source bytes — no longer pay for an `Optional`. `TelError.spanAt(line, column, length)` builds a span from 1-indexed coordinates and `TelError.describe(span)` renders one as `line 2, columns 4-6`.

Errors that previously pinned to column 1 of a line now span the token at fault: pragma phrases (version, sigil, schema identifier, misplaced head, excess atoms), trailing spaces, misaligned hard-space runs, over-wide tabulation values, an unclosed literal's opening delimiter, a misplaced `tel` keyword, and indent runs. `tel.locate(pointer)` still returns a `TelError.Position`, since zephyrine's `Positionable` requires a `Format.Position`; its `.span` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)