### PR TITLE
Bring LIRA support into full conformance with the specification

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2619,8 +2619,8 @@ object xenophile extends Library:
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
 
-  object lira extends Component(typescript, reliquary.core):
-    override def scalaJs = false // adapts the discipline to reliquary's JVM-only SPI
+  object lira extends Component(typescript, webidl, wit, cffi, kotlin, reliquary.core):
+    override def scalaJs = false // adapts the disciplines to reliquary's JVM-only SPI
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // The platform-neutral C front end (the `Native` ecosystem type markers and the `CHeaderDialect`

--- a/lib/degustation/src/core/degustation.Atomizer.scala
+++ b/lib/degustation/src/core/degustation.Atomizer.scala
@@ -76,12 +76,15 @@ object Atomizer:
 
     def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
 
-    // The subset of modifier flags that consumers can depend on, in a fixed bit order.
+    // The subset of modifier flags that consumers can depend on, in a fixed bit order. The
+    // `exported` flag is deliberately absent (`tasty.md` §9): an `export` forwarder atomizes
+    // identically to the equivalent hand-written forwarder, so converting between them is a
+    // non-event.
     def flagBits(symbol: Symbol): Long =
       val flags = symbol.flags
 
       scala.List(
-        Flags.Abstract, Flags.Case, Flags.Deferred, Flags.Enum, Flags.Erased, Flags.Exported,
+        Flags.Abstract, Flags.Case, Flags.Deferred, Flags.Enum, Flags.Erased,
         Flags.Final, Flags.Given, Flags.Implicit, Flags.Infix, Flags.Inline, Flags.Lazy,
         Flags.Macro, Flags.Module, Flags.Mutable, Flags.Opaque, Flags.Open, Flags.Protected,
         Flags.Sealed, Flags.Trait, Flags.Transparent)
@@ -258,7 +261,11 @@ object Atomizer:
     def excluded(symbol: Symbol): Boolean =
       val flags = symbol.flags
 
-      val hidden = flags.is(Flags.Private) || flags.is(Flags.PrivateLocal)
+      // Qualified-private (`private[scope]`) members are included, conservatively (`tasty.md`
+      // §5): macros and derivation can reach them from dependency TASTy, so only unqualified
+      // `private` and `private[this]` are outside the API.
+      val qualified = symbol.privateWithin.isDefined
+      val hidden = (flags.is(Flags.Private) && !qualified) || flags.is(Flags.PrivateLocal)
       val internal = flags.is(Flags.Artifact) || symbol.isLocalDummy || symbol.isNoSymbol
       hidden || internal
 

--- a/lib/degustation/src/lira/degustation.Tasty.scala
+++ b/lib/degustation/src/lira/degustation.Tasty.scala
@@ -57,7 +57,7 @@ object Tasty extends Discipline:
   // inherited member need not be re-atomized under each type that presents it. Classfile-level
   // linkage is the JVM ecosystem profile's, not this discipline's, so only the TASTy level is
   // certified here.
-  def domain: Discipline.Domain = Discipline.Domain.Universes(Set(t"jvm", t"sjsir", t"nir"))
+  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"jvm", t"sjsir", t"nir"))
   def keying: Discipline.Keying = Discipline.Keying.Declaration
 
   def guarantees(universe: Text): Set[Discipline.Guarantee] =

--- a/lib/degustation/src/lira/degustation.Tasty.scala
+++ b/lib/degustation/src/lira/degustation.Tasty.scala
@@ -49,13 +49,15 @@ import errorDiagnostics.emptyDiagnostics
 object Tasty extends Discipline:
   def id: Text = t"tasty/1"
 
-  // TASTy is carried in every universe of the motivating ecosystem, so the domain is universal
-  // and the cross-section invariant (§9.6) binds all of them — which is what makes "one API on
-  // every platform" checkable. Keying is by declaration (`tasty.md` §6): a TASTy reference names
-  // the declaring symbol, so an inherited member need not be re-atomized under each type that
-  // presents it. Classfile-level linkage is the JVM ecosystem profile's, not this discipline's,
-  // so only the TASTy level is certified here.
-  def domain: Discipline.Domain = Discipline.Domain.Universal
+  // The domain is the fixed set of TASTy-carrying universes (`tasty.md` §3) — not universal:
+  // the cross-section invariant (§9.6) binds exactly these, which is what makes "one API on
+  // every platform" checkable, while a universe that carries no TASTy lies outside the domain
+  // entirely, so L127 can reject a release that declares this discipline without one. Keying is
+  // by declaration (`tasty.md` §6): a TASTy reference names the declaring symbol, so an
+  // inherited member need not be re-atomized under each type that presents it. Classfile-level
+  // linkage is the JVM ecosystem profile's, not this discipline's, so only the TASTy level is
+  // certified here.
+  def domain: Discipline.Domain = Discipline.Domain.Universes(Set(t"jvm", t"sjsir", t"nir"))
   def keying: Discipline.Keying = Discipline.Keying.Declaration
 
   def guarantees(universe: Text): Set[Discipline.Guarantee] =

--- a/lib/degustation/src/test/degustation_test.scala
+++ b/lib/degustation/src/test/degustation_test.scala
@@ -355,7 +355,7 @@ object Tests extends Suite(m"Degustation Tests"):
 
       (lira.manifest.module,
        lira.manifest.api.stdlib.map(_.discipline),
-       lira.manifest.section.stdlib.map(_.universe),
+       lira.manifest.section.stdlib.map(_.world),
        lira.manifest.section.stdlib.forall(_.derivative.present),
        report.atomizations.stdlib.map(_.discipline))
     . assert(_ == (t"fixture-core", scala.List(t"tasty/1"), scala.List(t"jvm"), true,
@@ -396,15 +396,15 @@ object Tests extends Suite(m"Degustation Tests"):
             List(jvmInput, sjsInput),
             registry,
             toolchain = List(LiraBundle.tool[Universe.Classfile](t"3.9.0")),
-            classpath = { input => contextClasspath(input.universe) } )
+            classpath = { input => contextClasspath(input.world) } )
 
         val lira = Lira.read(bytes)
         val report = Verification.install(lira)
-        val sjsSection = lira.manifest.section.stdlib.find(_.universe == t"sjsir")
+        val sjsSection = lira.manifest.section.stdlib.find(_.world == t"sjsir")
 
-        (lira.manifest.section.stdlib.map(_.universe),
-         report.materialized.stdlib.map(_(0).universe),
-         report.materialized.stdlib.find(_(0).universe == t"sjsir")
+        (lira.manifest.section.stdlib.map(_.world),
+         report.materialized.stdlib.map(_(0).world),
+         report.materialized.stdlib.find(_(0).world == t"sjsir")
            . map(_(1).entries.stdlib.exists(_.path.text.s.endsWith(".sjsir"))))
       . assert(_ == (scala.List(t"jvm", t"sjsir"), scala.List(t"jvm", t"sjsir"),
           scala.Some(true)))

--- a/lib/degustation/src/test/degustation_test.scala
+++ b/lib/degustation/src/test/degustation_test.scala
@@ -134,6 +134,39 @@ object Tests extends Suite(m"Degustation Tests"):
       keys.exists(_.contains("hidden"))
     . assert(!_)
 
+    test(m"qualified-private members are conservatively API"):
+      val qualified = listing(t"""|package fixture
+          |
+          |class Scoped:
+          |  private[fixture] def limited: Int = 0
+          |  private def hidden: Int = 0
+          |""".s.stripMargin.tt)
+
+      (qualified.exists(_(0).s.contains("limited")), qualified.exists(_(0).s.contains("hidden")))
+    . assert(_ == (true, false))
+
+    test(m"an export forwarder atomizes as its hand-written equivalent"):
+      val exported = listing(t"""|package fixture
+          |
+          |object Impl:
+          |  def value: Int = 3
+          |
+          |object Front:
+          |  export Impl.value
+          |""".s.stripMargin.tt)
+
+      val written = listing(t"""|package fixture
+          |
+          |object Impl:
+          |  def value: Int = 3
+          |
+          |object Front:
+          |  final def value: Int = Impl.value
+          |""".s.stripMargin.tt)
+
+      exported == written
+    . assert(identity)
+
     test(m"an inline definition yields a replaceable atom"):
       keys.exists { key => key.startsWith("fixture.double(") && key.endsWith("[inline]") }
     . assert(identity)

--- a/lib/mandible/src/core/mandible.ClassSurface.scala
+++ b/lib/mandible/src/core/mandible.ClassSurface.scala
@@ -73,6 +73,7 @@ object ClassSurface:
     def protect: Boolean   = (flags & jlc.ClassFile.ACC_PROTECTED) != 0
     def priv: Boolean      = (flags & jlc.ClassFile.ACC_PRIVATE) != 0
     def static: Boolean    = (flags & jlc.ClassFile.ACC_STATIC) != 0
+    def finl: Boolean      = (flags & jlc.ClassFile.ACC_FINAL) != 0
     def abstrakt: Boolean  = (flags & jlc.ClassFile.ACC_ABSTRACT) != 0
     def bridge: Boolean    = (flags & jlc.ClassFile.ACC_BRIDGE) != 0
     def synthetic: Boolean = (flags & jlc.ClassFile.ACC_SYNTHETIC) != 0
@@ -82,9 +83,13 @@ object ClassSurface:
     def visible: Boolean = public || protect
 
     // A `static final` field of primitive or `String` type whose value javac may already have
-    // copied into every consumer's constant pool (JLS 13.4.9). Its value is therefore
-    // *replaceable* surface, not rigid — see `ClassfileAtomizer`.
-    def inlinable: Boolean = kind == Kind.Field && static && constant.present
+    // copied into every consumer's constant pool (JLS 13.4.9, `classfile.md` §11). Its value is
+    // therefore *replaceable* surface, not rigid — see `ClassfileAtomizer`. A `ConstantValue`
+    // on anything else is not a constant a consumer's compiler inlines, so the predicate tests
+    // all three conditions, not merely the attribute's presence.
+    def inlinable: Boolean =
+      val constable = descriptor == t"Ljava/lang/String;" || descriptor.s.length == 1
+      kind == Kind.Field && static && finl && constable && constant.present
 
   private def text(entry: jlc.constantpool.Utf8Entry): Text = entry.stringValue.nn.tt
 

--- a/lib/mandible/src/lira/mandible.ClassfileAtomizer.scala
+++ b/lib/mandible/src/lira/mandible.ClassfileAtomizer.scala
@@ -61,9 +61,9 @@ object ClassfileAtomizer:
 
   // Flag subsets, in a fixed bit order, chosen per element kind because the JVM reuses bit
   // values across kinds (`0x0040` is `ACC_BRIDGE` on a method and `ACC_VOLATILE` on a field).
-  // `ACC_SUPER`, `ACC_SYNCHRONIZED`, `ACC_NATIVE` and `ACC_STRICT` are excluded: none is
-  // resolvable surface, and all three of the latter vary with an implementation a consumer
-  // cannot observe through linkage.
+  // `ACC_SUPER`, `ACC_SYNCHRONIZED`, `ACC_NATIVE`, `ACC_STRICT` and `ACC_MANDATED` are excluded
+  // (`classfile.md` §8): none is resolvable surface, and each varies with an implementation no
+  // consumer can observe through linkage.
   private val classFlags: scala.List[Int] =
     scala.List
       ( jlc.ClassFile.ACC_PUBLIC, jlc.ClassFile.ACC_PROTECTED, jlc.ClassFile.ACC_FINAL,
@@ -208,10 +208,13 @@ object ClassfileAtomizer:
     // method breaks every existing implementor, so the abstract member set folds into the class's
     // own atom and the addition grades major. On a final class nothing can implement it, the fold
     // is empty, and the same addition is pure extension.
+    // The fold is the sorted *key* list (`classfile.md` §9 rule 6) — the presenting owner is
+    // this class for every member of its presented set, so each key is the class's name with
+    // the member's selector appended.
     val abstracts =
       if surface.isFinal then Nil else List.from:
         members.stdlib.collect:
-          case (member, _) if member.abstrakt => member.selector
+          case (member, _) if member.abstrakt => t"${surface.name}${member.selector}"
 
         . sortBy(_.s)
 

--- a/lib/mandible/src/lira/mandible.ClassfileDiscipline.scala
+++ b/lib/mandible/src/lira/mandible.ClassfileDiscipline.scala
@@ -59,7 +59,7 @@ object ClassfileDiscipline extends Discipline:
   // Classfiles exist in the `jvm` universe alone; `sjsir` and `nir` have no counterpart to
   // compare against, so the cross-section invariant (§9.6) is vacuous here and correctly so. A
   // single-universe domain is exactly the case §11.2 requirement 1 exempts from it.
-  def domain: Discipline.Domain = Discipline.Domain.Universes(Set(t"jvm"))
+  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"jvm"))
 
   // §11.2 requirement 4: a JVM call site names the receiver, not the declarer, so a type's
   // linkage surface includes members it inherits. Declaration keying would be unsound for a

--- a/lib/mandible/src/lira/mandible.JvmProfile.scala
+++ b/lib/mandible/src/lira/mandible.JvmProfile.scala
@@ -155,3 +155,14 @@ object JvmProfile extends EcosystemProfile:
     List.from:
       constants(previous, next).stdlib.map: key =>
         t"the constant $key changed value; consumers that inlined it are stale until recompiled"
+
+  // §6's toolchain predicate, at the scope where it is stated: every release on a buildpath
+  // must carry metadata a consuming compiler can read, and a release recording no toolchain at
+  // all makes the claim uncheckable rather than false — reported as a violation, per release.
+  // Which TASTy versions a *particular* consumer's compiler reads is that consumer's knowledge,
+  // not the manifests', so the window comparison belongs to the consuming tool; what is
+  // buildpath-decidable is that every release states what produced it.
+  override def coherence(releases: List[LiraManifest]): List[Text] =
+    List.from:
+      releases.stdlib.filter(_.toolchain.stdlib.isEmpty).map: manifest =>
+        t"${manifest.module} records no toolchain, so TASTy readability cannot be checked"

--- a/lib/mandible/src/lira/mandible.JvmProfile.scala
+++ b/lib/mandible/src/lira/mandible.JvmProfile.scala
@@ -145,3 +145,13 @@ object JvmProfile extends EcosystemProfile:
         . map { _ => key }
 
     List.from(changed.flatten.toList.sortBy(_.s))
+
+  // §7's SHOULD: changed constants are surfaced through the audit's advisory channel, so a
+  // publisher sees them without any bespoke call.
+  override def advisories
+    ( previous: EcosystemProfile.Evidence, next: EcosystemProfile.Evidence )
+  :   List[Text] raises DisciplineError =
+
+    List.from:
+      constants(previous, next).stdlib.map: key =>
+        t"the constant $key changed value; consumers that inlined it are stale until recompiled"

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -483,6 +483,25 @@ object Tests extends Suite(m"Mandible tests"):
       capture[LiraError](EcosystemProfile.audit(registry, declared, before, before)).reason
     . assert(_ == LiraError.Reason.ProfileViolated(t"broken/1", t"out of scope"))
 
+    test(m"the toolchain predicate reports releases with no toolchain record"):
+      def data(text: Text): Data = Array.unsafeFrozen(text.s.getBytes("UTF-8").nn)
+
+      def release(module: Text, toolchain: List[LiraManifest.Tool]): LiraManifest =
+        LiraManifest(
+          module    = module,
+          lineage   = List(LiraHash(LiraHash.Domain.Snapshot, data(module))),
+          toolchain = toolchain,
+          api       = List(),
+          section   = List(),
+          payload   = LiraManifest.Payload(t"brotli", 0L,
+              LiraHash(LiraHash.Domain.Blob, data(module))))
+
+      val tooled = release(t"alpha", List(LiraManifest.Tool(t"scala", t"3.9.0")))
+      val bare = release(t"beta", List())
+
+      JvmProfile.coherence(List(tooled, bare)).stdlib.map(_.s.takeWhile(_ != ' '))
+    . assert(_ == scala.List("beta"))
+
     test(m"changed constants surface through the audit's advisory channel"):
       val registry = EcosystemProfile.Registry(List(JvmProfile))
       val declared = List(LiraManifest.Profile(t"jvm/1"))

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -457,12 +457,38 @@ object Tests extends Suite(m"Mandible tests"):
 
       val after = evidence(edit(base, t"protected int guarded() { return 2; }", t""), derived, api)
 
-      EcosystemProfile.audit(registry, declared, before, after).stdlib
+      EcosystemProfile.audit(registry, declared, before, after).unchecked.stdlib
     . assert(_ == scala.List())
 
     test(m"a declared profile with no implementation is reported, not rejected"):
       val registry = EcosystemProfile.Registry(List(JvmProfile))
       val declared = List(LiraManifest.Profile(t"unknown/1"))
 
-      EcosystemProfile.audit(registry, declared, before, before).stdlib
+      EcosystemProfile.audit(registry, declared, before, before).unchecked.stdlib
     . assert(_ == scala.List(t"unknown/1"))
+
+    test(m"a violation at an uncertified level is the profile's defect, L128"):
+      val broken = new EcosystemProfile:
+        def id: Text = t"broken/1"
+        def certifies: Set[Discipline.Guarantee] = Set(Discipline.Guarantee.Linkage)
+
+        def check(previous: EcosystemProfile.Evidence, next: EcosystemProfile.Evidence)
+        :   List[EcosystemProfile.Violation] raises DisciplineError =
+          List(EcosystemProfile.Violation(Discipline.Guarantee.Recompilation, t"out of scope"))
+
+      val registry = EcosystemProfile.Registry(List(broken))
+      val declared = List(LiraManifest.Profile(t"broken/1"))
+
+      import errorDiagnostics.stackTracesDiagnostics
+      capture[LiraError](EcosystemProfile.audit(registry, declared, before, before)).reason
+    . assert(_ == LiraError.Reason.ProfileViolated(t"broken/1", t"out of scope"))
+
+    test(m"changed constants surface through the audit's advisory channel"):
+      val registry = EcosystemProfile.Registry(List(JvmProfile))
+      val declared = List(LiraManifest.Profile(t"jvm/1"))
+      val after = evidence(edit(base, t"CONSTANT = 7", t"CONSTANT = 8"), derived, api)
+
+      EcosystemProfile.audit(registry, declared, before, after).advisories.stdlib
+    . assert: advisories =>
+        advisories.length == 2
+          && advisories.forall(_.s.contains("changed value"))

--- a/lib/reliquary/res/test/reliquary/lira-capabilities.tel
+++ b/lib/reliquary/res/test/reliquary/lira-capabilities.tel
@@ -1,0 +1,17 @@
+tel 1.0
+
+# The capability listing of a host contract with no formal carrier (hosts.md §5): the single
+# tree item at the path `capabilities`, claimed by `capability/1`. Rows are sorted by ascending
+# name with no duplicates; `probe` is advisory and enters no atom. This document is the
+# canonical mirror of the hand-encoded `LiraSchemas.capabilities`; reliquary's test suite
+# asserts the two are structurally identical and pins this document's schema signature.
+
+name lira-capabilities
+
+record Capability
+  field name Identifier
+  field version String optional
+  field probe String optional
+
+document
+  field capability Capability optional repeatable

--- a/lib/reliquary/res/test/reliquary/lira.tel
+++ b/lib/reliquary/res/test/reliquary/lira.tel
@@ -1,11 +1,12 @@
 tel 1.0
 
-# The `lira` manifest schema (LIRA specification §14: `jvm | sjsir | nir` universes, optional
-# numeric-only `version`, dependencies scoped by universe and integration or `build`-pinned,
-# sections keyed by universe and integration with `derivative` hashes, `resource` claims for the
-# resource/1 discipline, and ecosystem `profile` claims). This document is the canonical mirror of the hand-encoded
-# `LiraSchemas.lira`; reliquary's test suite asserts the two are structurally identical and pins
-# this document's schema signature.
+# The `lira` manifest schema (LIRA specification §14: `jvm | sjsir | nir | host` worlds,
+# optional numeric-only `version`, dependencies scoped by universe and integration or
+# `build`-pinned, sections keyed by world and integration with `derivative` hashes and host
+# `requires` records, `resource` claims for the resource/1 discipline, and ecosystem `profile`
+# claims). This document is the canonical mirror of the hand-encoded `LiraSchemas.lira`;
+# reliquary's test suite asserts the two are structurally identical and pins this document's
+# schema signature.
 
 name lira
 
@@ -41,12 +42,19 @@ record Dependency
   field uses Hash optional
   field spans Hash optional repeatable
 
+record Requires
+  field module ModuleName
+  field api Hash
+  field version Semver optional
+  field uses Hash optional
+
 record Section
-  select Universe
+  select World
   field integration Identifier optional
   field tree Hash
   field delete String optional repeatable
   field derivative Hash optional
+  field requires Requires optional repeatable
 
 record Payload
   field compression Identifier
@@ -86,10 +94,11 @@ scalar TreePath
 scalar Guarantee
   validate guarantee
 
-select Universe
+select World
   variant jvm Flag
   variant sjsir Flag
   variant nir Flag
+  variant host Flag
 
 select ResourceMode
   variant export Flag

--- a/lib/reliquary/res/test/reliquary/lira.tel
+++ b/lib/reliquary/res/test/reliquary/lira.tel
@@ -38,6 +38,7 @@ record Dependency
   field version Semver optional
   field build Hash optional
   field universe Identifier optional repeatable
+  field serves Identifier optional
   field integration Identifier optional repeatable
   field uses Hash optional
   field spans Hash optional repeatable

--- a/lib/reliquary/src/core/reliquary.BlobStream.scala
+++ b/lib/reliquary/src/core/reliquary.BlobStream.scala
@@ -79,14 +79,14 @@ object BlobStream:
 
         mitigate:
           case _: VarintError =>
-            LiraError(Reason.InvalidBlobStream(t"a record length is malformed"))
+            LiraError(Reason.MalformedPayload(t"a record length is malformed"))
 
         . protect(Varint.decode(data, offset))
 
       val length = decoded.value
 
       if length > Int.MaxValue.toLong || decoded.next + length.toInt > data.length
-      then abort(LiraError(Reason.InvalidBlobStream(t"a record overruns the end of the stream")))
+      then abort(LiraError(Reason.MalformedPayload(t"a record overruns the end of the stream")))
 
       val content = Array[Byte](length.toInt)
       System.arraycopy(Array.unsafeJvm(data), decoded.next, content.raw, 0, length.toInt)

--- a/lib/reliquary/src/core/reliquary.Buildpath.scala
+++ b/lib/reliquary/src/core/reliquary.Buildpath.scala
@@ -161,14 +161,18 @@ case class Buildpath(releases: List[LiraManifest]):
           case _ => false
 
   // §13.3 structural rules, which no assignment can affect: at most one release per module
-  // (L111) and pairwise-disjoint `owns` claims (L112).
+  // (L111) and pairwise-disjoint `owns` claims (L112). Host contracts are exempt from rules 2–3
+  // (hosts.md §8): a contract describes an environment and contributes no namespace claims and
+  // no resources, so one mistakenly placed among the releases must not clash with anything.
   private def structural(): Unit raises LiraError =
     val all = releases.stdlib
 
     all.groupBy(_.module).foreach: (module, group) =>
       if group.size > 1 then abort(LiraError(Reason.DuplicateModule(module)))
 
-    val claims = all.flatMap: manifest =>
+    val libraries = all.filter { manifest => !manifest.hostContract }
+
+    val claims = libraries.flatMap: manifest =>
       manifest.owns.stdlib.map: namespace => (manifest.module, namespace)
 
     claims.zipWithIndex.foreach: (left, index) =>
@@ -183,7 +187,7 @@ case class Buildpath(releases: List[LiraManifest]):
     // L126: `export` and `track` paths are pairwise disjoint across modules, so a classpath-style
     // reference resolves to exactly one module. `scan` directories are exempt — cross-module
     // aggregation under a shared directory is precisely their purpose.
-    val named = all.flatMap: manifest =>
+    val named = libraries.flatMap: manifest =>
       manifest.resource.stdlib
         . filter(_.mode != LiraManifest.ResourceMode.Scan)
         . map: resource => (manifest.module, resource.path.text)
@@ -222,6 +226,70 @@ case class Buildpath(releases: List[LiraManifest]):
 
     List.from(advisories)
 
+  // The sections a target's universe and an assignment select (§13.3, §13.5): per release, the
+  // section for that universe and that release's assigned integration.
+  private def selected(universe: Text, assignment: Assignment): scala.List[Section] =
+    releases.stdlib.flatMap: manifest =>
+      manifest.section.stdlib.filter: section =>
+        section.world == universe
+        && section.integration.option == assignment(manifest.module).option
+
+  // The host-contract modules the selected sections' `requires` records name — the modules rule
+  // 7 needs contracts for, and what `HostPending` reports when validation runs without any.
+  def requiredContracts(universe: Text, assignment: Assignment): List[Text] =
+    List.from:
+      selected(universe, assignment).flatMap: section =>
+        section.requires.stdlib.map(_.module)
+
+      . distinct
+
+  // §13.3 rule 7 (L136, L137): every `requires` record of every selected section must be
+  // satisfied by the given contracts, per hosts.md §7 — the required snapshot appears in the
+  // named contract's lineage, or the requirement's used-set is contained in a contract's atom
+  // set. The latter extends across contracts of *different* modules, which is sound because
+  // atoms are content-addressed and module-blind; it needs the contract atom sets and the Uses
+  // blobs, which live in payloads, so callers supply them as lookups and a lookup left unset
+  // simply forgoes spanning. Aggregation (hosts.md §10) needs no extra pass: the contracts are
+  // one release per module, so requirements are jointly satisfiable iff each is individually —
+  // by lineage, both snapshots must be in the one given lineage; by spanning, a union of
+  // used-sets is contained in a contract's atoms iff each member is.
+  def hostRequirements
+    ( universe:   Text,
+      assignment: Assignment,
+      contracts:  List[LiraManifest],
+      atoms:      Text => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset },
+      used:       Data => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset } )
+  :   Unit raises LiraError =
+
+    contracts.stdlib.foreach: contract =>
+      if !contract.hostContract
+      then abort(LiraError(Reason.NotHostContract(contract.module)))
+
+    selected(universe, assignment).foreach: section =>
+      section.requires.stdlib.foreach: requirement =>
+        // L137, from the other end: a requirement naming a module whose releases are ordinary
+        // libraries is a category error, checkable wherever that module's manifest is in hand.
+        apply(requirement.module).let: release =>
+          if !release.hostContract
+          then abort(LiraError(Reason.NotHostContract(requirement.module)))
+
+        val named = contracts.stdlib.find(_.module == requirement.module)
+
+        val byLineage = named.exists: contract =>
+          Lineage.contains(contract.lineage, requirement.api)
+
+        val bySpanning = requirement.uses.let: usesHash =>
+          used(usesHash).let: usedSet =>
+            contracts.stdlib.exists: contract =>
+              atoms(contract.module).let(usedSet.subsetOf(_)).or(false)
+
+          . or(false)
+
+        . or(false)
+
+        if !byLineage && !bySpanning
+        then abort(LiraError(Reason.UnsatisfiedRequirement(requirement.module)))
+
   // §13.3 validity for one universe, with the assignment that establishes it. Diamond
   // dependencies resolve by construction: requirements on two snapshots of one module are
   // jointly satisfiable iff some lineage contains both.
@@ -230,13 +298,39 @@ case class Buildpath(releases: List[LiraManifest]):
   // entirely and the rules read exactly as they did before integrations existed — including the
   // diagnostics, which name the failing dependency rather than reporting that no assignment
   // exists.
-  def resolved(universe: Text): (Assignment, List[LiraAdvisory]) raises LiraError =
+  //
+  // Rule 7 runs against the given host contracts; where none are given the rule is left
+  // *pending*, not passed, and the `HostPending` advisory names the contracts still needed —
+  // the mode report §13.3 requires.
+  def resolved
+    ( universe:  Text,
+      contracts: List[LiraManifest] = List(),
+      atoms:     Text => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset },
+      used:      Data => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset } )
+  :   (Assignment, List[LiraAdvisory]) raises LiraError =
+
     structural()
 
     val assignment =
       if releases.stdlib.forall(_.integration.stdlib.isEmpty) then Assignment(List())
       else resolve(universe)
 
-    (assignment, audit(universe, assignment))
+    val advisories = audit(universe, assignment)
+    val required = requiredContracts(universe, assignment)
 
-  def validate(universe: Text): List[LiraAdvisory] raises LiraError = resolved(universe)(1)
+    if contracts.stdlib.isEmpty then
+      if required.stdlib.isEmpty then (assignment, advisories)
+      else
+        val pending = List(LiraAdvisory.HostPending(required))
+        (assignment, List.from(advisories.stdlib ++ pending.stdlib))
+    else
+      hostRequirements(universe, assignment, contracts, atoms, used)
+      (assignment, advisories)
+
+  def validate
+    ( universe:  Text,
+      contracts: List[LiraManifest] = List(),
+      atoms:     Text => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset },
+      used:      Data => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset } )
+  :   List[LiraAdvisory] raises LiraError =
+    resolved(universe, contracts, atoms, used)(1)

--- a/lib/reliquary/src/core/reliquary.Buildpath.scala
+++ b/lib/reliquary/src/core/reliquary.Buildpath.scala
@@ -33,7 +33,9 @@
 package reliquary
 
 import anticipation.*
+import anticipation.*
 import contingency.*
+import gossamer.*
 import vacuous.*
 
 import LiraError.Reason
@@ -120,9 +122,32 @@ case class Buildpath(releases: List[LiraManifest]):
   // Coupling would appear only in a resolver that also chose *which* releases to include, since
   // an integration can then pull a module in; that is dependency resolution proper, and it is
   // outside §13.3, which audits a buildpath it is handed.
-  def resolve(universe: Text): Assignment raises LiraError =
+  // §13.3: each release serves one universe of the target — the primary, unless a dependency
+  // record naming the release carries `serves` (§13.2), in which case the universe that record
+  // names. Closure and compatibility quantify over the records applicable to the universe a
+  // release serves, which is what makes a cross-universe dependency's own dependencies resolve
+  // in *its* universe rather than the target's.
+  def serving(primary: Text, module: Text): Text =
+    releases.stdlib.flatMap: manifest =>
+      manifest.dependency.stdlib.filter(_.module == module).flatMap(_.serves.option)
+
+    . headOption.getOrElse(primary)
+
+  // A pin is how a consumer states a preference the manifests cannot imply (§13.3): the named
+  // release takes the named integration, the remaining releases their canonical choices.
+  def resolve(universe: Text, pins: List[(Text, Text)] = List()): Assignment raises LiraError =
     val chosen = releases.stdlib.sortBy(_.module.s).map: manifest =>
-      candidates(manifest).find(satisfies(universe, manifest, _)) match
+      val pinned = pins.stdlib.find(_(0) == manifest.module).map(_(1))
+
+      val options: scala.List[Optional[Text]] = pinned match
+        case scala.Some(id) =>
+          if !manifest.integration.stdlib.exists(_.id == id)
+          then abort(LiraError(Reason.BadIntegration(t"the pin names undeclared $id")))
+          scala.List(id)
+
+        case _ => candidates(manifest)
+
+      options.find(satisfies(serving(universe, manifest.module), manifest, _)) match
         case scala.Some(candidate) => (manifest.module, candidate)
 
         // Because the choices are independent, a failure is always one release's: there is no
@@ -198,19 +223,31 @@ case class Buildpath(releases: List[LiraManifest]):
   // Closure (L113) and satisfaction (L114) under one assignment, reporting the precise rule that
   // fails. `resolve` answers only whether *some* assignment works; this says why a given one does
   // not, which is what a diagnostic needs.
-  private def audit(universe: Text, assignment: Assignment)
+  private def audit(universe: Text, joins: List[Text], assignment: Assignment)
   :   List[LiraAdvisory] raises LiraError =
 
     val advisories = scala.collection.mutable.ArrayBuffer[LiraAdvisory]()
 
     releases.stdlib.foreach: manifest =>
+      val served = serving(universe, manifest.module)
+
       manifest.dependency.stdlib.foreach: dependency =>
