### PR TITLE
Add release tags and the jsig/1 host-contract harvesting toolchain

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -583,7 +583,8 @@ object soundness extends Toolchain:
 
   object tool extends Bundle(anthology.core, decorum.plugin, degustation.core,
     degustation.lira, mandible.lira, xenophile.lira, harlequin.core, hellenism.core,
-    hyperbole.core, octogenarian.core, reliquary.core, revolution.core, umbrageous.plugin,
+    hyperbole.core, octogenarian.core, reliquary.core, reliquary.derive, revolution.core,
+    umbrageous.plugin,
     anthology.java,
     harlequin.md, harlequin.ansi, austronesian.core, anthology.linker, anthology.link, anthology.nir,
     anthology.lira,
@@ -690,7 +691,7 @@ object keywords extends BaseScalaModule:
 object groupCheck extends Module:
   // Library directories on disk that are deliberately not wired into the build
   // (work-in-progress modules with no compiling sources yet).
-  def disabledLibraries: Set[String] = Set()
+  def disabledLibraries: Set[String] = Set("murmuration")
 
   // Published `Component`s deliberately not included in any soundness.{base,cli,data,sci,
   // test,tool,web} group bundle: the compiler plugins (published but used via `-Xplugin`),
@@ -713,7 +714,10 @@ object groupCheck extends Module:
     "proscenium.core",
     "breviloquence.staged", "jacinta.staged", "locomotion.staged", "stratiform.staged",
     "stratiform.binaryStaged", "xylophone.staged",
-    "prescience.core", "prescience.leaves"
+    "prescience.core", "prescience.leaves",
+    // The Android link stages: published, but their R8 toolchain dependency is heavyweight and
+    // strictly opt-in, so they stay out of `soundness-all` rather than joining a group bundle.
+    "anthology.apk", "anthology.dex"
   )
 
   def validate(): Command[Unit] = Task.Command:
@@ -1912,7 +1916,7 @@ object mandible extends Library:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
     def mvnDeps = Seq(mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}")
 
-  object lira extends Component(core, reliquary.core):
+  object lira extends Component(core, reliquary.core, reliquary.derive):
     override def scalaJs = false // adapts the discipline to reliquary's JVM-only SPI
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))

--- a/lib/mandible/src/lira/mandible.HostContracts.scala
+++ b/lib/mandible/src/lira/mandible.HostContracts.scala
@@ -30,7 +30,92 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package mandible
 
-export mandible.{ClassfileAtomizer, ClassfileDiscipline, CtSym, HostArchive, HostContracts,
-    HostRelease, JsigDiscipline, JvmProfile}
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import reliquary.*
+import revolution.Semver
+import rudiments.*
+import vacuous.*
+
+import LiraError.Reason
+
+// One harvested release of a host's surface: the vendor's name for it (which becomes the
+// release's tag, LIRA §12.6) and its content tree.
+case class HostRelease(tag: Text, content: List[(TreePath, Data)])
+
+// Builds the release sequence of a host-contract module from harvested surfaces: each release
+// is atomized under `jsig/1`, graded against its predecessor by the ordinary algebra, given
+// the derived version §12.5 dictates, threaded onto the lineage — a major beginning a fresh
+// one — and assembled as a complete, tagged `.lira` host contract.
+//
+// A major is a removal in the host's history (the JDK 9 and 11 removals are the canonical
+// cases), and L110 requires the operator to sanction it: `allowMajor` is that sanction, per
+// tag, so an unexpected removal fails loudly rather than silently fracturing the lineage.
+object HostContracts:
+
+  def assemble
+    ( module:     Text,
+      releases:   List[HostRelease],
+      toolchain:  List[LiraManifest.Tool],
+      allowMajor: Text -> Boolean            = { _ => false },
+      sign:       LiraManifest -> LiraManifest = { manifest => manifest } )
+  :   List[(Text, Data)] raises LiraError raises DisciplineError =
+
+    val registry = Discipline.Registry(List(JsigDiscipline))
+    val context = Discipline.Context(t"host")
+    val results = scala.collection.mutable.ListBuffer[(Text, Data)]()
+
+    var previous: Optional[List[Atomization]] = Unset
+    var lineage: List[Data] = List()
+    var version: Semver = Semver(0, 1, 0)
+
+    var todo = releases.stdlib
+
+    while todo.nonEmpty do
+      val release = todo.head
+      todo = todo.tail
+      val atomizations = registry.atomize(release.content, context)
+      val snapshot = Snapshot(atomizations)
+
+      previous.let: before =>
+        Grade.between(before, atomizations) match
+          case Grade.Patch =>
+            version = Semver(version.major, version.minor, version.patch + 1)
+
+          case Grade.Minor =>
+            version = Semver(version.major, version.minor + 1, 0)
+            lineage = List.from(lineage.stdlib :+ snapshot)
+
+          case Grade.Major =>
+            if !allowMajor(release.tag)
+            then abort(LiraError(Reason.UngradedSuccessor))
+
+            // §12.5: in the 0 series the minor conventionally carries breaking steps.
+            version =
+              if version.major == 0 then Semver(0, version.minor + 1, 0)
+              else Semver(version.major + 1, 0, 0)
+
+            lineage = List(snapshot)
+
+      . or:
+          lineage = List(snapshot)
+
+      val bytes =
+        LiraAssembler.assemble
+          ( module,
+            List(LiraAssembler.SectionInput(t"host", release.content)),
+            registry,
+            version   = version,
+            tag       = List(release.tag),
+            lineage   = lineage,
+            toolchain = toolchain,
+            sign      = sign )
+
+      results += ((release.tag, bytes))
+      previous = atomizations
+
+    List.from(results.toList)

