### PR TITLE
Add the used-set extractor: host compatibility as a computation

### DIFF
--- a/lib/mandible/src/lira/mandible.UsedSets.scala
+++ b/lib/mandible/src/lira/mandible.UsedSets.scala
@@ -1,0 +1,141 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package mandible
+
+import java.lang.classfile as jlc
+import java.lang.classfile.constantpool as jlcc
+
+import scala.collection.immutable.SortedSet
+import scala.jdk.CollectionConverters.*
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import reliquary.*
+import rudiments.*
+import vacuous.*
+
+// The used-set extractor (LIRA §13.4, hosts.md §7): what a body of compiled classes actually
+// depends on, as membership keys, and — resolved against a contract's atom listing — as the
+// Uses blob a `requires` or `dependency` record attaches.
+//
+// A compiled consumer's dependencies are exactly its constant pool's outward references: every
+// `Class`, `Methodref`, `Fieldref` and `InterfaceMethodref` entry the JVM will resolve, spelled
+// by receiver — which is precisely membership-key spelling (`classfile.md` §6), so a reference
+// and the atom it uses agree by construction. References to classes the content itself declares
+// are internal and excluded.
+//
+// Resolution is against the listing of the contract release the module was *compiled against*
+// (`tasty.md` §12's rule, transposed): a matched key contributes its atom's value hash to the
+// used-set, and `used ⊆ atoms(H)` then decides — for any release `H` of any contract under the
+// same discipline — whether that host satisfies the module, by set inclusion (hosts.md §7).
+// Unmatched keys are returned rather than dropped: they are references to *other* modules
+// (buildpath dependencies, whose own used-sets cover their platform use transitively), and a
+// caller expecting the contract to cover everything can see at once what it did not.
+//
+// One boundary is worth stating: a platform member reached *through* a non-platform receiver —
+// `myWidget.hashCode()`, whose constant-pool owner is the widget class — is the widget module's
+// use, not this one's, and lands in its used-set when that module is published. Direct platform
+// references, which any real consumer of a platform also makes, are what this records.
+object UsedSets:
+
+  // The outward reference keys of the given classfiles, sorted: method and field references as
+  // `<owner>#<name>:<descriptor>` and `<owner>.<name>:<descriptor>`, referenced classes by
+  // internal name. Array references contribute their element class; primitives contribute
+  // nothing; references into the content itself are excluded.
+  def references(content: List[(TreePath, Data)]): List[Text] =
+    val own = scala.collection.mutable.HashSet[String]()
+    val found = scala.collection.mutable.SortedSet[String]()
+    val models = scala.collection.mutable.ListBuffer[jlc.ClassModel]()
+
+    content.stdlib.foreach: (path, data) =>
+      if path.text.s.endsWith(".class") || path.text.s.endsWith(".sig") then
+        val model = jlc.ClassFile.of().nn.parse(Array.unsafeJvm(data)).nn
+        models += model
+        own += model.thisClass.nn.asInternalName.nn
+
+    def classOf(internal: String): Optional[String] =
+      val element = internal.dropWhile(_ == '[')
+
+      if element.length == internal.length then internal
+      else if element.startsWith("L") && element.endsWith(";")
+      then element.substring(1, element.length - 1).nn
+      else Unset
+
+    models.foreach: model =>
+      model.constantPool.nn.asScala.foreach:
+        case entry: jlcc.ClassEntry =>
+          classOf(entry.asInternalName.nn).let: name =>
+            if !own.contains(name) then found += name
+
+        case entry: jlcc.MemberRefEntry =>
+          val owner = entry.owner.nn.asInternalName.nn
+
+          if classOf(owner).let { name => !own.contains(name) }.or(false) then
+            val name = entry.name.nn.stringValue.nn
+            val descriptor = entry.`type`.nn.stringValue.nn
+
+            val separator = entry match
+              case _: jlcc.FieldRefEntry => "."
+              case _                     => "#"
+
+            found += s"$owner$separator$name:$descriptor"
+
+        case _ => ()
+
+    List.from(found.toList.map(_.tt))
+
+  // Splits reference keys against a contract's atom listing: the value hashes of the matched
+  // keys — the used-set — and the keys the listing does not carry.
+  def resolve(references: List[Text], listing: Atomization): (List[Data], List[Text]) =
+    val byKey: scala.collection.immutable.Map[Text, Data] =
+      listing.atoms.stdlib.map { atom => atom.key -> atom.valueHash }.toMap
+
+    val matched = scala.collection.mutable.ListBuffer[Data]()
+    val unmatched = scala.collection.mutable.ListBuffer[Text]()
+
+    references.stdlib.foreach: key =>
+      byKey.get(key) match
+        case scala.Some(hash) => matched += hash
+        case _                => unmatched += key
+
+    (List.from(matched.toList), List.from(unmatched.toList))
+
+  // The Uses metadata blob for one module's use of one contract (§13.4, §14): the resolved
+  // used-set, encoded for a `requires` or `dependency` record's `uses` field, with the
+  // unmatched keys alongside for the caller's judgement.
+  def uses(module: Text, content: List[(TreePath, Data)], listing: Atomization)
+  :   (Data, List[Text]) =
+
+    val (matched, unmatched) = resolve(references(content), listing)
+    (UsesBlob.encode(module, matched), unmatched)