-        if dependency.applies(universe, assignment(manifest.module)) then
+        if dependency.applies(served, assignment(manifest.module)) then
           val candidate = apply(dependency.module) match
             case candidate: LiraManifest => candidate
 
             case _ =>
               abort(LiraError(Reason.AbsentDependency(dependency.module)))
+
+          // Rule 4's serves clause: a join edge to a universe the target does not include, or
+          // to content the candidate does not offer, fails closure exactly as an absent module
+          // does (§13.2, §13.3).
+          dependency.serves.let: target =>
+            if target != universe && !joins.stdlib.contains(target)
+            then abort(LiraError(Reason.AbsentDependency(dependency.module)))
+
+            if !candidate.section.stdlib.exists(_.world == target)
+            then abort(LiraError(Reason.AbsentDependency(dependency.module)))
 
           if !requirementMet(dependency, candidate)
           then abort(LiraError(Reason.Unsatisfiable(dependency.module)))
@@ -226,12 +263,14 @@ case class Buildpath(releases: List[LiraManifest]):
 
     List.from(advisories)
 
-  // The sections a target's universe and an assignment select (§13.3, §13.5): per release, the
-  // section for that universe and that release's assigned integration.
+  // The sections a target and an assignment select (§13.3, §13.5): per release, the section for
+  // the universe that release serves and its assigned integration.
   private def selected(universe: Text, assignment: Assignment): scala.List[Section] =
     releases.stdlib.flatMap: manifest =>
+      val served = serving(universe, manifest.module)
+
       manifest.section.stdlib.filter: section =>
-        section.world == universe
+        section.world == served
         && section.integration.option == assignment(manifest.module).option
 
   // The host-contract modules the selected sections' `requires` records name — the modules rule
@@ -302,20 +341,40 @@ case class Buildpath(releases: List[LiraManifest]):
   // Rule 7 runs against the given host contracts; where none are given the rule is left
   // *pending*, not passed, and the `HostPending` advisory names the contracts still needed —
   // the mode report §13.3 requires.
+  //
+  // `joins` completes the target (§13.3): the universes that join the primary one, which rule
+  // 4's serves clause admits join edges into. `pins` are the consumer's integration choices;
+  // unpinned releases take their canonical ones. `profiles` supplies rule 6's implementations:
+  // every profile declared by any release imposes its buildpath predicates over the whole path,
+  // and only an implemented profile can be checked here — an unimplementable declared profile
+  // is a registry's refusal at publish time (L140), not re-litigated on every resolution.
   def resolved
     ( universe:  Text,
+      joins:     List[Text]         = List(),
+      pins:      List[(Text, Text)] = List(),
       contracts: List[LiraManifest] = List(),
       atoms:     Text => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset },
-      used:      Data => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset } )
+      used:      Data => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset },
+      profiles:  EcosystemProfile.Registry = EcosystemProfile.Registry(List()) )
   :   (Assignment, List[LiraAdvisory]) raises LiraError =
 
     structural()
 
     val assignment =
-      if releases.stdlib.forall(_.integration.stdlib.isEmpty) then Assignment(List())
-      else resolve(universe)
+      if pins.stdlib.isEmpty && releases.stdlib.forall(_.integration.stdlib.isEmpty)
+      then Assignment(List())
+      else resolve(universe, pins)
 
-    val advisories = audit(universe, assignment)
+    val advisories = audit(universe, joins, assignment)
+
+    // Rule 6: profile coherence over the whole buildpath.
+    releases.stdlib.flatMap(_.profile.stdlib.map(_.id)).distinct.foreach: id =>
+      profiles(id).let: profile =>
+        val details = profile.coherence(releases).stdlib
+
+        if !details.isEmpty
+        then abort(LiraError(Reason.ProfileViolated(id, Text(details.map(_.s).mkString("; ")))))
+
     val required = requiredContracts(universe, assignment)
 
     if contracts.stdlib.isEmpty then
@@ -329,8 +388,11 @@ case class Buildpath(releases: List[LiraManifest]):
 
   def validate
     ( universe:  Text,
+      joins:     List[Text]         = List(),
+      pins:      List[(Text, Text)] = List(),
       contracts: List[LiraManifest] = List(),
       atoms:     Text => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset },
-      used:      Data => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset } )
+      used:      Data => Optional[scala.collection.immutable.Set[Text]] = { _ => Unset },
+      profiles:  EcosystemProfile.Registry = EcosystemProfile.Registry(List()) )
   :   List[LiraAdvisory] raises LiraError =
-    resolved(universe, contracts, atoms, used)(1)
+    resolved(universe, joins, pins, contracts, atoms, used, profiles)(1)

--- a/lib/reliquary/src/core/reliquary.CapabilityDiscipline.scala
+++ b/lib/reliquary/src/core/reliquary.CapabilityDiscipline.scala
@@ -30,11 +30,99 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package reliquary
 
-export reliquary.{Atom, AtomClass, Atomization, AtomReference, AtomsBlob, Blob, BlobStream,
-    Blobstore, Buildpath, CapabilityDiscipline, Discipline, DisciplineError, EcosystemProfile,
-    Grade, Lineage, Lira, LiraAdvisory,
-    LiraDelta, LiraError, LiraHash, LiraManifest, LiraPayload, LiraSchemas, LiraTree,
-    LiraValidators, LiraWorld, ManifestSigning, OpaqueDiscipline, Overlay, Publication,
-    Replacement, Section, Snapshot, TreeEntry, TreePath, UsesBlob, Verification, Versioning}
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import stratiform.*
+import turbulence.*
+import vacuous.*
+
+// The `capability/1` discipline (hosts.md §5): the discipline of host contracts with no formal
+// carrier. It claims the single tree item at the path `capabilities` — a TEL document under the
+// `lira-capabilities` schema — and emits one rigid atom per capability row: the key is the
+// capability's name, and the canonical encoding is the UTF-8 bytes of the name, a 0x00
+// separator, then 0x01 and the UTF-8 bytes of the version predicate where one is declared, or a
+// single 0x00 where none is. A predicate therefore folds into the atom's value, so tightening
+// or loosening one is a removal plus an addition — major, which is conservative and sound. The
+// advisory `probe` field enters no atom: it participates in implementation identity (it is
+// bytes in the payload) but never in API identity, so editing a probe is a patch.
+//
+// Like `opaque/1` and `resource/1` it is language-blind and lives in the core, since every
+// verifier must be able to implement it (§16, step 4).
+object CapabilityDiscipline extends Discipline:
+  def id: Text = t"capability/1"
+
+  def claims(path: TreePath, data: Data): Boolean = path.text == t"capabilities"
+
+  // The single world `{host}`: capability listings describe environments, never libraries, and
+  // L127 rejects a library release that declares this discipline.
+  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"host"))
+  def keying: Discipline.Keying = Discipline.Keying.Declaration
+
+  // Presence, on the same terms as `resource/1` — the recompilation level for content addressed
+  // by name, and the only level "the command exists" can mean.
+  def guarantees(world: Text): Set[Discipline.Guarantee] =
+    Set(Discipline.Guarantee.Recompilation)
+
+  private def malformed(detail: Text): DisciplineError =
+    import errorDiagnostics.emptyDiagnostics
+    DisciplineError(t"capability/1", DisciplineError.Reason.Malformed(detail))
+
+  def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
+  :   Atomization raises DisciplineError =
+
+    val atoms = content.stdlib.flatMap: (path, data) => rows(data)
+    Atomization.of(id, List.from(atoms))
+
+  private def rows(data: Data): scala.List[Atom] raises DisciplineError =
+    val document =
+      import errorDiagnostics.emptyDiagnostics
+
+      mitigate:
+        case TelError(reason, _) => malformed(t"the capability listing is invalid: $reason")
+
+      . protect:
+          import Tels.Decoder.validate
+          val tel = data.read[Tel]
+          tel.validate(using LiraSchemas.capabilities, LiraValidators.registry)
+          tel
+
+    val compounds = document.childCompounds.readable.filter(_.keyword == t"capability").toVector
+
+    val entries = compounds.map: compound =>
+      val fields = compound.children.readable.flatMap(_.compounds.readable).toVector
+
+      def field(keyword: Text): Optional[Text] =
+        val values = fields.filter(_.keyword == keyword).flatMap: field =>
+          field.atoms.readable.collect:
+            case Tel.Atom.Inline(text, _)  => text
+            case Tel.Atom.Source(text)     => text
+            case Tel.Atom.Literal(_, text) => text
+
+        values.headOption.getOrElse(Unset)
+
+      val name = field(t"name").or(abort(malformed(t"a capability row has no name")))
+      (name, field(t"version"))
+
+    entries.zip(entries.drop(1)).foreach: (left, right) =>
+      if left(0).s == right(0).s then abort(malformed(t"the capability ${left(0)} is duplicated"))
+      if left(0).s > right(0).s then abort(malformed(t"capability rows are not sorted by name"))
+
+    entries.toList.map: (name, predicate) =>
+      val out = java.io.ByteArrayOutputStream()
+      out.write(name.s.getBytes("UTF-8").nn)
+      out.write(0)
+
+      predicate.let: text =>
+        out.write(1)
+        out.write(text.s.getBytes("UTF-8").nn)
+
+      . or(out.write(0))
+
+      val encoding = Array.unsafeFrozen(out.toByteArray.nn)
+      Atom(name, AtomClass.Rigid, LiraHash(LiraHash.Domain.Atom(id), encoding))

--- a/lib/reliquary/src/core/reliquary.Discipline.scala
+++ b/lib/reliquary/src/core/reliquary.Discipline.scala
@@ -40,26 +40,27 @@ import vacuous.*
 
 object Discipline:
   // What a compiler-based discipline needs beyond the content itself: which section is being
-  // atomized — its universe and, where the release offers alternative dependency vectors (§9.5),
+  // atomized — its world and, where the release offers alternative dependency vectors (§9.5),
   // its integration — and the dependency classpath materialized from the buildpath (entries as
   // textual paths, so the core stays platform-light). The classpath is a property of the
   // integration, which is why atomization is per-section and not per-universe.
   case class Context
-    ( universe:    Text,
+    ( world:       Text,
       integration: Optional[Text] = Unset,
       classpath:   List[Text]     = List() )
 
-  // The universes a discipline atomizes at all (§11.2, requirement 1). A universal discipline
-  // atomizes whatever universe it is given; a universe-specific one names its universes, and the
-  // cross-section invariant (§9.6) is vacuous outside them. Claiming nothing in a universe
-  // outside the domain is not the same as claiming content atomless.
+  // The worlds a discipline atomizes at all (§11.2, requirement 1): universes, and possibly the
+  // `host` world (hosts.md). A universal discipline atomizes whatever world it is given — which
+  // is `dts/1`'s case, and brings host contracts within its reach; a world-specific one names
+  // its worlds, and the cross-section invariant (§9.6) is vacuous outside them. Claiming
+  // nothing in a world outside the domain is not the same as claiming content atomless.
   enum Domain:
     case Universal
-    case Universes(names: Set[Text])
+    case Worlds(names: Set[Text])
 
-    def covers(universe: Text): Boolean = this match
-      case Universal        => true
-      case Universes(names) => names.stdlib.contains(universe)
+    def covers(world: Text): Boolean = this match
+      case Universal     => true
+      case Worlds(names) => names.stdlib.contains(world)
 
   // Whether an atom's key names the type that *declares* a member, or every type that *presents*
   // it after inheritance (§11.2, requirement 4). Declaration keying is sound exactly where every
@@ -94,7 +95,7 @@ object Discipline:
 
       val results = all.stdlib.map: discipline =>
         val (claimed, rest) =
-          if !discipline.domain.covers(context.universe) then (scala.Nil, remaining)
+          if !discipline.domain.covers(context.world) then (scala.Nil, remaining)
           else remaining.partition: (path, data) => discipline.claims(path, data)
 
         remaining = rest

--- a/lib/reliquary/src/core/reliquary.EcosystemProfile.scala
+++ b/lib/reliquary/src/core/reliquary.EcosystemProfile.scala
@@ -167,3 +167,9 @@ trait EcosystemProfile:
   def advisories(previous: EcosystemProfile.Evidence, next: EcosystemProfile.Evidence)
   :   List[Text] raises DisciplineError =
     List()
+
+  // §13.3 rule 6: the predicates this profile imposes over a whole buildpath, decidable from
+  // manifests alone — a profile predicate requiring payload inspection is a publish-time check
+  // (§16), not a buildpath rule. Toolchain coherence (`jvm.md` §6) is the motivating case.
+  // Returns violation details; an empty list is coherence.
+  def coherence(releases: List[LiraManifest]): List[Text] = List()

--- a/lib/reliquary/src/core/reliquary.EcosystemProfile.scala
+++ b/lib/reliquary/src/core/reliquary.EcosystemProfile.scala
@@ -46,7 +46,7 @@ object EcosystemProfile:
   // is handed, because a profile that checks structural invariants over a universe's content
   // (§11.6, clause 2) needs exactly what a discipline over that universe would need.
   case class Section
-    ( universe:    Text,
+    ( world:       Text,
       content:     List[(TreePath, Data)],
       integration: Optional[Text] = Unset,
       classpath:   List[Text]     = List() )
@@ -59,8 +59,8 @@ object EcosystemProfile:
     ( sections: List[Section],
       manifest: Optional[LiraManifest] = Unset ):
 
-    def section(universe: Text): Optional[Section] =
-      sections.stdlib.find { section => section.universe == universe }.getOrElse(Unset)
+    def section(world: Text): Optional[Section] =
+      sections.stdlib.find { section => section.world == world }.getOrElse(Unset)
 
   // A predicate failure, at the guarantee level it breaks. A profile reports what it found; the
   // audit below decides whether the release accounted for it.

--- a/lib/reliquary/src/core/reliquary.EcosystemProfile.scala
+++ b/lib/reliquary/src/core/reliquary.EcosystemProfile.scala
@@ -33,6 +33,7 @@
 package reliquary
 
 import anticipation.*
+import anticipation.*
 import contingency.*
 import gossamer.*
 import rudiments.*
@@ -65,6 +66,11 @@ object EcosystemProfile:
   // audit below decides whether the release accounted for it.
   case class Violation(level: Discipline.Guarantee, detail: Text)
 
+  // What an audit found short of a violation: the profiles it could not check, and the advisory
+  // findings its profiles surfaced (`jvm/1`'s changed constants are the motivating case) — real
+  // information for a publisher, but no failure of any predicate.
+  case class Audit(unchecked: List[Text], advisories: List[Text])
+
   class Registry(profiles: List[EcosystemProfile]):
     def all: List[EcosystemProfile] = profiles
 
@@ -90,25 +96,40 @@ object EcosystemProfile:
       declared: List[LiraManifest.Profile],
       previous: Evidence,
       next:     Evidence )
-  :   List[Text] raises LiraError raises DisciplineError =
+  :   Audit raises LiraError raises DisciplineError =
 
     val unchecked = scala.collection.mutable.ListBuffer[Text]()
+    val advisories = scala.collection.mutable.ListBuffer[Text]()
 
     declared.stdlib.foreach: record =>
       registry(record.id) match
         case profile: EcosystemProfile =>
           val recorded = record.breaks.stdlib.map(guarantee(_)).toSet
+          val violations = profile.check(previous, next).stdlib
 
-          profile.check(previous, next).stdlib.foreach: violation =>
-            if !profile.certifies.stdlib.contains(violation.level)
-            then abort(LiraError(Reason.ProfileViolated(record.id, violation.detail)))
+          // Every offense is gathered before either abort, so the error a publisher sees names
+          // the whole finding for its rule, not merely the first violation encountered.
+          val uncertified = violations.filter: violation =>
+            !profile.certifies.stdlib.contains(violation.level)
 
-            if !recorded.contains(violation.level)
-            then abort(LiraError(Reason.UnrecordedBreak(record.id, keyword(violation.level))))
+          if !uncertified.isEmpty
+          then
+            val details = Text(uncertified.map(_.detail.s).mkString("; "))
+            abort(LiraError(Reason.ProfileViolated(record.id, details)))
+
+          val unrecorded = violations.map(_.level).distinct.filter: level =>
+            !recorded.contains(level)
+
+          if !unrecorded.isEmpty
+          then
+            val levels = Text(unrecorded.map(keyword(_).s).mkString(", "))
+            abort(LiraError(Reason.UnrecordedBreak(record.id, levels)))
+
+          advisories ++= profile.advisories(previous, next).stdlib
 
         case _ => unchecked += record.id
 
-    List.from(unchecked.toList)
+    Audit(List.from(unchecked.toList), List.from(advisories.toList))
 
   // Both vocabularies omit `behavior` for the same reason — no hash scheme certifies it (§11.5,
   // §18) — so the mapping is total in both directions.
@@ -140,3 +161,9 @@ trait EcosystemProfile:
 
   def check(previous: EcosystemProfile.Evidence, next: EcosystemProfile.Evidence)
   :   List[EcosystemProfile.Violation] raises DisciplineError
+
+  // Findings short of violations, surfaced for reporting (`jvm.md` §7's changed constants are
+  // the motivating case). Advisory only: nothing here affects the audit's verdict.
+  def advisories(previous: EcosystemProfile.Evidence, next: EcosystemProfile.Evidence)
+  :   List[Text] raises DisciplineError =
+    List()

--- a/lib/reliquary/src/core/reliquary.LiraAdvisory.scala
+++ b/lib/reliquary/src/core/reliquary.LiraAdvisory.scala
@@ -41,3 +41,9 @@ enum LiraAdvisory:
   case NotNumeric(version: Semver)
   case VersionMismatch(declared: Semver, expected: Semver)
   case UnreferencedBlobs(hashes: List[Text])
+
+  // §13.3 rule 7 was left pending: the buildpath was validated without a host contract, and the
+  // named modules' requirements remain unchecked. A tool MUST report which mode it validated in,
+  // since a buildpath can cohere as a library composition and still be unsatisfiable on the
+  // host a consumer intends.
+  case HostPending(modules: List[Text])

--- a/lib/reliquary/src/core/reliquary.LiraError.scala
+++ b/lib/reliquary/src/core/reliquary.LiraError.scala
@@ -68,11 +68,18 @@ object LiraError:
     case ResourceClash(path: Text)            extends Reason(126)
     case InapplicableDiscipline(id: Text)     extends Reason(127)
     case ProfileViolated(id: Text, detail: Text) extends Reason(128)
+    // L129 is structural — a profile can only add predicates through the `EcosystemProfile`
+    // SPI, never remove a core check — so this reason is reserved for a future profile-loading
+    // mechanism that could observe a weakening, and is deliberately never constructed today.
     case ProfileWeakens(id: Text)             extends Reason(129)
     case UnrecordedBreak(id: Text, level: Text) extends Reason(130)
     case BadIntegration(detail: Text)         extends Reason(131)
     case NoAssignment(module: Text)           extends Reason(132)
     case UnrealizedIntegration(id: Text)      extends Reason(133)
+    case BadDerivative(universe: Text)        extends Reason(138)
+    case MalformedPayload(detail: Text)       extends Reason(139)
+    case UnimplementedClaim(id: Text)         extends Reason(140)
+    case AtomsMismatch(id: Text)              extends Reason(141)
 
   given communicable: Reason is Communicable =
     case Reason.InvalidManifest(detail)       => m"the manifest is invalid: $detail"
@@ -87,7 +94,8 @@ object LiraError:
     case Reason.UngradedSuccessor             => m"the release is not a patch or minor successor"
     case Reason.DuplicateModule(module)       => m"the buildpath contains $module more than once"
     case Reason.NamespaceClash(space)         => m"the namespace $space is claimed twice"
-    case Reason.AbsentDependency(module)      => m"the dependency $module is not on the buildpath"
+    case Reason.AbsentDependency(module) =>
+      m"the buildpath does not supply $module in the required universe"
     case Reason.Unsatisfiable(module)         => m"no release of $module satisfies the requirement"
     case Reason.BadDirective                  => m"the interpreter directive is not byte-exact"
     case Reason.SigilSpecified                => m"a lira manifest must not specify a sigil"
@@ -118,6 +126,17 @@ object LiraError:
     case Reason.NoAssignment(module) =>
       m"no integration of $module is satisfiable on this buildpath"
     case Reason.UnrealizedIntegration(id)   => m"the integration $id has no section"
+
+    case Reason.BadDerivative(universe) =>
+      m"the declared derivative hash of the $universe section does not recompute"
+
+    case Reason.MalformedPayload(detail)    => m"the payload is malformed: $detail"
+
+    case Reason.UnimplementedClaim(id) =>
+      m"the declared discipline or profile $id has no implementation to check it"
+
+    case Reason.AtomsMismatch(id) =>
+      m"the declared $id atom listing does not recompute from the content"
 
 case class LiraError(reason: LiraError.Reason)(using Diagnostics)
 extends Error(640, reason.number)(m"the LIRA operation failed because $reason")

--- a/lib/reliquary/src/core/reliquary.LiraError.scala
+++ b/lib/reliquary/src/core/reliquary.LiraError.scala
@@ -76,6 +76,9 @@ object LiraError:
     case BadIntegration(detail: Text)         extends Reason(131)
     case NoAssignment(module: Text)           extends Reason(132)
     case UnrealizedIntegration(id: Text)      extends Reason(133)
+    case BadHostContract(detail: Text)        extends Reason(135)
+    case UnsatisfiedRequirement(module: Text) extends Reason(136)
+    case NotHostContract(module: Text)        extends Reason(137)
     case BadDerivative(universe: Text)        extends Reason(138)
     case MalformedPayload(detail: Text)       extends Reason(139)
     case UnimplementedClaim(id: Text)         extends Reason(140)
@@ -126,6 +129,13 @@ object LiraError:
     case Reason.NoAssignment(module) =>
       m"no integration of $module is satisfiable on this buildpath"
     case Reason.UnrealizedIntegration(id)   => m"the integration $id has no section"
+    case Reason.BadHostContract(detail)     => m"the host contract is ill-formed: $detail"
+
+    case Reason.UnsatisfiedRequirement(module) =>
+      m"no given host contract satisfies the requirement on $module"
+
+    case Reason.NotHostContract(module) =>
+      m"the requirement names $module, whose releases are not host contracts"
 
     case Reason.BadDerivative(universe) =>
       m"the declared derivative hash of the $universe section does not recompute"

--- a/lib/reliquary/src/core/reliquary.LiraManifest.scala
+++ b/lib/reliquary/src/core/reliquary.LiraManifest.scala
@@ -98,6 +98,16 @@ object LiraManifest:
 
       universeApplies && integrationApplies
 
+  // One host requirement of a section (hosts.md §6): the host contract's module name and the
+  // required contract snapshot, satisfied by lineage membership or by spanning where a Uses
+  // blob is attached (hosts.md §7). Authorial: no verifier can decide that code needs what it
+  // declares (§16), which is why the environment itself is probed at a third moment.
+  case class Requires
+    ( module:  Text,
+      api:     Data,
+      version: Optional[Semver] = Unset,
+      uses:    Optional[Data]   = Unset )
+
   // How a declared resource participates in the algebra (§11.4). `Export` guarantees the name is
   // present; `Track` additionally tracks the bytes as replaceable churn; `Scan` claims a whole
   // directory atomless, so nothing under it is contractual.
@@ -235,20 +245,30 @@ object LiraManifest:
           label = field(fields, t"label") )
 
     val section = top.filter(_.keyword == t"section").map: compound =>
-      val universe = texts(compound) match
-        case scala.collection.immutable.Vector(universe) => universe
+      val world = texts(compound) match
+        case scala.collection.immutable.Vector(world) => world
 
         case _ =>
-          abort(bad(t"a section needs exactly one universe"))
+          abort(bad(t"a section needs exactly one world"))
 
       val fields = children(compound)
 
+      val requires = fields.filter(_.keyword == t"requires").map: requirement =>
+        val subfields = children(requirement)
+
+        Requires
+          ( module  = required(subfields, t"module"),
+            api     = hash(required(subfields, t"api")),
+            version = field(subfields, t"version").let(semver(_)),
+            uses    = field(subfields, t"uses").let(hash(_)) )
+
       Section
-        ( universe    = universe,
+        ( world       = world,
           integration = field(fields, t"integration"),
           tree        = hash(required(fields, t"tree")),
           delete      = List.from(repeated(fields, t"delete").map(TreePath(_))),
-          derivative  = field(fields, t"derivative").let(hash(_)) )
+          derivative  = field(fields, t"derivative").let(hash(_)),
+          requires    = List.from(requires) )
 
     val payload = top.filter(_.keyword == t"payload").toList match
       case scala.List(compound) =>
@@ -310,6 +330,10 @@ case class LiraManifest
   def root: Optional[Section] = if section.stdlib.isEmpty then Unset else section.stdlib.head
 
   def development: Boolean = version.absent
+
+  // A release carrying a `host` section is a host contract (§9.4, hosts.md §4) — recognizable
+  // from its manifest alone, which is what makes L137 checkable at resolution time.
+  def hostContract: Boolean = section.stdlib.exists(_.world == t"host")
 
   // The canonical text of the whole file's manifest part: directive, pragma, one blank line,
   // then the compounds in schema order, LF-terminated. Deterministic; `Lira.read` accepts any
@@ -374,11 +398,21 @@ case class LiraManifest
     delta.let: delta => lines += s"delta ${LiraHash.text(delta)}"
 
     section.stdlib.foreach: section =>
-      lines += s"section ${section.universe}"
+      lines += s"section ${section.world}"
       section.integration.let: id => lines += s"  integration $id"
       lines += s"  tree ${LiraHash.text(section.tree)}"
       section.delete.stdlib.foreach: path => lines += s"  delete ${path.text}"
       section.derivative.let: hash => lines += s"  derivative ${LiraHash.text(hash)}"
+
+      section.requires.stdlib.foreach: requirement =>
+        lines += "  requires"
+        lines += s"    module ${requirement.module}"
+        lines += s"    api ${LiraHash.text(requirement.api)}"
+
+        requirement.version.let: version =>
+          lines += s"    version ${version.major}.${version.minor}.${version.patch}"
+
+        requirement.uses.let: uses => lines += s"    uses ${LiraHash.text(uses)}"
 
     lines += "payload"
     lines += s"  compression ${payload.compression}"

--- a/lib/reliquary/src/core/reliquary.LiraManifest.scala
+++ b/lib/reliquary/src/core/reliquary.LiraManifest.scala
@@ -76,12 +76,18 @@ object LiraManifest:
   // content rather than phrase separators.
   case class Integration(id: Text, rank: Optional[Long] = Unset, label: Optional[Text] = Unset)
 
+  // `serves` names the universe in which the dependency itself offers its content, when that
+  // differs from the universes the depending sections consume it in — the join case (§13.2): a
+  // Scala module whose `sjsir` build invokes a TypeScript module declares `universe sjsir` and
+  // `serves js`, and the two universes meet at a bundler join. A dependency without `serves` is
+  // satisfied in the same universe it applies to.
   case class Dependency
     ( module:      Text,
       api:         Data,
       version:     Optional[Semver] = Unset,
       build:       Optional[Data]   = Unset,
       universe:    List[Text]       = List(),
+      serves:      Optional[Text]   = Unset,
       integration: List[Text]       = List(),
       uses:        Optional[Data]   = Unset,
       spans:       List[Data]       = List() ):
@@ -214,6 +220,7 @@ object LiraManifest:
           version     = field(fields, t"version").let(semver(_)),
           build       = field(fields, t"build").let(hash(_)),
           universe    = List.from(repeated(fields, t"universe")),
+          serves      = field(fields, t"serves"),
           integration = List.from(repeated(fields, t"integration")),
           uses        = field(fields, t"uses").let(hash(_)),
           spans       = List.from(repeated(fields, t"spans").map(hash(_))) )
@@ -388,6 +395,7 @@ case class LiraManifest
 
       dependency.build.let: build => lines += s"  build ${LiraHash.text(build)}"
       dependency.universe.stdlib.foreach: universe => lines += s"  universe $universe"
+      dependency.serves.let: serves => lines += s"  serves $serves"
 
       dependency.integration.stdlib.foreach: integration =>
         lines += s"  integration $integration"

--- a/lib/reliquary/src/core/reliquary.LiraPayload.scala
+++ b/lib/reliquary/src/core/reliquary.LiraPayload.scala
@@ -58,7 +58,7 @@ object LiraPayload:
   def decompress(compressed: Data, length: Long, declaredHash: Data): Data raises LiraError =
     val result =
       try compressed.decompress[Brotli] catch case error: Exception =>
-        abort(LiraError(Reason.InvalidBlobStream(t"the payload does not decompress")))
+        abort(LiraError(Reason.MalformedPayload(t"the payload does not decompress")))
 
     if result.length.toLong != length then abort(LiraError(Reason.PayloadLength(length)))
     if Blob.compare(hash(result), declaredHash) != 0 then abort(LiraError(Reason.PayloadHash))

--- a/lib/reliquary/src/core/reliquary.LiraSchemas.scala
+++ b/lib/reliquary/src/core/reliquary.LiraSchemas.scala
@@ -153,6 +153,7 @@ object LiraSchemas:
         field("version", semver, required = Loose),
         field("build", hash, required = Loose),
         field("universe", identifier, required = Loose, repeatable = Loose),
+        field("serves", identifier, required = Loose),
         field("integration", identifier, required = Loose, repeatable = Loose),
         field("uses", hash, required = Loose),
         field("spans", hash, required = Loose, repeatable = Loose)),
@@ -289,7 +290,7 @@ object LiraSchemas:
   // The BASE-256 schema signatures of the six canonical documents, pinned as golden values (the
   // test suite recomputes each from its `res/test/reliquary/*.tel` mirror and checks agreement).
   // A conforming document of each schema carries its signature on the pragma line.
-  val liraSignature:  Text = t"εȑẀϗЫẃþyşẁЪƥdӯTzĝ8ӝήBϗĺӸḤῩῺṽOκḠôĻ"
+  val liraSignature:  Text = t"εUYțẀñẆơÇMĆẗΎŠľЭЂẉąӮ0ÅðϕῡΔẙȑẀĆӜ1M"
   val treeSignature:  Text = t"ǨẙơẗỵclϋẁЫĥᾸMôĮẍOώżӯάǢЗĆӸkҚțȐωǢέӫ"
   val atomsSignature: Text = t"2ӪççÃ5AḟǑXϋƤzᾱĺHϕЂẌǒEẂẁĮί9ḀẘΊÐιЪp"
   val usesSignature:  Text = t"şşCȧOӖGҐΪḍḋjΊӁῚƟȐЌĥέȦЬƜδĻĘ1Ȑḟ6ӟÔḍ"

--- a/lib/reliquary/src/core/reliquary.LiraSchemas.scala
+++ b/lib/reliquary/src/core/reliquary.LiraSchemas.scala
@@ -38,18 +38,20 @@ import proscenium.compat.*
 import stratiform.*
 import vacuous.*
 
-// Hand-encoded `Tels` values for the `lira` schema and its four metadata-blob schemas, following
+// Hand-encoded `Tels` values for the `lira` schema and its five metadata-blob schemas, following
 // the precedent of `Tels.Axiom`: the Scala literals below are primary, and each mirrors a
 // canonical `.tel` document (at `res/test/reliquary/`) verbatim; the test suite asserts the two
 // stay in agreement and pins each schema's signature as a golden value.
 //
-// The schemas encode the LIRA specification's §14: universes are `jvm | sjsir | nir`; a
-// `Section` is keyed by universe and integration (§9.5) and may carry a `derivative` hash (its
-// canonical derived JAR); a `version` is optional (a release without one is a development
-// release) and strictly numeric; a `Dependency` may be scoped to particular universes or
-// integrations, or pinned to an exact `build` during development; and a `Profile` records the
-// ecosystem predicates a release claims, with the guarantee levels its last step did not
-// preserve (§11.6, §12.4).
+// The schemas encode the LIRA specification's §14: worlds are `jvm | sjsir | nir | host` — the
+// three universes of the motivating ecosystem, and the one world that is not a universe, which
+// holds a host contract's content (hosts.md); a `Section` is keyed by world and integration
+// (§9.5), may carry a `derivative` hash (its canonical derived JAR), and may carry `requires`
+// records naming the host contracts its code assumes; a `version` is optional (a release
+// without one is a development release) and strictly numeric; a `Dependency` may be scoped to
+// particular universes or integrations, or pinned to an exact `build` during development; and a
+// `Profile` records the ecosystem predicates a release claims, with the guarantee levels its
+// last step did not preserve (§11.6, §12.4).
 object LiraSchemas:
   import Tels.{Field, Polarity, RecordDefinition, Reference, ScalarDefinition, SelectDefinition,
       SelectRef, Struct, Type, Variant}