--- a/lib/mandible/src/lira/mandible.HostSurfaces.scala
+++ b/lib/mandible/src/lira/mandible.HostSurfaces.scala
@@ -30,7 +30,118 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package mandible
 
-export mandible.{ClassfileAtomizer, ClassfileDiscipline, CtSym, HostArchive, HostContracts,
-    HostRelease, JsigDiscipline, JvmProfile}
+import scala.collection.immutable.List as SList
+import scala.jdk.CollectionConverters.*
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+import vacuous.*
+
+// Harvesters for host-contract surfaces (`jsig.md` §6): readers that turn the artifacts host
+// vendors already publish into the content trees a `.lira` host contract carries.
+//
+// `CtSym` reads the JDK's own `ct.sym` — the compile-time symbol table `--release` uses —
+// which holds the signature surface of every release back to JDK 8, so one modern JDK yields
+// the whole `jdk` lineage. `HostArchive` reads a stub jar (`android.jar` per API level, a
+// `scalajs-javalib` artifact) into the same shape.
+object CtSym:
+
+  // The running JDK's own `ct.sym`, where one exists.
+  def location(): Optional[Text] =
+    val home = java.lang.System.getProperty("java.home").nn
+    val path = java.nio.file.Paths.get(home, "lib", "ct.sym").nn
+    if java.nio.file.Files.exists(path) then Text(path.toString) else Unset
+
+  // `ct.sym` entry names begin with a run of release codes — `8`–`9` for JDK 8 and 9, then
+  // `A` = 10, `B` = 11, … — naming every release the entry's content is identical in.
+  private def decode(char: Char): Optional[Int] =
+    if char >= '5' && char <= '9' then char - '0'
+    else if char >= 'A' && char <= 'Z' then char - 'A' + 10
+    else Unset
+
+  private def code(release: Int): Char =
+    if release < 10 then ('0' + release).toChar else ('A' + release - 10).toChar
+
+  // The releases the symbol table carries, ascending.
+  def releases(path: Text): List[Int] =
+    val zip = java.util.zip.ZipFile(path.s)
+
+    try
+      val found = scala.collection.mutable.SortedSet[Int]()
+
+      zip.entries.nn.asScala.foreach: entry =>
+        val name = entry.nn.getName.nn
+        val slash = name.indexOf('/')
+
+        if slash > 0 then name.substring(0, slash).nn.foreach: char =>
+          decode(char).let { release => found += release }
+
+      List.from(found.toList)
+
+    finally zip.close()
+
+  // The signature surface of one release: every `.sig` entry present in it, with the release
+  // codes stripped from the path, so the tree reads `java.base/java/lang/Object.sig`.
+  // `module-info.sig` entries are omitted — module descriptors are not consumer surface. A
+  // `prefix`, where given, keeps a harvest to the paths beneath it; contracts SHOULD be
+  // harvested whole (`jsig.md` §4), and the filter exists for tooling and tests.
+  def surface(path: Text, release: Int, prefix: Optional[Text] = Unset)
+  :   List[(TreePath, Data)] raises LiraError =
+
+    val zip = java.util.zip.ZipFile(path.s)
+    val marker = code(release)
+
+    try
+      val entries = scala.collection.mutable.ListBuffer[(TreePath, Data)]()
+
+      zip.entries.nn.asScala.foreach: entry =>
+        val name = entry.nn.getName.nn
+        val slash = name.indexOf('/')
+
+        if slash > 0 && name.substring(0, slash).nn.indexOf(marker.toInt) >= 0 && name.endsWith(".sig")
+        && !name.endsWith("module-info.sig")
+        then
+          val inner = name.substring(slash + 1).nn
+
+          if prefix.let { p => inner.startsWith(p.s) }.or(true) then
+            val stream = zip.getInputStream(entry).nn
+            val bytes = stream.readAllBytes().nn
+            stream.close()
+            entries += ((TreePath(Text(inner)), Array.unsafeFrozen(bytes)))
+
+      List.from(entries.toList)
+
+    finally zip.close()
+
+// A stub jar — `android.jar` for one API level, or any signature-bearing archive — read into
+// the content tree a host contract carries.
+object HostArchive:
+
+  def surface(path: Text, prefix: Optional[Text] = Unset): List[(TreePath, Data)] raises
+      LiraError =
+
+    val zip = java.util.zip.ZipFile(path.s)
+
+    try
+      val entries = scala.collection.mutable.ListBuffer[(TreePath, Data)]()
+
+      zip.entries.nn.asScala.foreach: entry =>
+        val name = entry.nn.getName.nn
+
+        if name.endsWith(".class") && !name.endsWith("module-info.class")
+        && prefix.let { p => name.startsWith(p.s) }.or(true)
+        then
+          val stream = zip.getInputStream(entry).nn
+          val bytes = stream.readAllBytes().nn
+          stream.close()
+          entries += ((TreePath(Text(name)), Array.unsafeFrozen(bytes)))
+
+      List.from(entries.toList)
+
+    finally zip.close()