--- a/lib/mandible/src/lira/soundness_mandible_lira.scala
+++ b/lib/mandible/src/lira/soundness_mandible_lira.scala
@@ -33,4 +33,4 @@
 package soundness
 
 export mandible.{ClassfileAtomizer, ClassfileDiscipline, CtSym, HostArchive, HostContracts,
-    HostRelease, JsigDiscipline, JvmProfile}
+    HostRelease, JsigDiscipline, JvmProfile, UsedSets}

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -602,3 +602,135 @@ object Tests extends Suite(m"Mandible tests"):
           && lira.manifest.tag.stdlib == scala.List(tag)
           && lira.manifest.hostContract
     . assert(_ == true)
+
+    // --- used-set extraction ------------------------------------------------------------------
+
+    def encode(text: Text): Data = Array.unsafeFrozen(text.s.getBytes("UTF-8").nn)
+    def blob(data: Data): Data = LiraHash(LiraHash.Domain.Blob, data)
+
+    // Package-private: the source compiles in the `Holder.java` fixture slot, where a public
+    // class of another name could not.
+    val consumerOld: Text =
+      t"""|package fixture;
+          |class Consumer {
+          |  public int use(Base b) { return b.inherited(); }
+          |}
+          |""".s.stripMargin.tt
+
+    def consumerContent(baseSource: Text, consumer: Text): List[(TreePath, Data)] =
+      val (content, _) = compile(baseSource, derived, api, consumer)
+      List.from(content.filter { pair => pair(0).text.s.contains("Consumer") })
+
+    test(m"references spell membership keys and exclude the content's own classes"):
+      val refs = UsedSets.references(consumerContent(base, consumerOld))
+
+      (refs.stdlib.contains(t"fixture/Base#inherited:()I"),
+       refs.stdlib.contains(t"java/lang/Object"),
+       refs.stdlib.exists(_.s.startsWith("fixture/Consumer")))
+    . assert(_ == (true, true, false))
+
+    test(m"resolution splits a contract's atoms from foreign references"):
+      val (surface, _) = compile(base, derived, api)
+      val listing = JsigDiscipline.atomize(surface, Discipline.Context(t"host"))
+      val (matched, unmatched) = UsedSets.resolve(
+          UsedSets.references(consumerContent(base, consumerOld)), listing)
+
+      (matched.stdlib.nonEmpty,
+       unmatched.stdlib.contains(t"java/lang/Object"),
+       unmatched.stdlib.exists(_.s.startsWith("fixture/Base")))
+    . assert(_ == (true, true, false))
+
+    test(m"the uses blob round-trips its resolved hashes"):
+      val (surface, _) = compile(base, derived, api)
+      val listing = JsigDiscipline.atomize(surface, Discipline.Context(t"host"))
+      val content = consumerContent(base, consumerOld)
+      val (usesBlob, _) = UsedSets.uses(t"fixture-host", content, listing)
+      val (matched, _) = UsedSets.resolve(UsedSets.references(content), listing)
+
+      UsesBlob.decode(usesBlob)(1).stdlib.map { hash => LiraHash.text(hash) }.toSet
+      == matched.stdlib.map { hash => LiraHash.text(hash) }.toSet
+    . assert(identity)
+
+    test(m"a computed used-set decides host satisfaction by spanning"):
+      val added = edit(base, t"public int inherited",
+          t"public int added() { return 9; }\n  public int inherited")
+
+      val consumerNew = consumerOld.s.replace("b.inherited()", "b.added()").nn.tt
+
+      val (v1, _) = compile(base, derived, api)
+      val (v2, _) = compile(added, derived, api)
+
+      val contracts = HostContracts.assemble(t"fixture-host",
+        List(HostRelease(t"v1", v1), HostRelease(t"v2", v2)),
+        List(LiraManifest.Tool(t"jsig-harvest", t"0.1")))
+
+      val v1Manifest = Lira.read(contracts.stdlib.head(1)).manifest
+      val v2Manifest = Lira.read(contracts.stdlib.last(1)).manifest
+
+      val v1Listing = JsigDiscipline.atomize(v1, Discipline.Context(t"host"))
+      val v2Listing = JsigDiscipline.atomize(v2, Discipline.Context(t"host"))
+
+      // Both consumers compiled against, and resolved against, the v2 surface; the question is
+      // whether the *older* contract release satisfies each, and only their used-sets differ.
+      val snap2 = v2Manifest.lineage.stdlib.last
+      val markerOld = blob(encode(t"uses-old"))
+      val markerNew = blob(encode(t"uses-new"))
+
+      def library(marker: Data): LiraManifest =
+        LiraManifest(
+          module  = t"consumer",
+          lineage = List(LiraHash(LiraHash.Domain.Snapshot, encode(t"consumer"))),
+          api     = List(),
+          section = List(Section(t"jvm", tree = blob(encode(t"tree")),
+              requires = List(LiraManifest.Requires(t"fixture-host", snap2, uses = marker)))),
+          payload = LiraManifest.Payload(t"brotli", 0L, blob(encode(t"consumer"))))
+
+      def usedSet(consumer: Text): scala.collection.immutable.Set[Text] =
+        val (matched, _) = UsedSets.resolve(
+            UsedSets.references(consumerContent(added, consumer)), v2Listing)
+
+        matched.stdlib.map { hash => LiraHash.text(hash) }.toSet
+
+      val oldUses = usedSet(consumerOld)
+      val newUses = usedSet(consumerNew)
+
+      val contractAtoms = { (module: Text) =>
+        if module == t"fixture-host"
+        then v1Listing.atoms.stdlib.map { atom => LiraHash.text(atom.valueHash) }.toSet
+        else Unset
+      }
+
+      def lookup(marker: Data, set: scala.collection.immutable.Set[Text]) =
+        { (data: Data) => if Blob.compare(data, marker) == 0 then set else Unset }
+
+      // The old-surface consumer spans back to v1 by set inclusion; the one that calls the
+      // v2-only method provably does not.
+      val spans =
+        Buildpath(List(library(markerOld)))
+        . validate(t"jvm", contracts = List(v1Manifest), atoms = contractAtoms,
+            used = lookup(markerOld, oldUses))
+        . stdlib.isEmpty
+
+      import errorDiagnostics.stackTracesDiagnostics
+
+      val refused =
+        capture[LiraError]:
+          Buildpath(List(library(markerNew)))
+          . validate(t"jvm", contracts = List(v1Manifest), atoms = contractAtoms,
+              used = lookup(markerNew, newUses))
+        . reason
+
+      (spans, refused)
+    . assert(_ == (true, LiraError.Reason.UnsatisfiedRequirement(t"fixture-host")))
+
+    test(m"fixture references resolve against a harvested jdk surface"):
+      CtSym.location().lay(true): path =>
+        val release = CtSym.releases(path).stdlib.head
+        val surface = CtSym.surface(path, release, prefix = t"java.base/java/lang/")
+        val listing = JsigDiscipline.atomize(surface, Discipline.Context(t"host"))
+
+        val (matched, unmatched) = UsedSets.resolve(
+            UsedSets.references(consumerContent(base, consumerOld)), listing)
+
+        matched.stdlib.nonEmpty && !unmatched.stdlib.contains(t"java/lang/Object")
+    . assert(_ == true)