@@ -155,12 +157,19 @@ object LiraSchemas:
         field("uses", hash, required = Loose),
         field("spans", hash, required = Loose, repeatable = Loose)),
 
+      record("Requires",
+        field("module", moduleName),
+        field("api", hash),
+        field("version", semver, required = Loose),
+        field("uses", hash, required = Loose)),
+
       record("Section",
-        selectRef("Universe"),
+        selectRef("World"),
         field("integration", identifier, required = Loose),
         field("tree", hash),
         field("delete", string, required = Loose, repeatable = Loose),
-        field("derivative", hash, required = Loose)),
+        field("derivative", hash, required = Loose),
+        field("requires", Reference(t"Requires"), required = Loose, repeatable = Loose)),
 
       record("Payload",
         field("compression", identifier),
@@ -183,10 +192,11 @@ object LiraSchemas:
       scalar("TreePath", "tree-path"),
       scalar("Guarantee", "guarantee")),
     selects  = Array.of(
-      select("Universe",
+      select("World",
         variant("jvm"),
         variant("sjsir"),
-        variant("nir")),
+        variant("nir"),
+        variant("host")),
 
       select("ResourceMode",
         variant("export"),
@@ -257,11 +267,31 @@ object LiraSchemas:
     scalars  = builtins ++ Array.of(hashScalar),
     selects  = Array.empty[SelectDefinition])
 
-  // The BASE-256 schema signatures of the five canonical documents, pinned as golden values (the
+  // The capability listing of a host contract with no formal carrier (hosts.md §5): the single
+  // tree item at the path `capabilities`, claimed by `capability/1`. Rows are sorted by
+  // ascending name with no duplicates; `probe` is advisory and enters no atom.
+  val capabilities: Tels = Tels(
+    name     = t"lira-capabilities",
+    document = Struct(
+      members    = Array.of(field("capability", Reference(t"Capability"),
+          required = Loose, repeatable = Loose)),
+      validators = Array.empty[Text]),
+    layers   = Array.empty[Tels.Layer],
+    sigil    = Unset,
+    records  = Array.of(
+      record("Capability",
+        field("name", identifier),
+        field("version", string, required = Loose),
+        field("probe", string, required = Loose))),
+    scalars  = builtins,
+    selects  = Array.empty[SelectDefinition])
+
+  // The BASE-256 schema signatures of the six canonical documents, pinned as golden values (the
   // test suite recomputes each from its `res/test/reliquary/*.tel` mirror and checks agreement).
   // A conforming document of each schema carries its signature on the pragma line.
-  val liraSignature:  Text = t"ψñŻṛγeẙðẁƏơǣǿÐẇӂàfơẃẇḢAῘΔӮžSẙӜύYç"
+  val liraSignature:  Text = t"εȑẀϗЫẃþyşẁЪƥdӯTzĝ8ӝήBϗĺӸḤῩῺṽOκḠôĻ"
   val treeSignature:  Text = t"ǨẙơẗỵclϋẁЫĥᾸMôĮẍOώżӯάǢЗĆӸkҚțȐωǢέӫ"
   val atomsSignature: Text = t"2ӪççÃ5AḟǑXϋƤzᾱĺHϕЂẌǒEẂẁĮί9ḀẘΊÐιЪp"
   val usesSignature:  Text = t"şşCȧOӖGҐΪḍḋjΊӁῚƟȐЌĥέȦЬƜδĻĘ1Ȑḟ6ӟÔḍ"
   val deltaSignature: Text = t"gЪΪΞKῺκḢҚdḣulƒjazỲύþῺѝgļEvḞϕϊḟẉtǣ"
+  val capabilitiesSignature: Text = t"ẋƒҢιƟžŀæДNGqЌλ1ḞλſẉûÙῡẂȧώẆlώĘdSỲÔ"

--- a/lib/reliquary/src/core/reliquary.LiraWorld.scala
+++ b/lib/reliquary/src/core/reliquary.LiraWorld.scala
@@ -36,20 +36,28 @@ import anticipation.*
 import gossamer.*
 import vacuous.*
 
-object LiraUniverse:
-  def parse(keyword: Text): Optional[LiraUniverse] = keyword.s match
+object LiraWorld:
+  def parse(keyword: Text): Optional[LiraWorld] = keyword.s match
     case "jvm"   => Jvm
     case "sjsir" => Sjsir
     case "nir"   => Nir
+    case "host"  => Host
     case _       => Unset
 
-// The universes of the base `lira` schema: the library-composition worlds a section's content
-// belongs to. The vocabulary is open (§9.4) — universes beyond these arrive as TEL schema
-// layers, and sections of unknown universes are held opaque and never materialized.
-enum LiraUniverse:
-  case Jvm, Sjsir, Nir
+// The worlds of the base `lira` schema (§9.4): the three universes of the motivating ecosystem —
+// the library-composition worlds a section's content belongs to — and `host`, the one world that
+// is not a universe, holding a host contract's capability content (hosts.md). The universe
+// vocabulary is open — universes beyond these arrive as TEL schema layers, and sections of
+// unknown worlds are held opaque and never materialized.
+enum LiraWorld:
+  case Jvm, Sjsir, Nir, Host
 
   def keyword: Text = this match
     case Jvm   => t"jvm"
     case Sjsir => t"sjsir"
     case Nir   => t"nir"
+    case Host  => t"host"
+
+  // Whether independently-published libraries compose in this world: true of every world except
+  // `host`, whose sections are never materialized onto any artifact path (§13.5).
+  def universe: Boolean = this != Host

--- a/lib/reliquary/src/core/reliquary.Section.scala
+++ b/lib/reliquary/src/core/reliquary.Section.scala
@@ -35,20 +35,22 @@ package reliquary
 import anticipation.*
 import vacuous.*
 
-// One compiled view of a release (§9), keyed by universe and integration: a universe keyword
-// (kept textual so sections of unknown, layered universes survive as opaque data), the
-// integration realized (§9.5; absent where the release declares none, which is the single
-// implicit integration), the tree blob's hash, the overlay-delete list, and the canonical
-// derivative artifact's hash (§13.6).
+// One compiled view of a release (§9), keyed by world and integration: a world keyword (kept
+// textual so sections of unknown, layered universes survive as opaque data), the integration
+// realized (§9.5; absent where the release declares none, which is the single implicit
+// integration), the tree blob's hash, the overlay-delete list, the canonical derivative
+// artifact's hash (§13.6), and the host requirements this section's code assumes of its
+// environment (hosts.md §6).
 case class Section
-  ( universe:    Text,
+  ( world:       Text,
     integration: Optional[Text] = Unset,
     tree:        Data,
     delete:      List[TreePath] = List(),
-    derivative:  Optional[Data] = Unset ):
+    derivative:  Optional[Data] = Unset,
+    requires:    List[LiraManifest.Requires] = List() ):
 
-  def known: Optional[LiraUniverse] = LiraUniverse.parse(universe)
+  def known: Optional[LiraWorld] = LiraWorld.parse(world)
 
   // The key that must be unique within a release (L131), and by which a consumer selects a
   // section once an assignment has chosen an integration (§13.5).
-  def key: (Text, Optional[Text]) = (universe, integration)
+  def key: (Text, Optional[Text]) = (world, integration)

--- a/lib/reliquary/src/core/reliquary.Verification.scala
+++ b/lib/reliquary/src/core/reliquary.Verification.scala
@@ -57,7 +57,7 @@ object Verification:
 
     def tree(universe: Text, integration: Optional[Text]): Optional[LiraTree] =
       materialized.stdlib.find: pair =>
-        pair(0).universe == universe && pair(0).integration.option == integration.option
+        pair(0).world == universe && pair(0).integration.option == integration.option
 
       . map(_(1)).getOrElse(Unset)
 
@@ -90,9 +90,25 @@ object Verification:
 
       if !realized then abort(LiraError(Reason.UnrealizedIntegration(id)))
 
+  // L135 (§9.4, hosts.md §4): a release carrying a `host` section is a host contract, and its
+  // shape is fixed — exactly that one section, no integrations, no dependencies, and no
+  // `requires` records on the section. The exclusions are not arbitrary: an integration is an
+  // alternative dependency vector and a contract has no dependencies to vary, and a contract
+  // requiring a host would make satisfaction recursive. Decidable from the manifest alone.
+  def hostShape(manifest: LiraManifest): Unit raises LiraError =
+    if manifest.hostContract then
+      def bad(detail: Text): Nothing = abort(LiraError(Reason.BadHostContract(detail)))
+      if manifest.section.stdlib.size != 1 then bad(t"it carries more than one section")
+      if !manifest.integration.stdlib.isEmpty then bad(t"it declares integrations")
+      if !manifest.dependency.stdlib.isEmpty then bad(t"it declares dependencies")
+
+      manifest.section.stdlib.foreach: section =>
+        if !section.requires.stdlib.isEmpty then bad(t"its section carries requirements")
+
   def install(lira: Lira): Report raises LiraError =
     val manifest = lira.manifest
     integrations(manifest)
+    hostShape(manifest)
     ResourceDiscipline.check(manifest.resource)
 
     // Steps 1–2: decompress within the declared length, verify the payload hash, and re-derive
@@ -174,7 +190,7 @@ object Verification:
         abort(LiraError(Reason.UnimplementedClaim(id)))
 
     val registry = Discipline.Registry(List.from(resolved), manifest.resource)
-    val universes = manifest.section.stdlib.map(_.universe).toSet
+    val universes = manifest.section.stdlib.map(_.world).toSet
 
     resolved.foreach: discipline =>
       if !universes.exists(discipline.domain.covers)
@@ -200,7 +216,7 @@ object Verification:
 
       val context =
         Discipline.Context
-          (section.universe, section.integration, classpath(section.universe,
+          (section.world, section.integration, classpath(section.world,
               section.integration))
 
       (section, summary(registry.atomize(content, context)))
@@ -212,7 +228,7 @@ object Verification:
 
       computed.drop(1).foreach: (section, other) =>
         if other != root
-        then abort(LiraError(Reason.ApiDivergence(t"${section.universe} differs from the root")))
+        then abort(LiraError(Reason.ApiDivergence(t"${section.world} differs from the root")))
 
   // Step 4's sibling for profiles (§11.6, L128/L130). `install` stays language-blind, exactly as
   // it does for re-atomization and lineage-step grading, and this recovers the per-section
@@ -230,7 +246,7 @@ object Verification:
         (entry.path, report.blobstore.resolve(entry.blob))
 
       EcosystemProfile.Section
-        (section.universe, content, section.integration, classpath(section.universe,
+        (section.world, content, section.integration, classpath(section.world,
             section.integration))
 
     EcosystemProfile.Evidence(List.from(sections), manifest)

--- a/lib/reliquary/src/core/reliquary.Verification.scala
+++ b/lib/reliquary/src/core/reliquary.Verification.scala
@@ -149,6 +149,71 @@ object Verification:
 
     Report(store, atomizations, List.from(materialized), advisories)
 
+  // Step 4 (publish-time): re-atomization of every materialized section under the *declared*
+  // disciplines, in the manifest's `api`-record order — so the claiming order is the declared
+  // one (L134), never an accident of the caller's list. A declared discipline with no
+  // implementation fails the release (L140): an unverifiable claim is worse than an absent one,
+  // because consumers cannot tell the two apart from the manifest. The recomputed atomization
+  // must equal the declared listings on the root section (L141) and be identical across every
+  // other section (L108), and no declared discipline may be inapplicable (L127).
+  def reatomize
+    ( manifest:        LiraManifest,
+      report:          Report,
+      implementations: List[Discipline],
+      classpath:       (Text, Optional[Text]) => List[Text] = { (_, _) => List() } )
+  :   Unit raises LiraError raises DisciplineError =
+
+    val resourceId = ResourceDiscipline(manifest.resource).id
+    val declaredIds = manifest.api.map(_.discipline)
+
+    val languages = declaredIds.stdlib.filter: id =>
+      id != resourceId && id != OpaqueDiscipline.id
+
+    val resolved = languages.map: id =>
+      implementations.stdlib.find(_.id == id).getOrElse:
+        abort(LiraError(Reason.UnimplementedClaim(id)))
+
+    val registry = Discipline.Registry(List.from(resolved), manifest.resource)
+    val universes = manifest.section.stdlib.map(_.universe).toSet
+
+    resolved.foreach: discipline =>
+      if !universes.exists(discipline.domain.covers)
+      then abort(LiraError(Reason.InapplicableDiscipline(discipline.id)))
+
+    def summary(atomizations: List[Atomization])
+    :   scala.collection.immutable.Map
+          [Text, scala.collection.immutable.Set[(Text, AtomClass, Text)]] =
+
+      atomizations.stdlib.map: atomization =>
+        val atoms = atomization.atoms.stdlib.map: atom =>
+          (atom.key, atom.atomClass, LiraHash.text(atom.valueHash))
+
+        atomization.discipline -> atoms.toSet
+
+      . toMap
+
+    val declared = summary(report.atomizations)
+
+    val computed = report.materialized.stdlib.map: (section, tree) =>
+      val content = tree.entries.map: entry =>
+        (entry.path, report.blobstore.resolve(entry.blob))
+
+      val context =
+        Discipline.Context
+          (section.universe, section.integration, classpath(section.universe,
+              section.integration))
+
+      (section, summary(registry.atomize(content, context)))
+
+    computed.headOption.foreach: (_, root) =>
+      (declared.keySet ++ root.keySet).foreach: id =>
+        if declared.getOrElse(id, Set()) != root.getOrElse(id, Set())
+        then abort(LiraError(Reason.AtomsMismatch(id)))
+
+      computed.drop(1).foreach: (section, other) =>
+        if other != root
+        then abort(LiraError(Reason.ApiDivergence(t"${section.universe} differs from the root")))
+
   // Step 4's sibling for profiles (§11.6, L128/L130). `install` stays language-blind, exactly as
   // it does for re-atomization and lineage-step grading, and this recovers the per-section
   // content a profile's predicates read — which the report holds only as tree entries and blob

--- a/lib/reliquary/src/derive/reliquary.Derivative.scala
+++ b/lib/reliquary/src/derive/reliquary.Derivative.scala
@@ -91,6 +91,6 @@ object Derivative:
   def verify(manifest: LiraManifest, report: Verification.Report): Unit raises LiraError =
     manifest.section.stdlib.foreach: section =>
       section.derivative.let: declared =>
-        report.tree(section.universe, section.integration).let: tree =>
+        report.tree(section.world, section.integration).let: tree =>
           if Blob.compare(hash(tree, report.blobstore), declared) != 0
-          then abort(LiraError(Reason.BadDerivative(section.universe)))
+          then abort(LiraError(Reason.BadDerivative(section.world)))

--- a/lib/reliquary/src/derive/reliquary.Derivative.scala
+++ b/lib/reliquary/src/derive/reliquary.Derivative.scala
@@ -38,6 +38,7 @@ import distillate.*
 import fulminate.*
 import gossamer.*
 import prepositional.*
+import rudiments.*
 import serpentine.*
 import turbulence.*
 import vacuous.*
@@ -83,3 +84,13 @@ object Derivative:
 
   def hash(tree: LiraTree, store: Blobstore): Data raises LiraError =
     LiraHash(LiraHash.Domain.Derivative, jar(tree, store))
+
+  // §16 step 3 (L138): every declared derivative hash must recompute from the section's
+  // materialized tree. Sections of unknown universes are never materialized (§9.4), so a
+  // declared derivative there stays unchecked here, exactly as the rest of the section does.
+  def verify(manifest: LiraManifest, report: Verification.Report): Unit raises LiraError =
+    manifest.section.stdlib.foreach: section =>
+      section.derivative.let: declared =>
+        report.tree(section.universe, section.integration).let: tree =>
+          if Blob.compare(hash(tree, report.blobstore), declared) != 0
+          then abort(LiraError(Reason.BadDerivative(section.universe)))

--- a/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
+++ b/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
@@ -49,12 +49,15 @@ import errorDiagnostics.emptyDiagnostics
 // assembles the complete `.lira` file. Everything here is deterministic for fixed inputs.
 object LiraAssembler:
 
-  // One cell of the (universe × integration) matrix (§9.5). `integration` is absent where the
-  // release declares none, which is its single implicit integration.
+  // One cell of the (world × integration) matrix (§9.5). `integration` is absent where the
+  // release declares none, which is its single implicit integration. `requires` names the host
+  // contracts this section's code assumes (hosts.md §6) — authorial, so it arrives as input
+  // rather than being computed.
   case class SectionInput
-    ( universe:    Text,
+    ( world:       Text,
       content:     List[(TreePath, Data)],
-      integration: Optional[Text] = Unset )
+      integration: Optional[Text] = Unset,
+      requires:    List[LiraManifest.Requires] = List() )
 
   def assemble
     ( module:      Text,
@@ -96,8 +99,8 @@ object LiraAssembler:
     val registry = Discipline.Registry(disciplines.declared, resource)
 
     val atomized = inputs.map: input =>
-      val context = Discipline.Context(input.universe, input.integration, classpath(input))
-      (input.universe, registry.atomize(input.content, context))
+      val context = Discipline.Context(input.world, input.integration, classpath(input))
+      (input.world, registry.atomize(input.content, context))
 
     // The same per-section view a discipline is given, for the profile predicates below. Built
     // here so that a profile checking structural invariants over a universe's content (§11.6,
@@ -105,7 +108,7 @@ object LiraAssembler:
     val profileSections = List.from:
       inputs.map: input =>
         EcosystemProfile.Section
-          (input.universe, input.content, input.integration, classpath(input))
+          (input.world, input.content, input.integration, classpath(input))
 
     // L125: an `export` or `track` declaration must be effective — a declared path that resolves
     // to no item in any section, or that some other discipline claims, is an assembly-time
@@ -132,7 +135,7 @@ object LiraAssembler:
     // atomization of nothing is not a claim about anything. The rule quantifies over the
     // *declared* disciplines: `resource/1` and `opaque/1` are the registry's own and universal,
     // so the question never arises for them.
-    val universes = inputs.map(_.universe).toSet
+    val universes = inputs.map(_.world).toSet
 
     registry.declared.stdlib.foreach: discipline =>
       if !universes.exists(discipline.domain.covers)
@@ -181,11 +184,12 @@ object LiraAssembler:
 
       val section =
         Section
-          ( universe    = input.universe,
+          ( world       = input.world,
             integration = input.integration,
             tree        = LiraHash(LiraHash.Domain.Blob, tree.encode),
             delete      = delete,
-            derivative  = Derivative.hash(target, store) )
+            derivative  = Derivative.hash(target, store),
+            requires    = input.requires )
 
       (section, tree.encode)
 
@@ -211,9 +215,10 @@ object LiraAssembler:
           payload     = LiraManifest.Payload(t"brotli", 0L, LiraHash(LiraHash.Domain.Blob,
               Array.freeze(Array[Byte](0)))) )
 
-    // The producer never emits a file a consumer would reject: L131/L133 are decidable from the
-    // manifest, so they are checked here rather than discovered at install time.
+    // The producer never emits a file a consumer would reject: L131/L133/L135 are decidable
+    // from the manifest, so they are checked here rather than discovered at install time.
     Verification.integrations(manifest)
+    Verification.hostShape(manifest)
 
     // L140: the assembler is about to sign every declared profile as a checked claim, so a
     // declared profile it cannot check is refused outright — an unverifiable claim is worse

--- a/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
+++ b/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
@@ -72,6 +72,7 @@ object LiraAssembler:
       profiles:    EcosystemProfile.Registry      = EcosystemProfile.Registry(List()),
       predecessor: Optional[EcosystemProfile.Evidence] = Unset,
       classpath:   SectionInput => List[Text]     = { _ => List() },
+      report:      Text => Unit                   = { _ => () },
       sign:        LiraManifest => LiraManifest  = identity(_) )
   :   Data raises LiraError raises DisciplineError =
 
@@ -128,10 +129,12 @@ object LiraAssembler:
       then abort(LiraError(Reason.IneffectiveResource(path.text)))
 
     // L127: a declared discipline must atomize some universe this release carries. An
-    // atomization of nothing is not a claim about anything.
+    // atomization of nothing is not a claim about anything. The rule quantifies over the
+    // *declared* disciplines: `resource/1` and `opaque/1` are the registry's own and universal,
+    // so the question never arises for them.
     val universes = inputs.map(_.universe).toSet
 
-    registry.all.stdlib.foreach: discipline =>
+    registry.declared.stdlib.foreach: discipline =>
       if !universes.exists(discipline.domain.covers)
       then abort(LiraError(Reason.InapplicableDiscipline(discipline.id)))
 
@@ -212,6 +215,14 @@ object LiraAssembler:
     // manifest, so they are checked here rather than discovered at install time.
     Verification.integrations(manifest)
 
+    // L140: the assembler is about to sign every declared profile as a checked claim, so a
+    // declared profile it cannot check is refused outright — an unverifiable claim is worse
+    // than an absent one (§16). This holds with or without a predecessor: implementability is
+    // not a property of the step.
+    profile.stdlib.foreach: record =>
+      if profiles(record.id).absent
+      then abort(LiraError(Reason.UnimplementedClaim(record.id)))
+
     // L128/L130. Profile predicates are diachronic, so they can only run where the caller has the
     // predecessor's content in hand; with no predecessor there is no step to check, which is the
     // ordinary case for the first release of a lineage. The audit runs against the assembled
@@ -219,7 +230,8 @@ object LiraAssembler:
     // runs before signing, so nothing unverified is ever signed.
     predecessor.let: previous =>
       val evidence = EcosystemProfile.Evidence(profileSections, manifest)
-      EcosystemProfile.audit(profiles, profile, previous, evidence)
+      val audit = EcosystemProfile.audit(profiles, profile, previous, evidence)
+      audit.advisories.stdlib.foreach(report(_))
 
     val blobs = contentBlobs ++ builtSections.map(_(1)) ++ atomsBlobs ++ deltaBlob.option.toList
 

--- a/lib/reliquary/src/derive/reliquary.Materializer.scala
+++ b/lib/reliquary/src/derive/reliquary.Materializer.scala
@@ -64,9 +64,15 @@ object Materializer:
     if universe == t"host"
     then abort(LiraError(Reason.BadHostContract(t"the host world derives no artifacts")))
 
-    val (assignment, _) = Buildpath(liras.map(_.manifest)).resolved(universe)
+    val path = Buildpath(liras.map(_.manifest))
+    val (assignment, _) = path.resolved(universe)
 
-    val jars = liras.stdlib.map: lira =>
+    // §13.5: one artifact set *per universe of the target*. A release serving a joined universe
+    // (named by a `serves` record, §13.2) belongs to that universe's derivation, not this one.
+    val serving = liras.stdlib.filter: lira =>
+      path.serving(universe, lira.manifest.module) == universe
+
+    val jars = serving.map: lira =>
       val identity = lira.manifest.payload.hash.serialize[Hex]
       val integration = assignment(lira.manifest.module)
 

--- a/lib/reliquary/src/derive/reliquary.Materializer.scala
+++ b/lib/reliquary/src/derive/reliquary.Materializer.scala
@@ -59,6 +59,11 @@ object Materializer:
   def classpath(liras: List[Lira], universe: Text, cache: Path on Linux)
   :   LocalClasspath raises LiraError raises IoError raises StreamError =
 
+    // `host` sections are never materialized onto any artifact path (§13.5): a host contract's
+    // content describes the environment and joins nothing.
+    if universe == t"host"
+    then abort(LiraError(Reason.BadHostContract(t"the host world derives no artifacts")))
+
     val (assignment, _) = Buildpath(liras.map(_.manifest)).resolved(universe)
 
     val jars = liras.stdlib.map: lira =>

--- a/lib/reliquary/src/derive/reliquary.Materializer.scala
+++ b/lib/reliquary/src/derive/reliquary.Materializer.scala
@@ -79,8 +79,11 @@ object Materializer:
         val tree = report.tree(universe, integration) match
           case tree: LiraTree => tree
 
+          // §13.5 calls this a validation-time error, and it is closure's kind (L113): a
+          // release with no section serving the target universe fails the buildpath exactly as
+          // an absent module does. The manifest itself is not at fault.
           case _ =>
-            abort(LiraError(Reason.InvalidManifest(t"the release has no $universe section")))
+            abort(LiraError(Reason.AbsentDependency(lira.manifest.module)))
 
         val data = Derivative.jar(tree, report.blobstore)
 

--- a/lib/reliquary/src/test/reliquary_test.scala
+++ b/lib/reliquary/src/test/reliquary_test.scala
@@ -109,11 +109,12 @@ object Tests extends Suite(m"Reliquary Tests"):
 
 
     val schemas = List(
-      (t"lira",       LiraSchemas.lira,  LiraSchemas.liraSignature),
-      (t"lira-tree",  LiraSchemas.tree,  LiraSchemas.treeSignature),
-      (t"lira-atoms", LiraSchemas.atoms, LiraSchemas.atomsSignature),
-      (t"lira-uses",  LiraSchemas.uses,  LiraSchemas.usesSignature),
-      (t"lira-delta", LiraSchemas.delta, LiraSchemas.deltaSignature))
+      (t"lira",              LiraSchemas.lira,         LiraSchemas.liraSignature),
+      (t"lira-tree",         LiraSchemas.tree,         LiraSchemas.treeSignature),
+      (t"lira-atoms",        LiraSchemas.atoms,        LiraSchemas.atomsSignature),
+      (t"lira-uses",         LiraSchemas.uses,         LiraSchemas.usesSignature),
+      (t"lira-delta",        LiraSchemas.delta,        LiraSchemas.deltaSignature),
+      (t"lira-capabilities", LiraSchemas.capabilities, LiraSchemas.capabilitiesSignature))
 
     suite(m"Schema documents"):
       for (name, tels, signature) <- schemas do
@@ -721,7 +722,7 @@ object Tests extends Suite(m"Reliquary Tests"):
     suite(m"Container and verification"):
       test(m"an assembled lira reads back and verifies"):
         val report = Verification.install(Lira.read(makeLira()))
-        report.materialized.stdlib.map { pair => pair(0).universe }
+        report.materialized.stdlib.map { pair => pair(0).world }
       . assert(_ == scala.List(t"jvm", t"sjsir"))
 
       test(m"resource/1 atomizes exports by name and tracks content"):
@@ -978,7 +979,7 @@ object Tests extends Suite(m"Reliquary Tests"):
 
       test(m"the sjsir overlay materializes without the deleted classfile"):
         val report = Verification.install(Lira.read(makeLira()))
-        val sjsir = report.materialized.stdlib.find { pair => pair(0).universe == t"sjsir" }
+        val sjsir = report.materialized.stdlib.find { pair => pair(0).world == t"sjsir" }
 
         sjsir.map { pair => pair(1).entries.map(_.path.text).stdlib }
       . assert(_ == scala.Some(scala.List(t"a/A.sjsir", t"a/A.tasty")))
@@ -1733,7 +1734,7 @@ object Tests extends Suite(m"Reliquary Tests"):
         val evidence = Verification.evidence(lira.manifest, report)
 
         evidence.sections.stdlib.map: section =>
-          (section.universe, section.content.stdlib.map(_(0).text))
+          (section.world, section.content.stdlib.map(_(0).text))
 
       . assert(_ == scala.List(
           (t"jvm", scala.List(t"a/A.class", t"a/A.special")),
@@ -1743,7 +1744,7 @@ object Tests extends Suite(m"Reliquary Tests"):
         val scoped = new Discipline:
           def id: Text = t"scoped/1"
           def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".class")
-          def domain: Discipline.Domain = Discipline.Domain.Universes(Set(t"jvm"))
+          def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"jvm"))
           def keying: Discipline.Keying = Discipline.Keying.Membership
 
           def guarantees(universe: Text): Set[Discipline.Guarantee] =
@@ -1765,3 +1766,258 @@ object Tests extends Suite(m"Reliquary Tests"):
 
         (jvm.stdlib.map(_.discipline), sjsir.stdlib.map(_.discipline))
       . assert(_ == (scala.List(t"scoped/1"), scala.List(t"opaque/1")))
+
+    suite(m"Host contracts and requirements"):
+      def capabilities(rows: Text): Data =
+        encode(t"tel 1.0 ${LiraSchemas.capabilitiesSignature}\n\n$rows")
+
+      val hostContext = Discipline.Context(t"host")
+      val gitOnly = capabilities(t"capability\n  name git\n")
+
+      def atomsOf(data: Data): List[Atom] =
+        CapabilityDiscipline.atomize(List((TreePath(t"capabilities"), data)), hostContext).atoms
+
+      def hashesOf(data: Data): scala.List[Text] =
+        atomsOf(data).stdlib.map { atom => LiraHash.text(atom.valueHash) }
+
+      test(m"a capability listing atomizes to one rigid atom per row"):
+        val listing = capabilities(t"capability\n  name git\ncapability\n  name sh\n")
+
+        atomsOf(listing).stdlib.map { atom => (atom.key, atom.atomClass) }.toSet
+      . assert(_ == scala.collection.immutable.Set
+          ((t"git", AtomClass.Rigid), (t"sh", AtomClass.Rigid)))
+
+      test(m"a probe is advisory and enters no atom"):
+        hashesOf(capabilities(t"capability\n  name git\n  probe  command -v git\n"))
+        == hashesOf(gitOnly)
+      . assert(identity)
+
+      test(m"a version predicate folds into the atom's value"):
+        hashesOf(capabilities(t"capability\n  name git\n  version  >= 2.30\n"))
+        != hashesOf(gitOnly)
+      . assert(identity)
+
+      test(m"unsorted capability rows are rejected"):
+        val listing = capabilities(t"capability\n  name sh\ncapability\n  name git\n")
+
+        capture[DisciplineError](atomsOf(listing)).reason match
+          case DisciplineError.Reason.Malformed(_) => true
+          case _                                   => false
+      . assert(identity)
+
+      test(m"a duplicated capability is rejected"):
+        val listing = capabilities(t"capability\n  name git\ncapability\n  name git\n")
+
+        capture[DisciplineError](atomsOf(listing)).reason match
+          case DisciplineError.Reason.Malformed(_) => true
+          case _                                   => false
+      . assert(identity)
+
+      test(m"a host contract assembles, reads and verifies"):
+        val bytes = LiraAssembler.assemble(t"posix",
+          List(LiraAssembler.SectionInput(t"host",
+            List((TreePath(t"capabilities"), gitOnly)))),
+          Discipline.Registry(List(CapabilityDiscipline)),
+          toolchain = List(LiraManifest.Tool(t"lira", t"0.1")))
+
+        val lira = Lira.read(bytes)
+        Verification.install(lira)
+        (lira.manifest.hostContract, lira.manifest.section.stdlib.map(_.world))
+      . assert(_ == (true, scala.List(t"host")))
+
+      // L135's four exclusions, each on a hand-built manifest, since the assembler itself
+      // refuses to produce one.
+      def handBuilt
+        ( integrations:  List[LiraManifest.Integration] = List(),
+          integrationId: Optional[Text]                 = Unset,
+          dependencies:  List[LiraManifest.Dependency]  = List(),
+          requires:      List[LiraManifest.Requires]    = List(),
+          extraSection:  Boolean                        = false )
+      :   Data =
+
+        val tree = LiraTree.of(List(TreeEntry(TreePath(t"capabilities"), blob(gitOnly))))
+
+        val atomization =
+          CapabilityDiscipline.atomize(List((TreePath(t"capabilities"), gitOnly)), hostContext)
+
+        val atomsData = AtomsBlob.encode(atomization)
+        val snapshot = Snapshot(List(atomization))
+        val jvmTree = LiraTree.of(List(TreeEntry(TreePath(t"a/A.class"), blob(classA))))
+
+        val sections =
+          val host = Section(t"host", integrationId, blob(tree.encode), requires = requires)
+
+          if extraSection
+          then List(host, Section(t"jvm", integrationId, blob(jvmTree.encode)))
+          else List(host)
+
+        val manifest = LiraManifest(
+          module      = t"posix",
+          version     = revolution.Semver(0, 1, 0),
+          lineage     = List(snapshot),
+          toolchain   = List(LiraManifest.Tool(t"lira", t"0.1")),
+          api         = List(LiraManifest.Api(t"capability/1", blob(atomsData))),
+          integration = integrations,
+          dependency  = dependencies,
+          section     = sections,
+          payload     = LiraManifest.Payload(t"brotli", 0L, blob(encode(t""))))
+
+        Lira.assemble(manifest,
+          List(gitOnly, tree.encode, atomsData, classA, jvmTree.encode))
+
+      def shapeFailure(bytes: Data): Boolean =
+        capture[LiraError](Verification.install(Lira.read(bytes))).reason match
+          case LiraError.Reason.BadHostContract(_) => true
+          case _                                   => false
+
+      test(m"a host contract with a second section is L135"):
+        shapeFailure(handBuilt(extraSection = true))
+      . assert(identity)
+
+      test(m"a host contract declaring an integration is L135"):
+        shapeFailure(handBuilt(
+          integrations = List(LiraManifest.Integration(t"alt")), integrationId = t"alt"))
+      . assert(identity)
+
+      test(m"a host contract declaring a dependency is L135"):
+        shapeFailure(handBuilt(dependencies =
+          List(LiraManifest.Dependency(t"other", blob(encode(t"snap"))))))
+      . assert(identity)
+
+      test(m"a host contract carrying requirements is L135"):
+        shapeFailure(handBuilt(requires =
+          List(LiraManifest.Requires(t"other", blob(encode(t"snap"))))))
+      . assert(identity)
+
+      test(m"section requirements round-trip through the manifest"):
+        val requirement =
+          LiraManifest.Requires(t"posix", blob(encode(t"snap")), uses = blob(encode(t"uses")))
+
+        val bytes = LiraAssembler.assemble(t"consumer",
+          List(LiraAssembler.SectionInput(t"jvm",
+            List((TreePath(t"a/A.class"), classA)), requires = List(requirement))),
+          Discipline.Registry(List()),
+          toolchain = List(LiraManifest.Tool(t"scala", t"3.9.0")))
+
+        val back = Lira.read(bytes).manifest.section.stdlib.head.requires.stdlib
+
+        back.map: entry =>
+          (entry.module, LiraHash.text(entry.api), entry.uses.let(LiraHash.text(_)))
+      . assert(_ == scala.List(
+          (t"posix", LiraHash.text(blob(encode(t"snap"))),
+           Optional(LiraHash.text(blob(encode(t"uses")))))))
+
+      // Rule 7 (§13.3, hosts.md §7), over stub manifests: satisfaction is manifest-decidable,
+      // spanning arrives through the caller-supplied lookups.
+      val snapA = LiraHash(LiraHash.Domain.Snapshot, encode(t"contract-a"))
+      val snapB = LiraHash(LiraHash.Domain.Snapshot, encode(t"contract-b"))
+      val usesHash = blob(encode(t"uses-blob"))
+
+      def payloadStub(module: Text): LiraManifest.Payload =
+        LiraManifest.Payload(t"brotli", 0L, LiraHash(LiraHash.Domain.Blob, encode(module)))
+
+      def library(requires: List[LiraManifest.Requires], module: Text = t"consumer")
+      :   LiraManifest =
+        LiraManifest(
+          module  = module,
+          lineage = List(snapB),
+          api     = List(),
+          section = List(Section(t"jvm", tree = blob(encode(t"tree")), requires = requires)),
+          payload = payloadStub(module))
+
+      def contractStub(module: Text, lineage: List[Data]): LiraManifest =
+        LiraManifest(
+          module  = module,
+          lineage = lineage,
+          api     = List(),
+          section = List(Section(t"host", tree = blob(encode(t"host-tree")))),
+          payload = payloadStub(module))
+
+      test(m"a requirement satisfied by the contract's lineage passes rule 7"):
+        val lib = library(List(LiraManifest.Requires(t"posix", snapA)))
+        val contract = contractStub(t"posix", List(snapA))
+        Buildpath(List(lib)).validate(t"jvm", contracts = List(contract)).stdlib.size
+      . assert(_ == 0)
+
+      test(m"an unsatisfiable requirement is L136"):
+        val lib = library(List(LiraManifest.Requires(t"posix", snapA)))
+        val contract = contractStub(t"posix", List(snapB))
+
+        capture[LiraError]:
+          Buildpath(List(lib)).validate(t"jvm", contracts = List(contract))
+        . reason
+      . assert(_ == LiraError.Reason.UnsatisfiedRequirement(t"posix"))
+
+      test(m"validation without a contract reports rule 7 as pending"):
+        val lib = library(List(LiraManifest.Requires(t"posix", snapA)))
+
+        Buildpath(List(lib)).validate(t"jvm").stdlib.exists: advisory =>
+          advisory match
+            case LiraAdvisory.HostPending(modules) => modules.stdlib == scala.List(t"posix")
+            case _                                 => false
+      . assert(identity)
+
+      test(m"a requirement naming a library module is L137"):
+        val lib = library(List(LiraManifest.Requires(t"other", snapA)))
+        val other = library(List(), module = t"other")
+        val contract = contractStub(t"posix", List(snapA))
+
+        capture[LiraError]:
+          Buildpath(List(lib, other)).validate(t"jvm", contracts = List(contract))
+        . reason
+      . assert(_ == LiraError.Reason.NotHostContract(t"other"))
+
+      test(m"a non-contract given as a contract is L137"):
+        val lib = library(List(LiraManifest.Requires(t"posix", snapA)))
+        val fake = library(List(), module = t"posix")
+
+        capture[LiraError]:
+          Buildpath(List(lib)).validate(t"jvm", contracts = List(fake))
+        . reason
+      . assert(_ == LiraError.Reason.NotHostContract(t"posix"))
+
+      test(m"cross-contract spanning satisfies a requirement"):
+        // The requirement names `posix`, whose snapshot no given contract carries; the used-set
+        // is contained in a *different* module's atom set, which hosts.md §7 accepts because
+        // atoms are content-addressed and module-blind.
+        val lib = library(List(LiraManifest.Requires(t"posix", snapA, uses = usesHash)))
+        val javalib = contractStub(t"scalajs-javalib", List(snapB))
+
+        val atoms = { (module: Text) =>
+          if module == t"scalajs-javalib"
+          then scala.collection.immutable.Set(t"h1", t"h2")
+          else Unset
+        }
+
+        val used = { (data: Data) =>
+          if Blob.compare(data, usesHash) == 0
+          then scala.collection.immutable.Set(t"h1")
+          else Unset
+        }
+
+        Buildpath(List(lib))
+        . validate(t"jvm", contracts = List(javalib), atoms = atoms, used = used)
+        . stdlib.size
+      . assert(_ == 0)
+
+      test(m"spanning fails where the used-set is not contained"):
+        val lib = library(List(LiraManifest.Requires(t"posix", snapA, uses = usesHash)))
+        val javalib = contractStub(t"scalajs-javalib", List(snapB))
+
+        val atoms = { (module: Text) =>
+          if module == t"scalajs-javalib"
+          then scala.collection.immutable.Set(t"h2")
+          else Unset
+        }
+
+        val used = { (data: Data) =>
+          if Blob.compare(data, usesHash) == 0
+          then scala.collection.immutable.Set(t"h1")
+          else Unset
+        }
+
+        capture[LiraError]:
+          Buildpath(List(lib))
+          . validate(t"jvm", contracts = List(javalib), atoms = atoms, used = used)
+        . reason
+      . assert(_ == LiraError.Reason.UnsatisfiedRequirement(t"posix"))

--- a/lib/reliquary/src/test/reliquary_test.scala
+++ b/lib/reliquary/src/test/reliquary_test.scala
@@ -1159,16 +1159,20 @@ object Tests extends Suite(m"Reliquary Tests"):
           deps:         List[LiraManifest.Dependency]  = List(),
           version:      Optional[Semver]               = Unset,
           section:      List[Section]                  = List(),
-          integrations: List[LiraManifest.Integration] = List() )
+          integrations: List[LiraManifest.Integration] = List(),
+          profiles:     List[LiraManifest.Profile]     = List(),
+          toolchain:    List[LiraManifest.Tool]        = List() )
       :   LiraManifest =
 
         LiraManifest
           ( module      = module,
             version     = version,
             lineage     = lineage,
+            toolchain   = toolchain,
             owns        = owns,
             resource    = resources,
             api         = List(),
+            profile     = profiles,
             integration = integrations,
             dependency  = deps,
             section     = section,
@@ -1553,6 +1557,141 @@ object Tests extends Suite(m"Reliquary Tests"):
         (UsesBlob.staleness(List(old), List(Replacement(old, neo))),
          UsesBlob.staleness(List(neo), List(Replacement(old, neo))))
       . assert(_ == (true, false))
+
+    suite(m"Joins, pins and coherence"):
+      def payloadStub(module: Text): LiraManifest.Payload =
+        LiraManifest.Payload(t"brotli", 0L, LiraHash(LiraHash.Domain.Blob, encode(module)))
+
+      def stub
+        ( module:    Text,
+          lineage:   List[Data],
+          deps:      List[LiraManifest.Dependency] = List(),
+          section:   List[Section]                 = List(),
+          profiles:  List[LiraManifest.Profile]    = List(),
+          toolchain: List[LiraManifest.Tool]       = List() )
+      :   LiraManifest =
+
+        LiraManifest
+          ( module     = module,
+            lineage    = lineage,
+            toolchain  = toolchain,
+            api        = List(),
+            profile    = profiles,
+            dependency = deps,
+            section    = section,
+            payload    = payloadStub(module) )
+
+      val snapOne = LiraHash(LiraHash.Domain.Snapshot, encode(t"join-one"))
+      val snapTwo = LiraHash(LiraHash.Domain.Snapshot, encode(t"join-two"))
+      val jsSection = Section(t"js", tree = blob(encode(t"js-tree")))
+
+      def needy(): LiraManifest =
+        stub(t"alpha", List(snapOne),
+          deps = List(LiraManifest.Dependency(t"webstuff", snapTwo, serves = t"js")))
+
+      test(m"a serves dependency round-trips through the manifest"):
+        val bytes = LiraAssembler.assemble(t"consumer",
+          List(LiraAssembler.SectionInput(t"jvm", List((TreePath(t"a/A.class"), classA)))),
+          Discipline.Registry(List()),
+          toolchain = List(LiraManifest.Tool(t"scala", t"3.9.0")),
+          dependency = List(LiraManifest.Dependency(t"native-bits", snapTwo,
+            universe = List(t"jvm"), serves = t"nir")))
+
+        Lira.read(bytes).manifest.dependency.stdlib.map: dependency =>
+          (dependency.module, dependency.serves, dependency.universe.stdlib)
+      . assert(_ == scala.List((t"native-bits", Optional(t"nir"), scala.List(t"jvm"))))
+
+      test(m"a join edge to a universe outside the target fails closure"):
+        val web = stub(t"webstuff", List(snapTwo), section = List(jsSection))
+
+        capture[LiraError](Buildpath(List(needy(), web)).validate(t"jvm")).reason
+      . assert(_ == LiraError.Reason.AbsentDependency(t"webstuff"))
+
+      test(m"a join edge into the target's joins passes closure"):
+        val web = stub(t"webstuff", List(snapTwo), section = List(jsSection))
+        Buildpath(List(needy(), web)).validate(t"jvm", joins = List(t"js")).stdlib.size
+      . assert(_ == 0)
+
+      test(m"a join edge to content the candidate does not offer fails closure"):
+        val web = stub(t"webstuff", List(snapTwo),
+          section = List(Section(t"jvm", tree = blob(encode(t"t")))))
+
+        capture[LiraError]:
+          Buildpath(List(needy(), web)).validate(t"jvm", joins = List(t"js"))
+        . reason
+      . assert(_ == LiraError.Reason.AbsentDependency(t"webstuff"))
+
+      test(m"a serving release resolves its own dependencies in its universe"):
+        // `webstuff` serves `js`, and its own dependency is scoped to `js` — so the target
+        // being `jvm` does not exempt it: applicability quantifies over the universe a release
+        // serves (§13.3), and the absent `polyfill` fails closure.
+        val web = stub(t"webstuff", List(snapTwo), section = List(jsSection),
+          deps = List(LiraManifest.Dependency(t"polyfill", snapOne, universe = List(t"js"))))
+
+        capture[LiraError]:
+          Buildpath(List(needy(), web)).validate(t"jvm", joins = List(t"js"))
+        . reason
+      . assert(_ == LiraError.Reason.AbsentDependency(t"polyfill"))
+
+      test(m"a pin selects a declared integration over the canonical one"):
+        val alpha = LiraManifest(
+          module      = t"alpha",
+          lineage     = List(snapOne),
+          api         = List(),
+          integration = List(
+            LiraManifest.Integration(t"slow", rank = 7L),
+            LiraManifest.Integration(t"fast", rank = 2L)),
+          section     = List(),
+          payload     = payloadStub(t"alpha"))
+
+        Buildpath(List(alpha)).resolved(t"jvm", pins = List((t"alpha", t"slow")))(0)(t"alpha")
+      . assert(_ == t"slow")
+
+      test(m"a pin naming an undeclared integration is refused"):
+        val alpha = stub(t"alpha", List(snapOne))
+
+        capture[LiraError]:
+          Buildpath(List(alpha)).resolved(t"jvm", pins = List((t"alpha", t"missing")))
+        . reason match
+            case LiraError.Reason.BadIntegration(_) => true
+            case _                                  => false
+      . assert(identity)
+
+      test(m"rule 6 imposes a declared profile's coherence over the whole path"):
+        object Strict extends EcosystemProfile:
+          def id: Text = t"strict/1"
+          def certifies: Set[Discipline.Guarantee] = Set(Discipline.Guarantee.Linkage)
+
+          def check(previous: EcosystemProfile.Evidence, next: EcosystemProfile.Evidence)
+          :   List[EcosystemProfile.Violation] raises DisciplineError =
+            List()
+
+          override def coherence(releases: List[LiraManifest]): List[Text] =
+            List.from:
+              releases.stdlib.filter(_.toolchain.stdlib.isEmpty).map: manifest =>
+                t"${manifest.module} records no toolchain"
+
+        val registry = EcosystemProfile.Registry(List(Strict))
+        val scala39 = List(LiraManifest.Tool(t"scala", t"3.9.0"))
+
+        val declarer = stub(t"alpha", List(snapOne),
+          profiles = List(LiraManifest.Profile(t"strict/1")), toolchain = scala39)
+
+        val bare = stub(t"beta", List(snapTwo))
+        val tooled = stub(t"beta", List(snapTwo), toolchain = scala39)
+
+        val failing =
+          capture[LiraError]:
+            Buildpath(List(declarer, bare)).validate(t"jvm", profiles = registry)
+          . reason match
+              case LiraError.Reason.ProfileViolated(t"strict/1", _) => true
+              case _                                                => false
+
+        val passing =
+          Buildpath(List(declarer, tooled)).validate(t"jvm", profiles = registry).stdlib.size
+
+        (failing, passing)
+      . assert(_ == (true, 0))
 
     suite(m"Derivative artifacts"):
       import distillate.*

--- a/lib/reliquary/src/test/reliquary_test.scala
+++ b/lib/reliquary/src/test/reliquary_test.scala
@@ -290,14 +290,14 @@ object Tests extends Suite(m"Reliquary Tests"):
           case _                                     => false
       . assert(identity)
 
-      test(m"a truncated stream is rejected"):
+      test(m"a truncated stream is a malformed payload, not an L103 violation"):
         val stream = BlobStream.write(List(blobA, blobB))
         val short = Array[Byte](stream.length - 1)
         System.arraycopy(Array.unsafeJvm(stream), 0, short.raw, 0, stream.length - 1)
 
         capture[LiraError](BlobStream.read(Array.freeze(short))).reason match
-          case LiraError.Reason.InvalidBlobStream(_) => true
-          case _                                     => false
+          case LiraError.Reason.MalformedPayload(_) => true
+          case _                                    => false
       . assert(identity)
 
       test(m"resolving an absent hash is an L104 error"):
@@ -1051,10 +1051,10 @@ object Tests extends Suite(m"Reliquary Tests"):
         data(data.length - 1) = (data(data.length - 1) ^ 0x55).toByte
 
         capture[LiraError](Verification.install(Lira.read(Array.unsafeFrozen(data)))).reason match
-          case LiraError.Reason.InvalidBlobStream(_) => true
-          case LiraError.Reason.PayloadHash          => true
-          case LiraError.Reason.PayloadLength(_)     => true
-          case _                                     => false
+          case LiraError.Reason.MalformedPayload(_) => true
+          case LiraError.Reason.PayloadHash         => true
+          case LiraError.Reason.PayloadLength(_)    => true
+          case _                                    => false
       . assert(identity)
 
     suite(m"Manifest signing"):
@@ -1604,13 +1604,164 @@ object Tests extends Suite(m"Reliquary Tests"):
         (first.entries.stdlib.size, first.entries.stdlib == second.entries.stdlib)
       . assert(_ == (1, true))
 
-      test(m"materialization refuses a universe with no section"):
+      test(m"materialization refuses a universe with no section as a closure failure"):
         val cache = unsafely:
           t"/tmp/reliquary-test-${java.lang.System.nanoTime}".as[Path on Linux]
 
         val lira = Lira.read(makeLira())
 
-        capture[LiraError](Materializer.classpath(List(lira), t"nir", cache)).reason match
-          case LiraError.Reason.InvalidManifest(_) => true
-          case _                                   => false
+        capture[LiraError](Materializer.classpath(List(lira), t"nir", cache)).reason
+      . assert(_ == LiraError.Reason.AbsentDependency(t"example-core"))
+
+    suite(m"Publish-time verification"):
+      object Special extends Discipline:
+        def id: Text = t"special/1"
+        def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".special")
+        def domain: Discipline.Domain = Discipline.Domain.Universal
+        def keying: Discipline.Keying = Discipline.Keying.Declaration
+
+        def guarantees(universe: Text): Set[Discipline.Guarantee] =
+          Set(Discipline.Guarantee.Recompilation)
+
+        def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
+        :   Atomization raises DisciplineError =
+
+          val atoms = content.map: (path, data) =>
+            Atom(path.text, AtomClass.Rigid, LiraHash(LiraHash.Domain.Atom(id), data))
+
+          Atomization.of(id, atoms)
+
+      def assembled(): Data =
+        LiraAssembler.assemble(t"example-core",
+          List(
+            LiraAssembler.SectionInput(t"jvm",
+              List((TreePath(t"a/A.class"), classA), (TreePath(t"a/A.special"), tastyA))),
+            LiraAssembler.SectionInput(t"sjsir",
+              List((TreePath(t"a/A.class"), classA), (TreePath(t"a/A.special"), tastyA)))),
+          Discipline.Registry(List(Special)),
+          toolchain = List(LiraManifest.Tool(t"scala", t"3.9.0")))
+
+      test(m"sections presenting different APIs are L108"):
+        capture[LiraError]:
+          LiraAssembler.assemble(t"example-core",
+            List(
+              LiraAssembler.SectionInput(t"jvm", List((TreePath(t"a/A.class"), classA))),
+              LiraAssembler.SectionInput(t"sjsir", List((TreePath(t"a/A.class"), sjsirA)))),
+            Discipline.Registry(List()),
+            toolchain = List(LiraManifest.Tool(t"scala", t"3.9.0")))
+
+        . reason match
+            case LiraError.Reason.ApiDivergence(_) => true
+            case _                                 => false
       . assert(identity)
