### PR TITLE
Bounds-safe `Region` access for streams, ducts and cursors

### DIFF
--- a/lib/anthology/src/kotlin/anthology.Kotlinc.scala
+++ b/lib/anthology/src/kotlin/anthology.Kotlinc.scala
@@ -129,7 +129,7 @@ case class Kotlinc[version <: Kotlinc.Versions](options: List[Kotlinc.Option[ver
               val endLine = if location.getLineEnd < 1 then line else location.getLineEnd
               val endColumn = if location.getColumnEnd < 1 then column else location.getColumnEnd
 
-              Span.region((line - 1).z, (column - 1).z, (endLine - 1).z, (endColumn - 1).z)
+              Span.area((line - 1).z, (column - 1).z, (endLine - 1).z, (endColumn - 1).z)
 
           process.put(Notice(importance, file, text, span))
 

--- a/lib/anthology/src/scala/anthology_scala.scala
+++ b/lib/anthology/src/scala/anthology_scala.scala
@@ -148,7 +148,7 @@ private[anthology] def notice(diagnostic: Diagnostic): Notice =
   diagnostic.position.map: position =>
     position.nn.pipe: position =>
       val span =
-        Span.region
+        Span.area
           ( position.startLine.nn.z,
             position.startColumn.nn.z,
             position.endLine.nn.z,

--- a/lib/bitumen/src/jvm/bitumen.TarBuilder.scala
+++ b/lib/bitumen/src/jvm/bitumen.TarBuilder.scala
@@ -44,6 +44,7 @@ import scala.collection.mutable as scm
 import anticipation.*
 import aperture.*
 import contingency.*
+import denominative.*
 import galilei.CreateFlag
 import gossamer.*
 import hypotenuse.*
@@ -266,8 +267,11 @@ object TarBuilder:
         val out = ji.FileOutputStream(temporary.toFile)
 
         try
-          stream.sweep: (window, start, count) =>
-            out.write(window.asInstanceOf[scala.Array[Byte]], start, count)
+          stream.sweep: region =>
+            range =>
+              val interval: Interval = range
+              out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0,
+                  interval.size)
         finally out.close()
 
         jnf.Files.move(temporary, target, jnf.StandardCopyOption.ATOMIC_MOVE,

--- a/lib/caesura/src/core/caesura.Sheet.scala
+++ b/lib/caesura/src/core/caesura.Sheet.scala
@@ -141,8 +141,7 @@ object Sheet:
     rowIterator:
       new Parser(() => stream.refill(Credit(block)) match
         case count: Int =>
-          val window = stream.window(using Unsafe)
-          val text = stream.addressable.materialize(window, stream.start, count)
+          val text = stream.region { region => range => region.materialize(range.capped(count)) }
           stream.skip(count)
           text
 
@@ -164,8 +163,7 @@ object Sheet:
     DsvReader(format = format, tactic = caps.unsafe.unsafeAssumePure(tactic), parser =
       new Parser(() => stream.refill(Credit(block)) match
         case count: Int =>
-          val window = stream.window(using Unsafe)
-          val text = stream.addressable.materialize(window, stream.start, count)
+          val text = stream.region { region => range => region.materialize(range.capped(count)) }
           stream.skip(count)
           text
 

--- a/lib/caesura/src/core/caesura.Sheet.scala
+++ b/lib/caesura/src/core/caesura.Sheet.scala
@@ -141,7 +141,7 @@ object Sheet:
     rowIterator:
       new Parser(() => stream.refill(Credit(block)) match
         case count: Int =>
-          val text = stream.region { region => range => region.materialize(range.capped(count)) }
+          val text = stream.lend { region => range => region.materialize(range.capped(count)) }
           stream.skip(count)
           text
 
@@ -163,7 +163,7 @@ object Sheet:
     DsvReader(format = format, tactic = caps.unsafe.unsafeAssumePure(tactic), parser =
       new Parser(() => stream.refill(Credit(block)) match
         case count: Int =>
-          val text = stream.region { region => range => region.materialize(range.capped(count)) }
+          val text = stream.lend { region => range => region.materialize(range.capped(count)) }
           stream.skip(count)
           text
 

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -43,7 +43,7 @@ import rudiments.*
 import spectacular.*
 import turbulence.*
 import urticose.MacAddress
-import zephyrine.{Stream, Credit, Buffering, Substrate, stream}
+import zephyrine.{Stream, Credit, Buffering, Substrate, capped, stream}
 import vacuous.*
 
 import Control.*
@@ -140,7 +140,7 @@ extension [endpoint: Showable](endpoint: endpoint)(using serviceable: (endpoint 
       while !done do input.refill(demand) match
         case count: Int =>
           if count > 0 then
-            val data = input.addressable.materialize(input.window(using Unsafe), input.start, count)
+            val data = input.region { region => range => region.materialize(range.capped(count)) }
             input.skip(count)
 
             handle(using state)(message.deserialize(data)) match
@@ -200,7 +200,7 @@ extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint i
       while !done do input.refill(demand) match
         case count: Int =>
           if count > 0 then
-            val data = input.addressable.materialize(input.window(using Unsafe), input.start, count)
+            val data = input.region { region => range => region.materialize(range.capped(count)) }
             input.skip(count)
 
             handle(using state)(message.deserialize(data)) match

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -140,7 +140,7 @@ extension [endpoint: Showable](endpoint: endpoint)(using serviceable: (endpoint 
       while !done do input.refill(demand) match
         case count: Int =>
           if count > 0 then
-            val data = input.region { region => range => region.materialize(range.capped(count)) }
+            val data = input.lend { region => range => region.materialize(range.capped(count)) }
             input.skip(count)
 
             handle(using state)(message.deserialize(data)) match
@@ -200,7 +200,7 @@ extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint i
       while !done do input.refill(demand) match
         case count: Int =>
           if count > 0 then
-            val data = input.region { region => range => region.materialize(range.capped(count)) }
+            val data = input.lend { region => range => region.materialize(range.capped(count)) }
             input.skip(count)
 
             handle(using state)(message.deserialize(data)) match

--- a/lib/coaxial/src/jvm/coaxial_jvm.scala
+++ b/lib/coaxial/src/jvm/coaxial_jvm.scala
@@ -44,6 +44,7 @@ import java.util as ju
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import hypotenuse.*
 import prepositional.*
 import rudiments.*
@@ -97,7 +98,7 @@ package socketBackends:
         private var total: Long = 0
         private var ended: Boolean = false
 
-        protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+        protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
         def start: Int = start0
         def limit: Int = limit0
         update def skip(count: Int): Unit = start0 += count
@@ -288,13 +289,19 @@ package socketBackends:
       case ClientExchange.Tcp(socket) =>
         val out = socket.getOutputStream.nn
 
-        input.sweep: (storage, start, count) =>
-          out.write(storage.asInstanceOf[scala.Array[Byte]], start, count)
-          out.flush()
+        input.sweep: region =>
+          range =>
+            val interval: Interval = range
+            out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0,
+                interval.size)
+            out.flush()
 
       case ClientExchange.Domain(channel) =>
-        input.sweep: (storage, start, count) =>
-          channel.write(ByteBuffer.wrap(storage.asInstanceOf[scala.Array[Byte]], start, count))
+        input.sweep: region =>
+          range =>
+            val interval: Interval = range
+            channel.write(ByteBuffer.wrap(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]),
+                interval.start.n0, interval.size))
 
         channel.shutdownOutput()
 
@@ -490,7 +497,7 @@ private[coaxial] def streamsDuplex
         private var limit0: Int = 0
         private var ended: Boolean = false
 
-        protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+        protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
         def start: Int = start0
         def limit: Int = limit0
         update def skip(count: Int): Unit = start0 += count
@@ -518,9 +525,12 @@ private[coaxial] def streamsDuplex
                   count
 
     def send(consume data: (Stream[Data] over Credit)^): Unit =
-      data.sweep: (storage, start, count) =>
-        out.write(storage.asInstanceOf[scala.Array[Byte]], start, count)
-        out.flush()
+      data.sweep: region =>
+        range =>
+          val interval: Interval = range
+          out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0,
+              interval.size)
+          out.flush()
 
     def close(): Unit = shutdown()
 
@@ -528,9 +538,14 @@ private[coaxial] def streamsDuplex
 // reusable buffer and blocks in `read`; EOF (`-1`) terminates the stream.
 private[coaxial] def channelDuplex(socketChannel: jnc.SocketChannel): Duplex = new Duplex:
   def send(consume data: (Stream[Data] over Credit)^): Unit =
-    data.sweep: (storage, start, count) =>
-      val out = ByteBuffer.wrap(storage.asInstanceOf[scala.Array[Byte]], start, count).nn
-      while out.hasRemaining do socketChannel.write(out)
+    data.sweep: region =>
+      range =>
+        val interval: Interval = range
+
+        val out = ByteBuffer.wrap(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]),
+            interval.start.n0, interval.size).nn
+
+        while out.hasRemaining do socketChannel.write(out)
 
   def close(): Unit = socketChannel.close()
 
@@ -546,7 +561,7 @@ private[coaxial] def channelDuplex(socketChannel: jnc.SocketChannel): Duplex = n
       private var limit0: Int = 0
       private var ended: Boolean = false
 
-      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
       update def skip(count: Int): Unit = start0 += count

--- a/lib/coaxial/src/native/coaxial_native.scala
+++ b/lib/coaxial/src/native/coaxial_native.scala
@@ -97,7 +97,7 @@ package socketBackends:
         private var total: Long = 0
         private var ended: Boolean = false
 
-        protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+        protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
         def start: Int = start0
         def limit: Int = limit0
         update def skip(count: Int): Unit = start0 += count
@@ -458,7 +458,7 @@ private[coaxial] def streamsDuplex(in: ji.InputStream, out: ji.OutputStream)(shu
         private var limit0: Int = 0
         private var ended: Boolean = false
 
-        protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+        protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
         def start: Int = start0
         def limit: Int = limit0
         update def skip(count: Int): Unit = start0 += count
@@ -553,7 +553,7 @@ private[coaxial] def bioDuplex(bio: Ptr[Byte], context: Ptr[Byte]): Duplex =
         private var limit0: Int = 0
         private var ended: Boolean = false
 
-        protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+        protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
         def start: Int = start0
         def limit: Int = limit0
         update def skip(count: Int): Unit = start0 += count
@@ -568,7 +568,7 @@ private[coaxial] def bioDuplex(bio: Ptr[Byte], context: Ptr[Byte]): Duplex =
               start0 = 0
               limit0 = 0
 
-              // (`asInstanceOf` launders the field read's capture, as `window0` does, and
+              // (`asInstanceOf` launders the field read's capture, as `storage0` does, and
               // `atUnsafe` is Scala Native's array-to-pointer view — its bounds-checked `at`
               // is shadowed by rudiments' `at` extension; the indices here are in range by
               // construction.)

--- a/lib/coaxial/src/native/coaxial_native.scala
+++ b/lib/coaxial/src/native/coaxial_native.scala
@@ -45,6 +45,7 @@ import scala.scalanative.unsafe.*
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import hypotenuse.*
 import prepositional.*
 import rudiments.*
@@ -274,9 +275,12 @@ package socketBackends:
       case ClientExchange.Tcp(socket) =>
         val out = socket.getOutputStream.nn
 
-        caps.unsafe.unsafeAssumePure(input).sweep: (storage, start, count) =>
-          out.write(storage.asInstanceOf[scala.Array[Byte]], start, count)
-          out.flush()
+        caps.unsafe.unsafeAssumePure(input).sweep: region =>
+          range =>
+            val interval: Interval = range
+            out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0,
+                interval.size)
+            out.flush()
 
     def response(exchange: ClientExchange)(using Buffering, Tactic[StreamError])
     :   (Stream[Data] over Credit)^{caps.any} =
@@ -486,9 +490,12 @@ private[coaxial] def streamsDuplex(in: ji.InputStream, out: ji.OutputStream)(shu
                   count
 
     def send(consume data: (Stream[Data] over Credit)^): Unit =
-      data.sweep: (storage, start, count) =>
-        out.write(storage.asInstanceOf[scala.Array[Byte]], start, count)
-        out.flush()
+      data.sweep: region =>
+        range =>
+          val interval: Interval = range
+          out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0,
+              interval.size)
+          out.flush()
 
     def close(): Unit = shutdown()
 
@@ -587,14 +594,18 @@ private[coaxial] def bioDuplex(bio: Ptr[Byte], context: Ptr[Byte]): Duplex =
       // stream `write` throws at runtime; `Duplex.send` offers no typed error channel.
       import unsafeExceptions.canThrowAny
 
-      data.sweep: (storage, start, count) =>
-        val array = storage.asInstanceOf[scala.Array[Byte]]
-        var written = 0
+      data.sweep: region =>
+        range =>
+          val interval: Interval = range
+          val start = interval.start.n0
+          val count = interval.size
+          val array = unsafely(region.raw.asInstanceOf[scala.Array[Byte]])
+          var written = 0
 
-        while written < count do
-          val result = libcrypto.BIO_write(bio, array.atUnsafe(start + written), count - written)
-          if result <= 0 then throw ji.IOException("TLS: BIO_write failed: "+opensslError())
-          written += result
+          while written < count do
+            val result = libcrypto.BIO_write(bio, array.atUnsafe(start + written), count - written)
+            if result <= 0 then throw ji.IOException("TLS: BIO_write failed: "+opensslError())
+            written += result
 
     def close(): Unit =
       libcrypto.BIO_free_all(bio)

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -42,6 +42,7 @@ import java.net as jn
 import java.nio.channels as jnc
 
 import soundness.{transmit as _, listen as _, react as _, duplex as _, *}
+import zephyrine.capped
 
 import charEncoders.utf8Encoder
 import charDecoders.utf8Decoder
@@ -272,7 +273,7 @@ object Tests extends Suite(m"Coaxial tests"):
           val handler = (connection: Duplex) =>
             val source = connection.source
             val count = source.refill(zephyrine.Credit(64)).or(0)
-            source.addressable.materialize(source.window(using Unsafe), source.start, count)
+            source.region { region => range => region.materialize(range.capped(count)) }
 
           socket.listen[Data](handler):
 
@@ -283,7 +284,7 @@ object Tests extends Suite(m"Coaxial tests"):
               val source = duplex.source
               val count = source.refill(zephyrine.Credit(64)).or(0)
               val data =
-                source.addressable.materialize(source.window(using Unsafe), source.start, count)
+                source.region { region => range => region.materialize(range.capped(count)) }
 
               bytes(data)
         . assert(_ == bytes(ascii(t"ping")))

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -273,7 +273,7 @@ object Tests extends Suite(m"Coaxial tests"):
           val handler = (connection: Duplex) =>
             val source = connection.source
             val count = source.refill(zephyrine.Credit(64)).or(0)
-            source.region { region => range => region.materialize(range.capped(count)) }
+            source.lend { region => range => region.materialize(range.capped(count)) }
 
           socket.listen[Data](handler):
 
@@ -284,7 +284,7 @@ object Tests extends Suite(m"Coaxial tests"):
               val source = duplex.source
               val count = source.refill(zephyrine.Credit(64)).or(0)
               val data =
-                source.region { region => range => region.materialize(range.capped(count)) }
+                source.lend { region => range => region.materialize(range.capped(count)) }
 
               bytes(data)
         . assert(_ == bytes(ascii(t"ping")))

--- a/lib/coaxial/src/wasi/coaxial_wasi.scala
+++ b/lib/coaxial/src/wasi/coaxial_wasi.scala
@@ -146,7 +146,7 @@ package socketBackends:
         private var limit0: Int = 0
         private var ended: Boolean = false
 
-        protected def window0: AnyRef = chunk.asInstanceOf[AnyRef]
+        protected def storage0: AnyRef = chunk.asInstanceOf[AnyRef]
         def start: Int = start0
         def limit: Int = limit0
         update def skip(count: Int): Unit = start0 += count
@@ -178,9 +178,8 @@ package socketBackends:
 
       val stream: Foreign of "output-stream" from Wit = outputHandle
 
-      input.sweep: (storage, start, count) =>
-        val slice = storage.asInstanceOf[scala.Array[Byte]].slice(start, start + count).nn
-        stream.`blocking-write-and-flush`(Array.unsafeFrozen(slice)).invoke[Unit]
+      input.sweep: region =>
+        range => stream.`blocking-write-and-flush`(region.materialize(range)).invoke[Unit]
 
     // Presents a connected socket's stream halves as a `Duplex`: `source` reads, `send` writes,
     // `close` drops both streams and the socket.

--- a/lib/coaxial/src/wasi/coaxial_wasi.scala
+++ b/lib/coaxial/src/wasi/coaxial_wasi.scala
@@ -38,6 +38,7 @@ import scala.annotation.nowarn
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import distillate.*
 import gigantism.*
 import gossamer.*
@@ -172,14 +173,24 @@ package socketBackends:
                 Unset
 
     // Writes a whole pull-stream to a WASI `output-stream`, one `blocking-write-and-flush` per
-    // window.
+    // region. A hand-rolled drain loop rather than `sweep`: this body is pickled into the
+    // enclosing inline given and re-typechecked in wasm guests, whose flag set cannot
+    // elaborate `sweep`'s dependent-typed Region lambda.
     private def drain(outputHandle: WitHandle of "output-stream", input: (Stream[Data] over Credit)^)
     :   Unit =
 
       val stream: Foreign of "output-stream" from Wit = outputHandle
 
-      input.sweep: region =>
-        range => stream.`blocking-write-and-flush`(region.materialize(range)).invoke[Unit]
+      def loop(): Unit = input.refill(Credit(Long.MaxValue)) match
+        case count: Int =>
+          val chunk = input.addressable.materialize(input.storage(using Unsafe), input.start, count)
+          stream.`blocking-write-and-flush`(chunk).invoke[Unit]
+          input.skip(count)
+          loop()
+
+        case _ => ()
+
+      try loop() finally input.close()
 
     // Presents a connected socket's stream halves as a `Duplex`: `source` reads, `send` writes,
     // `close` drops both streams and the socket.

--- a/lib/denominative/src/core/denominative.internal.scala
+++ b/lib/denominative/src/core/denominative.internal.scala
@@ -42,7 +42,7 @@ object internal:
   opaque type Ordinal = Int
   opaque type Interval = Long
 
-  // A `Span` packs a located region of characters into a single `Long`, tagged by
+  // A `Span` packs a located range of characters into a single `Long`, tagged by
   // a 3-bit mode in the top bits. Lines, columns and offsets are 0-based and fit
   // an `Ordinal` (a 32-bit `Int`). Accessors return `Unset` for fields a mode does
   // not carry. The five modes (3 reserved for the future) are:
@@ -51,7 +51,7 @@ object internal:
   //   Offset (1)  offset(31), length(30)                       — line-less sources
   //   Line   (2)  line(23), column(19), length(19)             — single-line spans
   //   Lines  (3)  startLine(31), lineCount(30)                 — whole-line ranges
-  //   Region (4)  startLine(22), startColumn(14), lineDelta(11), endColumn(14)
+  //   Area   (4)  startLine(22), startColumn(14), lineDelta(11), endColumn(14)
   //                                  — multi-line with columns; endLine = start+delta
   opaque type Span = Long
 
@@ -148,18 +148,18 @@ object internal:
       case 1 => Span.Mode.Offset
       case 2 => Span.Mode.Line
       case 3 => Span.Mode.Lines
-      case 4 => Span.Mode.Region
+      case 4 => Span.Mode.Area
       case _ => Span.Mode.Empty
 
     def startLine: Optional[Ordinal] = mode match
       case Span.Mode.Line   => Ordinal.zerary(((span >>> 38) & 0x7fffffL).toInt)
       case Span.Mode.Lines  => Ordinal.zerary(((span >>> 30) & 0x7fffffffL).toInt)
-      case Span.Mode.Region => Ordinal.zerary(((span >>> 39) & 0x3fffffL).toInt)
+      case Span.Mode.Area => Ordinal.zerary(((span >>> 39) & 0x3fffffL).toInt)
       case _                => Unset
 
     def startColumn: Optional[Ordinal] = mode match
       case Span.Mode.Line   => Ordinal.zerary(((span >>> 19) & 0x7ffffL).toInt)
-      case Span.Mode.Region => Ordinal.zerary(((span >>> 25) & 0x3fffL).toInt)
+      case Span.Mode.Area => Ordinal.zerary(((span >>> 25) & 0x3fffL).toInt)
       case _                => Unset
 
     def endLine: Optional[Ordinal] = mode match
@@ -168,7 +168,7 @@ object internal:
       case Span.Mode.Lines =>
         Ordinal.zerary((((span >>> 30) & 0x7fffffffL) + (span & 0x3fffffffL) - 1).toInt)
 
-      case Span.Mode.Region =>
+      case Span.Mode.Area =>
         Ordinal.zerary((((span >>> 39) & 0x3fffffL) + ((span >>> 14) & 0x7ffL)).toInt)
 
       case _ => Unset
@@ -177,7 +177,7 @@ object internal:
       case Span.Mode.Line =>
         Ordinal.zerary(((span >>> 19) & 0x7ffffL).toInt + (span & 0x7ffffL).toInt)
 
-      case Span.Mode.Region => Ordinal.zerary((span & 0x3fffL).toInt)
+      case Span.Mode.Area => Ordinal.zerary((span & 0x3fffL).toInt)
       case _                => Unset
 
     def length: Optional[Int] = mode match
@@ -192,17 +192,17 @@ object internal:
     def lineCount: Optional[Int] = mode match
       case Span.Mode.Line   => 1
       case Span.Mode.Lines  => (span & 0x3fffffffL).toInt
-      case Span.Mode.Region => ((span >>> 14) & 0x7ffL).toInt + 1
+      case Span.Mode.Area => ((span >>> 14) & 0x7ffL).toInt + 1
       case _                => Unset
 
     def singleLine: Boolean = mode match
       case Span.Mode.Line   => true
-      case Span.Mode.Region => ((span >>> 14) & 0x7ffL) == 0L
+      case Span.Mode.Area => ((span >>> 14) & 0x7ffL) == 0L
       case _                => false
 
   object Span:
     enum Mode derives CanEqual:
-      case Empty, Offset, Line, Lines, Region
+      case Empty, Offset, Line, Lines, Area
 
     given equality: CanEqual[Span, Span] = CanEqual.derived
 
@@ -220,7 +220,7 @@ object internal:
     inline def lines(startLine: Ordinal, lineCount: Int): Span =
       (3L << 61) | ((startLine.n0.toLong & 0x7fffffffL) << 30) | (lineCount.toLong & 0x3fffffffL)
 
-    inline def region
+    inline def area
       ( startLine: Ordinal, startColumn: Ordinal, endLine: Ordinal, endColumn: Ordinal )
     :   Span =
 

--- a/lib/denominative/src/test/denominative_test.scala
+++ b/lib/denominative/src/test/denominative_test.scala
@@ -548,35 +548,35 @@ object Tests extends Suite(m"Denominative Tests"):
         span.startColumn
       . assert(_ == Unset)
 
-    suite(m"Span region-mode tests"):
-      val span = Span.region(2.z, 4.z, 6.z, 9.z)
+    suite(m"Span area-mode tests"):
+      val span = Span.area(2.z, 4.z, 6.z, 9.z)
 
-      test(m"region mode reports Region"):
+      test(m"area mode reports Area"):
         span.mode
-      . assert(_ == Span.Mode.Region)
+      . assert(_ == Span.Mode.Area)
 
-      test(m"region round-trips the start line"):
+      test(m"area round-trips the start line"):
         span.startLine.vouch
       . assert(_ == 2.z)
 
-      test(m"region round-trips the start column"):
+      test(m"area round-trips the start column"):
         span.startColumn.vouch
       . assert(_ == 4.z)
 
-      test(m"region round-trips the end line"):
+      test(m"area round-trips the end line"):
         span.endLine.vouch
       . assert(_ == 6.z)
 
-      test(m"region round-trips the end column"):
+      test(m"area round-trips the end column"):
         span.endColumn.vouch
       . assert(_ == 9.z)
 
-      test(m"a multi-line region is not single-line"):
+      test(m"a multi-line area is not single-line"):
         span.singleLine
       . assert(_ == false)
 
-      test(m"region line count is inclusive"):
-        Span.region(10.z, 0.z, 13.z, 0.z).lineCount.vouch
+      test(m"area line count is inclusive"):
+        Span.area(10.z, 0.z, 13.z, 0.z).lineCount.vouch
       . assert(_ == 4)
 
     suite(m"Span empty-mode tests"):

--- a/lib/dissonance/src/core/dissonance.Diff.scala
+++ b/lib/dissonance/src/core/dissonance.Diff.scala
@@ -172,11 +172,11 @@ case class Diff[element](edits: Edit[element]*):
 
   def rdiff(similar: (element, element) => Boolean, subSize: Int = 1): RDiff[element] =
     val changes = collate.bind:
-      case Region.Unchanged(pars)    => (pars: List[Change[element]])
-      case Region.Changed(dels, Nil) => (dels: List[Change[element]])
-      case Region.Changed(Nil, inss) => (inss: List[Change[element]])
+      case Tract.Unchanged(pars)    => (pars: List[Change[element]])
+      case Tract.Changed(dels, Nil) => (dels: List[Change[element]])
+      case Tract.Changed(Nil, inss) => (inss: List[Change[element]])
 
-      case Region.Changed(dels, inss) =>
+      case Tract.Changed(dels, inss) =>
         if inss.length == dels.length && inss.length <= subSize
         then
           val subs = dels.zip(inss).map: (del, ins) =>
@@ -198,17 +198,17 @@ case class Diff[element](edits: Edit[element]*):
 
     RDiff(changes*)
 
-  def collate: List[Region[element]] =
+  def collate: List[Tract[element]] =
     edits.to(List).runsBy:
       case Par(_, _, _) => true
       case _            => false
 
     . map:
         case xs@(Par(_, _, _) :: _) =>
-          Region.Unchanged(xs.collect { case par: Par[element] => par })
+          Tract.Unchanged(xs.collect { case par: Par[element] => par })
 
         case xs =>
-          Region.Changed
+          Tract.Changed
             ( xs.collect { case del: Del[element] => del },
               xs.collect { case ins: Ins[element] => ins } )
 

--- a/lib/dissonance/src/core/dissonance.Tract.scala
+++ b/lib/dissonance/src/core/dissonance.Tract.scala
@@ -32,6 +32,6 @@
                                                                                                   */
 package dissonance
 
-enum Region[element]:
+enum Tract[element]:
   case Changed(deletions: List[Del[element]], insertions: List[Ins[element]])
   case Unchanged(retentions: List[Par[element]])

--- a/lib/dissonance/src/core/soundness_dissonance_core.scala
+++ b/lib/dissonance/src/core/soundness_dissonance_core.scala
@@ -35,4 +35,4 @@ package soundness
 export
   dissonance
   . { Change, Chunk, Del, Diff, diff, DiffError, Edit, Evolution, evolve, Ins, Par, RDiff, Redraft,
-      RedraftError, Region, Sub }
+      RedraftError, Sub, Tract }

--- a/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
@@ -36,6 +36,7 @@ import scala.caps
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import gossamer.*
 import prepositional.*
 import proscenium.compat.*
@@ -171,27 +172,29 @@ extends Duct[Data, Data]:
 
     count
 
-  update def step
-    ( source: input.Storage,
-      sourceOffset: Int,
-      sourceLength: Int,
-      target: output.Storage,
-      targetOffset: Int,
-      targetSpace: Int )
+  update def step(source: Region[Data])(range: Interval in source.type)
+    ( target: Slate[Data] )(space: Interval in target.type)
   :   Duct.Progress =
 
-    val bytes = target.asInstanceOf[scala.Array[Byte]]
+    val sourceLength = (range: Interval).size
+    val targetInterval: Interval = space
+    val targetOffset = targetInterval.start.n0
+    val targetSpace = targetInterval.size
+    val bytes = unsafely(target.raw.asInstanceOf[scala.Array[Byte]])
 
     if offset < pending.length then Duct.Progress(0, deliver(bytes, targetOffset, targetSpace))
     else
-      val chunk = input.materialize(source, sourceOffset, sourceLength)
+      val chunk = source.materialize(range)
       total += sourceLength
       pending = session.update(chunk)
       offset = 0
       Duct.Progress(sourceLength, deliver(bytes, targetOffset, targetSpace))
 
-  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
-    val bytes = target.asInstanceOf[scala.Array[Byte]]
+  override update def flush(target: Slate[Data])(space: Interval in target.type): Int =
+    val targetInterval: Interval = space
+    val targetOffset = targetInterval.start.n0
+    val targetSpace = targetInterval.size
+    val bytes = unsafely(target.raw.asInstanceOf[scala.Array[Byte]])
 
     if offset < pending.length then deliver(bytes, targetOffset, targetSpace)
     else if !finished then
@@ -235,38 +238,32 @@ extends Duct[Data, Data]:
   def regulation: Credit is Regulation = summon[Credit is Regulation]
   def translate(demand: Credit): Credit = demand
 
-  update def step
-    ( source: input.Storage,
-      sourceOffset: Int,
-      sourceLength: Int,
-      target: output.Storage,
-      targetOffset: Int,
-      targetSpace: Int )
+  update def step(source: Region[Data])(range: Interval in source.type)
+    ( target: Slate[Data] )(space: Interval in target.type)
   :   Duct.Progress =
 
     inner match
-      case duct: CipherDuct =>
-        // `Addressable` instances are unique per medium, so the two ducts'
-        // `Storage` paths coincide at erasure.
-        duct.step
-          ( source.asInstanceOf[duct.input.Storage],
-            sourceOffset,
-            sourceLength,
-            target.asInstanceOf[duct.output.Storage],
-            targetOffset,
-            targetSpace )
+      case duct0: CipherDuct =>
+        // Re-asserts the exclusivity the untracked field forgot, as at every cast rim.
+        val duct = duct0.asInstanceOf[CipherDuct^]
+        duct.step(source)(range)(target)(space)
 
       case null =>
-        val take = sourceLength.min(ivSize - headerFilled)
-        System.arraycopy(source.asInstanceOf[scala.Array[Byte]], sourceOffset, header, headerFilled, take)
+        val sourceInterval: Interval = range
+        val take = sourceInterval.size.min(ivSize - headerFilled)
+
+        System.arraycopy(unsafely(source.raw.asInstanceOf[scala.Array[Byte]]),
+            sourceInterval.start.n0, header, headerFilled, take)
+
         headerFilled += take
         if headerFilled == ivSize then inner = begin().asInstanceOf[CipherDuct]
         Duct.Progress(take, 0)
 
-  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+  override update def flush(target: Slate[Data])(space: Interval in target.type): Int =
     inner match
-      case duct: CipherDuct =>
-        try duct.flush(target.asInstanceOf[duct.output.Storage], targetOffset, targetSpace)
+      case duct0: CipherDuct =>
+        val duct = duct0.asInstanceOf[CipherDuct^]
+        try duct.flush(target)(space)
         catch case error: Exception =>
           // Matched by class name (see `securityException`): `javax.crypto` types cannot be
           // referenced from this platform-neutral file. (`canThrowAny` only relicenses the
@@ -284,4 +281,4 @@ extends Duct[Data, Data]:
 
       case null =>
         inner = begin().asInstanceOf[CipherDuct]
-        flush(target, targetOffset, targetSpace)
+        flush(target)(space)

--- a/lib/exegesis/src/core/exegesis.Lsp.scala
+++ b/lib/exegesis/src/core/exegesis.Lsp.scala
@@ -80,7 +80,7 @@ object Lsp:
 
   case class Range(start: Position, end: Position):
     def span: Span =
-      Span.region(start.line.z, start.character.z, end.line.z, end.character.z)
+      Span.area(start.line.z, start.character.z, end.line.z, end.character.z)
 
   object Location:
     // Pure and throwing, like the other derivation anchors; see `CompletionItem.decodable`.

--- a/lib/facsimile/src/core/facsimile.Gathering.scala
+++ b/lib/facsimile/src/core/facsimile.Gathering.scala
@@ -35,6 +35,8 @@ package facsimile
 import proscenium.compat.*
 
 import anticipation.*
+import denominative.*
+import prepositional.*
 import rudiments.*
 import vacuous.*
 import zephyrine.*
@@ -57,38 +59,25 @@ private[facsimile] class Gathering(transform: Data => Data) extends Duct[Data, D
   def regulation: Credit is Regulation = summon[Credit is Regulation]
   def translate(demand: Credit): Credit = demand
 
-  update def step
-    ( source: input.Storage,
-      sourceOffset: Int,
-      sourceLength: Int,
-      target: output.Storage,
-      targetOffset: Int,
-      targetSpace: Int )
+  update def step(source: Region[Data])(range: Interval in source.type)
+    ( target: Slate[Data] )(space: Interval in target.type)
   :   Duct.Progress =
 
-    val bytes = source.asInstanceOf[scala.Array[Byte]]
-    var i = 0
+    source.visit(range) { index => gathered += source(index) }
+    Duct.Progress((range: Interval).size, 0)
 
-    while i < sourceLength do
-      gathered += bytes(sourceOffset + i)
-      i += 1
-
-    Duct.Progress(sourceLength, 0)
-
-  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
-    val out = target.asInstanceOf[scala.Array[Byte]]
-
+  override update def flush(target: Slate[Data])(space: Interval in target.type): Int =
     val data = result.or:
       val transformed = transform(Array.unsafeFrozen(gathered.toArray))
       result = transformed
       transformed
 
-    val count = targetSpace.min(data.length - delivered)
-    var i = 0
+    val count = (space: Interval).size.min(data.length - delivered)
+    var index = 0
 
-    while i < count do
-      writable(out)(targetOffset + i) = data(delivered + i)
-      i += 1
+    target.visit(space.capped(count)): ordinal =>
+      target(ordinal) = data(delivered + index)
+      index += 1
 
     delivered += count
     count

--- a/lib/facsimile/src/test/facsimile_test.scala
+++ b/lib/facsimile/src/test/facsimile_test.scala
@@ -1267,7 +1267,7 @@ object Tests extends Suite(m"Facsimile tests"):
 
         def recur(): Unit = stream.refill(Credit(4096)) match
           case count: Int =>
-            val window = unsafely(stream.window).asInstanceOf[scala.Array[Byte]]
+            val window = unsafely(stream.storage).asInstanceOf[scala.Array[Byte]]
             var i = 0
 
             while i < count do

--- a/lib/gastronomy/src/core/gastronomy_core.scala
+++ b/lib/gastronomy/src/core/gastronomy_core.scala
@@ -35,6 +35,9 @@ package gastronomy
 import scala.caps
 
 import anticipation.*
+import contingency.*
+import denominative.*
+import vacuous.*
 import prepositional.*
 import turbulence.*
 import zephyrine.*
@@ -153,8 +156,15 @@ extension [source: Streamable by Data over Credit](source: source)
   :   Digest in hash =
 
     val digester = Digester: digestion =>
-      source.source[Data].sweep: (storage, start, count) =>
-        digestion.append(storage.asInstanceOf[Array[Byte]^{caps.any.rd}], start, count)
+      source.source[Data].sweep: region =>
+        range =>
+          val interval: Interval = range
+
+          val storage = unsafely(region.raw.asInstanceOf[scala.Array[Byte]])
+
+          digestion.append
+            ( storage.asInstanceOf[Array[Byte]^{caps.any.rd}],
+              interval.start.n0, interval.size )
 
     digester.apply
 

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -758,7 +758,7 @@ object Html extends Tag.Container
     private inline def cursor: Cursor[Text, ?]^ = cursor0.asInstanceOf[Cursor[Text, ?]^]
     private var heldToken: Cursor.Held | Null = null
 
-    type Region = Cursor.Mark
+    type Anchor = Cursor.Mark
 
     // ─── parser-local snapshot of the cursor's buffer / position ───────────
     //
@@ -913,7 +913,7 @@ object Html extends Tag.Container
     protected inline def let(inline body: Char => Unit): Unit =
       if more then body(peek)
 
-    type Mark = Region
+    type Mark = Anchor
 
     // Render line/column on demand for error messages.
     protected inline def currentPosition(): Position = computePosition()

--- a/lib/monotonous/src/core/monotonous.Alphabet.scala
+++ b/lib/monotonous/src/core/monotonous.Alphabet.scala
@@ -37,6 +37,8 @@ import proscenium.compat.*
 import scala.caps
 
 import anticipation.*
+import denominative.*
+import prepositional.*
 import rudiments.*
 import vacuous.*
 import contingency.*
@@ -100,18 +102,21 @@ object Alphabet:
           def translate(demand: Credit): Credit =
             Credit((demand.count.min(Long.MaxValue/8)*base/8).max(1))
 
-          update def step
-            ( source: input.Storage,
-              sourceOffset: Int,
-              sourceLength: Int,
-              target: output.Storage,
-              targetOffset: Int,
-              targetSpace: Int )
+          update def step(source: Region[Data])(range: Interval in source.type)
+            ( target: Slate[Text] )(space: Interval in target.type)
           :   Duct.Progress =
 
-            val bytes = source.asInstanceOf[scala.Array[Byte]]
+            val sourceInterval: Interval = range
+            val sourceOffset = sourceInterval.start.n0
+            val sourceLength = sourceInterval.size
+            val targetInterval: Interval = space
+            val targetOffset = targetInterval.start.n0
+            val targetSpace = targetInterval.size
+            val bytes = unsafely(source.raw.asInstanceOf[scala.Array[Byte]])
+
             // The stage's own buffer, asserted exclusive at the cast rim.
-            val chars: scala.Array[Char]^ = target.asInstanceOf[scala.Array[Char]^]
+            val chars: scala.Array[Char]^ =
+              unsafely(target.raw.asInstanceOf[scala.Array[Char]]).asInstanceOf[scala.Array[Char]^]
             var consumed: Int = 0
             var produced: Int = 0
             var continue: Boolean = true
@@ -151,10 +156,13 @@ object Alphabet:
 
             Duct.Progress(consumed, produced)
 
-          override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
-          :   Int =
+          override update def flush(target: Slate[Text])(space: Interval in target.type): Int =
+            val targetInterval: Interval = space
+            val targetOffset = targetInterval.start.n0
+            val targetSpace = targetInterval.size
 
-            val chars: scala.Array[Char]^ = target.asInstanceOf[scala.Array[Char]^]
+            val chars: scala.Array[Char]^ =
+              unsafely(target.raw.asInstanceOf[scala.Array[Char]]).asInstanceOf[scala.Array[Char]^]
             var produced: Int = 0
 
             if !flushing then
@@ -225,18 +233,21 @@ object Alphabet:
           def translate(demand: Credit): Credit =
             Credit((demand.count.min(Long.MaxValue/8)*8/base).max(1))
 
-          update def step
-            ( source: input.Storage,
-              sourceOffset: Int,
-              sourceLength: Int,
-              target: output.Storage,
-              targetOffset: Int,
-              targetSpace: Int )
+          update def step(source: Region[Text])(range: Interval in source.type)
+            ( target: Slate[Data] )(space: Interval in target.type)
           :   Duct.Progress =
 
-            val chars = source.asInstanceOf[scala.Array[Char]]
+            val sourceInterval: Interval = range
+            val sourceOffset = sourceInterval.start.n0
+            val sourceLength = sourceInterval.size
+            val targetInterval: Interval = space
+            val targetOffset = targetInterval.start.n0
+            val targetSpace = targetInterval.size
+            val chars = unsafely(source.raw.asInstanceOf[scala.Array[Char]])
+
             // The stage's own buffer, asserted exclusive at the cast rim.
-            val bytes: scala.Array[Byte]^ = target.asInstanceOf[scala.Array[Byte]^]
+            val bytes: scala.Array[Byte]^ =
+              unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
             var consumed: Int = 0
             var produced: Int = 0
             var continue: Boolean = true

--- a/lib/monotonous/src/test/monotonous_test.scala
+++ b/lib/monotonous/src/test/monotonous_test.scala
@@ -247,7 +247,7 @@ object Drain:
 
     def recur(): Unit = stream.refill(Credit(credit)) match
       case count: Int =>
-        val window = unsafely(stream.window).asInstanceOf[scala.Array[Char]]
+        val window = unsafely(stream.storage).asInstanceOf[scala.Array[Char]]
         builder.append(String(window, stream.start, count))
         stream.skip(count)
         recur()
@@ -262,7 +262,7 @@ object Drain:
 
     def recur(): Unit = stream.refill(Credit(credit)) match
       case count: Int =>
-        val window = unsafely(stream.window).asInstanceOf[scala.Array[Byte]]
+        val window = unsafely(stream.storage).asInstanceOf[scala.Array[Byte]]
         target.write(window, stream.start, count)
         stream.skip(count)
         recur()

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -159,7 +159,7 @@ private def readHandshake(input: (zephyrine.Stream[Data] over zephyrine.Credit)^
   while result.absent do input.refill(demand) match
     case count: Int =>
       if count > 0 then
-        val window = input.region { region => range => region.materialize(range.capped(count)) }
+        val window = input.lend { region => range => region.materialize(range.capped(count)) }
         val acc2: Data = acc ++ window
         val marker = crlfCrlf(acc2)
 

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -50,7 +50,7 @@ import hieroglyph.*
 import monotonous.*
 import parasite.*
 import prepositional.*
-import zephyrine.memoize
+import zephyrine.{capped, memoize}
 import rudiments.*
 import spectacular.*
 import telekinesis.*
@@ -159,7 +159,7 @@ private def readHandshake(input: (zephyrine.Stream[Data] over zephyrine.Credit)^
   while result.absent do input.refill(demand) match
     case count: Int =>
       if count > 0 then
-        val window = input.addressable.materialize(input.window(using Unsafe), input.start, count)
+        val window = input.region { region => range => region.materialize(range.capped(count)) }
         val acc2: Data = acc ++ window
         val marker = crlfCrlf(acc2)
 

--- a/lib/pneumatic/src/core/pneumatic.Brotli.scala
+++ b/lib/pneumatic/src/core/pneumatic.Brotli.scala
@@ -35,6 +35,9 @@ package pneumatic
 import scala.caps
 
 import anticipation.*
+import contingency.*
+import denominative.*
+import prepositional.*
 import proscenium.compat.*
 import rudiments.*
 import turbulence.*
@@ -140,27 +143,32 @@ private[pneumatic] class BrotliStage(engine0: => BrotliEngine^) extends Duct[Dat
   def regulation: Credit is Regulation = summon[Credit is Regulation]
   def translate(demand: Credit): Credit = demand
 
-  update def step
-    ( source: input.Storage,
-      sourceOffset: Int,
-      sourceLength: Int,
-      target: output.Storage,
-      targetOffset: Int,
-      targetSpace: Int )
+  update def step(source: Region[Data])(range: Interval in source.type)
+    ( target: Slate[Data] )(space: Interval in target.type)
   :   Duct.Progress =
 
-    engine.accept(source.asInstanceOf[Array[Byte]^{caps.any.rd}], sourceOffset, sourceLength)
+    val sourceInterval: Interval = range
+    val targetInterval: Interval = space
+    val bytes = unsafely(source.raw.asInstanceOf[scala.Array[Byte]])
+    val out: scala.Array[Byte]^ =
+      unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
+
+    engine.accept(bytes.asInstanceOf[Array[Byte]^{caps.any.rd}], sourceInterval.start.n0,
+        sourceInterval.size)
 
     Duct.Progress
-      ( sourceLength,
-        engine.deliver(target.asInstanceOf[scala.Array[Byte]], targetOffset, targetSpace) )
+      ( sourceInterval.size,
+        engine.deliver(out, targetInterval.start.n0, targetInterval.size) )
 
-  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+  override update def flush(target: Slate[Data])(space: Interval in target.type): Int =
     if !finishing then
       engine.finish()
       finishing = true
 
-    engine.deliver(target.asInstanceOf[scala.Array[Byte]], targetOffset, targetSpace)
+    val targetInterval: Interval = space
+    val out: scala.Array[Byte]^ =
+      unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
+    engine.deliver(out, targetInterval.start.n0, targetInterval.size)
 
 object Brotli:
   given compression: Brotli is Compression:

--- a/lib/pneumatic/src/core/pneumatic.LzwEngine.scala
+++ b/lib/pneumatic/src/core/pneumatic.LzwEngine.scala
@@ -35,6 +35,9 @@ package pneumatic
 import scala.caps
 
 import anticipation.*
+import contingency.*
+import denominative.*
+import prepositional.*
 import rudiments.*
 import vacuous.*
 import zephyrine.*
@@ -238,24 +241,29 @@ private[pneumatic] class LzwStage(engine0: => LzwEngine^) extends Duct[Data, Dat
   def regulation: Credit is Regulation = summon[Credit is Regulation]
   def translate(demand: Credit): Credit = demand
 
-  update def step
-    ( source: input.Storage,
-      sourceOffset: Int,
-      sourceLength: Int,
-      target: output.Storage,
-      targetOffset: Int,
-      targetSpace: Int )
+  update def step(source: Region[Data])(range: Interval in source.type)
+    ( target: Slate[Data] )(space: Interval in target.type)
   :   Duct.Progress =
 
-    engine.accept(source.asInstanceOf[Array[Byte]^{caps.any.rd}], sourceOffset, sourceLength)
+    val sourceInterval: Interval = range
+    val targetInterval: Interval = space
+    val bytes = unsafely(source.raw.asInstanceOf[scala.Array[Byte]])
+    val out: scala.Array[Byte]^ =
+      unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
+
+    engine.accept(bytes.asInstanceOf[Array[Byte]^{caps.any.rd}], sourceInterval.start.n0,
+        sourceInterval.size)
 
     Duct.Progress
-      ( sourceLength,
-        engine.deliver(target.asInstanceOf[scala.Array[Byte]], targetOffset, targetSpace) )
+      ( sourceInterval.size,
+        engine.deliver(out, targetInterval.start.n0, targetInterval.size) )
 
-  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+  override update def flush(target: Slate[Data])(space: Interval in target.type): Int =
     if !finishing then
       engine.finish()
       finishing = true
 
-    engine.deliver(target.asInstanceOf[scala.Array[Byte]], targetOffset, targetSpace)
+    val targetInterval: Interval = space
+    val out: scala.Array[Byte]^ =
+      unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
+    engine.deliver(out, targetInterval.start.n0, targetInterval.size)

--- a/lib/pneumatic/src/core/pneumatic.Xz.scala
+++ b/lib/pneumatic/src/core/pneumatic.Xz.scala
@@ -39,6 +39,9 @@ import proscenium.compat.*
 import scala.collection.mutable as scm
 
 import anticipation.*
+import contingency.*
+import denominative.*
+import prepositional.*
 import rudiments.*
 import turbulence.*
 import vacuous.*
@@ -198,27 +201,32 @@ private[pneumatic] class XzStage(engine0: => XzEngine^) extends Duct[Data, Data]
   def regulation: Credit is Regulation = summon[Credit is Regulation]
   def translate(demand: Credit): Credit = demand
 
-  update def step
-    ( source: input.Storage,
-      sourceOffset: Int,
-      sourceLength: Int,
-      target: output.Storage,
-      targetOffset: Int,
-      targetSpace: Int )
+  update def step(source: Region[Data])(range: Interval in source.type)
+    ( target: Slate[Data] )(space: Interval in target.type)
   :   Duct.Progress =
 
-    engine.accept(source.asInstanceOf[Array[Byte]^{caps.any.rd}], sourceOffset, sourceLength)
+    val sourceInterval: Interval = range
+    val targetInterval: Interval = space
+    val bytes = unsafely(source.raw.asInstanceOf[scala.Array[Byte]])
+    val out: scala.Array[Byte]^ =
+      unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
+
+    engine.accept(bytes.asInstanceOf[Array[Byte]^{caps.any.rd}], sourceInterval.start.n0,
+        sourceInterval.size)
 
     Duct.Progress
-      ( sourceLength,
-        engine.deliver(target.asInstanceOf[scala.Array[Byte]], targetOffset, targetSpace) )
+      ( sourceInterval.size,
+        engine.deliver(out, targetInterval.start.n0, targetInterval.size) )
 
-  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+  override update def flush(target: Slate[Data])(space: Interval in target.type): Int =
     if !finishing then
       engine.finish()
       finishing = true
 
-    engine.deliver(target.asInstanceOf[scala.Array[Byte]], targetOffset, targetSpace)
+    val targetInterval: Interval = space
+    val out: scala.Array[Byte]^ =
+      unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
+    engine.deliver(out, targetInterval.start.n0, targetInterval.size)
 
 object Xz:
   inline val DefaultPreset = 6

--- a/lib/pneumatic/src/flate/pneumatic.Deflation.scala
+++ b/lib/pneumatic/src/flate/pneumatic.Deflation.scala
@@ -33,6 +33,10 @@
 package pneumatic
 
 import anticipation.*
+import contingency.*
+import denominative.*
+import prepositional.*
+import vacuous.*
 import zephyrine.*
 
 // Streaming compression as a pipeline stage, over the pure-Scala `Deflater`. The three
@@ -75,17 +79,19 @@ extends Duct[Data, Data]:
 
     target(offset + 9) = -1
 
-  update def step
-    ( source: input.Storage,
-      sourceOffset: Int,
-      sourceLength: Int,
-      target: output.Storage,
-      targetOffset: Int,
-      targetSpace: Int )
+  update def step(source: Region[Data])(range: Interval in source.type)
+    ( target: Slate[Data] )(space: Interval in target.type)
   :   Duct.Progress =
 
-    val bytes = source.asInstanceOf[scala.Array[Byte]]
-    val out: scala.Array[Byte]^ = target.asInstanceOf[scala.Array[Byte]]
+    val sourceInterval: Interval = range
+    val sourceOffset = sourceInterval.start.n0
+    val sourceLength = sourceInterval.size
+    val targetInterval: Interval = space
+    val targetOffset = targetInterval.start.n0
+    val targetSpace = targetInterval.size
+    val bytes = unsafely(source.raw.asInstanceOf[scala.Array[Byte]])
+    val out: scala.Array[Byte]^ =
+      unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
     var consumed: Int = 0
     var produced: Int = 0
 
@@ -119,8 +125,12 @@ extends Duct[Data, Data]:
 
     Duct.Progress(consumed, produced)
 
-  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
-    val out: scala.Array[Byte]^ = target.asInstanceOf[scala.Array[Byte]]
+  override update def flush(target: Slate[Data])(space: Interval in target.type): Int =
+    val targetInterval: Interval = space
+    val targetOffset = targetInterval.start.n0
+    val targetSpace = targetInterval.size
+    val out: scala.Array[Byte]^ =
+      unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
     var produced: Int = 0
 
     if !headerDone && targetSpace >= 10 then
@@ -233,17 +243,19 @@ extends Duct[Data, Data]:
   private update def afterComment: Header =
     if (flags & 2) != 0 then Header.Checksum(2) else Header.Done
 
-  update def step
-    ( source: input.Storage,
-      sourceOffset: Int,
-      sourceLength: Int,
-      target: output.Storage,
-      targetOffset: Int,
-      targetSpace: Int )
+  update def step(source: Region[Data])(range: Interval in source.type)
+    ( target: Slate[Data] )(space: Interval in target.type)
   :   Duct.Progress =
 
-    val bytes = source.asInstanceOf[scala.Array[Byte]]
-    val out: scala.Array[Byte]^ = target.asInstanceOf[scala.Array[Byte]]
+    val sourceInterval: Interval = range
+    val sourceOffset = sourceInterval.start.n0
+    val sourceLength = sourceInterval.size
+    val targetInterval: Interval = space
+    val targetOffset = targetInterval.start.n0
+    val targetSpace = targetInterval.size
+    val bytes = unsafely(source.raw.asInstanceOf[scala.Array[Byte]])
+    val out: scala.Array[Byte]^ =
+      unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
     var consumed: Int = 0
     var produced: Int = 0
 
@@ -284,8 +296,12 @@ extends Duct[Data, Data]:
 
   // The inflater may hold far more pending output than one step's space, so
   // it must keep draining after the upstream ends.
-  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
-    val out: scala.Array[Byte]^ = target.asInstanceOf[scala.Array[Byte]]
+  override update def flush(target: Slate[Data])(space: Interval in target.type): Int =
+    val targetInterval: Interval = space
+    val targetOffset = targetInterval.start.n0
+    val targetSpace = targetInterval.size
+    val out: scala.Array[Byte]^ =
+      unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
     var produced: Int = 0
     var run: Int = 1
 

--- a/lib/pneumatic/src/test/pneumatic_test.scala
+++ b/lib/pneumatic/src/test/pneumatic_test.scala
@@ -621,7 +621,7 @@ object Tests extends Suite(m"Pneumatic tests"):
         def recur(): Unit = scala.caps.unsafe.unsafeAssumeSeparate:
          stream.refill(Credit(3)) match
           case count: Int =>
-            val window = unsafely(stream.window).asInstanceOf[scala.Array[Byte]]
+            val window = unsafely(stream.storage).asInstanceOf[scala.Array[Byte]]
             var index = 0
             while index < count do
               builder += window(stream.start + index)

--- a/lib/reliquary/src/derive/reliquary.Derivative.scala
+++ b/lib/reliquary/src/derive/reliquary.Derivative.scala
@@ -34,6 +34,7 @@ package reliquary
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import distillate.*
 import fulminate.*
 import gossamer.*
@@ -77,8 +78,11 @@ object Derivative:
 
     val out = java.io.ByteArrayOutputStream()
 
-    Zipfile(List.from(entries), Unset, Unset).serialize.sweep: (window, start, count) =>
-      out.write(window.asInstanceOf[scala.Array[Byte]], start, count)
+    Zipfile(List.from(entries), Unset, Unset).serialize.sweep: region =>
+      range =>
+        val interval: Interval = range
+        out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0,
+            interval.size)
 
     Array.unsafeFrozen(out.toByteArray.nn)
 

--- a/lib/scintillate/src/server/scintillate.Http2Serve.scala
+++ b/lib/scintillate/src/server/scintillate.Http2Serve.scala
@@ -38,6 +38,7 @@ import proscenium.compat.*
 import anticipation.*
 import coaxial.*
 import contingency.*
+import denominative.*
 import cordillera.*
 import gossamer.*
 import parasite.*
@@ -128,11 +129,9 @@ object Http2Serve:
                 case Http.Body.Flowing(source) =>
                   connection0.sendHeaders(streamId, List.of(headEntries), endStream = false)
 
-                  source().sweep: (storage, start, size) =>
-                    val window = storage.asInstanceOf[scala.Array[Byte]]
-                    val block = Array.unsafeFrozen(window.slice(start, start + size))
-
-                    connection0.sendData(streamId, block, endStream = false)
+                  source().sweep: region =>
+                    range =>
+                      connection0.sendData(streamId, region.materialize(range), endStream = false)
 
                   // Trailers close the stream; otherwise an empty END_STREAM DATA.
                   if trailing then sendTrailers()
@@ -216,8 +215,11 @@ extends Duplex:
   def source(using Buffering): (Stream[Data] over Credit)^ = Streamable.inputStream.stream(in)
 
   def send(consume data: (Stream[Data] over Credit)^): Unit =
-    data.sweep: (storage, start, size) =>
-      out.write(storage.asInstanceOf[scala.Array[Byte]], start, size)
+    data.sweep: region =>
+      range =>
+        val interval: Interval = range
+        out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0,
+            interval.size)
 
     out.flush()
 

--- a/lib/scintillate/src/server/scintillate.HttpConnection.scala
+++ b/lib/scintillate/src/server/scintillate.HttpConnection.scala
@@ -42,6 +42,7 @@ import com.sun.net.httpserver as csnh
 import anticipation.*
 import beneficence.*
 import contingency.*
+import denominative.*
 import distillate.*
 import gossamer.*
 import prepositional.*
@@ -153,8 +154,13 @@ object HttpConnection:
             def recur(): Unit = stream.refill(Credit(Long.MaxValue)) match
               case size: Int =>
                 try
-                  val window = stream.window(using Unsafe).asInstanceOf[scala.Array[Byte]]
-                  responseBody.write(window, stream.start, size)
+                  stream.region: region =>
+                    range =>
+                      val interval: Interval = range
+
+                      responseBody.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]),
+                          interval.start.n0, interval.size)
+
                   count += size
                   responseBody.flush()
                 catch case _: ji.IOException => abort(StreamError(count.b))

--- a/lib/scintillate/src/server/scintillate.HttpConnection.scala
+++ b/lib/scintillate/src/server/scintillate.HttpConnection.scala
@@ -154,7 +154,7 @@ object HttpConnection:
             def recur(): Unit = stream.refill(Credit(Long.MaxValue)) match
               case size: Int =>
                 try
-                  stream.region: region =>
+                  stream.lend: region =>
                     range =>
                       val interval: Interval = range
 

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -81,13 +81,17 @@ extends RequestServable:
     // into memory or sit unflushed in the buffer.
     var failed: Boolean = false
 
-    stream.sweep: (storage, start, size) =>
-      if !failed then
-        try
-          out.write(storage.asInstanceOf[scala.Array[Byte]], start, size)
-          out.flush()
-          count += size
-        catch case error: ji.IOException => failed = true
+    stream.sweep: region =>
+      range =>
+        if !failed then
+          val interval: Interval = range
+
+          try
+            out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0,
+                interval.size)
+            out.flush()
+            count += interval.size
+          catch case error: ji.IOException => failed = true
 
     if failed then abort(StreamError(count.b))
 

--- a/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
@@ -38,6 +38,7 @@ import proscenium.compat.*
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import distillate.*
 import gossamer.*
 import rudiments.*
@@ -126,7 +127,12 @@ open class JavaServlet(handle: HttpConnection => Http.Response) extends jsh.Http
 
             while draining do stream.refill(Credit(Long.MaxValue)) match
               case count: Int =>
-                out.write(stream.window(using Unsafe).asInstanceOf[scala.Array[Byte]], stream.start, count)
+                stream.region: region =>
+                  range =>
+                    val interval: Interval = range
+                    out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]),
+                        interval.start.n0, interval.size)
+
                 out.flush()
                 stream.skip(count)
 

--- a/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
@@ -127,7 +127,7 @@ open class JavaServlet(handle: HttpConnection => Http.Response) extends jsh.Http
 
             while draining do stream.refill(Credit(Long.MaxValue)) match
               case count: Int =>
-                stream.region: region =>
+                stream.lend: region =>
                   range =>
                     val interval: Interval = range
                     out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]),

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -310,7 +310,7 @@ object Http:
 
             case count: Int =>
               result =
-                endpoint.region { region => range => region.materialize(range.capped(count)) }
+                endpoint.lend { region => range => region.materialize(range.capped(count)) }
 
               endpoint.skip(count)
               continue = false
@@ -799,7 +799,7 @@ object Http:
 
               case count: Int =>
                 result =
-                  endpoint.region { region => range => region.materialize(range.capped(count)) }
+                  endpoint.lend { region => range => region.materialize(range.capped(count)) }
 
                 endpoint.skip(count)
                 continue = false

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -310,8 +310,7 @@ object Http:
 
             case count: Int =>
               result =
-                endpoint.addressable.materialize
-                  ( endpoint.window(using Unsafe), endpoint.start, count )
+                endpoint.region { region => range => region.materialize(range.capped(count)) }
 
               endpoint.skip(count)
               continue = false
@@ -521,7 +520,7 @@ object Http:
         private var start0: Int = 0
         private var limit0: Int = 0
 
-        protected def window0: AnyRef = storage
+        protected def storage0: AnyRef = storage
         def start: Int = start0
         def limit: Int = limit0
 
@@ -800,8 +799,7 @@ object Http:
 
               case count: Int =>
                 result =
-                  endpoint.addressable.materialize
-                    ( endpoint.window(using Unsafe), endpoint.start, count )
+                  endpoint.region { region => range => region.materialize(range.capped(count)) }
 
                 endpoint.skip(count)
                 continue = false

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -122,7 +122,7 @@ object HttpClient:
 
               case Some(header) =>
                 // Drain the discarded intermediate body to free its connection.
-                safely(response.body.stream.sweep { (_, _, _) => () })
+                safely(response.body.stream.sweep { _ => _ => () })
 
                 val nextUri = uri.resolve(jn.URI.create(header.value.s).nn).nn
                 Log.fine(HttpEvent.Redirect(uri.toString.tt, nextUri.toString.tt))

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -121,8 +121,7 @@ trait Postable extends Typeclass:
     try endpoint.refill(Credit(1024)) match
       case count: Int =>
         val sample =
-          endpoint.addressable.materialize
-            ( endpoint.window(using Unsafe), endpoint.start, count )
+          endpoint.region { region => range => region.materialize(range.capped(count)) }
 
         val string: Text = sample.serialize[Hex]
         if count > 128 then t"$string..." else string

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -121,7 +121,7 @@ trait Postable extends Typeclass:
     try endpoint.refill(Credit(1024)) match
       case count: Int =>
         val sample =
-          endpoint.region { region => range => region.materialize(range.capped(count)) }
+          endpoint.lend { region => range => region.materialize(range.capped(count)) }
 
         val string: Text = sample.serialize[Hex]
         if count > 128 then t"$string..." else string

--- a/lib/telekinesis/src/http2/cordillera.FrameReader.scala
+++ b/lib/telekinesis/src/http2/cordillera.FrameReader.scala
@@ -41,7 +41,7 @@ import gossamer.*
 import rudiments.*
 import vacuous.*
 import prepositional.*
-import zephyrine.{Stream, Credit, Buffering, Substrate}
+import zephyrine.{Slate, Stream, Credit, Buffering, Substrate, capped}
 
 import Http2.Frame
 import Http2Error.Reason
@@ -82,7 +82,12 @@ extends caps.ExclusiveCapability, caps.Stateful:
           val remaining = buffer.length - pos
           val grown = new scala.Array[Byte](remaining + count)
           System.arraycopy(buffer, pos, grown, 0, remaining)
-          System.arraycopy(input.window(using Unsafe), input.start, grown, remaining, count)
+
+          input.region: region =>
+            range =>
+              Slate.over[Bytes, Int](grown, remaining, remaining + count): slate =>
+                space => region.blit(range.capped(count))(slate)(space)
+
           input.skip(count)
           // The cast erases the fresh array's capture: it is confined to this
           // (exclusive) reader from here on.

--- a/lib/telekinesis/src/http2/cordillera.FrameReader.scala
+++ b/lib/telekinesis/src/http2/cordillera.FrameReader.scala
@@ -83,10 +83,10 @@ extends caps.ExclusiveCapability, caps.Stateful:
           val grown = new scala.Array[Byte](remaining + count)
           System.arraycopy(buffer, pos, grown, 0, remaining)
 
-          input.region: region =>
+          input.lend: region =>
             range =>
               Slate.over[Bytes, Int](grown, remaining, remaining + count): slate =>
-                space => region.blit(range.capped(count))(slate)(space)
+                space => region.transfer(range.capped(count))(slate)(space)
 
           input.skip(count)
           // The cast erases the fresh array's capture: it is confined to this

--- a/lib/telekinesis/src/http2/telekinesis.HttpSession.scala
+++ b/lib/telekinesis/src/http2/telekinesis.HttpSession.scala
@@ -77,7 +77,7 @@ object HttpSession:
       import ConnectError.Reason.*
 
       pending.let: stream =>
-        try stream.asInstanceOf[(Stream[Data] over Credit)^].sweep { (_, _, _) => () } catch
+        try stream.asInstanceOf[(Stream[Data] over Credit)^].sweep { _ => _ => () } catch
           case error: ji.IOException => abort(ConnectError(Unknown))
 
       pending = Unset

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -40,6 +40,7 @@ import gastronomy.providers.javaStdlibProvider, gastronomy.crypto.permitUnauthen
 import parasite.*, threading.virtualThreading, probates.panicProbate
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
+import denominative.*
 import fulminate.*
 import gossamer.*
 import hellenism.*, classloaders.threadContextClassloader
@@ -162,7 +163,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
   // A fixed-capacity `Buffering`, for the block-size sweep.
   def buffering(n: Int): Buffering = new Buffering:
     def capacity(substrate: Substrate): Int = n
-    def window: Int = 4
+    def depth: Int = 4
 
   // Int rather than Long: ZIO's `take`/`drop` are `Int`-counted, and both values
   // fit; Soundness's and FS2's `Long`-counted versions widen automatically.
@@ -292,7 +293,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             var total = 0L
 
             turbulence.Benchmarks.textData.stream.via(summon[CharDecoder])
-            . sweep((_, _, count) => total += count)
+            . sweep(region => range => total += (range: Interval).size)
 
             total
         }