### PR DESCRIPTION
The last piece of the host-compatibility pipeline: `UsedSets` extracts what a body of compiled
classes actually depends on and resolves it into the Uses blob a `requires` record attaches —
so with the harvested contracts of #1732, whether a library runs on a given host is decided by
set inclusion through buildpath rule 7 rather than declared.

## Release notes

- **`UsedSets.references`** reads a classfile set's outward constant-pool references — `Class`,
  `Methodref`, `Fieldref`, `InterfaceMethodref` — which spell membership keys by construction
  (a JVM reference names its receiver, exactly as `classfile.md` §6 keys atoms), excluding
  references into the content itself.
- **`UsedSets.resolve`** splits those keys against a contract release's atom listing into the
  used-set (value hashes) and the unmatched remainder (references to buildpath dependencies,
  whose own used-sets cover their platform use transitively — returned, never silently
  dropped).
- **`UsedSets.uses`** emits the Uses metadata blob for the `uses` field of a `requires` or
  `dependency` record.
- The test suite closes the loop end-to-end: two consumers compiled against one surface, where
  the computed used-sets alone decide that the one using only old surface **spans** back to the
  older contract release (hosts.md §7) while the one calling the newer method is refused with
  L136 — and fixture references resolve against a real surface harvested from `ct.sym`.
- Documented boundary: a platform member reached through a non-platform receiver is the
  receiver module's use, recorded when that module is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