+
+      test(m"a declared profile with no implementation refuses assembly, L140"):
+        capture[LiraError]:
+          LiraAssembler.assemble(t"example-core",
+            List(LiraAssembler.SectionInput(t"jvm", List((TreePath(t"a/A.class"), classA)))),
+            Discipline.Registry(List()),
+            toolchain = List(LiraManifest.Tool(t"scala", t"3.9.0")),
+            profile = List(LiraManifest.Profile(t"jvm/1")))
+
+        . reason
+      . assert(_ == LiraError.Reason.UnimplementedClaim(t"jvm/1"))
+
+      test(m"declared derivative hashes recompute at verification"):
+        val lira = Lira.read(assembled())
+        val report = Verification.install(lira)
+        Derivative.verify(lira.manifest, report)
+        true
+      . assert(identity)
+
+      test(m"a tampered derivative hash is L138"):
+        val lira = Lira.read(assembled())
+        val report = Verification.install(lira)
+
+        val bogus = blob(encode(t"not the derivative"))
+
+        val tampered = lira.manifest.copy(section = List.from:
+          lira.manifest.section.stdlib.map: section =>
+            section.copy(derivative = bogus))
+
+        capture[LiraError](Derivative.verify(tampered, report)).reason
+      . assert(_ == LiraError.Reason.BadDerivative(t"jvm"))
+
+      test(m"re-atomization accepts what the assembler produced"):
+        val lira = Lira.read(assembled())
+        val report = Verification.install(lira)
+        Verification.reatomize(lira.manifest, report, List(Special))
+        true
+      . assert(identity)
+
+      test(m"a declared discipline with no implementation is L140 at re-atomization"):
+        val lira = Lira.read(assembled())
+        val report = Verification.install(lira)
+
+        capture[LiraError](Verification.reatomize(lira.manifest, report, List())).reason
+      . assert(_ == LiraError.Reason.UnimplementedClaim(t"special/1"))
+
+      test(m"an atoms listing that does not recompute is L141"):
+        // The declared listing is computed over different bytes than the tree carries, which
+        // `install` cannot see — the listing parses and the snapshot matches it — and only
+        // re-atomization catches.
+        val context = Discipline.Context(t"jvm")
+        val registry = Discipline.Registry(List())
+        val wrong = List((TreePath(t"a/A.class"), sjsirA))
+
+        val tree = LiraTree.of(List(TreeEntry(TreePath(t"a/A.class"), blob(classA))))
+        val listing = AtomsBlob.encode(registry.atomize(wrong, context).stdlib.head)
+        val snapshot = Snapshot(registry.atomize(wrong, context))
+
+        val manifest = LiraManifest(
+          module    = t"example-core",
+          version   = revolution.Semver(0, 1, 0),
+          lineage   = List(snapshot),
+          toolchain = List(LiraManifest.Tool(t"scala", t"3.9.0")),
+          api       = List(LiraManifest.Api(t"opaque/1", blob(listing))),
+          section   = List(Section(t"jvm", tree = blob(tree.encode))),
+          payload   = LiraManifest.Payload(t"brotli", 0L, blob(encode(t""))))
+
+        val lira = Lira.read(Lira.assemble(manifest, List(classA, tree.encode, listing)))
+        val report = Verification.install(lira)
+
+        capture[LiraError](Verification.reatomize(lira.manifest, report, List())).reason
+      . assert(_ == LiraError.Reason.AtomsMismatch(t"opaque/1"))
+
+      test(m"evidence reconstructs each section's content for profiles"):
+        val lira = Lira.read(assembled())
+        val report = Verification.install(lira)
+        val evidence = Verification.evidence(lira.manifest, report)
+
+        evidence.sections.stdlib.map: section =>
+          (section.universe, section.content.stdlib.map(_(0).text))
+
+      . assert(_ == scala.List(
+          (t"jvm", scala.List(t"a/A.class", t"a/A.special")),
+          (t"sjsir", scala.List(t"a/A.class", t"a/A.special"))))
+
+      test(m"a universe-specific discipline claims nothing outside its domain"):
+        val scoped = new Discipline:
+          def id: Text = t"scoped/1"
+          def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".class")
+          def domain: Discipline.Domain = Discipline.Domain.Universes(Set(t"jvm"))
+          def keying: Discipline.Keying = Discipline.Keying.Membership
+
+          def guarantees(universe: Text): Set[Discipline.Guarantee] =
+            Set(Discipline.Guarantee.Linkage)
+
+          def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
+          :   Atomization raises DisciplineError =
+
+            val atoms = content.map: (path, data) =>
+              Atom(path.text, AtomClass.Rigid, LiraHash(LiraHash.Domain.Atom(id), data))
+
+            Atomization.of(id, atoms)
+
+        val content = List((TreePath(t"a/A.class"), classA))
+        val registry = Discipline.Registry(List(scoped))
+
+        val jvm = registry.atomize(content, Discipline.Context(t"jvm"))
+        val sjsir = registry.atomize(content, Discipline.Context(t"sjsir"))
+
+        (jvm.stdlib.map(_.discipline), sjsir.stdlib.map(_.discipline))
+      . assert(_ == (scala.List(t"scoped/1"), scala.List(t"opaque/1")))

--- a/lib/xenophile/src/cffi/xenophile.CHeaderDeclaration.scala
+++ b/lib/xenophile/src/cffi/xenophile.CHeaderDeclaration.scala
@@ -30,7 +30,53 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{CHeaderAtomizer, CHeaderDiscipline, DtsAtomizer, DtsDiscipline,
-    WebIdlAtomizer, WebIdlDiscipline, WitAtomizer, WitDiscipline}
+import anticipation.*
+import fulminate.*
+import gossamer.*
+
+// The declaration model of a C header, as `cheader/1` atomizes it (`cheader.md`). Unlike
+// `CHeaderDialect`, which canonicalizes for FFI marshalling — collapsing signedness, pointer
+// depth and enumerators, none of which a downcall needs — this model retains the declared
+// surface: exact arithmetic spellings, pointer structure, struct and union fields, and
+// enumerator names with their values.
+enum CDeclaration:
+  case Function
+    ( name:       Text,
+      result:     Foreign.Type,
+      parameters: List[Foreign.Type],
+      variadic:   Boolean = false )
+
+  case Alias(name: Text, target: Foreign.Type)
+
+  case Structure
+    ( name:   Text,
+      union:  Boolean,
+      fields: List[(Text, Foreign.Type)],
+      opaque: Boolean = false )
+
+  case Enumeration(name: Text, cases: List[(Text, Long)])
+
+  def named: Text = this match
+    case Function(name, _, _, _)  => name
+    case Alias(name, _)           => name
+    case Structure(name, _, _, _) => name
+    case Enumeration(name, _)     => name
+
+object CHeaderError:
+  enum Reason(val number: Int) extends Clarification:
+    case Syntax(detail: Text, near: Text)  extends Reason(1)
+    case Unsupported(construct: Text)      extends Reason(2)
+
+  given communicable: Reason is Communicable =
+    case Reason.Syntax(detail, near) => m"$detail, near $near"
+
+    case Reason.Unsupported(construct) =>
+      m"the construct $construct is outside the grammar this parser accepts"
+
+// A C header could not be read as declarations. `Unsupported` is deliberately an error and not
+// a silent skip: a partially-read header understates the contract, and every claim computed
+// from it would be unsound.
+case class CHeaderError(reason: CHeaderError.Reason)(using Diagnostics)
+extends Error(646, reason.number)(m"the C header could not be read because $reason")

