### PR TITLE
Make wrong-key decryption tests deterministic

### DIFF
--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -340,21 +340,36 @@ object Tests extends Suite(m"Enigmatic tests"):
         t"Hello world".encrypt(InitializationVector.random).decrypt.as[Text]
     . assert(_ == t"Hello world")
 
-    test(m"Decryption with the wrong key fails with a CryptoError"):
+    // Wrong-key CBC decryption yields uniform garbage, and PKCS7 unpadding accepts any
+    // final block ending `0x01` (or `0x02 0x02`, and so on), so about one run in 256 the
+    // garbage forms valid padding and decryption "succeeds". Both outcomes demonstrate
+    // the property that matters, so both are accepted; `Invalid PKCS7 padding is reported
+    // as BadPadding` below covers the padding failure deterministically.
+    test(m"Decryption with the wrong key never recovers the plaintext"):
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       val wrongKey = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       val ciphertext = key.uncloak(t"Hello world".encrypt(InitializationVector.random))
-      capture[CryptoError](wrongKey.uncloak(ciphertext.decrypt.as[Text])).reason
-    . assert(_ == CryptoError.Reason.BadPadding)
 
-    test(m"Streaming decryption with the wrong key raises a CryptoError"):
+      attempt[CryptoError](wrongKey.uncloak(ciphertext.decrypt.as[Text])) match
+        case Attempt.Failure(error) => error.reason == CryptoError.Reason.BadPadding
+        case Attempt.Success(text)  => text != t"Hello world"
+
+    . assert(_ == true)
+
+    test(m"Streaming decryption with the wrong key never recovers the plaintext"):
       // The provider's tag/padding failure surfaces at end-of-stream as a typed
       // `CryptoError`, not the raw JCE exception, when the final window is pulled.
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       val wrongKey = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       val ciphertext = key.uncloak(t"Hello world".encrypt(InitializationVector.random))
-      capture[CryptoError](wrongKey.uncloak(ciphertext.stream.decrypt.memoize)).reason
-    . assert(_ == CryptoError.Reason.BadPadding)
+
+      attempt[CryptoError](wrongKey.uncloak(ciphertext.stream.decrypt.memoize)) match
+        case Attempt.Failure(error) => error.reason == CryptoError.Reason.BadPadding
+
+        case Attempt.Success(data) =>
+          data.serialize[Hex] != t"Hello world".in[Data].serialize[Hex]
+
+    . assert(_ == true)
 
     test(m"AES/CBC/NoPadding round-trips block-aligned input"):
       val key = SymmetricKey.generate[Aes[256] over Cbc against NoPadding]()
@@ -366,6 +381,17 @@ object Tests extends Suite(m"Enigmatic tests"):
       val key = SymmetricKey.generate[Aes[256] over Cbc against NoPadding]()
       capture[CryptoError](key.uncloak(t"Hello world".encrypt(InitializationVector.random))).reason
     . assert(_ == CryptoError.Reason.IllegalBlockSize)
+
+    test(m"Invalid PKCS7 padding is reported as BadPadding"):
+      val bytes: Data = t"a-32-byte-key-for-aes-256-cbc!!!".in[Data]
+      val rawKey: SymmetricKey[Aes[256] over Cbc against NoPadding] = SymmetricKey(bytes)
+      val paddedKey: SymmetricKey[Aes[256] over Cbc against Pkcs7] = SymmetricKey(bytes)
+
+      // The recovered final block ends in `f` (0x66), which is never a valid PKCS7 pad
+      // length, so unpadding fails for every run rather than for 255 runs in 256.
+      val ciphertext = rawKey.uncloak(t"0123456789abcdef".encrypt(InitializationVector.random))
+      capture[CryptoError](paddedKey.uncloak(ciphertext.decrypt.as[Text])).reason
+    . assert(_ == CryptoError.Reason.BadPadding)
 
     test(m"AES/CTR/NoPadding (stream mode) accepts any length"):
       val key = SymmetricKey.generate[Aes[256] over Ctr against NoPadding]()


### PR DESCRIPTION
The enigmatic test suite's two wrong-key decryption tests asserted that PKCS7 unpadding rejects the garbage produced by decrypting under the wrong key, which it only does about 255 times in 256 — any final block ending `0x01` is valid padding, so roughly one attestation in a hundred failed on a test unrelated to the branch being attested. Both tests now accept either outcome, since neither one recovers the plaintext, and a new deterministic test covers the padding-failure path that the probabilistic ones were only nominally exercising.

Two symmetric-cipher tests were renamed and one was added; no library code changed, so there is nothing to do when upgrading.

`Decryption with the wrong key fails with a CryptoError` and its streaming sibling are now `… never recovers the plaintext`, and assert the property they were really after: decrypting with the wrong key either raises `CryptoError(BadPadding)` or returns something that is not the original plaintext.

```scala
attempt[CryptoError](wrongKey.uncloak(ciphertext.decrypt.as[Text])) match
  case Attempt.Failure(error) => error.reason == CryptoError.Reason.BadPadding
  case Attempt.Success(text)  => text != t"Hello world"
```

The new `Invalid PKCS7 padding is reported as BadPadding` covers the `BadPaddingException` → `CryptoError.Reason.BadPadding` mapping without relying on chance, by decrypting a `NoPadding` ciphertext whose recovered final byte can never be a valid pad length under a `Pkcs7` key built from the same material.

Closes #1738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
