### PR TITLE
Re-express the FFI dialects as projections of the declaration parsers

### DIFF
--- a/lib/xenophile/src/cffi/xenophile.CHeaderDialect.scala
+++ b/lib/xenophile/src/cffi/xenophile.CHeaderDialect.scala
@@ -32,22 +32,30 @@
                                                                                                   */
 package xenophile
 
-// Deliberate stdlib opt-out for `Map`: this dialect's parsing accumulators are map-algebraic
-// throughout; the single `parse` boundary re-wraps as the opaque `Map` (erasure-identical cast).
+// The dialect works with ordinary Scala collections internally; the single `parse` boundary
+// re-wraps as the opaque `Map` (erasure-identical cast).
 import scala.collection.immutable.Map
 
 import proscenium.compat.*
 
 import anticipation.*
+import contingency.*
 import gossamer.*
 import rudiments.*
 import vacuous.*
 
-// A minimal grammar for C header files (the `extern "C"` subset that Rust's `cbindgen`, and C/C++
-// public headers, expose): `struct`/`union` definitions become navigable foreign types whose
-// members are their fields, top-level function prototypes become members of a synthetic `"library"`
-// type, `enum`s are treated as `int`, and `typedef` aliases are resolved. Preprocessor lines and
-// comments are skipped; the rest of C is not interpreted.
+// The C grammar for foreign navigation: a *projection* of `CHeaderParser`'s declaration model
+// onto the flat form the FFI backends marshal against — one reader per language, two views,
+// exactly as `TypescriptDialect` projects from `TypescriptParser`.
+//
+// The parser retains the declared surface faithfully — exact arithmetic spellings, pointer
+// structure, enumerators — and this projection deliberately erases what a downcall cannot use:
+// `struct`/`union` definitions become navigable foreign types whose members are their fields,
+// top-level prototypes become members of a synthetic `"library"` type, `enum`s are treated as
+// `int`, `typedef` aliases are resolved transitively, signedness and pointer depth collapse to
+// keep the FFM layouts correct, and a plain `char*` is the C-string type. Array fields,
+// function-pointer typedefs and opaque tags are outside the marshalling vocabulary and are not
+// navigable.
 object CHeaderDialect extends Dialect:
   val library: Text = t"library"
 
@@ -55,251 +63,89 @@ object CHeaderDialect extends Dialect:
     parse0(source).asInstanceOf[proscenium.Map[Text, proscenium.Map[Text, Prototype]]]
 
   private def parse0(source: Text): Map[Text, Map[Text, Prototype]] =
-    val (structs, functions, typedefs) = declarations(tokenize(source.s), Map(), Map(), Map())
-    val all = if functions.isEmpty then structs else structs.updated(library, functions)
+    import strategies.throwUnsafely
+    val declarations = CHeaderParser.parse(source).stdlib
 
+    val typedefs: Map[Text, Foreign.Type] =
+      declarations.collect:
+        case CDeclaration.Enumeration(name, _) => name -> Foreign.Type.Named(t"int")
+
+        case CDeclaration.Alias(name, target) if !functionPointer(target) =>
+          name -> project(target)
+
+      . toMap
+
+    val structs: Map[Text, Map[Text, Prototype]] =
+      declarations.collect:
+        case CDeclaration.Structure(name, _, fields, false) =>
+          val members = fields.stdlib.filter { (_, typed) => !array(typed) }.map:
+            (field, typed) => field -> Prototype(Unset, project(typed))
+
+          name -> members.toMap
+
+      . toMap
+
+    val functions: Map[Text, Prototype] =
+      declarations.collect:
+        case CDeclaration.Function(name, result, parameters, _) =>
+          name -> Prototype(List.from(parameters.stdlib.map(project(_))), project(result))
+
+      . toMap
+
+    val all = if functions.isEmpty then structs else structs.updated(library, functions)
     resolve(all, typedefs)
 
-  private def punctuation(char: Char): Boolean =
-    char == '{' || char == '}' || char == '(' || char == ')' || char == ';' || char == ',' ||
-      char == '*' || char == '[' || char == ']'
+  private def functionPointer(typed: Foreign.Type): Boolean = typed match
+    case applied: Foreign.Type.Applied =>
+      applied.constructor == t"fn" || applied.constructor == t"variadic"
 
-  // Splits the source into identifier and punctuation tokens, skipping whitespace, `//` and
-  // `/* … */` comments, and `#…` preprocessor lines (the only use of `#` in a header).
-  private def tokenize(source: String): List[String] =
-    def skipLine(index: Int): Int =
-      if index >= source.length || source.charAt(index) == '\n' then index + 1
-      else skipLine(index + 1)
+    case _ => false
 
-    def skipBlock(index: Int): Int =
-      if index + 1 >= source.length then source.length
-      else if source.charAt(index) == '*' && source.charAt(index + 1) == '/' then index + 2
-      else skipBlock(index + 1)
+  private def array(typed: Foreign.Type): Boolean = typed match
+    case applied: Foreign.Type.Applied => applied.constructor == t"array"
+    case _                             => false
 
-    def recur(index: Int, current: String, tokens: scala.collection.immutable.List[String])
-    :   scala.collection.immutable.List[String] =
+  // Collapses the parser's faithful types to the marshalling vocabulary. Only a *plain* `char*`
+  // is the C-string type: `unsigned char*`/`signed char*` conventionally mean a byte buffer,
+  // not text, so they stay pointers.
+  private def project(typed: Foreign.Type): Foreign.Type = typed match
+    case Foreign.Type.Named(name) => Foreign.Type.Named(canonical(name))
 
-      val flushed = if current.isEmpty then tokens else current :: tokens
+    case applied: Foreign.Type.Applied =>
+      if applied.constructor == t"ptr" then
+        val (base, count) = unwrap(typed)
 
-      if index >= source.length then flushed.reverse else
-        val char = source.charAt(index)
-        val next = if index + 1 < source.length then source.charAt(index + 1) else ' '
+        if base == t"char" && count == 1 then Foreign.Type.Named(t"string")
+        else Foreign.Type.Applied(t"ptr", List(Foreign.Type.Named(canonical(base))))
+      else if applied.constructor == t"const" then project(applied.arguments.stdlib.head)
+      else Foreign.Type.Applied(applied.constructor, applied.arguments.map(project(_)))
 
-        if char == '#' || (char == '/' && next == '/') then recur(skipLine(index), "", flushed)
-        else if char == '/' && next == '*' then recur(skipBlock(index + 2), "", flushed)
-        else if char.isLetterOrDigit || char == '_' then recur(index + 1, current + char, tokens)
-        else if punctuation(char) then recur(index + 1, "", char.toString :: flushed)
-        else recur(index + 1, "", flushed)
+    case other => other
 
-    List.of(recur(0, "", Nil.stdlib))
+  // The innermost named base beneath `ptr` and `const` wrappers, with the pointer depth.
+  private def unwrap(typed: Foreign.Type): (Text, Int) = typed match
+    case Foreign.Type.Named(name) => (name, 0)
 
-  private def isWord(token: String): Boolean =
-    token.nonEmpty && (token.charAt(0).isLetter || token.charAt(0) == '_')
+    case applied: Foreign.Type.Applied =>
+      if applied.constructor == t"const" then unwrap(applied.arguments.stdlib.head)
+      else if applied.constructor == t"ptr" then
+        val (base, inner) = unwrap(applied.arguments.stdlib.head)
+        (base, inner + 1)
+      else (t"*", 0)
 
-  private def isKeyword(token: String): Boolean = token match
-    case "unsigned" | "signed" | "long" | "short" | "int" | "char" => true
-    case "double" | "float" | "void" | "bool" | "_Bool"            => true
-    case _                                                         => false
+    case _ => (t"*", 0)
 
