### PR TITLE
Prefer infix types over refinements when rendering types

### DIFF
--- a/lib/stenography/src/core/stenography.Bindings.scala
+++ b/lib/stenography/src/core/stenography.Bindings.scala
@@ -34,6 +34,7 @@ package stenography
 
 import java.util.IdentityHashMap
 
+import scala.collection.immutable as sci
 import scala.collection.mutable as scm
 
 import anticipation.*
@@ -43,7 +44,15 @@ import anticipation.*
 // when pure functions are on, and as `=>` when they are off, since `A => B` desugars to
 // `ImpureFunctionN` only in the former case. Without a compiler context to consult we assume
 // the pure-functions reading, so `->` and `=>` at least stay distinguishable.
-final class Bindings(val pureFuns: Boolean = true):
+//
+// `infixAliases` maps a refinement member's name to the infix type alias which refines it, so
+// that `Foo { type Form = Bar }` can be written back as `Foo in Bar`. It is keyed by member
+// name because that is what a refinement carries once the alias has been expanded away. Only
+// `internal.name` populates it, from the aliases which are in scope at the expansion site;
+// every other caller gets an empty map and hence the refinement form.
+final class Bindings
+  ( val pureFuns:     Boolean = true,
+    val infixAliases: sci.Map[String, Text] = sci.Map() ):
   private val names = IdentityHashMap[AnyRef, Text]()
   private val counters = scm.HashMap[Text, Int]()
   private[stenography] val cache = scm.HashMap[Any, Syntax]()

--- a/lib/stenography/src/core/stenography.Syntax.scala
+++ b/lib/stenography/src/core/stenography.Syntax.scala
@@ -378,6 +378,27 @@ object Syntax:
     case _            => panic(m"expected a Value")
 
 
+  // A refinement of a single type member can be written with an infix type alias, where one
+  // which refines that member is in scope: `Foo { type Form = Bar }` is `Foo in Bar`. Only an
+  // alias member qualifies; `Foo { type Form <: Bar }` is not what `Foo in Bar` expands to, so
+  // it stays a refinement rather than acquiring a wildcard operand.
+  private def infixAlias(using Quotes)(using bindings: Bindings)
+    ( base: quotes.reflect.TypeRepr, name: String, member: quotes.reflect.TypeRepr )
+  :   Optional[Syntax] =
+
+    import quotes.reflect.*
+
+    if !bindings.infixAliases.contains(name) then Unset else
+      val operator = bindings.infixAliases(name)
+
+      member match
+        case TypeBounds(lower, upper) if lower == upper =>
+          Infix(apply(base), operator, apply(lower))
+
+        case _ =>
+          Unset
+
+
   def apply(using Quotes)(using bindings: Bindings = Bindings())
     ( repr: quotes.reflect.TypeRepr, retry: Boolean = true )
   :   Syntax =
@@ -545,7 +566,8 @@ object Syntax:
           functionSyntax(typ, Nil, false).or(apply(member))
 
         case Refinement(base, name, member) =>
-          if name == "Self" then Infix(apply(member), "is", apply(base)) else
+          if name == "Self" then Infix(apply(member), "is", apply(base))
+          else infixAlias(base, name, member).or:
             val refined: Structural = apply(base) match
               case refined@Structural(base, members, defs) => refined
 

--- a/lib/stenography/src/core/stenography.internal.scala
+++ b/lib/stenography/src/core/stenography.internal.scala
@@ -39,6 +39,7 @@ import scala.quoted.*
 
 import anticipation.*
 import gigantism.*
+import vacuous.*
 
 object internal:
   import dotty.tools.dotc.*
@@ -58,6 +59,9 @@ object internal:
 
       case _ => true
 
+    // The bindings the scan below runs with. They carry no infix aliases: the scan renders
+    // nothing but bare `TypeRef`s, for which the aliases it is in the middle of discovering
+    // could not matter. The type itself is rendered with alias-carrying bindings at the end.
     given Bindings = Bindings(pureFuns)
 
     val outer: List[Designator] = quotes.absolve match
@@ -76,35 +80,56 @@ object internal:
 
     val imports: sci.Set[Designator] = metaprogramming.imports.map(_.term).map(Syntax.term(_)).toSet
 
