### PR TITLE
Never refill past a message's final byte in Cursor consumers

### DIFF
--- a/lib/perihelion/src/core/perihelion.Frame.scala
+++ b/lib/perihelion/src/core/perihelion.Frame.scala
@@ -61,14 +61,19 @@ object Frame:
   // payload — or `Unset` at a clean end of stream. The byte-level counterpart of
   // `Frame.encode`. `Masking` fixes the direction: a server requires the frame to be
   // masked (a client's), a client requires it to be unmasked (a server's). Uses
-  // `peek`/`next`/`take` (not `lay`/`seek`), which don't reference the cursor's erased
-  // `Operand` type, so it works on a bare `Cursor[Data, ?]` parameter.
+  // `peek`/`advance`/`take` (not `lay`/`seek`), which don't reference the cursor's
+  // erased `Operand` type, so it works on a bare `Cursor[Data, ?]` parameter.
+  // Header bytes are consumed with `advance()` rather than `next()`: `next`'s
+  // trailing `more` forces a blocking refill, so for a zero-payload unmasked frame
+  // (an empty server→client Ping/Pong/Close, whose last byte is `byte1`) it would
+  // stall the completed frame until the peer happened to send another (issue #1301).
+  // Blocking is intended only at the head of a frame — the `finished` guard below.
   def parse(cursor: Cursor[Data, {}]^)(using masking: Masking)
     ( using Tactic[WebsocketError] )
   :   Optional[Frame] =
     if cursor.finished then Unset else
       val byte0 = cursor.peek.asInt
-      cursor.next()
+      cursor.advance()
       val fin = (byte0 & 0x80) != 0
 
       // RFC 6455 §5.2: RSV1/2/3 must be zero unless an extension negotiated them,
@@ -78,7 +83,7 @@ object Frame:
       val opcode = byte0 & 0x0f
 
       val byte1 = cursor.peek.asInt
-      cursor.next()
+      cursor.advance()
       val masked = (byte1 & 0x80) != 0
 
       // RFC 6455 §5.1: a server must reject an unmasked client frame; a client must

--- a/lib/perihelion/src/test/perihelion.Test.scala
+++ b/lib/perihelion/src/test/perihelion.Test.scala
@@ -243,6 +243,31 @@ object Tests extends Suite(m"Perihelion tests"):
         capture[WebsocketError](parseFrame(frame(0x8, closeBytes(1004, "")))).reason
       . assert(_ == WebsocketError.Reason.BadClose)
 
+      // Simulates a live connection delivering a complete zero-payload
+      // unmasked control frame (a server's empty Pong: 0x8a 0x00) and then
+      // nothing until some later frame. Parsing must return the frame without
+      // pulling past its final byte — that pull would stall the completed
+      // frame behind the peer's next transmission (issue #1301).
+      test(m"An empty control frame parses without reading past its end"):
+        class Live() extends Iterator[Data]:
+          @scala.caps.unsafe.untrackedCaptures
+          var pulls: Int = 0
+          def hasNext: Boolean = true
+
+          def next(): Data =
+            pulls += 1
+            if pulls == 1 then Data(0x8a.toByte, 0x00.toByte) else Data(0x8a.toByte)
+
+        val live = Live()
+        val frame = Frame.parse(Cursor[Data](live))(using Masking.Client())
+
+        val isEmptyPong = frame match
+          case Frame.Pong(payload) => payload.length == 0
+          case _                   => false
+
+        (isEmptyPong, live.pulls)
+      . assert(_ == (true, 1))
+
     suite(m"Message reassembly"):
       test(m"A single text frame yields one message"):
         texts(readMessages(frame(0x1, octets("hello"))))

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -926,7 +926,14 @@ object Http:
 
       while reading do
         if cursor.peek == '\r' then
-          cursor.next()
+          // Consume the head's final CRLF with `advance` rather than `next`:
+          // `next` calls `more`, which forces a blocking refill of the
+          // underlying stream. That is fatal for a bodiless response (204,
+          // 304, 1xx, or an answer to `HEAD`) on a kept-alive connection: the
+          // server sends nothing after the head until our next request, so
+          // the refill would deadlock. The symmetric hazard to the server
+          // side's `Http.Request.parseHead`; see issue #1301.
+          cursor.advance()
           cursor.expect('\n')(expected('\n'))
           reading = false
 
@@ -946,7 +953,7 @@ object Http:
             cursor.seek('\r'.toByte.asInstanceOf[cursor.addressable.Operand])
             Ascii(cursor.grab(start, cursor.mark)).show
 
-          cursor.next()
+          cursor.advance()
           cursor.expect('\n')(expected('\n'))
           headers = Http.Header(header, value) :: headers
 

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -278,6 +278,28 @@ object Tests extends Suite(m"Telekinesis tests"):
           case HttpResponseError.Reason.Status(_) => true
           case _                                  => false
 