-  // Canonicalises a base type: `unsigned`/`signed` are dropped, and the width-exact fixed-width
-  // names are mapped to the primitive of the same size (so the FFM layout stays correct). Widths
-  // without a matching primitive (`int8_t`, `int16_t`, `short`) are left as-is.
-  private def canonical(words: List[String]): Text =
-    val cleaned = words.stdlib.filterNot: word =>
-      word == "unsigned" || word == "signed"
-
-    val name = if cleaned.isEmpty then t"int" else cleaned.mkString(" ").tt
-
-    if name == t"int32_t" || name == t"uint32_t" then t"int"
-    else if name == t"int64_t" || name == t"uint64_t" || name == t"long long" then t"long"
-    else if name == t"intptr_t" || name == t"uintptr_t" then t"long"
-    else if name == t"size_t" || name == t"ssize_t" then t"long"
-    else name
-
-  // Reads a type and an optional declarator name: `int x` → (int, "x"), `const char* s` →
-  // (string, "s"), and an abstract `int` / `char*` → (…, Unset). The base type is its leading
-  // keywords (`unsigned int`) or single identifier (`Point`, `size_t`), then trailing `*`s; a
-  // lone `char*` / `const char*` is the C-string type `"string"`, any other `T*` is `"ptr" over T`.
-  private def declarator(tokens: List[String]): (Foreign.Type, Optional[Text], List[String]) =
-    def typeWords(todo: List[String], acc: List[String]): (List[String], List[String]) =
-      todo match
-        case ("const" | "volatile" | "struct" | "enum" | "union") :: more =>
-          typeWords(more, acc)
-
-        case word :: more if isKeyword(word) =>
-          typeWords(more, word :: acc)
-
-        case word :: more if isWord(word) && acc.stdlib.isEmpty =>
-          (List(word), more)
-
-        case _ =>
-          (acc.reverse, todo)
-
-    def stars(todo: List[String], count: Int): (Int, List[String]) = todo match
-      case "*" :: more => stars(more, count + 1)
-      case _           => (count, todo)
-
-    val (words, rest0) = typeWords(tokens, Nil)
-    val (pointers, rest1) = stars(rest0, 0)
-
-    val (name, rest) = rest1 match
-      case word :: more if isWord(word) => (word.tt, more)
-      case _                            => (Unset, rest1)
-
-    val base = canonical(words)
-
-    // Only a *plain* `char*` is the C-string type: `unsigned char*`/`signed char*`
-    // conventionally mean a byte buffer, not text, so they stay pointers (`canonical` has
-    // already dropped the signedness from `base`, hence the check against the original words).
-    val foreign =
-      if pointers == 0 then Foreign.Type.Named(base)
-      else if words == List("char") && pointers == 1 then Foreign.Type.Named(t"string")
-      else Foreign.Type.Applied(t"ptr", List(Foreign.Type.Named(base)))
-
-    (foreign, name, rest)
-
-  // Walks the top-level declarations, accumulating named types (`structs`), the synthetic
-  // `"library"` type's function members (`functions`), and `typedef` aliases (`typedefs`).
-  private def declarations
-    ( tokens:    List[String],
-      structs:   Map[Text, Map[Text, Prototype]],
-      functions: Map[Text, Prototype],
-      typedefs:  Map[Text, Foreign.Type] )
-  :   (Map[Text, Map[Text, Prototype]], Map[Text, Prototype], Map[Text, Foreign.Type]) =
-
-    tokens match
-      case Nil =>
-        (structs, functions, typedefs)
-
-      case "typedef" :: rest =>
-        typedef(rest, structs, functions, typedefs)
-
-      case ("struct" | "union") :: name :: "{" :: more =>
-        val (fields, after) = members(more, Ledger())
-
-        declarations
-          ( skipStatement(after), structs.updated(name.tt, fields.stdlib), functions, typedefs )
-
-      case ("struct" | "union") :: "{" :: more =>
-        declarations(skipStatement(skipBraces(more, 1)), structs, functions, typedefs)
-
-      case "enum" :: rest =>
-        val (name, body) = rest match
-          case word :: "{" :: more if isWord(word) => (word.tt, more)
-          case "{" :: more                         => (Unset, more)
-          case _                                   => (Unset, rest)
-
-        val after = skipStatement(skipBraces(body, 1))
-
-        val updated = name.lay(typedefs): word => typedefs.updated(word, Foreign.Type.Named(t"int"))
-
-        declarations(after, structs, functions, updated)
-
-      // A top-level function prototype: `<type> <name> ( <params> ) ;`.
-      case _ =>
-        val (result, name, rest) = declarator(tokens)
-
-        rest match
-          case "(" :: more =>
-            name.lay(declarations(skipStatement(more), structs, functions, typedefs)): function =>
-              val (params, after) = parameters(more, Nil)
-
-              declarations
-                ( skipStatement(after),
-                  structs,
-                  functions.updated(function, Prototype(params, result)),
-                  typedefs )
-
-          case _ =>
-            declarations(skipStatement(tokens), structs, functions, typedefs)
-
-  // Handles a `typedef`: a wrapped `struct`/`union` (a named type), a wrapped `enum` (treated as
-  // `int`), or a simple `typedef <type> Alias;` alias.
-  private def typedef
-    ( tokens:    List[String],
-      structs:   Map[Text, Map[Text, Prototype]],
-      functions: Map[Text, Prototype],
-      typedefs:  Map[Text, Foreign.Type] )
-  :   (Map[Text, Map[Text, Prototype]], Map[Text, Prototype], Map[Text, Foreign.Type]) =
-
-    tokens match
-      case ("struct" | "union") :: name :: "{" :: more =>
-        val (fields, after) = members(more, Ledger())
-        val (alias, after2) = aliasName(after)
-        declarations(after2, structs.updated(alias.or(name.tt), fields.stdlib), functions, typedefs)
-
-      case ("struct" | "union") :: "{" :: more =>
-        val (fields, after) = members(more, Ledger())
-        val (alias, after2) = aliasName(after)
-
-        alias.lay(declarations(after2, structs, functions, typedefs)): name =>
-          declarations(after2, structs.updated(name, fields.stdlib), functions, typedefs)
-
-      case "enum" :: rest =>
-        val body = rest match
-          case _ :: "{" :: more => more
-          case "{" :: more      => more
-          case _                => rest
-
-        val (alias, after) = aliasName(skipBraces(body, 1))
-
-        val updated = alias.lay(typedefs): word =>
-          typedefs.updated(word, Foreign.Type.Named(t"int"))
-
-        declarations(after, structs, functions, updated)
-
-      case _ =>
-        val (kind, name, after) = declarator(tokens)
-
-        name.lay(declarations(skipStatement(tokens), structs, functions, typedefs)): alias =>
-          declarations(skipStatement(after), structs, functions, typedefs.updated(alias, kind))
-
-  // Reads a struct or union body's fields up to the closing `}`.
-  private def members(tokens: List[String], acc: Ledger[Text, Prototype])
-  :   (Ledger[Text, Prototype], List[String]) =
-
-    tokens match
-      case "}" :: rest =>
-        (acc, rest)
-
-      case Nil =>
-        (acc, Nil)
-
-      case _ =>
-        val (kind, name, rest) = declarator(tokens)
-
-        rest match
-          case ";" :: more =>
-            name.lay(members(more, acc)): field =>
-              members(more, acc.updated(field, Prototype(Unset, kind)))
-
-          case _ =>
-            members(skipStatement(tokens), acc)
-
-  // After a struct's closing `}`, reads an optional `typedef` alias name before the `;`.
-  private def aliasName(tokens: List[String]): (Optional[Text], List[String]) = tokens match
-    case ";" :: rest         => (Unset, rest)
-    case name :: ";" :: rest => (name.tt, rest)
-    case _                   => (Unset, skipStatement(tokens))
-
-  // Reads a function's parameter types up to the closing `)`; `(void)` denotes no parameters.
-  private def parameters(tokens: List[String], acc: List[Foreign.Type])
-  :   (Optional[List[Foreign.Type]], List[String]) =
-
-    tokens match
-      case ")" :: rest =>
-        (acc.reverse, rest)
-
-      case "void" :: ")" :: rest =>
-        (acc.reverse, rest)
-
-      case _ =>
-        val (kind, _, rest) = declarator(tokens)
-
-        rest match
-          case "," :: more => parameters(more, kind :: acc)
-          case ")" :: more => (List.of((kind :: acc).reverse), more)
-          case _           => (acc.reverse, skipStatement(rest))
+  // The width-exact and sign-qualified names map to the primitive of the same size, so the FFM
+  // layout stays correct; widths without a matching primitive are left as-is.
+  private def canonical(name: Text): Text = name.s match
+    case "unsigned-int" | "int32_t" | "uint32_t"              => t"int"
+    case "unsigned-char" | "signed-char"                      => t"char"
+    case "unsigned-short"                                     => t"short"
+    case "long-long" | "unsigned-long" | "unsigned-long-long" => t"long"
+    case "int64_t" | "uint64_t" | "intptr_t" | "uintptr_t"    => t"long"
+    case "size_t" | "ssize_t"                                 => t"long"
+    case "long-double"                                        => t"long double"
+    case _                                                    => name
 
   // Resolves every `typedef` alias appearing in a type, transitively.
   private def resolve
@@ -321,16 +167,3 @@ object CHeaderDialect extends Dialect:
 
     definitions.map: (name, members) =>
       (name, members.map { (member, sig) => (member, signature(sig)) })
-
-  // Skips tokens up to and including the next `;` (to recover from constructs we do not model).
-  private def skipStatement(tokens: List[String]): List[String] = tokens match
-    case Nil         => Nil
-    case ";" :: rest => rest
-    case _ :: rest   => skipStatement(rest)
-
-  // Skips a balanced `{ … }` block, given the tokens just inside the opening brace (depth 1).
-  private def skipBraces(tokens: List[String], depth: Int): List[String] = tokens match
-    case Nil         => Nil
-    case "{" :: rest => skipBraces(rest, depth + 1)
-    case "}" :: rest => if depth <= 1 then rest else skipBraces(rest, depth - 1)
-    case _ :: rest   => skipBraces(rest, depth)

--- a/lib/xenophile/src/lira/xenophile.WitAtomizer.scala
+++ b/lib/xenophile/src/lira/xenophile.WitAtomizer.scala
@@ -259,13 +259,35 @@ object WitAtomizer:
       document.worlds.stdlib.foreach: world =>
         val worldId = t"$pkg/${world.name}$suffix"
         val imports = world.imports.stdlib.map(qualify(_))
-        val exports = world.exports.stdlib.map(qualify(_)).sortBy(_.s)
+
+        // Inline items follow the same polarity as referenced ones: an inline function import
+        // is a capability the host supplies (standalone, its signature folded into the value),
+        // and an inline export joins the folded obligation list by its bare name.
+        val exports =
+          (world.exports.stdlib.map(qualify(_))
+            ++ world.inlineExports.stdlib.map { (name, _) => name })
+          . sortBy(_.s)
 
         imports.foreach: imported =>
           atoms += Atom(t"$worldId#import $imported", AtomClass.Rigid, hash: out =>
             tag(out, 'i')
             utf8(out, worldId)
             utf8(out, imported))