@@ -320,7 +321,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         ( target = 1*Second, operationSize = textSize ):
         '{
             var total = 0L
-            turbulence.Benchmarks.textData.stream.delineate.sweep((_, _, count) => total += count)
+            turbulence.Benchmarks.textData.stream.delineate.sweep(region => range => total += (range: Interval).size)
             total
         }
 
@@ -345,10 +346,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         ( target = 1*Second, operationSize = size ):
         '{
             var total = 0L
-            turbulence.Benchmarks.input.stream.sweep: (storage, start, count) =>
-              val arr = storage.asInstanceOf[scala.Array[Byte]]
-              var i = start
-              while i < start + count do { total += (arr(i) & 0xff); i += 1 }
+            turbulence.Benchmarks.input.stream.sweep: region =>
+              range => region.visit(range) { index => total += (region(index) & 0xff) }
             total
         }
 
@@ -621,7 +620,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             turbulence.Benchmarks.textData.stream.discard(turbulence.Benchmarks.dropBytes)
             . via(summon[CharDecoder]).via(summon[CharEncoder])
             . truncate(turbulence.Benchmarks.takeBytes)
-            . gather(0L)((total, _, _, count) => total + count)
+            . gather(0L)(_ => (total, range) => total + (range: Interval).size)
         }
 
       bench(m"FS2  drop.utf8.take.count")(target = 1*Second, operationSize = textSize):