--- a/lib/mandible/src/lira/mandible.JsigDiscipline.scala
+++ b/lib/mandible/src/lira/mandible.JsigDiscipline.scala
@@ -30,7 +30,58 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package mandible
 
-export mandible.{ClassfileAtomizer, ClassfileDiscipline, CtSym, HostArchive, HostContracts,
-    HostRelease, JsigDiscipline, JvmProfile}
+import anticipation.*
+import contingency.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+
+// The `jsig/1` discipline (`jsig.md`): the declared signature surface of Java classfiles, as
+// the discipline of host contracts carried as API stubs — `ct.sym`'s signature files,
+// `android.jar`'s stub classes — and of any content whose contract is what can be *compiled*
+// against rather than the linkage of shipped bytecode.
+//
+// It shares `classfile/1`'s canonical encoding (the full fold, since generic signatures are
+// precisely the recompilation surface it certifies) and differs in claim: recompilation and
+// presence, never linkage — LIRA §11.2 requirement 7 is why the two cannot be one discipline.
+// The closure obligation is correspondingly softer: a supertype outside the claimed content is
+// a boundary, not an error, since a contract that is not the JDK's cannot be faulted for
+// `java.lang.Object`'s absence; producers harvest closures whole, and a supertype *within* the
+// claimed content that fails to read still fails the atomization.
+object JsigDiscipline extends Discipline:
+  def id: Text = t"jsig/1"
+
+  // Host contracts carried as signature stubs are the motivating case; the `jvm` inclusion
+  // admits a library whose interface carrier genuinely is Java signatures.
+  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"jvm", t"host"))
+
+  // A call site names the receiver, so a type's contract surface includes what it presents —
+  // sound here as it is for `classfile/1`, and required for the same reason.
+  def keying: Discipline.Keying = Discipline.Keying.Membership
+
+  def guarantees(world: Text): Set[Discipline.Guarantee] =
+    Set(Discipline.Guarantee.Recompilation)
+
+  // `.sig` is the JDK's own spelling for signature classfiles; the format is the classfile
+  // format, without `Code`.
+  def claims(path: TreePath, data: Data): Boolean =
+    path.text.s.endsWith(".sig") || path.text.s.endsWith(".class")
+
+  def atomize(content: List[(TreePath, Data)], context: Discipline.Context)
+  :   Atomization raises DisciplineError =
+
+    val classes = content.stdlib.map: (path, data) =>
+      // Same erasure; the parser reads the bytes and retains nothing of them.
+      val surface = ClassSurface(data.asInstanceOf[scala.IArray[Byte]])
+      surface.name -> surface
+
+    . to(scala.collection.immutable.Map)
+
+    val outcome = ClassfileAtomizer.atomize(Map.of(classes), context.classpath)
+
+    // `outcome.unresolved` is deliberately not consulted: a supertype outside the claimed
+    // content contributes nothing to presented sets (`jsig.md` §4), exactly as a metadata-less
+    // supertype contributes nothing to `kotlin-metadata/1`.
+    Atomization.of(id, outcome.atoms)

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -511,3 +511,94 @@ object Tests extends Suite(m"Mandible tests"):
     . assert: advisories =>
         advisories.length == 2
           && advisories.forall(_.s.contains("changed value"))