+      suite(m"Keep-alive boundary"):
+        // Simulates a kept-alive connection: the server sends a complete
+        // bodiless response and then nothing until the next request. Parsing
+        // the head must not read past its final CRLF — the pull for a further
+        // chunk would deadlock on a real socket (issue #1301). The second
+        // chunk here stands in for a later response that must stay unread.
+        test(m"Bodiless response head does not read past the final CRLF"):
+          class Live() extends Iterator[Data]:
+            @scala.caps.unsafe.untrackedCaptures
+            var pulls: Int = 0
+            def hasNext: Boolean = true
+
+            def next(): Data =
+              pulls += 1
+              if pulls == 1 then t"HTTP/1.1 204 No Content\r\nServer: test\r\n\r\n".in[Data]
+              else t"HTTP/1.1 200 OK\r\n\r\n".in[Data]
+
+          val live = Live()
+          val head = Http.Response.parseHead(Cursor[Data](live))
+          (head.status, live.pulls)
+        . assert(_ == (Http.NoContent, 1))
+
       test(m"Fetch a URL"):
         url"https://httpbin.org/post"
         . submit(Http.Post, contentEncoding = enc"UTF-8", accept = media"application/json")

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -241,7 +241,9 @@ object Cursor:
 
   // Safe, allocation-free single-element peek. Returns `Datum.End` when the
   // cursor is finished; otherwise the current byte (unsigned, `0..255`) or
-  // char wrapped as a `Datum`. The `Datum` opaque type (backed by `Int`)
+  // char wrapped as a `Datum`. May block (via `finished` → refill) to fetch
+  // the operand being inspected — acceptable, since that operand must exist
+  // for any match — but never reads past it. The `Datum` opaque type (backed by `Int`)
   // is deliberately distinct from raw `Int` so that arithmetic or
   // `Byte`/`Char` confusion can't happen silently — comparison with the
   // expected literal is via the dedicated `Datum.==` overloads, which still
@@ -272,6 +274,12 @@ object Cursor:
   // target is `Char` for both variants so callers don't need `'X'.toByte`
   // on `Cursor[Data]`; for ASCII targets the `Datum`-vs-`Char` comparison
   // compiles to a single primitive `int == int`.
+  //
+  // The match consumes with `advance()`, not `next()`: `peek` has already
+  // confirmed the operand is present, and `next()`'s trailing `more` would
+  // force a blocking refill for the byte *after* the match — fatal when
+  // `expect` consumes the final delimiter of a message on a keep-alive
+  // stream whose peer sends nothing more until we reply (issue #1301).
   extension [cap^](cursor: Cursor[Data, cap])
     @targetName("expectByte")
     inline def expect[error <: Hazard](target: Char)
@@ -279,7 +287,7 @@ object Cursor:
       ( using Tactic[error] )
     :   Unit =
 
-      if cursor.peek == target then cursor.next() else raise(failure)
+      if cursor.peek == target then cursor.advance() else raise(failure)
 
   extension [cap^](cursor: Cursor[Text, cap])
     @targetName("expectChar")
@@ -288,7 +296,7 @@ object Cursor:
       ( using Tactic[error] )
     :   Unit =
 
-      if cursor.peek == target then cursor.next() else raise(failure)
+      if cursor.peek == target then cursor.advance() else raise(failure)
 
   // Run `action` inside a hold and always restore the cursor position to
   // where it was on entry, regardless of the result — i.e. a non-consuming
@@ -323,6 +331,18 @@ object Cursor:
     inline def buffer(using erased unsafe: Unsafe): scala.Array[Char] =
       cursor.unsafeBuffer(using Unsafe).asInstanceOf[scala.Array[Char]]
 
+// BLOCKING-LOOKAHEAD HAZARD (issue #1301): every operation that asks whether data exists —
+// `more`, `finished`, `peek`, and `next()` (whose trailing `more` runs after consuming) —
+// refills from the source once the buffer drains, and a refill BLOCKS until the source
+// yields data or EOF. On finite or EOF-terminated input that is always prompt and harmless.
+// But a parser that stops at a message boundary on a LIVE stream with no EOF between
+// messages (HTTP/1.1 keep-alive, any half-duplex request/response protocol) must never
+// look past the message's final operand: the peer sends nothing more until we reply, so
+// the refill deadlocks. Such parsers must consume the final delimiter with `peek` (or
+// `expect`) then `advance()` — which never refills — and bound reads with `available`,
+// `take`, or an explicit length. `expect` and `take` are internally safe; the exemplar
+// call site is telekinesis's `Http.Request.parseHead`.
+//
 // `cap^` is the capture set of the `load` thunk: `{}` for an in-memory cursor (the loader is a
 // no-op), or the capabilities a streaming loader draws from (e.g. a socket). Tracking it as an
 // explicit capture parameter — rather than letting capture checking infer a blanket self-capture —
@@ -502,6 +522,13 @@ extends caps.Mutable:
   // `Cursor.forward` rationale and keeps the inner loop one instruction
   // tighter — important for raw byte-scan parsers like Merino where the
   // hot loop is `while more && {peek-test} do advance()`.