@@ -814,7 +813,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               turbulence.Benchmarks.inputChunks.each(intake.put)
               intake.finish())
             var total = 0L
-            stream.sweep((_, _, count) => total += count)
+            stream.sweep(region => range => total += (range: Interval).size)
             producer.join()
             total
         }
@@ -873,7 +872,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             supervise:
               val merged = Confluence(turbulence.Benchmarks.quarters.map(q => q.stream)*)
               var total = 0L
-              merged.sweep((_, _, count) => total += count)
+              merged.sweep(region => range => total += (range: Interval).size)
               total
         }
 
@@ -909,7 +908,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               val tasks = subscribers.map: subscriber =>
                 async:
                   var total = 0L
-                  subscriber.sweep((_, _, count) => total += count)
+                  subscriber.sweep(region => range => total += (range: Interval).size)
                   total
               tasks.map(_.await()).sum
         }
@@ -947,7 +946,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               turbulence.Benchmarks.inputChunks.each(intake.put)
               intake.finish())
             var total = 0L
-            stream.sweep((_, _, count) => total += count)
+            stream.sweep(region => range => total += (range: Interval).size)
             producer.join()
             total
         }
@@ -994,7 +993,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               turbulence.Benchmarks.inputChunks.each(intake.put)
               intake.finish())
             var total = 0L