+
+        world.inlineImports.stdlib.foreach: (name, function) =>
+          atoms += Atom(t"$worldId#import $name", AtomClass.Rigid, hash: out =>
+            tag(out, 'i')
+            utf8(out, worldId)
+            utf8(out, name)
+
+            function.let: fn =>
+              uvarint(out, fn.parameters.stdlib.length.toLong)
+
+              fn.parameters.stdlib.foreach: (parameter, typed) =>
+                utf8(out, parameter)
+                encode(out, typed, SMap())
+
+              fn.result.lay(tag(out, '0')) { typed => tag(out, '1'); encode(out, typed, SMap()) })
 
         atoms += Atom(worldId, AtomClass.Rigid, hash: out =>
           tag(out, 'W')

--- a/lib/xenophile/src/lira/xenophile.WitDiscipline.scala
+++ b/lib/xenophile/src/lira/xenophile.WitDiscipline.scala
@@ -58,13 +58,13 @@ object WitDiscipline extends Discipline:
   def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
   :   Atomization raises DisciplineError =
 
-    val documents = content.stdlib.map: (path, data) =>
+    val documents = content.stdlib.flatMap: (path, data) =>
       val source = Text(String(Array.unsafeJvm(data), "UTF-8"))
 
       mitigate:
         case WitParseError(reason) =>
           DisciplineError(id, DisciplineError.Reason.Malformed(t"${path.text}: $reason"))
 
-      . protect(WitParser.parse(source))
+      . protect(WitParser.parse(source).stdlib)
 
     Atomization.of(id, WitAtomizer.atomize(List.from(documents)))

--- a/lib/xenophile/src/webidl/xenophile.WebIdlDialect.scala
+++ b/lib/xenophile/src/webidl/xenophile.WebIdlDialect.scala
@@ -32,371 +32,119 @@
                                                                                                   */
 package xenophile
 
-// Deliberate stdlib opt-out for `Map`: this dialect's parsing accumulators are map-algebraic
-// throughout; the single `parse` boundary re-wraps as the opaque `Map` (erasure-identical cast).
+// The dialect works with ordinary Scala collections internally; the single `parse` boundary
+// re-wraps as the opaque `Map` (erasure-identical cast).
+import scala.collection.immutable.List as SList
 import scala.collection.immutable.Map
 
 import proscenium.compat.*
 
 import anticipation.*
+import contingency.*
 import gossamer.*
 import rudiments.*
 import vacuous.*
 
-// A grammar for the subset of WebIDL (https://webidl.spec.whatwg.org/) needed to navigate the web
-// platform — most importantly the DOM. An `interface` becomes a navigable foreign type whose
-// members are its attributes (fields) and operations (methods); a `dictionary` becomes a record;
-// and an `enum` is a `string`. WebIDL's numeric types canonicalise to the Hypotenuse-aligned
-// tokens the ecosystem maps (`octet` → `u8`, `unsigned long` → `u32`, `long long` → `s64`,
-// `double` → `f64`, …) and `DOMString`/`USVString`/`ByteString` to `string`.
+// The WebIDL grammar for foreign navigation: a *projection* of `WebIdlParser`'s declaration
+// model onto the flat form the JS backend marshals against — one reader per language, two
+// views, exactly as `TypescriptDialect` projects from `TypescriptParser`.
 //
-// Crucially, inheritance is flattened here: each interface's members include those of its base
-// chain (`interface B : A`) and of every mixin applied to it (`B includes M`), so navigating an
-// inherited member (e.g. `Node`'s `nodeName` on an `HTMLElement`) resolves. `partial interface`
-// bodies are merged into the interface they extend. `typedef` aliases are resolved transitively.
-// `callback`, `namespace`, `[extended attributes]`, and unrecognised constructs are skipped.
+// The parser retains the declared surface faithfully — partiality, mixin identity, `[Exposed]`
+// scopes, required-versus-optional dictionary members, enumeration values — and this
+// projection deliberately erases what a navigation cannot use. An `interface` becomes a
+// navigable foreign type whose members are its attributes, constants and named operations; a
+// `dictionary` a record; an `enum` a `string`. Inheritance is flattened, so an inherited
+// member (`Node`'s `nodeName` on an `HTMLElement`) resolves: each type's members include its
+// base chain's and those of every mixin applied by `includes`, with its own overriding.
+// `partial` bodies merge into the type they extend, and `typedef`/`enum` aliases resolve
+// transitively. Constructors, special operations and intrinsic declarations are not navigable.
 object WebIdlDialect extends Dialect:
-  // The accumulated structure of a WebIDL source before inheritance is flattened: each type's own
-  // members, each interface's base type, the mixins applied by `includes`, and the `typedef`/`enum`
-  // aliases.
-  private case class Idl
-    ( types:    Map[Text, Map[Text, Prototype]],
-      parents:  Map[Text, Text],
-      includes: Map[Text, List[Text]],
-      typedefs: Map[Text, Foreign.Type] )
 
   def parse(source: Text): proscenium.Map[Text, proscenium.Map[Text, Prototype]] =
     parse0(source).asInstanceOf[proscenium.Map[Text, proscenium.Map[Text, Prototype]]]
 
   private def parse0(source: Text): Map[Text, Map[Text, Prototype]] =
-    val idl = items(tokenize(source.s), Idl(Map(), Map(), Map(), Map()))
-
-    resolve(flatten(idl), idl.typedefs)
-
-  // WebIDL identifiers are `[A-Za-z0-9_]` (a leading `_` escapes a keyword). String literals (in
-  // `enum` bodies and default values) are lexed whole so their contents never break brace/semicolon
-  // tracking; `...` (variadic) is a single token; `//` and `/* … */` comments are skipped.
-  private def tokenize(source: String): List[String] =
-    def skipLine(index: Int): Int =
-      if index >= source.length || source.charAt(index) == '\n' then index + 1
-      else skipLine(index + 1)
-
-    def skipBlock(index: Int): Int =
-      if index + 1 >= source.length then source.length
-      else if source.charAt(index) == '*' && source.charAt(index + 1) == '/' then index + 2
-      else skipBlock(index + 1)
-
-    def endString(index: Int): Int =
-      if index >= source.length then source.length
-      else if source.charAt(index) == '"' then index + 1
-      else endString(index + 1)
-
-    def ident(char: Char): Boolean = char.isLetterOrDigit || char == '_'
-
-    def recur(index: Int, current: String, tokens: scala.collection.immutable.List[String])
-    :   scala.collection.immutable.List[String] =
-
-      val flushed = if current.isEmpty then tokens else current :: tokens
-
-      if index >= source.length then flushed.reverse else
-        val char = source.charAt(index)
-        val next = if index + 1 < source.length then source.charAt(index + 1) else ' '
-        val next2 = if index + 2 < source.length then source.charAt(index + 2) else ' '
-
-        if char == '/' && next == '/' then
-          recur(skipLine(index), "", flushed)
-        else if char == '/' && next == '*' then
-          recur(skipBlock(index + 2), "", flushed)
-        else if char == '"' then
-          val end = endString(index + 1)
-          recur(end, "", source.substring(index, end).nn :: flushed)
-        else if char == '.' && next == '.' && next2 == '.' then
-          recur(index + 3, "", "..." :: flushed)
-        else if ident(char) then
-          recur(index + 1, current + char, tokens)
-        else if char.isWhitespace then
-          recur(index + 1, "", flushed)
-        else
-          recur(index + 1, "", char.toString :: flushed)
-
-    List.of(recur(0, "", Nil.stdlib))
-
-  // Parses a WebIDL type, including a trailing `?` (nullable, read as the union `T | null`).
-  private def typeOf(tokens: List[String]): (Foreign.Type, List[String]) =
-    val (base, rest) = baseType(tokens)
-
-    rest match
-      case "?" :: more => (Foreign.Type.Union(List(base, Foreign.Type.Named(t"null"))), more)
-      case _           => (base, rest)
-
-  // Parses a non-nullable WebIDL type: a parenthesised `(A or B …)` union, a multi-word numeric
-  // primitive canonicalised to its Hypotenuse-aligned token, a `name<args>` generic application
-  // (`sequence`, `FrozenArray`, `record`, `Promise`, …), or a bare named reference.
-  private def baseType(tokens: List[String]): (Foreign.Type, List[String]) = tokens match
-    case "(" :: rest                                  => union(rest, Nil)
-    case "unsigned" :: "long" :: "long" :: rest       => (Foreign.Type.Named(t"u64"), rest)
-    case "unsigned" :: "long" :: rest                 => (Foreign.Type.Named(t"u32"), rest)
-    case "unsigned" :: "short" :: rest                => (Foreign.Type.Named(t"u16"), rest)
-    case "long" :: "long" :: rest                     => (Foreign.Type.Named(t"s64"), rest)
-    case "long" :: rest                               => (Foreign.Type.Named(t"s32"), rest)
-    case "short" :: rest                              => (Foreign.Type.Named(t"s16"), rest)
-    case "byte" :: rest                               => (Foreign.Type.Named(t"s8"), rest)
-    case "octet" :: rest                              => (Foreign.Type.Named(t"u8"), rest)
-    case "unrestricted" :: "float" :: rest            => (Foreign.Type.Named(t"f32"), rest)
-    case "unrestricted" :: "double" :: rest           => (Foreign.Type.Named(t"f64"), rest)
-    case "float" :: rest                              => (Foreign.Type.Named(t"f32"), rest)
-    case "double" :: rest                             => (Foreign.Type.Named(t"f64"), rest)
-    case "boolean" :: rest                            => (Foreign.Type.Named(t"boolean"), rest)
-    case "void" :: rest                               => (Foreign.Type.Named(t"undefined"), rest)
-
-    case ("DOMString" | "USVString" | "ByteString" | "CSSOMString") :: rest =>
-      (Foreign.Type.Named(t"string"), rest)
-
-    case name :: "<" :: rest =>
-      val (args, after) = typeArguments(rest, Nil)
-      (Foreign.Type.Applied(name.tt, args), after)
-
-    case name :: rest =>
-      (Foreign.Type.Named(name.tt), rest)
-
-    case Nil =>
-      (Foreign.Type.Named(t""), Nil)
-
-  // Parses the members of a `(A or B or …)` union, given the tokens just inside the opening `(`.
-  private def union(tokens: List[String], acc: List[Foreign.Type]): (Foreign.Type, List[String]) =
-    val (member, rest) = typeOf(tokens)
-
-    rest match
-      case "or" :: more => union(more, member :: acc)
-      case ")" :: more  => (Foreign.Type.Union(List.of((member :: acc).reverse)), more)
-      case _            => (Foreign.Type.Union(List.of((member :: acc).reverse)), skipTo(rest, t")"))
+    import strategies.throwUnsafely
+    val definitions = WebIdlParser.parse(source).stdlib
 
-  private def typeArguments(tokens: List[String], acc: List[Foreign.Type])
-  :   (List[Foreign.Type], List[String]) =
+    var types = Map[Text, Map[Text, Prototype]]()
+    var parents = Map[Text, Text]()
+    var includes = Map[Text, SList[Text]]()
+    var typedefs = Map[Text, Foreign.Type]()
 
-    tokens match
-      case ">" :: rest =>
-        (acc.reverse, rest)
+    def record(name: Text, parent: Optional[Text], members: Map[Text, Prototype]): Unit =
+      val merged = types.get(name).optional.lay(members)(_ ++ members)
+      types = types.updated(name, merged)
+      parent.let { base => parents = parents.updated(name, base) }
 
-      case _ =>
-        val (arg, rest) = typeOf(tokens)
+    def navigable(members: List[WebIdlMember]): Map[Text, Prototype] =
+      members.stdlib.flatMap: member =>
+        member.kind match
+          case WebIdlMember.Kind.Attribute | WebIdlMember.Kind.Constant =>
+            SList(member.name -> Prototype(Unset, member.typed))
 
-        rest match
-          case "," :: more => typeArguments(more, arg :: acc)
-          case ">" :: more => (List.of((arg :: acc).reverse), more)
-          case _           => (acc.reverse, skipTo(rest, t">"))
+          case WebIdlMember.Kind.Operation =>
+            if member.special.present || member.name.s.isEmpty then SList()
+            else
+              val parameters = List.from(member.arguments.stdlib.map(_.typed))
+              SList(member.name -> Prototype(parameters, member.typed))
 
-  // Walks the top-level declarations. `interface`/`dictionary`/`namespace`/`interface mixin` become
-  // navigable types; `partial` declarations merge into the type they extend; `enum`/`typedef`
-  // become aliases; `X includes Y;` records a mixin application; `[extended attributes]`,
-  // `callback`s and anything unrecognised are skipped.
-  private def items(tokens: List[String], idl: Idl): Idl = tokens match
-    case Nil =>
-      idl
+          case WebIdlMember.Kind.Constructor => SList()
 
-    case "[" :: rest =>
-      items(skipBrackets(rest, 1), idl)
+      . toMap
 
-    case ";" :: rest =>
-      items(rest, idl)
+    definitions.foreach:
+      case WebIdlDefinition.Interface(name, parent, _, members, _, _, _, _) =>
+        record(name, parent, navigable(members))
 
-    case "partial" :: rest =>
-      items(rest, idl)
+      case WebIdlDefinition.Dictionary(name, parent, fields, _) =>
+        val members = fields.stdlib.map: field =>
+          field.name -> Prototype(Unset, field.typed)
 
-    case "callback" :: "interface" :: name :: ":" :: base :: "{" :: rest =>
-      val (idl2, after) = body(rest, name.tt, base.tt, idl)
-      items(after, idl2)
+        record(name, parent, members.toMap)
 
-    case "callback" :: "interface" :: name :: "{" :: rest =>
-      val (idl2, after) = body(rest, name.tt, Unset, idl)
-      items(after, idl2)
+      case WebIdlDefinition.Namespace(name, _, members, _) =>
+        record(name, Unset, navigable(members))
 
-    case "callback" :: rest =>
-      items(skipTo(rest, t";"), idl)
+      case WebIdlDefinition.Enumeration(name, _) =>
+        typedefs = typedefs.updated(name, Foreign.Type.Named(t"string"))
 
-    case "interface" :: "mixin" :: name :: "{" :: rest =>
-      val (idl2, after) = body(rest, name.tt, Unset, idl)
-      items(after, idl2)
+      case WebIdlDefinition.Alias(name, typed) =>
+        typedefs = typedefs.updated(name, typed)
 
-    case "interface" :: name :: ":" :: base :: "{" :: rest =>
-      val (idl2, after) = body(rest, name.tt, base.tt, idl)
-      items(after, idl2)
+      case WebIdlDefinition.Includes(target, mixin) =>
+        includes = includes.updated(target, includes.getOrElse(target, SList()) :+ mixin)
 
-    case "interface" :: name :: "{" :: rest =>
-      val (idl2, after) = body(rest, name.tt, Unset, idl)
-      items(after, idl2)
+      case WebIdlDefinition.CallbackFunction(_, _, _) => ()
 
-    case "dictionary" :: name :: ":" :: base :: "{" :: rest =>
-      val (idl2, after) = body(rest, name.tt, base.tt, idl)
-      items(after, idl2)
+    resolve(flatten(types, parents, includes), typedefs)
 
-    case "dictionary" :: name :: "{" :: rest =>
-      val (idl2, after) = body(rest, name.tt, Unset, idl)
-      items(after, idl2)
+  // Flattens inheritance: each type's members are those of its base chain, then of every
+  // applied mixin, then its own (so a type's own members override inherited ones of the same
+  // name). A visited set guards against cycles.
+  private def flatten
+    ( types:    Map[Text, Map[Text, Prototype]],
+      parents:  Map[Text, Text],
+      includes: Map[Text, SList[Text]] )
+  :   Map[Text, Map[Text, Prototype]] =
 
-    case "namespace" :: name :: "{" :: rest =>
-      val (idl2, after) = body(rest, name.tt, Unset, idl)
-      items(after, idl2)
-
-    case "enum" :: name :: "{" :: rest =>
-      val updated = idl.typedefs.updated(name.tt, Foreign.Type.Named(t"string"))
-      items(skipBraces(rest, 1), idl.copy(typedefs = updated))
-
-    case "typedef" :: rest =>
-      val rest1 = skipExtAttrs(rest)
-      val (kind, after) = typeOf(rest1)
-
-      after match
-        case name :: more =>
-          items(skipTo(more, t";"), idl.copy(typedefs = idl.typedefs.updated(name.tt, kind)))
-
-        case Nil =>
-          idl
-
-    case name :: "includes" :: mixin :: rest =>
-      val existing = idl.includes.get(name.tt).getOrElse(Nil)
-      val updated = idl.includes.updated(name.tt, existing :+ mixin.tt)
-      items(skipTo(rest, t";"), idl.copy(includes = updated))
-
-    case _ =>
-      items(skipTo(tokens, t";"), idl)
-
-  // Parses a `{ … }` body (of an interface, mixin, dictionary or namespace), merging its members
-  // into any already recorded for `name` (so `partial` declarations accumulate) and recording its
-  // base type, if any.
-  private def body(tokens: List[String], name: Text, parent: Optional[Text], idl: Idl)
-  :   (Idl, List[String]) =
-
-    val (members, rest) = memberList(tokens, Ledger())
-    val merged = idl.types.get(name).optional.lay(members.stdlib)(_ ++ members.stdlib)
-
-    val parents = parent.lay(idl.parents): base => idl.parents.updated(name, base)
-
-    (idl.copy(types = idl.types.updated(name, merged), parents = parents), rest)
-
-  // Walks a type body, collecting attributes (and constants) as fields and operations as methods.
-  // Modifiers (`readonly`, `static`, `inherit`, `required`) are stripped; special members
-  // (`getter`, `setter`, `iterable`, `constructor`, …), `[extended attributes]` and stray `;` are
-  // skipped. A bare `Type name;` (a dictionary member) is read as a field; `Type name(args);` as a
-  // method.
-  private def memberList(tokens: List[String], members: Ledger[Text, Prototype])
-  :   (Ledger[Text, Prototype], List[String]) =
-
-    tokens match
-      case "}" :: rest =>
-        (members, rest)
-
-      case Nil =>
-        (members, Nil)
-
-      case "[" :: rest =>
-        memberList(skipBrackets(rest, 1), members)
-
-      case ";" :: rest =>
-        memberList(rest, members)
-
-      case ("readonly" | "static" | "inherit" | "required" | "async") :: rest =>
-        memberList(rest, members)
-
-      case "attribute" :: rest =>
-        val (kind, after) = typeOf(skipExtAttrs(rest))
-
-        after match
-          case name :: more =>
-            memberList(skipTo(more, t";"), members.updated(name.tt, Prototype(Unset, kind)))
-
-          case Nil =>
-            (members, Nil)
-
-      case "const" :: rest =>
-        val (kind, after) = typeOf(rest)
-
-        after match
-          case name :: more =>
-            memberList(skipTo(more, t";"), members.updated(name.tt, Prototype(Unset, kind)))
-
-          case Nil =>
-            (members, Nil)
-
-      case ( "getter" | "setter" | "deleter" | "stringifier" | "iterable" | "maplike"
-           | "setlike" | "constructor" ) :: rest =>
-        memberList(skipTo(rest, t";"), members)
-
-      case _ =>
-        val (kind, after) = typeOf(tokens)
-
-        after match
-          case name :: "(" :: more =>
-            val (parameters, rest) = params(more, Nil)
-            memberList(skipTo(rest, t";"), members.updated(name.tt, Prototype(parameters, kind)))
-
-          case name :: more =>
-            memberList(skipTo(more, t";"), members.updated(name.tt, Prototype(Unset, kind)))
-
-          case Nil =>
-            (members, Nil)
-
-  // Parses an operation's parameter list, given the tokens just inside the opening `(`. Each
-  // argument may carry `[extended attributes]`, an `optional` keyword, or a `...` variadic marker
-  // (all recorded only by their type), and a `= default` value (skipped). Returns a non-`Unset`
-  // (possibly empty) list, marking the member as a method.
-  private def params(tokens: List[String], acc: List[Foreign.Type])
-  :   (Optional[List[Foreign.Type]], List[String]) =
-
-    tokens match
-      case ")" :: rest =>
-        (acc.reverse, rest)
-
-      case "[" :: rest =>
-        params(skipBrackets(rest, 1), acc)
-
-      case "optional" :: rest =>
-        params(rest, acc)
-
-      case _ =>
-        val (kind, rest) = typeOf(tokens)
-
-        val rest1 = rest match
-          case "..." :: more => more
-          case more          => more
-
-        rest1 match
-          case name :: more =>
-            val after = more match
-              case "=" :: value => skipDefault(value, 0)
-              case _            => more
-
-            after match
-              case "," :: tail => params(tail, kind :: acc)
-              case ")" :: tail => (List.of((kind :: acc).reverse), tail)
-              case _           => (List.of((kind :: acc).reverse), skipTo(after, t")"))
-
-          case Nil =>
-            (acc.reverse, Nil)
-
-  // Flattens inheritance: each type's members are those of its base chain, then of every applied
-  // mixin, then its own (so a type's own members override inherited ones of the same name). A
-  // visited set guards against cycles.
-  private def flatten(idl: Idl): Map[Text, Map[Text, Prototype]] =
-    // An empty `Ledger`'s underlying map: as the left operand of the `++`-merges below, its
-    // factory keeps the flattened members insertion-ordered.
-    val empty = Ledger.empty[Text, Prototype].stdlib
+    val empty = Map[Text, Prototype]()
 
     def collect(name: Text, visiting: Set[Text]): Map[Text, Prototype] =
-      if visiting.has(name) then idl.types.get(name).getOrElse(empty)
+      if visiting.has(name) then types.getOrElse(name, empty)
       else
         val visiting2 = visiting + name
-        val own = idl.types.get(name).getOrElse(empty)
+        val own = types.getOrElse(name, empty)
 
-        val inherited = idl.parents.get(name).optional.lay(empty): base =>
+        val inherited = parents.get(name).optional.lay(empty): base =>
           collect(base, visiting2)
 
-        val mixedIn = idl.includes.get(name).getOrElse(Nil).fold(inherited): (acc, mixin) =>
+        val mixedIn = includes.getOrElse(name, SList()).foldLeft(inherited): (acc, mixin) =>
           acc ++ collect(mixin, visiting2)
 
         mixedIn ++ own
 
-    idl.types.map: (name, _) => (name, collect(name, Set()))
+    types.map { (name, _) => (name, collect(name, Set())) }
 
   // Resolves every `typedef`/`enum` alias appearing in a type, transitively.
   private def resolve
@@ -418,39 +166,3 @@ object WebIdlDialect extends Dialect:
 
     definitions.map: (name, members) =>
       (name, members.map { (member, sig) => (member, signature(sig)) })
-
-  // Skips tokens up to and including the next occurrence of `token`.
-  private def skipTo(tokens: List[String], token: Text): List[String] = tokens match
-    case Nil          => Nil
-    case head :: rest => if head == token.s then rest else skipTo(rest, token)
-
-  // Skips a balanced `{ … }` block, given the tokens just inside the opening brace (depth 1).
-  private def skipBraces(tokens: List[String], depth: Int): List[String] = tokens match
-    case Nil         => Nil
-    case "{" :: rest => skipBraces(rest, depth + 1)
-    case "}" :: rest => if depth <= 1 then rest else skipBraces(rest, depth - 1)
-    case _ :: rest   => skipBraces(rest, depth)
-
-  // Skips a balanced `[ … ]` extended-attribute block, given the tokens just inside the `[`.
-  private def skipBrackets(tokens: List[String], depth: Int): List[String] = tokens match
-    case Nil         => Nil
-    case "[" :: rest => skipBrackets(rest, depth + 1)
-    case "]" :: rest => if depth <= 1 then rest else skipBrackets(rest, depth - 1)
-    case _ :: rest   => skipBrackets(rest, depth)
-
-  // Skips a `[ … ]` block at the head of `tokens`, if present.
-  private def skipExtAttrs(tokens: List[String]): List[String] = tokens match
-    case "[" :: rest => skipBrackets(rest, 1)
-    case _           => tokens
-
-  // Skips an argument's `= default` value: tokens up to (but not including) the next top-level `,`
-  // or `)`, ignoring separators nested inside balanced brackets, braces or parentheses.
-  private def skipDefault(tokens: List[String], depth: Int): List[String] = tokens match
-    case Nil =>
-      Nil
-
-    case head :: rest =>
-      if depth == 0 && (head == "," || head == ")") then tokens
-      else if head == "(" || head == "{" || head == "[" then skipDefault(rest, depth + 1)
-      else if head == ")" || head == "}" || head == "]" then skipDefault(rest, depth - 1)
-      else skipDefault(rest, depth)

--- a/lib/xenophile/src/wit/xenophile.WitDeclaration.scala
+++ b/lib/xenophile/src/wit/xenophile.WitDeclaration.scala
@@ -73,7 +73,15 @@ enum WitItem:
 
 case class WitInterface(name: Text, items: List[WitItem])
 
-case class WitWorldModel(name: Text, imports: List[Text], exports: List[Text])
+// A world's referenced imports and exports are interface ids; its *inline* items — `import
+// name: func(…)`, `export name: interface { … }` — define rather than reference, and are
+// carried as (name, function) pairs, the function absent for an inline interface.
+case class WitWorldModel
+  ( name:          Text,
+    imports:       List[Text],
+    exports:       List[Text],
+    inlineImports: List[(Text, Optional[WitFunction])] = List(),
+    inlineExports: List[(Text, Optional[WitFunction])] = List() )
 
 case class WitDocument
   ( packageName: Optional[Text],

--- a/lib/xenophile/src/wit/xenophile.WitDialect.scala
+++ b/lib/xenophile/src/wit/xenophile.WitDialect.scala
@@ -32,25 +32,31 @@
                                                                                                   */
 package xenophile
 
-// Deliberate stdlib opt-out for `Map`: this dialect's parsing accumulators are map-algebraic
-// throughout; the single `parse` boundary re-wraps as the opaque `Map` (erasure-identical cast).
+// The dialect works with ordinary Scala collections internally; the single `parse` boundary
+// re-wraps as the opaque `Map` (erasure-identical cast).
 import scala.collection.immutable.Map
 
 import proscenium.compat.*
 
 import anticipation.*
+import contingency.*
 import gossamer.*
 import rudiments.*
 import vacuous.*
 
-// A minimal grammar for WIT (the WebAssembly Component Model's interface-definition language).
-// `record`s become navigable foreign types whose members are their fields; an `interface`'s
-// functions become members of a type named after the interface; `enum`s and `flags` are treated as
-// `s32`; `type` aliases are resolved. The `package` declaration is read to qualify each interface's
-// functions with their Component Model module id (e.g. `wasi:random/random@0.2.0`); `use`,
-// `variant` and `resource` declarations are recognised but their bodies are skipped. A `world`'s
-// body is skipped for navigation purposes, but `worlds` reads its imports and exports. Line and
-// block comments are ignored.
+// The WIT grammar for foreign navigation: a *projection* of `WitParser`'s declaration model
+// onto the flat form the wasm backend marshals against — one reader per language, two views,
+// exactly as `TypescriptDialect` projects from `TypescriptParser`.
+//
+// The parser retains the declared surface faithfully — enum and variant cases, package
+// structure, `use` clauses — and this projection deliberately erases what an invocation cannot
+// use: `record`s become navigable foreign types whose members are their fields, an interface's
+// functions become members of a type named after the interface, `enum`s collapse to the
+// unsigned discriminant that holds their cases and `flags` to a bit-vector, `option<T>`
+// becomes the union `T | none`, a `result` always carries exactly two arms (missing ones
+// padded with `_`), and `type` aliases are resolved transitively. The `package` declaration
+// qualifies each interface's functions with their Component Model module id
+// (`wasi:random/random@0.2.0`).
 object WitDialect extends Dialect:
   // The imports and exports of a `world` declaration, as Component Model interface ids. A world
   // states which host capabilities a component needs and which interfaces it offers — which is
@@ -61,402 +67,134 @@ object WitDialect extends Dialect:
   def parse(source: Text): proscenium.Map[Text, proscenium.Map[Text, Prototype]] =
     parse0(source).asInstanceOf[proscenium.Map[Text, proscenium.Map[Text, Prototype]]]
 
-  // Every `world` declared in a source, by name. A bare interface name (`import monotonic-clock;`,
-  // naming an interface in the same package) is qualified with the package id, so every id in the
-  // result is a full Component Model id. Inline definitions — `import name: func(…)` and
-  // `export name: interface { … }` — reference no interface, so they contribute no id.
+  // Every `world` declared in a source, by name. A bare interface name (`import
+  // monotonic-clock;`, naming an interface in the same package) is qualified with the package
+  // id, so every id in the result is a full Component Model id.
   def worlds(source: Text): proscenium.Map[Text, World] =
-    worlds0(tokenize(source.s), Map(), Unset).asInstanceOf[proscenium.Map[Text, World]]
+    worlds0(source).asInstanceOf[proscenium.Map[Text, World]]
+
+  private def packageOf(document: WitDocument): Optional[Text] =
+    document.packageName.let: name =>
+      document.version.let { version => t"$name@$version" }.or(name)
+
+  private def worlds0(source: Text): Map[Text, World] =
+    import strategies.throwUnsafely
+
+    WitParser.parse(source).stdlib.flatMap: document =>
+      val pkg = packageOf(document)
+
+      def qualify(id: Text): Text =
+        if id.s.contains(":") then id else moduleId(pkg, id).or(id)
+
+      document.worlds.stdlib.map: world =>
+        world.name ->
+          World(world.name, world.imports.map(qualify(_)), world.exports.map(qualify(_)))
+
+    . toMap
 
   private def parse0(source: Text): Map[Text, Map[Text, Prototype]] =
-    val (types, typedefs) = items(tokenize(source.s), Map(), Map(), Unset)
+    import strategies.throwUnsafely
+    val documents = WitParser.parse(source).stdlib
 
-    resolve(types, typedefs)
+    var types = Map[Text, Map[Text, Prototype]]()
+    var typedefs = Map[Text, Foreign.Type]()
 
-  // Walks the top-level items looking only for `world` declarations, tracking the `package` id so
-  // bare interface names inside a world can be qualified.
-  private def worlds0(tokens: List[String], worlds: Map[Text, World], pkg: Optional[Text])
-  :   Map[Text, World] =
+    for
+      document  <- documents
+      interface <- document.interfaces.stdlib
+    do
+      val pkg = packageOf(document)
+      val module = moduleId(pkg, interface.name)
+      val functions = scala.collection.mutable.LinkedHashMap[Text, Prototype]()
 
-    tokens match
-      case Nil =>
-        worlds
+      def signature(fn: WitFunction, resource: Optional[Text]): Prototype =
+        Prototype
+          ( List.from(fn.parameters.stdlib.map { (_, typed) => project(typed) }),
+            if fn.constructor then Foreign.Type.Named(resource.or(t""))
+            else fn.result.let(project(_)).or(Foreign.Type.Named(t"unit")),
+            module,
+            resource,
+            fn.static || fn.constructor )
 
-      case "package" :: rest =>
-        val (id, after) = packageId(rest)
-        worlds0(after, worlds, id)
+      interface.items.stdlib.foreach:
+        case WitItem.Function(fn) =>
+          functions(fn.name) = signature(fn, Unset)
 
-      case "world" :: name :: "{" :: rest =>
-        val (parsed, after) = world(rest, name.tt, Nil, Nil, pkg)
-        worlds0(after, worlds.updated(name.tt, parsed), pkg)
+        case WitItem.Record(name, fields) =>
+          val members = fields.stdlib.map: (field, typed) =>
+            field -> Prototype(Unset, project(typed))
 
-      // An interface body can contain neither a world nor a package, so it is skipped wholesale;
-      // without this, a `use` inside one could be mistaken for a top-level item.
-      case "interface" :: _ :: "{" :: rest =>
-        worlds0(skipBraces(rest, 1), worlds, pkg)
+          types = types.updated(name, members.toMap)
 
-      case _ :: rest =>
-        worlds0(rest, worlds, pkg)
-
-  // Walks a world body, accumulating the ids named by its `import` and `export` items. Anything
-  // else — `include`, `use`, a stray token — is stepped over.
-  private def world
-    ( tokens:  List[String],
-      name:    Text,
-      imports: List[Text],
-      exports: List[Text],
-      pkg:     Optional[Text] )
-  :   (World, List[String]) =
-
-    def built = World(name, List.of(imports.stdlib.reverse), List.of(exports.stdlib.reverse))
-
-    tokens match
-      case Nil =>
-        (built, Nil)
-
-      case "}" :: rest =>
-        (built, rest)
-
-      case "import" :: rest =>
-        val (id, after) = worldItem(rest, Nil, pkg)
-        world(after, name, id.lay(imports)(_ :: imports), exports, pkg)
-
-      case "export" :: rest =>
-        val (id, after) = worldItem(rest, Nil, pkg)
-        world(after, name, imports, id.lay(exports)(_ :: exports), pkg)
-
-      case _ :: rest =>
-        world(rest, name, imports, exports, pkg)
-
-  // Reads one `import`/`export` item, returning the interface id it references — `Unset` for an
-  // inline definition, which references none — and the tokens after it. Ids contain no internal
-  // whitespace, so joining the tokens with no separator reassembles `wasi:cli/run@0.2.0` exactly.
-  private def worldItem(tokens: List[String], acc: List[String], pkg: Optional[Text])
-  :   (Optional[Text], List[String]) =
-
-    tokens match
-      case Nil =>
-        (Unset, Nil)
-
-      // `name: interface { … }` defines an interface inline rather than referencing one.
-      case "{" :: rest =>
-        (Unset, skipBraces(rest, 1))
-
-      case ";" :: rest =>
-        val id = acc.stdlib.reverse.mkString
-
-        // `name: func(…)` is an inline function import, not an interface reference. A name with no
-        // `:` is an interface in this package, which the package id qualifies.
-        if id.contains("func(") then (Unset, rest)
-        else if id.contains(":") then (id.tt, rest)
-        else (moduleId(pkg, id.tt).or(id.tt), rest)
-
-      case head :: rest =>
-        worldItem(rest, head :: acc, pkg)
-
-  // WIT identifiers are kebab-case, so `-` is an identifier character — except in `->` (the
-  // return-type arrow). Other punctuation becomes single-character tokens; `//` and `/* … */`
-  // comments are skipped.
-  private def tokenize(source: String): List[String] =
-    def skipLine(index: Int): Int =
-      if index >= source.length || source.charAt(index) == '\n' then index + 1
-      else skipLine(index + 1)
-
-    def skipBlock(index: Int): Int =
-      if index + 1 >= source.length then source.length
-      else if source.charAt(index) == '*' && source.charAt(index + 1) == '/' then index + 2
-      else skipBlock(index + 1)
-
-    def ident(char: Char): Boolean =
-      char.isLetterOrDigit || char == '_' || char == '-'
-
-    def recur(index: Int, current: String, tokens: scala.collection.immutable.List[String])
-    :   scala.collection.immutable.List[String] =
-
-      val flushed = if current.isEmpty then tokens else current :: tokens
-
-      if index >= source.length then flushed.reverse else
-        val char = source.charAt(index)
-        val next = if index + 1 < source.length then source.charAt(index + 1) else ' '
-
-        if char == '/' && next == '/' then recur(skipLine(index), "", flushed)
-        else if char == '/' && next == '*' then recur(skipBlock(index + 2), "", flushed)
-        else if char == '-' && next == '>' then recur(index + 2, "", "->" :: flushed)
-        // `%` escapes an identifier that collides with a WIT keyword (`%stream`); the name
-        // itself is the unescaped form.
-        else if char == '%' then recur(index + 1, current, tokens)
-        else if ident(char) then recur(index + 1, current + char, tokens)
-        else if char.isWhitespace then recur(index + 1, "", flushed)
-        else recur(index + 1, "", char.toString :: flushed)
-
-    List.of(recur(0, "", Nil.stdlib))
-
-  // Parses a WIT type. `name<args>` is a generic application — `option<T>` becomes the union
-  // `T | none` (an `Optional`), and `list`/`tuple`/`result` stay applications. Primitive names are
-  // kept verbatim (`u32`, `s8`, `char`, …); the ecosystem maps each to a Hypotenuse type.
-  private def typeOf(tokens: List[String]): (Foreign.Type, List[String]) = tokens match
-    case name :: "<" :: rest =>
-      val (args, after) = typeArguments(rest, Nil)
-
-      if name == "option" then args match
-        case inner :: Nil => (Foreign.Type.Union(List(inner, Foreign.Type.Named(t"none"))), after)
-        case _            => (Foreign.Type.Applied(t"option", args), after)
-      else if name == "result" then (result(args), after)
-      else (Foreign.Type.Applied(name.tt, args), after)
-
-    case "result" :: rest =>
-      (result(Nil), rest)
-
-    case name :: rest =>
-      (Foreign.Type.Named(name.tt), rest)
-
-    case Nil =>
-      (Foreign.Type.Named(t""), Nil)
-
-  // A `result` type always carries exactly two arms: `result` and `result<T>` pad the missing
-  // `ok`/`err` arm(s) with `_`, so consumers see one uniform shape.
-  private def result(args: List[Foreign.Type]): Foreign.Type =
-    val unit = Foreign.Type.Named(t"_")
-    Foreign.Type.Applied(t"result", List.of((args.stdlib ++ List(unit, unit).stdlib).take(2)))
-
-  private def typeArguments(tokens: List[String], acc: List[Foreign.Type])
-  :   (List[Foreign.Type], List[String]) =
-
-    tokens match
-      case ">" :: rest =>
-        (acc.reverse, rest)
-
-      case _ =>
-        val (arg, rest) = typeOf(tokens)
-
-        rest match
-          case "," :: more => typeArguments(more, arg :: acc)
-          case ">" :: more => (List.of((arg :: acc).reverse), more)
-          case _           => (acc.reverse, skipTo(rest, t">"))
-
-  // Walks the top-level items, accumulating navigable types (records, and each interface's
-  // functions) and `type` aliases.
-  private def items
-    ( tokens:   List[String],
-      types:    Map[Text, Map[Text, Prototype]],
-      typedefs: Map[Text, Foreign.Type],
-      pkg:      Optional[Text] )
-  :   (Map[Text, Map[Text, Prototype]], Map[Text, Foreign.Type]) =
-
-    tokens match
-      case Nil =>
-        (types, typedefs)
-
-      case "package" :: rest =>
-        val (id, after) = packageId(rest)
-        items(after, types, typedefs, id)
-
-      case "interface" :: name :: "{" :: rest =>
-        val (types2, typedefs2, after) = interface(rest, name.tt, types, typedefs, pkg)
-        items(after, types2, typedefs2, pkg)
-
-      case "type" :: name :: "=" :: rest =>
-        val (kind, after) = typeOf(rest)
-        items(skipTo(after, t";"), types, typedefs.updated(name.tt, kind), pkg)
-
-      case ("world" | "interface") :: _ :: "{" :: rest =>
-        items(skipBraces(rest, 1), types, typedefs, pkg)
-
-      case _ =>
-        items(skipTo(tokens, t";"), types, typedefs, pkg)
-
-  // Walks an interface body: `record`s and the interface's own functions become navigable types;
-  // an `enum` becomes the unsigned discriminant (`u8`/`u16`/`u32`) that holds its cases and `flags`
-  // a bit-vector (`b8`/`b16`/`b32`/`b64`) that holds its members; `variant` is an opaque type; and
-  // `resource`/`use` declarations are skipped (their `{ … }` bodies and statements bypassed).
-  private def interface
-    ( tokens:   List[String],
-      name:     Text,
-      types:    Map[Text, Map[Text, Prototype]],
-      typedefs: Map[Text, Foreign.Type],
-      pkg:      Optional[Text] )
-  :   (Map[Text, Map[Text, Prototype]], Map[Text, Foreign.Type], List[String]) =
-
-    val module = moduleId(pkg, name)
-
-    def recur
-      ( todo:      List[String],
-        functions: Ledger[Text, Prototype],
-        types:     Map[Text, Map[Text, Prototype]],
-        typedefs:  Map[Text, Foreign.Type] )
-    :   (Map[Text, Map[Text, Prototype]], Map[Text, Foreign.Type], List[String]) =
-
-      todo match
-        // Merge, rather than overwrite: a resource or variant sharing the interface's own name
-        // (e.g. the `network` resource in `interface network`) has already recorded its module
-        // under this key, which a plain overwrite with the interface's (possibly empty) functions
-        // would discard.
-        case "}" :: rest =>
-          val merged = types.get(name).optional.lay(functions.stdlib)(_ ++ functions.stdlib)
-          (types.updated(name, merged), typedefs, rest)
-
-        case Nil =>
-          val merged = types.get(name).optional.lay(functions.stdlib)(_ ++ functions.stdlib)
-          (types.updated(name, merged), typedefs, Nil)
-
-        case "record" :: record :: "{" :: rest =>
-          val (fields, after) = recordFields(rest, Ledger())
-          recur(after, functions, types.updated(record.tt, fields.stdlib), typedefs)
-
-        case "enum" :: alias :: "{" :: rest =>
-          val (count, after) = enumerators(rest, 0)
+        // An `enum` collapses to the unsigned discriminant that holds its cases, and `flags`
+        // to the bit-vector that holds its members, so the FFM layouts stay correct.
+        case WitItem.Enumeration(name, cases) =>
+          val count = cases.stdlib.length
           val topic = if count <= 256 then t"u8" else if count <= 65536 then t"u16" else t"u32"
-          recur(after, functions, types, typedefs.updated(alias.tt, Foreign.Type.Named(topic)))
+          typedefs = typedefs.updated(name, Foreign.Type.Named(topic))
 
-        case "flags" :: alias :: "{" :: rest =>
-          val (count, after) = enumerators(rest, 0)
+        case WitItem.Flags(name, names) =>
+          val count = names.stdlib.length
 
           val topic =
             if count <= 8 then t"b8" else if count <= 16 then t"b16"
             else if count <= 32 then t"b32" else t"b64"
 
-          recur(after, functions, types, typedefs.updated(alias.tt, Foreign.Type.Named(topic)))
+          typedefs = typedefs.updated(name, Foreign.Type.Named(topic))
+
+        case WitItem.Alias(name, target) =>
+          typedefs = typedefs.updated(name, project(target))
 
         // A variant (or a bodyless resource) has no navigable members, but must still record
-        // which module defines it, so functions in *other* interfaces that mention it (e.g. in a
-        // `result` error arm) resolve its facade class through `definingModule`: a single
-        // unnameable member carries the module.
-        case "variant" :: variant :: "{" :: rest =>
-          val updated = types.updated(variant.tt, declaration(variant.tt, module))
-          recur(skipBraces(rest, 1), functions, updated, typedefs)
+        // which module defines it, so functions in *other* interfaces that mention it (e.g. in
+        // a `result` error arm) resolve its facade class: a single unnameable member carries
+        // the module.
+        case WitItem.Variant(name, _) =>
+          types = types.updated(name, declaration(name, module))
 
-        case "resource" :: resource :: "{" :: rest =>
-          val (methods, after) = resourceBody(rest, resource.tt, module, Ledger())
-          recur(after, functions, types.updated(resource.tt, methods.stdlib), typedefs)
+        case WitItem.Resource(name, methods) =>
+          if methods.stdlib.isEmpty then types = types.updated(name, declaration(name, module))
+          else
+            val members = methods.stdlib.map: method =>
+              method.name -> signature(method, name)
 
-        case "resource" :: resource :: ";" :: rest =>
-          val updated = types.updated(resource.tt, declaration(resource.tt, module))
-          recur(rest, functions, updated, typedefs)
+            types = types.updated(name, members.toMap)
 
-        case "use" :: rest =>
-          recur(skipTo(rest, t";"), functions, types, typedefs)
+        case WitItem.Use(_, _) => ()
 
-        case "type" :: alias :: "=" :: rest =>
-          val (kind, after) = typeOf(rest)
-          recur(skipTo(after, t";"), functions, types, typedefs.updated(alias.tt, kind))
+      // Merge, rather than overwrite: a resource or variant sharing the interface's own name
+      // (e.g. the `network` resource in `interface network`) has already recorded its module
+      // under this key, which a plain overwrite with the interface's (possibly empty)
+      // functions would discard.
+      val merged = types.get(interface.name).optional.lay(functions.toMap)(_ ++ functions.toMap)
+      types = types.updated(interface.name, merged)
 
-        case function :: ":" :: "func" :: "(" :: rest =>
-          val (parameters, after) = params(rest, Nil)
+    resolve(types, typedefs)
 
-          val (result, after2) = after match
-            case "->" :: more => typeOf(more)
-            case more         => (Foreign.Type.Named(t"unit"), more)
+  // Collapses the parser's faithful types to the marshalling vocabulary: `option<T>` is the
+  // union `T | none` (an `Optional`), and a `result` always carries exactly two arms.
+  private def project(typed: Foreign.Type): Foreign.Type = typed match
+    case Foreign.Type.Named(name) =>
+      if name == t"result" then padded(scala.Nil) else typed
 
-          val signature = Prototype(parameters, result, module)
-          recur(skipTo(after2, t";"), functions.updated(function.tt, signature), types, typedefs)
+    case applied: Foreign.Type.Applied =>
+      val arguments = applied.arguments.stdlib.map(project(_))
 
-        // Any unrecognised `{ … }` block is skipped wholesale rather than token-by-token, so its
-        // closing brace is never mistaken for the end of the interface.
-        case "{" :: rest =>
-          recur(skipBraces(rest, 1), functions, types, typedefs)
+      if applied.constructor == t"option" && arguments.length == 1
+      then Foreign.Type.Union(List(arguments.head, Foreign.Type.Named(t"none")))
+      else if applied.constructor == t"result" then padded(arguments)
+      else Foreign.Type.Applied(applied.constructor, List.from(arguments))
 
-        case _ :: rest =>
-          recur(rest, functions, types, typedefs)
+    case Foreign.Type.Union(members) =>
+      Foreign.Type.Union(members.map(project(_)))
 
-    recur(tokens, Ledger(), types, typedefs)
-
-  // Walks a `resource … { … }` body: its methods become members of a type named after the
-  // resource, each marked with the resource it belongs to (so an invocation can address it as
-  // `[method]resource.name` and thread the receiver's handle). `constructor` and `static`
-  // declarations are recognised but skipped for now.
-  private def resourceBody
-    ( tokens:   List[String],
-      resource: Text,
-      module:   Optional[Text],
-      methods:  Ledger[Text, Prototype] )
-  :   (Ledger[Text, Prototype], List[String]) =
-
-    tokens match
-      case "}" :: rest =>
-        (methods, rest)
-
-      case Nil =>
-        (methods, Nil)
-
-      // A constructor is registered as the member `constructor`, returning the resource itself; a
-      // `static func` is a member addressed through the resource but taking no receiver.
-      case "constructor" :: "(" :: rest =>
-        val (parameters, after) = params(rest, Nil)
-        val signature = Prototype(parameters, Foreign.Type.Named(resource), module, resource, true)
-        val updated = methods.updated(t"constructor", signature)
-        resourceBody(skipTo(after, t";"), resource, module, updated)
-
-      case method :: ":" :: "static" :: "func" :: "(" :: rest =>
-        val (parameters, after) = params(rest, Nil)
-
-        val (result, after2) = after match
-          case "->" :: more => typeOf(more)
-          case more         => (Foreign.Type.Named(t"unit"), more)
-
-        val signature = Prototype(parameters, result, module, resource, true)
-        resourceBody(skipTo(after2, t";"), resource, module, methods.updated(method.tt, signature))
-
-      case method :: ":" :: "func" :: "(" :: rest =>
-        val (parameters, after) = params(rest, Nil)
-
-        val (result, after2) = after match
-          case "->" :: more => typeOf(more)
-          case more         => (Foreign.Type.Named(t"unit"), more)
-
-        val signature = Prototype(parameters, result, module, resource)
-        resourceBody(skipTo(after2, t";"), resource, module, methods.updated(method.tt, signature))
-
-      case _ :: rest =>
-        resourceBody(rest, resource, module, methods)
+  private def padded(args: scala.List[Foreign.Type]): Foreign.Type =
+    val unit = Foreign.Type.Named(t"_")
+    Foreign.Type.Applied(t"result", List.from((args ++ scala.List(unit, unit)).take(2)))
 
   // The pseudo-member recording, for a memberless type declaration, the module that defines it.
-  // A `Ledger`'s underlying map, not a plain `Map(...)`: this single entry seeds the value that
-  // later `++`-merges with an interface's functions, and the LEFT operand's factory decides
-  // whether the merged map stays insertion-ordered.
   private def declaration(name: Text, module: Optional[Text]): Map[Text, Prototype] =
-    Ledger(t"" -> Prototype(Unset, Foreign.Type.Named(name), module)).stdlib
-
-  private def recordFields(tokens: List[String], acc: Ledger[Text, Prototype])
-  :   (Ledger[Text, Prototype], List[String]) =
-
-    tokens match
-      case "}" :: rest =>
-        (acc, rest)
-
-      case name :: ":" :: rest =>
-        val (kind, after) = typeOf(rest)
-        val updated = acc.updated(name.tt, Prototype(Unset, kind))
-
-        after match
-          case "," :: more => recordFields(more, updated)
-          case _           => recordFields(after, updated)
-
-      case _ :: rest =>
-        recordFields(rest, acc)
-
-      case Nil =>
-        (acc, Nil)
-
-  private def params(tokens: List[String], acc: List[Foreign.Type])
-  :   (Optional[List[Foreign.Type]], List[String]) =
-
-    tokens match
-      case ")" :: rest =>
-        (acc.reverse, rest)
-
-      case name :: ":" :: rest =>
-        val (kind, after) = typeOf(rest)
-
-        after match
-          case "," :: more => params(more, kind :: acc)
-          case ")" :: more => (List.of((kind :: acc).reverse), more)
-          case _           => (acc.reverse, skipTo(after, t")"))
-
-      case _ :: rest =>
-        params(rest, acc)
-
-      case Nil =>
-        (acc.reverse, Nil)
+    Map(t"" -> Prototype(Unset, Foreign.Type.Named(name), module))
 
   // Resolves every `type` alias appearing in a type, transitively.
   private def resolve
@@ -484,41 +222,11 @@ object WitDialect extends Dialect:
     definitions.map: (name, members) =>
       (name, members.map { (member, sig) => (member, signature(sig)) })
 
-  // Reads the tokens of a `package …;` declaration up to (not including) the `;` and joins them
-  // with no separator — WIT package ids contain no internal whitespace, so an id such as
-  // `wasi:random@0.2.0` reassembles exactly — returning the id and the tokens after the `;`.
-  private def packageId(tokens: List[String]): (Text, List[String]) =
-    def recur(todo: List[String], acc: List[String]): (Text, List[String]) = todo match
-      case ";" :: rest  => (acc.stdlib.reverse.mkString.tt, rest)
-      case Nil          => (acc.stdlib.reverse.mkString.tt, Nil)
-      case head :: rest => recur(rest, head :: acc)
-
-    recur(tokens, Nil)
-
-  // Builds the Component Model module id for an interface from the enclosing package id: package
-  // `wasi:random@0.2.0` and interface `random` give `wasi:random/random@0.2.0` — the interface name
-  // is spliced in before the `@version`. `Unset` when there is no `package` declaration.
+  // Builds the Component Model module id for an interface from the enclosing package id:
+  // package `wasi:random@0.2.0` and interface `random` give `wasi:random/random@0.2.0` — the
+  // interface name is spliced in before the `@version`. `Unset` when there is no `package`
+  // declaration.
   private def moduleId(pkg: Optional[Text], iface: Text): Optional[Text] = pkg.let: id =>
     id.cut(t"@") match
       case base :: version :: _ => t"$base/$iface@$version"
       case _                    => t"$id/$iface"
-
-  // Skips tokens up to and including the next occurrence of `token`.
-  private def skipTo(tokens: List[String], token: Text): List[String] = tokens match
-    case Nil          => Nil
-    case head :: rest => if head == token.s then rest else skipTo(rest, token)
-
-  // Skips a balanced `{ … }` block, given the tokens just inside the opening brace (depth 1).
-  private def skipBraces(tokens: List[String], depth: Int): List[String] = tokens match
-    case Nil         => Nil
-    case "{" :: rest => skipBraces(rest, depth + 1)
-    case "}" :: rest => if depth <= 1 then rest else skipBraces(rest, depth - 1)
-    case _ :: rest   => skipBraces(rest, depth)
-
-  // Counts the case/flag names inside an `enum`/`flags` body (used to size the discriminant or
-  // bit-vector), returning the count and the tokens after the closing `}`.
-  private def enumerators(tokens: List[String], count: Int): (Int, List[String]) = tokens match
-    case "}" :: rest                          => (count, rest)
-    case Nil                                  => (count, Nil)
-    case name :: rest if name.head.isLetter   => enumerators(rest, count + 1)
-    case _ :: rest                            => enumerators(rest, count)

--- a/lib/xenophile/src/wit/xenophile.WitParser.scala
+++ b/lib/xenophile/src/wit/xenophile.WitParser.scala
@@ -55,8 +55,11 @@ import WitParseError.Reason
 // unstable surface.
 object WitParser:
 
-  def parse(source: Text): WitDocument raises WitParseError =
-    document(tokenize(source.s))
+  // One `WitDocument` per `package` section: a curated `.wit` file may hold several packages
+  // (the WASI subsets the backends carry do), and every interface and world belongs to the
+  // package declared above it.
+  def parse(source: Text): List[WitDocument] raises WitParseError =
+    List.from(documents(tokenize(source.s)))
 
   private def fail(detail: Text, tokens: SList[String]): Nothing raises WitParseError =
     val near = Text(tokens.take(5).mkString(" "))
@@ -359,41 +362,93 @@ object WitParser:
 
   // --- worlds ---------------------------------------------------------------------------------
 
-  private def worldBody(tokens: SList[String])
-  :   (List[Text], List[Text], SList[String]) raises WitParseError =
+  private def worldBody(name: Text, tokens: SList[String])
+  :   (WitWorldModel, SList[String]) raises WitParseError =
 
-    def recur(tokens: SList[String], imports: SList[Text], exports: SList[Text])
-    :   (List[Text], List[Text], SList[String]) raises WitParseError =
+    def recur
+      ( tokens:        SList[String],
+        imports:       SList[Text],
+        exports:       SList[Text],
+        inlineImports: SList[(Text, Optional[WitFunction])],
+        inlineExports: SList[(Text, Optional[WitFunction])] )
+    :   (WitWorldModel, SList[String]) raises WitParseError =
+
+      def inlineItem(name: String, tokens: SList[String])
+      :   (Optional[WitFunction], SList[String]) raises WitParseError =
+
+        tokens match
+          case "func" :: _ =>
+            val (function, after) = functionType(Text(name.stripPrefix("%").nn), tokens, false)
+            (Optional(function), after)
+
+          // An inline interface's body is parsed — so its vocabulary is still checked — but
+          // only its name enters the world model.
+          case "interface" :: "{" :: body =>
+            val (_, after) = interfaceBody(body)
+            (Unset, after)
+
+          case _ => fail(t"`func` or `interface` was expected", tokens)
 
       gates(tokens) match
-        case "}" :: rest => (List.from(imports.reverse), List.from(exports.reverse), rest)
+        case "}" :: rest =>
+          val world =
+            WitWorldModel
+              ( name,
+                List.from(imports.reverse),
+                List.from(exports.reverse),
+                List.from(inlineImports.reverse),
+                List.from(inlineExports.reverse) )
 
-        case "import" :: name :: ";" :: rest => recur(rest, name.tt :: imports, exports)
-        case "export" :: name :: ";" :: rest => recur(rest, imports, name.tt :: exports)
+          (world, rest)
 
-        case ("import" | "export") :: _ :: ":" :: _ =>
-          unsupported(t"an inline world item")
+        case "import" :: name :: ":" :: rest =>
+          val (function, after) = inlineItem(name, rest)
+          recur(after, imports, exports, (name.tt, function) :: inlineImports, inlineExports)
+
+        case "export" :: name :: ":" :: rest =>
+          val (function, after) = inlineItem(name, rest)
+          recur(after, imports, exports, inlineImports, (name.tt, function) :: inlineExports)
+
+        case "import" :: name :: ";" :: rest =>
+          recur(rest, name.tt :: imports, exports, inlineImports, inlineExports)
+
+        case "export" :: name :: ";" :: rest =>
+          recur(rest, imports, name.tt :: exports, inlineImports, inlineExports)
 
         case "include" :: _ => unsupported(t"a world include")
         case construct :: _ => unsupported(construct.tt)
         case SNil           => fail(t"a world body is unterminated", tokens)
 
-    recur(tokens, SList(), SList())
+    recur(tokens, SList(), SList(), SList(), SList())
 
   // --- documents ------------------------------------------------------------------------------
 
-  private def document(tokens: SList[String]): WitDocument raises WitParseError =
+  private def documents(tokens: SList[String]): SList[WitDocument] raises WitParseError =
+    def flush
+      ( pkg:        Optional[Text],
+        version:    Optional[Text],
+        interfaces: SList[WitInterface],
+        worlds:     SList[WitWorldModel],
+        acc:        SList[WitDocument] )
+    :   SList[WitDocument] =
+
+      if pkg.absent && interfaces.isEmpty && worlds.isEmpty then acc
+      else
+        WitDocument(pkg, version, List.from(interfaces.reverse), List.from(worlds.reverse))
+          :: acc
+
     def recur
       ( tokens:     SList[String],
         pkg:        Optional[Text],
         version:    Optional[Text],
         interfaces: SList[WitInterface],
-        worlds:     SList[WitWorldModel] )
-    :   WitDocument raises WitParseError =
+        worlds:     SList[WitWorldModel],
+        acc:        SList[WitDocument] )
+    :   SList[WitDocument] raises WitParseError =
 
       gates(tokens) match
         case SNil =>
-          WitDocument(pkg, version, List.from(interfaces.reverse), List.from(worlds.reverse))
+          flush(pkg, version, interfaces, worlds, acc).reverse
 
         case "package" :: name :: ";" :: rest =>
           val at = name.indexOf('@')
@@ -402,17 +457,17 @@ object WitParser:
             if at < 0 then (name.tt, Unset)
             else (name.substring(0, at).nn.tt, Optional(name.substring(at + 1).nn.tt))
 
-          recur(rest, bare, declared, interfaces, worlds)
+          recur(rest, bare, declared, SList(), SList(),
+              flush(pkg, version, interfaces, worlds, acc))
 
         case "interface" :: name :: "{" :: rest =>
           val (items, after) = interfaceBody(rest)
-          recur(after, pkg, version, WitInterface(name.tt, items) :: interfaces, worlds)
+          recur(after, pkg, version, WitInterface(name.tt, items) :: interfaces, worlds, acc)
 
         case "world" :: name :: "{" :: rest =>
-          val (imports, exports, after) = worldBody(rest)
-          recur(after, pkg, version, interfaces,
-              WitWorldModel(name.tt, imports, exports) :: worlds)
+          val (world, after) = worldBody(name.tt, rest)
+          recur(after, pkg, version, interfaces, world :: worlds, acc)
 
         case construct :: _ => unsupported(construct.tt)
 
-    recur(tokens, Unset, Unset, SList(), SList())
+    recur(tokens, Unset, Unset, SList(), SList(), SList())


### PR DESCRIPTION
Removes the parser duplication introduced when the LIRA disciplines gained declaration-grade
parsers beside the FFI dialects: each foreign language now has one reader and two views, on the
precedent of `TypescriptDialect` over `TypescriptParser`. The dialects' deliberate erasures —
pointer and signedness collapse and `char*`-as-string for C; enum discriminants,
`option`-to-union, `result` padding and module-id qualification for WIT; inheritance
flattening and typedef resolution for WebIDL — survive as explicit projection logic over the
faithful declaration models, and three tokenizers and three type grammars are deleted
(−684 lines net).

## Release notes

- `CHeaderDialect`, `WitDialect` and `WebIdlDialect` are now projections of `CHeaderParser`,
  `WitParser` and `WebIdlParser`. Their navigation surfaces are unchanged.
- `WitParser.parse` now yields one `WitDocument` per `package` section: the curated `.wit`
  files the WASI backends carry hold several packages per file, and this is what keeps a
  `use`-imported type attributed to its defining package — a misattribution the wasm e2e
  scenarios caught, and which also corrects `wit/1` atomization for multi-package files.
- `WitParser` models inline world items (`import name: func(…)`, `export name: interface
  { … }`), and `wit/1` atomizes them under the same polarity as referenced ones: inline
  imports stand alone, inline exports join the world's folded obligation list.
- The dialects are now strict: a construct outside the grammar is reported as a compile-time
  diagnostic at the `Interface` site, where it was previously skipped — a partially-read
  header or IDL fragment could silently present a smaller surface than the file declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