-    // Build the `direct` set by drilling into every wildcard import that's in
-    // scope (including REPL-accumulated imports across earlier lines, captured
-    // by `metaprogramming.imports`) and collecting type aliases carrying the
-    // `Exported` flag. Those aliases' *target* types are reachable via just
-    // their leaf in the current scope, so we render them that way.
-    val direct: sci.Set[Designator] = quotes.absolve match
+    // Drill into every scope whose members are reachable unqualified from here — each wildcard
+    // import that's in scope (including the REPL-accumulated ones across earlier lines,
+    // captured by `metaprogramming.imports`) and this unit's own package — and harvest two
+    // things from a single pass over its declarations.
+    //
+    // The `direct` set holds type aliases carrying the `Exported` flag. Those aliases' *target*
+    // types are reachable via just their leaf in the current scope, so we render them that way.
+    //
+    // The `aliases` map holds the infix type aliases which refine a single type member, keyed
+    // by that member's name, so `Foo { type Form = Bar }` can be written back as `Foo in Bar`.
+    // Scanning scopes rather than the whole classpath is what keeps the rendering honest: an
+    // alias is only worth preferring where it is in scope to be written.
+    val (direct, aliases) = quotes.absolve match
       case quotes: runtime.impl.QuotesImpl =>
         given context: core.Contexts.Context = quotes.ctx
 
-        metaprogramming.imports.filter(_.wildcard).flatMap: imp =>
-          val rootSym = imp.term.asInstanceOf[core.Types.Type].termSymbol(using context)
+        val imported = metaprogramming.imports.filter(_.wildcard).map: imp =>
+          imp.term.asInstanceOf[core.Types.Type].termSymbol(using context)
 
-          if !rootSym.exists then Nil else exportedTargets(rootSym)
+        // This unit's own package, so that a module's aliases apply within the module which
+        // declares them, without it having to import itself.
+        val own = context.compilationUnit.tpdTree.absolve match
+          case ast.tpd.PackageDef(root, _) => List(root.symbol)
+          case _                           => Nil
 
-        .toSet
+        val harvested = (imported ++ own).filter(_.exists).map(scopeInfo)
 
-      case _ => sci.Set.empty[Designator]
+        // Where two aliases claim the same member, choose by name, so that the rendering does
+        // not depend on the order the scopes happened to be walked in.
+        val aliases = harvested.flatMap(_(1)).groupBy(_(0)).view.mapValues: candidates =>
+          candidates.map(_(1).s).min.tt
+
+        (harvested.flatMap(_(0)).toSet, aliases.toMap)
+
+      case _ =>
+        (sci.Set.empty[Designator], sci.Map.empty[String, Text])
 
     given Imports =
       Imports(sci.Set(Designator("scala"), Designator("scala.Predef")) ++ imports ++ outer, direct)
 
-    Syntax(typeRepr).text
+    Syntax(using quotes)(using Bindings(pureFuns, aliases))(typeRepr).text
 
-  private def exportedTargets(using Quotes, dotty.tools.dotc.core.Contexts.Context)
+  // Everything worth knowing about one scope whose members are reachable unqualified: the
+  // targets of its `Exported` aliases, and the infix type aliases it declares which refine a
+  // single type member.
+  private def scopeInfo(using Quotes, dotty.tools.dotc.core.Contexts.Context)
     ( rootSym: dotty.tools.dotc.core.Symbols.Symbol )
-  :   List[Designator] =
+  :   (List[Designator], List[(String, Text)]) =
 
-    import dotty.tools.dotc.core.{Flags, Types}
-    import quotes.reflect.TypeRepr
+    import dotty.tools.dotc.core.Flags
 
     // Top-level definitions in a package are stored inside synthetic
     // `<filename>$package` classes; export forwarders for types live there.
@@ -112,23 +137,82 @@ object internal:
     val packageClasses = directDecls.filter(_.name.toString.endsWith("$package"))
     val nestedDecls = packageClasses.flatMap(_.info.decls.toList)
 