-            stream.sweep((_, _, count) => total += count)
+            stream.sweep(region => range => total += (range: Interval).size)
             producer.join()
             total
         }
@@ -1044,7 +1043,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             var total = 0L
 
             turbulence.Benchmarks.gzippedInput.stream.decompress[Gzip]
-            . sweep((_, _, count) => total += count)
+            . sweep(region => range => total += (range: Interval).size)
 
             total
         }
@@ -1080,7 +1079,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             var total = 0L
 
             turbulence.Benchmarks.textData.stream.via(summon[CharDecoder])
-            . sweep((_, _, count) => total += count)
+            . sweep(region => range => total += (range: Interval).size)
 
             total
         }
@@ -1119,7 +1118,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
                 turbulence.Benchmarks.inputChunks.each(intake.put)
                 intake.finish())
               var total = 0L
-              stream.sweep((_, _, count) => total += count)
+              stream.sweep(region => range => total += (range: Interval).size)
               producer.join()
               total
           }
@@ -1167,7 +1166,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               turbulence.Benchmarks.inputChunks.each(intake.put)
               intake.finish())
             var total = 0L
-            stream.sweep((_, _, count) => total += count)
+            stream.sweep(region => range => total += (range: Interval).size)
             producer.join()
             total
         }
@@ -1183,7 +1182,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               turbulence.Benchmarks.inputChunks.each(intake.put)
               intake.finish())
             var total = 0L
-            stream.sweep((_, _, count) => total += count)
+            stream.sweep(region => range => total += (range: Interval).size)
             producer.join()
             total
         }
@@ -1193,7 +1192,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             var total = 0L
 
             turbulence.Benchmarks.gzippedInput.stream.decompress[Gzip]
-            . sweep((_, _, count) => total += count)
+            . sweep(region => range => total += (range: Interval).size)
 
             total
         }

--- a/lib/turbulence/src/core/turbulence.Aggregable.scala
+++ b/lib/turbulence/src/core/turbulence.Aggregable.scala
@@ -43,14 +43,15 @@ import vacuous.*
 import zephyrine.*
 
 object Aggregable:
-  // Drain a pull endpoint into the medium's builder: one copy per window,
+  // Drain a pull endpoint into the medium's builder: one copy per region,
   // no intermediate chunks. The native `accept` for whole-value aggregation.
   private def gather[medium](consume stream: (Stream[medium] over Credit)^): medium =
+    given stream.addressable.type = stream.addressable
     val target = stream.addressable.blank(4096)
 
     def recur(): Unit = stream.refill(Credit(Long.MaxValue)) match
       case count: Int =>
-        stream.addressable.cloneStorage(stream.window(using Unsafe), stream.start, count)(target)
+        stream.region { region => range => region.cloneTo(range)(target) }
         stream.skip(count)
         recur()
 
@@ -122,12 +123,12 @@ trait Aggregable extends Typeclass, Operable:
   // and delegates to the legacy `aggregate`; instances override it to build
   // directly from the stream's windows.
   def accept(stream: (Stream[Operand] over Credit)^): Self =
+    given stream.addressable.type = stream.addressable
+
     def recur(): Chain[Operand] =
       stream.refill(Credit(Long.MaxValue)) match
         case count: Int =>
-          val chunk =
-            stream.addressable.materialize(stream.window(using Unsafe), stream.start, count)
-
+          val chunk = stream.region { region => range => region.materialize(range) }
           stream.skip(count)
           chunk #:: recur()
 

--- a/lib/turbulence/src/core/turbulence.Aggregable.scala
+++ b/lib/turbulence/src/core/turbulence.Aggregable.scala
@@ -51,7 +51,7 @@ object Aggregable:
 
     def recur(): Unit = stream.refill(Credit(Long.MaxValue)) match
       case count: Int =>
-        stream.region { region => range => region.cloneTo(range)(target) }
+        stream.lend { region => range => region.cloneTo(range)(target) }
         stream.skip(count)
         recur()
 
@@ -128,7 +128,7 @@ trait Aggregable extends Typeclass, Operable:
     def recur(): Chain[Operand] =
       stream.refill(Credit(Long.MaxValue)) match
         case count: Int =>
-          val chunk = stream.region { region => range => region.materialize(range) }
+          val chunk = stream.lend { region => range => region.materialize(range) }
           stream.skip(count)
           chunk #:: recur()
 

--- a/lib/turbulence/src/core/turbulence.Confluence.scala
+++ b/lib/turbulence/src/core/turbulence.Confluence.scala
@@ -71,7 +71,7 @@ object Confluence:
     val block: Int = buffering.transfer(addressable0.substrate)
 
     val queue: juc.ArrayBlockingQueue[AnyRef] =
-      juc.ArrayBlockingQueue(buffering.window.max(sources.length))
+      juc.ArrayBlockingQueue(buffering.depth.max(sources.length))
 
     val remaining: juca.AtomicInteger = juca.AtomicInteger(sources.length)
     @volatile var error: Throwable | Null = null
@@ -92,7 +92,7 @@ object Confluence:
 
       async:
         val source = handoff.asInstanceOf[(Stream[medium] over Credit)^]
-        val stable: Boolean = source.windowStable
+        val stable: Boolean = source.regionStable
 
         // A shared (stable) block costs no memory, so pull the whole window at
         // once and collapse the hand-off count; a copied block stays bounded.
@@ -111,12 +111,12 @@ object Confluence:
               val start = source.start
 
               val storage =
-                if stable then source.window(using Unsafe)
+                if stable then source.storage(using Unsafe)
                 else
                   val fresh = addressable0.allocate(count)
 
                   addressable0.transfer
-                    ( source.window(using Unsafe).asInstanceOf[addressable0.Storage],
+                    ( source.storage(using Unsafe).asInstanceOf[addressable0.Storage],
                       source.start, fresh, 0, count )
 
                   fresh
@@ -148,7 +148,7 @@ object Confluence:
       private var end0: Int = 0
       private var ended: Boolean = false
 
-      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
       update def skip(count: Int): Unit = start0 += count

--- a/lib/turbulence/src/core/turbulence.Divergence.scala
+++ b/lib/turbulence/src/core/turbulence.Divergence.scala
@@ -73,11 +73,11 @@ object Divergence:
     // aliasing analysis (as `Conduit`'s core), so the capture is erased to let
     // the rings ride the collection.
     val queues: IndexedSeq[Handoff] =
-      IndexedSeq.fill(count)(caps.unsafe.unsafeAssumePure(Handoff(buffering.window)))
+      IndexedSeq.fill(count)(caps.unsafe.unsafeAssumePure(Handoff(buffering.depth)))
 
     @volatile var error: Throwable | Null = null
 
-    val stable: Boolean = source.windowStable
+    val stable: Boolean = source.regionStable
 
     // A shared (stable) block costs no memory per element, so there is no reason
     // to bound its size: pull the whole window at once, collapsing the hand-off
@@ -96,12 +96,12 @@ object Divergence:
           val start = source.start
 
           val storage =
-            if stable then source.window(using Unsafe)
+            if stable then source.storage(using Unsafe)
             else
               val fresh = addressable0.allocate(size)
 
               addressable0.transfer
-                ( source.window(using Unsafe).asInstanceOf[addressable0.Storage],
+                ( source.storage(using Unsafe).asInstanceOf[addressable0.Storage],
                   source.start, fresh, 0, size )
 
               fresh
@@ -155,7 +155,7 @@ object Divergence:
           private var end0: Int = 0
           private var ended: Boolean = false
 
-          protected def window0: AnyRef = storage
+          protected def storage0: AnyRef = storage
           def start: Int = start0
           def limit: Int = limit0
           update def skip(count: Int): Unit = start0 += count

--- a/lib/turbulence/src/core/turbulence.LineSeparation.scala
+++ b/lib/turbulence/src/core/turbulence.LineSeparation.scala
@@ -38,6 +38,9 @@ import rudiments.reverse
 import java.lang as jl
 
 import anticipation.*
+import contingency.*
+import denominative.*
+import vacuous.*
 import beneficence.*
 import prepositional.*
 import zephyrine.*
@@ -136,16 +139,19 @@ object LineSeparation:
 
             written
 
-          update def step
-            ( source: input.Storage,
-              sourceOffset: Int,
-              sourceLength: Int,
-              target: output.Storage,
-              targetOffset: Int,
-              targetSpace: Int )
+          update def step(source: Region[Text])(range: Interval in source.type)
+            ( target: Slate[Array[Text]^{}] )(space: Interval in target.type)
           :   Duct.Progress =
 
-            val chars = source.asInstanceOf[scala.Array[Char]]
+            val sourceInterval: Interval = range
+            val sourceOffset = sourceInterval.start.n0
+            val sourceLength = sourceInterval.size
+            val targetInterval: Interval = space
+            val targetOffset = targetInterval.start.n0
+            val targetSpace = targetInterval.size
+            val chars = unsafely(source.raw.asInstanceOf[scala.Array[Char]])
+            val slots: scala.Array[AnyRef]^ =
+              unsafely(target.raw.asInstanceOf[scala.Array[AnyRef]]).asInstanceOf[scala.Array[AnyRef]^]
             var consumed: Int = 0
             var produced: Int = 0
 
@@ -164,7 +170,7 @@ object LineSeparation:
                   if char == '\n' then { consumed += 1; act(stage.crlf) }
                   else act(stage.cr)
 
-                produced += deliver(target.asInstanceOf[scala.Array[AnyRef]^], targetOffset + produced)
+                produced += deliver(slots, targetOffset + produced)
               else
                 val char = chars(sourceOffset + consumed)
 
@@ -176,8 +182,7 @@ object LineSeparation:
                     then { consumed += 1; act(stage.lfcr) }
                     else act(stage.lf)
 
-                    produced +=
-                      deliver(target.asInstanceOf[scala.Array[AnyRef]^], targetOffset + produced)
+                    produced += deliver(slots, targetOffset + produced)
                   else pending = 10
                 else if char == '\r' then
                   consumed += 1
@@ -187,8 +192,7 @@ object LineSeparation:
                     then { consumed += 1; act(stage.crlf) }
                     else act(stage.cr)
 
-                    produced +=
-                      deliver(target.asInstanceOf[scala.Array[AnyRef]^], targetOffset + produced)
+                    produced += deliver(slots, targetOffset + produced)
                   else pending = 13
                 else
                   // Bulk-append the run of ordinary chars up to the next
@@ -204,9 +208,12 @@ object LineSeparation:
 
             Duct.Progress(consumed, produced)
 
-          override update def flush
-            ( target: output.Storage, targetOffset: Int, targetSpace: Int )
+          override update def flush(target: Slate[Array[Text]^{}])(space: Interval in target.type)
           :   Int =
+
+            val targetInterval: Interval = space
+            val targetOffset = targetInterval.start.n0
+            val targetSpace = targetInterval.size
 
             if !drained then
               drained = true
@@ -231,10 +238,11 @@ object LineSeparation:
 
             var count: Int = 0
 
-            while count < targetSpace && tail.nonEmpty do
-              target.asInstanceOf[scala.Array[AnyRef]^](targetOffset + count) =
-                tail.head.asInstanceOf[AnyRef]
+            val slots: scala.Array[AnyRef]^ =
+              unsafely(target.raw.asInstanceOf[scala.Array[AnyRef]]).asInstanceOf[scala.Array[AnyRef]^]
 
+            while count < targetSpace && tail.nonEmpty do
+              slots(targetOffset + count) = tail.head.asInstanceOf[AnyRef]
               tail = tail.tail
               count += 1
 

--- a/lib/turbulence/src/core/turbulence.Relay.scala
+++ b/lib/turbulence/src/core/turbulence.Relay.scala
@@ -99,7 +99,7 @@ class Relay[record]():
       private var limit0: Int = 0
       private var ended: Boolean = false
 
-      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
       update def skip(count: Int): Unit = start0 += count

--- a/lib/turbulence/src/core/turbulence.Streamable.scala
+++ b/lib/turbulence/src/core/turbulence.Streamable.scala
@@ -106,7 +106,7 @@ object Streamable:
         private var total: Long = 0
         private var ended: Boolean = false
 
-        protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+        protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
         def start: Int = start0
         def limit: Int = limit0
         update def skip(count: Int): Unit = start0 += count
@@ -160,7 +160,7 @@ object Streamable:
       private var total: Long = 0
       private var ended: Boolean = false
 
-      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
       update def skip(count: Int): Unit = start0 += count

--- a/lib/turbulence/src/core/turbulence.Writable.scala
+++ b/lib/turbulence/src/core/turbulence.Writable.scala
@@ -37,6 +37,7 @@ import java.nio as jn
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import hieroglyph.*
 import prepositional.*
 import rudiments.*
@@ -58,12 +59,14 @@ object Writable:
 
     // The non-consume `write` signature crosses to the consuming drain as a
     // neutral reference (the `accept` convention).
-    stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Data] over Credit)^].sweep:
-      (storage, start, count) =>
+    stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Data] over Credit)^].sweep: region =>
+      range =>
         if !failed then
+          val interval: Interval = range
+
           try
-            outputStream.write(storage.asInstanceOf[scala.Array[Byte]], start, count)
-            total += count
+            outputStream.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0, interval.size)
+            total += interval.size
           catch case error: ji.IOException => failed = true
 
     if failed then raise(StreamError(total.b))
@@ -133,10 +136,11 @@ object Writable:
       var total: Long = 0L
       var failed: Boolean = false
 
-      stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Data] over Credit)^].sweep:
-        (storage, start, count) =>
+      stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Data] over Credit)^].sweep: region =>
+        range =>
           if !failed then
-            val buffer = jn.ByteBuffer.wrap(storage.asInstanceOf[scala.Array[Byte]], start, count).nn
+            val interval: Interval = range
+            val buffer = jn.ByteBuffer.wrap(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0, interval.size).nn
 
             try
               while buffer.hasRemaining do
@@ -144,7 +148,7 @@ object Writable:
                   failed = true
                   buffer.limit(0)
 
-              total += count
+              total += interval.size
             catch case error: Exception => failed = true
 
       if failed then raise(StreamError(total.b))

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -173,7 +173,7 @@ extension (consume stream: (Stream[Data] over Credit)^)
 
         if available < 0 then -1 else
           var byte: Int = 0
-          stream.region { region => range => region.visit(range.capped(1)) { index => byte = region(index) & 0xff } }
+          stream.lend { region => range => region.visit(range.capped(1)) { index => byte = region(index) & 0xff } }
           stream.skip(1)
           byte
 
@@ -188,10 +188,10 @@ extension (consume stream: (Stream[Data] over Credit)^)
             // this array over to be filled, so treating it as exclusive is sound.
             val buffer: scala.Array[Byte]^ = target.nn.asInstanceOf[scala.Array[Byte]^]
 
-            stream.region: region =>
+            stream.lend: region =>
               range =>
                 Slate.over[Data, Int](buffer, offset, offset + take): slate =>
-                  space => region.blit(range.capped(take))(slate)(space)
+                  space => region.transfer(range.capped(take))(slate)(space)
 
             stream.skip(take)
             take
@@ -207,7 +207,7 @@ extension (consume stream: (Stream[Data] over Credit)^)
     stream.refill(Credit(limit)) match
       case count: Int =>
         val take = count.min(limit)
-        val chunk = stream.region { region => range => region.materialize(range.capped(take)) }
+        val chunk = stream.lend { region => range => region.materialize(range.capped(take)) }
         stream.skip(take)
         chunk
 

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -172,7 +172,8 @@ extension (consume stream: (Stream[Data] over Credit)^)
         val available = ensure()
 
         if available < 0 then -1 else
-          val byte = stream.window(using Unsafe).asInstanceOf[scala.Array[Byte]](stream.start) & 0xff
+          var byte: Int = 0
+          stream.region { region => range => region.visit(range.capped(1)) { index => byte = region(index) & 0xff } }
           stream.skip(1)
           byte
 
@@ -182,7 +183,16 @@ extension (consume stream: (Stream[Data] over Credit)^)
 
           if available < 0 then -1 else
             val take = available.min(length)
-            System.arraycopy(stream.window(using Unsafe), stream.start, target, offset, take)
+
+            // The cast launders the Java-signature parameter's capture: the caller hands
+            // this array over to be filled, so treating it as exclusive is sound.
+            val buffer: scala.Array[Byte]^ = target.nn.asInstanceOf[scala.Array[Byte]^]
+
+            stream.region: region =>
+              range =>
+                Slate.over[Data, Int](buffer, offset, offset + take): slate =>
+                  space => region.blit(range.capped(take))(slate)(space)
+
             stream.skip(take)
             take
 
@@ -192,12 +202,12 @@ extension (consume stream: (Stream[Data] over Credit)^)
 
 extension (consume stream: (Stream[Data] over Credit)^)
   // Adapt a pull endpoint to the HTTP-body interchange protocol: each `next`
-  // refills with `limit` credit and materializes the delivered window.
+  // refills with `limit` credit and materializes the delivered region.
   def httpBody: HttpStreams.Body^ = limit =>
     stream.refill(Credit(limit)) match
       case count: Int =>
         val take = count.min(limit)
-        val chunk = stream.addressable.materialize(stream.window(using Unsafe), stream.start, take)
+        val chunk = stream.region { region => range => region.materialize(range.capped(take)) }
         stream.skip(take)
         chunk
 
@@ -218,7 +228,7 @@ extension (body: HttpStreams.Body)
       private var ended: Boolean = false
 
       // The chunk is immutable and only ever read through the window.
-      protected def window0: AnyRef = chunk.asInstanceOf[AnyRef]
+      protected def storage0: AnyRef = chunk.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
       update def skip(count: Int): Unit = start0 += count

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -442,8 +442,8 @@ object Tests extends Suite(m"Turbulence tests"):
         relay.stop()
         var windows: Int = 0
 
-        relay.stream.sweep: (storage, start, count) =>
-          windows += 1
+        relay.stream.sweep: _ =>
+          _ => windows += 1
 
         windows
       . assert(_ == 1)
@@ -627,7 +627,7 @@ object Tests extends Suite(m"Turbulence tests"):
         def recur(): Unit = scala.caps.unsafe.unsafeAssumeSeparate:
          stream.refill(Credit(64)) match
           case count: Int =>
-            val window = unsafely(stream.window).asInstanceOf[scala.Array[Char]]
+            val window = unsafely(stream.storage).asInstanceOf[scala.Array[Char]]
             builder.append(String(window, stream.start, count))
             stream.skip(count)
             scala.caps.unsafe.unsafeAssumeSeparate(recur())

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -32,10 +32,14 @@
                                                                                                   */
 package soundness
 
+// `Region`, `Slate` and `capped` are deliberately absent: their lenders and combinators are
+// dependent-typed inline extensions, which synthesized export forwarders break (see the
+// hand-written `via`/`accepting` forwarders below for the same problem). Consumers import
+// them from `zephyrine` directly.
 export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum,
     Duct, Ductile, Expanse, Malleable, Pace,
     Format, Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
-    Records, records, Region, Regulation, Slate, Spring, Stream, Substrate, capped, chunks,
+    Records, records, Regulation, Spring, Stream, Substrate, chunks,
     discard, gather, locate,
     locateKey, memoize, pump, stream, streamOf, sweep, toProgression, truncate,
     viaDuct, acceptingDuct}

--- a/lib/zephyrine/src/core/zephyrine.Addressable.scala
+++ b/lib/zephyrine/src/core/zephyrine.Addressable.scala
@@ -479,7 +479,7 @@ trait Addressable extends Typeclass.Pure, Operable, Targetable:
 
   // The value's backing storage, when the medium is immutable and its erased
   // representation *is* its `Storage` type, so a whole chunk can be exposed as