+  //
+  // Deferring the refill also makes `advance()` the boundary-safety
+  // primitive: it is the only way to consume an operand *without* touching
+  // the source. A parser stopping at a message boundary on a live stream
+  // (see the hazard note on the class) must consume its final delimiter
+  // with `peek`-then-`advance()` — as `expect` and `take` do — never with
+  // `next()`.
   inline update def advance(): Unit =
     if lineationActive then
       val operand = addressable.storageAddress(buffer, pos)
@@ -546,7 +573,10 @@ extends caps.Mutable:
     columnNo = denominative.Ordinal.zerary(value)
 
   // `next()` is `advance(); more`, so it returns `true` while more data is
-  // available and `false` when the stream is exhausted.
+  // available and `false` when the stream is exhausted. The trailing `more`
+  // means it blocks on a refill once the buffer drains — so never use it to
+  // consume the last operand of a message on a live stream (see the hazard
+  // note on the class); consume with `peek`-then-`advance()` instead.
   inline update def next(): Boolean =
     advance()
     more
@@ -653,9 +683,15 @@ extends caps.Mutable:
 
   // ─── search primitives ────────────────────────────────────────────────────
 
+  // Entered via `more`, not unconditionally: the previous operation may have
+  // consumed the buffer's last operand with a deferred-refill `advance()`
+  // (directly, or via `expect`/`take`), leaving `pos` at `writeEnd` with the
+  // current operand not yet loaded. Reading `datum` before a refill would
+  // then see stale storage. Stopping on a match performs no further refill,
+  // so `seek` never reads past the operand it finds.
   inline update def seek(target: addressable.Operand): Boolean =
     var found = false
-    var continue = true
+    var continue = more
 
     while continue do
       found = datum(using Unsafe) == target

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -567,6 +567,28 @@ object Tests extends Suite(m"Zephyrine tests"):
           cursor.peek == 'b'
         . assert(identity)
 
+        // Simulates a live keep-alive stream: the source yields a whole
+        // two-byte message in its first chunk, and the next chunk (a later,
+        // independent message) would only arrive after we reply. Consuming
+        // the final byte with `expect` must not pull that second chunk
+        // (issue #1301) — on a real socket the pull would deadlock.
+        test(m"Cursor[Data].expect on a message's final byte does not refill"):
+          class Live() extends Iterator[Data]:
+            @scala.caps.unsafe.untrackedCaptures
+            var pulls: Int = 0
+            def hasNext: Boolean = true
+
+            def next(): Data =
+              pulls += 1
+              if pulls == 1 then Data('a'.toByte, 'b'.toByte) else Data('X'.toByte)
+
+          val live = Live()
+          val cursor = Cursor(live)
+          cursor.expect('a')(Mismatch())
+          cursor.expect('b')(Mismatch())
+          live.pulls
+        . assert(_ == 1)
+
       suite(m"lookahead tests"):
         test(m"lookahead returns result without advancing on success"):
           val cursor = Cursor[Text](Iterator(t"abcd"))


### PR DESCRIPTION
This resolves the remaining actions on #1301: `Cursor.expect` consumed its matched operand via `next()`, whose trailing `more` forces a blocking refill — reading one byte past the match, which deadlocks when the match is a message's final delimiter on a keep-alive stream. The hazard had become live: the raw HTTP/1.1 client backends now parse responses off kept-alive sockets, where a bodiless response (204/304/1xx/`HEAD`) would hang in `Http.Response.parseHead`, and a zero-payload WebSocket control frame was stalled behind the peer's next frame. `expect` now consumes with `advance()`, `seek` guards its entry with `more` instead of assuming a filled buffer, the response and frame parsers consume boundary bytes with `advance()`, and the hazard is documented on `Cursor` and its lookahead members, with regression tests in all three modules. Closes #1301.

## Release notes

- `Cursor.expect` no longer reads ahead of the operand it matches. Previously, matching the final byte of a logical message forced a blocking read of the byte after it — a deadlock on a keep-alive connection whose peer sends nothing further until you reply:

  ```scala
  // Parsing "…\r\n\r\n" at the end of an HTTP head on a live socket:
  cursor.expect('\n')(expected('\n'))  // previously blocked awaiting a further byte;
                                       // now returns as soon as the match is consumed
  ```

- `Cursor.seek` no longer assumes the current operand is already buffered on entry, so it is now safe immediately after a deferred-refill `advance()` (including via `expect` and `take`).
- `Http.Response.parseHead` no longer reads past the head's final CRLF, so bodiless responses (204, 304, 1xx, or answers to `HEAD`) parse promptly on kept-alive connections — required by the raw-socket HTTP/1.1 client backends.
- `perihelion.Frame.parse` returns a zero-payload control frame (an empty `Ping`, `Pong` or `Close`) as soon as its last byte arrives, instead of waiting for the next frame.
- The blocking-lookahead hazard and the safe stop-at-boundary pattern (`peek` then `advance()`, bounding reads with `available`/`take`) are now documented on `Cursor`, `next()`, `advance()` and `peek`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)