-    (directDecls ++ nestedDecls).filter(_.is(Flags.Exported)).flatMap: decl =>
-      decl.info match
-        // Only simple (non-polymorphic) alias targets can shorten to a name. Polymorphic
-        // re-exports (tuple types, `Some`, `<:<`, …) carry `TypeParamRef`s that `Syntax`
-        // cannot render — matching only `TypeRef` skips them instead of crashing. This path
-        // is now exercised by proscenium's prelude re-exports of the primitives.
-        case alias: Types.TypeAlias => alias.alias match
-          case ref: Types.TypeRef =>
-            Syntax(ref.asInstanceOf[TypeRepr]) match
-              // Add both forms so the same import path can shorten references
-              // to either the type itself or its companion (e.g. `Textual` and
-              // `Textual.foo` both resolve via `import soundness.*`).
-              case Syntax.Simple(designator) => List(designator, designator.companionObject)
-              case _                       => Nil
+    // A type alias can never be a *direct* member of a package — a top-level one lives in the
+    // `$package` class above — so a package's own declarations cannot hold an infix alias and
+    // are skipped. That is not just an optimisation: `java.lang` is a root import, and reading
+    // the `Infix` flag off each of its members would complete every class in it, which on a JDK
+    // whose classfiles this compiler cannot fully read fails outright.
+    val aliasDecls = if rootSym.is(Flags.Package) then nestedDecls else directDecls ++ nestedDecls
 
-          case _ =>
-            Nil
+    val exported = (directDecls ++ nestedDecls).filter(_.is(Flags.Exported))
+
+    (exported.flatMap(exportedTarget), aliasDecls.filter(_.is(Flags.Infix)).flatMap(refiningAlias))
+
+
+  private def exportedTarget(using Quotes, dotty.tools.dotc.core.Contexts.Context)
+    ( decl: dotty.tools.dotc.core.Symbols.Symbol )
+  :   List[Designator] =
+
+    import dotty.tools.dotc.core.Types
+    import quotes.reflect.TypeRepr
+
+    decl.info match
+      // Only simple (non-polymorphic) alias targets can shorten to a name. Polymorphic
+      // re-exports (tuple types, `Some`, `<:<`, …) carry `TypeParamRef`s that `Syntax`
+      // cannot render — matching only `TypeRef` skips them instead of crashing. This path
+      // is now exercised by proscenium's prelude re-exports of the primitives.
+      case alias: Types.TypeAlias => alias.alias match
+        case ref: Types.TypeRef =>
+          Syntax(ref.asInstanceOf[TypeRepr]) match
+            // Add both forms so the same import path can shorten references
+            // to either the type itself or its companion (e.g. `Textual` and
+            // `Textual.foo` both resolve via `import soundness.*`).
+            case Syntax.Simple(designator) => List(designator, designator.companionObject)
+            case _                         => Nil
 
         case _ =>
           Nil
+
+      case _ =>
+        Nil
+
+
+  // Recognises an alias of the shape
+  //
+  //     infix type in [refined, form] = refined { type Form = form }
+  //
+  // and pairs the refined member's name with the operator's, `"Form" -> "in"`. The two type
+  // parameters have to appear in exactly those positions: the first as the refinement's parent
+  // and the second as the sole member's alias. Anything else — a fixed parent, a second member,
+  // an abstract member, a different arity — has no two-operand infix form and is skipped, which
+  // is what excludes `transcribes` and every infix alias that is not a refinement at all.
+  private def refiningAlias(using Quotes, dotty.tools.dotc.core.Contexts.Context)
+    ( decl: dotty.tools.dotc.core.Symbols.Symbol )
+  :   List[(String, Text)] =
+
+    import dotty.tools.dotc.core.Types
+
+    def parameter(repr: Types.Type, binder: Types.HKTypeLambda, index: Int): Boolean =
+      repr match
+        case ref: Types.TypeParamRef => ref.binder == binder && ref.paramNum == index
+        case _                       => false
+
+    val lambda: Optional[Types.HKTypeLambda] = decl.info match
+      case alias: Types.TypeAlias => alias.alias match
+        case lambda: Types.HKTypeLambda => lambda
+        case _                          => Unset
+
+      case lambda: Types.HKTypeLambda => lambda
+      case _                          => Unset
+
+    lambda.lay(Nil): lambda =>
+      if lambda.paramNames.length != 2 then Nil else
+        // An `export`ed alias forwards to the original as an applied type, so dealiasing the
+        // body is what lets an alias reached through a prelude be recognised too.
+        lambda.resType.dealias match
+          case Types.RefinedType(parent, name, Types.TypeAlias(rhs))
+          if parameter(parent, lambda, 0) && parameter(rhs, lambda, 1) =>
+            List(name.toString -> decl.name.toString.tt)
+
+          case _ =>
+            Nil

--- a/lib/stenography/src/test/stenography_test.scala
+++ b/lib/stenography/src/test/stenography_test.scala
@@ -241,6 +241,43 @@ object Tests extends Suite(m"Stenography Tests"):
       Syntax.name[Addable { type Q = Int; type Other = String}]
     . assert(_ == t"Addable { type Q = Int; type Other = String }")
 