--- a/lib/xenophile/src/cffi/xenophile.CHeaderParser.scala
+++ b/lib/xenophile/src/cffi/xenophile.CHeaderParser.scala
@@ -1,0 +1,358 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import scala.collection.immutable.List as SList
+import scala.collection.immutable.{::, Nil as SNil}
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+import CHeaderError.Reason
+
+// A declaration parser for C headers, retaining what `cheader/1` atomizes: prototypes with
+// exact arithmetic spellings and pointer structure, typedefs, structs and unions with their
+// fields, and enumerations with their enumerator values.
+//
+// Preprocessor lines are skipped by sanction (`cheader.md` §6: macros are not part of the
+// parsed vocabulary), and comments likewise; any other unrecognized construct is a hard error.
+object CHeaderParser:
+
+  def parse(source: Text): List[CDeclaration] raises CHeaderError =
+    val declarations = scala.collection.mutable.ListBuffer[CDeclaration]()
+    var tokens = tokenize(source.s)
+
+    while tokens.nonEmpty do
+      val (declaration, rest) = item(tokens)
+      declaration.let { value => declarations += value }
+      tokens = rest
+
+    List.from(declarations.toList)
+
+  private def fail(detail: Text, tokens: SList[String]): Nothing raises CHeaderError =
+    val near = Text(tokens.take(6).mkString(" "))
+    abort(CHeaderError(Reason.Syntax(detail, if near.s.isEmpty then t"the end" else near)))
+
+  private def unsupported(construct: Text): Nothing raises CHeaderError =
+    abort(CHeaderError(Reason.Unsupported(construct)))
+
+  // --- lexing ---------------------------------------------------------------------------------
+
+  private def tokenize(source: String): SList[String] =
+    def skipLine(index: Int): Int =
+      if index >= source.length || source.charAt(index) == '\n' then index + 1
+      else skipLine(index + 1)
+
+    def skipBlock(index: Int): Int =
+      if index + 1 >= source.length then source.length
+      else if source.charAt(index) == '*' && source.charAt(index + 1) == '/' then index + 2
+      else skipBlock(index + 1)
+
+    def ident(char: Char): Boolean = char.isLetterOrDigit || char == '_'
+
+    def recur(index: Int, current: String, tokens: SList[String], line: Boolean)
+    :   SList[String] =
+
+      val flushed = if current.isEmpty then tokens else current :: tokens
+
+      if index >= source.length then flushed.reverse else
+        val char = source.charAt(index)
+        val next = if index + 1 < source.length then source.charAt(index + 1) else ' '
+        val next2 = if index + 2 < source.length then source.charAt(index + 2) else ' '
+
+        if char == '/' && next == '/' then recur(skipLine(index), "", flushed, true)
+        else if char == '/' && next == '*' then recur(skipBlock(index + 2), "", flushed, line)
+        else if char == '#' && line then recur(skipLine(index), "", flushed, true)
+        else if char == '.' && next == '.' && next2 == '.' then
+          recur(index + 3, "", "..." :: flushed, false)
+        else if ident(char) then recur(index + 1, current + char, tokens, false)
+        else if char == '\n' then recur(index + 1, "", flushed, true)
+        else if char.isWhitespace then recur(index + 1, "", flushed, line)
+        else recur(index + 1, "", char.toString :: flushed, false)
+
+    recur(0, "", SList(), true)
+
+  // --- types ----------------------------------------------------------------------------------
+
+  // The canonical arithmetic spellings (`cheader.md` §7): sign and length normalize to one
+  // hyphenated name, so `unsigned int` and `int unsigned` could never hash apart (the latter
+  // is not accepted; C headers do not write it).
+  private def baseType(tokens: SList[String]): (Foreign.Type, SList[String]) raises CHeaderError =
+    def named(name: Text, rest: SList[String]): (Foreign.Type, SList[String]) =
+      (Foreign.Type.Named(name), rest)
+
+    tokens match
+      case "unsigned" :: "long" :: "long" :: "int" :: rest => named(t"unsigned-long-long", rest)
+      case "unsigned" :: "long" :: "long" :: rest          => named(t"unsigned-long-long", rest)
+      case "unsigned" :: "long" :: "int" :: rest           => named(t"unsigned-long", rest)
+      case "unsigned" :: "long" :: rest                    => named(t"unsigned-long", rest)
+      case "unsigned" :: "short" :: "int" :: rest          => named(t"unsigned-short", rest)
+      case "unsigned" :: "short" :: rest                   => named(t"unsigned-short", rest)
+      case "unsigned" :: "char" :: rest                    => named(t"unsigned-char", rest)
+      case "unsigned" :: "int" :: rest                     => named(t"unsigned-int", rest)
+      case "unsigned" :: rest                              => named(t"unsigned-int", rest)
+      case "signed" :: "char" :: rest                      => named(t"signed-char", rest)
+      case "signed" :: "int" :: rest                       => named(t"int", rest)
+      case "signed" :: rest                                => named(t"int", rest)
+      case "long" :: "long" :: "int" :: rest               => named(t"long-long", rest)
+      case "long" :: "long" :: rest                        => named(t"long-long", rest)
+      case "long" :: "int" :: rest                         => named(t"long", rest)
+      case "long" :: "double" :: rest                      => named(t"long-double", rest)
+      case "long" :: rest                                  => named(t"long", rest)
+      case "short" :: "int" :: rest                        => named(t"short", rest)
+      case "short" :: rest                                 => named(t"short", rest)
+
+      case ("struct" | "union" | "enum") :: tag :: rest =>
+        named(tag.tt, rest)
+
+      case name :: rest if name.headOption.exists { char => char.isLetter || char == '_' } =>
+        named(name.tt, rest)
+
+      case _ => fail(t"a type was expected", tokens)
+
+  // A type as it appears in a parameter, return or field position: qualifiers, a base, then
+  // pointer structure. `const` on a by-value type is not contract and drops away; `const`
+  // through a pointer is, and folds (`cheader.md` §7).
+  private def typeOf(tokens: SList[String]): (Foreign.Type, SList[String]) raises CHeaderError =
+    val (constant, afterConst) = tokens match
+      case "const" :: rest    => (true, rest)
+      case "volatile" :: rest => (false, rest)
+      case _                  => (false, tokens)
+
+    val (base, afterBase) = baseType(afterConst)
+
+    def pointers(tokens: SList[String], typed: Foreign.Type, constant: Boolean)
+    :   (Foreign.Type, SList[String]) =
+
+      tokens match
+        case "*" :: rest =>
+          val pointee = if constant then Foreign.Type.Applied(t"const", List(typed)) else typed
+          pointers(rest, Foreign.Type.Applied(t"ptr", List(pointee)), false)
+
+        case "const" :: rest => pointers(rest, typed, constant)
+        case _               => (typed, tokens)
+
+    pointers(afterBase, base, constant)
+
+  // --- parameters -----------------------------------------------------------------------------
+
+  private def parameters(tokens: SList[String])
+  :   (List[Foreign.Type], Boolean, SList[String]) raises CHeaderError =
+
+    def recur(tokens: SList[String], acc: SList[Foreign.Type])
+    :   (List[Foreign.Type], Boolean, SList[String]) raises CHeaderError =
+
+      tokens match
+        case ")" :: rest   => (List.from(acc.reverse), false, rest)
+        case "," :: rest   => recur(rest, acc)
+        case "..." :: ")" :: rest => (List.from(acc.reverse), true, rest)
+
+        case _ =>
+          val (typed, afterType) = typeOf(tokens)
+
+          // The parameter name is optional and never contract (C calls are positional); an
+          // array suffix degrades to a pointer, which is what the caller passes.
+          val afterName = afterType match
+            case name :: rest if name.headOption.exists { c => c.isLetter || c == '_' } => rest
+            case rest                                                                   => rest
+
+          val (adjusted, afterArray) = afterName match
+            case "[" :: "]" :: rest      => (Foreign.Type.Applied(t"ptr", List(typed)), rest)
+            case "[" :: _ :: "]" :: rest => (Foreign.Type.Applied(t"ptr", List(typed)), rest)
+            case rest                    => (typed, rest)
+
+          recur(afterArray, adjusted :: acc)
+
+    tokens match
+      case "(" :: "void" :: ")" :: rest => (List(), false, rest)
+      case "(" :: rest                  => recur(rest, SList())
+      case _                            => fail(t"a parameter list was expected", tokens)
+
+  // --- declarations ---------------------------------------------------------------------------
+
+  private def fieldList(tokens: SList[String])
+  :   (List[(Text, Foreign.Type)], SList[String]) raises CHeaderError =
+
+    def recur(tokens: SList[String], acc: SList[(Text, Foreign.Type)])
+    :   (List[(Text, Foreign.Type)], SList[String]) raises CHeaderError =
+
+      tokens match
+        case "}" :: rest => (List.from(acc.reverse), rest)
+
+        case _ =>
+          val (typed, afterType) = typeOf(tokens)
+
+          afterType match
+            case name :: ";" :: rest => recur(rest, (name.tt, typed) :: acc)
+
+            case name :: "[" :: size :: "]" :: ";" :: rest =>
+              val array = Foreign.Type.Applied(t"array", List(typed,
+                  Foreign.Type.Named(size.tt)))
+              recur(rest, (name.tt, array) :: acc)
+
+            case _ => fail(t"a field was expected", afterType)
+
+    recur(tokens, SList())
+
+  private def enumerators(tokens: SList[String])
+  :   (List[(Text, Long)], SList[String]) raises CHeaderError =
+
+    def recur(tokens: SList[String], next: Long, acc: SList[(Text, Long)])
+    :   (List[(Text, Long)], SList[String]) raises CHeaderError =
+
+      tokens match
+        case "}" :: rest => (List.from(acc.reverse), rest)
+        case "," :: rest => recur(rest, next, acc)
+
+        case name :: "=" :: value :: rest =>
+          val parsed =
+            try java.lang.Long.decode(value).nn.longValue
+            catch case _: NumberFormatException =>
+              fail(t"an enumerator value must be numeric", tokens)
+
+          recur(rest, parsed + 1, (name.tt, parsed) :: acc)
+
+        case name :: rest => recur(rest, next + 1, (name.tt, next) :: acc)
+        case SNil         => fail(t"an enumerator list is unterminated", tokens)
+
+    recur(tokens, 0L, SList())
+
+  private def item(tokens: SList[String])
+  :   (Optional[CDeclaration], SList[String]) raises CHeaderError =
+
+    tokens match
+      case ";" :: rest      => (Unset, rest)
+      case "extern" :: rest => item(rest)
+      case "static" :: rest => item(rest)
+
+      case "typedef" :: ("struct" | "union") :: rest =>
+        val union = tokens(1) == "union"
+
+        rest match
+          case tag :: "{" :: body =>
+            val (fields, after) = fieldList(body)
+
+            after match
+              case alias :: ";" :: more =>
+                (CDeclaration.Structure(alias.tt, union, fields), more)
+
+              case _ => fail(t"a typedef name was expected", after)
+
+          case "{" :: body =>
+            val (fields, after) = fieldList(body)
+
+            after match
+              case alias :: ";" :: more =>
+                (CDeclaration.Structure(alias.tt, union, fields), more)
+
+              case _ => fail(t"a typedef name was expected", after)
+
+          case tag :: alias :: ";" :: more =>
+            (CDeclaration.Alias(alias.tt, Foreign.Type.Named(tag.tt)), more)
+
+          case _ => fail(t"a struct typedef was expected", rest)
+
+      case "typedef" :: "enum" :: rest =>
+        rest match
+          case "{" :: body =>
+            val (cases, after) = enumerators(body)
+
+            after match
+              case alias :: ";" :: more => (CDeclaration.Enumeration(alias.tt, cases), more)
+              case _                    => fail(t"a typedef name was expected", after)
+
+          case tag :: "{" :: body =>
+            val (cases, after) = enumerators(body)
+
+            after match
+              case alias :: ";" :: more => (CDeclaration.Enumeration(alias.tt, cases), more)
+              case _                    => fail(t"a typedef name was expected", after)
+
+          case _ => fail(t"an enum typedef was expected", rest)
+
+      case "typedef" :: rest =>
+        val (typed, afterType) = typeOf(rest)
+
+        afterType match
+          // A function-pointer typedef: `typedef ret (*name)(params);`.
+          case "(" :: "*" :: name :: ")" :: more =>
+            val (params, variadic, after) = parameters(more)
+            val fn = Foreign.Type.Applied(t"fn", List.from(typed :: params.stdlib))
+
+            after match
+              case ";" :: rest2 =>
+                val target = if variadic then Foreign.Type.Applied(t"variadic", List(fn)) else fn
+                (CDeclaration.Alias(name.tt, target), rest2)
+
+              case _ => fail(t"a `;` was expected", after)
+
+          case name :: ";" :: more => (CDeclaration.Alias(name.tt, typed), more)
+          case _                   => fail(t"a typedef name was expected", afterType)
+
+      case ("struct" | "union") :: tag :: "{" :: body =>
+        val union = tokens.head == "union"
+        val (fields, after) = fieldList(body)
+
+        after match
+          case ";" :: more => (CDeclaration.Structure(tag.tt, union, fields), more)
+          case _           => fail(t"a `;` was expected", after)
+
+      case ("struct" | "union") :: tag :: ";" :: rest =>
+        (CDeclaration.Structure(tag.tt, tokens.head == "union", List(), opaque = true), rest)
+
+      case "enum" :: tag :: "{" :: body =>
+        val (cases, after) = enumerators(body)
+
+        after match
+          case ";" :: more => (CDeclaration.Enumeration(tag.tt, cases), more)
+          case _           => fail(t"a `;` was expected", after)
+
+      case _ =>
+        val (result, afterType) = typeOf(tokens)
+
+        afterType match
+          case name :: "(" :: _ =>
+            val (params, variadic, after) = parameters(afterType.tail)
+
+            after match
+              case ";" :: more =>
+                (CDeclaration.Function(name.tt, result, params, variadic), more)
+
+              case _ => fail(t"a `;` was expected", after)
+
+          case construct :: _ => unsupported(construct.tt)
+          case SNil           => fail(t"a declaration was expected", afterType)

--- a/lib/xenophile/src/lira/xenophile.CHeaderAtomizer.scala
+++ b/lib/xenophile/src/lira/xenophile.CHeaderAtomizer.scala
@@ -30,7 +30,97 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{CHeaderAtomizer, CHeaderDiscipline, DtsAtomizer, DtsDiscipline,
-    WebIdlAtomizer, WebIdlDiscipline, WitAtomizer, WitDiscipline}
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+import vacuous.*
+
+// The atomization rules of `cheader/1` (`cheader.md`): one rigid atom per declaration, keyed by
+// bare name — C has one flat namespace — with functions standalone and structs, unions, enums
+// and typedefs folding their contents.
+object CHeaderAtomizer:
+  val id: Text = t"cheader/1"
+
+  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+    var value = value0
+
+    while value >= 0x80L do
+      out.write(((value & 0x7f) | 0x80).toInt)
+      value >>>= 7
+
+    out.write(value.toInt)
+
+  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
+    val bytes = text.s.getBytes("UTF-8").nn
+    uvarint(out, bytes.length.toLong)
+    out.write(bytes)
+
+  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+
+  private def flag(out: java.io.ByteArrayOutputStream, value: Boolean): Unit =
+    out.write(if value then 1 else 0)
+
+  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
+    val out = java.io.ByteArrayOutputStream()
+    encode(out)
+    LiraHash(LiraHash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+
+  private def encode(out: java.io.ByteArrayOutputStream, typed: Foreign.Type): Unit =
+    typed match
+      case Foreign.Type.Named(name) =>
+        tag(out, 'N')
+        utf8(out, name)
+
+      case Foreign.Type.Applied(constructor, arguments) =>
+        tag(out, 'A')
+        utf8(out, constructor)
+        uvarint(out, arguments.stdlib.length.toLong)
+        arguments.stdlib.foreach { argument => encode(out, argument) }
+
+      case Foreign.Type.Union(_) => () // not producible by `CHeaderParser`
+
+  def atomize(declarations: List[CDeclaration]): List[Atom] =
+    List.from:
+      declarations.stdlib.map:
+        case CDeclaration.Function(name, result, parameters, variadic) =>
+          Atom(name, AtomClass.Rigid, hash: out =>
+            tag(out, 'f')
+            utf8(out, name)
+            flag(out, variadic)
+            uvarint(out, parameters.stdlib.length.toLong)
+            parameters.stdlib.foreach { parameter => encode(out, parameter) }
+            encode(out, result))
+
+        case CDeclaration.Alias(name, target) =>
+          Atom(name, AtomClass.Rigid, hash: out =>
+            tag(out, 't')
+            utf8(out, name)
+            encode(out, target))
+
+        // Fields fold in declaration order — layout is positional — and an opaque tag folds an
+        // opacity marker instead, so completing it later is a value change (`cheader.md` §6).
+        case CDeclaration.Structure(name, union, fields, opaque) =>
+          Atom(name, AtomClass.Rigid, hash: out =>
+            tag(out, if union then 'u' else 's')
+            utf8(out, name)
+            flag(out, opaque)
+            uvarint(out, fields.stdlib.length.toLong)
+
+            fields.stdlib.foreach: (field, typed) =>
+              utf8(out, field)
+              encode(out, typed))
+
+        case CDeclaration.Enumeration(name, cases) =>
+          Atom(name, AtomClass.Rigid, hash: out =>
+            tag(out, 'e')
+            utf8(out, name)
+            uvarint(out, cases.stdlib.length.toLong)
+
+            cases.stdlib.foreach: (label, value) =>
+              utf8(out, label)
+              utf8(out, Text(value.toString)))

--- a/lib/xenophile/src/lira/xenophile.CHeaderDiscipline.scala
+++ b/lib/xenophile/src/lira/xenophile.CHeaderDiscipline.scala
@@ -30,7 +30,42 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{CHeaderAtomizer, CHeaderDiscipline, DtsAtomizer, DtsDiscipline,
-    WebIdlAtomizer, WebIdlDiscipline, WitAtomizer, WitDiscipline}
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+
+import errorDiagnostics.emptyDiagnostics
+
+// The `cheader/1` discipline, adapted to reliquary's SPI: the declared surface of an
+// environment-supplied shared library, carried as C headers and atomized per `cheader.md`. Its
+// domain is the single world `{host}` — FFI is a host assumption, and the header describes what
+// the environment provides, never what a library on the buildpath supplies.
+object CHeaderDiscipline extends Discipline:
+  def id: Text = t"cheader/1"
+
+  def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".h")
+
+  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"host"))
+  def keying: Discipline.Keying = Discipline.Keying.Declaration
+
+  def guarantees(world: Text): Set[Discipline.Guarantee] =
+    Set(Discipline.Guarantee.Recompilation)
+
+  def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
+  :   Atomization raises DisciplineError =
+
+    val declarations = content.stdlib.flatMap: (path, data) =>
+      val source = Text(String(Array.unsafeJvm(data), "UTF-8"))
+
+      mitigate:
+        case CHeaderError(reason) =>
+          DisciplineError(id, DisciplineError.Reason.Malformed(t"${path.text}: $reason"))
+
+      . protect(CHeaderParser.parse(source).stdlib)
+
+    Atomization.of(id, CHeaderAtomizer.atomize(List.from(declarations)))

--- a/lib/xenophile/src/lira/xenophile.KotlinMetadataAtomizer.scala
+++ b/lib/xenophile/src/lira/xenophile.KotlinMetadataAtomizer.scala
@@ -1,0 +1,412 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import scala.collection.immutable.List as SList
+import scala.collection.immutable.Map as SMap
+import scala.collection.immutable.{::, Nil as SNil}
+import scala.jdk.CollectionConverters.*
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import kotlin.metadata.*
+import kotlin.metadata.jvm.*
+import reliquary.*
+import rudiments.*
+import vacuous.*
+
+// The atomization rules of `kotlin-metadata/1` (`kotlin.md`): the Kotlin declaration surface
+// carried by the `@Metadata` annotation, read through the same published metadata library the
+// Kotlin toolchain uses — never the bytecode.
+//
+// Keying is by membership: a Kotlin call site resolves members through the receiver, so a
+// type's contract surface includes what it presents through its *Kotlin* supertype closure. A
+// supertype carrying no metadata — a Java class, or a virtual builtin such as `kotlin.Any` —
+// contributes nothing here: its surface is a classfile-level concern, not this carrier's.
+object KotlinMetadataAtomizer:
+  val id: Text = t"kotlin-metadata/1"
+
+  private def malformed(detail: Text): DisciplineError =
+    import errorDiagnostics.emptyDiagnostics
+    DisciplineError(id, DisciplineError.Reason.Malformed(detail))
+
+  // --- canonical binary encoding -------------------------------------------------------------
+
+  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+    var value = value0
+
+    while value >= 0x80L do
+      out.write(((value & 0x7f) | 0x80).toInt)
+      value >>>= 7
+
+    out.write(value.toInt)
+
+  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
+    val bytes = text.s.getBytes("UTF-8").nn
+    uvarint(out, bytes.length.toLong)
+    out.write(bytes)
+
+  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+
+  private def flag(out: java.io.ByteArrayOutputStream, value: Boolean): Unit =
+    out.write(if value then 1 else 0)
+
+  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
+    val out = java.io.ByteArrayOutputStream()
+    encode(out)
+    LiraHash(LiraHash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+
+  // --- type rendering -------------------------------------------------------------------------
+
+  // Kotlin spelling with nullability marks; type parameters as `#<id>` (metadata ids are
+  // already declaration-order indices, so binder names never enter a hash).
+  private def render(tpe: KmType): Text =
+    val base = tpe.classifier match
+      case classifier: KmClassifier.Class =>
+        val name = classifier.getName.nn.replace("/", ".").nn
+
+        val arguments = tpe.getArguments.nn.asScala.to(SList).map: projection =>
+          Optional(projection.getType).let { inner => render(inner).s }.or("*")
+
+        if arguments.isEmpty then name else s"$name<${arguments.mkString(",")}>"
+
+      case classifier: KmClassifier.TypeAlias =>
+        classifier.getName.nn.replace("/", ".").nn
+
+      case classifier: KmClassifier.TypeParameter => s"#${classifier.getId}"
+      case _                                      => "*"
+
+    if Attributes.isNullable(tpe) then Text(s"$base?") else Text(base)
+
+  private def parameterTypes(function: KmFunction): Text =
+    val types = function.getValueParameters.nn.asScala.to(SList).map: parameter =>
+      render(parameter.getType.nn).s
+
+    Text(types.mkString(","))
+
+  // --- member atoms ---------------------------------------------------------------------------
+
+  private def visible(visibility: Visibility): Boolean =
+    visibility == Visibility.PUBLIC || visibility == Visibility.PROTECTED
+
+  private def functionKey(owner: Text, function: KmFunction): Text =
+    t"$owner#${function.getName.nn.tt}(${parameterTypes(function)})"
+
+  private def functionAtom(owner: Text, function: KmFunction, static: Boolean): Atom =
+    Atom(functionKey(owner, function), AtomClass.Rigid, hash: out =>
+      tag(out, 'f')
+      utf8(out, owner)
+      utf8(out, function.getName.nn.tt)
+      flag(out, static)
+      flag(out, Attributes.isSuspend(function))
+      flag(out, Attributes.isOperator(function))
+      flag(out, Attributes.isInfix(function))
+      flag(out, Attributes.isInline(function))
+      uvarint(out, Attributes.getVisibility(function).ordinal.toLong)
+      uvarint(out, Attributes.getModality(function).ordinal.toLong)
+
+      Optional(function.getReceiverParameterType)
+      . lay(tag(out, '0')) { receiver => tag(out, '1'); utf8(out, render(receiver)) }
+
+      val parameters = function.getValueParameters.nn.asScala.to(SList)
+      uvarint(out, parameters.length.toLong)
+
+      // Parameter names are named-argument surface, and a default's *existence* is call
+      // surface; both fold (`kotlin.md` §6).
+      parameters.foreach: parameter =>
+        utf8(out, parameter.getName.nn.tt)
+        flag(out, Attributes.getDeclaresDefaultValue(parameter))
+        utf8(out, render(parameter.getType.nn))
+
+      utf8(out, render(function.getReturnType.nn)))
+
+  private def propertyAtom(owner: Text, property: KmProperty, static: Boolean): Atom =
+    Atom(t"$owner.${property.getName.nn.tt}", AtomClass.Rigid, hash: out =>
+      tag(out, 'p')
+      utf8(out, owner)
+      utf8(out, property.getName.nn.tt)
+      flag(out, static)
+      flag(out, Attributes.isVar(property))
+      uvarint(out, Attributes.getVisibility(property).ordinal.toLong)
+      uvarint(out, Attributes.getModality(property).ordinal.toLong)
+
+      Optional(property.getReceiverParameterType)
+      . lay(tag(out, '0')) { receiver => tag(out, '1'); utf8(out, render(receiver)) }
+
+      utf8(out, render(property.getReturnType.nn)))
+
+  private def constructorAtom(owner: Text, constructor: KmConstructor): Atom =
+    val types = constructor.getValueParameters.nn.asScala.to(SList).map: parameter =>
+      render(parameter.getType.nn).s
+
+    Atom(t"$owner#constructor(${Text(types.mkString(","))})", AtomClass.Rigid, hash: out =>
+      tag(out, 'c')
+      utf8(out, owner)
+      uvarint(out, Attributes.getVisibility(constructor).ordinal.toLong)
+
+      val parameters = constructor.getValueParameters.nn.asScala.to(SList)
+      uvarint(out, parameters.length.toLong)
+
+      parameters.foreach: parameter =>
+        utf8(out, parameter.getName.nn.tt)
+        flag(out, Attributes.getDeclaresDefaultValue(parameter))
+        utf8(out, render(parameter.getType.nn)))
+
+  private def aliasAtom(owner: Text, alias: KmTypeAlias): Atom =
+    Atom(t"$owner.${alias.getName.nn.tt}", AtomClass.Rigid, hash: out =>
+      tag(out, 'a')
+      utf8(out, owner)
+      utf8(out, alias.getName.nn.tt)
+      utf8(out, render(alias.getUnderlyingType.nn)))
+
+  // --- membership -----------------------------------------------------------------------------
+
+  // The presented member set of one class: its own visible functions and properties, then those
+  // of its Kotlin supertype closure, nearest first, the first occurrence of each selector
+  // winning — an override shadows what it overrides.
+  private def presented
+    ( kmClass: KmClass,
+      resolve: Text => Optional[KmClass] )
+  :   (SList[KmFunction], SList[KmProperty]) =
+
+    val seenFunctions = scala.collection.mutable.LinkedHashSet[String]()
+    val seenProperties = scala.collection.mutable.LinkedHashSet[String]()
+    val functions = scala.collection.mutable.ListBuffer[KmFunction]()
+    val properties = scala.collection.mutable.ListBuffer[KmProperty]()
+    val visited = scala.collection.mutable.HashSet[String]()
+
+    def walk(current: KmClass): Unit =
+      if visited.add(current.getName.nn) then
+        current.getFunctions.nn.asScala.foreach: function =>
+          if visible(Attributes.getVisibility(function))
+          && seenFunctions.add(s"${function.getName}(${parameterTypes(function)})")
+          then functions += function
+
+        current.getProperties.nn.asScala.foreach: property =>
+          if visible(Attributes.getVisibility(property))
+          && seenProperties.add(property.getName.nn)
+          then properties += property
+
+        current.getSupertypes.nn.asScala.foreach: supertype =>
+          supertype.classifier match
+            case classifier: KmClassifier.Class =>
+              resolve(classifier.getName.nn.tt).let(walk(_))
+
+            case _ => ()
+
+    walk(kmClass)
+    (functions.to(SList), properties.to(SList))
+
+  // --- class atoms ----------------------------------------------------------------------------
+
+  private def classAtoms
+    ( kmClass: KmClass,
+      resolve: Text => Optional[KmClass] )
+  :   SList[Atom] =
+
+    val owner = kmClass.getName.nn.replace("/", ".").nn.tt
+    val atoms = scala.collection.mutable.ListBuffer[Atom]()
+    val (functions, properties) = presented(kmClass, resolve)
+
+    functions.foreach { function => atoms += functionAtom(owner, function, false) }
+    properties.foreach { property => atoms += propertyAtom(owner, property, false) }
+
+    kmClass.getConstructors.nn.asScala.foreach: constructor =>
+      if visible(Attributes.getVisibility(constructor))
+      then atoms += constructorAtom(owner, constructor)
+
+    val modality = Attributes.getModality(kmClass)
+
+    // Iff the class is open to subclassing, the sorted key list of its abstract members folds
+    // into its own atom — the rule of `tasty.md` §8 rule 5, transposed (`kotlin.md` §6).
+    val abstracts =
+      if modality == Modality.FINAL then SList() else
+        functions.filter { function => Attributes.getModality(function) == Modality.ABSTRACT }
+        . map { function => functionKey(owner, function).s }
+        . ++ (properties
+            .filter { property => Attributes.getModality(property) == Modality.ABSTRACT }
+            .map { property => s"$owner.${property.getName}" })
+        . sorted
+
+    // A data class's constructor parameters fold into the class atom: `copy`'s signature
+    // changes when any is added, so the addition is correctly major.
+    val dataParameters =
+      if !Attributes.isData(kmClass) then SList() else
+        kmClass.getConstructors.nn.asScala.to(SList)
+        . filter { constructor => !Attributes.isSecondary(constructor) }
+        . flatMap: constructor =>
+            constructor.getValueParameters.nn.asScala.to(SList).map: parameter =>
+              s"${parameter.getName}:${render(parameter.getType.nn)}"
+
+    atoms += Atom(owner, AtomClass.Rigid, hash: out =>
+      tag(out, 'K')
+      utf8(out, owner)
+      uvarint(out, Attributes.getKind(kmClass).ordinal.toLong)
+      uvarint(out, modality.ordinal.toLong)
+      uvarint(out, Attributes.getVisibility(kmClass).ordinal.toLong)
+      flag(out, Attributes.isData(kmClass))
+      flag(out, Attributes.isValue(kmClass))
+
+      val typeParameters = kmClass.getTypeParameters.nn.asScala.to(SList)
+      uvarint(out, typeParameters.length.toLong)
+
+      typeParameters.foreach: parameter =>
+        uvarint(out, parameter.getVariance.nn.ordinal.toLong)
+        val bounds = parameter.getUpperBounds.nn.asScala.to(SList).map(render(_).s)
+        utf8(out, Text(bounds.mkString(",")))
+
+      // Supertypes keep declaration order (linearization is semantic); sealed subclasses and
+      // abstract-member keys sort; enum entries keep declaration order (ordinals are surface).
+      val supertypes = kmClass.getSupertypes.nn.asScala.to(SList).map(render(_).s)
+      uvarint(out, supertypes.length.toLong)
+      supertypes.foreach { supertype => utf8(out, Text(supertype)) }
+
+      val sealedList = kmClass.getSealedSubclasses.nn.asScala.to(SList)
+        . map(_.toString.replace("/", ".").nn)
+        . sorted
+
+      uvarint(out, sealedList.length.toLong)
+      sealedList.foreach { subclass => utf8(out, Text(subclass)) }
+
+      val entries = kmClass.getEnumEntries.nn.asScala.to(SList)
+      uvarint(out, entries.length.toLong)
+      entries.foreach { entry => utf8(out, Text(entry.toString)) }
+
+      uvarint(out, abstracts.length.toLong)
+      abstracts.foreach { key => utf8(out, Text(key)) }
+
+      uvarint(out, dataParameters.length.toLong)
+      dataParameters.foreach { parameter => utf8(out, Text(parameter)) })
+
+    atoms.to(SList)
+
+  private def packageAtoms(owner: Text, kmPackage: KmPackage): SList[Atom] =
+    val atoms = scala.collection.mutable.ListBuffer[Atom]()
+
+    kmPackage.getFunctions.nn.asScala.foreach: function =>
+      if visible(Attributes.getVisibility(function))
+      then atoms += functionAtom(owner, function, true)
+
+    kmPackage.getProperties.nn.asScala.foreach: property =>
+      if visible(Attributes.getVisibility(property))
+      then atoms += propertyAtom(owner, property, true)
+
+    kmPackage.getTypeAliases.nn.asScala.foreach: alias =>
+      if visible(Attributes.getVisibility(alias))
+      then atoms += aliasAtom(owner, alias)
+
+    atoms.to(SList)
+
+  // --- entry point ----------------------------------------------------------------------------
+
+  // Atomizes the metadata-carrying classes among `content`, resolving supertypes through the
+  // release's own classes first and the classpath second.
+  def atomize(content: SList[(Text, Data)], classpath: SList[Text])
+  :   List[Atom] raises DisciplineError =
+
+    val own: SMap[String, Data] = content.map { (name, data) => (name.s, data) }.toMap
+
+    val urls = classpath.map { entry => java.io.File(entry.s).toURI.nn.toURL.nn }
+
+    val loader: ClassLoader =
+      new java.net.URLClassLoader(urls.toArray, getClass.getClassLoader):
+        override def findClass(name: String | Null): Class[?] =
+          own.get(name.nn) match
+            case scala.Some(bytes) =>
+              defineClass(name, Array.unsafeJvm(bytes), 0, bytes.length).nn
+
+            case _ => super.findClass(name).nn
+
+    def load(binary: String): Optional[Class[?]] =
+      try Class.forName(binary, false, loader).nn catch case _: Throwable => Unset
+
+    // A metadata class name (`a/b/Outer.Inner`) resolves by trying each nesting split.
+    def loadMetadataName(name: Text): Optional[Class[?]] =
+      val dotted = name.s.replace("/", ".").nn
+
+      def attempt(candidate: String): Optional[Class[?]] = load(candidate)
+
+      def variants(name: String): SList[String] =
+        val indices = name.indices.filter(name(_) == '.').reverse.to(SList)
+        name :: indices.map { index => name.updated(index, '$') }
+
+      def search(candidates: SList[String]): Optional[Class[?]] = candidates match
+        case SNil => Unset
+
+        case candidate :: rest =>
+          attempt(candidate) match
+            case cls: Class[?] => cls
+            case _             => search(rest)
+
+      search(variants(dotted))
+
+    val metadataCache = scala.collection.mutable.HashMap[String, Optional[KmClass]]()
+
+    def kmClassOf(metadataName: Text): Optional[KmClass] =
+      metadataCache.getOrElseUpdate(metadataName.s,
+        loadMetadataName(metadataName).let: cls =>
+          Optional(cls.getAnnotation(classOf[kotlin.Metadata])).let: annotation =>
+            try
+              KotlinClassMetadata.readStrict(annotation).nn match
+                case metadata: KotlinClassMetadata.Class => metadata.getKmClass.nn
+                case _                                   => Unset
+
+            catch case _: Exception => Unset)
+
+    val atoms = scala.collection.mutable.ListBuffer[Atom]()
+
+    content.foreach: (binary, data) =>
+      load(binary.s).let: cls =>
+        Optional(cls.getAnnotation(classOf[kotlin.Metadata])).let: annotation =>
+          val metadata =
+            try KotlinClassMetadata.readStrict(annotation).nn catch case error: Exception =>
+              abort(malformed(t"the metadata of $binary is unreadable"))
+
+          metadata match
+            case metadata: KotlinClassMetadata.Class =>
+              atoms ++= classAtoms(metadata.getKmClass.nn, kmClassOf(_))
+
+            case metadata: KotlinClassMetadata.FileFacade =>
+              atoms ++= packageAtoms(binary, metadata.getKmPackage.nn)
+
+            case metadata: KotlinClassMetadata.MultiFileClassPart =>
+              val facade = metadata.getFacadeClassName.nn.replace("/", ".").nn.tt
+              atoms ++= packageAtoms(facade, metadata.getKmPackage.nn)
+
+            // The multi-file facade's parts carry its content, and a synthetic class carries
+            // none: claimed, but contributing no atoms.
+            case _ => ()
+
+    List.from(atoms.toList)

--- a/lib/xenophile/src/lira/xenophile.KotlinMetadataDiscipline.scala
+++ b/lib/xenophile/src/lira/xenophile.KotlinMetadataDiscipline.scala
@@ -30,8 +30,52 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{CHeaderAtomizer, CHeaderDiscipline, DtsAtomizer, DtsDiscipline,
-    KotlinMetadataAtomizer, KotlinMetadataDiscipline, WebIdlAtomizer, WebIdlDiscipline,
-    WitAtomizer, WitDiscipline}
+import scala.collection.immutable.List as SList
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+
+// The `kotlin-metadata/1` discipline, adapted to reliquary's SPI: the Kotlin declaration
+// surface carried by `@Metadata` annotations on JVM classfiles, atomized per `kotlin.md`.
+//
+// Claiming order beside `classfile/1` is load-bearing (`kotlin.md` §3): both claim `.class`
+// files, this discipline only those carrying the annotation, so a registry must list
+// `kotlin-metadata/1` first or it is left nothing to claim. The claiming test itself is a
+// constant-pool scan for the annotation's descriptor — cheap, and confirmed properly against
+// the loaded class before any atom is emitted.
+object KotlinMetadataDiscipline extends Discipline:
+  def id: Text = t"kotlin-metadata/1"
+
+  def claims(path: TreePath, data: Data): Boolean =
+    path.text.s.endsWith(".class") && carries(data)
+
+  // ISO-8859-1 maps bytes to chars one-to-one, so a string search over the classfile's bytes
+  // finds the descriptor wherever the constant pool holds it.
+  private def carries(data: Data): Boolean =
+    String(Array.unsafeJvm(data), "ISO-8859-1").contains("Lkotlin/Metadata;")
+
+  // `{jvm, host}`: the metadata rides in JVM classfiles, and the `host` inclusion admits
+  // contracts carried as API-stub classfiles — the anticipated Android surface (hosts.md §3).
+  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"jvm", t"host"))
+
+  // Membership, as `classfile.md` §6: a Kotlin call site resolves members through the receiver.
+  def keying: Discipline.Keying = Discipline.Keying.Membership
+
+  def guarantees(world: Text): Set[Discipline.Guarantee] =
+    Set(Discipline.Guarantee.Recompilation)
+
+  def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
+  :   Atomization raises DisciplineError =
+
+    val classes: SList[(Text, Data)] = content.stdlib.map: (path, data) =>
+      val binary = Text(path.text.s.stripSuffix(".class").nn.replace("/", ".").nn)
+      (binary, data)
+
+    Atomization.of(id,
+        KotlinMetadataAtomizer.atomize(classes, context.classpath.stdlib))

