### PR TITLE
Take an encoder's value frozen, so sum derivation survives capture checking

### DIFF
--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -433,7 +433,12 @@ trait Tel2 extends Tel3:
 
           Morphology.Obj(fields, fields.collect { case (label, shape) if !shape.optional => label })
 
-        def encoded(value: derivation): Tel =
+        // The encoded value is taken FROZEN (`^{}`) rather than as a bare `derivation`. The type
+        // parameter may capture, so writing it plainly here re-elaborates it with a fresh capture
+        // set, which no longer matches the `Self` of `Encodable.encoded` — the definition then
+        // fails its override check under capture checking. A frozen parameter is no restriction:
+        // an encoder reads its argument and retains nothing of it.
+        def encoded(value: derivation^{}): Tel =
           val compounds = scala.collection.mutable.ArrayBuffer.empty[Tel.Compound]
 
           fields(value): [field] =>
@@ -457,7 +462,7 @@ trait Tel2 extends Tel3:
 
         // The §22.2 member description of a value, in field order — the
         // input to `Mutation.construct` for the canonical forms below.
-        private def membersOf(value: derivation)
+        private def membersOf(value: derivation^{})
         :   scala.collection.immutable.List[Mutation.Member] =
 
           val members = scala.collection.mutable.ListBuffer.empty[Mutation.Member]
@@ -524,13 +529,13 @@ trait Tel2 extends Tel3:
 
         // The canonical child form: this record's compound with its §22.2
         // leading inline run, for embedding under a keyword.
-        override def constructed(value: derivation): Tel =
+        override def constructed(value: derivation^{}): Tel =
           Tel.make(Mutation.construct(t"", List.of(membersOf(value)), '#'))
 
         // The canonical document form: the root carries no atoms (§20.2),
         // so a leading `Break` suppresses the root's own run while nested
         // records keep theirs.
-        override def canonicalized(value: derivation): Tel =
+        override def canonicalized(value: derivation^{}): Tel =
           val compound =
             Mutation.construct(t"", List.of(Mutation.Member.Break :: membersOf(value)), '#')
 
@@ -548,7 +553,8 @@ trait Tel2 extends Tel3:
         type Self = derivation
         def shape(): Morphology = Morphology.Any
 
-        def encoded(value: derivation): Tel =
+        // Frozen, as in `conjunction` above.
+        def encoded(value: derivation^{}): Tel =
           variant(value): [variant <: derivation] =>
             v =>
               val keyword: Text = Tel.camelToKebab(label.s)
@@ -562,7 +568,7 @@ trait Tel2 extends Tel3:
 
         // The canonical child form: the chosen variant in its own §22.2
         // construct form, so a record variant carries its inline run.
-        override def constructed(value: derivation): Tel =
+        override def constructed(value: derivation^{}): Tel =
           variant(value): [variant <: derivation] =>
             v =>
               val keyword: Text = Tel.camelToKebab(label.s)


### PR DESCRIPTION
`Tel.EncodableDerivation` writes its `encoded`, `constructed`, `canonicalized` and `membersOf` parameters as a bare `derivation`. The type parameter may capture, so naming it inside the anonymous `Tel.Encodable` re-elaborates it with a fresh capture set, and `encoded(value: derivation^'s1)` no longer overrides `Encodable.encoded(value: Self)`. Deriving an encoder for a sum then fails outright under capture checking:

```
error overriding method encoded in trait Encodable of type (value: Self): Form;
  method encoded of type (value: Wire^'s1): stratiform.Tel has incompatible type
```

Both halves of the derivation are affected: the sum's own encoder, and the product encoder it delegates to for each variant, whose `derivation <: Product` bound does not pin the intersection type a variant presents (`Wire.One & Wire & Product`).

Taking each value frozen (`derivation^{}`) states what an encoder does anyway — it reads its argument and retains nothing of it — and matches the `Self` the trait declares.

## Reproducing

Any enum, compiled with `-Ycc-new -language:experimental.captureChecking`:

```scala
enum Wire:
  case One(id: Int, name: Text)
  case Two(id: Int)

object Wire:
  given wireEncodable: Wire is Tel.Encodable = Tel.EncodableDerivation.derived[Wire]
```

A plain case class is unaffected; it is sums, and the per-variant products they delegate to, that fail.

## Why the existing tests miss it

stratiform already round-trips sums (`Shape2.Circle(7).encode` and friends in `stratiform_test.scala`), and those pass. `Tests` compiles with `settings.scalaOptions`, which enables neither capture nor separation checking, so the derivation is only ever exercised unchecked there — while `stratiform.core` itself is built with `settings.sep`. The failure surfaces in a capture-checked *client*: it was found in a REPL encoding its wire protocol, whose `Request`/`Reply` enums would not compile against `0.64.0`.

I have not added a regression test, because guarding this needs a capture-checked test module rather than a new case; happy to follow up if you want that plumbed in.

## Verification

- `./mill stratiform.core.compile` — clean.
- `./mill stratiform.test` — 1276 passed, 0 failed.
- The client that hit it now compiles and its own suite passes (88/88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)