+    // Written as refinements rather than as `Addable by Int`, because the compiler keeps the
+    // alias when it is written, and it is precisely the dealiased form these cover.
+    test(m"Prefer an infix alias over the refinement it expands to"):
+      Syntax.name[Addable { type Operand = Int }]
+    . assert(_ == t"Addable by Int")
+
+    test(m"Prefer `in` over a `Form` refinement"):
+      Syntax.name[Addable { type Form = Int }]
+    . assert(_ == t"Addable in Int")
+
+    test(m"Prefer infix aliases for several refined members"):
+      Syntax.name[Addable { type Operand = Int; type Result = Double }]
+    . assert(_ == t"Addable by Int to Double")
+
+    test(m"Prefer an infix alias alongside a member which has none"):
+      Syntax.name[Addable { type Operand = Int; type Q = String }]
+    . assert(_ == t"Addable by Int { type Q = String }")
+
+    // The parentheses are redundant — an alphabetic infix type operator binds tighter than the
+    // function arrow — but `Function` parenthesises any parameter whose precedence it exceeds,
+    // and alphabetic operators score lowest. That applies equally to the `is` this generalises,
+    // so it is left alone here.
+    test(m"Prefer an infix alias within a function type"):
+      Syntax.name[(Addable { type Operand = Int }) => String]
+    . assert(_ == t"(Addable by Int) => String")
+
+    // `Addable by (? <: Int)` is not what `by` expands to, so a bounded member has to stay a
+    // refinement rather than acquire a wildcard operand.
+    test(m"Leave a refinement which bounds, rather than aliases, its member"):
+      Syntax.name[Addable { type Operand <: Int }]
+    . assert(_ == t"Addable { type Operand = ? <: Int }")
+
+    // `Q` has no infix alias refining it, so this must not pick up a neighbour's operator.
+    test(m"Leave a refinement whose member has no infix alias"):
+      Syntax.name[Addable { type Q = Int }]
+    . assert(_ == t"Addable { type Q = Int }")
+
     test(m"Refined higher-kinded type member"):
       Syntax.name[Addable { type Hkt[Bar] = Option[Bar] }]
     . assert(_ == t"Addable { type Hkt = [Bar] =>> Option[Bar] }")


### PR DESCRIPTION
Stenography now writes a refined type using the infix type alias it came from, so a type that the compiler has dealiased renders as `Foo in Bar` rather than `Foo { type Form = Bar }`. It already did this for `is`; the preference is now general, and applies to any infix alias in scope at the point where the type is printed. This affects every diagnostic that goes through Stenography, including Frontier's missing-given messages, Delicious's semantic diagnostics and Prophesy's completions.

Soundness declares a family of infix type aliases whose right-hand side refines a single type member — `by`, `in`, `to`, `of`, `on`, `onto`, `over`, `from`, `across`, `against`, `under`, `at` in `prepositional`, and others such as `aperture`'s `granting`. The compiler expands these away during inference, so by the time Stenography saw a type, `Foo in Bar` had usually become `Foo { type Form = Bar }`, and that is what appeared in error messages.

Stenography now recognises the expansion and writes the alias back:

```scala
Syntax.name[Addable { type Operand = Int }]              // "Addable by Int"
Syntax.name[Addable { type Operand = Int; type Result = Double }]
                                                         // "Addable by Int to Double"
```

A member with no alias still renders as a refinement, and the two compose:

```scala
Syntax.name[Addable { type Operand = Int; type Q = String }]
                                                         // "Addable by Int { type Q = String }"
```

The aliases are discovered by scanning the scopes that are reachable unqualified from the point of expansion — each wildcard import, plus the compilation unit's own package — so an alias is only used where it is genuinely in scope to be written. Aliases reached through a prelude such as `import soundness.*` are resolved through their export forwarders. No annotation or registration is needed: declaring

```scala
infix type granting[refined, grants] = refined { type Grants = grants }
```

is enough for `Mode { type Grants = Grant.Read }` to render as `Mode granting Grant.Read` wherever `granting` is in scope.

Only an alias member qualifies. `Foo { type Form <: Bar }` continues to render as a refinement, because `Foo in Bar` does not expand to a bounded member, and rewriting it would produce something that no longer describes the same type.

Closes #1689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)