--- a/lib/xenophile/src/lira/xenophile.WebIdlAtomizer.scala
+++ b/lib/xenophile/src/lira/xenophile.WebIdlAtomizer.scala
@@ -1,0 +1,325 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import scala.collection.immutable.List as SList
+import scala.collection.immutable.Map as SMap
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+import vacuous.*
+
+// The atomization rules of `webidl/1` (`webidl.md`).
+//
+// The folding decisions are the platform's own compatibility rules, and they invert `dts/1`'s
+// where the IDL declares what TypeScript cannot see: `partial interface` and `includes` exist
+// because the platform adds members to existing interfaces continuously, and nothing outside
+// the browser implements `Element` — so interface members are standalone atoms whose addition
+// is minor, and only *required* dictionary members fold (adding one breaks every caller
+// constructing the dictionary), while optional members stand alone.
+object WebIdlAtomizer:
+  val id: Text = t"webidl/1"
+
+  private def malformed(detail: Text): DisciplineError =
+    import errorDiagnostics.emptyDiagnostics
+    DisciplineError(id, DisciplineError.Reason.Malformed(detail))
+
+  // --- canonical binary encoding -------------------------------------------------------------
+
+  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+    var value = value0
+
+    while value >= 0x80L do
+      out.write(((value & 0x7f) | 0x80).toInt)
+      value >>>= 7
+
+    out.write(value.toInt)
+
+  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
+    val bytes = text.s.getBytes("UTF-8").nn
+    uvarint(out, bytes.length.toLong)
+    out.write(bytes)
+
+  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+
+  private def flag(out: java.io.ByteArrayOutputStream, value: Boolean): Unit =
+    out.write(if value then 1 else 0)
+
+  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
+    val out = java.io.ByteArrayOutputStream()
+    encode(out)
+    LiraHash(LiraHash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+
+  // Union members sort by their encoded bytes (`webidl.md` §7): `(A or B)` is `(B or A)`.
+  private def encode(out: java.io.ByteArrayOutputStream, typed: Foreign.Type): Unit =
+    typed match
+      case Foreign.Type.Named(name) =>
+        tag(out, 'N')
+        utf8(out, name)
+
+      case Foreign.Type.Union(members) =>
+        tag(out, '|')
+
+        val encodings = members.stdlib.map: member =>
+          val buffer = java.io.ByteArrayOutputStream()
+          encode(buffer, member)
+          val bytes: scala.Array[Byte] = buffer.toByteArray().nn
+          scala.Vector.tabulate(bytes.length) { index => bytes(index) & 0xff }
+
+        uvarint(out, encodings.length.toLong)
+
+        encodings.sortWith { (left, right) => compare(left, right) < 0 }.foreach: encoding =>
+          uvarint(out, encoding.length.toLong)
+          encoding.foreach { byte => out.write(byte) }
+
+      case Foreign.Type.Applied(constructor, arguments) =>
+        tag(out, 'A')
+        utf8(out, constructor)
+        uvarint(out, arguments.stdlib.length.toLong)
+        arguments.stdlib.foreach { argument => encode(out, argument) }
+
+  private def compare(left: scala.Vector[Int], right: scala.Vector[Int]): Int =
+    val shared = left.length.min(right.length)
+    var index = 0
+    var result = 0
+
+    while result == 0 && index < shared do
+      result = left(index) - right(index)
+      index += 1
+
+    if result != 0 then result else left.length - right.length
+
+  // Argument *names* are not folded — WebIDL calls are positional — while optionality,
+  // variadicity and a default's existence decide which calls are legal, so all three are.
+  private def arguments(out: java.io.ByteArrayOutputStream, list: List[WebIdlArgument]): Unit =
+    uvarint(out, list.stdlib.length.toLong)
+
+    list.stdlib.foreach: argument =>
+      flag(out, argument.optional)
+      flag(out, argument.variadic)
+      flag(out, argument.default)
+      encode(out, argument.typed)
+
+  private def encodeMember
+    ( out: java.io.ByteArrayOutputStream, container: Text, member: WebIdlMember )
+  :   Unit =
+
+    // The container's key folds into the value, not merely the atom's key: the snapshot hashes
+    // the set of *distinct* value hashes (LIRA §12.1), so two identically-shaped members of
+    // different interfaces must not collapse into one term.
+    tag(out, 'M')
+    utf8(out, container)
+    utf8(out, member.selector)
+    uvarint(out, member.kind.ordinal.toLong)
+    flag(out, member.readonly)
+    flag(out, member.static)
+    utf8(out, member.special.or(t""))
+    encode(out, member.typed)
+    arguments(out, member.arguments)
+
+  // --- resolution -----------------------------------------------------------------------------
+
+  // `webidl.md` §4: partials merge into their targets and mixins fold into their includers
+  // before atomization, exactly as the platform presents them. The merge is a set union keyed
+  // by member selector, independent of definition order across files.
+  private def resolved(definitions: List[WebIdlDefinition])
+  :   SList[WebIdlDefinition] raises DisciplineError =
+
+    import WebIdlDefinition.*
+
+    val all = definitions.stdlib
+
+    val mixinMembers: SMap[Text, SList[WebIdlMember]] =
+      all.collect { case interface: Interface if interface.mixin => interface }
+      . groupBy(_.name)
+      . map { (name, group) => name -> group.flatMap(_.members.stdlib) }
+      . toMap
+
+    val includes: SMap[Text, SList[Text]] =
+      all.collect { case Includes(target, mixin) => (target, mixin) }
+      . groupBy(_(0))
+      . map { (target, group) => target -> group.map(_(1)) }
+      . toMap
+
+    def mixedIn(name: Text): SList[WebIdlMember] =
+      includes.getOrElse(name, SList()).flatMap: mixin =>
+        mixinMembers.getOrElse(mixin,
+            abort(malformed(t"the mixin $mixin is included but never defined")))
+
+    val names = scala.collection.mutable.HashSet[Text]()
+
+    val complete = all.flatMap:
+      case interface: Interface if interface.mixin || interface.partial => SList()
+      case Includes(_, _)                                              => SList()
+      case Dictionary(_, _, _, true)                                   => SList()
+      case Namespace(_, _, _, true)                                    => SList()
+
+      case interface: Interface =>
+        val partials = all.collect:
+          case partial: Interface if partial.partial && partial.name == interface.name => partial
+
+        val members = interface.members.stdlib
+          ++ partials.flatMap(_.members.stdlib)
+          ++ mixedIn(interface.name)
+
+        val intrinsics = interface.intrinsics.stdlib ++ partials.flatMap(_.intrinsics.stdlib)
+
+        SList(interface.copy(members = List.from(members),
+            intrinsics = List.from(intrinsics), partial = false))
+
+      case dictionary: Dictionary =>
+        val partials = all.collect:
+          case partial: Dictionary if partial.partial && partial.name == dictionary.name =>
+            partial
+
+        val fields = dictionary.fields.stdlib ++ partials.flatMap(_.fields.stdlib)
+        SList(dictionary.copy(fields = List.from(fields), partial = false))
+
+      case namespace: Namespace =>
+        val partials = all.collect:
+          case partial: Namespace if partial.partial && partial.name == namespace.name => partial
+
+        val members = namespace.members.stdlib ++ partials.flatMap(_.members.stdlib)
+        SList(namespace.copy(members = List.from(members), partial = false))
+
+      case other => SList(other)
+
+    complete.foreach: definition =>
+      if !names.add(definition.named)
+      then abort(malformed(t"the definition ${definition.named} appears twice"))
+
+    complete
+
+  // --- atoms ----------------------------------------------------------------------------------
+
+  // The atom key of a definition: its name, with the sorted `[Exposed]` scopes appended where
+  // any are declared (`webidl.md` §5) — `Window` and `WorkerGlobalScope` genuinely offer
+  // different surfaces.
+  private def keyOf(name: Text, exposed: List[Text]): Text =
+    if exposed.stdlib.isEmpty then name
+    else Text(s"$name[${exposed.stdlib.map(_.s).sorted.mkString(",")}]")
+
+  def atomize(definitions: List[WebIdlDefinition]): List[Atom] raises DisciplineError =
+    import WebIdlDefinition.*
+
+    val atoms = scala.collection.mutable.ListBuffer[Atom]()
+
+    resolved(definitions).foreach:
+      case Interface(name, parent, exposed, members, intrinsics, _, _, callback) =>
+        val key = keyOf(name, exposed)
+
+        members.stdlib.foreach: member =>
+          atoms += Atom(t"$key#${member.selector}", AtomClass.Rigid,
+              hash(encodeMember(_, key, member)))
+
+        // Member lists do *not* fold into the interface's own atom — the deliberate inversion
+        // of `dts/1`, licensed by the declared usage direction (`webidl.md` §6). Intrinsics
+        // (`iterable<…>` and kin) are features of the type and do fold, sorted by keyword.
+        atoms += Atom(key, AtomClass.Rigid, hash: out =>
+          tag(out, 'I')
+          utf8(out, key)
+          utf8(out, parent.or(t""))
+          flag(out, callback)
+
+          val ordered = intrinsics.stdlib.sortBy(_(0).s)
+          uvarint(out, ordered.length.toLong)
+
+          ordered.foreach: (keyword, args) =>
+            utf8(out, keyword)
+            uvarint(out, args.stdlib.length.toLong)
+            args.stdlib.foreach { arg => encode(out, arg) })
+
+      case Dictionary(name, parent, fields, _) =>
+        val required = fields.stdlib.filter(_.required).sortBy(_.name.s)
+
+        fields.stdlib.filter(!_.required).foreach: field =>
+          atoms += Atom(t"$name#${field.name}", AtomClass.Rigid, hash: out =>
+            tag(out, 'F')
+            utf8(out, name)
+            utf8(out, field.name)
+            flag(out, field.default)
+            encode(out, field.typed))
+
+        atoms += Atom(name, AtomClass.Rigid, hash: out =>
+          tag(out, 'D')
+          utf8(out, name)
+          utf8(out, parent.or(t""))
+          uvarint(out, required.length.toLong)
+
+          required.foreach: field =>
+            utf8(out, field.name)
+            flag(out, field.default)
+            encode(out, field.typed))
+
+      case Namespace(name, exposed, members, _) =>
+        val key = keyOf(name, exposed)
+
+        members.stdlib.foreach: member =>
+          atoms += Atom(t"$key#${member.selector}", AtomClass.Rigid,
+              hash(encodeMember(_, key, member)))
+
+        atoms += Atom(key, AtomClass.Rigid, hash: out =>
+          tag(out, 'S')
+          utf8(out, key))
+
+      case Enumeration(name, values) =>
+        values.stdlib.foreach: value =>
+          atoms += Atom(t"$name#$value", AtomClass.Rigid, hash: out =>
+            tag(out, 'V')
+            utf8(out, name)
+            utf8(out, value))
+
+        atoms += Atom(name, AtomClass.Rigid, hash: out =>
+          tag(out, 'E')
+          utf8(out, name))
+
+      case Alias(name, typed) =>
+        atoms += Atom(name, AtomClass.Rigid, hash: out =>
+          tag(out, 'T')
+          utf8(out, name)
+          encode(out, typed))
+
+      case CallbackFunction(name, result, args) =>
+        atoms += Atom(name, AtomClass.Rigid, hash: out =>
+          tag(out, 'C')
+          utf8(out, name)
+          encode(out, result)
+          arguments(out, args))
+
+      case Includes(_, _) => ()
+
+    List.from(atoms.toList)

--- a/lib/xenophile/src/lira/xenophile.WebIdlDiscipline.scala
+++ b/lib/xenophile/src/lira/xenophile.WebIdlDiscipline.scala
@@ -30,7 +30,46 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{CHeaderAtomizer, CHeaderDiscipline, DtsAtomizer, DtsDiscipline,
-    WebIdlAtomizer, WebIdlDiscipline, WitAtomizer, WitDiscipline}
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+
+import errorDiagnostics.emptyDiagnostics
+
+// The `webidl/1` discipline, adapted to reliquary's SPI: the Web IDL of a browser host
+// contract, atomized per `webidl.md`. Its domain is the single world `{host}` — a browser is a
+// host, not a universe, and a `js`-universe library's carrier is `.d.ts` — so a release
+// carrying it is a host contract (L135) and L127 rejects a library that declares it.
+object WebIdlDiscipline extends Discipline:
+  def id: Text = t"webidl/1"
+
+  def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".idl")
+
+  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"host"))
+  def keying: Discipline.Keying = Discipline.Keying.Declaration
+
+  // Recompilation, for consumers type-checking against declarations generated from the IDL;
+  // there is no linkage in a browser to protect, and behavior is never certified (§18).
+  def guarantees(world: Text): Set[Discipline.Guarantee] =
+    Set(Discipline.Guarantee.Recompilation)
+
+  def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
+  :   Atomization raises DisciplineError =
+
+    val definitions = content.stdlib.flatMap: (path, data) =>
+      val source = Text(String(Array.unsafeJvm(data), "UTF-8"))
+
+      mitigate:
+        case WebIdlError(reason) =>
+          DisciplineError(id, DisciplineError.Reason.Malformed(t"${path.text}: $reason"))
+
+      . protect(WebIdlParser.parse(source).stdlib)
+
+    // Partial/mixin resolution spans the whole claimed set: a partial in one file completes an
+    // interface in another, exactly as the platform's own IDL is distributed.
+    Atomization.of(id, WebIdlAtomizer.atomize(List.from(definitions)))

--- a/lib/xenophile/src/lira/xenophile.WitAtomizer.scala
+++ b/lib/xenophile/src/lira/xenophile.WitAtomizer.scala
@@ -1,0 +1,276 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import scala.collection.immutable.Map as SMap
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+import vacuous.*
+
+// The atomization rules of `wit/1` (`wit.md`).
+//
+// Functions are standalone atoms — adding one to an interface is additive, and nothing
+// implements a host interface from outside — while records, variants, enums and flags fold
+// their contents in declaration order, since the canonical ABI is positional and gated
+// evolution is not modelled in version 1. A world's imports are standalone (a host gaining a
+// capability is a minor) and its exports fold (an export is an obligation on every component
+// targeting the world).
+object WitAtomizer:
+  val id: Text = t"wit/1"
+
+  private def malformed(detail: Text): DisciplineError =
+    import errorDiagnostics.emptyDiagnostics
+    DisciplineError(id, DisciplineError.Reason.Malformed(detail))
+
+  private def unresolved(name: Text): DisciplineError =
+    import errorDiagnostics.emptyDiagnostics
+    DisciplineError(id, DisciplineError.Reason.Unresolved(name))
+
+  // --- canonical binary encoding -------------------------------------------------------------
+
+  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+    var value = value0
+
+    while value >= 0x80L do
+      out.write(((value & 0x7f) | 0x80).toInt)
+      value >>>= 7
+
+    out.write(value.toInt)
+
+  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
+    val bytes = text.s.getBytes("UTF-8").nn
+    uvarint(out, bytes.length.toLong)
+    out.write(bytes)
+
+  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+
+  private def flag(out: java.io.ByteArrayOutputStream, value: Boolean): Unit =
+    out.write(if value then 1 else 0)
+
+  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
+    val out = java.io.ByteArrayOutputStream()
+    encode(out)
+    LiraHash(LiraHash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+
+  private val primitives: Set[Text] =
+    Set(t"bool", t"u8", t"u16", t"u32", t"u64", t"s8", t"s16", t"s32", t"s64", t"f32", t"f64",
+        t"char", t"string", t"_")
+
+  private val constructors: Set[Text] =
+    Set(t"list", t"option", t"result", t"tuple", t"own", t"borrow")
+
+  // Every named type reference is encoded fully qualified (`wit.md` §7): local names under the
+  // declaring interface's id, `use`-imported names under the interface they came from. A name
+  // that resolves to neither is a hard error, never a guess.
+  private def encode
+    ( out:   java.io.ByteArrayOutputStream,
+      typed: Foreign.Type,
+      scope: SMap[Text, Text] )
+  :   Unit raises DisciplineError =
+
+    typed match
+      case Foreign.Type.Named(name) =>
+        tag(out, 'N')
+
+        if primitives.stdlib.contains(name) then utf8(out, name)
+        else utf8(out, scope.getOrElse(name, abort(unresolved(name))))
+
+      case Foreign.Type.Applied(constructor, arguments) =>
+        if !constructors.stdlib.contains(constructor)
+        then abort(malformed(t"$constructor is not a type constructor"))
+
+        tag(out, 'A')
+        utf8(out, constructor)
+        uvarint(out, arguments.stdlib.length.toLong)
+        arguments.stdlib.foreach { argument => encode(out, argument, scope) }
+
+      case Foreign.Type.Union(_) =>
+        abort(malformed(t"a union type is not WIT"))
+
+  private def function
+    ( container: Text,
+      resource:  Optional[Text],
+      fn:        WitFunction,
+      scope:     SMap[Text, Text] )
+  :   Atom raises DisciplineError =
+
+    val key = resource.let { res => t"$container#$res.${fn.name}" }.or(t"$container#${fn.name}")
+
+    Atom(key, AtomClass.Rigid, hash: out =>
+      tag(out, 'f')
+      utf8(out, container)
+      utf8(out, resource.or(t""))
+      utf8(out, fn.name)
+      flag(out, fn.static)
+      flag(out, fn.constructor)
+      uvarint(out, fn.parameters.stdlib.length.toLong)
+
+      // WIT calls are by named parameter, so names fold beside types (`wit.md` §6).
+      fn.parameters.stdlib.foreach: (name, typed) =>
+        utf8(out, name)
+        encode(out, typed, scope)
+
+      fn.result.lay(tag(out, '0')) { typed => tag(out, '1'); encode(out, typed, scope) })
+
+  // --- atomization ----------------------------------------------------------------------------
+
+  def atomize(documents: List[WitDocument]): List[Atom] raises DisciplineError =
+    val atoms = scala.collection.mutable.ListBuffer[Atom]()
+
+    documents.stdlib.foreach: document =>
+      val pkg = document.packageName.or(abort(malformed(t"a document declares no package")))
+      val suffix = document.version.let { version => t"@$version" }.or(t"")
+
+      def qualify(interface: Text): Text =
+        if interface.s.contains(":") then interface else t"$pkg/$interface$suffix"
+
+      document.interfaces.stdlib.foreach: interface =>
+        val ifaceId = t"$pkg/${interface.name}$suffix"
+
+        // The qualification scope: local item names under this interface's id, `use`-imported
+        // names under the id they came from. `use` clauses are otherwise transparent
+        // (`wit.md` §6) — a re-export or rename carries no semantic content.
+        val scope: SMap[Text, Text] =
+          val local = interface.items.stdlib.collect:
+            case item if !item.isInstanceOf[WitItem.Use] => item.named -> t"$ifaceId#${item.named}"
+
+          val imported = interface.items.stdlib.collect:
+            case WitItem.Use(from, names) =>
+              names.stdlib.map: (original, alias) =>
+                alias -> t"${qualify(from)}#$original"
+
+          . flatten
+
+          (local ++ imported).toMap
+
+        val typeKeys = scala.collection.mutable.ListBuffer[Text]()
+
+        interface.items.stdlib.foreach:
+          case WitItem.Use(_, _) => ()
+
+          case WitItem.Function(fn) =>
+            atoms += function(ifaceId, Unset, fn, scope)
+
+          case WitItem.Alias(name, target) =>
+            typeKeys += t"$ifaceId#$name"
+
+            atoms += Atom(t"$ifaceId#$name", AtomClass.Rigid, hash: out =>
+              tag(out, 't')
+              utf8(out, t"$ifaceId#$name")
+              encode(out, target, scope))
+
+          case WitItem.Record(name, fields) =>
+            typeKeys += t"$ifaceId#$name"
+
+            // Fields fold in declaration order: the canonical ABI is positional (`wit.md` §6).
+            atoms += Atom(t"$ifaceId#$name", AtomClass.Rigid, hash: out =>
+              tag(out, 'r')
+              utf8(out, t"$ifaceId#$name")
+              uvarint(out, fields.stdlib.length.toLong)
+
+              fields.stdlib.foreach: (field, typed) =>
+                utf8(out, field)
+                encode(out, typed, scope))
+
+          case WitItem.Variant(name, cases) =>
+            typeKeys += t"$ifaceId#$name"
+
+            atoms += Atom(t"$ifaceId#$name", AtomClass.Rigid, hash: out =>
+              tag(out, 'v')
+              utf8(out, t"$ifaceId#$name")
+              uvarint(out, cases.stdlib.length.toLong)
+
+              cases.stdlib.foreach: (label, payload) =>
+                utf8(out, label)
+                payload.lay(tag(out, '0')) { typed => tag(out, '1'); encode(out, typed, scope) })
+
+          case WitItem.Enumeration(name, cases) =>
+            typeKeys += t"$ifaceId#$name"
+
+            atoms += Atom(t"$ifaceId#$name", AtomClass.Rigid, hash: out =>
+              tag(out, 'e')
+              utf8(out, t"$ifaceId#$name")
+              uvarint(out, cases.stdlib.length.toLong)
+              cases.stdlib.foreach { label => utf8(out, label) })
+
+          case WitItem.Flags(name, names) =>
+            typeKeys += t"$ifaceId#$name"
+
+            atoms += Atom(t"$ifaceId#$name", AtomClass.Rigid, hash: out =>
+              tag(out, 'g')
+              utf8(out, t"$ifaceId#$name")
+              uvarint(out, names.stdlib.length.toLong)
+              names.stdlib.foreach { label => utf8(out, label) })
+
+          case WitItem.Resource(name, methods) =>
+            typeKeys += t"$ifaceId#$name"
+
+            atoms += Atom(t"$ifaceId#$name", AtomClass.Rigid, hash: out =>
+              tag(out, 'R')
+              utf8(out, t"$ifaceId#$name"))
+
+            methods.stdlib.foreach: method =>
+              atoms += function(ifaceId, name, method, scope)
+
+        // The interface's own atom folds the sorted key list of its *type* declarations, not
+        // its functions: adding a function is additive (`wit.md` §6).
+        atoms += Atom(ifaceId, AtomClass.Rigid, hash: out =>
+          tag(out, 'I')
+          utf8(out, ifaceId)
+          val sorted = typeKeys.toList.sortBy(_.s)
+          uvarint(out, sorted.length.toLong)
+          sorted.foreach { key => utf8(out, key) })
+
+      document.worlds.stdlib.foreach: world =>
+        val worldId = t"$pkg/${world.name}$suffix"
+        val imports = world.imports.stdlib.map(qualify(_))
+        val exports = world.exports.stdlib.map(qualify(_)).sortBy(_.s)
+
+        imports.foreach: imported =>
+          atoms += Atom(t"$worldId#import $imported", AtomClass.Rigid, hash: out =>
+            tag(out, 'i')
+            utf8(out, worldId)
+            utf8(out, imported))
+
+        atoms += Atom(worldId, AtomClass.Rigid, hash: out =>
+          tag(out, 'W')
+          utf8(out, worldId)
+          uvarint(out, exports.length.toLong)
+          exports.foreach { exported => utf8(out, exported) })
+
+    List.from(atoms.toList)

--- a/lib/xenophile/src/lira/xenophile.WitDiscipline.scala
+++ b/lib/xenophile/src/lira/xenophile.WitDiscipline.scala
@@ -30,7 +30,41 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{CHeaderAtomizer, CHeaderDiscipline, DtsAtomizer, DtsDiscipline,
-    WebIdlAtomizer, WebIdlDiscipline, WitAtomizer, WitDiscipline}
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+
+import errorDiagnostics.emptyDiagnostics
+
+// The `wit/1` discipline, adapted to reliquary's SPI: the WIT surface of a WASI-world host
+// contract — and, when the reserved `component` universe's schema layer lands, of a library
+// component — atomized per `wit.md`.
+object WitDiscipline extends Discipline:
+  def id: Text = t"wit/1"
+
+  def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".wit")
+
+  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"host", t"component"))
+  def keying: Discipline.Keying = Discipline.Keying.Declaration
+
+  def guarantees(world: Text): Set[Discipline.Guarantee] =
+    Set(Discipline.Guarantee.Recompilation)
+
+  def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
+  :   Atomization raises DisciplineError =
+
+    val documents = content.stdlib.map: (path, data) =>
+      val source = Text(String(Array.unsafeJvm(data), "UTF-8"))
+
+      mitigate:
+        case WitParseError(reason) =>
+          DisciplineError(id, DisciplineError.Reason.Malformed(t"${path.text}: $reason"))
+
+      . protect(WitParser.parse(source))
+
+    Atomization.of(id, WitAtomizer.atomize(List.from(documents)))

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -792,6 +792,9 @@ object Tests extends Suite(m"Xenophile tests"):
 
     typescriptParserTests()
     dtsDisciplineTests()
+    webIdlDisciplineTests()
+    witDisciplineTests()
+    cheaderDisciplineTests()
 
   def typescriptParserTests(): Unit =
     import strategies.throwUnsafely
@@ -1084,3 +1087,364 @@ object Tests extends Suite(m"Xenophile tests"):
 
       registry.atomize(js, Discipline.Context(t"jvm")).stdlib.map(_.discipline)
     . assert(_ == scala.List(t"opaque/1"))