-  // a window — or handed across an asynchronous boundary — without copying.
+  // a region — or handed across an asynchronous boundary — without copying.
   // `Data` returns its backing array; media without a directly-exposable
   // backing (`Text`, whose `String` is not an `Array[Char]`) return `Unset`,
   // and callers copy. Exposed backing must never be mutated.

--- a/lib/zephyrine/src/core/zephyrine.Buffering.scala
+++ b/lib/zephyrine/src/core/zephyrine.Buffering.scala
@@ -37,7 +37,7 @@ import scala.caps
 // Contextual configuration determining how streaming stages are instantiated
 // with buffers. `capacity` is consulted once per stage at construction time, so
 // an adaptive instance (e.g. one consulting available memory) sees each new
-// stage, but never resizes a live one. `window` is the number of blocks of
+// stage, but never resizes a live one. `depth` is the number of blocks of
 // headroom a `Conduit` holds between its writer and reader threads.
 object Buffering:
   given standard: Buffering:
@@ -49,23 +49,23 @@ object Buffering:
     // Deep enough that a producer/consumer pair in lockstep exchange several
     // transfer blocks per wakeup rather than parking after every few: hand-off
     // throughput scales almost linearly with depth up to this point, at a
-    // bounded cost of `window` in-flight transfer blocks.
+    // bounded cost of `depth` in-flight transfer blocks.
     //
     // The capacity-search stress tests show hand-off throughput under high
-    // concurrency keeps improving well past this depth: a window covering a whole
+    // concurrency keeps improving well past this depth: a queue covering a whole
     // burst, so the producer streams it without ever parking, more than doubled
-    // sustained throughput at 64. But a deeper window multiplies the worst-case
+    // sustained throughput at 64. But a deeper depth multiplies the worst-case
     // in-flight bound of every copy-path conduit, so the default stays
-    // conservative; burst-heavy pipelines should override `window` to their burst
+    // conservative; burst-heavy pipelines should override `depth` to their burst
     // size in hand-off blocks, and the shared `Blockpool` keeps the deeper ring's
     // allocation amortised across conduit instances.
-    def window: Int = 16
+    def depth: Int = 16
 
 // Pure: a `Buffering` is only sizing policy, so instances are untracked under capture
 // checking and closures over them stay pure.
 trait Buffering extends caps.Pure:
   def capacity(substrate: Substrate): Int
-  def window: Int
+  def depth: Int
 
   // The preferred size of a block crossing an asynchronous boundary (a `Conduit`
   // hand-off, or a fan-in/fan-out pump transfer). Staging buffers want to stay

--- a/lib/zephyrine/src/core/zephyrine.Conduit.scala
+++ b/lib/zephyrine/src/core/zephyrine.Conduit.scala
@@ -58,7 +58,7 @@ import vacuous.*
 object Conduit:
   // A queued hand-off: `storage` is either a block the writer minted and
   // filled (start 0), or the immutable backing of a chunk passed through by
-  // reference, windowed at [start, start + size). `recyclable` is true only for
+  // reference, regioned at [start, start + size). `recyclable` is true only for
   // writer-minted blocks, whose storage the reader may return to the freelist
   // for reuse; a passed-through backing is the caller's immutable data and must
   // never be recycled.
@@ -67,9 +67,9 @@ object Conduit:
   // The synchronized substrate both endpoints capture: a spin-then-park SPSC
   // ring, the failure flag, and a non-blocking pool of spent blocks the reader
   // returns to the writer for reuse.
-  private final class Core(val window: Int) extends caps.SharedCapability:
-    val handoff: Handoff = Handoff(window)
-    val freelist: Freelist = Freelist(window + 1)
+  private final class Core(val depth: Int) extends caps.SharedCapability:
+    val handoff: Handoff = Handoff(depth)
+    val freelist: Freelist = Freelist(depth + 1)
     // A JMM-managed flag: its safety is the volatile publication guarantee, not
     // aliasing analysis, so its captures are untracked.
     @caps.unsafe.untrackedCaptures @volatile var error: Throwable | Null = null
@@ -80,7 +80,7 @@ object Conduit:
 
     val block: Int = buffering.capacity(addressable0.substrate)
     val ceiling: Int = buffering.transfer(addressable0.substrate).max(block)
-    val core = new Core(buffering.window)
+    val core = new Core(buffering.depth)
 
     // Whether to recycle drained transfer blocks. When on, every minted block is
     // physically `ceiling`-sized, so the pool holds a single size and a reused
@@ -100,7 +100,7 @@ object Conduit:
     // synchronized queue transfer. With recycling, every block is physically
     // `ceiling`-sized (so any drained block fits any future reservation and the
     // pool stays single-size), while `capacity` still bounds the usable prefix,
-    // leaving the publish cadence unchanged. The memory bound is `window + 1`
+    // leaving the publish cadence unchanged. The memory bound is `depth + 1`
     // blocks of at most `ceiling` either way.
     val intake: (Intake[medium] over Credit)^ = new Intake[medium](using addressable0):
       type Transport = Credit
@@ -235,7 +235,7 @@ object Conduit:
       // backing (the caller's immutable data, never to be recycled).
       private var recyclable0: Boolean = false
 
-      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
 
@@ -292,7 +292,7 @@ object Conduit:
                 // `publish`), and a passed-through chunk backing is immutable.
                 //
                 // The outgoing block is fully drained (this branch runs only
-                // once `limit0` reached `end0`) and its window is relinquished
+                // once `limit0` reached `end0`) and its region is relinquished
                 // the moment this `refill` returns a new one, so a ceiling-sized
                 // minted block is safe to return to the writer for reuse. The
                 // freelist's publication order carries the ownership across; a

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -167,7 +167,7 @@ object Cursor:
   // allocation. The credit bounds how much any upstream stage produces per fill, so
   // memory stays bounded through a parse of an arbitrarily large input. The region is
   // read and skipped within the fill, before the stream can refill again — the borrow
