### PR TITLE
Confined indexing: safe combinators for the `while`-loop corpus

### DIFF
--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -43,7 +43,8 @@ import rudiments.*
 import spectacular.*
 import turbulence.*
 import urticose.MacAddress
-import zephyrine.{Stream, Credit, Buffering, Substrate, capped, stream}
+import denominative.capped
+import zephyrine.{Stream, Credit, Buffering, Substrate, stream}
 import vacuous.*
 
 import Control.*

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -42,7 +42,7 @@ import java.net as jn
 import java.nio.channels as jnc
 
 import soundness.{transmit as _, listen as _, react as _, duplex as _, *}
-import zephyrine.capped
+import denominative.capped
 
 import charEncoders.utf8Encoder
 import charDecoders.utf8Decoder

--- a/lib/denominative/src/core/denominative_core.scala
+++ b/lib/denominative/src/core/denominative_core.scala
@@ -54,6 +54,12 @@ extension [populable: Vacuiscible](value: populable)
 extension [countable: Countable](value: countable)
   inline def gamut: Interval = Interval.initial(countable.size(value))
 
+  // The whole extent as a branded interval: `gamut`, confined to this value. Sound for
+  // immutable receivers on stable paths, like `within` and `confine`; a mutable countable
+  // that shrinks after the brand is minted invalidates it.
+  inline def extent: Interval in value.type =
+    Interval.initial(countable.size(value)).asInstanceOf[Interval in value.type]
+
   inline def iterate(inline lambda: (Ordinal in value.type) => Unit): Unit =
     var index: Int = 0
 

--- a/lib/denominative/src/core/denominative_core.scala
+++ b/lib/denominative/src/core/denominative_core.scala
@@ -34,6 +34,7 @@ package denominative
 
 import anticipation.*
 import prepositional.*
+import vacuous.*
 
 final val Prim: Ordinal = Ordinal.zerary(0)
 final val Sec: Ordinal  = Ordinal.zerary(1)
@@ -59,6 +60,82 @@ extension [countable: Countable](value: countable)
     while index < countable.size(value) do
       lambda(Ordinal.zerary(index).asInstanceOf[Ordinal in value.type])
       index += 1
+
+  // As `iterate`, over a branded sub-interval: a sub-interval of a valid extent is itself
+  // valid, so its ordinals share the brand.
+  inline def iterate(range: Interval in value.type)
+    ( inline lambda: (Ordinal in value.type) => Unit )
+  :   Unit =
+
+    val interval: Interval = range
+    var index: Int = interval.start.n0
+    val end: Int = interval.limit.n0
+
+    while index < end do
+      lambda(Ordinal.zerary(index).asInstanceOf[Ordinal in value.type])
+      index += 1
+
+  // The first index satisfying the predicate, confined to this value, or `Unset`: the safe
+  // form of a guarded forward scan whose caller consumes the stopping index.
+  inline def spot(inline predicate: (Ordinal in value.type) => Boolean)
+  :   Optional[Ordinal in value.type] =
+
+    var index: Int = 0
+    val size: Int = countable.size(value)
+    var found: Int = -1
+
+    while found < 0 && index < size do
+      if predicate(Ordinal.zerary(index).asInstanceOf[Ordinal in value.type]) then found = index
+      else index += 1
+
+    if found < 0 then Unset else Ordinal.zerary(found).asInstanceOf[Ordinal in value.type]
+
+  // The longest prefix whose every index satisfies the predicate, as a branded interval —
+  // possibly empty, possibly the whole extent. Its `limit` is the stopping index, so
+  // `value.lead(...)` replaces `while i < size && p(i) do i += 1` loops whose callers then
+  // slice or resume from `i`.
+  inline def lead(inline predicate: (Ordinal in value.type) => Boolean)
+  :   Interval in value.type =
+
+    var index: Int = 0
+    val size: Int = countable.size(value)
+
+    while index < size
+      && predicate(Ordinal.zerary(index).asInstanceOf[Ordinal in value.type])
+    do index += 1
+
+    Interval.zerary(0, index).asInstanceOf[Interval in value.type]
+
+  // The interval remaining after dropping the longest suffix whose indexes satisfy the
+  // predicate, never shrinking below `floor` elements: the trailing-trim shape
+  // (`while count > 1 && result(count - 1) == 0 do count -= 1` becomes `pare(1)(...)`).
+  inline def pare(inline floor: Int)(inline predicate: (Ordinal in value.type) => Boolean)
+  :   Interval in value.type =
+
+    var count: Int = countable.size(value)
+    val least: Int = floor.max(0)
+
+    while count > least
+      && predicate(Ordinal.zerary(count - 1).asInstanceOf[Ordinal in value.type])
+    do count -= 1
+
+    Interval.zerary(0, count).asInstanceOf[Interval in value.type]
+
+  // As `iterate`, in reverse: from the last index down to the first.
+  inline def retrace(inline lambda: (Ordinal in value.type) => Unit): Unit =
+    var index: Int = countable.size(value) - 1
+
+    while index >= 0 do
+      lambda(Ordinal.zerary(index).asInstanceOf[Ordinal in value.type])
+      index -= 1
+
+
+// Brand-preserving narrowing: a sub-interval of a valid extent is itself valid, so clamping
+// preserves the brand. `capped` keeps at most the first `count` indexes of the extent.
+extension [form](range: Interval in form)
+  inline def capped(count: Int): Interval in form =
+    val interval: Interval = range
+    Interval.sized(interval.start.n0, interval.size.min(count.max(0))).asInstanceOf[Interval in form]
 
 export denominative.internal.{Ordinal, Interval, Span}
 

--- a/lib/denominative/src/core/soundness_denominative_core.scala
+++ b/lib/denominative/src/core/soundness_denominative_core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export
   denominative