+
+  def webIdlDisciplineTests(): Unit =
+    import reliquary.*
+    import strategies.throwUnsafely
+
+    def content(source: Text): List[(TreePath, Data)] =
+      List((TreePath(t"idl/browser.idl"), Array.unsafeFrozen(source.s.getBytes("UTF-8").nn)))
+
+    def atomize(source: Text): Atomization =
+      WebIdlDiscipline.atomize(content(source), Discipline.Context(t"host"))
+
+    def keys(source: Text): scala.List[Text] =
+      atomize(source).atoms.stdlib.map(_.key).sortBy(_.s)
+
+    def grade(before: Text, after: Text): Grade =
+      Grade.between(List(atomize(before)), List(atomize(after)))
+
+    val baseline: Text =
+      t"""|interface Widget {
+          |  readonly attribute DOMString name;
+          |  undefined render(long depth);
+          |};
+          |dictionary Options {
+          |  required DOMString mode;
+          |  long retries = 3;
+          |};
+          |enum Direction { "up", "down" };
+          |""".s.stripMargin.tt
+
+    suite(m"The `webidl/1` discipline"):
+      test(m"the discipline claims idl files in the host world and nothing else"):
+        val data = Array.freeze(Array[Byte](0))
+
+        (WebIdlDiscipline.claims(TreePath(t"idl/dom.idl"), data),
+         WebIdlDiscipline.claims(TreePath(t"lib/index.js"), data),
+         WebIdlDiscipline.domain.covers(t"host"),
+         WebIdlDiscipline.domain.covers(t"jvm"))
+      . assert(_ == (true, false, true, false))
+
+      test(m"declarations, members, fields and values yield atoms"):
+        keys(baseline)
+      . assert(_ == scala.List(t"Direction", t"Direction#down", t"Direction#up", t"Options",
+          t"Options#retries", t"Widget", t"Widget#name", t"Widget#render(s32)"))
+
+      test(m"adding an interface member is a minor for callers"):
+        val grown = t"${baseline}partial interface Widget { attribute long depth; };"
+        grade(baseline, grown)
+      . assert(_ == Grade.Minor)
+
+      test(m"adding a required dictionary member is major"):
+        val grown = baseline.s.replace("required DOMString mode;",
+            "required DOMString mode;\n  required long width;").nn.tt
+        grade(baseline, grown)
+      . assert(_ == Grade.Major)
+
+      test(m"adding an optional dictionary member is minor"):
+        val grown = baseline.s.replace("long retries = 3;",
+            "long retries = 3;\n  boolean verbose = false;").nn.tt
+        grade(baseline, grown)
+      . assert(_ == Grade.Minor)
+
+      test(m"adding an enumeration value is minor"):
+        grade(baseline, baseline.s.replace("\"down\"", "\"down\", \"left\"").nn.tt)
+      . assert(_ == Grade.Minor)
+
+      test(m"removing a member is major"):
+        grade(baseline, baseline.s.replace("  undefined render(long depth);\n", "").nn.tt)
+      . assert(_ == Grade.Major)
+
+      test(m"a mixin's members atomize under the including interface"):
+        val mixed =
+          t"""|interface Base {};
+              |interface mixin Extras { undefined extra(); };
+              |Base includes Extras;
+              |""".s.stripMargin.tt
+
+        keys(mixed)
+      . assert(_ == scala.List(t"Base", t"Base#extra()"))
+
+      test(m"a partial interface in another file completes its target"):
+        val split = List(
+          (TreePath(t"idl/a.idl"),
+           Array.unsafeFrozen(t"interface W {};".s.getBytes("UTF-8").nn)),
+          (TreePath(t"idl/b.idl"),
+           Array.unsafeFrozen(t"partial interface W { attribute long x; };".s
+              .getBytes("UTF-8").nn)))
+
+        WebIdlDiscipline.atomize(split, Discipline.Context(t"host")).atoms.stdlib.map(_.key)
+        . sortBy(_.s)
+      . assert(_ == scala.List(t"W", t"W#x"))
+
+      test(m"exposure scopes are part of the key"):
+        keys(t"[Exposed=(Window,Worker)] interface Scoped {};")
+      . assert(_ == scala.List(t"Scoped[Window,Worker]"))
+
+      test(m"identically-shaped members of different interfaces do not alias"):
+        val twins = t"interface A { attribute long x; };\ninterface B { attribute long x; };"
+        val atoms = atomize(twins).atoms.stdlib
+
+        atoms.map { atom => LiraHash.text(atom.valueHash) }.distinct.size
+        == atoms.size
+      . assert(identity)
+
+      test(m"union member order does not affect a hash"):
+        val one = atomize(t"interface U { attribute (long or DOMString) x; };")
+        val two = atomize(t"interface U { attribute (DOMString or long) x; };")
+
+        one.atoms.stdlib.map { atom => LiraHash.text(atom.valueHash) }
+        == two.atoms.stdlib.map { atom => LiraHash.text(atom.valueHash) }
+      . assert(identity)
+
+      test(m"an unsupported construct is an atomization error"):
+        import errorDiagnostics.stackTracesDiagnostics
+
+        capture[DisciplineError](atomize(t"weird thing;")).reason match
+          case DisciplineError.Reason.Malformed(_) => true
+          case _                                   => false
+      . assert(identity)
+
+      test(m"the real DOM excerpt atomizes"):
+        val stream = getClass.getResourceAsStream("/xenophile/dom.idl").nn
+        val bytes = stream.readAllBytes().nn
+        stream.close()
+        atomize(Text(String(bytes, "UTF-8"))).atoms.stdlib.size
+      . assert(_ > 50)
+
+  def witDisciplineTests(): Unit =
+    import reliquary.*
+    import strategies.throwUnsafely
+
+    def content(source: Text): List[(TreePath, Data)] =
+      List((TreePath(t"wit/api.wit"), Array.unsafeFrozen(source.s.getBytes("UTF-8").nn)))
+
+    def atomize(source: Text): Atomization =
+      WitDiscipline.atomize(content(source), Discipline.Context(t"host"))
+
+    def keys(source: Text): scala.List[Text] =
+      atomize(source).atoms.stdlib.map(_.key).sortBy(_.s)
+
+    def grade(before: Text, after: Text): Grade =
+      Grade.between(List(atomize(before)), List(atomize(after)))
+
+    val baseline: Text =
+      t"""|package wasi:random@0.2.0;
+          |
+          |interface random {
+          |  record seed { value: u64 }
+          |  get-random-bytes: func(len: u64) -> list<u8>;
+          |}
+          |
+          |world host {
+          |  import random;
+          |  export run;
+          |}
+          |""".s.stripMargin.tt
+
+    suite(m"The `wit/1` discipline"):
+      test(m"the discipline claims wit files in its two worlds and nothing else"):
+        val data = Array.freeze(Array[Byte](0))
+
+        (WitDiscipline.claims(TreePath(t"wit/world.wit"), data),
+         WitDiscipline.claims(TreePath(t"lib/api.idl"), data),
+         WitDiscipline.domain.covers(t"host"),
+         WitDiscipline.domain.covers(t"component"),
+         WitDiscipline.domain.covers(t"jvm"))
+      . assert(_ == (true, false, true, true, false))
+
+      test(m"interfaces, items and worlds yield package-qualified atoms"):
+        keys(baseline)
+      . assert(_ == scala.List(
+          t"wasi:random/host@0.2.0",
+          t"wasi:random/host@0.2.0#import wasi:random/random@0.2.0",
+          t"wasi:random/random@0.2.0",
+          t"wasi:random/random@0.2.0#get-random-bytes",
+          t"wasi:random/random@0.2.0#seed"))
+
+      test(m"adding a function to an interface is minor"):
+        val grown = baseline.s.replace("}\n\nworld",
+            "  get-random-u64: func() -> u64;\n}\n\nworld").nn.tt
+        grade(baseline, grown)
+      . assert(_ == Grade.Minor)
+
+      test(m"adding a record field is major"):
+        grade(baseline, baseline.s.replace("{ value: u64 }", "{ value: u64, extra: u32 }").nn.tt)
+      . assert(_ == Grade.Major)
+
+      test(m"a world gaining an import is minor"):
+        val source = baseline.s.replace("interface random {",
+            "interface insecure { i: func(); }\ninterface random {").nn.tt
+        val grown = source.s.replace("import random;", "import random;\n  import insecure;").nn.tt
+        grade(source, grown)
+      . assert(_ == Grade.Minor)
+
+      test(m"a world gaining an export is major"):
+        grade(baseline, baseline.s.replace("export run;", "export run;\n  export other;").nn.tt)
+      . assert(_ == Grade.Major)
+
+      test(m"a use-imported reference is qualified to its source interface"):
+        val direct =
+          t"""|package a:pkg;
+              |interface one {
+              |  type id = u64;
+              |}
+              |interface two {
+              |  use one.{id};
+              |  get: func() -> id;
+              |}
+              |""".s.stripMargin.tt
+
+        val renamed = direct.s.replace("use one.{id};", "use one.{id as key};").nn
+          .replace("-> id;", "-> key;").nn.tt
+
+        val hashes = { (source: Text) =>
+          atomize(source).atoms.stdlib
+          . filter(_.key == t"a:pkg/two#get")
+          . map { atom => LiraHash.text(atom.valueHash) }
+        }
+
+        hashes(direct) == hashes(renamed)
+      . assert(identity)
+
+      test(m"a since gate is consumed and an unstable gate is refused"):
+        import errorDiagnostics.stackTracesDiagnostics
+
+        val gated =
+          t"""|package a:pkg;
+              |interface one {
+              |  @since(version = 0.2.1)
+              |  get: func() -> u64;
+              |}
+              |""".s.stripMargin.tt
+
+        val unstable = gated.s.replace("@since(version = 0.2.1)",
+            "@unstable(feature = fancy)").nn.tt
+
+        val accepted = atomize(gated).atoms.stdlib.exists(_.key == t"a:pkg/one#get")
+
+        val refused =
+          capture[DisciplineError](atomize(unstable)).reason match
+            case DisciplineError.Reason.Malformed(_) => true
+            case _                                   => false
+
+        (accepted, refused)
+      . assert(_ == (true, true))
+
+      test(m"an unresolvable type reference is an error"):
+        import errorDiagnostics.stackTracesDiagnostics
+
+        capture[DisciplineError]:
+          atomize(t"package a:pkg;\ninterface one { get: func() -> mystery; }")
+        . reason match
+            case DisciplineError.Reason.Unresolved(_) => true
+            case _                                    => false
+      . assert(identity)
+
+      test(m"the sample wit fixture atomizes"):
+        val stream = getClass.getResourceAsStream("/xenophile/api.wit").nn
+        val bytes = stream.readAllBytes().nn
+        stream.close()
+        atomize(Text(String(bytes, "UTF-8"))).atoms.stdlib.size
+      . assert(_ > 10)
+
+  def cheaderDisciplineTests(): Unit =
+    import reliquary.*
+    import strategies.throwUnsafely
+
+    def content(source: Text): List[(TreePath, Data)] =
+      List((TreePath(t"include/library.h"), Array.unsafeFrozen(source.s.getBytes("UTF-8").nn)))
+
+    def atomize(source: Text): Atomization =
+      CHeaderDiscipline.atomize(content(source), Discipline.Context(t"host"))
+
+    def keys(source: Text): scala.List[Text] =
+      atomize(source).atoms.stdlib.map(_.key).sortBy(_.s)
+
+    def hashOf(source: Text, key: Text): Optional[Text] =
+      atomize(source).atoms.stdlib.find(_.key == key)
+      . map { atom => LiraHash.text(atom.valueHash) }.getOrElse(Unset)
+
+    def grade(before: Text, after: Text): Grade =
+      Grade.between(List(atomize(before)), List(atomize(after)))
+
+    val baseline: Text =
+      t"""|typedef struct Point { int x; int y; } Point;
+          |typedef enum { LEFT, RIGHT } Direction;
+          |int add(int a, int b);
+          |size_t strlen(const char* s);
+          |""".s.stripMargin.tt
+
+    suite(m"The `cheader/1` discipline"):
+      test(m"the discipline claims headers in the host world and nothing else"):
+        val data = Array.freeze(Array[Byte](0))
+
+        (CHeaderDiscipline.claims(TreePath(t"include/openssl.h"), data),
+         CHeaderDiscipline.claims(TreePath(t"src/main.c"), data),
+         CHeaderDiscipline.domain.covers(t"host"),
+         CHeaderDiscipline.domain.covers(t"nir"))
+      . assert(_ == (true, false, true, false))
+
+      test(m"declarations are keyed by bare name"):
+        keys(baseline)
+      . assert(_ == scala.List(t"Direction", t"Point", t"add", t"strlen"))
+
+      test(m"adding a declaration is minor and removing one is major"):
+        val grown = t"${baseline}double pow(double base, double exponent);"
+        (grade(baseline, grown), grade(grown, baseline))
+      . assert(_ == (Grade.Minor, Grade.Major))
+
+      test(m"signedness distinguishes hashes"):
+        hashOf(t"int f(unsigned int x);", t"f") != hashOf(t"int f(int x);", t"f")
+      . assert(identity)
+
+      test(m"pointer depth distinguishes hashes"):
+        hashOf(t"int f(char** x);", t"f") != hashOf(t"int f(char* x);", t"f")
+      . assert(identity)
+
+      test(m"pointee constness folds and by-value constness does not"):
+        (hashOf(t"int f(const char* x);", t"f") != hashOf(t"int f(char* x);", t"f"),
+         hashOf(t"int f(const int x);", t"f") == hashOf(t"int f(int x);", t"f"))
+      . assert(_ == (true, true))
+
+      test(m"parameter names do not fold"):
+        hashOf(t"int add(int a, int b);", t"add") == hashOf(t"int add(int x, int y);", t"add")
+      . assert(identity)
+
+      test(m"enumerator values fold, explicit or implicit"):
+        (hashOf(t"typedef enum { A, B } E;", t"E")
+           == hashOf(t"typedef enum { A = 0, B = 1 } E;", t"E"),
+         hashOf(t"typedef enum { A, B } E;", t"E")
+           != hashOf(t"typedef enum { A, B = 5 } E;", t"E"))
+      . assert(_ == (true, true))
+
+      test(m"completing an opaque struct changes its value"):
+        hashOf(t"struct S;", t"S") != hashOf(t"struct S { int x; };", t"S")
+      . assert(identity)
+
+      test(m"an unsupported construct is an atomization error"):
+        import errorDiagnostics.stackTracesDiagnostics
+
+        capture[DisciplineError](atomize(t"int x = 4;")).reason match
+          case DisciplineError.Reason.Malformed(_) => true
+          case _                                   => false
+      . assert(identity)
+
+      test(m"the sample library header atomizes"):
+        val stream = getClass.getResourceAsStream("/xenophile/library.h").nn
+        val bytes = stream.readAllBytes().nn
+        stream.close()
+        atomize(Text(String(bytes, "UTF-8"))).atoms.stdlib.map(_.key).sortBy(_.s)
+      . assert(_.contains(t"HMAC") == false)
+
+      test(m"the openssl header atomizes with its functions keyed by symbol"):
+        // The header lives in enigmatic's resources; where it is absent from this suite's
+        // classpath the test degenerates to a pass rather than a false failure.
+        val stream = getClass.getResourceAsStream("/enigmatic/openssl.h")
+
+        if stream == null then true else
+          val bytes = stream.nn.readAllBytes().nn
+          stream.nn.close()
+          atomize(Text(String(bytes, "UTF-8"))).atoms.stdlib.exists(_.key == t"RAND_bytes")
+      . assert(_ == true)

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -795,6 +795,7 @@ object Tests extends Suite(m"Xenophile tests"):
     webIdlDisciplineTests()
     witDisciplineTests()
     cheaderDisciplineTests()
+    kotlinMetadataDisciplineTests()
 
   def typescriptParserTests(): Unit =
     import strategies.throwUnsafely
@@ -1448,3 +1449,76 @@ object Tests extends Suite(m"Xenophile tests"):
           stream.nn.close()
           atomize(Text(String(bytes, "UTF-8"))).atoms.stdlib.exists(_.key == t"RAND_bytes")
       . assert(_ == true)
+
+  def kotlinMetadataDisciplineTests(): Unit =
+    import reliquary.*
+    import strategies.throwUnsafely
+
+    // Real Kotlin classfiles from the kotlin-stdlib fixture already on this suite's classpath.
+    def classfile(name: Text): Data =
+      val stream = getClass.getResourceAsStream(s"/${name.s.replace(".", "/")}.class").nn
+      val bytes = stream.readAllBytes().nn
+      stream.close()
+      Array.unsafeFrozen(bytes)
+
+    def content(names: Text*): List[(TreePath, Data)] =
+      List.from:
+        names.map: name =>
+          (TreePath(t"${name.s.replace(".", "/").nn}.class"), classfile(name))
+
+    def atomize(names: Text*): Atomization =
+      KotlinMetadataDiscipline.atomize(content(names*), Discipline.Context(t"jvm"))
+
+    suite(m"The `kotlin-metadata/1` discipline"):
+      test(m"the discipline claims metadata-carrying classfiles and nothing else"):
+        val kotlin = classfile(t"kotlin.Pair")
+        val scala0 = classfile(t"xenophile.Tests")
+
+        (KotlinMetadataDiscipline.claims(TreePath(t"kotlin/Pair.class"), kotlin),
+         KotlinMetadataDiscipline.claims(TreePath(t"xenophile/Tests.class"), scala0),
+         KotlinMetadataDiscipline.claims(TreePath(t"readme.md"), kotlin))
+      . assert(_ == (true, false, false))
+
+      test(m"a data class atomizes its members, constructor and class atom"):
+        val keys = atomize(t"kotlin.Pair").atoms.stdlib.map(_.key)
+
+        (keys.contains(t"kotlin.Pair"),
+         keys.contains(t"kotlin.Pair.first"),
+         keys.exists(_.s.startsWith("kotlin.Pair#component1(")),
+         keys.exists(_.s.startsWith("kotlin.Pair#constructor(")))
+      . assert(_ == (true, true, true, true))
+
+      test(m"parameter types carry nullability marks in the key"):
+        atomize(t"kotlin.Pair").atoms.stdlib.map(_.key.s)
+        . exists { key => key.startsWith("kotlin.Pair#constructor(") }
+      . assert(identity)
+
+      test(m"suspend functions are atomized rather than dropped"):
+        // `kotlin.sequences.SequenceScope` is the canonical suspend surface: `yield` is a
+        // suspend function, and the whole point of this discipline is that it is visible.
+        atomize(t"kotlin.sequences.SequenceScope").atoms.stdlib.map(_.key.s)
+        . exists(_.startsWith("kotlin.sequences.SequenceScope#yield("))
+      . assert(identity)
+
+      test(m"an enum class atomizes with its class atom"):
+        atomize(t"kotlin.DeprecationLevel").atoms.stdlib.map(_.key)
+        . contains(t"kotlin.DeprecationLevel")
+      . assert(identity)
+
+      test(m"atomization is deterministic"):
+        val one = atomize(t"kotlin.Pair").atoms.stdlib.map { a => LiraHash.text(a.valueHash) }
+        val two = atomize(t"kotlin.Pair").atoms.stdlib.map { a => LiraHash.text(a.valueHash) }
+        one == two
+      . assert(identity)
+
+      test(m"identically-shaped members of different classes do not alias"):
+        val atoms = atomize(t"kotlin.Pair", t"kotlin.Triple").atoms.stdlib
+        atoms.map { atom => LiraHash.text(atom.valueHash) }.distinct.size == atoms.size
+      . assert(identity)
+
+      test(m"the registry claims kotlin classes ahead of the opaque fallback"):
+        val registry = Discipline.Registry(List(KotlinMetadataDiscipline))
+        val mixed = content(t"kotlin.Pair") 
+
+        registry.atomize(mixed, Discipline.Context(t"jvm")).stdlib.map(_.discipline)
+      . assert(_ == scala.List(t"kotlin-metadata/1"))

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -933,6 +933,10 @@ object Tests extends Suite(m"Xenophile tests"):
       refuses(t"type T<A> = Array<infer B>;")
     . assert(_ == TypescriptError.Reason.Unsupported(t"an `infer` binder"))
 
+    test(m"a mapped type is refused under its own name"):
+      refuses(t"interface A { [K in B]: number; }")
+    . assert(_ == TypescriptError.Reason.Unsupported(t"a mapped type"))
+
     test(m"an unterminated string literal is a syntax error"):
       refuses(t"""type T = "unterminated;""").let:
         case TypescriptError.Reason.Syntax(_, _) => true

--- a/lib/xenophile/src/typescript/xenophile.TypescriptParser.scala
+++ b/lib/xenophile/src/typescript/xenophile.TypescriptParser.scala
@@ -500,6 +500,11 @@ object TypescriptParser:
             List(TypescriptType.Function(List(TypescriptType.Argument(key, keyType)), value)),
             visibility, static, readonly )
 