+
+    // --- jsig/1 and host contracts ------------------------------------------------------------
+
+    test(m"jsig claims signature files and classfiles in both its worlds"):
+      val data = Array.freeze(Array[Byte](0))
+
+      (JsigDiscipline.claims(TreePath(t"java.base/java/lang/Object.sig"), data),
+       JsigDiscipline.claims(TreePath(t"android/view/View.class"), data),
+       JsigDiscipline.claims(TreePath(t"readme.md"), data),
+       JsigDiscipline.domain.covers(t"host"),
+       JsigDiscipline.domain.covers(t"jvm"),
+       JsigDiscipline.domain.covers(t"sjsir"))
+    . assert(_ == (true, true, false, true, true, false))
+
+    test(m"a supertype outside the claimed content is a boundary, not an error"):
+      val (content, _) = compile(base, derived, api)
+      val derivedOnly = List.from(content.filter { pair => pair(0).text.s.contains("Derived") })
+
+      // The classpath is empty, so `Base` is unresolvable: `classfile/1` must fail here, and
+      // `jsig/1` must not — the presented set simply lacks what the boundary hides.
+      val atoms = JsigDiscipline.atomize(derivedOnly, Discipline.Context(t"host")).atoms
+
+      (atoms.stdlib.exists(_.key == t"fixture/Derived"),
+       atoms.stdlib.exists(_.key.s.startsWith("fixture/Derived#")),
+       atoms.stdlib.exists(_.key.s.startsWith("fixture/Base")))
+    . assert(_ == (true, true, false))
+
+    test(m"host contract sequences derive versions, lineages and tags"):
+      val (v1, _) = compile(base, derived, api)
+
+      val (v2, _) = compile(edit(base, t"public int inherited",
+          t"public int added() { return 9; }\n  public int inherited"), derived, api)
+
+      val (v3, _) = compile(edit(base, t"protected int guarded() { return 2; }", t""),
+          derived, api)
+
+      val releases = List(
+        HostRelease(t"jdk-17", v1),
+        HostRelease(t"jdk-18", v2),
+        HostRelease(t"jdk-19", v3))
+
+      val liras = HostContracts.assemble(t"fixture-host", releases,
+        List(LiraManifest.Tool(t"jsig-harvest", t"0.1")),
+        allowMajor = { tag => tag == t"jdk-19" })
+
+      val parsed = liras.stdlib.map { (tag, bytes) => (tag, Lira.read(bytes)) }
+      parsed.foreach { (_, lira) => Verification.install(lira) }
+
+      val versions = parsed.map: (_, lira) =>
+        lira.manifest.version.let { v => s"${v.major}.${v.minor}.${v.patch}" }.or("")
+
+      (versions,
+       parsed.map { (_, lira) => lira.manifest.lineage.stdlib.size },
+       parsed.flatMap { (_, lira) => lira.manifest.tag.stdlib },
+       parsed.forall { (_, lira) => lira.manifest.hostContract })
+    . assert(_ == (scala.List("0.1.0", "0.2.0", "0.3.0"), scala.List(1, 2, 1),
+        scala.List(t"jdk-17", t"jdk-18", t"jdk-19"), true))
+
+    test(m"an unsanctioned major refuses the sequence, L110"):
+      val (v1, _) = compile(base, derived, api)
+
+      val (v2, _) = compile(edit(base, t"protected int guarded() { return 2; }", t""),
+          derived, api)
+
+      import errorDiagnostics.stackTracesDiagnostics
+
+      capture[LiraError]:
+        HostContracts.assemble(t"fixture-host",
+          List(HostRelease(t"a", v1), HostRelease(t"b", v2)),
+          List(LiraManifest.Tool(t"jsig-harvest", t"0.1")))
+      . reason
+    . assert(_ == LiraError.Reason.UngradedSuccessor)
+
+    test(m"ct.sym harvests a verifiable, tagged jdk contract"):
+      CtSym.location().lay(true): path =>
+        val releases = CtSym.releases(path)
+        val earliest = releases.stdlib.head
+        val surface = CtSym.surface(path, earliest, prefix = t"java.base/java/lang/")
+        val tag = Text(s"jdk-$earliest")
+
+        val liras = HostContracts.assemble(t"jdk", List(HostRelease(tag, surface)),
+          List(LiraManifest.Tool(t"jsig-harvest", t"0.1")))
+
+        val lira = Lira.read(liras.stdlib.head(1))
+        Verification.install(lira)
+
+        releases.stdlib.size >= 2
+          && surface.stdlib.size > 20
+          && lira.manifest.tag.stdlib == scala.List(tag)
+          && lira.manifest.hostContract
+    . assert(_ == true)