-  . { aka, capped, Countable, Vacuiscible, Indexable, gamut, Interval, iterate, lead, nil, Ordinal, pare, Prim,
+  . { aka, capped, Countable, Vacuiscible, Indexable, gamut, Interval, extent, iterate, lead, nil, Ordinal, pare, Prim,
       Quat, Quin, retrace, Sec, Sen, Sept, Span, spot, Ter, u, z, Zerary, limit, ult, ant, pen,
       LinearSizeComplexity, LinearAccessComplexity, UnboundedSizeComplexity }
 

--- a/lib/denominative/src/core/soundness_denominative_core.scala
+++ b/lib/denominative/src/core/soundness_denominative_core.scala
@@ -34,9 +34,9 @@ package soundness
 
 export
   denominative
-  . { aka, Countable, Vacuiscible, Indexable, gamut, Interval, iterate, nil, Ordinal, Prim, Quat, Quin, Sec,
-      Sen, Sept, Span, Ter, u, z, Zerary, limit, ult, ant, pen, LinearSizeComplexity, LinearAccessComplexity,
-      UnboundedSizeComplexity }
+  . { aka, capped, Countable, Vacuiscible, Indexable, gamut, Interval, iterate, lead, nil, Ordinal, pare, Prim,
+      Quat, Quin, retrace, Sec, Sen, Sept, Span, spot, Ter, u, z, Zerary, limit, ult, ant, pen,
+      LinearSizeComplexity, LinearAccessComplexity, UnboundedSizeComplexity }
 
 package asymptotics:
   export denominative.asymptotics.{linearSizeComplexity, linearAccessComplexity,

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -101,17 +101,12 @@ object Teletype:
     def fromChar(char: Char): Char = char
 
     def map(text: Teletype)(lambda: Char => Char): Teletype =
-      val plain = text.plain.s
-      val array = Array[Char](plain.length)
-      plain.getChars(0, plain.length, array.raw, 0)
-      var index = 0
-
-      while index < plain.length do
-        array(index) = lambda(array(index))
-        index += 1
+      val plain = text.plain
+      val array = Array.scribe[Char](plain.length): scribe =>
+        _ => plain.iterate { index => scribe.append(lambda(plain.at(index))) }
 
       Teletype
-        ( new String(array.raw).tt,
+        ( new String(Array.unsafeJvm(array)).tt,
           text.styles,
           text.hyperlinks,
           text.insertions,
@@ -181,36 +176,43 @@ object Teletype:
     if n == 0
     then (Array.of(if denseStyles.length > 0 then denseStyles(0) else 0L), Array.empty[Int])
     else
-      // Count runs
+      // Count runs, tracking the previous style rather than reading `i - 1` again: the
+      // confined scan visits each index once.
       var runs = 1
-      var i = 1
+      var previous: Long = denseStyles.at(Prim).or(0L)
 
-      while i < n do
-        if denseStyles(i) != denseStyles(i - 1) then runs += 1
-        i += 1
+      denseStyles.iterate(denseStyles.extent.capped(n)): index =>
+        val style = denseStyles.at(index)
+        if style != previous then runs += 1
+        previous = style
 
       if runs * SparseThreshold > n then
         // Keep dense
         (denseStyles, Array.empty[Int])
       else
-        // Convert to sparse
-        val newStyles = Array[Long](runs + 1)
-        val newBoundaries = Array[Int](runs)
-        newBoundaries(0) = 0
-        newStyles(0) = denseStyles(0)
-        var src = 1
-        var dst = 1
+        // Convert to sparse: sequential appends track the irregular write position.
+        var newBoundaries: Array[Int]^{} = Array.empty[Int]
 
-        while src < n do
-          if denseStyles(src) != denseStyles(src - 1) then
-            newBoundaries(dst) = src
-            newStyles(dst) = denseStyles(src)
-            dst += 1
+        val newStyles = Array.scribe[Long](runs + 1): styleScribe =>
+          _ =>
+            newBoundaries = Array.scribe[Int](runs): boundaryScribe =>
+              _ =>
+                boundaryScribe.append(0)
+                previous = denseStyles.at(Prim).or(0L)
+                styleScribe.append(previous)
 
-          src += 1
+                denseStyles.iterate(denseStyles.extent.capped(n)): index =>
+                  val style = denseStyles.at(index)
 
-        newStyles(runs) = denseStyles(n)  // trailing
-        (Array.freeze(newStyles), Array.freeze(newBoundaries))
+                  if style != previous then
+                    boundaryScribe.append((index: Ordinal).n0)
+                    styleScribe.append(style)
+
+                  previous = style
+
+                styleScribe.append(denseStyles.at(Ordinal.zerary(n)).or(0L))  // trailing
+
+        (newStyles, newBoundaries)
 
 
 // `boundaries` is the run-start array for the sparse form; empty for the dense form.
@@ -229,20 +231,26 @@ case class Teletype
 
   inline def isDense: Boolean = boundaries.length == 0
 
+  // The run-lookup binary search shared by `styleAt`, `dropChars` and `takeChars`: the
+  // greatest `lo` in [0, boundaries.length) whose boundary is `<= position` (`< position`
+  // when `strict`). Each probe is bounds-checked: log₂ n checks on a cold path, and the
+  // default is unreachable because `mid` always lies strictly between `lo` and `hi`.
+  private def searchRun(position: Int, strict: Boolean): Int =
+    var lo = 0
+    var hi = boundaries.length
+
+    while lo + 1 < hi do
+      val mid = (lo + hi) >>> 1
+      val boundary = boundaries.at(Ordinal.zerary(mid)).or(Int.MaxValue)
+      if (if strict then boundary < position else boundary <= position) then lo = mid else hi = mid
+
+    lo
+
   // Style at position p (0 ≤ p ≤ plain.length, where length means "trailing").
   def styleAt(p: Int): Long =
     if isDense then styles(p)
     else if p >= plain.length then styles(boundaries.length)
-    else
-      // Binary search for the run that contains p.
-      var lo = 0
-      var hi = boundaries.length
-
-      while lo + 1 < hi do
-        val mid = (lo + hi) >>> 1
-        if boundaries(mid) <= p then lo = mid else hi = mid
-
-      styles(lo)
+    else styles(searchRun(p, strict = false))
 
   // Trailing style (the style after the last char; used for joins).
   inline def trailingStyle: Long =
@@ -255,31 +263,37 @@ case class Teletype
     else if plain.length == 0 then (Array.of(if styles.length > 0 then styles(0) else 0L), Array.of(0))
     else
       val n = plain.length
-      // Count runs
+      // Count runs, tracking the previous style; see `compressIfBeneficial`.
       var runs = 1
-      var i = 1
+      var previous: Long = styles.at(Prim).or(0L)
 
-      while i < n do
-        if styles(i) != styles(i - 1) then runs += 1
-        i += 1
+      styles.iterate(styles.extent.capped(n)): index =>
+        val style = styles.at(index)
+        if style != previous then runs += 1
+        previous = style
 
-      val newStyles = Array[Long](runs + 1)
-      val newBoundaries = Array[Int](runs)
-      newBoundaries(0) = 0
-      newStyles(0) = styles(0)
-      var src = 1
-      var dst = 1
+      var newBoundaries: Array[Int]^{} = Array.empty[Int]
 
-      while src < n do
-        if styles(src) != styles(src - 1) then
-          newBoundaries(dst) = src
-          newStyles(dst) = styles(src)
-          dst += 1
+      val newStyles = Array.scribe[Long](runs + 1): styleScribe =>
+        _ =>
+          newBoundaries = Array.scribe[Int](runs): boundaryScribe =>
+            _ =>
+              boundaryScribe.append(0)
+              previous = styles.at(Prim).or(0L)
+              styleScribe.append(previous)
 
-        src += 1
+              styles.iterate(styles.extent.capped(n)): index =>
+                val style = styles.at(index)
 
-      newStyles(runs) = styles(n)
-      (Array.freeze(newStyles), Array.freeze(newBoundaries))
+                if style != previous then
+                  boundaryScribe.append((index: Ordinal).n0)
+                  styleScribe.append(style)
+
+                previous = style
+
+              styleScribe.append(styles.at(Ordinal.zerary(n)).or(0L))
+
+      (newStyles, newBoundaries)
 
   def explicit: Text = Text:
     render(termcapDefinitions.xtermTrueColorTermcap).s.flatMap: char =>
@@ -293,18 +307,13 @@ case class Teletype
       if isDense then
         // Stay dense: extend styles array with the trailing style
         val newLength = plain.length + text.length + 1
-        val arr = Array[Long](newLength)
-        var i = 0
 
-        while i < plain.length do
-          arr(i) = styles(i)
-          i += 1
+        // For indexes within the old array this reads the old style (the old trailing style
+        // at `plain.length` equals `tail`); beyond it, the default IS the extension.
+        val arr = Array.scribe[Long](newLength): scribe =>
+          _ => scribe.iterate { i => scribe(i) = styles.at(i).or(tail) }
 
-        while i < newLength do
-          arr(i) = tail
-          i += 1
-
-        Teletype(combinedPlain, Array.freeze(arr), hyperlinks, insertions, Array.empty[Int])
+        Teletype(combinedPlain, arr, hyperlinks, insertions, Array.empty[Int])
       else
         // Stay sparse: the new chars become part of the last run (since trailing style = last run
         // style) unless the last run's style differs from the trailing style — but that can't
@@ -408,16 +417,12 @@ case class Teletype
           insertions.collect { case (k, v) if k >= n => (k - n) -> v }.to(TreeMap)
 
         if isDense then
-          val arr = Array[Long](keepLength + 1)
-          var i = 0
-
-          while i <= keepLength do
-            arr(i) = styles(n + i)
-            i += 1
+          val arr = Array.scribe[Long](keepLength + 1): scribe =>
+            _ => scribe.iterate { i => scribe(i) = styles.at(Ordinal.zerary(n + (i: Ordinal).n0)).or(0L) }
 
           Teletype
             ( plain.skip(n),
-              Array.freeze(arr),
+              arr,
               newHyperlinks,
               newInsertions,
               Array.empty[Int] )
@@ -425,35 +430,26 @@ case class Teletype
           // Sparse: find the run that contains position n; drop earlier runs;
           // adjust the first kept run's boundary to 0; shift all other boundaries by -n.
           val k = boundaries.length
-          // Binary search for the run at position n
-          var lo = 0
-          var hi = k
-
-          while lo + 1 < hi do
-            val mid = (lo + hi) >>> 1
-            if boundaries(mid) <= n then lo = mid else hi = mid
-
-          val firstRun = lo
+          val firstRun = searchRun(n, strict = false)
           val newK = k - firstRun
-          val newBoundariesArr = Array[Int](newK)
-          val newStylesArr = Array[Long](newK + 1)
-          newBoundariesArr(0) = 0
-          newStylesArr(0) = styles(firstRun)
-          var i = 1
 
-          while i < newK do
-            newBoundariesArr(i) = boundaries(firstRun + i) - n
-            newStylesArr(i) = styles(firstRun + i)
-            i += 1
+          val newBoundariesArr = Array.scribe[Int](newK): scribe =>
+            _ =>
+              scribe.append(0)
 
-          newStylesArr(newK) = styles(k)
+              scribe.iterate: i =>
+                if (i: Ordinal) != Prim then
+                  scribe(i) = boundaries.at(Ordinal.zerary(firstRun + (i: Ordinal).n0)).or(0) - n
+
+          val newStylesArr = Array.scribe[Long](newK + 1): scribe =>
+            _ => scribe.iterate { i => scribe(i) = styles.at(Ordinal.zerary(firstRun + (i: Ordinal).n0)).or(0L) }
 
           Teletype
             ( plain.skip(n),
-              Array.freeze(newStylesArr),
+              newStylesArr,
               newHyperlinks,
               newInsertions,
-              Array.freeze(newBoundariesArr) )
+              newBoundariesArr )
 
   def takeChars(n: Int, dir: Bidi = Ltr): Teletype = dir match
     case Rtl => dropChars(plain.length - n)
@@ -466,51 +462,32 @@ case class Teletype
         val newInsertions = insertions.rangeUntil(n)
 
         if isDense then
-          val arr = Array[Long](n + 1)
-          var i = 0
-
-          while i < n do
-            arr(i) = styles(i)
-            i += 1
-
-          arr(n) = 0L
+          val arr = Array.scribe[Long](n + 1): scribe =>
+            _ => scribe.iterate { i => scribe(i) = if (i: Ordinal).n0 == n then 0L else styles.at(i).or(0L) }
 
           Teletype
             ( plain.keep(n),
-              Array.freeze(arr),
+              arr,
               newHyperlinks,
               newInsertions,
               Array.empty[Int] )
         else
           // Sparse: keep runs whose start is < n; trim the last kept run; trailing style = 0L.
-          val k = boundaries.length
-          // Binary search for the last run whose start is < n
-          var lo = 0
-          var hi = k
-
-          while lo + 1 < hi do
-            val mid = (lo + hi) >>> 1
-            if boundaries(mid) < n then lo = mid else hi = mid
-
-          val lastRun = lo
+          val lastRun = searchRun(n, strict = true)
           val newK = lastRun + 1
-          val newBoundariesArr = Array[Int](newK)
-          val newStylesArr = Array[Long](newK + 1)
-          var i = 0
 
-          while i < newK do
-            newBoundariesArr(i) = boundaries(i)
-            newStylesArr(i) = styles(i)
-            i += 1
+          val newBoundariesArr = Array.scribe[Int](newK): scribe =>
+            _ => scribe.iterate { i => scribe(i) = boundaries.at(i).or(0) }
 
-          newStylesArr(newK) = 0L
+          val newStylesArr = Array.scribe[Long](newK + 1): scribe =>
+            _ => scribe.iterate { i => scribe(i) = if (i: Ordinal).n0 == newK then 0L else styles.at(i).or(0L) }
 
           Teletype
             ( plain.keep(n),
-              Array.freeze(newStylesArr),
+              newStylesArr,
               newHyperlinks,
               newInsertions,
-              Array.freeze(newBoundariesArr) )
+              newBoundariesArr )
 
   def render(termcap: Termcap): Text =
     if !termcap.ansi then plain else

--- a/lib/facsimile/src/core/facsimile.Ascii85.scala
+++ b/lib/facsimile/src/core/facsimile.Ascii85.scala
@@ -36,6 +36,7 @@ import proscenium.compat.*
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import gossamer.*
 import rudiments.*
 import vacuous.*
@@ -49,7 +50,6 @@ private[facsimile] object Ascii85:
     val group = new scala.Array[Int](5)
     var members = 0
     var done = false
-    var i = 0
 
     def emit(count: Int): Unit =
       var value = 0L
@@ -65,26 +65,27 @@ private[facsimile] object Ascii85:
         bytes += ((value >> shift) & 0xff).toByte
         shift -= 8
 
-    while i < data.length && !done do
-      val byte = data(i) & 0xff
-      i += 1
+    data.survey: surveyor =>
+      while !done && surveyor.more do
+        surveyor.next(()): element =>
+          val byte = element & 0xff
 
-      if byte == '~' then
-        done = true
-      else if byte == 'z' && members == 0 then
-        bytes += 0
-        bytes += 0
-        bytes += 0
-        bytes += 0
-      else if byte >= '!' && byte <= 'u' then
-        group(members) = byte - '!'
-        members += 1
+          if byte == '~' then
+            done = true
+          else if byte == 'z' && members == 0 then
+            bytes += 0
+            bytes += 0
+            bytes += 0
+            bytes += 0
+          else if byte >= '!' && byte <= 'u' then
+            group(members) = byte - '!'
+            members += 1
 
-        if members == 5 then
-          emit(5)
-          members = 0
-      else if !CosLexer.whitespace(byte) then
-        abort(PdfError(PdfError.Reason.CorruptStream(t"ASCII85Decode")))
+            if members == 5 then
+              emit(5)
+              members = 0
+          else if !CosLexer.whitespace(byte) then
+            abort(PdfError(PdfError.Reason.CorruptStream(t"ASCII85Decode")))
 
     if members == 1 then abort(PdfError(PdfError.Reason.CorruptStream(t"ASCII85Decode")))
     if members > 1 then emit(members)

--- a/lib/facsimile/src/core/facsimile.Filter.scala
+++ b/lib/facsimile/src/core/facsimile.Filter.scala
@@ -36,6 +36,7 @@ import proscenium.compat.*
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import gossamer.*
 import rudiments.*
 import pneumatic.*
@@ -209,21 +210,21 @@ private[facsimile] object Filter:
     val bytes = DataBuilder()
     var high = -1
     var done = false
-    var i = 0
 
-    while i < data.length && !done do
-      val byte = data(i) & 0xff
-      i += 1
+    data.survey: surveyor =>
+      while !done && surveyor.more do
+        surveyor.next(()): element =>
+          val byte = element & 0xff
 
-      if byte == '>' then done = true
-      else if !CosLexer.whitespace(byte) then
-        val value = CosLexer.hexadecimal(byte)
+          if byte == '>' then done = true
+          else if !CosLexer.whitespace(byte) then
+            val value = CosLexer.hexadecimal(byte)
 
-        if value < 0 then abort(PdfError(PdfError.Reason.CorruptStream(t"ASCIIHexDecode")))
-        else if high < 0 then high = value
-        else
-          bytes += ((high << 4) + value).toByte
-          high = -1
+            if value < 0 then abort(PdfError(PdfError.Reason.CorruptStream(t"ASCIIHexDecode")))
+            else if high < 0 then high = value
+            else
+              bytes += ((high << 4) + value).toByte
+              high = -1
 
     if high >= 0 then bytes += (high << 4).toByte
     bytes.result()
@@ -231,33 +232,30 @@ private[facsimile] object Filter:
   private def runLength(data: Data)(using Tactic[PdfError]): Data =
     val bytes = DataBuilder()
     var done = false
-    var i = 0
 
-    while i < data.length && !done do
-      val length = data(i) & 0xff
-      i += 1
+    data.survey: surveyor =>
+      while !done && surveyor.more do
+        surveyor.next(()): element =>
+          val length = element & 0xff
 
-      if length == 128 then done = true
-      else if length < 128 then
-        if i + length + 1 > data.length
-        then abort(PdfError(PdfError.Reason.CorruptStream(t"RunLengthDecode")))
+          if length == 128 then done = true
+          else if length < 128 then
+            // A literal run of `length + 1` bytes: `take` clamps at exhaustion, so a short
+            // read means the stream is corrupt.
+            val run = surveyor.take(length + 1)
 
-        var j = 0
+            if (run: Interval).size <= length
+            then abort(PdfError(PdfError.Reason.CorruptStream(t"RunLengthDecode")))
 
-        while j <= length do
-          bytes += data(i + j)
-          j += 1
+            data.iterate(run) { index => bytes += data.at(index) }
+          else
+            // One byte, repeated `257 - length` times.
+            surveyor.next(abort(PdfError(PdfError.Reason.CorruptStream(t"RunLengthDecode")))):
+              byte =>
+                var j = 0
 
-        i += length + 1
-      else
-        if i >= data.length then abort(PdfError(PdfError.Reason.CorruptStream(t"RunLengthDecode")))
-
-        var j = 0
-
-        while j < 257 - length do
-          bytes += data(i)
-          j += 1
-
-        i += 1
+                while j < 257 - length do
+                  bytes += byte
+                  j += 1
 
     bytes.result()

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -697,7 +697,7 @@ extends caps.ExclusiveCapability:
     val window = source.read(position, 24)
 
     window.survey: surveyor =>
-      surveyor.skipWhile { byte => CosLexer.whitespace(byte & 0xff) }
+      surveyor.pace { byte => CosLexer.whitespace(byte & 0xff) }
       surveyor.matches(marker) { (byte, char) => (byte & 0xff) == char.toInt }
 
   // Resolves a value and, one level down, the elements of an array or the values of a

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -132,16 +132,20 @@ object Pdf:
     def digit(byte: Int): Boolean = byte >= '0' && byte <= '9'
 
     var found: Optional[Version] = Unset
-    var i = 0
 
-    while found.absent && i <= window.length - 8 do
-      var j = 0
-      while j < marker.length && (window(i + j) & 0xff) == marker.s.charAt(j).toInt do j += 1
+    window.survey: surveyor =>
+      while found.absent && surveyor.glimpse(8).present do
+        if surveyor.matches(marker) { (byte, char) => (byte & 0xff) == char.toInt } then
+          surveyor.glimpse(8).let: eight =>
+            val start = (eight: Interval).start.n0
+            val major = window.at(Ordinal.zerary(start + 5)).lay(-1)(_ & 0xff)
+            val dot = window.at(Ordinal.zerary(start + 6)).lay(-1)(_ & 0xff)
+            val minor = window.at(Ordinal.zerary(start + 7)).lay(-1)(_ & 0xff)
 
-      if j == marker.length && digit(window(i + 5) & 0xff) &&
-        (window(i + 6) & 0xff) == '.' && digit(window(i + 7) & 0xff)
-      then found = Version((window(i + 5) & 0xff) - '0', (window(i + 7) & 0xff) - '0')
-      else i += 1
+            if digit(major) && dot == '.' && digit(minor)
+            then found = Version(major - '0', minor - '0')
+
+        if found.absent then surveyor.advance()
 
     found.or(abort(PdfError(PdfError.Reason.NotPdf)))
 
@@ -666,12 +670,12 @@ extends caps.ExclusiveCapability:
 
         while found.absent && offset < source.size do
           val chunk = source.read(offset, chunkSize + marker.length - 1)
-          var i = 0
 
-          while found.absent && i <= chunk.length - marker.length do
-            var j = 0
-            while j < marker.length && (chunk(i + j) & 0xff) == marker.s.charAt(j).toInt do j += 1
-            if j == marker.length then found = offset + i else i += 1
+          chunk.survey: surveyor =>
+            while found.absent && surveyor.glimpse(marker.length).present do
+              if surveyor.matches(marker) { (byte, char) => (byte & 0xff) == char.toInt }
+              then found = offset + surveyor.passed
+              else surveyor.advance()
 
           offset += chunkSize
 
@@ -691,14 +695,10 @@ extends caps.ExclusiveCapability:
   private def endstreamFollows(position: Long): Boolean =
     val marker = t"endstream"
     val window = source.read(position, 24)
-    var i = 0
 
-    while i < window.length && CosLexer.whitespace(window(i) & 0xff) do i += 1
-
-    if i + marker.length > window.length then false else
-      var j = 0
-      while j < marker.length && (window(i + j) & 0xff) == marker.s.charAt(j).toInt do j += 1
-      j == marker.length
+    window.survey: surveyor =>
+      surveyor.skipWhile { byte => CosLexer.whitespace(byte & 0xff) }
+      surveyor.matches(marker) { (byte, char) => (byte & 0xff) == char.toInt }
 
   // Resolves a value and, one level down, the elements of an array or the values of a
   // dictionary: sufficient for `/Filter` and `/DecodeParms` shapes.

--- a/lib/gossamer/src/core/gossamer.Writing.scala
+++ b/lib/gossamer/src/core/gossamer.Writing.scala
@@ -42,6 +42,7 @@ import scala.reflect.*
 
 import anticipation.*
 import denominative.*
+import rudiments.*
 import hieroglyph.*
 import spectacular.*
 import symbolism.*
@@ -66,12 +67,9 @@ object Writing:
     val s = writing.text.s
     val boundaries = writing.boundaries
     var total = 0
-    var i = 0
-    val n = boundaries.readable.length - 1
 
-    while i < n do
-      total += graphemeM.width(Grapheme(s.substring(boundaries.readable(i), boundaries.readable(i + 1)).nn))
-      i += 1
+    boundaries.adjacent: (start, limit) =>
+      total += graphemeM.width(Grapheme(s.substring(start, limit).nn))
 
     total
 
@@ -91,13 +89,10 @@ object Writing:
 
     def map(writing: Writing)(lambda: Grapheme => Grapheme): Writing =
       val builder = jl.StringBuilder()
-      val n = writing.boundaries.readable.length - 1
-      var i = 0
 
-      while i < n do
-        val piece = writing.text.s.substring(writing.boundaries.readable(i), writing.boundaries.readable(i + 1)).nn
+      writing.boundaries.adjacent: (start, limit) =>
+        val piece = writing.text.s.substring(start, limit).nn
         builder.append(lambda(Grapheme(piece)).text.s)
-        i += 1
 
       Writing(builder.toString.nn.tt)
 

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -100,14 +100,10 @@ extension (module: Text.type)
   def ascii(bytes: Data): Text = new String(Array.unsafeJvm(bytes), "ASCII").tt
 
   def fill(length: Int)(lambda: Int => Char): Text =
-    val buffer = Array[Char](length)
-    var index = 0
+    val buffer = Array.scribe[Char](length): scribe =>
+      _ => scribe.iterate { index => scribe(index) = lambda((index: Ordinal).n0) }
 
-    while index < length do
-      buffer(index) = lambda(index)
-      index += 1
-
-    String(buffer.raw).tt
+    String(Array.unsafeJvm(buffer)).tt
 
 extension (inline context: StringContext)
   transparent inline def txt(inline parts: Any*): Text =

--- a/lib/hallucination/src/core/hallucination.GifCodec.scala
+++ b/lib/hallucination/src/core/hallucination.GifCodec.scala
@@ -36,6 +36,9 @@ import scala.collection.mutable as scm
 import proscenium.compat.*
 
 import anticipation.*
+import denominative.*
+import rudiments.*
+import vacuous.*
 import contingency.*
 
 import Binary.*
@@ -129,41 +132,54 @@ private[hallucination] object GifCodec:
             val indices =
               GifLzw.decode(minimum, Array.unsafeFrozen(compressed.result()), pixels)
 
-            // Interlaced frames deliver their rows in four passes.
-            val rows: scala.Array[Int]^ = new scala.Array[Int](frameHeight)
+            // Interlaced frames deliver their rows in four passes: the row permutation is a
+            // pure sequence of appends.
+            val rowMap: Array[Int]^{} = Array.scribe[Int](frameHeight): scribe =>
+              _ =>
+                if interlaced then
+                  var passes = List((0, 8), (4, 8), (2, 4), (1, 2)).stdlib
 
-            if interlaced then
-              var row = 0
-              var passes = List((0, 8), (4, 8), (2, 4), (1, 2)).stdlib
+                  while passes.nonEmpty do
+                    val (start, step) = passes.head
+                    var y = start
 
-              while passes.nonEmpty do
-                val (start, step) = passes.head
-                var y = start
+                    while y < frameHeight do
+                      scribe.append(y)
+                      y += step
 
-                while y < frameHeight do
-                  rows(row) = y
-                  row += 1
-                  y += step
+                    passes = passes.tail
+                else
+                  var y = 0
 
-                passes = passes.tail
-            else
-              var y = 0
+                  while y < frameHeight do
+                    scribe.append(y)
+                    y += 1
 
-              while y < frameHeight do
-                rows(y) = y
-                y += 1
+            // Composite the frame onto the screen: both sides are lattices, so the frame's
+            // overhang beyond the screen — previously two manual guards — is `point`'s
+            // bounds check. The palette read is checked too: a malformed GIF may index
+            // beyond a small palette (as few as two entries), which previously crashed;
+            // an out-of-range entry now composites as opaque black.
+            val screenScribe = Scribe(screen)
+            val frame = Scribe(indices.asInstanceOf[scala.Array[Byte]^])
 
-            for row <- 0 until frameHeight do
-              val y = top + rows(row)
-              var x = 0
+            screenScribe.lattice(width): target =>
+              frame.lattice(frameWidth): source =>
+                rowMap.iterate: rowOrdinal =>
+                  val row = (rowOrdinal: Ordinal).n0
+                  val y = top + rowMap.at(rowOrdinal)
 
-              while x < frameWidth do
-                val entry = indices(row*frameWidth + x)&0xff
+                  source.row(row).let: sourceRow =>
+                    var x = 0
 
-                if entry != transparentIndex && y < height && left + x < width then
-                  screen((left + x) + y*width) = palette(entry).toLong << 8 | 0xff
+                    frame.iterate(sourceRow): sourceIndex =>
+                      val entry = frame(sourceIndex)&0xff
 
-                x += 1
+                      if entry != transparentIndex then
+                        target.point(left + x, y).let: targetIndex =>
+                          screenScribe(targetIndex) = palette.at(Ordinal.zerary(entry)).or(0).toLong << 8 | 0xff
+
+                      x += 1
 
             finished = true
 

--- a/lib/monotonous/src/core/monotonous.Serializable.scala
+++ b/lib/monotonous/src/core/monotonous.Serializable.scala
@@ -39,6 +39,8 @@ import scala.caps
 import java.nio.charset.StandardCharsets
 
 import anticipation.*
+import denominative.*
+import rudiments.*
 import beneficence.*
 import hypotenuse.*
 import prepositional.*
@@ -62,16 +64,16 @@ object Serializable:
       def encode(bytes: Data): Text =
         val src = bytes.asInstanceOf[scala.Array[Byte]]
 
-        val out = bits match
-          case 4 => hex(src)
-          case 5 => base32(src)
-          case 6 => base64(src)
-          case _ => generic(src)
+        val out: Array[Byte]^{} = bits match
+          case 4 => hex(bytes)
+          case 5 => Array.freeze(base32(src))
+          case 6 => base64(bytes)
+          case _ => Array.freeze(generic(src))
 
         // Every alphabet character is ASCII, so decoding the output as Latin-1
         // yields identical text while letting the JVM adopt the byte array as the
         // compact-string backing directly, with no validating charset scan.
-        Text(String(out.raw, StandardCharsets.ISO_8859_1))
+        Text(String(Array.unsafeJvm(out), StandardCharsets.ISO_8859_1))
 
       // Hex: each byte is a self-contained group of two characters, so there is
       // no bit carry and never any padding. Both output bytes for a given input
@@ -84,25 +86,21 @@ object Serializable:
           val lo = lookup(b & 0xf) & 0xff
           (hi | (lo << 8)).toShort
 
-      private def hex(src: scala.Array[Byte]): Array[Byte]^ =
-        val pairs = hexPairs
-        val n = src.length
-        val out = Array[Byte](n*2)
-        var i = 0
-        var j = 0
+      private def hex(src: Data): Array[Byte]^{} =
+        // The one raw gate of this kernel: the pair table is indexed by *value* (`& 0xff`
+        // confines it to the table's 256 entries), which branding cannot express.
+        val pairTable = Array.unsafeJvm(hexPairs)
 
-        while i < n do
-          val pair = pairs(src(i) & 0xff).toInt
-          out(j) = pair.toByte
-          out(j + 1) = (pair >>> 8).toByte
-          i += 1
-          j += 2
-
-        out
+        Array.scribe[Byte](src.length*2): scribe =>
+          _ =>
+            src.iterate: index =>
+              val pair = pairTable(src.at(index) & 0xff).toInt
+              scribe.append(pair.toByte)
+              scribe.append((pair >>> 8).toByte)
 
       // Base64: three input bytes become four characters; a trailing group of
       // one or two bytes is completed with padding when the alphabet demands it.
-      private def base64(src: scala.Array[Byte]): Array[Byte]^ =
+      private def base64(src: Data): Array[Byte]^{} =
         val n = src.length
         val full = n/3
         val rem = n - full*3
@@ -111,41 +109,41 @@ object Serializable:
           if padding then (full + (if rem > 0 then 1 else 0))*4
           else full*4 + (if rem == 1 then 2 else if rem == 2 then 3 else 0)
 
-        val out = Array[Byte](length)
-        var i = 0
-        var j = 0
-        var g = 0
+        // The one raw gate of this kernel: the alphabet table is indexed by *value* (each
+        // index is a masked 6-bit group), which branding cannot express.
+        val table = Array.unsafeJvm(lookup)
 
-        while g < full do
-          val b0 = src(i) & 0xff
-          val b1 = src(i + 1) & 0xff
-          val b2 = src(i + 2) & 0xff
-          out(j) = lookup(b0 >>> 2)
-          out(j + 1) = lookup(((b0 & 0x3) << 4) | (b1 >>> 4))
-          out(j + 2) = lookup(((b1 & 0xf) << 2) | (b2 >>> 6))
-          out(j + 3) = lookup(b2 & 0x3f)
-          i += 3
-          j += 4
-          g += 1
+        Array.scribe[Byte](length): scribe =>
+          _ =>
+            val remainder = src.triples: (byte0, byte1, byte2) =>
+              val b0 = byte0 & 0xff
+              val b1 = byte1 & 0xff
+              val b2 = byte2 & 0xff
+              scribe.append(table(b0 >>> 2))
+              scribe.append(table(((b0 & 0x3) << 4) | (b1 >>> 4)))
+              scribe.append(table(((b1 & 0xf) << 2) | (b2 >>> 6)))
+              scribe.append(table(b2 & 0x3f))
 
-        if rem == 1 then
-          val b0 = src(i) & 0xff
-          out(j) = lookup(b0 >>> 2)
-          out(j + 1) = lookup((b0 & 0x3) << 4)
-          j += 2
-        else if rem == 2 then
-          val b0 = src(i) & 0xff
-          val b1 = src(i + 1) & 0xff
-          out(j) = lookup(b0 >>> 2)
-          out(j + 1) = lookup(((b0 & 0x3) << 4) | (b1 >>> 4))
-          out(j + 2) = lookup((b1 & 0xf) << 2)
-          j += 3
+            if rem == 1 then
+              src.iterate(remainder): index =>
+                val b0 = src.at(index) & 0xff
+                scribe.append(table(b0 >>> 2))
+                scribe.append(table((b0 & 0x3) << 4))
+            else if rem == 2 then
+              var b0 = 0
+              var first = true
 
-        while j < length do
-          out(j) = padByte
-          j += 1
+              src.iterate(remainder): index =>
+                if first then
+                  b0 = src.at(index) & 0xff
+                  first = false
+                else
+                  val b1 = src.at(index) & 0xff
+                  scribe.append(table(b0 >>> 2))
+                  scribe.append(table(((b0 & 0x3) << 4) | (b1 >>> 4)))
+                  scribe.append(table((b1 & 0xf) << 2))
 
-        out
+            while scribe.mark < length do scribe.append(padByte)
 
       // Base32: five input bytes become eight characters; trailing groups of
       // 1/2/3/4 bytes emit 2/4/5/7 characters, padded to a multiple of eight.

--- a/lib/monotonous/src/core/monotonous.Serializable.scala
+++ b/lib/monotonous/src/core/monotonous.Serializable.scala
@@ -62,13 +62,12 @@ object Serializable:
       private val padByte: Byte = if padding then alphabet(1 << bits).toByte else 0
 
       def encode(bytes: Data): Text =
-        val src = bytes.asInstanceOf[scala.Array[Byte]]
 
         val out: Array[Byte]^{} = bits match
           case 4 => hex(bytes)
-          case 5 => Array.freeze(base32(src))
+          case 5 => base32(bytes)
           case 6 => base64(bytes)
-          case _ => Array.freeze(generic(src))
+          case _ => generic(bytes)
 
         // Every alphabet character is ASCII, so decoding the output as Latin-1
         // yields identical text while letting the JVM adopt the byte array as the
@@ -147,7 +146,7 @@ object Serializable:
 
       // Base32: five input bytes become eight characters; trailing groups of
       // 1/2/3/4 bytes emit 2/4/5/7 characters, padded to a multiple of eight.
-      private def base32(src: scala.Array[Byte]): Array[Byte]^ =
+      private def base32(src: Data): Array[Byte]^{} =
         val n = src.length
         val full = n/5
         val rem = n - full*5
@@ -160,59 +159,48 @@ object Serializable:
           case _ => 7
 
         val length = if padding then (full + (if rem > 0 then 1 else 0))*8 else full*8 + tail
-        val out = Array[Byte](length)
-        var i = 0
-        var j = 0
-        var g = 0
 
-        while g < full do
-          val b0 = src(i) & 0xff
-          val b1 = src(i + 1) & 0xff
-          val b2 = src(i + 2) & 0xff
-          val b3 = src(i + 3) & 0xff
-          val b4 = src(i + 4) & 0xff
-          out(j) = lookup(b0 >>> 3)
-          out(j + 1) = lookup(((b0 & 0x7) << 2) | (b1 >>> 6))
-          out(j + 2) = lookup((b1 >>> 1) & 0x1f)
-          out(j + 3) = lookup(((b1 & 0x1) << 4) | (b2 >>> 4))
-          out(j + 4) = lookup(((b2 & 0xf) << 1) | (b3 >>> 7))
-          out(j + 5) = lookup((b3 >>> 2) & 0x1f)
-          out(j + 6) = lookup(((b3 & 0x3) << 3) | (b4 >>> 5))
-          out(j + 7) = lookup(b4 & 0x1f)
-          i += 5
-          j += 8
-          g += 1
+        // The one raw gate of this kernel: the alphabet table is indexed by *value* (each
+        // index is a masked 5-bit group), which branding cannot express.
+        val table = Array.unsafeJvm(lookup)
 
-        // The <=4-byte remainder runs once, so a small bit-accumulator emits its
-        // `tail` characters rather than another unrolled case analysis.
-        if rem > 0 then
-          var acc = 0
-          var k = 0
+        Array.scribe[Byte](length): scribe =>
+          _ =>
+            val remainder = src.quints: (byte0, byte1, byte2, byte3, byte4) =>
+              val b0 = byte0 & 0xff
+              val b1 = byte1 & 0xff
+              val b2 = byte2 & 0xff
+              val b3 = byte3 & 0xff
+              val b4 = byte4 & 0xff
+              scribe.append(table(b0 >>> 3))
+              scribe.append(table(((b0 & 0x7) << 2) | (b1 >>> 6)))
+              scribe.append(table((b1 >>> 1) & 0x1f))
+              scribe.append(table(((b1 & 0x1) << 4) | (b2 >>> 4)))
+              scribe.append(table(((b2 & 0xf) << 1) | (b3 >>> 7)))
+              scribe.append(table((b3 >>> 2) & 0x1f))
+              scribe.append(table(((b3 & 0x3) << 3) | (b4 >>> 5)))
+              scribe.append(table(b4 & 0x1f))
 
-          while k < rem do
-            acc = (acc << 8) | (src(i + k) & 0xff)
-            k += 1
+            // The <=4-byte remainder runs once, so a small bit-accumulator emits its
+            // `tail` characters rather than another unrolled case analysis.
+            if rem > 0 then
+              var acc = 0
+              src.iterate(remainder) { index => acc = (acc << 8) | (src.at(index) & 0xff) }
 
-          val loaded = rem*8
-          var t = 0
+              val loaded = rem*8
+              var t = 0
 
-          while t < tail do
-            val shift = loaded - 5*(t + 1)
-            val value = if shift >= 0 then acc >>> shift else acc << -shift
-            out(j + t) = lookup(value & 0x1f)
-            t += 1
+              while t < tail do
+                val shift = loaded - 5*(t + 1)
+                val value = if shift >= 0 then acc >>> shift else acc << -shift
+                scribe.append(table(value & 0x1f))
+                t += 1
 
-          j += tail
-
-        while j < length do
-          out(j) = padByte
-          j += 1
-
-        out
+            while scribe.mark < length do scribe.append(padByte)
 
       // Binary/quaternary/octal: a general bit-accumulator, for the bases whose
       // group size makes an unrolled kernel unprofitable.
-      private def generic(src: scala.Array[Byte]): Array[Byte]^ =
+      private def generic(src: Data): Array[Byte]^{} =
         val mask = (1 << bits) - 1
         val divisor = bits/bits.gcd(8)
         val multiple = 8/bits.gcd(8)
@@ -221,31 +209,27 @@ object Serializable:
           if padding then multiple*((src.length + divisor - 1)/divisor)
           else (src.length*8 + bits - 1)/bits
 
-        val out = Array[Byte](length)
-        var current = 0
-        var loaded = 0
-        var index = 0
-        var next = 0
+        // The one raw gate of this kernel: the alphabet table is indexed by *value* (each
+        // index is a masked group of `bits`), which branding cannot express.
+        val table = Array.unsafeJvm(lookup)
 
-        while next < src.length do
-          current = (current << 8) | (src(next) & 0xff)
-          next += 1
-          loaded += 8
+        Array.scribe[Byte](length): scribe =>
+          _ =>
+            var current = 0
+            var loaded = 0
 
-          while loaded >= bits do
-            out(index) = lookup((current >>> (loaded - bits)) & mask)
-            index += 1
-            loaded -= bits
+            src.iterate: index =>
+              current = (current << 8) | (src.at(index) & 0xff)
+              loaded += 8
 
-        if loaded > 0 && index < length then
-          out(index) = lookup((current << (bits - loaded)) & mask)
-          index += 1
+              while loaded >= bits do
+                scribe.append(table((current >>> (loaded - bits)) & mask))
+                loaded -= bits
 
-        while index < length do
-          out(index) = padByte
-          index += 1
+            if loaded > 0 && scribe.mark < length
+            then scribe.append(table((current << (bits - loaded)) & mask))
 
-        out
+            while scribe.mark < length do scribe.append(padByte)
 
   given binary: Alphabet[Binary] => Serializable in Binary = base(1)
   given quaternary: Alphabet[Quaternary] => Serializable in Quaternary = base(2)

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -50,7 +50,8 @@ import hieroglyph.*
 import monotonous.*
 import parasite.*
 import prepositional.*
-import zephyrine.{capped, memoize}
+import denominative.capped
+import zephyrine.memoize
 import rudiments.*
 import spectacular.*
 import telekinesis.*

--- a/lib/rudiments/src/core/rudiments.Grouping.scala
+++ b/lib/rudiments/src/core/rudiments.Grouping.scala
@@ -120,3 +120,54 @@ extension [collection](value: collection)
           indexable.access(value, Ordinal.zerary(index)) )
 
       index += 1
+
+  // Whole disjoint groups of five; the branded remainder holds the 0-4 trailing elements.
+  inline def quints
+    ( using countable: collection is Countable, indexable: (collection is Indexable by Ordinal) )
+    ( inline lambda:
+        ( indexable.Result, indexable.Result, indexable.Result, indexable.Result,
+          indexable.Result ) => Unit )
+  :   Interval in value.type =
+
+    val size = countable.size(value)
+    val full = size - size%5
+    var index = 0
+
+    while index < full do
+      lambda
+        ( indexable.access(value, Ordinal.zerary(index)),
+          indexable.access(value, Ordinal.zerary(index + 1)),
+          indexable.access(value, Ordinal.zerary(index + 2)),
+          indexable.access(value, Ordinal.zerary(index + 3)),
+          indexable.access(value, Ordinal.zerary(index + 4)) )
+
+      index += 5
+
+    Interval.zerary(full, size).asInstanceOf[Interval in value.type]
+
+  // Whole disjoint octuples; the branded remainder holds the 0-7 trailing elements.
+  inline def octuples
+    ( using countable: collection is Countable, indexable: (collection is Indexable by Ordinal) )
+    ( inline lambda:
+        ( indexable.Result, indexable.Result, indexable.Result, indexable.Result,
+          indexable.Result, indexable.Result, indexable.Result, indexable.Result ) => Unit )
+  :   Interval in value.type =
+
+    val size = countable.size(value)
+    val full = size - size%8
+    var index = 0
+
+    while index < full do
+      lambda
+        ( indexable.access(value, Ordinal.zerary(index)),
+          indexable.access(value, Ordinal.zerary(index + 1)),
+          indexable.access(value, Ordinal.zerary(index + 2)),
+          indexable.access(value, Ordinal.zerary(index + 3)),
+          indexable.access(value, Ordinal.zerary(index + 4)),
+          indexable.access(value, Ordinal.zerary(index + 5)),
+          indexable.access(value, Ordinal.zerary(index + 6)),
+          indexable.access(value, Ordinal.zerary(index + 7)) )
+
+      index += 8
+
+    Interval.zerary(full, size).asInstanceOf[Interval in value.type]

--- a/lib/rudiments/src/core/rudiments.Grouping.scala
+++ b/lib/rudiments/src/core/rudiments.Grouping.scala
@@ -1,0 +1,122 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package rudiments
+
+import denominative.*
+import prepositional.*
+
+// Disjoint-group and sliding-window iteration (issue #1666, category 7): the read side of
+// mismatched-stride codecs. Each combinator walks whole groups of a static arity, passing
+// the *values* — a codec's transformation needs the elements, not their positions — and
+// returns the branded remainder (the trailing partial group, possibly empty), which feeds
+// `iterate`/`at` for the tail-handling the codec defines. The write side of these loops is
+// sequential by nature, which `Scribe.append` already expresses, so no write-side grouping
+// is needed.
+extension [collection](value: collection)
+  // Whole disjoint pairs, in order; the branded remainder holds the 0 or 1 trailing element.
+  inline def pairs
+    ( using countable: collection is Countable, indexable: (collection is Indexable by Ordinal) )
+    ( inline lambda: (indexable.Result, indexable.Result) => Unit )
+  :   Interval in value.type =
+
+    val size = countable.size(value)
+    val full = size - size%2
+    var index = 0
+
+    while index < full do
+      lambda
+        ( indexable.access(value, Ordinal.zerary(index)),
+          indexable.access(value, Ordinal.zerary(index + 1)) )
+
+      index += 2
+
+    Interval.zerary(full, size).asInstanceOf[Interval in value.type]
+
+  // Whole disjoint triples; the branded remainder holds the 0-2 trailing elements.
+  inline def triples
+    ( using countable: collection is Countable, indexable: (collection is Indexable by Ordinal) )
+    ( inline lambda: (indexable.Result, indexable.Result, indexable.Result) => Unit )
+  :   Interval in value.type =
+
+    val size = countable.size(value)
+    val full = size - size%3
+    var index = 0
+
+    while index < full do
+      lambda
+        ( indexable.access(value, Ordinal.zerary(index)),
+          indexable.access(value, Ordinal.zerary(index + 1)),
+          indexable.access(value, Ordinal.zerary(index + 2)) )
+
+      index += 3
+
+    Interval.zerary(full, size).asInstanceOf[Interval in value.type]
+
+  // Whole disjoint quadruples; the branded remainder holds the 0-3 trailing elements.
+  inline def quads
+    ( using countable: collection is Countable, indexable: (collection is Indexable by Ordinal) )
+    ( inline lambda:
+        (indexable.Result, indexable.Result, indexable.Result, indexable.Result) => Unit )
+  :   Interval in value.type =
+
+    val size = countable.size(value)
+    val full = size - size%4
+    var index = 0
+
+    while index < full do
+      lambda
+        ( indexable.access(value, Ordinal.zerary(index)),
+          indexable.access(value, Ordinal.zerary(index + 1)),
+          indexable.access(value, Ordinal.zerary(index + 2)),
+          indexable.access(value, Ordinal.zerary(index + 3)) )
+
+      index += 4
+
+    Interval.zerary(full, size).asInstanceOf[Interval in value.type]
+
+  // Every adjacent (overlapping) pair, in order: the boundary-window shape. A collection of
+  // fewer than two elements yields nothing.
+  inline def adjacent
+    ( using countable: collection is Countable, indexable: (collection is Indexable by Ordinal) )
+    ( inline lambda: (indexable.Result, indexable.Result) => Unit )
+  :   Unit =
+
+    val size = countable.size(value)
+    var index = 1
+
+    while index < size do
+      lambda
+        ( indexable.access(value, Ordinal.zerary(index - 1)),
+          indexable.access(value, Ordinal.zerary(index)) )
+
+      index += 1

--- a/lib/rudiments/src/core/rudiments.Lattice.scala
+++ b/lib/rudiments/src/core/rudiments.Lattice.scala
@@ -1,0 +1,93 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package rudiments
+
+import denominative.*
+import prepositional.*
+import vacuous.*
+
+// The 2-D geometry helper for confined indexing (issue #1666): a `Lattice` brands nothing
+// itself, but derives *linear* branded intervals and ordinals for its underlying collection
+// from two-dimensional coordinates, so all access flows through the existing confined
+// machinery — and since `Scribe` is `Countable`, the same lattice addresses a write handle.
+//
+// The dangerous arithmetic it replaces is `y*stride + x` with stride ≠ width: pixel planes,
+// interlaced rows, subsampled chroma. The lender clamps the height so that every row it can
+// mint lies wholly within the storage, making `row` and `point` total by construction; a
+// partial trailing row is simply outside the lattice.
+final class Lattice[brand] @scala.annotation.publicInBinary private[rudiments]
+  ( val width: Int, val height: Int, stride: Int, offset: Int ):
+
+  // Row `y` as a branded linear interval, or `Unset` outside the lattice.
+  inline def row(y: Int): Optional[Interval in brand] =
+    if y < 0 || y >= height then Unset else
+      val start = offset + y*stride
+      Interval.zerary(start, start + width).asInstanceOf[Interval in brand]
+
+  // The linear position of `(x, y)`, or `Unset` outside the lattice.
+  inline def point(x: Int, y: Int): Optional[Ordinal in brand] =
+    if x < 0 || x >= width || y < 0 || y >= height then Unset
+    else Ordinal.zerary(offset + y*stride + x).asInstanceOf[Ordinal in brand]
+
+  // Every row in order, as its index and branded interval.
+  inline def rows(inline lambda: (Int, Interval in brand) => Unit): Unit =
+    var y = 0
+
+    while y < height do
+      val start = offset + y*stride
+      lambda(y, Interval.zerary(start, start + width).asInstanceOf[Interval in brand])
+      y += 1
+
+extension [collection: Countable](value: collection)
+  // Lend a lattice of `width`-element rows spaced `stride` apart, starting at `offset`: the
+  // height is the number of whole rows that fit, so everything the lattice mints is in
+  // range. `stride` is clamped to at least `width` (overlapping rows would alias), and a
+  // degenerate geometry yields a zero-height lattice rather than anything partial.
+  inline def lattice[result](width: Int, stride: Int, offset: Int)
+    ( inline lambda: Lattice[value.type] => result )
+  :   result =
+
+    val size = summon[collection is Countable].size(value)
+    val width2 = width.max(0)
+    val stride2 = stride.max(width2).max(1)
+    val offset2 = offset.max(0)
+
+    val height =
+      if width2 == 0 || offset2 + width2 > size then 0
+      else (size - offset2 - width2)/stride2 + 1
+
+    lambda(new Lattice[value.type](width2, height, stride2, offset2))
+
+  // A lattice over the whole extent from the start.
+  inline def lattice[result](width: Int)(inline lambda: Lattice[value.type] => result): result =
+    lattice(width, width, 0)(lambda)

--- a/lib/rudiments/src/core/rudiments.Scribe.scala
+++ b/lib/rudiments/src/core/rudiments.Scribe.scala
@@ -49,23 +49,38 @@ import prepositional.*
 //
 // The accessors live in the companion (found through implicit scope) rather than at the top
 // level, so same-named extensions imported by wildcard cannot shadow them.
-// An untyped carrier, as `Region`/`Slate`: an opaque alias of `scala.Array` directly would be
-// mutable-classified by the mutalias patch, annotating every in-module signature with
-// `^{any.rd}` and breaking capture-free summons across the boundary. The casts are sound:
-// a scribe is minted only over the array `Array.scribe` just allocated.
-opaque type Scribe[element] = AnyRef
+// The carrier holds the buffer untyped, as `Region`/`Slate` (an opaque alias of `scala.Array`
+// directly would be mutable-classified by the mutalias patch, annotating every in-module
+// signature with `^{any.rd}` and breaking capture-free summons across the boundary), plus the
+// append cursor. The casts are sound: a scribe is minted only over the array `Array.scribe`
+// just allocated.
+opaque type Scribe[element] = Scribe.Core
 
 object Scribe:
+  // Public (with a package-private constructor routed through `apply`) because the inline
+  // lender and accessors expand in caller packages, which must be able to reference the
+  // carrier and its members. Minting a scribe grants only bounds-confined access to the
+  // array, so the public mint is not a safety hole; the freeze soundness argument belongs
+  // to `Array.scribe`, which confines the scribe it mints to one lambda.
+  final class Core private[rudiments] (val buffer: AnyRef):
+    // Untracked: the cursor is reached only through the scribe, which the lender confines
+    // to one lambda; `Stateful` would force capability typing onto a transient builder.
+    @scala.caps.unsafe.untrackedCaptures
+    var mark: Int = 0
   // Written out (not a SAM lambda): the lambda form infers a capture-annotated `Self`
   // (`Scribe[element]^{any.rd}`), which then fails to match capture-free summons.
   given countable: [element] => Scribe[element] is Countable:
-    def size(self: Scribe[element]): Int = self.asInstanceOf[scala.Array[element]].length
+    def size(self: Scribe[element]): Int =
+      self.asInstanceOf[Core].buffer.asInstanceOf[scala.Array[element]].length
 
-  private[rudiments] inline def over[element, result](buffer: scala.Array[element])
+  def apply[element](buffer: scala.Array[element]^): Scribe[element] =
+    new Core(buffer.asInstanceOf[AnyRef])
+
+  private[rudiments] inline def over[element, result](buffer: scala.Array[element]^)
     ( inline lambda: (scribe: Scribe[element]) => (Interval in scribe.type) => result )
   :   result =
 
-    val scribe: Scribe[element] = buffer.asInstanceOf[AnyRef]
+    val scribe = Scribe[element](buffer)
     lambda(scribe)(Interval.initial(buffer.length).asInstanceOf[Interval in scribe.type])
 
   extension [element](scribe: Scribe[element])
@@ -73,17 +88,32 @@ object Scribe:
       val ordinal: Ordinal = index
       // The cast re-asserts the exclusivity the carrier forgot: the array is reached only
       // through this scribe, which the lender confines to one lambda.
-      scribe.asInstanceOf[scala.Array[element]^](ordinal.n0) = value
+      scribe.asInstanceOf[Core].buffer.asInstanceOf[scala.Array[element]^](ordinal.n0) = value
 
     inline def apply(index: Ordinal in scribe.type): element =
       val ordinal: Ordinal = index
-      scribe.asInstanceOf[scala.Array[element]](ordinal.n0)
+      scribe.asInstanceOf[Core].buffer.asInstanceOf[scala.Array[element]](ordinal.n0)
+
+    // Sequential writes for data-dependent positions: each `append` writes at the scribe's own
+    // cursor and advances it, clamping silently at the end of the buffer, so no position a
+    // caller can reach is out of range. The dominant safe form for compaction and filtering
+    // loops, whose write index advances irregularly while the read index scans.
+    inline def append(value: element): Unit =
+      val core = scribe.asInstanceOf[Core]
+      val target = core.buffer.asInstanceOf[scala.Array[element]^]
+      if core.mark < target.length then
+        target(core.mark) = value
+        core.mark += 1
+
+    // The number of elements appended so far.
+    inline def mark: Int = scribe.asInstanceOf[Core].mark
 
     // Bulk copy of a whole frozen array into the scribe at `at`, clamped to the space that
     // remains: the confined form of `place`. Returns the count copied.
     inline def place(source: Array[element]^{}, at: Ordinal in scribe.type): Int =
       val ordinal: Ordinal = at
-      val target: scala.Array[element]^ = scribe.asInstanceOf[scala.Array[element]^]
+      val target: scala.Array[element]^ =
+        scribe.asInstanceOf[Core].buffer.asInstanceOf[scala.Array[element]^]
       val count = source.readable.length.min(target.length - ordinal.n0)
 
       System.arraycopy
@@ -98,6 +128,6 @@ extension (companion: Array.type)
     ( inline lambda: (scribe: Scribe[element]) => (Interval in scribe.type) => Unit )
   :   Array[element]^{} =
 
-    val buffer = new scala.Array[element](size.max(0))
+    val buffer: scala.Array[element]^ = new scala.Array[element](size.max(0))
     Scribe.over[element, Unit](buffer)(lambda)
     buffer.asInstanceOf[Array[element]^{}]

--- a/lib/rudiments/src/core/rudiments.Scribe.scala
+++ b/lib/rudiments/src/core/rudiments.Scribe.scala
@@ -30,26 +30,74 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package rudiments
 
-export
-  rudiments
-  // `Scribe`/`scribe` are deliberately absent: their lender and combinators are
-  // dependent-typed inline extensions, which synthesized export forwarders break (the same
-  // policy as zephyrine's `Region`/`Slate`). Consumers import them from `rudiments` directly.
-  . { !!, &, all, also, and, annex, at, b, bi, Bijection, bijection, Bytes, bytes, collate, Counter,
-      DecimalConverter, Defaulting, Defaulting2, defines, Digit, each, establish, Exit,
-      fuse, gib,
-      give, immutable, indexBy, intercalate, javaInputStream, kib,
-      longestTrain,
-      Loop, loop, matchable, mean, mib, mutable, Mutex, next, ordinal, pipe, place, plus,
-      prim, prior, probe, product, reflectClass, repeat, runs, runsBy, sec, segment, Segmentable,
-      indexed, least, most, sift, snapshot, state, std, sumBy, tap, ter, that, tib, to, total, tri, triple, tuple, twin,
-      typed, typeName, unit, unwind, upsert, variance, waive, weave, when, yet, upon, context,
-      mean2, unique, seek, where,
-      Populated, head, reduce, confine, populatedEquality }
+import scala.reflect.ClassTag
 
-// `zip` is deliberately NOT re-exported: zeppelin's contextual archive accessor owns the bare
-// name `zip` in this package, and a generic-receiver extension overload commits without falling
-// through when its givens fail. The extension remains available via `import rudiments.*`; the
-// collection aliases will host `zip` in their companions (implicit scope) once opaque.
+import denominative.*
+import prepositional.*
+
+// The write-side counterpart of confined reading (issue #1666), as a builder-lender: an
+// opaque handle over a freshly-allocated array that grants writes (and read-back) only
+// through `Ordinal`s branded to the handle's identity, so no index it accepts can be out of
+// range. `Array.build` allocates, lends the scribe with its branded extent, and freezes the
+// result — the only writer is statically retired when the lender returns, so the freeze is
+// sound by construction, exactly as `Array.freeze`'s `consume` form.
+//
+// A `Scribe` is `Countable`, so the whole confined-scan family (`iterate`, `spot`, `lead`,
+// `pare`, `retrace`) applies to it directly: `scribe.iterate { i => scribe(i) = ... }`.
+//
+// The accessors live in the companion (found through implicit scope) rather than at the top
+// level, so same-named extensions imported by wildcard cannot shadow them.
+// An untyped carrier, as `Region`/`Slate`: an opaque alias of `scala.Array` directly would be
+// mutable-classified by the mutalias patch, annotating every in-module signature with
+// `^{any.rd}` and breaking capture-free summons across the boundary. The casts are sound:
+// a scribe is minted only over the array `Array.scribe` just allocated.
+opaque type Scribe[element] = AnyRef
+
+object Scribe:
+  // Written out (not a SAM lambda): the lambda form infers a capture-annotated `Self`
+  // (`Scribe[element]^{any.rd}`), which then fails to match capture-free summons.
+  given countable: [element] => Scribe[element] is Countable:
+    def size(self: Scribe[element]): Int = self.asInstanceOf[scala.Array[element]].length
+
+  private[rudiments] inline def over[element, result](buffer: scala.Array[element])
+    ( inline lambda: (scribe: Scribe[element]) => (Interval in scribe.type) => result )
+  :   result =
+
+    val scribe: Scribe[element] = buffer.asInstanceOf[AnyRef]
+    lambda(scribe)(Interval.initial(buffer.length).asInstanceOf[Interval in scribe.type])
+
+  extension [element](scribe: Scribe[element])
+    inline def update(index: Ordinal in scribe.type, value: element): Unit =
+      val ordinal: Ordinal = index
+      // The cast re-asserts the exclusivity the carrier forgot: the array is reached only
+      // through this scribe, which the lender confines to one lambda.
+      scribe.asInstanceOf[scala.Array[element]^](ordinal.n0) = value
+
+    inline def apply(index: Ordinal in scribe.type): element =
+      val ordinal: Ordinal = index
+      scribe.asInstanceOf[scala.Array[element]](ordinal.n0)
+
+    // Bulk copy of a whole frozen array into the scribe at `at`, clamped to the space that
+    // remains: the confined form of `place`. Returns the count copied.
+    inline def place(source: Array[element]^{}, at: Ordinal in scribe.type): Int =
+      val ordinal: Ordinal = at
+      val target: scala.Array[element]^ = scribe.asInstanceOf[scala.Array[element]^]
+      val count = source.readable.length.min(target.length - ordinal.n0)
+
+      System.arraycopy
+        (source.asInstanceOf[scala.Array[element]], 0, target, ordinal.n0, count)
+
+      count
+
+extension (companion: Array.type)
+  // Allocate, lend, freeze: `lambda` receives the scribe and its branded extent, and the
+  // frozen result is returned once the only writer has been retired.
+  inline def scribe[element: ClassTag](size: Int)
+    ( inline lambda: (scribe: Scribe[element]) => (Interval in scribe.type) => Unit )
+  :   Array[element]^{} =
+
+    val buffer = new scala.Array[element](size.max(0))
+    Scribe.over[element, Unit](buffer)(lambda)
+    buffer.asInstanceOf[Array[element]^{}]

--- a/lib/rudiments/src/core/rudiments.Surveyor.scala
+++ b/lib/rudiments/src/core/rudiments.Surveyor.scala
@@ -73,6 +73,23 @@ final class Surveyor[collection, brand, operand] @scala.annotation.publicInBinar
   inline def peek(inline predicate: operand => Boolean): Boolean =
     mark0 < size && predicate(read(value, mark0))
 
+  // Consume the current element: apply the lambda to it and advance, or yield `otherwise`
+  // at exhaustion — the `read-then-advance` shape of byte-at-a-time decoders, fused so
+  // nothing partial exists to call and nothing boxes.
+  inline def next[result](inline otherwise: => result)(inline lambda: operand => result): result =
+    if mark0 < size then
+      val element = read(value, mark0)
+      mark0 += 1
+      lambda(element)
+    else otherwise
+
+  // Consume up to `count` elements, returning the branded run actually traversed (clamped
+  // at exhaustion): the counted form of `skipWhile`.
+  inline def take(count: Int): Interval in brand =
+    val start = mark0
+    mark0 = (mark0 + count.max(0)).min(size)
+    Interval.zerary(start, mark0).asInstanceOf[Interval in brand]
+
   // The branded position, when not exhausted.
   inline def point: Optional[Ordinal in brand] =
     if mark0 < size then Ordinal.zerary(mark0).asInstanceOf[Ordinal in brand] else Unset

--- a/lib/rudiments/src/core/rudiments.Surveyor.scala
+++ b/lib/rudiments/src/core/rudiments.Surveyor.scala
@@ -45,7 +45,7 @@ import vacuous.*
 // converged on informally with `i`/`j` walker loops.
 //
 // Position may equal the size (exhaustion); no read is offered at the bare position, so
-// there is nothing partial to call: reads happen only inside `skipWhile`-family combinators,
+// there is nothing partial to call: reads happen only inside the pacing combinators,
 // which check `more` and the predicate together, or through the branded products.
 //
 // The brand is sound for immutable receivers on stable paths, like `within` and `extent`.
@@ -84,7 +84,7 @@ final class Surveyor[collection, brand, operand] @scala.annotation.publicInBinar
     else otherwise
 
   // Consume up to `count` elements, returning the branded run actually traversed (clamped
-  // at exhaustion): the counted form of `skipWhile`.
+  // at exhaustion): the counted form of `pace`.
   inline def take(count: Int): Interval in brand =
     val start = mark0
     mark0 = (mark0 + count.max(0)).min(size)
@@ -123,20 +123,16 @@ final class Surveyor[collection, brand, operand] @scala.annotation.publicInBinar
   inline def remainder: Interval in brand =
     Interval.zerary(mark0, size).asInstanceOf[Interval in brand]
 
-  // Advance while the predicate holds of the current element, returning the branded run
-  // traversed (possibly empty): `surveyor.skipWhile(_ == ' ')` is the whitespace skip, and
-  // `surveyor.skipWhile(_ == style)` is run detection, with the run's length available as the
-  // interval's size.
-  inline def skipWhile(inline predicate: operand => Boolean): Interval in brand =
+  // Pace out the run of elements satisfying the predicate — advancing over it and returning
+  // it as a branded interval, possibly empty: `surveyor.pace(_ == ' ')` is the whitespace
+  // skip, `surveyor.pace(_ == style)` is run detection (with the run's length as the
+  // interval's size), and a delimited scan is a negated predicate, `pace(_ != ':')`.
+  inline def pace(inline predicate: operand => Boolean): Interval in brand =
     val start = mark0
 
     while mark0 < size && predicate(read(value, mark0)) do mark0 += 1
 
     Interval.zerary(start, mark0).asInstanceOf[Interval in brand]
-
-  // Advance until the predicate holds (or exhaustion), returning the branded run skipped.
-  inline def skipUntil(inline predicate: operand => Boolean): Interval in brand =
-    skipWhile(!predicate(_))
 
 extension [collection](value: collection)
   // Lend a surveyor over this collection: reads resolve through the `Indexable` instance, and

--- a/lib/rudiments/src/core/rudiments.Surveyor.scala
+++ b/lib/rudiments/src/core/rudiments.Surveyor.scala
@@ -90,6 +90,31 @@ final class Surveyor[collection, brand, operand] @scala.annotation.publicInBinar
     mark0 = (mark0 + count.max(0)).min(size)
     Interval.zerary(start, mark0).asInstanceOf[Interval in brand]
 
+  // Whether the elements at the current position match `pattern` under `equal`, without
+  // advancing: the marker-match primitive of scanning parsers. False when fewer elements
+  // remain than the pattern's size.
+  inline def matches[pattern](pattern: pattern)
+    ( using countable: pattern is Countable, indexable: (pattern is Indexable by Ordinal) )
+    ( inline equal: (operand, indexable.Result) => Boolean )
+  :   Boolean =
+
+    val count = countable.size(pattern)
+
+    if size - mark0 < count then false else
+      var index = 0
+
+      while index < count
+        && equal(read(value, mark0 + index), indexable.access(pattern, Ordinal.zerary(index)))
+      do index += 1
+
+      index == count
+
+  // The branded window of the next `count` elements, without advancing, or `Unset` when
+  // fewer remain: fixed-lookahead reads then go through checked or iterated access.
+  inline def glimpse(count: Int): Optional[Interval in brand] =
+    if size - mark0 < count then Unset
+    else Interval.zerary(mark0, mark0 + count).asInstanceOf[Interval in brand]
+
   // The branded position, when not exhausted.
   inline def point: Optional[Ordinal in brand] =
     if mark0 < size then Ordinal.zerary(mark0).asInstanceOf[Ordinal in brand] else Unset

--- a/lib/rudiments/src/core/rudiments.Surveyor.scala
+++ b/lib/rudiments/src/core/rudiments.Surveyor.scala
@@ -30,26 +30,82 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package rudiments
 
-export
-  rudiments
-  // `Scribe`/`scribe` and `Surveyor`/`survey` are deliberately absent: their lenders and combinators are
-  // dependent-typed inline extensions, which synthesized export forwarders break (the same
-  // policy as zephyrine's `Region`/`Slate`). Consumers import them from `rudiments` directly.
-  . { !!, &, all, also, and, annex, at, b, bi, Bijection, bijection, Bytes, bytes, collate, Counter,
-      DecimalConverter, Defaulting, Defaulting2, defines, Digit, each, establish, Exit,
-      fuse, gib,
-      give, immutable, indexBy, intercalate, javaInputStream, kib,
-      longestTrain,
-      Loop, loop, matchable, mean, mib, mutable, Mutex, next, ordinal, pipe, place, plus,
-      prim, prior, probe, product, reflectClass, repeat, runs, runsBy, sec, segment, Segmentable,
-      indexed, least, most, sift, snapshot, state, std, sumBy, tap, ter, that, tib, to, total, tri, triple, tuple, twin,
-      typed, typeName, unit, unwind, upsert, variance, waive, weave, when, yet, upon, context,
-      mean2, unique, seek, where,
-      Populated, head, reduce, confine, populatedEquality }
+import denominative.*
+import prepositional.*
+import vacuous.*
 
-// `zip` is deliberately NOT re-exported: zeppelin's contextual archive accessor owns the bare
-// name `zip` in this package, and a generic-receiver extension overload commits without falling
-// through when its givens fail. The extension remains available via `import rudiments.*`; the
-// collection aliases will host `zip` in their companions (implicit scope) once opaque.
+// The confined parser cursor (issue #1666, category 5): a mutable position over a stable,
+// indexable collection, lent by `value.survey { surveyor => ... }`. Every product is branded to
+// the *collection* — runs come back as `Interval in value.type` and positions as
+// `Ordinal in value.type` — so they feed the confined machinery (`at`, `iterate`,
+// `Segmentable`) with no bounds checks, and run lengths come from interval sizes rather
+// than raw index arithmetic. This is the shape ypsiloid, stratiform, facsimile and escapade
+// converged on informally with `i`/`j` walker loops.
+//
+// Position may equal the size (exhaustion); no read is offered at the bare position, so
+// there is nothing partial to call: reads happen only inside `skipWhile`-family combinators,
+// which check `more` and the predicate together, or through the branded products.
+//
+// The brand is sound for immutable receivers on stable paths, like `within` and `extent`.
+final class Surveyor[collection, brand, operand] @scala.annotation.publicInBinary private[rudiments]
+  ( value: collection, read: (collection, Int) => operand, size: Int ):
+
+  // Untracked: the position is reached only through the surveyor, which the lender confines to
+  // one lambda; `Stateful` would force capability typing onto a transient walker.
+  @scala.caps.unsafe.untrackedCaptures
+  private var mark0: Int = 0
+
+  // The number of elements already passed over.
+  inline def passed: Int = mark0
+
+  // Whether at least one element remains.
+  inline def more: Boolean = mark0 < size
+
+  // Step over one element; false at exhaustion.
+  inline def advance(): Boolean = if mark0 < size then { mark0 += 1; true } else false
+
+  // Whether the current element satisfies the predicate, without advancing: the dispatch
+  // primitive (`surveyor.peek(_ == '-')`), false at exhaustion — the same non-consuming
+  // meaning as zephyrine's `Cursor.peek`, fused with the exhaustion check so there is no
+  // boxed `Optional` on the hot path.
+  inline def peek(inline predicate: operand => Boolean): Boolean =
+    mark0 < size && predicate(read(value, mark0))
+
+  // The branded position, when not exhausted.
+  inline def point: Optional[Ordinal in brand] =
+    if mark0 < size then Ordinal.zerary(mark0).asInstanceOf[Ordinal in brand] else Unset
+
+  // Everything not yet passed over, as a branded interval (possibly empty).
+  inline def remainder: Interval in brand =
+    Interval.zerary(mark0, size).asInstanceOf[Interval in brand]
+
+  // Advance while the predicate holds of the current element, returning the branded run
+  // traversed (possibly empty): `surveyor.skipWhile(_ == ' ')` is the whitespace skip, and
+  // `surveyor.skipWhile(_ == style)` is run detection, with the run's length available as the
+  // interval's size.
+  inline def skipWhile(inline predicate: operand => Boolean): Interval in brand =
+    val start = mark0
+
+    while mark0 < size && predicate(read(value, mark0)) do mark0 += 1
+
+    Interval.zerary(start, mark0).asInstanceOf[Interval in brand]
+
+  // Advance until the predicate holds (or exhaustion), returning the branded run skipped.
+  inline def skipUntil(inline predicate: operand => Boolean): Interval in brand =
+    skipWhile(!predicate(_))
+
+extension [collection](value: collection)
+  // Lend a surveyor over this collection: reads resolve through the `Indexable` instance, and
+  // the products carry the collection's brand.
+  inline def survey[result]
+    ( using indexable: (collection is Indexable by Ordinal), countable: collection is Countable )
+    ( inline lambda: Surveyor[collection, value.type, indexable.Result] => result )
+  :   result =
+
+    lambda:
+      new Surveyor
+        ( value,
+          (collection, index) => indexable.access(collection, Ordinal.zerary(index)),
+          countable.size(value) )

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -243,6 +243,64 @@ object Tests extends Suite(m"Rudiments Tests"):
         count
       . assert(_ == 2)
 
+      test(m"a surveyor skips whitespace and reports the run"):
+        val line = t"   indent"
+        var skipped = -1
+        var next = ' '
+
+        line.survey: surveyor =>
+          skipped = (surveyor.skipWhile(_ == ' '): Interval).size
+          surveyor.point.let { i => next = line.at(i) }
+
+        (skipped, next)
+      . assert(_ == ((3, 'i')))
+
+      test(m"a surveyor detects successive runs with their lengths"):
+        val styles = Array.of(7L, 7L, 7L, 9L, 9L, 3L)
+        var lengths: List[Int] = Nil
+
+        styles.survey: surveyor =>
+          while surveyor.more do
+            surveyor.point.let: start =>
+              val style = styles.at(start)
+              lengths ::= (surveyor.skipWhile(_ == style): Interval).size
+
+        lengths.reverse
+      . assert(_ == List(3, 2, 1))
+
+      test(m"`skipUntil` stops at the delimiter, and `remainder` brands the rest"):
+        val csv = t"key:value"
+        var key = t""
+        var rest = -1
+
+        csv.survey: surveyor =>
+          val name = surveyor.skipUntil(_ == ':')
+          val builder = java.lang.StringBuilder()
+          csv.iterate(name) { i => builder.append(csv.at(i)) }
+          key = builder.toString.tt
+          rest = (surveyor.remainder: Interval).size
+
+        (key, rest)
+      . assert(_ == ((t"key", 6)))
+
+      test(m"`peek` tests the current element without advancing"):
+        val text = t"-x"
+
+        text.survey: surveyor =>
+          val dash = surveyor.peek(_ == '-')
+          val same = surveyor.peek(_ == '-')
+          surveyor.advance()
+          (dash, same, surveyor.peek(_ == '-'), surveyor.peek(_ == 'x'))
+      . assert(_ == ((true, true, false, true)))
+
+      test(m"an exhausted surveyor has no point and an empty remainder"):
+        val text = t"ab"
+
+        text.survey: surveyor =>
+          surveyor.skipWhile { _ => true }
+          (surveyor.more, surveyor.point, (surveyor.remainder: Interval).size)
+      . assert(_ == ((false, Unset, 0)))
+
       test(m"the scan family applies to a scribe"):
         var kept = -1
 

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -249,7 +249,7 @@ object Tests extends Suite(m"Rudiments Tests"):
         var next = ' '
 
         line.survey: surveyor =>
-          skipped = (surveyor.skipWhile(_ == ' '): Interval).size
+          skipped = (surveyor.pace(_ == ' '): Interval).size
           surveyor.point.let { i => next = line.at(i) }
 
         (skipped, next)
@@ -263,18 +263,18 @@ object Tests extends Suite(m"Rudiments Tests"):
           while surveyor.more do
             surveyor.point.let: start =>
               val style = styles.at(start)
-              lengths ::= (surveyor.skipWhile(_ == style): Interval).size
+              lengths ::= (surveyor.pace(_ == style): Interval).size
 
         lengths.reverse
       . assert(_ == List(3, 2, 1))
 
-      test(m"`skipUntil` stops at the delimiter, and `remainder` brands the rest"):
+      test(m"a negated `pace` stops at the delimiter, and `remainder` brands the rest"):
         val csv = t"key:value"
         var key = t""
         var rest = -1
 
         csv.survey: surveyor =>
-          val name = surveyor.skipUntil(_ == ':')
+          val name = surveyor.pace(_ != ':')
           val builder = java.lang.StringBuilder()
           csv.iterate(name) { i => builder.append(csv.at(i)) }
           key = builder.toString.tt
@@ -410,7 +410,7 @@ object Tests extends Suite(m"Rudiments Tests"):
         val text = t"ab"
 
         text.survey: surveyor =>
-          surveyor.skipWhile { _ => true }
+          surveyor.pace { _ => true }
           (surveyor.more, surveyor.point, (surveyor.remainder: Interval).size)
       . assert(_ == ((false, Unset, 0)))
 

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -221,6 +221,28 @@ object Tests extends Suite(m"Rudiments Tests"):
         target.to[List]
       . assert(_ == List(0, 1, 2, 3))
 
+      test(m"`append` writes sequentially and clamps at the end"):
+        Array.scribe[Int](3): scribe =>
+          _ =>
+            scribe.append(5)
+            scribe.append(6)
+            scribe.append(7)
+            scribe.append(8)
+        . to[List]
+      . assert(_ == List(5, 6, 7))
+
+      test(m"`mark` counts appended elements"):
+        var count = -1
+
+        Array.scribe[Int](5): scribe =>
+          _ =>
+            scribe.append(1)
+            scribe.append(2)
+            count = scribe.mark
+
+        count
+      . assert(_ == 2)
+
       test(m"the scan family applies to a scribe"):
         var kept = -1
 

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -293,6 +293,48 @@ object Tests extends Suite(m"Rudiments Tests"):
           (dash, same, surveyor.peek(_ == '-'), surveyor.peek(_ == 'x'))
       . assert(_ == ((true, true, false, true)))
 
+      test(m"`matches` compares a pattern without advancing"):
+        val data = t"abcdef"
+
+        data.survey: surveyor =>
+          surveyor.advance()
+          val hit = surveyor.matches(t"bcd") { (left, right) => left == right }
+          val miss = surveyor.matches(t"bce") { (left, right) => left == right }
+          val long = surveyor.matches(t"bcdefgh") { (left, right) => left == right }
+          (hit, miss, long, surveyor.passed)
+      . assert(_ == ((true, false, false, 1)))
+
+      test(m"`glimpse` lends a branded lookahead window without advancing"):
+        val text = t"hello"
+
+        text.survey: surveyor =>
+          val window = surveyor.glimpse(3).let { interval => (interval: Interval).size }
+          val overrun = surveyor.glimpse(9)
+          (window, overrun, surveyor.passed)
+      . assert(_ == ((3, Unset, 0)))
+
+      test(m"`next` consumes elements one at a time"):
+        val text = t"ab"
+        val builder = java.lang.StringBuilder()
+
+        text.survey: surveyor =>
+          while surveyor.more do surveyor.next(()) { char => builder.append(char) }
+          surveyor.next(builder.append('!')) { char => builder.append(char) }
+
+        builder.toString.tt
+      . assert(_ == t"ab!")
+
+      test(m"`take` consumes a counted, clamped run"):
+        val text = t"abcde"
+        var sizes: List[Int] = Nil
+
+        text.survey: surveyor =>
+          sizes ::= (surveyor.take(2): Interval).size
+          sizes ::= (surveyor.take(9): Interval).size
+
+        sizes.reverse
+      . assert(_ == List(2, 3))
+
       test(m"an exhausted surveyor has no point and an empty remainder"):
         val text = t"ab"
 

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -364,6 +364,48 @@ object Tests extends Suite(m"Rudiments Tests"):
         builder.toString.tt
       . assert(_ == t"ab.bc.cd.")
 
+      test(m"a lattice mints whole rows within the storage"):
+        // 10 elements, rows of 3 spaced 4 apart: rows at 0, 4 — a third row (start 8,
+        // needing 8+3 <= 10) does not fit.
+        val data = Array.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+        var rows: List[List[Int]] = Nil
+
+        data.lattice(3, 4, 0): lattice =>
+          lattice.rows: (y, row) =>
+            var elements: List[Int] = Nil
+            data.iterate(row) { i => elements ::= data.at(i) }
+            rows ::= elements.reverse
+
+        rows.reverse
+      . assert(_ == List(List(0, 1, 2), List(4, 5, 6)))
+
+      test(m"`point` linearizes in-range coordinates and rejects others"):
+        val data = Array.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+
+        data.lattice(3, 4, 0): lattice =>
+          val hit = lattice.point(2, 1).let { i => data.at(i) }
+          (hit, lattice.point(3, 1), lattice.point(0, 3), lattice.height)
+      . assert(_ == ((6, Unset, Unset, 3)))
+
+      test(m"a lattice with an offset addresses a sub-plane"):
+        val data = Array.of(9, 9, 0, 1, 2, 3)
+        var sum = 0
+
+        data.lattice(2, 2, 2): lattice =>
+          lattice.rows { (y, row) => data.iterate(row) { i => sum += data.at(i) } }
+          sum += lattice.height*100
+
+        sum
+      . assert(_ == 206)
+
+      test(m"a lattice over a scribe writes through branded rows"):
+        Array.scribe[Int](6): scribe =>
+          _ =>
+            scribe.lattice(2, 3, 0): lattice =>
+              lattice.rows { (y, row) => scribe.iterate(row) { i => scribe(i) = y + 1 } }
+        . to[List]
+      . assert(_ == List(1, 1, 0, 2, 2, 0))
+
       test(m"an exhausted surveyor has no point and an empty remainder"):
         val text = t"ab"
 

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -153,6 +153,48 @@ object Tests extends Suite(m"Rudiments Tests"):
         total
       . assert(_ == 60)
 
+      test(m"`iterate` over a branded sub-interval visits only that range"):
+        var total = 0
+        array.iterate(array.lead(_ => true).capped(2)) { i => total += array.at(i) }
+        total
+      . assert(_ == 30)
+
+      test(m"`spot` finds the first matching confined index"):
+        text.spot { i => text.at(i) == 'l' }.let { i => (i: Ordinal).n0 }
+      . assert(_ == 2)
+
+      test(m"`spot` returns Unset when nothing matches"):
+        text.spot { i => text.at(i) == 'z' }
+      . assert(_ == Unset)
+
+      test(m"`lead` spans the matching prefix and stops at the first mismatch"):
+        val interval: Interval = text.lead { i => text.at(i) != 'l' }
+        interval.size
+      . assert(_ == 2)
+
+      test(m"`lead` spans the whole extent when everything matches"):
+        val interval: Interval = text.lead { _ => true }
+        interval.size
+      . assert(_ == 5)
+
+      test(m"`pare` drops the matching suffix, respecting the floor"):
+        val digits = Array.of(3, 7, 0, 0, 0)
+        val interval: Interval = digits.pare(1) { i => digits.at(i) == 0 }
+        interval.size
+      . assert(_ == 2)
+
+      test(m"`pare` never shrinks below its floor"):
+        val zeros = Array.of(0, 0, 0)
+        val interval: Interval = zeros.pare(1) { i => zeros.at(i) == 0 }
+        interval.size
+      . assert(_ == 1)
+
+      test(m"`retrace` visits confined indices in reverse"):
+        val builder = java.lang.StringBuilder()
+        text.retrace { i => builder.append(text.at(i)) }
+        builder.toString.tt
+      . assert(_ == t"olleh")
+
     // test(m"Display a PID"):
     //   Pid(2999).toString
     // .assert(_ == "↯2999")

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -335,6 +335,35 @@ object Tests extends Suite(m"Rudiments Tests"):
         sizes.reverse
       . assert(_ == List(2, 3))
 
+      test(m"`triples` visits whole groups and returns the branded remainder"):
+        val data = Array.of[Byte](1, 2, 3, 4, 5, 6, 7, 8)
+        var sums: List[Int] = Nil
+        var rest = -1
+
+        val remainder = data.triples { (a, b, c) => sums ::= a + b + c }
+        rest = (remainder: Interval).size
+
+        (sums.reverse, rest)
+      . assert(_ == ((List(6, 15), 2)))
+
+      test(m"`pairs` and `quads` group evenly with empty remainders"):
+        val data = Array.of[Byte](1, 2, 3, 4)
+        var pairSum = 0
+        var quadSum = 0
+
+        val pairRest = data.pairs { (a, b) => pairSum += a + b }
+        val quadRest = data.quads { (a, b, c, d) => quadSum += a + b + c + d }
+
+        (pairSum, (pairRest: Interval).size, quadSum, (quadRest: Interval).size)
+      . assert(_ == ((10, 0, 10, 0)))
+
+      test(m"`adjacent` visits every overlapping pair"):
+        val text = t"abcd"
+        val builder = java.lang.StringBuilder()
+        text.adjacent { (left, right) => builder.append(left).nn.append(right).nn.append('.') }
+        builder.toString.tt
+      . assert(_ == t"ab.bc.cd.")
+
       test(m"an exhausted surveyor has no point and an empty remainder"):
         val text = t"ab"
 

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -195,6 +195,43 @@ object Tests extends Suite(m"Rudiments Tests"):
         builder.toString.tt
       . assert(_ == t"olleh")
 
+    suite(m"Scribe tests"):
+      test(m"`Array.scribe` fills through branded indices"):
+        Array.scribe[Int](4) { scribe => range => scribe.iterate { i => scribe(i) = (i: Ordinal).n0*2 } }
+        . to[List]
+      . assert(_ == List(0, 2, 4, 6))
+
+      test(m"a scribe reads back what it wrote"):
+        var last = -1
+
+        Array.scribe[Int](3): scribe =>
+          range =>
+            scribe.iterate { i => scribe(i) = 7 }
+            scribe.iterate { i => last = scribe(i) }
+
+        last
+      . assert(_ == 7)
+
+      test(m"`place` copies a whole frozen array, clamped to the space"):
+        val source = Array.of(1, 2, 3, 4, 5)
+
+        val target = Array.scribe[Int](4): scribe =>
+          range => scribe.iterate { i => if (i: Ordinal) == Sec then scribe.place(source, i) }
+
+        target.to[List]
+      . assert(_ == List(0, 1, 2, 3))
+
+      test(m"the scan family applies to a scribe"):
+        var kept = -1
+
+        Array.scribe[Int](5): scribe =>
+          range =>
+            scribe.iterate { i => scribe(i) = (i: Ordinal).n0 }
+            kept = (scribe.pare(0) { i => scribe(i) > 2 }: Interval).size
+
+        kept
+      . assert(_ == 3)
+
     // test(m"Display a PID"):
     //   Pid(2999).toString
     // .assert(_ == "↯2999")

--- a/lib/stratiform/src/core/stratiform.internal.scala
+++ b/lib/stratiform/src/core/stratiform.internal.scala
@@ -46,6 +46,7 @@ import fulminate.*
 import gigantism.*
 import gossamer.*
 import prepositional.*
+import denominative.*
 import rudiments.*
 import vacuous.*
 
@@ -69,14 +70,7 @@ object internal:
   private final val MarkerString: String = Marker.toString
 
   private def hasMarker(text: Text): Boolean =
-    var i = 0
-    val s = text.s
-
-    while i < s.length do
-      if s.charAt(i) == Marker then return true
-      i += 1
-
-    false
+    text.spot { index => text.at(index) == Marker }.present
 
   def interpolator[parts <: Tuple: Type, origins <: Tuple: Type]
     ( insertions0: Expr[Seq[Any]] )
@@ -328,15 +322,9 @@ object internal:
      out:     scala.collection.mutable.ListBuffer[Tel] )
   :   Boolean =
 