+      // A mapped type (`[K in T]: U`) is refused under its own name: it fails the index-signature
+      // test above because `in` follows the binder where `:` would, but calling it a computed
+      // property name would misdirect whoever reads the diagnostic.
+      else if at(t"[") && ahead(2, t"in")
+      then abort(TypescriptError(Reason.Unsupported(t"a mapped type")))
       else if at(t"[") then abort(TypescriptError(Reason.Unsupported(t"a computed property name")))
       else
         val getter = at(t"get") && !(ahead(1, t":")

--- a/lib/xenophile/src/webidl/xenophile.WebIdlDefinition.scala
+++ b/lib/xenophile/src/webidl/xenophile.WebIdlDefinition.scala
@@ -1,0 +1,143 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import anticipation.*
+import fulminate.*
+import gossamer.*
+import prepositional.*
+import vacuous.*
+
+// The declaration model of a WebIDL fragment, as `webidl/1` atomizes it (`webidl.md`). Unlike
+// `WebIdlDialect`, which flattens inheritance and erases exactly the distinctions foreign
+// navigation does not need, this model retains what the compatibility algebra depends on:
+// partiality and mixin identity (resolved by the atomizer, not the parser), required-versus-
+// optional dictionary members, `[Exposed]` scopes, and enumeration values.
+case class WebIdlArgument
+  ( name:     Text,
+    typed:    Foreign.Type,
+    optional: Boolean = false,
+    variadic: Boolean = false,
+    default:  Boolean = false )
+
+object WebIdlMember:
+  enum Kind:
+    case Attribute, Operation, Constant, Constructor
+
+case class WebIdlMember
+  ( kind:      WebIdlMember.Kind,
+    name:      Text,
+    typed:     Foreign.Type,
+    arguments: List[WebIdlArgument] = List(),
+    readonly:  Boolean              = false,
+    static:    Boolean              = false,
+    special:   Optional[Text]       = Unset ):
+
+  // The member's selector within its container (`webidl.md` §5): the bare name for attributes
+  // and constants, the name with argument types for operations (overloads have distinct
+  // selectors), `new(…)` for constructors, and the special-operation keyword in brackets for
+  // anonymous getters, setters and deleters.
+  def selector: Text =
+    def signature: Text = Text(arguments.stdlib.map(_.typed.text.s).mkString(","))
+
+    kind match
+      case WebIdlMember.Kind.Attribute | WebIdlMember.Kind.Constant => name
+      case WebIdlMember.Kind.Constructor                            => Text(s"new($signature)")
+
+      case WebIdlMember.Kind.Operation =>
+        if name.s.isEmpty then Text(s"${special.or(t"?")}[]($signature)")
+        else Text(s"$name($signature)")
+
+// One field of a dictionary. A required member folds into the dictionary's own atom — adding
+// one breaks every caller constructing the dictionary — while an optional member stands alone
+// (`webidl.md` §6).
+case class WebIdlField(name: Text, typed: Foreign.Type, required: Boolean, default: Boolean)
+
+enum WebIdlDefinition:
+  // `intrinsics` carries the type-level declarations — `iterable<…>`, `maplike<…>`,
+  // `setlike<…>`, `async iterable<…>`, bare `stringifier` — as (keyword, type arguments)
+  // pairs: they are features of the type rather than members, and fold into the interface's
+  // own atom.
+  case Interface
+    ( name:       Text,
+      parent:     Optional[Text] = Unset,
+      exposed:    List[Text]     = List(),
+      members:    List[WebIdlMember],
+      intrinsics: List[(Text, List[Foreign.Type])] = List(),
+      partial:    Boolean        = false,
+      mixin:      Boolean        = false,
+      callback:   Boolean        = false )
+
+  case Dictionary
+    ( name:    Text,
+      parent:  Optional[Text] = Unset,
+      fields:  List[WebIdlField],
+      partial: Boolean        = false )
+
+  case Namespace(name: Text, exposed: List[Text], members: List[WebIdlMember],
+      partial: Boolean = false)
+
+  case Enumeration(name: Text, values: List[Text])
+  case Alias(name: Text, typed: Foreign.Type)
+  case CallbackFunction(name: Text, result: Foreign.Type, arguments: List[WebIdlArgument])
+  case Includes(target: Text, mixin: Text)
+
+  // The definition's own name — for `includes` statements, the including target.
+  def named: Text = this match
+    case Interface(name, _, _, _, _, _, _, _) => name
+    case Dictionary(name, _, _, _)            => name
+    case Namespace(name, _, _, _)             => name
+    case Enumeration(name, _)                 => name
+    case Alias(name, _)                       => name
+    case CallbackFunction(name, _, _)         => name
+    case Includes(target, _)                  => target
+
+object WebIdlError:
+  enum Reason(val number: Int) extends Clarification:
+    case Syntax(detail: Text, near: Text)  extends Reason(1)
+    case Unsupported(construct: Text)      extends Reason(2)
+    case Duplicate(name: Text)             extends Reason(3)
+
+  given communicable: Reason is Communicable =
+    case Reason.Syntax(detail, near) => m"$detail, near $near"
+
+    case Reason.Unsupported(construct) =>
+      m"the construct $construct is outside the grammar this parser accepts"
+
+    case Reason.Duplicate(name) => m"the definition $name appears twice"
+
+// A WebIDL fragment could not be read. `Unsupported` is deliberately an error and not a silent
+// skip, for the reason `TypescriptError` records: a capability contract read partially is a
+// smaller contract than the file declares, and every claim computed from it would be unsound.
+case class WebIdlError(reason: WebIdlError.Reason)(using Diagnostics)
+extends Error(644, reason.number)(m"the WebIDL could not be read because $reason")

--- a/lib/xenophile/src/webidl/xenophile.WebIdlParser.scala
+++ b/lib/xenophile/src/webidl/xenophile.WebIdlParser.scala
@@ -1,0 +1,530 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import scala.collection.immutable.List as SList
+import scala.collection.immutable.{::, Nil as SNil}
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+import WebIdlError.Reason
+
+// A declaration parser for WebIDL (https://webidl.spec.whatwg.org/), retaining what `webidl/1`
+// atomizes: definitions with their partiality, mixin identity, `[Exposed]` scopes,
+// required-versus-optional dictionary members, enumeration values, and special operations. It
+// deliberately does *not* resolve partials, mixins or typedefs — resolution is the atomizer's
+// first step (`webidl.md` §4), and folding it into parsing would erase the very structure the
+// atomizer needs to merge deterministically.
+//
+// A construct outside the vocabulary is a hard error, never a skip (`webidl.md` §4): a
+// partially-read capability contract understates what the file declares. Extended attributes
+// other than `[Exposed]` are consumed and dropped — they are recognized structure, not
+// unrecognized constructs.
+//
+// Types are canonicalized as `WebIdlDialect` canonicalizes them — numeric primitives to their
+// width-explicit names, the string types to `string`, `T?` to a union with `null` — so the two
+// readers of one `.idl` file agree about what a type is called.
+object WebIdlParser:
+
+  def parse(source: Text): List[WebIdlDefinition] raises WebIdlError =
+    val definitions = scala.collection.mutable.ListBuffer[WebIdlDefinition]()
+    var tokens = tokenize(source.s)
+
+    while tokens.nonEmpty do
+      val (definition, rest) = item(tokens)
+      definitions += definition
+      tokens = rest
+
+    List.from(definitions.toList)
+
+  private def fail(detail: Text, tokens: SList[String]): Nothing raises WebIdlError =
+    val near = Text(tokens.take(5).mkString(" "))
+    abort(WebIdlError(Reason.Syntax(detail, if near.s.isEmpty then t"the end" else near)))
+
+  private def unsupported(construct: Text): Nothing raises WebIdlError =
+    abort(WebIdlError(Reason.Unsupported(construct)))
+
+  // --- lexing ---------------------------------------------------------------------------------
+
+  private def tokenize(source: String): SList[String] =
+    def skipLine(index: Int): Int =
+      if index >= source.length || source.charAt(index) == '\n' then index + 1
+      else skipLine(index + 1)
+
+    def skipBlock(index: Int): Int =
+      if index + 1 >= source.length then source.length
+      else if source.charAt(index) == '*' && source.charAt(index + 1) == '/' then index + 2
+      else skipBlock(index + 1)
+
+    def endString(index: Int): Int =
+      if index >= source.length then source.length
+      else if source.charAt(index) == '"' then index + 1
+      else endString(index + 1)
+
+    def ident(char: Char): Boolean = char.isLetterOrDigit || char == '_' || char == '-'
+
+    def recur(index: Int, current: String, tokens: SList[String]): SList[String] =
+      val flushed = if current.isEmpty then tokens else current :: tokens
+
+      if index >= source.length then flushed.reverse else
+        val char = source.charAt(index)
+        val next = if index + 1 < source.length then source.charAt(index + 1) else ' '
+        val next2 = if index + 2 < source.length then source.charAt(index + 2) else ' '
+
+        if char == '/' && next == '/' then recur(skipLine(index), "", flushed)
+        else if char == '/' && next == '*' then recur(skipBlock(index + 2), "", flushed)
+        else if char == '"' then
+          val end = endString(index + 1)
+          recur(end, "", source.substring(index, end).nn :: flushed)
+        else if char == '.' && next == '.' && next2 == '.' then
+          recur(index + 3, "", "..." :: flushed)
+        else if ident(char) then recur(index + 1, current + char, tokens)
+        else if char.isWhitespace then recur(index + 1, "", flushed)
+        else recur(index + 1, "", char.toString :: flushed)
+
+    recur(0, "", SList())
+
+  // --- extended attributes --------------------------------------------------------------------
+
+  // Consumes one `[…]` extended-attribute group, returning the `[Exposed]` scopes it names.
+  // `Exposed=Window`, `Exposed=(Window,Worker)` and `Exposed=*` are all read; every other
+  // attribute is structure to skip, including argument lists and nested parentheses.
+  private def attributes(tokens: SList[String]): (List[Text], SList[String]) raises WebIdlError =
+    def scopes(tokens: SList[String], acc: SList[Text]): (SList[Text], SList[String]) =
+      tokens match
+        case ")" :: rest        => (acc.reverse, rest)
+        case "," :: rest        => scopes(rest, acc)
+        case name :: rest       => scopes(rest, name.tt :: acc)
+        case SNil            => (acc.reverse, SList())
+
+    def group(tokens: SList[String], depth: Int, acc: SList[Text])
+    :   (SList[Text], SList[String]) raises WebIdlError =
+      tokens match
+        case "]" :: rest if depth == 0 => (acc, rest)
+        case "[" :: rest               => group(rest, depth + 1, acc)
+        case "]" :: rest               => group(rest, depth - 1, acc)
+
+        case "Exposed" :: "=" :: "(" :: rest if depth == 0 =>
+          val (names, more) = scopes(rest, SList())
+          group(more, depth, acc ++ names)
+
+        case "Exposed" :: "=" :: name :: rest if depth == 0 =>
+          group(rest, depth, acc :+ name.tt)
+
+        case _ :: rest => group(rest, depth, acc)
+        case SNil   => fail(t"an extended attribute is unterminated", tokens)
+
+    tokens match
+      case "[" :: rest =>
+        val (scopes, more) = group(rest, 0, SList())
+        (List.from(scopes), more)
+
+      case _ => (List(), tokens)
+
+  // --- types ----------------------------------------------------------------------------------
+
+  private def typeOf(tokens: SList[String]): (Foreign.Type, SList[String]) raises WebIdlError =
+    // A type may carry its own extended-attribute group (`[LegacyNullToEmptyString] DOMString`);
+    // none of them is contract, so the group is consumed here for every type position at once.
+    val (_, afterAttrs) = attributes(tokens)
+    val (base, rest) = baseType(afterAttrs)
+
+    rest match
+      case "?" :: more => (Foreign.Type.Union(List(base, Foreign.Type.Named(t"null"))), more)
+      case _           => (base, rest)
+
+  private def baseType(tokens: SList[String]): (Foreign.Type, SList[String]) raises WebIdlError =
+    tokens match
+      case "(" :: rest                            => union(rest, SList())
+      case "unsigned" :: "long" :: "long" :: rest => (Foreign.Type.Named(t"u64"), rest)
+      case "unsigned" :: "long" :: rest           => (Foreign.Type.Named(t"u32"), rest)
+      case "unsigned" :: "short" :: rest          => (Foreign.Type.Named(t"u16"), rest)
+      case "long" :: "long" :: rest               => (Foreign.Type.Named(t"s64"), rest)
+      case "long" :: rest                         => (Foreign.Type.Named(t"s32"), rest)
+      case "short" :: rest                        => (Foreign.Type.Named(t"s16"), rest)
+      case "byte" :: rest                         => (Foreign.Type.Named(t"s8"), rest)
+      case "octet" :: rest                        => (Foreign.Type.Named(t"u8"), rest)
+      case "unrestricted" :: "float" :: rest      => (Foreign.Type.Named(t"f32"), rest)
+      case "unrestricted" :: "double" :: rest     => (Foreign.Type.Named(t"f64"), rest)
+      case "float" :: rest                        => (Foreign.Type.Named(t"f32"), rest)
+      case "double" :: rest                       => (Foreign.Type.Named(t"f64"), rest)
+      case "boolean" :: rest                      => (Foreign.Type.Named(t"boolean"), rest)
+      case "void" :: rest                         => (Foreign.Type.Named(t"undefined"), rest)
+
+      case ("DOMString" | "USVString" | "ByteString" | "CSSOMString") :: rest =>
+        (Foreign.Type.Named(t"string"), rest)
+
+      case name :: "<" :: rest =>
+        val (args, after) = typeArguments(rest, SList())
+        (Foreign.Type.Applied(name.tt, args), after)
+
+      case name :: rest if name.headOption.exists(_.isLetter) =>
+        (Foreign.Type.Named(name.tt), rest)
+
+      case _ => fail(t"a type was expected", tokens)
+
+  private def union(tokens: SList[String], acc: SList[Foreign.Type])
+  :   (Foreign.Type, SList[String]) raises WebIdlError =
+
+    val (member, rest) = typeOf(tokens)
+
+    rest match
+      case "or" :: more => union(more, member :: acc)
+      case ")" :: more  => (Foreign.Type.Union(List.from((member :: acc).reverse)), more)
+      case _            => fail(t"a union member must be followed by `or` or `)`", rest)
+
+  private def typeArguments(tokens: SList[String], acc: SList[Foreign.Type])
+  :   (List[Foreign.Type], SList[String]) raises WebIdlError =
+
+    val (arg, rest) = typeOf(tokens)
+
+    rest match
+      case "," :: more => typeArguments(more, arg :: acc)
+      case ">" :: more => (List.from((arg :: acc).reverse), more)
+      case _           => fail(t"a type argument must be followed by `,` or `>`", rest)
+
+  // --- default values -------------------------------------------------------------------------
+
+  // A default's *value* is behaviour rather than contract; its existence is what folds. The
+  // value forms are WebIDL's own: a literal, `null`, `[]`, `{}`.
+  private def skipDefault(tokens: SList[String]): (Boolean, SList[String]) = tokens match
+    case "=" :: "[" :: "]" :: rest => (true, rest)
+    case "=" :: "{" :: "}" :: rest => (true, rest)
+    case "=" :: "-" :: _ :: rest   => (true, rest)
+    case "=" :: _ :: rest          => (true, rest)
+    case _                         => (false, tokens)
+
+  // --- members --------------------------------------------------------------------------------
+
+  private def argumentList(tokens: SList[String])
+  :   (List[WebIdlArgument], SList[String]) raises WebIdlError =
+
+    def recur(tokens: SList[String], acc: SList[WebIdlArgument])
+    :   (List[WebIdlArgument], SList[String]) raises WebIdlError =
+
+      tokens match
+        case ")" :: rest => (List.from(acc.reverse), rest)
+
+        case _ =>
+          val (_, afterAttrs) = attributes(tokens)
+
+          val (optional, afterOptional) = afterAttrs match
+            case "optional" :: rest => (true, rest)
+            case _                  => (false, afterAttrs)
+
+          val (typed, afterType) = typeOf(afterOptional)
+
+          val (variadic, afterVariadic) = afterType match
+            case "..." :: rest => (true, rest)
+            case _             => (false, afterType)
+
+          afterVariadic match
+            case name :: rest =>
+              val (default, afterDefault) = skipDefault(rest)
+              val argument = WebIdlArgument(name.tt, typed, optional, variadic, default)
+
+              afterDefault match
+                case "," :: more => recur(more, argument :: acc)
+                case ")" :: more => (List.from((argument :: acc).reverse), more)
+                case _           => fail(t"an argument must be followed by `,` or `)`", afterDefault)
+
+            case SNil => fail(t"an argument name was expected", afterVariadic)
+
+    tokens match
+      case "(" :: rest => recur(rest, SList())
+      case _           => fail(t"an argument list was expected", tokens)
+
+  private def member(tokens: SList[String])
+  :   (Optional[WebIdlMember], Optional[(Text, List[Foreign.Type])], SList[String]) raises
+        WebIdlError =
+
+    val (_, afterAttrs) = attributes(tokens)
+
+    val (static, afterStatic) = afterAttrs match
+      case "static" :: rest => (true, rest)
+      case _                => (false, afterAttrs)
+
+    def semicolon(tokens: SList[String]): SList[String] raises WebIdlError = tokens match
+      case ";" :: rest => rest
+      case _           => fail(t"a `;` was expected", tokens)
+
+    def attribute(tokens: SList[String], readonly: Boolean)
+    :   (Optional[WebIdlMember], Optional[(Text, List[Foreign.Type])], SList[String]) raises
+          WebIdlError =
+
+      val (typed, afterType) = typeOf(tokens)
+
+      afterType match
+        case name :: rest =>
+          val member =
+            WebIdlMember(WebIdlMember.Kind.Attribute, name.tt, typed, readonly = readonly,
+                static = static)
+
+          (member, Unset, semicolon(rest))
+
+        case SNil => fail(t"an attribute name was expected", afterType)
+
+    def intrinsic(keyword: Text, tokens: SList[String])
+    :   (Optional[WebIdlMember], Optional[(Text, List[Foreign.Type])], SList[String]) raises
+          WebIdlError =
+
+      tokens match
+        case "<" :: rest =>
+          val (args, after) = typeArguments(rest, SList())
+          (Unset, (keyword, args), semicolon(after))
+
+        case _ => fail(t"`$keyword` needs type arguments", tokens)
+
+    def operation(tokens: SList[String], special: Optional[Text])
+    :   (Optional[WebIdlMember], Optional[(Text, List[Foreign.Type])], SList[String]) raises
+          WebIdlError =
+
+      val (typed, afterType) = typeOf(tokens)
+
+      afterType match
+        case "(" :: _ =>
+          // An anonymous special operation: the name position is empty.
+          val (arguments, after) = argumentList(afterType)
+
+          val member =
+            WebIdlMember(WebIdlMember.Kind.Operation, t"", typed, arguments, static = static,
+                special = special)
+
+          (member, Unset, semicolon(after))
+
+        case name :: rest =>
+          val (arguments, after) = argumentList(rest)
+
+          val member =
+            WebIdlMember(WebIdlMember.Kind.Operation, name.tt, typed, arguments, static = static,
+                special = special)
+
+          (member, Unset, semicolon(after))
+
+        case SNil => fail(t"an operation was expected", afterType)
+
+    afterStatic match
+      case "readonly" :: "attribute" :: rest => attribute(rest, readonly = true)
+      case "inherit" :: "attribute" :: rest  => attribute(rest, readonly = false)
+      case "attribute" :: rest               => attribute(rest, readonly = false)
+
+      case "readonly" :: ("maplike" | "setlike") :: _ =>
+        member(afterStatic.tail)
+
+      case "const" :: rest =>
+        val (typed, afterType) = typeOf(rest)
+
+        afterType match
+          case name :: more =>
+            val (_, afterValue) = skipDefault(more)
+
+            val constant =
+              WebIdlMember(WebIdlMember.Kind.Constant, name.tt, typed, readonly = true)
+
+            (constant, Unset, semicolon(afterValue))
+
+          case SNil => fail(t"a constant name was expected", afterType)
+
+      case "constructor" :: rest =>
+        val (arguments, after) = argumentList(rest)
+
+        val member =
+          WebIdlMember(WebIdlMember.Kind.Constructor, t"", Foreign.Type.Named(t"undefined"),
+              arguments)
+
+        (member, Unset, semicolon(after))
+
+      case "stringifier" :: ";" :: rest      => (Unset, (t"stringifier", List()), rest)
+      case "stringifier" :: rest             => member(rest)
+      case "iterable" :: rest                => intrinsic(t"iterable", rest)
+      case "maplike" :: rest                 => intrinsic(t"maplike", rest)
+      case "setlike" :: rest                 => intrinsic(t"setlike", rest)
+      case "async" :: "iterable" :: rest     => intrinsic(t"async-iterable", rest)
+      case "getter" :: rest                  => operation(rest, t"getter")
+      case "setter" :: rest                  => operation(rest, t"setter")
+      case "deleter" :: rest                 => operation(rest, t"deleter")
+      case _                                 => operation(afterStatic, Unset)
+
+  private def memberList(tokens: SList[String])
+  :   (List[WebIdlMember], List[(Text, List[Foreign.Type])], SList[String]) raises
+        WebIdlError =
+
+    def recur
+      ( tokens:     SList[String],
+        members:    SList[WebIdlMember],
+        intrinsics: SList[(Text, List[Foreign.Type])] )
+    :   (List[WebIdlMember], List[(Text, List[Foreign.Type])], SList[String]) raises
+          WebIdlError =
+
+      tokens match
+        case "}" :: ";" :: rest =>
+          (List.from(members.reverse), List.from(intrinsics.reverse), rest)
+
+        case "}" :: rest => fail(t"a definition must end `};`", rest)
+        case SNil     => fail(t"a definition body is unterminated", tokens)
+
+        case _ =>
+          val (parsed, intrinsic, rest) = member(tokens)
+          val nextMembers = parsed.let(_ :: members).or(members)
+          val nextIntrinsics = intrinsic.let(_ :: intrinsics).or(intrinsics)
+          recur(rest, nextMembers, nextIntrinsics)
+
+    tokens match
+      case "{" :: rest => recur(rest, SList(), SList())
+      case _           => fail(t"a definition body was expected", tokens)
+
+  // --- definitions ----------------------------------------------------------------------------
+
+  private def item(tokens: SList[String]): (WebIdlDefinition, SList[String]) raises WebIdlError =
+    val (exposed, afterAttrs) = attributes(tokens)
+
+    def interface(tokens: SList[String], partial: Boolean, mixin: Boolean, callback: Boolean)
+    :   (WebIdlDefinition, SList[String]) raises WebIdlError =
+
+      tokens match
+        case name :: rest =>
+          val (parent, afterParent) = rest match
+            case ":" :: parent :: more => (Optional(parent.tt), more)
+            case _                     => (Unset, rest)
+
+          val (members, intrinsics, after) = memberList(afterParent)
+
+          (WebIdlDefinition.Interface(name.tt, parent, exposed, members, intrinsics, partial,
+              mixin, callback), after)
+
+        case SNil => fail(t"an interface name was expected", tokens)
+
+    def dictionary(tokens: SList[String], partial: Boolean)
+    :   (WebIdlDefinition, SList[String]) raises WebIdlError =
+
+      def fields(tokens: SList[String], acc: SList[WebIdlField])
+      :   (List[WebIdlField], SList[String]) raises WebIdlError =
+
+        tokens match
+          case "}" :: ";" :: rest => (List.from(acc.reverse), rest)
+          case SNil            => fail(t"a dictionary body is unterminated", tokens)
+
+          case _ =>
+            val (_, afterAttrs) = attributes(tokens)
+
+            val (required, afterRequired) = afterAttrs match
+              case "required" :: rest => (true, rest)
+              case _                  => (false, afterAttrs)
+
+            val (typed, afterType) = typeOf(afterRequired)
+
+            afterType match
+              case name :: rest =>
+                val (default, afterDefault) = skipDefault(rest)
+
+                afterDefault match
+                  case ";" :: more =>
+                    fields(more, WebIdlField(name.tt, typed, required, default) :: acc)
+
+                  case _ => fail(t"a `;` was expected", afterDefault)
+
+              case SNil => fail(t"a dictionary member name was expected", afterType)
+
+      tokens match
+        case name :: rest =>
+          val (parent, afterParent) = rest match
+            case ":" :: parent :: more => (Optional(parent.tt), more)
+            case _                     => (Unset, rest)
+
+          afterParent match
+            case "{" :: body =>
+              val (members, after) = fields(body, SList())
+              (WebIdlDefinition.Dictionary(name.tt, parent, members, partial), after)
+
+            case _ => fail(t"a dictionary body was expected", afterParent)
+
+        case SNil => fail(t"a dictionary name was expected", tokens)
+
+    afterAttrs match
+      case "partial" :: "interface" :: "mixin" :: rest => interface(rest, true, true, false)
+      case "partial" :: "interface" :: rest            => interface(rest, true, false, false)
+      case "partial" :: "dictionary" :: rest           => dictionary(rest, true)
+      case "interface" :: "mixin" :: rest              => interface(rest, false, true, false)
+      case "interface" :: rest                         => interface(rest, false, false, false)
+      case "callback" :: "interface" :: rest           => interface(rest, false, false, true)
+      case "dictionary" :: rest                        => dictionary(rest, false)
+
+      case "partial" :: "namespace" :: name :: rest =>
+        val (members, _, after) = memberList(rest)
+        (WebIdlDefinition.Namespace(name.tt, exposed, members, partial = true), after)
+
+      case "namespace" :: name :: rest =>
+        val (members, _, after) = memberList(rest)
+        (WebIdlDefinition.Namespace(name.tt, exposed, members), after)
+
+      case "enum" :: name :: "{" :: rest =>
+        def values(tokens: SList[String], acc: SList[Text])
+        :   (List[Text], SList[String]) raises WebIdlError =
+
+          tokens match
+            case "}" :: ";" :: rest => (List.from(acc.reverse), rest)
+            case "," :: rest        => values(rest, acc)
+
+            case value :: rest if value.startsWith("\"") =>
+              values(rest, Text(value.substring(1, value.length - 1).nn) :: acc)
+
+            case _ => fail(t"an enumeration value was expected", tokens)
+
+        val (list, after) = values(rest, SList())
+        (WebIdlDefinition.Enumeration(name.tt, list), after)
+
+      case "typedef" :: rest =>
+        val (typed, afterType) = typeOf(rest)
+
+        afterType match
+          case name :: ";" :: more => (WebIdlDefinition.Alias(name.tt, typed), more)
+          case _                   => fail(t"a typedef name and `;` were expected", afterType)
+
+      case "callback" :: name :: "=" :: rest =>
+        val (result, afterResult) = typeOf(rest)
+        val (arguments, after) = argumentList(afterResult)
+
+        after match
+          case ";" :: more => (WebIdlDefinition.CallbackFunction(name.tt, result, arguments), more)
+          case _           => fail(t"a `;` was expected", after)
+
+      case target :: "includes" :: mixin :: ";" :: rest =>
+        (WebIdlDefinition.Includes(target.tt, mixin.tt), rest)
+
+      case construct :: _ => unsupported(construct.tt)
+      case SNil        => fail(t"a definition was expected", afterAttrs)

--- a/lib/xenophile/src/wit/xenophile.WitDeclaration.scala
+++ b/lib/xenophile/src/wit/xenophile.WitDeclaration.scala
@@ -30,7 +30,77 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{CHeaderAtomizer, CHeaderDiscipline, DtsAtomizer, DtsDiscipline,
-    WebIdlAtomizer, WebIdlDiscipline, WitAtomizer, WitDiscipline}
+import anticipation.*
+import fulminate.*
+import gossamer.*
+import vacuous.*
+
+// The declaration model of a WIT document, as `wit/1` atomizes it (`wit.md`). Unlike
+// `WitDialect`, which flattens what foreign navigation does not need — enum and variant case
+// names, package structure, worlds' contents — this model retains the declared surface whole.
+case class WitFunction
+  ( name:        Text,
+    parameters:  List[(Text, Foreign.Type)],
+    result:      Optional[Foreign.Type] = Unset,
+    static:      Boolean               = false,
+    constructor: Boolean               = false )
+
+enum WitItem:
+  case Alias(name: Text, target: Foreign.Type)
+  case Record(name: Text, fields: List[(Text, Foreign.Type)])
+  case Variant(name: Text, cases: List[(Text, Optional[Foreign.Type])])
+  case Enumeration(name: Text, cases: List[Text])
+  case Flags(name: Text, names: List[Text])
+  case Resource(name: Text, methods: List[WitFunction])
+  case Function(function: WitFunction)
+
+  // One `use` clause: the interface it draws from (package-qualified or same-package) and the
+  // (original, local) name pairs it introduces. Transparent to atomization — references are
+  // encoded fully qualified — but load-bearing for the qualification itself.
+  case Use(from: Text, names: List[(Text, Text)])
+
+  def named: Text = this match
+    case Alias(name, _)        => name
+    case Record(name, _)       => name
+    case Variant(name, _)      => name
+    case Enumeration(name, _)  => name
+    case Flags(name, _)        => name
+    case Resource(name, _)     => name
+    case Function(function)    => function.name
+    case Use(from, _)          => from
+
+case class WitInterface(name: Text, items: List[WitItem])
+
+case class WitWorldModel(name: Text, imports: List[Text], exports: List[Text])
+
+case class WitDocument
+  ( packageName: Optional[Text],
+    version:     Optional[Text],
+    interfaces:  List[WitInterface],
+    worlds:      List[WitWorldModel] )
+
+object WitParseError:
+  enum Reason(val number: Int) extends Clarification:
+    case Syntax(detail: Text, near: Text)  extends Reason(1)
+    case Unsupported(construct: Text)      extends Reason(2)
+    case Duplicate(name: Text)             extends Reason(3)
+    case Unresolved(name: Text)            extends Reason(4)
+
+  given communicable: Reason is Communicable =
+    case Reason.Syntax(detail, near) => m"$detail, near $near"
+
+    case Reason.Unsupported(construct) =>
+      m"the construct $construct is outside the grammar this parser accepts"
+
+    case Reason.Duplicate(name)  => m"the definition $name appears twice"
+    case Reason.Unresolved(name) => m"the type $name resolves to no declaration"
+
+// A WIT document could not be read. `Unsupported` is deliberately an error and not a silent
+// skip: a contract read partially is a smaller contract than the file declares, and every
+// claim computed from it would be unsound. `@unstable` items are `Unsupported` by design
+// (`wit.md` §4): an unstable item in a published contract would be a stable claim about an
+// unstable surface.
+case class WitParseError(reason: WitParseError.Reason)(using Diagnostics)
+extends Error(645, reason.number)(m"the WIT could not be read because $reason")

--- a/lib/xenophile/src/wit/xenophile.WitParser.scala
+++ b/lib/xenophile/src/wit/xenophile.WitParser.scala
@@ -1,0 +1,418 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import scala.collection.immutable.List as SList
+import scala.collection.immutable.{::, Nil as SNil}
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+import WitParseError.Reason
+
+// A declaration parser for WIT (WebAssembly Interface Types), retaining what `wit/1` atomizes:
+// packages with their versions, interfaces with their full item vocabulary — records, variants,
+// enums, flags, resources, aliases, functions, `use` clauses — and worlds with their imports
+// and exports.
+//
+// A construct outside the vocabulary is a hard error, never a skip (`wit.md` §4). `@since`
+// gates are consumed — the lineage already records when an item arrived — while `@unstable`
+// is refused: an unstable item in a published contract would be a stable claim about an
+// unstable surface.
+object WitParser:
+
+  def parse(source: Text): WitDocument raises WitParseError =
+    document(tokenize(source.s))
+
+  private def fail(detail: Text, tokens: SList[String]): Nothing raises WitParseError =
+    val near = Text(tokens.take(5).mkString(" "))
+    abort(WitParseError(Reason.Syntax(detail, if near.s.isEmpty then t"the end" else near)))
+
+  private def unsupported(construct: Text): Nothing raises WitParseError =
+    abort(WitParseError(Reason.Unsupported(construct)))
+
+  // --- lexing ---------------------------------------------------------------------------------
+
+  // WIT identifiers are kebab-case words; `%` escapes a keyword. Package references
+  // (`wasi:io/streams@0.2.0`) are lexed as words including `:`, `/`, `@` and version dots, so
+  // one token carries one reference.
+  private def tokenize(source: String): SList[String] =
+    def skipLine(index: Int): Int =
+      if index >= source.length || source.charAt(index) == '\n' then index + 1
+      else skipLine(index + 1)
+
+    def skipBlock(index: Int): Int =
+      if index + 1 >= source.length then source.length
+      else if source.charAt(index) == '*' && source.charAt(index + 1) == '/' then index + 2
+      else skipBlock(index + 1)
+
+    def ident(char: Char): Boolean =
+      char.isLetterOrDigit || char == '-' || char == '_' || char == '%'
+
+    // The reference punctuation (`:`, `/`, `@`, `.`) joins a token only *between* ident
+    // characters, so `wasi:io/streams@0.2.0` is one token while `value: u64` splits at the
+    // colon and `one.{id}` splits at the dot.
+    def glue(char: Char): Boolean =
+      char == ':' || char == '/' || char == '@' || char == '.'
+
+    def recur(index: Int, current: String, tokens: SList[String]): SList[String] =
+      val flushed = if current.isEmpty then tokens else current :: tokens
+
+      if index >= source.length then flushed.reverse else
+        val char = source.charAt(index)
+        val next = if index + 1 < source.length then source.charAt(index + 1) else ' '
+
+        if char == '/' && next == '/' then recur(skipLine(index), "", flushed)
+        else if char == '/' && next == '*' then recur(skipBlock(index + 2), "", flushed)
+        else if ident(char) then recur(index + 1, current + char, tokens)
+        else if glue(char) && current.nonEmpty && ident(next) then
+          recur(index + 1, current + char, tokens)
+        else if char == '@' && current.isEmpty && ident(next) then
+          recur(index + 1, "@", tokens)
+        else if char.isWhitespace then recur(index + 1, "", flushed)
+        else recur(index + 1, "", char.toString :: flushed)
+
+    recur(0, "", SList())
+
+  // --- gates ----------------------------------------------------------------------------------
+
+  private def gates(tokens: SList[String]): SList[String] raises WitParseError = tokens match
+    case "@since" :: "(" :: rest =>
+      rest.dropWhile(_ != ")") match
+        case ")" :: more => gates(more)
+        case other       => fail(t"an unterminated @since gate", other)
+
+    case "@unstable" :: _ => unsupported(t"an @unstable item")
+    case _                => tokens
+
+  // --- types ----------------------------------------------------------------------------------
+
+  private val primitives: Set[String] =
+    Set("bool", "u8", "u16", "u32", "u64", "s8", "s16", "s32", "s64", "f32", "f64", "char",
+        "string")
+
+  private def typeOf(tokens: SList[String]): (Foreign.Type, SList[String]) raises WitParseError =
+    tokens match
+      case ("stream" | "future") :: _ => unsupported(t"a stream or future type")
+
+      case name :: "<" :: rest =>
+        def arguments(tokens: SList[String], acc: SList[Foreign.Type])
+        :   (SList[Foreign.Type], SList[String]) raises WitParseError =
+
+          val (arg, after) = tokens match
+            case "_" :: more => (Foreign.Type.Named(t"_"), more)
+            case _           => typeOf(tokens)
+
+          after match
+            case "," :: more => arguments(more, arg :: acc)
+            case ">" :: more => ((arg :: acc).reverse, more)
+            case _           => fail(t"a type argument must be followed by `,` or `>`", after)
+
+        val (args, after) = arguments(rest, SList())
+        (Foreign.Type.Applied(name.tt, List.from(args)), after)
+
+      case name :: rest if name.headOption.exists { char => char.isLetter || char == '%' } =>
+        (Foreign.Type.Named(Text(name.stripPrefix("%").nn)), rest)
+
+      case _ => fail(t"a type was expected", tokens)
+
+  // --- functions ------------------------------------------------------------------------------
+
+  private def parameters(tokens: SList[String])
+  :   (List[(Text, Foreign.Type)], SList[String]) raises WitParseError =
+
+    def recur(tokens: SList[String], acc: SList[(Text, Foreign.Type)])
+    :   (List[(Text, Foreign.Type)], SList[String]) raises WitParseError =
+
+      tokens match
+        case ")" :: rest => (List.from(acc.reverse), rest)
+        case "," :: rest => recur(rest, acc)
+
+        case name :: ":" :: rest =>
+          val (typed, after) = typeOf(rest)
+          recur(after, (Text(name.stripPrefix("%").nn), typed) :: acc)
+
+        case _ => fail(t"a parameter was expected", tokens)
+
+    tokens match
+      case "(" :: rest => recur(rest, SList())
+      case _           => fail(t"a parameter list was expected", tokens)
+
+  private def functionType(name: Text, tokens: SList[String], static: Boolean)
+  :   (WitFunction, SList[String]) raises WitParseError =
+
+    val afterAsync = tokens match
+      case "async" :: rest => unsupported(t"an async function")
+      case _               => tokens
+
+    afterAsync match
+      case "func" :: rest =>
+        val (params, afterParams) = parameters(rest)
+
+        val (result, afterResult) = afterParams match
+          case "-" :: ">" :: more =>
+            val (typed, after) = typeOf(more)
+            (Optional(typed), after)
+
+          case _ => (Unset, afterParams)
+
+        afterResult match
+          case ";" :: more => (WitFunction(name, params, result, static), more)
+          case _           => fail(t"a `;` was expected", afterResult)
+
+      case _ => fail(t"`func` was expected", afterAsync)
+
+  // --- interface items ------------------------------------------------------------------------
+
+  private def nameList(tokens: SList[String])
+  :   (List[(Text, Text)], SList[String]) raises WitParseError =
+
+    def recur(tokens: SList[String], acc: SList[(Text, Text)])
+    :   (List[(Text, Text)], SList[String]) raises WitParseError =
+
+      tokens match
+        case "}" :: rest => (List.from(acc.reverse), rest)
+        case "," :: rest => recur(rest, acc)
+
+        case name :: "as" :: alias :: rest =>
+          recur(rest, (name.tt, alias.tt) :: acc)
+
+        case name :: rest => recur(rest, (name.tt, name.tt) :: acc)
+        case SNil         => fail(t"a use list is unterminated", tokens)
+
+    tokens match
+      case "{" :: rest => recur(rest, SList())
+      case _           => fail(t"a `{` was expected", tokens)
+
+  private def fieldList(tokens: SList[String], closer: Text)
+  :   (List[(Text, Foreign.Type)], SList[String]) raises WitParseError =
+
+    def recur(tokens: SList[String], acc: SList[(Text, Foreign.Type)])
+    :   (List[(Text, Foreign.Type)], SList[String]) raises WitParseError =
+
+      gates(tokens) match
+        case "}" :: rest => (List.from(acc.reverse), rest)
+        case "," :: rest => recur(rest, acc)
+
+        case name :: ":" :: rest =>
+          val (typed, after) = typeOf(rest)
+          recur(after, (Text(name.stripPrefix("%").nn), typed) :: acc)
+
+        case _ => fail(t"a field was expected", tokens)
+
+    recur(tokens, SList())
+
+  private def caseList(tokens: SList[String])
+  :   (List[(Text, Optional[Foreign.Type])], SList[String]) raises WitParseError =
+
+    def recur(tokens: SList[String], acc: SList[(Text, Optional[Foreign.Type])])
+    :   (List[(Text, Optional[Foreign.Type])], SList[String]) raises WitParseError =
+
+      gates(tokens) match
+        case "}" :: rest => (List.from(acc.reverse), rest)
+        case "," :: rest => recur(rest, acc)
+
+        case name :: "(" :: rest =>
+          val (typed, after) = typeOf(rest)
+
+          after match
+            case ")" :: more => recur(more, (name.tt, Optional(typed)) :: acc)
+            case _           => fail(t"a `)` was expected", after)
+
+        case name :: rest => recur(rest, (name.tt, Unset) :: acc)
+        case SNil         => fail(t"a case list is unterminated", tokens)
+
+    recur(tokens, SList())
+
+  private def bareList(tokens: SList[String])
+  :   (List[Text], SList[String]) raises WitParseError =
+
+    def recur(tokens: SList[String], acc: SList[Text])
+    :   (List[Text], SList[String]) raises WitParseError =
+
+      gates(tokens) match
+        case "}" :: rest  => (List.from(acc.reverse), rest)
+        case "," :: rest  => recur(rest, acc)
+        case name :: rest => recur(rest, name.tt :: acc)
+        case SNil         => fail(t"a name list is unterminated", tokens)
+
+    recur(tokens, SList())
+
+  private def resourceBody(tokens: SList[String])
+  :   (List[WitFunction], SList[String]) raises WitParseError =
+
+    def recur(tokens: SList[String], acc: SList[WitFunction])
+    :   (List[WitFunction], SList[String]) raises WitParseError =
+
+      gates(tokens) match
+        case "}" :: rest => (List.from(acc.reverse), rest)
+
+        case "constructor" :: "(" :: rest =>
+          val (params, afterParams) = parameters("(" :: rest)
+
+          afterParams match
+            case ";" :: more =>
+              recur(more, WitFunction(t"constructor", params, constructor = true) :: acc)
+
+            case _ => fail(t"a `;` was expected", afterParams)
+
+        case name :: ":" :: "static" :: rest =>
+          val (function, after) = functionType(Text(name.stripPrefix("%").nn), rest, true)
+          recur(after, function :: acc)
+
+        case name :: ":" :: rest =>
+          val (function, after) = functionType(Text(name.stripPrefix("%").nn), rest, false)
+          recur(after, function :: acc)
+
+        case _ => fail(t"a resource member was expected", tokens)
+
+    recur(tokens, SList())
+
+  private def interfaceBody(tokens: SList[String])
+  :   (List[WitItem], SList[String]) raises WitParseError =
+
+    def recur(tokens: SList[String], acc: SList[WitItem])
+    :   (List[WitItem], SList[String]) raises WitParseError =
+
+      gates(tokens) match
+        case "}" :: rest => (List.from(acc.reverse), rest)
+
+        case "use" :: from :: "." :: rest =>
+          val (names, after) = nameList(rest)
+
+          after match
+            case ";" :: more => recur(more, WitItem.Use(from.tt, names) :: acc)
+            case _           => fail(t"a `;` was expected", after)
+
+        case "type" :: name :: "=" :: rest =>
+          val (typed, after) = typeOf(rest)
+
+          after match
+            case ";" :: more => recur(more, WitItem.Alias(name.tt, typed) :: acc)
+            case _           => fail(t"a `;` was expected", after)
+
+        case "record" :: name :: "{" :: rest =>
+          val (fields, after) = fieldList(rest, t"}")
+          recur(after, WitItem.Record(name.tt, fields) :: acc)
+
+        case "variant" :: name :: "{" :: rest =>
+          val (cases, after) = caseList(rest)
+          recur(after, WitItem.Variant(name.tt, cases) :: acc)
+
+        case "enum" :: name :: "{" :: rest =>
+          val (cases, after) = bareList(rest)
+          recur(after, WitItem.Enumeration(name.tt, cases) :: acc)
+
+        case "flags" :: name :: "{" :: rest =>
+          val (names, after) = bareList(rest)
+          recur(after, WitItem.Flags(name.tt, names) :: acc)
+
+        case "resource" :: name :: "{" :: rest =>
+          val (methods, after) = resourceBody(rest)
+          recur(after, WitItem.Resource(name.tt, methods) :: acc)
+
+        case "resource" :: name :: ";" :: rest =>
+          recur(rest, WitItem.Resource(name.tt, List()) :: acc)
+
+        case name :: ":" :: rest =>
+          val (function, after) = functionType(Text(name.stripPrefix("%").nn), rest, false)
+          recur(after, WitItem.Function(function) :: acc)
+
+        case construct :: _ => unsupported(construct.tt)
+        case SNil           => fail(t"an interface body is unterminated", tokens)
+
+    recur(tokens, SList())
+
+  // --- worlds ---------------------------------------------------------------------------------
+
+  private def worldBody(tokens: SList[String])
+  :   (List[Text], List[Text], SList[String]) raises WitParseError =
+
+    def recur(tokens: SList[String], imports: SList[Text], exports: SList[Text])
+    :   (List[Text], List[Text], SList[String]) raises WitParseError =
+
+      gates(tokens) match
+        case "}" :: rest => (List.from(imports.reverse), List.from(exports.reverse), rest)
+
+        case "import" :: name :: ";" :: rest => recur(rest, name.tt :: imports, exports)
+        case "export" :: name :: ";" :: rest => recur(rest, imports, name.tt :: exports)
+
+        case ("import" | "export") :: _ :: ":" :: _ =>
+          unsupported(t"an inline world item")
+
+        case "include" :: _ => unsupported(t"a world include")
+        case construct :: _ => unsupported(construct.tt)
+        case SNil           => fail(t"a world body is unterminated", tokens)
+
+    recur(tokens, SList(), SList())
+
+  // --- documents ------------------------------------------------------------------------------
+
+  private def document(tokens: SList[String]): WitDocument raises WitParseError =
+    def recur
+      ( tokens:     SList[String],
+        pkg:        Optional[Text],
+        version:    Optional[Text],
+        interfaces: SList[WitInterface],
+        worlds:     SList[WitWorldModel] )
+    :   WitDocument raises WitParseError =
+
+      gates(tokens) match
+        case SNil =>
+          WitDocument(pkg, version, List.from(interfaces.reverse), List.from(worlds.reverse))
+
+        case "package" :: name :: ";" :: rest =>
+          val at = name.indexOf('@')
+
+          val (bare, declared) =
+            if at < 0 then (name.tt, Unset)
+            else (name.substring(0, at).nn.tt, Optional(name.substring(at + 1).nn.tt))
+
+          recur(rest, bare, declared, interfaces, worlds)
+
+        case "interface" :: name :: "{" :: rest =>
+          val (items, after) = interfaceBody(rest)
+          recur(after, pkg, version, WitInterface(name.tt, items) :: interfaces, worlds)
+
+        case "world" :: name :: "{" :: rest =>
+          val (imports, exports, after) = worldBody(rest)
+          recur(after, pkg, version, interfaces,
+              WitWorldModel(name.tt, imports, exports) :: worlds)
+
+        case construct :: _ => unsupported(construct.tt)
+
+    recur(tokens, Unset, Unset, SList(), SList())


### PR DESCRIPTION
Audited every part of Soundness that implements LIRA against the current specification and
closed the gaps in both directions, in five steps: conformance and labelling fixes across
reliquary, degustation, mandible and xenophile; the host-contract axis of hosts.md (the `host`
world, `requires`, `capability/1`, L135–L137 and buildpath rule 7 with cross-contract
spanning); the completion of buildpath validity (`serves` joins, rule 6 profile coherence,
integration pinning); and four new disciplines — `wit/1`, `webidl/1`, `cheader/1` and
`kotlin-metadata/1` — each with a declaration-grade parser beside its FFI dialect and a
normative companion document now in the LIRA spec. The spec itself gained labels L138–L141 and
a series of corrections discovered by implementing it.

## Release notes

- **Host contracts are now first-class.** A release with a `host` section is a host contract:
  `capability/1` atomizes its capability listing, sections may carry `requires` records naming
  the contracts their code assumes, and buildpath validation decides satisfaction by lineage
  membership or cross-contract spanning — with an explicit `HostPending` advisory when
  validation runs without a contract.

  ```scala
  Buildpath(List(app)).validate(t"jvm", contracts = List(posix))
  ```

- **Cross-universe dependencies.** `Dependency.serves` expresses joins (a Scala module's
  `sjsir` build invoking a TypeScript module), closure checks the join edge, and derivation
  produces one artifact set per universe of the target.

- **Four new disciplines.** `wit/1` (WASI worlds and component interfaces), `webidl/1`
  (browser host contracts, with the platform's own additive folding), `cheader/1`
  (shared-library contracts such as OpenSSL's, per-symbol), and `kotlin-metadata/1` (the
  Kotlin surface no bytecode-level discipline can see: nullability, properties, defaults,
  suspend coloring).

- **Publish-time verification.** `Verification.reatomize` re-checks a release's declared atom
  listings under the manifest's own discipline order (L134/L140/L141), and declared derivative
  hashes are recomputed (L138). The `jvm/1` profile's audit now aggregates findings and
  surfaces changed constants through an advisory channel.

- Consumers can pin releases to named integrations; profiles impose buildpath-wide predicates
  (rule 6); and `tasty/1` now declares its true domain, includes qualified-private members,
  and strips the `exported` flag so an `export` forwarder atomizes as its hand-written
  equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