--- a/lib/reliquary/res/test/reliquary/lira.tel
+++ b/lib/reliquary/res/test/reliquary/lira.tel
@@ -80,6 +80,9 @@ scalar Namespace
 scalar Semver
   validate semver
 
+scalar TagName
+  validate tag-name
+
 scalar Natural
   validate natural
 
@@ -109,6 +112,7 @@ select ResourceMode
 document
   field module ModuleName
   field version Semver optional
+  field tag TagName optional repeatable
   field lineage Hash repeatable
   field toolchain Tool repeatable
   field owns Namespace optional repeatable

--- a/lib/reliquary/src/core/reliquary.Buildpath.scala
+++ b/lib/reliquary/src/core/reliquary.Buildpath.scala
@@ -50,6 +50,25 @@ object Buildpath:
     val version = manifest.version.or(abort(LiraError(Reason.VersionRequired)))
     if !Versioning.numeric(version) then abort(LiraError(Reason.VersionRequired))
 
+    // L142: a tag names exactly one release of its module, forever. A tag carried by any other
+    // published release of the module is a reassignment; and a re-signed manifest for the
+    // *same* release (the same implementation identity) may add tags but never drop one a
+    // published manifest carries.
+    val siblings = published.stdlib.filter(_.module == manifest.module)
+
+    manifest.tag.stdlib.foreach: tag =>
+      val elsewhere = siblings.exists: sibling =>
+        sibling.tag.stdlib.contains(tag)
+          && Blob.compare(sibling.payload.hash, manifest.payload.hash) != 0
+
+      if elsewhere then abort(LiraError(Reason.TagReassigned(tag)))
+
+    siblings.filter { sibling => Blob.compare(sibling.payload.hash, manifest.payload.hash) == 0 }
+    . foreach: sibling =>
+        sibling.tag.stdlib.foreach: tag =>
+          if !manifest.tag.stdlib.contains(tag)
+          then abort(LiraError(Reason.TagReassigned(tag)))
+
     manifest.dependency.stdlib.foreach: dependency =>
       // L118: build pins are development-only; publication requires snapshot requirements.
       dependency.build.let: _ => abort(LiraError(Reason.BuildPinned(dependency.module)))

--- a/lib/reliquary/src/core/reliquary.LiraError.scala
+++ b/lib/reliquary/src/core/reliquary.LiraError.scala
@@ -83,6 +83,7 @@ object LiraError:
     case MalformedPayload(detail: Text)       extends Reason(139)
     case UnimplementedClaim(id: Text)         extends Reason(140)
     case AtomsMismatch(id: Text)              extends Reason(141)