-  // discipline `Stream.region` documents, applied at the one place a cursor touches it.
+  // discipline `Stream.lend` documents, applied at the one place a cursor touches it.
   def apply[data](consume stream: (Stream[data] over Credit)^)
     ( using addressable0: data is Addressable,
             lineation0:   Lineation by addressable0.Operand,
@@ -619,7 +619,7 @@ extends caps.Mutable:
   // `unsafeBuffer`, with the bounds arithmetic taken away. Parsers that snapshot the buffer
   // into fields for register-resident hot loops (the `unsafeBuffer` protocol) remain trusted
   // kernels behind `Unsafe`.
-  inline def region[result]
+  inline def lend[result]
     ( inline lambda: (region: Region[data]) => (Interval in region.type) => result )
   :   result =
 

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -611,6 +611,20 @@ extends caps.Mutable:
   inline def unsafePos(using erased unsafe: Unsafe): Int = pos
   inline def unsafeWriteEnd(using erased unsafe: Unsafe): Int = writeEnd
 
+  // Bounds-safe view of the cursor's readable region, elements `pos until writeEnd`: the
+  // region and its branded interval are lent to `lambda`, so every index a consumer can form
+  // is in range (see `zephyrine.Region.scala`) — the preferred boundary for scan loops that
+  // don't cache the buffer across cursor operations. Valid only until the next operation that
+  // may refill, compact or grow the buffer — the same single-owner discipline as
+  // `unsafeBuffer`, with the bounds arithmetic taken away. Parsers that snapshot the buffer
+  // into fields for register-resident hot loops (the `unsafeBuffer` protocol) remain trusted
+  // kernels behind `Unsafe`.
+  inline def region[result]
+    ( inline lambda: (region: Region[data]) => (Interval in region.type) => result )
+  :   result =
+
+    Region.over[data, result](using addressable)(buffer, pos, writeEnd)(lambda)
+
   // Bulk-advance without per-byte lineation tracking. Caller is responsible
   // for line/column updates if `lineation.active`. Intended for callers that
   // maintain a parser-local copy of `pos` for register-resident hot loops

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -64,7 +64,7 @@ object Cursor:
   // A direct refill strategy: writes up to `space` elements straight into the cursor's
   // buffer at `offset`, returning the count written, `0` when nothing was granted (the
   // cursor retries), or `-1` at end-of-stream. Bypasses the `Loader` chunk protocol so a
-  // pull endpoint's window can be transferred into the cursor in a single copy, instead
+  // pull endpoint's region can be transferred into the cursor in a single copy, instead
   // of materializing an intermediate chunk that `refill` then copies again. `block` is
   // the growth hint: the cursor guarantees at least one element of space and grows its
   // buffer towards `writeEnd + block` before each fill.
@@ -162,12 +162,12 @@ object Cursor:
 
 
   // Build a Cursor over a pull endpoint: each fill refills the stream with a credit
-  // bounded by the ambient `Buffering` block size and transfers the delivered window
+  // bounded by the ambient `Buffering` block size and transfers the delivered region
   // straight into the cursor's buffer — a single copy, with no intermediate chunk
   // allocation. The credit bounds how much any upstream stage produces per fill, so
-  // memory stays bounded through a parse of an arbitrarily large input. The window is
+  // memory stays bounded through a parse of an arbitrarily large input. The region is
   // read and skipped within the fill, before the stream can refill again — the borrow
-  // discipline `Stream.window` documents, applied at the one place a cursor touches it.
+  // discipline `Stream.region` documents, applied at the one place a cursor touches it.
   def apply[data](consume stream: (Stream[data] over Credit)^)
     ( using addressable0: data is Addressable,
             lineation0:   Lineation by addressable0.Operand,
@@ -194,8 +194,8 @@ object Cursor:
             def fill(storage: addressable0.Storage, offset: Int, space: Int): Int =
               stream.refill(Credit(space.min(block))).lay(-1): count =>
                 val copied = count.min(space)
-                val window = stream.window(using Unsafe).asInstanceOf[addressable0.Storage]
-                addressable0.transfer(window, stream.start, storage, offset, copied)
+                val source = stream.storage(using Unsafe).asInstanceOf[addressable0.Storage]
+                addressable0.transfer(source, stream.start, storage, offset, copied)
                 stream.skip(copied)
                 copied
 

--- a/lib/zephyrine/src/core/zephyrine.Duct.scala
+++ b/lib/zephyrine/src/core/zephyrine.Duct.scala
@@ -34,6 +34,7 @@ package zephyrine
 
 import scala.caps
 
+import denominative.*
 import prepositional.*
 import vacuous.*
 
@@ -97,7 +98,11 @@ object Duct:
     var consumed = 0
 
     while consumed < length do
-      val progress = duct.step(source0, consumed, length - consumed, buffer0, 0, space)
+      val progress =
+        Region.over[in, Duct.Progress](using duct.input)(source0, consumed, length): region =>
+          range =>
+            Slate.over[out, Duct.Progress](using duct.output)(buffer, 0, space): slate =>
+              slateSpace => duct.step(region)(range)(slate)(slateSpace)
 
       if progress.produced > 0 then duct.output.cloneStorage(buffer0, 0, progress.produced)(target)
 
@@ -106,11 +111,15 @@ object Duct:
       if progress.consumed == 0 && progress.produced == 0 then consumed = length
       else consumed += progress.consumed
 
-    var flushed = duct.flush(buffer0, 0, space)
+    def flushOnce(): Int =
+      Slate.over[out, Int](using duct.output)(buffer, 0, space): slate =>
+        slateSpace => duct.flush(slate)(slateSpace)
+
+    var flushed = flushOnce()
 
     while flushed > 0 do
       duct.output.cloneStorage(buffer0, 0, flushed)(target)
-      flushed = duct.flush(buffer0, 0, space)
+      flushed = flushOnce()
 
     duct.close()
     duct.output.build(target)
@@ -118,9 +127,16 @@ object Duct:
 // A duct is single-owner mutable state (compressors, partial atoms), so it is a stateful
 // capability: `step`/`flush`/`close` mutate it and require exclusive access, while
 // `translate`/`quantum`/`regulation` are pure queries.
-abstract class Duct[in, out]
-  ( using val input: in is Addressable, val output: out is Addressable )
+// Type parameters are named `operand`/`result` (not `in`/`out`) so the prepositional infix
+// `in` remains usable in member signatures. The two `Addressable` instances are exposed as
+// plain (non-given) members: were they `using val`s, every summon of an `Addressable` inside
+// a same-medium duct (`Duct[Data, Data]`) would be ambiguous between them.
+abstract class Duct[operand, result]
+  ( using input0: operand is Addressable, output0: result is Addressable )
 extends caps.ExclusiveCapability, caps.Stateful:
+
+  val input: operand is Addressable = input0
+  val output: result is Addressable = output0
 
   type Transport
   type Upstream
@@ -138,13 +154,13 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // a duct whose smallest output atom is two elements.
   def quantum: Int = 1
 
-  update def step
-    ( source: input.Storage,
-      sourceOffset: Int,
-      sourceLength: Int,
-      target: output.Storage,
-      targetOffset: Int,
-      targetSpace: Int )
+  // Transform the readable `range` of `source` into the writable `space` of `target`. The
+  // regions carry their windows as branded intervals, so an implementation cannot index
+  // outside them except through the greppable `unsafely(raw)` escape hatch — which kernels
+  // wrapping offset-based JDK APIs (charsets, ciphers, compressors) legitimately take,
+  // widening the intervals back to offsets at that boundary.
+  update def step(source: Region[operand])(range: Interval in source.type)
+    ( target: Slate[result] )(space: Interval in target.type)
   :   Duct.Progress
 
   // Emit terminal state after the upstream ends: a compressor's tail, and —
@@ -153,6 +169,6 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // undelivered output than one step's space). A duct whose state can retain
   // output MUST override this; the first `0` it returns is taken as the end
   // of the stream. Called repeatedly until it returns `0`.
-  update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int = 0
+  update def flush(target: Slate[result])(space: Interval in target.type): Int = 0
 
   update def close(): Unit = ()

--- a/lib/zephyrine/src/core/zephyrine.Duct.scala
+++ b/lib/zephyrine/src/core/zephyrine.Duct.scala
@@ -69,11 +69,11 @@ object Duct:
 
   opaque type Progress = Long
 
-  // Drive a duct over a whole value, as if it were the single window of a
+  // Drive a duct over a whole value, as if it were the single region of a
   // stream — but with none of the stream machinery: no endpoint, no credit
   // accounting, no refill cycle. `step` runs over the value's storage (its
   // backing directly when the medium exposes one, else one copy in) until the
-  // input is consumed, output windows accumulate into the medium's builder,
+  // input is consumed, output regions accumulate into the medium's builder,
   // and `flush` drains the duct's terminal state. This is the whole-value
   // counterpart of `stream.viaDuct(duct)`: one transformation, two drivers.
   def feed[in, out](value: in, consume duct: (Duct[in, out])^)(using buffering: Buffering): out =
@@ -86,31 +86,31 @@ object Duct:
 
     val target = duct.output.blank(buffering.capacity(duct.output.substrate))
     val space = buffering.transfer(duct.output.substrate).max(duct.quantum)
-    val window: duct.output.Storage^ = duct.output.allocate(space)
+    val buffer: duct.output.Storage^ = duct.output.allocate(space)
 
     // `step`/`flush` declare pure `Storage` parameters; the kernel drivers
-    // cross that rim with cast-erased windows (the established recipe), and
+    // cross that rim with cast-erased regions (the established recipe), and
     // this driver does the same — the storage never escapes this method.
     val source0 = source.asInstanceOf[duct.input.Storage]
-    val window0 = window.asInstanceOf[duct.output.Storage]
+    val buffer0 = buffer.asInstanceOf[duct.output.Storage]
 
     var consumed = 0
 
     while consumed < length do
-      val progress = duct.step(source0, consumed, length - consumed, window0, 0, space)
+      val progress = duct.step(source0, consumed, length - consumed, buffer0, 0, space)
 
-      if progress.produced > 0 then duct.output.cloneStorage(window0, 0, progress.produced)(target)
+      if progress.produced > 0 then duct.output.cloneStorage(buffer0, 0, progress.produced)(target)
 
       // The step contract guarantees progress given input and `quantum` space;
       // a zero-progress step would loop forever, so treat it as terminal.
       if progress.consumed == 0 && progress.produced == 0 then consumed = length
       else consumed += progress.consumed
 
-    var flushed = duct.flush(window0, 0, space)
+    var flushed = duct.flush(buffer0, 0, space)
 
     while flushed > 0 do
-      duct.output.cloneStorage(window0, 0, flushed)(target)
-      flushed = duct.flush(window0, 0, space)
+      duct.output.cloneStorage(buffer0, 0, flushed)(target)
+      flushed = duct.flush(buffer0, 0, space)
 
     duct.close()
     duct.output.build(target)

--- a/lib/zephyrine/src/core/zephyrine.Ductile.scala
+++ b/lib/zephyrine/src/core/zephyrine.Ductile.scala
@@ -37,6 +37,8 @@ import scala.caps
 import java.nio as jn, jn.charset as jnc
 
 import anticipation.*
+import contingency.*
+import denominative.*
 import hieroglyph.*
 import prepositional.*
 import rudiments.*
@@ -268,19 +270,21 @@ object Ductile:
               else
                 Duct.Progress(src - sourceOffset, dst - targetOffset)
 
-          update def step
-            ( source: input.Storage,
-              sourceOffset: Int,
-              sourceLength: Int,
-              target: output.Storage,
-              targetOffset: Int,
-              targetSpace: Int )
+          update def step(source: Region[Data])(range: Interval in source.type)
+            ( target: Slate[Text] )(space: Interval in target.type)
           :   Duct.Progress =
 
-            val bytes = source.asInstanceOf[scala.Array[Byte]]
+            val sourceInterval: Interval = range
+            val sourceOffset = sourceInterval.start.n0
+            val sourceLength = sourceInterval.size
+            val targetInterval: Interval = space
+            val targetOffset = targetInterval.start.n0
+            val targetSpace = targetInterval.size
+
+            val bytes = unsafely(source.raw.asInstanceOf[scala.Array[Byte]])
             // The exclusive cast is sound for the same reason as `Conduit.put`'s:
             // the target is the stage's single-owner output buffer.
-            val chars = target.asInstanceOf[scala.Array[Char]^]
+            val chars = unsafely(target.raw.asInstanceOf[scala.Array[Char]]).asInstanceOf[scala.Array[Char]^]
 
             if staging.position == 0 then
               // Fast path: with no carried bytes, decode straight from the source
@@ -304,11 +308,12 @@ object Ductile:
 
               Duct.Progress(copy, out.position - targetOffset)
 
-          override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
-          :   Int =
-
+          override update def flush(target: Slate[Text])(space: Interval in target.type): Int =
             if ended then 0 else
-              val chars = target.asInstanceOf[scala.Array[Char]]
+              val targetInterval: Interval = space
+              val targetOffset = targetInterval.start.n0
+              val targetSpace = targetInterval.size
+              val chars = unsafely(target.raw.asInstanceOf[scala.Array[Char]])
               val out = jn.CharBuffer.wrap(chars, targetOffset, targetSpace).nn
               staging.flip()
               decode(staging, out, total, true)
@@ -358,17 +363,19 @@ object Ductile:
 
           override def quantum: Int = worst
 
-          def step
-            ( source: input.Storage,
-              sourceOffset: Int,
-              sourceLength: Int,
-              target: output.Storage,
-              targetOffset: Int,
-              targetSpace: Int )
+          def step(source: Region[Text])(range: Interval in source.type)
+            ( target: Slate[Data] )(space: Interval in target.type)
           :   Duct.Progress =
 
-            val chars = source.asInstanceOf[scala.Array[Char]]
-            val bytes = target.asInstanceOf[scala.Array[Byte]]
+            val sourceInterval: Interval = range
+            val sourceOffset = sourceInterval.start.n0
+            val sourceLength = sourceInterval.size
+            val targetInterval: Interval = space
+            val targetOffset = targetInterval.start.n0
+            val targetSpace = targetInterval.size
+
+            val chars = unsafely(source.raw.asInstanceOf[scala.Array[Char]])
+            val bytes = unsafely(target.raw.asInstanceOf[scala.Array[Byte]])
             val copy = sourceLength.min(staging.remaining)
             staging.put(chars, sourceOffset, copy)
             staging.flip()
@@ -379,11 +386,12 @@ object Ductile:
 
             Duct.Progress(copy, out.position - targetOffset)
 
-          override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
-          :   Int =
-
+          override update def flush(target: Slate[Data])(space: Interval in target.type): Int =
             if ended then 0 else
-              val bytes = target.asInstanceOf[scala.Array[Byte]]
+              val targetInterval: Interval = space
+              val targetOffset = targetInterval.start.n0
+              val targetSpace = targetInterval.size
+              val bytes = unsafely(target.raw.asInstanceOf[scala.Array[Byte]])
               val out = jn.ByteBuffer.wrap(bytes, targetOffset, targetSpace).nn
               staging.flip()
               encoder.encode(staging, out, true)

--- a/lib/zephyrine/src/core/zephyrine.Ductile.scala
+++ b/lib/zephyrine/src/core/zephyrine.Ductile.scala
@@ -114,9 +114,9 @@ object Ductile:
               in.position(in.position + result.length)
               decode(in, out, base, last)
 
-          // Decode window bytes `[start, sourceOffset + sourceLength)` through
+          // Decode region bytes `[start, sourceOffset + sourceLength)` through
           // the charset decoder into `[first, targetOffset + targetSpace)`:
-          // the whole window for a non-UTF-8 charset, or the remainder after
+          // the whole region for a non-UTF-8 charset, or the remainder after
           // the point where the UTF-8 kernel encountered malformed input.
           private update def stepDecoder
             ( bytes: scala.Array[Byte],
@@ -142,7 +142,7 @@ object Ductile:
               Duct.Progress(sourceLength, out.position - targetOffset)
             else
               // Output filled with complete bytes still to come, or input
-              // drained cleanly: leave any remainder for the next window.
+              // drained cleanly: leave any remainder for the next region.
               Duct.Progress(consumed, out.position - targetOffset)
 
           // The UTF-8 kernel: ASCII runs widen through an unrolled block copy
@@ -151,7 +151,7 @@ object Ductile:
           // anything above U+10FFFF all reject), and only exceptional input
           // leaves the loop: a valid-but-incomplete tail is carried exactly as
           // the decoder path carries it, and malformed input falls back to the
-          // charset decoder for the window remainder, which owns sanitizer
+          // charset decoder for the region remainder, which owns sanitizer
           // semantics unchanged.
           private update def stepUtf8
             ( bytes: scala.Array[Byte],
@@ -284,7 +284,7 @@ object Ductile:
 
             if staging.position == 0 then
               // Fast path: with no carried bytes, decode straight from the source
-              // window — no intermediate copy of the bulk of the stream.
+              // region — no intermediate copy of the bulk of the stream.
               if utf8 then
                 stepUtf8(bytes, sourceOffset, sourceLength, chars, targetOffset, targetSpace)
               else
@@ -293,7 +293,7 @@ object Ductile:
                     chars, targetOffset, targetSpace, targetOffset )
             else
               // Carry path: prior incomplete bytes are staged, so append the new
-              // window to make the split character contiguous, then decode.
+              // region to make the split character contiguous, then decode.
               val out = jn.CharBuffer.wrap(chars, targetOffset, targetSpace).nn
               val copy = sourceLength.min(staging.remaining)
               staging.put(bytes, sourceOffset, copy)

--- a/lib/zephyrine/src/core/zephyrine.Handoff.scala
+++ b/lib/zephyrine/src/core/zephyrine.Handoff.scala
@@ -53,8 +53,8 @@ import java.util.concurrent.locks.LockSupport
 //
 // A `SharedCapability`: like `Conduit`'s core, its guarantees come from
 // volatile publication order, not aliasing analysis.
-final class Handoff(window: Int) extends caps.SharedCapability:
-  private val capacity: Int = Integer.highestOneBit((window.max(2)*2) - 1)
+final class Handoff(depth: Int) extends caps.SharedCapability:
+  private val capacity: Int = Integer.highestOneBit((depth.max(2)*2) - 1)
   private val mask: Int = capacity - 1
   private val slots: juca.AtomicReferenceArray[AnyRef] = juca.AtomicReferenceArray(capacity)
   private val head: juca.AtomicLong = juca.AtomicLong(0)

--- a/lib/zephyrine/src/core/zephyrine.Intake.scala
+++ b/lib/zephyrine/src/core/zephyrine.Intake.scala
@@ -38,7 +38,7 @@ import rudiments.*
 import vacuous.*
 
 // The push endpoint of a streaming pipeline: a mutable buffer whose writable
-// window is exposed zero-copy to exactly one producer, and which reports its
+// region is exposed zero-copy to exactly one producer, and which reports its
 // current `demand` — the reactive message telling that producer how much it
 // can accept. An `Intake` is transformed into a differently-typed `Intake`
 // with `accepting`. `Intake` extends `Producer`, so producing code written
@@ -47,7 +47,7 @@ import vacuous.*
 // The primitive protocol is `reserve`/`buffer`/`mark`/`commit`: a writer
 // reserves contiguous space, writes directly into the intake's storage at
 // `mark`, then commits. `put`, `push` and `absorb` are final loops over that
-// protocol, so implementations provide only the window and its lifecycle.
+// protocol, so implementations provide only the region and its lifecycle.
 // The intake inherits Producer's capability classification: writes require an exclusive
 // reference; `demand` and `mark` are read-only queries.
 trait Intake[medium](using val addressable: medium is Addressable) extends Producer[medium]:
@@ -70,7 +70,7 @@ trait Intake[medium](using val addressable: medium is Addressable) extends Produ
 
   // Zero-copy view of this intake's buffer; elements from `mark` are writable
   // up to the last `reserve`d space. Valid only until the next `commit`,
-  // `flush` or `finish` — single-owner discipline, as `Stream.window`.
+  // `flush` or `finish` — single-owner discipline, as `Stream.region`.
   // Implementations provide the untyped `buffer0`; since `Addressable`
   // instances are unique per medium, the cast in `buffer` is sound.
   final def buffer(using Unsafe): addressable.Storage =

--- a/lib/zephyrine/src/core/zephyrine.Intake.scala
+++ b/lib/zephyrine/src/core/zephyrine.Intake.scala
@@ -70,7 +70,7 @@ trait Intake[medium](using val addressable: medium is Addressable) extends Produ
 
   // Zero-copy view of this intake's buffer; elements from `mark` are writable
   // up to the last `reserve`d space. Valid only until the next `commit`,
-  // `flush` or `finish` — single-owner discipline, as `Stream.region`.
+  // `flush` or `finish` — single-owner discipline, as `Stream.lend`.
   // Implementations provide the untyped `buffer0`; since `Addressable`
   // instances are unique per medium, the cast in `buffer` is sound.
   final def buffer(using Unsafe): addressable.Storage =

--- a/lib/zephyrine/src/core/zephyrine.Producer.scala
+++ b/lib/zephyrine/src/core/zephyrine.Producer.scala
@@ -52,11 +52,11 @@ object Producer:
   type Bytes = Producer[Data] { type Operand = Byte }
 
   // Streaming: chunks are queued (with backpressure) and drained through `iterator`. The producing
-  // code must run on a separate fiber, since `put` blocks once the window is full.
-  def apply[medium](block: Int = 4096, window: Int = 2)(using addr: medium is Addressable)
+  // code must run on a separate fiber, since `put` blocks once the queue is full.
+  def apply[medium](block: Int = 4096, depth: Int = 2)(using addr: medium is Addressable)
   :   (Channel[medium] { type Operand = addr.Operand })^ =
 
-    Channel(block, window)(using addr)
+    Channel(block, depth)(using addr)
 
   // Synchronous: run `body`, accumulating directly into a builder, and return the whole value. No
   // concurrency, no chunk buffer, and none of the streaming path's single-thread deadlock risk.
@@ -81,7 +81,7 @@ object Producer:
     body(producer)
     addressable.build(target)
 
-  final class Channel[medium](block: Int, window: Int)(using val addressable: medium is Addressable)
+  final class Channel[medium](block: Int, depth: Int)(using val addressable: medium is Addressable)
   extends Producer[medium]:
 
     type Operand = addressable.Operand
@@ -89,7 +89,7 @@ object Producer:
     private object Done
 
     private val queue: juc.ArrayBlockingQueue[medium | Done.type] =
-      juc.ArrayBlockingQueue(window)
+      juc.ArrayBlockingQueue(depth)
 
     // Untracked, cast-erased: reached only through this producer.
     @caps.unsafe.untrackedCaptures

--- a/lib/zephyrine/src/core/zephyrine.Region.scala
+++ b/lib/zephyrine/src/core/zephyrine.Region.scala
@@ -40,22 +40,22 @@ import vacuous.*
 
 // A `Region` is a bounds-safe fragment of a medium's backing storage (issue #1666): an opaque
 // reference to the storage that grants no direct access — no `length`, no raw indexed read.
-// The valid window travels separately as an `Interval` branded to the region's identity
+// The valid extent travels separately as an `Interval` branded to the region's identity
 // (`Interval in region.type`), and the only producers of branded `Ordinal`s are the trusted
 // combinators below, so `apply` is total: no bounds check, no `Optional`. A region plus its
-// window is one reference and one `Long` — allocation-free, replacing the unsafe
+// extent is one reference and one `Long` — allocation-free, replacing the unsafe
 // `(storage, offset, length)` triples previously threaded through streams and ducts.
 //
-// `Slate` is the writable counterpart, for duct output windows: `update` in place of `apply`,
+// `Slate` is the writable counterpart, for duct output storage: `update` in place of `apply`,
 // with the same branding discipline.
 //
 // Both erase to an untyped `AnyRef` carrier; since `Addressable` instances are unique per
 // medium, the casts back to `addressable.Storage` are sound — the same argument as
-// `Stream.window0`. Validity is temporal (a region is valid until the lender's next refill or
+// `Stream.storage0`. Validity is temporal (a region is valid until the lender's next refill or
 // reuse), which branding alone cannot express; that remains the single-owner discipline, and
 // the lender shape below is the hook by which separation checking will later enforce it.
 //
-// Within the trusted kernel, a brand must be widened away (`val window: Interval = range`)
+// Within the trusted kernel, a brand must be widened away (`val interval: Interval = range`)
 // before the opaque type's own inline ops apply: the inliner's opaque transparency does not
 // see through the refinement `Interval { type Form = region.type }`.
 
@@ -63,7 +63,7 @@ opaque type Region[medium] = AnyRef
 
 object Region:
   // The trusted boundary constructor: binds the region to a stable name and lends the caller
-  // its branded window, clamped to the storage's true extent so the totality invariant is
+  // its branded extent, clamped to the storage's true extent so the totality invariant is
   // established by construction. The brand is sound because storage length is fixed at
   // allocation and `region` cannot be rebound.
   inline def over[medium, result](using addressable: medium is Addressable)
@@ -87,9 +87,9 @@ object Region:
       ( inline lambda: (Ordinal in region.type) => Unit )
     :   Unit =
 
-      val window: Interval = range
-      var index: Int = window.start.n0
-      val end: Int = window.limit.n0
+      val interval: Interval = range
+      var index: Int = interval.start.n0
+      val end: Int = interval.limit.n0
 
       while index < end do
         lambda(region.ordinal(index))
@@ -106,9 +106,9 @@ object Region:
       ( inline rest: (Ordinal in region.type) => Unit )
     :   Unit =
 
-      val window: Interval = range
-      var index: Int = window.start.n0
-      val end: Int = window.limit.n0
+      val interval: Interval = range
+      var index: Int = interval.start.n0
+      val end: Int = interval.limit.n0
 
       while index + 8 <= end do
         whole
@@ -123,16 +123,16 @@ object Region:
         index += 1
 
     // Bulk operations, for the `arraycopy`/`materialize`-shaped consumers: each wraps one
-    // `Addressable` primitive with the window's bounds, so no caller ever re-derives offsets.
+    // `Addressable` primitive with the extent's bounds, so no caller ever re-derives offsets.
     inline def materialize(range: Interval in region.type): medium =
-      val window: Interval = range
+      val interval: Interval = range
       addressable.materialize
-       (region.asInstanceOf[addressable.Storage], window.start.n0, window.size)
+       (region.asInstanceOf[addressable.Storage], interval.start.n0, interval.size)
 
     inline def cloneTo(range: Interval in region.type)(target: addressable.Target): Unit =
-      val window: Interval = range
+      val interval: Interval = range
       addressable.cloneStorage
-       (region.asInstanceOf[addressable.Storage], window.start.n0, window.size)(target)
+       (region.asInstanceOf[addressable.Storage], interval.start.n0, interval.size)(target)
 
     // Copies as much of `range` as fits in `space` — the minimum of the two sizes, returned —
     // so the operation is total by construction.
@@ -152,17 +152,18 @@ object Region:
 
     // The escape hatch for kernels whose index arithmetic outruns the combinators (compressor
     // back-references and the like): the raw storage, behind `Unsafe`, with the caller taking
-    // back responsibility for bounds.
-    inline def raw(using Unsafe): addressable.Storage^{caps.any.rd} =
+    // back responsibility for bounds. Unannotated, like `Stream.storage`: the cast launders
+    // the capture, and the `Unsafe` gate marks the responsibility boundary.
+    inline def raw(using Unsafe): addressable.Storage =
       region.asInstanceOf[addressable.Storage]
 
     // The only branded-ordinal producer, for the trusted combinators above.
     private inline def ordinal(inline n: Int): Ordinal in region.type =
       Ordinal.zerary(n).asInstanceOf[Ordinal in region.type]
 
-// Brand-preserving narrowing: a sub-interval of a valid window is itself valid, so clamping
-// preserves the brand. `capped` keeps at most the first `count` indexes of the window.
+// Brand-preserving narrowing: a sub-interval of a valid extent is itself valid, so clamping
+// preserves the brand. `capped` keeps at most the first `count` indexes of the extent.
 extension [form](range: Interval in form)
   inline def capped(count: Int): Interval in form =
-    val window: Interval = range
-    Interval.sized(window.start.n0, window.size.min(count.max(0))).asInstanceOf[Interval in form]
+    val interval: Interval = range
+    Interval.sized(interval.start.n0, interval.size.min(count.max(0))).asInstanceOf[Interval in form]

--- a/lib/zephyrine/src/core/zephyrine.Region.scala
+++ b/lib/zephyrine/src/core/zephyrine.Region.scala
@@ -136,7 +136,7 @@ object Region:
 
     // Copies as much of `range` as fits in `space` — the minimum of the two sizes, returned —
     // so the operation is total by construction.
-    inline def blit(range: Interval in region.type)(slate: Slate[medium])
+    inline def transfer(range: Interval in region.type)(slate: Slate[medium])
       ( space: Interval in slate.type )
     :   Int =
 

--- a/lib/zephyrine/src/core/zephyrine.Region.scala
+++ b/lib/zephyrine/src/core/zephyrine.Region.scala
@@ -1,0 +1,168 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package zephyrine
+
+import scala.caps
+
+import denominative.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+// A `Region` is a bounds-safe fragment of a medium's backing storage (issue #1666): an opaque
+// reference to the storage that grants no direct access — no `length`, no raw indexed read.
+// The valid window travels separately as an `Interval` branded to the region's identity
+// (`Interval in region.type`), and the only producers of branded `Ordinal`s are the trusted
+// combinators below, so `apply` is total: no bounds check, no `Optional`. A region plus its
+// window is one reference and one `Long` — allocation-free, replacing the unsafe
+// `(storage, offset, length)` triples previously threaded through streams and ducts.
+//
+// `Slate` is the writable counterpart, for duct output windows: `update` in place of `apply`,
+// with the same branding discipline.
+//
+// Both erase to an untyped `AnyRef` carrier; since `Addressable` instances are unique per
+// medium, the casts back to `addressable.Storage` are sound — the same argument as
+// `Stream.window0`. Validity is temporal (a region is valid until the lender's next refill or
+// reuse), which branding alone cannot express; that remains the single-owner discipline, and
+// the lender shape below is the hook by which separation checking will later enforce it.
+//
+// Within the trusted kernel, a brand must be widened away (`val window: Interval = range`)
+// before the opaque type's own inline ops apply: the inliner's opaque transparency does not
+// see through the refinement `Interval { type Form = region.type }`.
+
+opaque type Region[medium] = AnyRef
+
+object Region:
+  // The trusted boundary constructor: binds the region to a stable name and lends the caller
+  // its branded window, clamped to the storage's true extent so the totality invariant is
+  // established by construction. The brand is sound because storage length is fixed at
+  // allocation and `region` cannot be rebound.
+  inline def over[medium, result](using addressable: medium is Addressable)
+    ( storage: addressable.Storage^{caps.any.rd}, offset: Int, limit: Int )
+    ( inline lambda: (region: Region[medium]) => (Interval in region.type) => result )
+  :   result =
+
+    val size = addressable.storageSize(storage)
+    val start = offset.max(0).min(size)
+    val end = limit.max(start).min(size)
+    val region: Region[medium] = storage.asInstanceOf[AnyRef]
+    lambda(region)(Interval.zerary(start, end).asInstanceOf[Interval in region.type])
+
+  extension [medium](region: Region[medium])(using addressable: medium is Addressable)
+    // Total: only branded ordinals are accepted, and only the trusted combinators produce them.
+    inline def apply(index: Ordinal in region.type): addressable.Operand =
+      val ordinal: Ordinal = index
+      addressable.storageAddress(region.asInstanceOf[addressable.Storage], ordinal.n0)
+
+    inline def visit(range: Interval in region.type)
+      ( inline lambda: (Ordinal in region.type) => Unit )
+    :   Unit =
+
+      val window: Interval = range
+      var index: Int = window.start.n0
+      val end: Int = window.limit.n0
+
+      while index < end do
+        lambda(region.ordinal(index))
+        index += 1
+
+    // The derived-index answer for unrolled hot loops (`stepUtf8`'s `bytes(src + 7)`): the
+    // `+1`..`+7` arithmetic lives here, proven once, and user code only ever sees branded
+    // ordinals. `whole` receives eight consecutive in-range ordinals; `rest` mops up the tail.
+    inline def visit8(range: Interval in region.type)
+      ( inline whole: ( Ordinal in region.type, Ordinal in region.type,
+                        Ordinal in region.type, Ordinal in region.type,
+                        Ordinal in region.type, Ordinal in region.type,
+                        Ordinal in region.type, Ordinal in region.type ) => Unit )
+      ( inline rest: (Ordinal in region.type) => Unit )
+    :   Unit =
+
+      val window: Interval = range
+      var index: Int = window.start.n0
+      val end: Int = window.limit.n0
+
+      while index + 8 <= end do
+        whole
+         ( region.ordinal(index), region.ordinal(index + 1), region.ordinal(index + 2),
+           region.ordinal(index + 3), region.ordinal(index + 4), region.ordinal(index + 5),
+           region.ordinal(index + 6), region.ordinal(index + 7) )
+
+        index += 8
+
+      while index < end do
+        rest(region.ordinal(index))
+        index += 1
+
+    // Bulk operations, for the `arraycopy`/`materialize`-shaped consumers: each wraps one
+    // `Addressable` primitive with the window's bounds, so no caller ever re-derives offsets.
+    inline def materialize(range: Interval in region.type): medium =
+      val window: Interval = range
+      addressable.materialize
+       (region.asInstanceOf[addressable.Storage], window.start.n0, window.size)
+
+    inline def cloneTo(range: Interval in region.type)(target: addressable.Target): Unit =
+      val window: Interval = range
+      addressable.cloneStorage
+       (region.asInstanceOf[addressable.Storage], window.start.n0, window.size)(target)
+
+    // Copies as much of `range` as fits in `space` — the minimum of the two sizes, returned —
+    // so the operation is total by construction.
+    inline def blit(range: Interval in region.type)(slate: Slate[medium])
+      ( space: Interval in slate.type )
+    :   Int =
+
+      val source: Interval = range
+      val dest: Interval = space
+      val count = source.size.min(dest.size)
+
+      addressable.transfer
+       ( region.asInstanceOf[addressable.Storage], source.start.n0,
+         slate.asInstanceOf[addressable.Storage], dest.start.n0, count )
+
+      count
+
+    // The escape hatch for kernels whose index arithmetic outruns the combinators (compressor
+    // back-references and the like): the raw storage, behind `Unsafe`, with the caller taking
+    // back responsibility for bounds.
+    inline def raw(using Unsafe): addressable.Storage^{caps.any.rd} =
+      region.asInstanceOf[addressable.Storage]
+
+    // The only branded-ordinal producer, for the trusted combinators above.
+    private inline def ordinal(inline n: Int): Ordinal in region.type =
+      Ordinal.zerary(n).asInstanceOf[Ordinal in region.type]
+
+// Brand-preserving narrowing: a sub-interval of a valid window is itself valid, so clamping
+// preserves the brand. `capped` keeps at most the first `count` indexes of the window.
+extension [form](range: Interval in form)
+  inline def capped(count: Int): Interval in form =
+    val window: Interval = range
+    Interval.sized(window.start.n0, window.size.min(count.max(0))).asInstanceOf[Interval in form]

--- a/lib/zephyrine/src/core/zephyrine.Slate.scala
+++ b/lib/zephyrine/src/core/zephyrine.Slate.scala
@@ -46,11 +46,14 @@ opaque type Slate[medium] = AnyRef
 object Slate:
   // As `Region.over`, but lending write access: the storage must be exclusive.
   inline def over[medium, result](using addressable: medium is Addressable)
-    ( storage: addressable.Storage^, offset: Int, limit: Int )
+    ( storage: addressable.Storage^{caps.any}, offset: Int, limit: Int )
     ( inline lambda: (slate: Slate[medium]) => (Interval in slate.type) => result )
   :   result =
 
-    val size = addressable.storageSize(storage)
+    // The cast erases the exclusive capture for the read-only size query: passing an
+    // exclusive reference into a `{caps.any.rd}` parameter is rejected when `Storage` is
+    // abstract, and nothing of the reference is retained.
+    val size = addressable.storageSize(storage.asInstanceOf[addressable.Storage])
     val start = offset.max(0).min(size)
     val end = limit.max(start).min(size)
     val slate: Slate[medium] = storage.asInstanceOf[AnyRef]

--- a/lib/zephyrine/src/core/zephyrine.Slate.scala
+++ b/lib/zephyrine/src/core/zephyrine.Slate.scala
@@ -27,41 +27,51 @@
 ┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
 ┃    either express or implied. See the License for the specific language governing permissions    ┃
 ┃    and limitations under the License.                                                            ┃
-┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package zephyrine
 
-export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum,
-    Duct, Ductile, Expanse, Malleable, Pace,
-    Format, Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
-    Records, records, Region, Regulation, Slate, Spring, Stream, Substrate, capped, chunks,
-    discard, gather, locate,
-    locateKey, memoize, pump, stream, streamOf, sweep, toProgression, truncate,
-    viaDuct, acceptingDuct}
+import scala.caps
 
-// Hand-written forwarders: the synthesized export forwarders for these dependent-typed
-// extensions lose the `ductile.Result`/`ductile.Operand` path refinements under capture
-// checking and fail to retypecheck.
-extension [in, transport](consume stream: (Stream[in] over transport)^)
-  def via[stage](consume stage: stage^)
-    ( using ductile: (stage is Ductile by in) { type Upstream = transport },
-            buffering: Buffering )
-  :   (Stream[ductile.Result] over ductile.Transport)^ =
-    // The call's dependent result widens to a `Ductile{...}#Result` projection rather than
-    // narrowing back to this forwarder's `ductile.Result`; the value is returned unchanged,
-    // so the cast only restores the dependent typing the export forwarder would have lost.
-    zephyrine.via[in, transport](stream)[stage](stage)(using ductile, buffering)
-    . asInstanceOf[(Stream[ductile.Result] over ductile.Transport)^]
+import denominative.*
+import prepositional.*
+import vacuous.*
 
-extension [out, transport](consume intake: (Intake[out] over transport)^)
-  def accepting[stage](consume stage: stage^)
-    ( using ductile: (stage is Ductile to out) { type Transport = transport },
-            buffering: Buffering )
-  :   (Intake[ductile.Operand] over ductile.Upstream)^ =
-    // See `via` above.
-    zephyrine.accepting[out, transport](intake)[stage](stage)(using ductile, buffering)
-    . asInstanceOf[(Intake[ductile.Operand] over ductile.Upstream)^]
+// The writable counterpart of `Region`, for duct output windows: `update` in place of
+// `apply`, with the same branding discipline. See `zephyrine.Region.scala` for the design.
+// The accessors live in the companion (found through implicit scope) rather than at the top
+// level: top-level extensions in separate files of one package cannot overload `Region`'s.
+opaque type Slate[medium] = AnyRef
 
-package parsing:
-  export zephyrine.parsing.trackPositions
+object Slate:
+  // As `Region.over`, but lending write access: the storage must be exclusive.
+  inline def over[medium, result](using addressable: medium is Addressable)
+    ( storage: addressable.Storage^, offset: Int, limit: Int )
+    ( inline lambda: (slate: Slate[medium]) => (Interval in slate.type) => result )
+  :   result =
+
+    val size = addressable.storageSize(storage)
+    val start = offset.max(0).min(size)
+    val end = limit.max(start).min(size)
+    val slate: Slate[medium] = storage.asInstanceOf[AnyRef]
+    lambda(slate)(Interval.zerary(start, end).asInstanceOf[Interval in slate.type])
+
+  extension [medium](slate: Slate[medium])(using addressable: medium is Addressable)
+    inline def update(index: Ordinal in slate.type, operand: addressable.Operand): Unit =
+      val ordinal: Ordinal = index
+      addressable.storageUpdate(slate.asInstanceOf[addressable.Storage^], ordinal.n0, operand)
+
+    inline def visit(range: Interval in slate.type)
+      ( inline lambda: (Ordinal in slate.type) => Unit )
+    :   Unit =
+
+      val window: Interval = range
+      var index: Int = window.start.n0
+      val end: Int = window.limit.n0
+
+      while index < end do
+        lambda(Ordinal.zerary(index).asInstanceOf[Ordinal in slate.type])
+        index += 1
+
+    inline def raw(using Unsafe): addressable.Storage^ =
+      slate.asInstanceOf[addressable.Storage^]

--- a/lib/zephyrine/src/core/zephyrine.Slate.scala
+++ b/lib/zephyrine/src/core/zephyrine.Slate.scala
@@ -37,7 +37,7 @@ import denominative.*
 import prepositional.*
 import vacuous.*
 
-// The writable counterpart of `Region`, for duct output windows: `update` in place of
+// The writable counterpart of `Region`, for duct output storage: `update` in place of
 // `apply`, with the same branding discipline. See `zephyrine.Region.scala` for the design.
 // The accessors live in the companion (found through implicit scope) rather than at the top
 // level: top-level extensions in separate files of one package cannot overload `Region`'s.
@@ -65,9 +65,9 @@ object Slate:
       ( inline lambda: (Ordinal in slate.type) => Unit )
     :   Unit =
 
-      val window: Interval = range
-      var index: Int = window.start.n0
-      val end: Int = window.limit.n0
+      val interval: Interval = range
+      var index: Int = interval.start.n0
+      val end: Int = interval.limit.n0
 
       while index < end do
         lambda(Ordinal.zerary(index).asInstanceOf[Ordinal in slate.type])

--- a/lib/zephyrine/src/core/zephyrine.Stream.scala
+++ b/lib/zephyrine/src/core/zephyrine.Stream.scala
@@ -34,12 +34,13 @@ package zephyrine
 
 import scala.caps
 
+import denominative.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
 
 // The pull endpoint of a streaming pipeline: a mutable buffer whose readable
-// window is exposed zero-copy to exactly one consumer. Backpressure is
+// region is exposed zero-copy to exactly one consumer. Backpressure is
 // intrinsic to pulling — a consumer that does not call `refill` demands
 // nothing — and the `demand` argument of each `refill` call is the reactive
 // message bounding how much the upstream may produce to satisfy it. A `Stream`
@@ -49,7 +50,7 @@ import vacuous.*
 // thread.
 object Stream:
   // A single-chunk in-memory stream. The chunk is copied into fresh storage
-  // once, at construction, so the window can be exposed mutably.
+  // once, at construction, so the region can be exposed mutably.
   def apply[medium](value: medium)(using addressable0: medium is Addressable)
   :   (Stream[medium] over Credit)^ =
 
@@ -66,10 +67,10 @@ object Stream:
       private var loaded: Boolean = false
 
       // The single buffer is filled once and only ever read thereafter, so its
-      // window ranges stay valid indefinitely — safe to share by reference.
-      override def windowStable: Boolean = true
+      // region ranges stay valid indefinitely — safe to share by reference.
+      override def regionStable: Boolean = true
 
-      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
       update def skip(count: Int): Unit = start0 += count
@@ -108,7 +109,7 @@ object Stream:
       private var limit0: Int = 0
       private var size: Int = 0
 
-      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
       update def skip(count: Int): Unit = start0 += count
@@ -151,31 +152,42 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // producing no more than `demand` permits, and return the number of
   // readable elements, i.e. `limit - start`. Returns `0` only when `demand`
   // grants nothing; returns `Unset` at end-of-stream. If unconsumed elements
-  // remain in the window, they are reported without producing more.
+  // remain in the region, they are reported without producing more.
   update def refill(demand: Transport): Optional[Int]
 
-  // Zero-copy view of this stream's buffer; elements `start until limit` are
-  // readable. Valid only until the next `refill` or `close` — the same
-  // single-owner discipline as `Cursor.unsafeBuffer`, and the hook by which
-  // separation checking will later enforce it. Implementations provide the
-  // untyped `window0`; since `Addressable` instances are unique per medium,
-  // the cast in `window` is sound.
-  final def window(using Unsafe): addressable.Storage =
-    window0.asInstanceOf[addressable.Storage]
+  // Zero-copy, bounds-safe view of this stream's readable region, elements
+  // `start until limit`: the region and its branded interval are lent to
+  // `lambda`, so every index the consumer can form is in range (see
+  // `zephyrine.Region.scala`). Valid only until the next `refill` or `close` —
+  // the same single-owner discipline as `Cursor.unsafeBuffer`, and the hook by
+  // which separation checking will later enforce it.
+  final inline def region[result]
+    ( inline lambda: (region: Region[medium]) => (Interval in region.type) => result )
+  :   result =
 
-  protected def window0: AnyRef
+    Region.over[medium, result](storage0.asInstanceOf[addressable.Storage], start, limit)(lambda)
+
+  // The raw backing storage, for fan-out plumbing that shares region ranges
+  // across endpoints by reference and for kernels whose index arithmetic
+  // outruns the region combinators. Implementations provide the untyped
+  // `storage0`; since `Addressable` instances are unique per medium, the cast
+  // is sound.
+  final def storage(using Unsafe): addressable.Storage =
+    storage0.asInstanceOf[addressable.Storage]
+
+  protected def storage0: AnyRef
   def start: Int
   def limit: Int
 
-  // Consume `count` elements of the window without materializing them.
+  // Consume `count` elements of the region without materializing them.
   update def skip(count: Int): Unit
 
-  // True when the window's backing is never overwritten while earlier ranges
+  // True when the region's backing is never overwritten while earlier ranges
   // may still be read — a single fixed buffer that `refill` only extends and
-  // `skip` only advances, so a fan-out or fan-in may share window ranges by
+  // `skip` only advances, so a fan-out or fan-in may share region ranges by
   // reference rather than copying them out. Conservatively `false`: a stream
   // that reuses its buffer between refills must never claim stability.
-  def windowStable: Boolean = false
+  def regionStable: Boolean = false
 
   // Release resources, propagating upstream through the whole chain.
   update def close(): Unit = ()

--- a/lib/zephyrine/src/core/zephyrine.Stream.scala
+++ b/lib/zephyrine/src/core/zephyrine.Stream.scala
@@ -161,7 +161,7 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // `zephyrine.Region.scala`). Valid only until the next `refill` or `close` —
   // the same single-owner discipline as `Cursor.unsafeBuffer`, and the hook by
   // which separation checking will later enforce it.
-  final inline def region[result]
+  final inline def lend[result]
     ( inline lambda: (region: Region[medium]) => (Interval in region.type) => result )
   :   result =
 

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -519,6 +519,11 @@ private def throughDuct[in, out, upTransport, downTransport]
       private var ended: Boolean = false
       private var flushed: Boolean = false
 
+      // Re-asserts the exclusivity the cast-erased field forgot: the buffer is
+      // reached only through this (exclusive) endpoint.
+      private def exclusive(): duct.output.Storage^ =
+        storage.asInstanceOf[duct.output.Storage^]
+
       protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
@@ -537,7 +542,10 @@ private def throughDuct[in, out, upTransport, downTransport]
 
             while limit0 == 0 && !flushed do
               if ended then
-                val produced = duct.flush(storage, limit0, space - limit0)
+                val produced =
+                  Slate.over[out, Int](using duct.output)(exclusive(), limit0, space): slate =>
+                    slateSpace => duct.flush(slate)(slateSpace)
+
                 if produced == 0 then flushed = true else limit0 += produced
               else
                 stream.refill(duct.translate(demand)) match
@@ -552,13 +560,13 @@ private def throughDuct[in, out, upTransport, downTransport]
                       // stream's storage and the duct's input storage
                       // coincide, even though their paths differ.
                       val progress =
-                        duct.step
+                        Region.over[in, Duct.Progress](using duct.input)
                           ( stream.storage(using Unsafe).asInstanceOf[duct.input.Storage],
-                            stream.start,
-                            count,
-                            storage,
-                            limit0,
-                            space - limit0 )
+                            stream.start, stream.start + count )
+                          ( region => range =>
+                              Slate.over[out, Duct.Progress](using duct.output)
+                                (exclusive(), limit0, space): slate =>
+                                  slateSpace => duct.step(region)(range)(slate)(slateSpace) )
 
                       stream.skip(progress.consumed)
                       limit0 += progress.produced
@@ -668,13 +676,12 @@ private def intakeThroughDuct[in, out, upTransport, downTransport]
           val free = intake.reserve(duct.quantum)
 
           val progress =
-            duct.step
-              ( storage,
-                offset,
-                mark0 - offset,
-                intake.buffer(using Unsafe).asInstanceOf[duct.output.Storage],
-                intake.mark,
-                free )
+            Region.over[in, Duct.Progress](using duct.input)(storage, offset, mark0): region =>
+              range =>
+                Slate.over[out, Duct.Progress](using duct.output)
+                  ( intake.buffer(using Unsafe).asInstanceOf[duct.output.Storage^],
+                    intake.mark, intake.mark + free )
+                  ( slate => slateSpace => duct.step(region)(range)(slate)(slateSpace) )
 
           intake.commit(progress.produced)
           offset += progress.consumed
@@ -690,10 +697,10 @@ private def intakeThroughDuct[in, out, upTransport, downTransport]
           val free = intake.reserve(duct.quantum)
 
           produced =
-            duct.flush
-              ( intake.buffer(using Unsafe).asInstanceOf[duct.output.Storage],
-                intake.mark,
-                free )
+            Slate.over[out, Int](using duct.output)
+              ( intake.buffer(using Unsafe).asInstanceOf[duct.output.Storage^],
+                intake.mark, intake.mark + free )
+              ( slate => slateSpace => duct.flush(slate)(slateSpace) )
 
           if produced > 0 then intake.commit(produced)
 

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -36,6 +36,7 @@ import scala.caps
 import proscenium.compat.*
 
 import anticipation.*
+import denominative.*
 import fulminate.*
 import hieroglyph.*
 import prepositional.*
@@ -98,12 +99,12 @@ package parsing:
 
 export Cursor.{Mark, Offset}
 
-// A stream of parsed records: each window is a frozen-array chunk of them (the boxed
+// A stream of parsed records: each region is a frozen-array chunk of them (the boxed
 // medium), so credit counts records and `Buffering` sizes stage buffers by
 // reference count. Records are immutable values, so they cross stage and thread
 // boundaries by reference; a record must not itself hold a live endpoint. This
 // alias is the conventional shape for record-granularity streaming (rows, events,
-// frames, messages) between the windowed media (`Data`, `Text`) and materialized
+// frames, messages) between the region-based media (`Data`, `Text`) and materialized
 // collections. The record type is unbounded here — the `Addressable` given that
 // admits a record type governs at stream construction — but it must erase to a
 // reference type.
@@ -140,7 +141,7 @@ extension [in, transport](consume stream: (Stream[in] over transport)^)
     throughDuct[in, out, transport, downTransport](duct, stream)
 
   // The pump loop connecting a pull-chain to a push-chain, on the calling
-  // thread: poll the intake's demand, refill with it, transfer the window.
+  // thread: poll the intake's demand, refill with it, transfer the region.
   // This is the only place data crosses from the pull side to the push side
   // of a pipeline.
   def pump(consume intake: (Intake[in] over transport)^): Unit =
@@ -152,7 +153,7 @@ extension [in, transport](consume stream: (Stream[in] over transport)^)
         case count: Int =>
           if count > 0 then
             intake.absorb
-              ( stream.window(using Unsafe).asInstanceOf[intake.addressable.Storage],
+              ( stream.storage(using Unsafe).asInstanceOf[intake.addressable.Storage],
                 stream.start,
                 count )
 
@@ -167,7 +168,7 @@ extension [in, transport](consume stream: (Stream[in] over transport)^)
 extension [out, transport](consume intake: (Intake[out] over transport)^)
   // Push-composition: a differently-typed `Intake` which reports translated
   // demand, and whose commits step synchronously through the stage into
-  // this intake's writable window. The same stage value serves `via`
+  // this intake's writable region. The same stage value serves `via`
   // and `accepting`; only the attachment differs.
   def accepting[stage](consume stage: stage^)
     ( using ductile: (stage is Ductile to out) { type Transport = transport },
@@ -192,23 +193,24 @@ extension [out, transport](consume intake: (Intake[out] over transport)^)
 //
 // The safe front-end replacing the Chain views: pipeline stages compose with the
 // consume-typed `through`, and these terminal operations drain an exclusive endpoint
-// without exposing its window — each borrow is read, used and skipped before the next
+// without exposing its region — each borrow is read, used and skipped before the next
 // refill. `memoize` is the explicit replacement for Chain's implicit caching: it
 // drains the stream once into an immutable value, which may then be shared freely.
 
 extension [medium](consume stream: (Stream[medium] over Credit)^)
-  // Drain the stream, applying `operation` to each successive window (its raw
-  // storage, start index and element count); it must not retain the storage.
-  // For a byte stream the `Stream[Data]` overload below types the window as
-  // `Array[Byte]`, so the common case needs no cast.
-  def sweep(operation: (AnyRef, Int, Int) => Unit)(using buffering: Buffering): Unit =
+  // Drain the stream, applying `operation` to each successive region and its
+  // branded readable interval; it must not retain the region beyond the call.
+  def sweep(operation: (region: Region[medium]) => (Interval in region.type) => Unit)
+    (using buffering: Buffering)
+  :   Unit =
+
     // A drain loop wants boundary-transfer-sized credit: a staging-block ask
-    // would slice each larger window into many partial refills.
+    // would slice each larger region into many partial refills.
     val block = buffering.transfer(stream.addressable.substrate)
 
     def loop(): Unit = stream.refill(Credit(block)) match
       case count: Int =>
-        operation(stream.window(using Unsafe).asInstanceOf[AnyRef], stream.start, count)
+        stream.region(operation(_))
         stream.skip(count)
         loop()
 
@@ -219,32 +221,30 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
   // Drain the stream into a single immutable value: the explicit, bounded replacement
   // for a Chain's implicit memoization. The result is frozen and freely shareable.
   def memoize(using buffering: Buffering): medium =
-    val addressable = stream.addressable
-    val target = addressable.blank(buffering.capacity(addressable.substrate))
+    given stream.addressable.type = stream.addressable
+    val target = stream.addressable.blank(buffering.capacity(stream.addressable.substrate))
 
-    sweep: (storage, start, count) =>
-      addressable.cloneStorage(storage.asInstanceOf[addressable.Storage], start, count)(target)
+    sweep: region =>
+      range => region.cloneTo(range)(target)
 
-    addressable.build(target)
+    stream.addressable.build(target)
 
-  // Drain the stream, threading an accumulator through each window: `sweep`'s
+  // Drain the stream, threading an accumulator through each region: `sweep`'s
   // accumulating counterpart, the terminal end of a pull chain. The operation
-  // receives the running state, the raw window storage, its start index and its
-  // element count; it must not retain the storage. Unlike an element-wise fold
-  // over a collection, this exposes the raw window, so a byte reduction runs
-  // over the array with no per-element boxing. (The `Stream[Data]` overload
-  // below types the window.)
-  def gather[state](initial: state)(operation: (state, AnyRef, Int, Int) => state)
-    (using buffering: Buffering)
+  // receives the running state alongside the region and its branded interval,
+  // and must not retain the region beyond the call. Unlike an element-wise fold
+  // over a collection, this exposes the whole region, so a byte reduction runs
+  // over the array with no per-element boxing.
+  def gather[state](initial: state)
+    ( operation: (region: Region[medium]) => (state, Interval in region.type) => state )
+    ( using buffering: Buffering )
   :   state =
 
     val block = buffering.transfer(stream.addressable.substrate)
 
     def loop(state: state): state = stream.refill(Credit(block)) match
       case count: Int =>
-        val state2 =
-          operation(state, stream.window(using Unsafe).asInstanceOf[AnyRef], stream.start, count)
-
+        val state2 = stream.region { region => range => operation(region)(state, range) }
         stream.skip(count)
         loop(state2)
 
@@ -280,11 +280,11 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
   def toProgression(using buffering: Buffering): Chain[medium] =
     val block = buffering.transfer(stream.addressable.substrate)
 
+    given stream.addressable.type = stream.addressable
+
     def recur(): Chain[medium] = stream.refill(Credit(block)) match
       case count: Int =>
-        val chunk =
-          stream.addressable.materialize(stream.window(using Unsafe), stream.start, count)
-
+        val chunk = stream.region { region => range => region.materialize(range) }
         stream.skip(count)
         chunk #:: recur()
 
@@ -296,16 +296,16 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
 
 extension [record](consume stream: (Stream[Array[record]^{}] over Credit)^)
   // Element-wise access to a stream of records: a single-consumer iterator over
-  // the records of successive windows, in order. The iterator owns the endpoint:
+  // the records of successive regions, in order. The iterator owns the endpoint:
   // it closes the stream when it reports exhaustion, so a consumer must drain it
   // (or close the stream by other means) to release the upstream. Per-record
   // combinators come free from the `Iterator` interface (and rudiments' `each`);
-  // window-level access for hot loops is `sweep`/`gather` above.
+  // region-level access for hot loops is `sweep`/`gather` above.
   def records(using Buffering): Iterator[record]^ = recordIterator(stream)
 
 // A pull endpoint lending a bounded view of a cursor: the next `length` elements
 // (or all remaining, if `Unset`), exposed zero-copy — the cursor's own buffer
-// backs each window, and skipping the stream advances the cursor. The cursor is
+// backs each region, and skipping the stream advances the cursor. The cursor is
 // LENT, not consumed: closing this stream leaves it open, positioned at the
 // boundary, and the caller resumes it there. This is the shape of a delimited
 // payload inside a longer parse: an HTTP body before the next pipelined request,
@@ -334,7 +334,7 @@ def streamOf[data](cursor: Cursor[data, {}]^, length: Optional[Long] = Unset)
       private var start0: Int = 0
       private var limit0: Int = 0
 
-      protected def window0: AnyRef = storage
+      protected def storage0: AnyRef = storage
       def start: Int = start0
       def limit: Int = limit0
 
@@ -345,7 +345,7 @@ def streamOf[data](cursor: Cursor[data, {}]^, length: Optional[Long] = Unset)
 
       // Demand does not bound exposure: the cursor refills by its own bounded
       // block, which is what bounds memory (as the iterator factory on
-      // `Stream`'s companion notes of its chunks). An unconsumed window is
+      // `Stream`'s companion notes of its chunks). An unconsumed region is
       // reported, not extended: `cursor.more` short-circuits while buffered
       // elements remain, so re-snapshotting it is free.
       update def refill(demand: Credit): Optional[Int] =
@@ -364,7 +364,7 @@ def streamOf[data](cursor: Cursor[data, {}]^, length: Optional[Long] = Unset)
 
 // A pull endpoint over a bounded range of an `Expanse`: each refill reads the
 // next chunk of the range — sized by the buffering policy's transfer block — and
-// exposes the freshly-read buffer as the window, zero-copy. Reads are issued
+// exposes the freshly-read buffer as the region, zero-copy. Reads are issued
 // only as the consumer demands them, so an unconsumed payload costs nothing and
 // a payload of any length streams in bounded memory. The expanse states its own
 // lifetime discipline (it may hold a resource open, or re-acquire one per
@@ -379,7 +379,7 @@ def streamOf(expanse: Expanse^, offset: Long, length: Long)(using buffering: Buf
       private val end: Long = offset + length
       private var position: Long = offset
 
-      // Each window is backed by the immutable chunk `read` returns, cast-erased
+      // Each region is backed by the immutable chunk `read` returns, cast-erased
       // and reached only through this endpoint; it is never written through, and
       // the next refill replaces it wholesale (hence the pure placeholder
       // initial, as in the cursor-lending factory above).
@@ -390,9 +390,9 @@ def streamOf(expanse: Expanse^, offset: Long, length: Long)(using buffering: Buf
 
       // Every refill installs a fresh immutable chunk rather than overwriting a
       // shared buffer, so previously-exposed ranges stay valid indefinitely.
-      override def windowStable: Boolean = true
+      override def regionStable: Boolean = true
 
-      protected def window0: AnyRef = storage
+      protected def storage0: AnyRef = storage
       def start: Int = start0
       def limit: Int = limit0
       update def skip(count: Int): Unit = start0 += count
@@ -431,9 +431,8 @@ private def chunkIterator[medium](consume stream: (Stream[medium] over Credit)^)
 
       private def advance(): Boolean = stream.refill(Credit(block)) match
         case count: Int =>
-          chunk =
-            stream.addressable.materialize(stream.window(using Unsafe), stream.start, count)
-
+          given stream.addressable.type = stream.addressable
+          chunk = stream.region { region => range => region.materialize(range) }
           stream.skip(count)
           true
 
@@ -456,9 +455,9 @@ private def recordIterator[record]
     new Iterator[record]:
       private val block: Int = buffering.transfer(Substrate.Boxes)
 
-      // The current window: records `index until limit` of `storage` are
+      // The current region: records `index until limit` of `storage` are
       // unread; `consumed` is skipped lazily, just before the next refill, per
-      // the refill contract (an unskipped window is reported, not extended).
+      // the refill contract (an unskipped region is reported, not extended).
       // A stdlib class cannot extend `Stateful`, so its state is untracked
       // (the `inputStream` adapter's precedent).
       @caps.unsafe.untrackedCaptures
@@ -481,7 +480,7 @@ private def recordIterator[record]
 
         stream.refill(Credit(block)) match
           case count: Int =>
-            storage = stream.window(using Unsafe).asInstanceOf[scala.Array[AnyRef]]
+            storage = stream.storage(using Unsafe).asInstanceOf[scala.Array[AnyRef]]
             index = stream.start
             limit = stream.start + count
             consumed = count
@@ -520,7 +519,7 @@ private def throughDuct[in, out, upTransport, downTransport]
       private var ended: Boolean = false
       private var flushed: Boolean = false
 
-      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      protected def storage0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
       update def skip(count: Int): Unit = start0 += count
@@ -554,7 +553,7 @@ private def throughDuct[in, out, upTransport, downTransport]
                       // coincide, even though their paths differ.
                       val progress =
                         duct.step
-                          ( stream.window(using Unsafe).asInstanceOf[duct.input.Storage],
+                          ( stream.storage(using Unsafe).asInstanceOf[duct.input.Storage],
                             stream.start,
                             count,
                             storage,
@@ -576,7 +575,7 @@ private def throughDuct[in, out, upTransport, downTransport]
 // `truncate`/`discard` wrappers, in helpers rather than inline in the
 // extension for the same reason as `throughDuct`: a local binding of the
 // upstream would hide it from the anonymous class, whereas the consumed
-// parameter carries its capture explicitly. Each delegates window access to
+// parameter carries its capture explicitly. Each delegates storage access to
 // the upstream (zero copy) and only adjusts the element budget.
 
 private def truncateStream[medium](consume stream: (Stream[medium] over Credit)^, count: Long)
@@ -587,7 +586,7 @@ private def truncateStream[medium](consume stream: (Stream[medium] over Credit)^
 
       private var remaining: Long = count.max(0)
 
-      protected def window0: AnyRef = stream.window(using Unsafe).asInstanceOf[AnyRef]
+      protected def storage0: AnyRef = stream.storage(using Unsafe).asInstanceOf[AnyRef]
       def start: Int = stream.start
 
       def limit: Int =
@@ -615,7 +614,7 @@ private def discardStream[medium](consume stream: (Stream[medium] over Credit)^,
 
       private var pending: Long = count.max(0)
 
-      protected def window0: AnyRef = stream.window(using Unsafe).asInstanceOf[AnyRef]
+      protected def storage0: AnyRef = stream.storage(using Unsafe).asInstanceOf[AnyRef]
       def start: Int = stream.start
       def limit: Int = stream.limit
       update def skip(elements: Int): Unit = stream.skip(elements)

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -210,7 +210,7 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
 
     def loop(): Unit = stream.refill(Credit(block)) match
       case count: Int =>
-        stream.region(operation(_))
+        stream.lend(operation(_))
         stream.skip(count)
         loop()
 
@@ -244,7 +244,7 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
 
     def loop(state: state): state = stream.refill(Credit(block)) match
       case count: Int =>
-        val state2 = stream.region { region => range => operation(region)(state, range) }
+        val state2 = stream.lend { region => range => operation(region)(state, range) }
         stream.skip(count)
         loop(state2)
 
@@ -284,7 +284,7 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
 
     def recur(): Chain[medium] = stream.refill(Credit(block)) match
       case count: Int =>
-        val chunk = stream.region { region => range => region.materialize(range) }
+        val chunk = stream.lend { region => range => region.materialize(range) }
         stream.skip(count)
         chunk #:: recur()
 
@@ -432,7 +432,7 @@ private def chunkIterator[medium](consume stream: (Stream[medium] over Credit)^)
       private def advance(): Boolean = stream.refill(Credit(block)) match
         case count: Int =>
           given stream.addressable.type = stream.addressable
-          chunk = stream.region { region => range => region.materialize(range) }
+          chunk = stream.lend { region => range => region.materialize(range) }
           stream.skip(count)
           true
 

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -835,7 +835,7 @@ object Tests extends Suite(m"Zephyrine tests"):
           def recur(): Unit = scala.caps.unsafe.unsafeAssumeSeparate:
            stream.refill(Credit(8)) match
             case count: Int =>
-              val window = unsafely(stream.window).asInstanceOf[scala.Array[Char]]
+              val window = unsafely(stream.storage).asInstanceOf[scala.Array[Char]]
               builder.append(String(window, stream.start, count))
               stream.skip(count)
               scala.caps.unsafe.unsafeAssumeSeparate(recur())
@@ -869,7 +869,7 @@ object Tests extends Suite(m"Zephyrine tests"):
           def recur(): Unit = scala.caps.unsafe.unsafeAssumeSeparate:
            stream.refill(Credit(8)) match
             case count: Int =>
-              val window = unsafely(stream.window).asInstanceOf[scala.Array[Char]]
+              val window = unsafely(stream.storage).asInstanceOf[scala.Array[Char]]
               builder.append(String(window, stream.start, count))
               stream.skip(count)
               scala.caps.unsafe.unsafeAssumeSeparate(recur())
@@ -888,7 +888,7 @@ object Tests extends Suite(m"Zephyrine tests"):
 
           def recur(): Unit = decoded.refill(Credit(4)) match
             case count: Int =>
-              val window = unsafely(decoded.window).asInstanceOf[scala.Array[Char]]
+              val window = unsafely(decoded.storage).asInstanceOf[scala.Array[Char]]
               builder.append(String(window, decoded.start, count))
               decoded.skip(count)
               scala.caps.unsafe.unsafeAssumeSeparate(recur())
@@ -907,7 +907,7 @@ object Tests extends Suite(m"Zephyrine tests"):
           def recur(): Unit = scala.caps.unsafe.unsafeAssumeSeparate:
            stream.refill(Credit(7)) match
             case count: Int =>
-              val window = unsafely(stream.window).asInstanceOf[scala.Array[AnyRef]]
+              val window = unsafely(stream.storage).asInstanceOf[scala.Array[AnyRef]]
 
               for index <- 0 until count
               do collected = window(stream.start + index).asInstanceOf[String] :: collected
@@ -933,9 +933,8 @@ object Tests extends Suite(m"Zephyrine tests"):
           var collected: List[Byte] = Nil
 
           Stream(Iterator(Array.of[Byte](1, 2, 3), Array.of[Byte](), Array.of[Byte](4, 5)))
-          . sweep: (storage, start, count) =>
-              val bytes = storage.asInstanceOf[scala.Array[Byte]]
-              for index <- 0 until count do collected = bytes(start + index) :: collected
+          . sweep: region =>
+              range => region.visit(range) { index => collected = region(index) :: collected }
 
           collected.reverse
         . assert(_ == List[Byte](1, 2, 3, 4, 5))
@@ -994,13 +993,12 @@ object Tests extends Suite(m"Zephyrine tests"):
           small.stream.truncate(3).viaDuct(Doubler()).memoize.to[List]
         . assert(_ == List[Byte](1, 1, 2, 2, 3, 3))
 
-        test(m"gather reduces over windows without boxing"):
-          bytes.stream.gather(0L): (total, storage, start, count) =>
-            val array = storage.asInstanceOf[scala.Array[Byte]]
-            var sum = total
-            var index = 0
-            while index < count do { sum += (array(start + index) & 0xff); index += 1 }
-            sum
+        test(m"gather reduces over regions without boxing"):
+          bytes.stream.gather(0L): region =>
+            (total, range) =>
+              var sum = total
+              region.visit(range) { index => sum += (region(index) & 0xff) }
+              sum
         . assert(_ == bytes.to[List].map(_ & 0xff).sum.toLong)
 
         test(m"toProgression yields the stream's chunks in order"):
@@ -1203,9 +1201,9 @@ object Tests extends Suite(m"Zephyrine tests"):
       demands ::= demand.count
       underlying.refill(demand)
 
-    protected def window0: AnyRef =
+    protected def storage0: AnyRef =
       val current = underlying
-      unsafely(current.window).asInstanceOf[AnyRef]
+      unsafely(current.storage).asInstanceOf[AnyRef]
     def start: Int = underlying.start
     def limit: Int = underlying.limit
     update def skip(count: Int): Unit = underlying.skip(count)

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -581,6 +581,92 @@ object Tests extends Suite(m"Zephyrine tests"):
             (inner, cursor.grab(outer, cursor.mark).s)
         . assert(_ == ((true, "a")))
 
+      suite(m"Region tests"):
+        def sample(size: Int): scala.Array[Byte]^ =
+          val buffer = Array.scratch[Byte](size)
+          var index = 0
+
+          while index < size do
+            buffer(index) = index.toByte
+            index += 1
+
+          buffer
+
+        test(m"visit sums a clamped window"):
+          val buffer = sample(10)
+          var total = 0
+
+          Region.over[Data, Unit](buffer, 1, 9): region =>
+            range => region.visit(range) { index => total += region(index).toInt }
+
+          total
+        . assert(_ == 36)
+
+        test(m"over clamps an oversized window to the storage"):
+          val buffer = sample(4)
+          var count = 0
+
+          Region.over[Data, Unit](buffer, 0, 100): region =>
+            range => region.visit(range) { _ => count += 1 }
+
+          count
+        . assert(_ == 4)
+
+        test(m"visit8 takes the unrolled path and mops up the tail"):
+          val buffer = sample(19)
+          var whole = 0
+          var rest = 0
+
+          Region.over[Data, Unit](buffer, 0, 19): region =>
+            range =>
+              region.visit8(range)
+               ( (i0, i1, i2, i3, i4, i5, i6, i7) =>
+                   whole += region(i0) + region(i1) + region(i2) + region(i3)
+                     + region(i4) + region(i5) + region(i6) + region(i7) )
+               ( index => rest += region(index).toInt )
+
+          (whole, rest)
+        . assert(_ == ((120, 51)))
+
+        test(m"capped narrows a window, preserving its brand"):
+          val buffer = sample(10)
+          var count = 0
+
+          Region.over[Data, Unit](buffer, 2, 10): region =>
+            range => region.visit(range.capped(3)) { _ => count += 1 }
+
+          count
+        . assert(_ == 3)
+
+        test(m"materialize copies exactly the window"):
+          val buffer = sample(10)
+
+          Region.over[Data, Data](buffer, 2, 5): region =>
+            range => region.materialize(range)
+        . assert(_.to[List] == List[Byte](2, 3, 4))
+
+        test(m"blit copies no more than the slate's space"):
+          val source = sample(10)
+          val target = Array.scratch[Byte](4)
+
+          val copied = Region.over[Data, Int](source, 5, 10): region =>
+            range =>
+              Slate.over[Data, Int](target, 0, 4): slate =>
+                space => region.blit(range)(slate)(space)
+
+          (copied, target(0), target(3))
+        . assert(_ == ((4, 5.toByte, 8.toByte)))
+
+        test(m"slate update writes through branded ordinals"):
+          val target = Array.scratch[Byte](6)
+
+          Slate.over[Data, Unit](target, 2, 5): slate =>
+            space => slate.visit(space) { index => slate(index) = 7.toByte }
+
+          (target(1), target(2), target(4),
+           target(5))
+        . assert(_ == ((0.toByte, 7.toByte, 7.toByte, 0.toByte)))
+
       suite(m"Streaming kernel tests"):
         val small = Array.of[Byte](1, 2, 3, 4, 5)
 

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -231,8 +231,8 @@ object Tests extends Suite(m"Zephyrine tests"):
           val builder = java.lang.StringBuilder()
 
           while
-            cursor.region { region => range => region.visit(range) { index => builder.append(region(index)) } }
-            val count = cursor.region { _ => range => (range: Interval).size }
+            cursor.lend { region => range => region.visit(range) { index => builder.append(region(index)) } }
+            val count = cursor.lend { _ => range => (range: Interval).size }
             cursor.unsafeAdvanceBy(count)(using Unsafe)
             cursor.more
           do ()
@@ -659,14 +659,14 @@ object Tests extends Suite(m"Zephyrine tests"):
             range => region.materialize(range)
         . assert(_.to[List] == List[Byte](2, 3, 4))
 
-        test(m"blit copies no more than the slate's space"):
+        test(m"transfer copies no more than the slate's space"):
           val source = sample(10)
           val target = Array.scratch[Byte](4)
 
           val copied = Region.over[Data, Int](source, 5, 10): region =>
             range =>
               Slate.over[Data, Int](target, 0, 4): slate =>
-                space => region.blit(range)(slate)(space)
+                space => region.transfer(range)(slate)(space)
 
           (copied, target(0), target(3))
         . assert(_ == ((4, 5.toByte, 8.toByte)))
@@ -1187,7 +1187,7 @@ object Tests extends Suite(m"Zephyrine tests"):
       ( target: Slate[Data] )(space: Interval in target.type)
     :   Duct.Progress =
 
-      val count = source.blit(range)(target)(space)
+      val count = source.transfer(range)(target)(space)
       Duct.Progress(count, count)
 
     override update def flush(target: Slate[Data])(space: Interval in target.type): Int =

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -1131,23 +1131,28 @@ object Tests extends Suite(m"Zephyrine tests"):
 
     override def quantum: Int = 2
 
-    def step
-      ( source: input.Storage,
-        sourceOffset: Int,
-        sourceLength: Int,
-        target: output.Storage,
-        targetOffset: Int,
-        targetSpace: Int )
+    def step(source: Region[Data])(range: Interval in source.type)
+      ( target: Slate[Data] )(space: Interval in target.type)
     :   Duct.Progress =
+
+      val sourceInterval: Interval = range
+      val sourceOffset = sourceInterval.start.n0
+      val sourceLength = sourceInterval.size
+      val targetInterval: Interval = space
+      val targetOffset = targetInterval.start.n0
+      val targetSpace = targetInterval.size
+      val bytes = unsafely(source.raw.asInstanceOf[scala.Array[Byte]])
+
+      val out: scala.Array[Byte]^ =
+        unsafely(target.raw.asInstanceOf[scala.Array[Byte]]).asInstanceOf[scala.Array[Byte]^]
 
       var consumed: Int = 0
       var produced: Int = 0
-      val target2 = target.asInstanceOf[input.Storage]
 
       while consumed < sourceLength && produced + 2 <= targetSpace do
-        val byte = input.storageAddress(source, sourceOffset + consumed)
-        input.storageUpdate(target2, targetOffset + produced, byte)
-        input.storageUpdate(target2, targetOffset + produced + 1, byte)
+        val byte = bytes(sourceOffset + consumed)
+        out(targetOffset + produced) = byte
+        out(targetOffset + produced + 1) = byte
         consumed += 1
         produced += 2
 
@@ -1164,25 +1169,23 @@ object Tests extends Suite(m"Zephyrine tests"):
     def regulation: Credit is Regulation = summon[Credit is Regulation]
     def translate(demand: Credit): Credit = demand
 
-    update def step
-      ( source: input.Storage,
-        sourceOffset: Int,
-        sourceLength: Int,
-        target: output.Storage,
-        targetOffset: Int,
-        targetSpace: Int )
+    update def step(source: Region[Data])(range: Interval in source.type)
+      ( target: Slate[Data] )(space: Interval in target.type)
     :   Duct.Progress =
 
-      val count = sourceLength.min(targetSpace)
-      input.transfer(source, sourceOffset, target.asInstanceOf[input.Storage], targetOffset, count)
-
+      val count = source.blit(range)(target)(space)
       Duct.Progress(count, count)
 
-    override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+    override update def flush(target: Slate[Data])(space: Interval in target.type): Int =
       if emitted then 0 else
         emitted = true
-        output.storageUpdate(target, targetOffset, 99.toByte.asInstanceOf[output.Operand])
-        1
+        var written = 0
+
+        target.visit(space.capped(1)): ordinal =>
+          target(ordinal) = 99.toByte
+          written = 1
+
+        written
 
   // Passes refills through unchanged, recording each demand it receives.
   class Recorder(consume underlying0: (Stream[Data] over Credit)^) extends Stream[Data]:

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -226,6 +226,20 @@ object Tests extends Suite(m"Zephyrine tests"):
           builder.toString
         . assert(_ == "Hello world!")
 
+        test(m"region lends the readable window with branded indexes"):
+          val cursor = hello
+          val builder = java.lang.StringBuilder()
+
+          while
+            cursor.region { region => range => region.visit(range) { index => builder.append(region(index)) } }
+            val count = cursor.region { _ => range => (range: Interval).size }
+            cursor.unsafeAdvanceBy(count)(using Unsafe)
+            cursor.more
+          do ()
+
+          builder.toString
+        . assert(_ == "Hello world!")
+
         test(m"Capture part of first block"):
           val cursor = hello
           val builder = java.lang.StringBuilder()

--- a/lib/zeppelin/src/core/zeppelin.ZipBuilder.scala
+++ b/lib/zeppelin/src/core/zeppelin.ZipBuilder.scala
@@ -42,6 +42,7 @@ import java.nio.file as jnf
 import anticipation.*
 import aperture.*
 import contingency.*
+import denominative.*
 import galilei.CreateFlag
 import gossamer.*
 import prepositional.*
@@ -160,8 +161,11 @@ object ZipBuilder:
         val out = ji.FileOutputStream(temporary.toFile)
 
         try
-          zipfile.serialize.sweep: (window, start, count) =>
-            out.write(window.asInstanceOf[scala.Array[Byte]], start, count)
+          zipfile.serialize.sweep: region =>
+            range =>
+              val interval: Interval = range
+              out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0,
+                  interval.size)
         finally out.close()
 
         jnf.Files.move(temporary, target, jnf.StandardCopyOption.ATOMIC_MOVE,

--- a/lib/zeppelin/src/core/zeppelin.Zipfile.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zipfile.scala
@@ -71,8 +71,12 @@ object Zipfile:
     checkDuplicates(entries)
     val out = ji.FileOutputStream(ji.File(path.generic.s))
 
-    try Zipfile(entries.to(List), Unset, prefix).serialize.sweep: (window, start, count) =>
-      out.write(window.asInstanceOf[scala.Array[Byte]], start, count)
+    try
+      Zipfile(entries.to(List), Unset, prefix).serialize.sweep: region =>
+        range =>
+          val interval: Interval = range
+          out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0,
+              interval.size)
     finally out.close()
 
     Log.info(ZipEvent.Wrote(path.generic, entries.size))


### PR DESCRIPTION
Zephyrine now exposes stream buffers, duct windows and cursor buffers as `Region`s: opaque, allocation-free fragments of backing storage whose valid extent travels as an `Interval` branded to the region's identity, so every index a consumer can form is provably in range and access is total — no bounds checks, no `Optional`, and identical bytecode to the raw `while` loops it replaces. This is the first delivery of #1666's safety programme, and it retires the word "window" from the streaming vocabulary in favour of `Region`.

A `Region` grants no `length` and no raw indexed access. A stream *lends* it, together with its readable extent as an `Interval in region.type`, and only trusted combinators produce branded `Ordinal`s, so `region(index)` is total:

```scala
stream.lend: region =>
  range => region.visit(range): index =>
    total += region(index)   // cannot be out of range; no check is emitted
```

`Slate` is the writable counterpart, used for duct output. Bulk operations (`materialize`, `cloneTo`, `transfer`, the 8-way-unrolled `visit8`) own all index arithmetic, so hot loops keep their shape with every index branded. `Duct.step` and `flush` now receive a `Region` with its branded readable interval and a `Slate` with its branded writable interval; every duct — charsets, base-N serializers, line splitting, ciphers, all compressors — has been converted, with kernels wrapping offset-based JDK APIs taking a greppable `unsafely(raw)` escape hatch. `Cursor` gains the same lender for parser scan loops. `Stream.window(using Unsafe)` is replaced by the `lend` lender (with `storage(using Unsafe)` remaining for fan-out plumbing), `windowStable` becomes `regionStable`, and `Buffering`'s queue-depth `window` becomes `depth`. To free the name, dissonance's diff enum `Region` is now `Tract`, `Span.Mode.Region` is `Area` (with `Span.region` becoming `Span.area`), and honeycomb's private alias is `Anchor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