-    if pattern.length != input.length then false
-    else
-      var i = 0
-
-      while i < pattern.length do
-        if !matchBlock(pattern(i), input(i), marker, out) then return false
-        i += 1
-
-      true
+    pattern.length == input.length && pattern.spot: index =>
+      !input.at(index).lay(false)(matchBlock(pattern.at(index), _, marker, out))
+    . absent
 
   private def matchBlock
     ( pattern: Tel.Block,
@@ -347,14 +335,12 @@ object internal:
 
     if pattern.compounds.length != input.compounds.length then false
     else
-      var i = 0
+      val left = pattern.compounds
+      val right = input.compounds
 
-      while i < pattern.compounds.length do
-        if !matchCompound(pattern.compounds(i), input.compounds(i), marker, out) then return false
-
-        i += 1
-
-      true
+      left.spot: index =>
+        !right.at(index).lay(false)(matchCompound(left.at(index), _, marker, out))
+      . absent
 
   private def matchCompound
     ( pattern: Tel.Compound,
@@ -366,13 +352,14 @@ object internal:
     if pattern.keyword != input.keyword then false
     else if pattern.atoms.length != input.atoms.length then false
     else
-      var i = 0
+      val left = pattern.atoms
+      val right = input.atoms
 
-      while i < pattern.atoms.length do
-        if !matchAtom(pattern.atoms(i), input.atoms(i), marker, out) then return false
-        i += 1
+      val atoms = left.spot: index =>
+        !right.at(index).lay(false)(matchAtom(left.at(index), _, marker, out))
+      . absent
 
-      matchBlocks(pattern.children, input.children, marker, out)
+      atoms && matchBlocks(pattern.children, input.children, marker, out)
 
   private def matchAtom
     ( pattern: Tel.Atom,

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -38,6 +38,7 @@ import scala.language.dynamics
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import distillate.*
 import fulminate.*
 import gesticulate.*

--- a/lib/telekinesis/src/http2/cordillera.FrameReader.scala
+++ b/lib/telekinesis/src/http2/cordillera.FrameReader.scala
@@ -41,7 +41,8 @@ import gossamer.*
 import rudiments.*
 import vacuous.*
 import prepositional.*
-import zephyrine.{Slate, Stream, Credit, Buffering, Substrate, capped}
+import denominative.capped
+import zephyrine.{Slate, Stream, Credit, Buffering, Substrate}
 
 import Http2.Frame
 import Http2Error.Reason

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-// `Region`, `Slate` and `capped` are deliberately absent: their lenders and combinators are
+// `Region` and `Slate` are deliberately absent: their lenders and combinators are
 // dependent-typed inline extensions, which synthesized export forwarders break (see the
 // hand-written `via`/`accepting` forwarders below for the same problem). Consumers import
 // them from `zephyrine` directly.

--- a/lib/zephyrine/src/core/zephyrine.Region.scala
+++ b/lib/zephyrine/src/core/zephyrine.Region.scala
@@ -160,10 +160,3 @@ object Region:
     // The only branded-ordinal producer, for the trusted combinators above.
     private inline def ordinal(inline n: Int): Ordinal in region.type =
       Ordinal.zerary(n).asInstanceOf[Ordinal in region.type]
-
-// Brand-preserving narrowing: a sub-interval of a valid extent is itself valid, so clamping
-// preserves the brand. `capped` keeps at most the first `count` indexes of the extent.
-extension [form](range: Interval in form)
-  inline def capped(count: Int): Interval in form =
-    val interval: Interval = range
-    Interval.sized(interval.start.n0, interval.size.min(count.max(0))).asInstanceOf[Interval in form]


### PR DESCRIPTION
Continuing #1666 after `Region` (#1730), this delivers the vocabulary for replacing raw indexed `while` loops — a survey of the ~1,500-loop corpus drove the design — and proves it across six modules of different characters. Every combinator is inline and allocation-free, and only trusted combinators produce branded indexes, so access through them is total: no bounds checks, no `Optional`.

The confined-scan family answers the largest category, guarded scans whose callers consume the stopping index: `spot` finds the first matching confined index, `lead` and `pare` return matching prefixes and trailing trims as branded intervals, `retrace` iterates in reverse, and `extent` brands the whole range. `Array.scribe` lends a `Scribe`, the write-side handle: branded `update`, clamped bulk `place`, and a sequential `append` cursor for irregular write positions; a scribe is `Countable`, so the scan family applies to it directly. `value.survey` lends a `Surveyor`, the parser cursor: `pace` advances over a run and returns it as a branded interval (run lengths come from interval sizes, not index arithmetic), `peek` tests without advancing, `next` and `take` consume, and `matches`/`glimpse` express marker scans. `pairs` through `octuples` walk disjoint groups for mismatched-stride codecs, `adjacent` covers boundary pairs, and a `Lattice` derives branded rows and points from 2-D coordinates with the height clamped at the lender — retiring the `y*stride + x` arithmetic where stride ≠ width bugs live.

Migrated as proof: escapade's `Teletype` (including three duplicated binary searches collapsing into one confined `searchRun`), facsimile's stream decoders and PDF marker scans (`endstreamFollows` is now `pace` then `matches`), all four monotonous serialization kernels (a 4 MiB microbenchmark shows performance unchanged), gossamer's `fill` and grapheme-boundary loops, stratiform's TEL pattern matchers, and hallucination's GIF compositor — where the frame-overhang guards became `Lattice.point`'s bounds check, and a latent crash on malformed GIFs indexing beyond a small palette became defined behaviour. Codec kernels whose index arithmetic is data-derived (compressors, the Knuth-division core, PNG predictor feedback) deliberately remain behind one documented gate each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