+    case TagReassigned(tag: Text)             extends Reason(142)
 
   given communicable: Reason is Communicable =
     case Reason.InvalidManifest(detail)       => m"the manifest is invalid: $detail"
@@ -147,6 +148,9 @@ object LiraError:
 
     case Reason.AtomsMismatch(id) =>
       m"the declared $id atom listing does not recompute from the content"
+
+    case Reason.TagReassigned(tag) =>
+      m"the tag $tag already names a different release of this module"
 
 case class LiraError(reason: LiraError.Reason)(using Diagnostics)
 extends Error(640, reason.number)(m"the LIRA operation failed because $reason")

--- a/lib/reliquary/src/core/reliquary.LiraManifest.scala
+++ b/lib/reliquary/src/core/reliquary.LiraManifest.scala
@@ -300,6 +300,7 @@ object LiraManifest:
     LiraManifest
       ( module      = required(top, t"module"),
         version     = field(top, t"version").let(semver(_)),
+        tag         = List.from(repeated(top, t"tag")),
         lineage     = List.from(repeated(top, t"lineage").map(hash(_))),
         toolchain   = List.from(toolchain),
         owns        = List.from(repeated(top, t"owns")),
@@ -320,6 +321,7 @@ object LiraManifest:
 case class LiraManifest
   ( module:      Text,
     version:     Optional[Semver]                = Unset,
+    tag:         List[Text]                      = List(),
     lineage:     List[Data],
     toolchain:   List[LiraManifest.Tool]         = List(),
     owns:        List[Text]                      = List(),
@@ -353,6 +355,7 @@ case class LiraManifest
     lines += s"module $module"
 
     version.let: v => lines += s"version ${v.major}.${v.minor}.${v.patch}"
+    tag.stdlib.foreach: name => lines += s"tag $name"
     lineage.stdlib.foreach: hash => lines += s"lineage ${LiraHash.text(hash)}"
 
     toolchain.stdlib.foreach: tool =>

--- a/lib/reliquary/src/core/reliquary.LiraSchemas.scala
+++ b/lib/reliquary/src/core/reliquary.LiraSchemas.scala
@@ -92,6 +92,7 @@ object LiraSchemas:
   private val guarantee:    Type = Reference(t"Guarantee")
   private val string:       Type = Reference(t"String")
   private val treePath:     Type = Reference(t"TreePath")
+  private val tagName:      Type = Reference(t"TagName")
 
   private val hashScalar: ScalarDefinition = scalar("Hash", "base-256-hash")
 
@@ -109,6 +110,7 @@ object LiraSchemas:
       members = Array.of(
         field("module", moduleName),
         field("version", semver, required = Loose),
+        field("tag", tagName, required = Loose, repeatable = Loose),
         field("lineage", hash, repeatable = Loose),
         field("toolchain", Reference(t"Tool"), repeatable = Loose),
         field("owns", namespace, required = Loose, repeatable = Loose),
@@ -187,6 +189,7 @@ object LiraSchemas:
       scalar("ModuleName", "module-name"),
       scalar("Namespace", "namespace"),
       scalar("Semver", "semver"),
+      scalar("TagName", "tag-name"),
       scalar("Natural", "natural"),
       scalar("DisciplineId", "discipline-id"),
       scalar("ProfileId", "profile-id"),
@@ -290,7 +293,7 @@ object LiraSchemas:
   // The BASE-256 schema signatures of the six canonical documents, pinned as golden values (the
   // test suite recomputes each from its `res/test/reliquary/*.tel` mirror and checks agreement).
   // A conforming document of each schema carries its signature on the pragma line.
-  val liraSignature:  Text = t"εUYțẀñẆơÇMĆẗΎŠľЭЂẉąӮ0ÅðϕῡΔẙȑẀĆӜ1M"
+  val liraSignature:  Text = t"ϗƤҚЂЫǑmӪwUKΎ5ύ9ẈGÅЖӸψðΩȦӂSẓῩҚӂЊHk"
   val treeSignature:  Text = t"ǨẙơẗỵclϋẁЫĥᾸMôĮẍOώżӯάǢЗĆӸkҚțȐωǢέӫ"
   val atomsSignature: Text = t"2ӪççÃ5AḟǑXϋƤzᾱĺHϕЂẌǒEẂẁĮί9ḀẘΊÐιЪp"
   val usesSignature:  Text = t"şşCȧOӖGҐΪḍḋjΊӁῚƟȐЌĥέȦЬƜδĻĘ1Ȑḟ6ӟÔḍ"

--- a/lib/reliquary/src/core/reliquary.LiraValidators.scala
+++ b/lib/reliquary/src/core/reliquary.LiraValidators.scala
@@ -68,6 +68,7 @@ object LiraValidators:
           case "guarantee"     => guarantee(value)
           case "tree-path"     => treePath(value)
           case "atom-class"    => atomClass(value)
+          case "tag-name"      => tagName(value)
           case _               => unknown(method)
 
         case Request.Struct(method, _) => unknown(method)
@@ -100,6 +101,22 @@ object LiraValidators:
     if s.isEmpty then fail(t"the module name must not be empty", (0, 0))
     else if !s.split("[/.]", -1).nn.forall(good)
     then fail(t"each `/`- or `.`-separated segment must be kebab-case", (0, s.length))
+    else Response.Valid
+
+  // A tag name (§12.6): a letter followed by letters, digits, `-` and `.` — `jdk-19`,
+  // `scala-3.9`.
+  private def tagName(value: Text): Response =
+    val s = value.s
+
+    def tagChar(c: Char): Boolean =
+      c == '-' || c == '.' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+        || (c >= '0' && c <= '9')
+
+    if s.isEmpty then fail(t"the tag must not be empty", (0, 0))
+    else if !s.charAt(0).isLetter
+    then fail(t"a tag must start with a letter", (0, 1))
+    else if !s.forall(tagChar)
+    then fail(t"a tag may contain only letters, digits, `-` and `.`", (0, s.length))
     else Response.Valid
 
   private def namespaceChar(c: Char): Boolean =

--- a/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
+++ b/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
@@ -64,6 +64,7 @@ object LiraAssembler:
       sections:    List[SectionInput],
       disciplines: Discipline.Registry,
       version:     Optional[Semver]              = Unset,
+      tag:         List[Text]                    = List(),
       lineage:     List[Data]                    = List(),
       toolchain:   List[LiraManifest.Tool]       = List(),
       owns:        List[Text]                    = List(),
@@ -202,6 +203,7 @@ object LiraAssembler:
       LiraManifest
         ( module      = module,
           version     = version,
+          tag         = tag,
           lineage     = fullLineage,
           toolchain   = toolchain,
           owns        = owns,

--- a/lib/reliquary/src/test/reliquary_test.scala
+++ b/lib/reliquary/src/test/reliquary_test.scala
@@ -2160,3 +2160,70 @@ object Tests extends Suite(m"Reliquary Tests"):
           . validate(t"jvm", contracts = List(javalib), atoms = atoms, used = used)
         . reason
       . assert(_ == LiraError.Reason.UnsatisfiedRequirement(t"posix"))
+
+    suite(m"Tags"):
+      def payloadStub(module: Text): LiraManifest.Payload =
+        LiraManifest.Payload(t"brotli", 0L, LiraHash(LiraHash.Domain.Blob, encode(module)))
+
+      def release
+        ( module: Text, tags: List[Text], payload: Text, version: revolution.Semver )
+      :   LiraManifest =
+
+        LiraManifest(
+          module  = module,
+          version = version,
+          tag     = tags,
+          lineage = List(LiraHash(LiraHash.Domain.Snapshot, encode(payload))),
+          api     = List(),
+          section = List(Section(t"jvm", tree = blob(encode(t"tree")))),
+          payload = LiraManifest.Payload(t"brotli", 0L, LiraHash(LiraHash.Domain.Blob,
+              encode(payload))))
+
+      val one = revolution.Semver(0, 1, 0)
+      val two = revolution.Semver(0, 2, 0)
+
+      test(m"tags round-trip through the manifest"):
+        val bytes = LiraAssembler.assemble(t"jdk",
+          List(LiraAssembler.SectionInput(t"jvm", List((TreePath(t"a/A.class"), classA)))),
+          Discipline.Registry(List()),
+          tag = List(t"jdk-19", t"jdk-19.0.1"),
+          toolchain = List(LiraManifest.Tool(t"jsig-harvest", t"0.1")))
+
+        Lira.read(bytes).manifest.tag.stdlib
+      . assert(_ == scala.List(t"jdk-19", t"jdk-19.0.1"))
+
+      test(m"a tag carried by another release of the module is L142"):
+        val earlier = release(t"jdk", List(t"jdk-19"), t"one", one)
+        val later = release(t"jdk", List(t"jdk-19"), t"two", two)
+
+        capture[LiraError](Buildpath.publishable(later, List(earlier))).reason
+      . assert(_ == LiraError.Reason.TagReassigned(t"jdk-19"))
+
+      test(m"re-signing the same release may add tags but never drop one"):
+        val original = release(t"jdk", List(t"jdk-19"), t"one", one)
+        val augmented = release(t"jdk", List(t"jdk-19", t"jdk-19-ga"), t"one", one)
+        val stripped = release(t"jdk", List(), t"one", one)
+
+        Buildpath.publishable(augmented, List(original))
+
+        capture[LiraError](Buildpath.publishable(stripped, List(original))).reason
+      . assert(_ == LiraError.Reason.TagReassigned(t"jdk-19"))
+
+      test(m"the same tag on a different module is no clash"):
+        val jdk = release(t"jdk", List(t"lts"), t"one", one)
+        val android = release(t"android", List(t"lts"), t"two", two)
+        Buildpath.publishable(android, List(jdk))
+        true
+      . assert(identity)
+
+      test(m"a malformed tag fails schema validation"):
+        val bytes = LiraAssembler.assemble(t"jdk",
+          List(LiraAssembler.SectionInput(t"jvm", List((TreePath(t"a/A.class"), classA)))),
+          Discipline.Registry(List()),
+          tag = List(t"9uplet"),
+          toolchain = List(LiraManifest.Tool(t"jsig-harvest", t"0.1")))
+
+        capture[LiraError](Lira.read(bytes)).reason match
+          case LiraError.Reason.InvalidManifest(_) => true
+          case _                                   => false
+      . assert(identity)


### PR DESCRIPTION
Develops the host-compatibility story into working tooling. Tags (LIRA §12.6, L142) give
releases user-facing, immutable names — signed under the manifest, unique within their module
forever, without algebraic authority — so a host contract's vendor numbering (`jdk-19`,
`android-37`) rides beside the derived version the lineage arithmetic produces. The new
`jsig/1` discipline atomizes the signature surface host contracts carry, and mandible gains the
harvesters and the sequencer that turn vendor artifacts into verifiable contract lineages.

## Release notes

- **Tags.** A release may carry `tag` fields: unique and immutable within their module (L142 —
  publication refuses a reassignment, and a re-signed manifest may add tags but never drop
  one), signed as part of the manifest, and resolved by tools to snapshots — a stable alias
  where the `version` hint is only a courtesy.

- **`jsig/1`.** The Java signature-surface discipline: `classfile/1`'s canonical encoding,
  claiming what API stubs can promise — recompilation and presence, never linkage — with a
  domain of `{jvm, host}` and a soft closure boundary for supertypes outside the claimed
  content.

- **Host-surface harvesting.** `CtSym` reads the JDK's own `ct.sym`, which carries every
  release's signature surface back to JDK 8 — so one modern JDK yields the whole `jdk`
  lineage — and `HostArchive` reads stub jars such as `android.jar` per API level.

- **`HostContracts.assemble`.** Harvested surfaces in, contract lineage out: each release
  atomized under `jsig/1`, graded against its predecessor, given the derived version §12.5
  dictates, threaded onto the lineage (majors — the JDK 9/11 removals — begin fresh ones and
  require explicit sanction, L110), tagged with the vendor's name, and assembled as a
  complete `.lira` host contract.

  ```scala
  val path = CtSym.location().vouch
  val releases = CtSym.releases(path).map: release =>
    HostRelease(Text(s"jdk-$release"), CtSym.surface(path, release))

  HostContracts.assemble(t"jdk", releases, toolchain, allowMajor = removals)
  ```

- The groupCheck manifest is repaired: `reliquary.derive` joins the tool bundle, the Android
  link stages are documented opt-in exclusions, and a work-in-progress library directory on
  disk no longer fails the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
