### PR TITLE
Compile identically on the Proscala 3.9 and 3.10 streams

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -54,10 +54,10 @@ object settings:
   //      https://github.com/propensive/proscala/releases; each release ships a single
   //      `proscala-<tag>.tar.gz` asset whose contents are a `lib` directory (the unversioned core
   //      jars plus the versioned third-party jars). The `toolchain` module below downloads
-  //      `SOUNDNESS_SCALA_RELEASE` (default `3.9.0-RC4-p1`, the latest in the 3.9.0 stream) and
+  //      `SOUNDNESS_SCALA_RELEASE` (default `3.9.0-RC5-p11`, the latest in the 3.9.0 stream) and
   //      extracts it into a shared cache, exposing its jars to every coursier resolution — no
   //      local compiler build and no publishing step needed. Switch streams by setting
-  //      `SOUNDNESS_SCALA_RELEASE` (e.g. `3.10.0-dev-p2`).
+  //      `SOUNDNESS_SCALA_RELEASE` (e.g. `3.10.0-dev-p11`).
   //
   //   2. Local (fork developers). Point `SOUNDNESS_SCALA_HOME` at a `make`-built `release`
   //      directory to use its `release/lib` jars directly instead of downloading. After
@@ -71,8 +71,8 @@ object settings:
   // (`SOUNDNESS_SCALA_RELEASE`) is a separate concept, though from `3.9.0-RC4-p1` on the two
   // coincide (earlier releases shipped jars built as e.g. `3.9.0-RC1-propensive`). Override the
   // coordinate with `SOUNDNESS_SCALA_VERSION`.
-  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC4-p9")
-  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC4-p9")
+  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC5-p11")
+  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC5-p11")
   // Empty by default → download `scalaRelease`. Set to a local `release` directory to use its
   // `release/lib` jars directly (fork-developer mode).
   val scalaHome = sys.env.getOrElse("SOUNDNESS_SCALA_HOME", "")

--- a/lib/anthology/src/scala/anthology.ScalacEdges.scala
+++ b/lib/anthology/src/scala/anthology.ScalacEdges.scala
@@ -96,8 +96,12 @@ object scalacEdges:
         CompileEvents.relay(using linkEvents)
 
       mitigate:
-        case CompilerError() => LinkError(LinkError.Reason.CompilerUnusable(t"scalac"))
-        case AsyncError(_)   => LinkError(LinkError.Reason.CompilerUnusable(t"scalac"))
+        // A type test, not `CompilerError()`: when the mitigation macro re-splices these
+        // cases, one compiler stream mis-retypes a nullary case-class pattern (its
+        // `Boolean` unapply) while a type test — identical in meaning for an empty case
+        // class — retypes correctly on both.
+        case _: CompilerError => LinkError(LinkError.Reason.CompilerUnusable(t"scalac"))
+        case AsyncError(_)    => LinkError(LinkError.Reason.CompilerUnusable(t"scalac"))
 
       . protect:
           val process = scalac(classpath)(sources, out)

--- a/lib/anthology/src/scala/anthology.ScalacEdges.scala
+++ b/lib/anthology/src/scala/anthology.ScalacEdges.scala
@@ -96,12 +96,8 @@ object scalacEdges:
         CompileEvents.relay(using linkEvents)
 
       mitigate:
-        // A type test, not `CompilerError()`: when the mitigation macro re-splices these
-        // cases, one compiler stream mis-retypes a nullary case-class pattern (its
-        // `Boolean` unapply) while a type test — identical in meaning for an empty case
-        // class — retypes correctly on both.
-        case _: CompilerError => LinkError(LinkError.Reason.CompilerUnusable(t"scalac"))
-        case AsyncError(_)    => LinkError(LinkError.Reason.CompilerUnusable(t"scalac"))
+        case CompilerError() => LinkError(LinkError.Reason.CompilerUnusable(t"scalac"))
+        case AsyncError(_)   => LinkError(LinkError.Reason.CompilerUnusable(t"scalac"))
 
       . protect:
           val process = scalac(classpath)(sources, out)

--- a/lib/anthology/src/scala/anthology.ScalacSession.scala
+++ b/lib/anthology/src/scala/anthology.ScalacSession.scala
@@ -64,7 +64,7 @@ object ScalacSession:
   // artifacts, and `save` materializes them under a directory, only if the caller wants
   // them on disk. Since session compiles run synchronously, the result is already complete
   // by the time the process is returned.
-  class Process private[anthology] (output: dtio.VirtualDirectory) extends CompileProcess():
+  class Process private[anthology] (output: dtio.AbstractFile) extends CompileProcess():
     // Every artifact the compile emitted — classfiles, TASTy, `.sjsir`, `.nir` — keyed by
     // its location on the classpath this output constitutes. Empty if the compile failed
     // before the back-end ran.
@@ -124,7 +124,7 @@ extends caps.ExclusiveCapability, caps.Stateful:
     baseContext = driver.baseContext(arguments).getOrElse(abort(CompilerError()))
 
   update def compile(sources: Map[Text, Text]): ScalacSession.Process^{this, caps.any} =
-    val output = dtio.VirtualDirectory("<session output>")
+    val output = dtio.virtualDirectory("<session output>")
     val process = ScalacSession.Process(output)
     val reporter = processReporter(process)
 

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -584,10 +584,13 @@ object Tests extends Suite(m"Anthology Tests"):
           val linked: soundness.Path on Linux = unsafely(temporaryDirectory / Uuid())
 
           test(m"Linking natively produces a runnable binary"):
+            val host =
+              Triple.host.or(panic(m"the host triple always resolves on a supported platform"))
+
             Toolchain(edges).produce
               ( Deliverable.Emission(out, classpath),
                 Universe.Nir,
-                Binary(Triple.host.vouch),
+                Binary(host),
                 linked,
                 Nil,
                 List(EntryPoint(Fqcn(t"Main"))) )

--- a/lib/aperture/src/test/aperture_test.scala
+++ b/lib/aperture/src/test/aperture_test.scala
@@ -191,8 +191,8 @@ object Tests extends Suite(m"Aperture Tests"):
     test(m"Instantiation creates an empty artifact and returns the target"):
       val vault = Vault()
       val target = VaultRef(vault).create()
-      (target.vault.made, vault.committed.vouch)
-    . assert(_ == (true, Nil))
+      (target.vault.made, vault.committed.lay(true)(_ == Nil))
+    . assert(_ == (true, true))
 
     test(m"Scoped authoring commits at scope close"):
       val vault = Vault()
@@ -201,8 +201,8 @@ object Tests extends Suite(m"Aperture Tests"):
         scribe.append(t"first")
         scribe.append(t"second")
 
-      vault.committed.vouch
-    . assert(_ == List(t"first", t"second"))
+      vault.committed
+    . assert(_.lay(false)(_ == List(t"first", t"second")))
 
     test(m"An exception escaping the scope commits nothing"):
       val vault = Vault()

--- a/lib/apoplexy/src/core/apoplexy.Api.scala
+++ b/lib/apoplexy/src/core/apoplexy.Api.scala
@@ -50,6 +50,7 @@ import spectacular.*
 import telekinesis.*
 import turbulence.*
 import urticose.*
+import fulminate.*
 import vacuous.*
 import xylophone.*
 import zephyrine.*
@@ -108,7 +109,13 @@ object Api:
     val headers: List[Http.Header] = Http.Header(t"accept", accept) :: contentTypeHeader
 
     val httpRequest =
-      Http.Request(request.method, 1.1, url.host.vouch, url.requestTarget, headers, body)
+      Http.Request
+        ( request.method,
+          1.1,
+          url.host.or(panic(m"an http or https URL always has a host")),
+          url.requestTarget,
+          headers,
+          body )
 
     client.request(httpRequest, url.origin)
 

--- a/lib/apoplexy/src/core/apoplexy.OpenApi.scala
+++ b/lib/apoplexy/src/core/apoplexy.OpenApi.scala
@@ -156,7 +156,7 @@ object OpenApi:
             Http.Trace -> trace )
 
       verbs
-      . stdlib.collect { case (method, operation) if operation.present => method -> operation.vouch }
+      . stdlib.collect { case (method, operation: Operation) => method -> operation }
       . pipe(Map.from(_))
 
   object Components:
@@ -210,67 +210,67 @@ object OpenApi:
     def field[value: Decodable in Yaml](name: Text): Optional[value] =
       yaml(name).as[Optional[value]]
 
-    val reference = field[Text]("$ref".tt)
+    field[Text]("$ref".tt).let: reference =>
+      JsonSchema.Ref(reference.as[JsonPointer], field[Text](t"description"))
 
-    if !reference.absent
-    then JsonSchema.Ref(reference.vouch.as[JsonPointer], field[Text](t"description"))
-    else field[Text](t"type") match
-      case t"array" =>
-        JsonSchema.Array
-          ( field[Text](t"description"),
-            field[JsonSchema](t"items"),
-            field[Int](t"minItems"),
-            field[Int](t"maxItems"),
-            false,
-            field[Int](t"maxContains"),
-            field[Int](t"minContains") )
+    . or:
+        field[Text](t"type") match
+          case t"array" =>
+            JsonSchema.Array
+              ( field[Text](t"description"),
+                field[JsonSchema](t"items"),
+                field[Int](t"minItems"),
+                field[Int](t"maxItems"),
+                false,
+                field[Int](t"maxContains"),
+                field[Int](t"minContains") )
 
-      case t"string" =>
-        JsonSchema.String
-          ( field[Text](t"description"),
-            field[Int](t"minLength"),
-            field[Int](t"maxLength"),
-            field[Text](t"pattern"),
-            field[JsonSchema.Format](t"format"),
-            false )
+          case t"string" =>
+            JsonSchema.String
+              ( field[Text](t"description"),
+                field[Int](t"minLength"),
+                field[Int](t"maxLength"),
+                field[Text](t"pattern"),
+                field[JsonSchema.Format](t"format"),
+                false )
 
-      case t"number" =>
-        JsonSchema.Number
-          ( field[Text](t"description"),
-            field[Double](t"multipleOf"),
-            field[Double](t"maximum"),
-            field[Double](t"minimum"),
-            field[Double](t"exclusiveMinimum"),
-            field[Double](t"exclusiveMaximum"),
-            false )
+          case t"number" =>
+            JsonSchema.Number
+              ( field[Text](t"description"),
+                field[Double](t"multipleOf"),
+                field[Double](t"maximum"),
+                field[Double](t"minimum"),
+                field[Double](t"exclusiveMinimum"),
+                field[Double](t"exclusiveMaximum"),
+                false )
 
-      case t"integer" =>
-        JsonSchema.Integer
-          ( field[Text](t"description"),
-            field[Int](t"maximum"),
-            field[Int](t"minimum"),
-            field[Int](t"exclusiveMinimum"),
-            field[Int](t"exclusiveMaximum"),
-            false )
+          case t"integer" =>
+            JsonSchema.Integer
+              ( field[Text](t"description"),
+                field[Int](t"maximum"),
+                field[Int](t"minimum"),
+                field[Int](t"exclusiveMinimum"),
+                field[Int](t"exclusiveMaximum"),
+                false )
 
-      case t"boolean" =>
-        JsonSchema.Boolean(field[Text](t"description"), false)
+          case t"boolean" =>
+            JsonSchema.Boolean(field[Text](t"description"), false)
 
-      case t"null" =>
-        JsonSchema.Null(field[Text](t"description"), false)
+          case t"null" =>
+            JsonSchema.Null(field[Text](t"description"), false)
 
-      case _ =>
-        JsonSchema.Object
-          ( field[Text](t"description"),
-            field[Map[Text, JsonSchema]](t"properties").or(Map()),
-            false,
-            field[List[Text]](t"required"),
-            // `enum` holds raw `Json` values, and there is no `Yaml`->`Json`
-            // bridge, so enum constraint values are not carried through the YAML
-            // path; they do not affect endpoint structure.
-            Unset,
-            yaml(t"additionalProperties").as[Optional[scala.Boolean]].or(false),
-            field[List[JsonSchema]](t"oneOf") )
+          case _ =>
+            JsonSchema.Object
+              ( field[Text](t"description"),
+                field[Map[Text, JsonSchema]](t"properties").or(Map()),
+                false,
+                field[List[Text]](t"required"),
+                // `enum` holds raw `Json` values, and there is no `Yaml`->`Json`
+                // bridge, so enum constraint values are not carried through the YAML
+                // path; they do not affect endpoint structure.
+                Unset,
+                yaml(t"additionalProperties").as[Optional[scala.Boolean]].or(false),
+                field[List[JsonSchema]](t"oneOf") )
 
   // Anchor the top-level model so `as[OpenApi]` (below) materialises its decoder
   // once — with each nested type resolving to its own anchor — rather than inlining

--- a/lib/apoplexy/src/core/apoplexy.internal.scala
+++ b/lib/apoplexy/src/core/apoplexy.internal.scala
@@ -303,8 +303,10 @@ object Apoplexy:
 
     val reqWire = operation.requestBody.let: body => wireOf(body.content)
 
-    if respWire.present && reqWire.present && respWire.vouch != reqWire.vouch
-    then halt(m"apoplexy: $verb $locus mixes request and response media types")
+    respWire.let: resp =>
+      reqWire.let: req =>
+        if resp != req
+        then halt(m"apoplexy: $verb $locus mixes request and response media types")
 
     val wire = respWire.or(reqWire.or(Wire.Json))
 

--- a/lib/apoplexy/src/test/apoplexy_test.scala
+++ b/lib/apoplexy/src/test/apoplexy_test.scala
@@ -164,18 +164,18 @@ components:
     test(m"JSON and YAML specs decode to the same model")(fromYaml).assert(_ == fromJson)
 
     test(m"the operationId of GET /pets is read"):
-      fromJson.paths(t"/pets").vouch.get.vouch.operationId.vouch
+      fromJson.paths(t"/pets").let(_.get).let(_.operationId)
     .assert(_ == t"listPets")
 
     test(m"the path parameter location is decoded as Path"):
-      fromJson.paths(t"/pets/{id}").vouch.get.vouch.parameters.head.in
+      fromJson.paths(t"/pets/{id}").let(_.get).let(_.parameters.head.in)
     .assert(_ == OpenApi.Parameter.In.Path)
 
     test(m"a reference property is kept lazy"):
-      fromJson.components.vouch.schemas(t"Pet").vouch
+      fromJson.components.let(_.schemas(t"Pet"))
     .assert:
       case JsonSchema.Object(_, properties, _, _, _, _, _) =>
-        properties(t"owner").vouch match
+        properties(t"owner") match
           case JsonSchema.Ref(pointer, _, _) => pointer.encode == t"#/components/schemas/Owner"
           case _                             => false
       case _ => false

--- a/lib/archimedes/src/core/archimedes.Cell.scala
+++ b/lib/archimedes/src/core/archimedes.Cell.scala
@@ -101,13 +101,15 @@ object Cell:
       val ascent = cells.stdlib.map(_.baseline).reduceLeft(max)
       val descent = cells.stdlib.map { cell => cell.height - 1 - cell.baseline }.reduceLeft(max)
       val framed = cells.stdlib.map(_.framed(ascent, descent))
-      val height = ascent + descent + 1
 
-      val lines = Sequence.from:
-        (0 until height).map: row =>
-          Writing(List.of(framed.map { cell => cell.lines((row).z).vouch.text }).join)
+      // Every framed cell has exactly `ascent + descent + 1` lines, so joining row-wise is an
+      // n-ary zip of the line sequences — no indexing, hence no bounds obligation to discharge.
+      val rows =
+        framed
+        . map { cell => cell.lines.stdlib.map(_.text) }
+        . reduceLeft { (left, right) => left.zip(right).map { (l, r) => t"$l$r" } }
 
-      Cell(lines, cells.stdlib.map(_.width).reduceLeft(_ + _), ascent)
+      Cell(Sequence.of(rows.map(Writing(_))), cells.stdlib.map(_.width).reduceLeft(_ + _), ascent)
 
   def fraction(numerator: Cell, denominator: Cell): Cell =
     val width = max(numerator.width, denominator.width) + 2
@@ -142,17 +144,17 @@ object Cell:
       (0 until height).map: row =>
         val left = slice(base, row - superscript.height)
 
-        val scripts =
-          if row < superscript.height then
-            val text = superscript.lines((row).z).vouch.text
-            val pad = spaces(right - superscript.width).text
-            t"$text$pad"
-          else if row >= middle then
-            val text = subscript.lines((row - middle).z).vouch.text
-            val pad = spaces(right - subscript.width).text
-            t"$text$pad"
-          else
-            spaces(right).text
+        // `confine` makes the branch guard and the bounds proof the same act: a confined
+        // ordinal indexes its own sequence bare, and an out-of-range row is simply `Unset`.
+        val fromSuperscript = superscript.lines.confine(row.z).let: ord =>
+          val pad = spaces(right - superscript.width).text
+          t"${superscript.lines(ord).text}$pad"
+
+        val fromSubscript = subscript.lines.confine((row - middle).z).let: ord =>
+          val pad = spaces(right - subscript.width).text
+          t"${subscript.lines(ord).text}$pad"
+
+        val scripts = fromSuperscript.or(fromSubscript.or(spaces(right).text))
 
         Writing(t"$left$scripts")
 
@@ -178,16 +180,17 @@ object Cell:
   def radical(inner: Cell): Cell =
     if inner.height > 1 then tallRadical(inner) else
       val overline = Writing(t"$Corner${repeat(Bar, inner.width).text}")
-      val body = Writing(t"$Radical${inner.lines((0).z).vouch.text}")
+      val body = Writing(t"$Radical${slice(inner, 0)}")
       Cell(Sequence(overline, body), inner.width + 1, 1)
 
   private def tallRadical(inner: Cell): Cell =
     val overline = Writing(t" $Corner${repeat(Bar, inner.width).text}")
 
-    val body = Sequence.from:
-      (0 until inner.height).map: row =>
-        val foot = if row == inner.height - 1 then Tick else ' '
-        Writing(t"$foot$Stem${inner.lines((row).z).vouch.text}")
+    // Traversing `inner`'s own lines directly, the row content needs no index at all; the
+    // index survives only to mark the last row with the radical's foot.
+    val body = inner.lines.zipWithIndex.map: (line, row) =>
+      val foot = if row == inner.height - 1 then Tick else ' '
+      Writing(t"$foot$Stem${line.text}")
 
     Cell(Sequence(overline) ::: body, inner.width + 2, inner.baseline + 1)
 
@@ -196,10 +199,10 @@ object Cell:
   def root(base: Cell, index: Cell): Cell =
     val radicand = tallRadical(base)
 
-    val lines = Sequence.from:
-      (0 until radicand.height).map: row =>
-        val prefix = if row < index.height then index.lines((row).z).vouch.text else spaces(index.width).text
-        Writing(t"$prefix${radicand.lines((row).z).vouch.text}")
+    // The radicand's rows come from traversing its own lines, so they need no proof; the
+    // (shorter) index cell is a checked lookup with a blank fallback — exactly `slice`.
+    val lines = radicand.lines.zipWithIndex.map: (line, row) =>
+      Writing(t"${slice(index, row)}${line.text}")
 
     Cell(lines, index.width + radicand.width, radicand.baseline)
 

--- a/lib/archimedes/src/core/archimedes.internal.scala
+++ b/lib/archimedes/src/core/archimedes.internal.scala
@@ -57,7 +57,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)

--- a/lib/aviation/src/core/aviation.Regime.scala
+++ b/lib/aviation/src/core/aviation.Regime.scala
@@ -72,11 +72,9 @@ class Regime(name: Text, segments: List[Regime.Segment]) extends RomanCalendar(n
     def recur(remaining: List[(Segment, Int)]): Optional[Date] = remaining match
       case (segment, upper) :: tail =>
         val candidate: Optional[Date] = safely(segment.calendar.jdn(year, month, day))
-        val jdn: Optional[Int] = candidate.let(_.jdn)
 
-        if jdn.present && segment.from.jdn <= jdn.vouch && jdn.vouch <= upper
-        then candidate
-        else recur(tail)
+        candidate.lay(recur(tail)): date =>
+          if segment.from.jdn <= date.jdn && date.jdn <= upper then date else recur(tail)
 
       case Nil =>
         Unset

--- a/lib/aviation/src/core/aviation.Rrule.scala
+++ b/lib/aviation/src/core/aviation.Rrule.scala
@@ -96,11 +96,14 @@ object Rrule:
     def part(condition: Boolean, text: => Text): List[Text] =
       if condition then List(text) else List()
 
+    def partOf[value](optional: Optional[value])(text: value => Text): List[Text] =
+      optional.lay(List())(value => List(text(value)))
+
     val parts =
       part(true, t"FREQ=${rule.frequency.toString.tt.upper}") :::
         part(rule.interval != 1, t"INTERVAL=${rule.interval}") :::
-        part(rule.count.present, t"COUNT=${rule.count.vouch}") :::
-        part(rule.until.present, t"UNTIL=${rule.until.vouch.encode}") :::
+        partOf(rule.count) { count => t"COUNT=$count" } :::
+        partOf(rule.until) { until => t"UNTIL=${until.encode}" } :::
         part(rule.byMonth.nonEmpty, t"BYMONTH=${rule.byMonth.map(_.numerical.show).join(t",")}") :::
         part(rule.byWeekNo.nonEmpty, t"BYWEEKNO=${rule.byWeekNo.map(_.show).join(t",")}") :::
         part(rule.byYearDay.nonEmpty, t"BYYEARDAY=${rule.byYearDay.map(_.show).join(t",")}") :::
@@ -326,19 +329,16 @@ object Rrule:
 
     val byDayDates: Optional[List[Date]] =
       if rule.byDay.isEmpty then Unset else rule.byDay.bind: (entry: WeekdayOrdinal) =>
-        if entry.ordinal.absent then weekdaysOfMonth(year, month, entry.weekday)
-        else list(nthWeekday(year, month, entry.weekday, entry.ordinal.vouch))
+        entry.ordinal.lay(weekdaysOfMonth(year, month, entry.weekday)): ordinal =>
+          list(nthWeekday(year, month, entry.weekday, ordinal))
 
     val byMonthDayDates: Optional[List[Date]] =
       if rule.byMonthDay.isEmpty then Unset else rule.byMonthDay.bind: (day: Int) =>
         list(monthDay(year, month, day))
 
     val candidates =
-      if byDayDates.present && byMonthDayDates.present
-      then byDayDates.vouch.filter(byMonthDayDates.vouch.has(_))
-      else if byDayDates.present then byDayDates.vouch
-      else if byMonthDayDates.present then byMonthDayDates.vouch
-      else list(monthDay(year, month, dayOf(start)))
+      byDayDates.lay(byMonthDayDates.or(list(monthDay(year, month, dayOf(start))))): byDay =>
+        byMonthDayDates.lay(byDay)(monthDays => byDay.filter(monthDays.has(_)))
 
     candidates.distinct.sort(_.jdn)
 

--- a/lib/aviation/src/core/aviation.Vernacular.scala
+++ b/lib/aviation/src/core/aviation.Vernacular.scala
@@ -264,7 +264,7 @@ trait Vernacular:
   protected final def durations(span: Timespan): List[Text] = Vernacular.components(span).map(quantity)
 
   protected final def dayPhrase(entry: (Optional[Int], Text)): Text =
-    if entry(0).absent then entry(1) else t"${position(entry(0).vouch)} ${entry(1)}"
+    entry(0).lay(entry(1))(ordinal => t"${position(ordinal)} ${entry(1)}")
 
   final def relativeTimespan(span: Timespan): Text = Vernacular.components(span) match
     case Nil => justNow

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -144,7 +144,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)
@@ -330,7 +330,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)
@@ -374,7 +374,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)
@@ -397,7 +397,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -555,17 +555,16 @@ object internal:
     strip(leftTree) match
       case Apply(fn, scala.collection.immutable.List(yearArg, monthArg))
       if fn.symbol.name == "apply" || fn.symbol.name == "<init>" =>
-        val year = constInt(yearArg)
-        val month = monthOrdinal(monthArg)
-        val day = constInt(rightTree)
+        (constInt(yearArg), monthOrdinal(monthArg), constInt(rightTree)) match
+          case (year: Int, month: Int, day: Int) =>
+            staticCalendar match
+              case calendar: RomanCalendar =>
+                jdnOf(calendar, year, month + 1, day) match
+                  case Right(jdn)  => '{Date.julianDay(${Expr(jdn)})}
+                  case Left(error) => halt(error)
 
-        val literal = year.present && month.present && day.present
-
-        if !literal then runtime else staticCalendar match
-          case calendar: RomanCalendar =>
-            jdnOf(calendar, year.vouch, month.vouch + 1, day.vouch) match
-              case Right(jdn)  => '{Date.julianDay(${Expr(jdn)})}
-              case Left(error) => halt(error)
+              case _ =>
+                runtime
 
           case _ =>
             runtime

--- a/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
+++ b/lib/beneficence/src/plugin/beneficence.GivensPhase.scala
@@ -57,7 +57,7 @@ class GivensPhase() extends PluginPhase:
       val sources: mutable.LinkedHashSet[String] = mutable.LinkedHashSet.empty
 
       units.foreach: unit =>
-        sources += unit.source.file.path
+        sources += unit.source.path
         collect(unit, collectedGivens, collectedSuites, findable, suite)
 
       GivensWriter.merge(collectedGivens, sources.toSet)
@@ -73,7 +73,7 @@ class GivensPhase() extends PluginPhase:
     ( using Context )
   :   Unit =
 
-    val sourceFile = unit.source.file.path
+    val sourceFile = unit.source.path
 
     val traverser = new tpd.TreeTraverser:
       def traverse(tree: tpd.Tree)(using Context): Unit =

--- a/lib/bitumen/src/core/bitumen.TarBody.scala
+++ b/lib/bitumen/src/core/bitumen.TarBody.scala
@@ -73,15 +73,14 @@ class TarBody private (initial: List[Data], pull: () -> Optional[Data]):
   // Extend the memo by one chunk, or record exhaustion.
   private def fetch(): Boolean =
     if exhausted then false else
-      val next = pull()
+      pull() match
+        case Unset =>
+          exhausted = true
+          false
 
-      if next.absent then
-        exhausted = true
-        false
-      else
-        val chunk = next.vouch
-        if chunk.length > 0 then memo += chunk
-        chunk.length > 0 || fetch()
+        case chunk: Data =>
+          if chunk.length > 0 then memo += chunk
+          chunk.length > 0 || fetch()
 
   // Read the remainder of the body from its producer, so the producer may move
   // past it. Memoized chunks are never re-read.

--- a/lib/bitumen/src/core/bitumen.Tarfile.scala
+++ b/lib/bitumen/src/core/bitumen.Tarfile.scala
@@ -137,11 +137,13 @@ object Tarfile:
 
       def hasNext: Boolean = !lookahead.absent || (!finished && advance())
 
-      def next(): Tar.Entry =
-        if !hasNext then panic(m"the archive has no more entries")
-        val entry = lookahead.vouch
-        lookahead = Unset
-        entry
+      def next(): Tar.Entry = lookahead match
+        case entry: Tar.Entry =>
+          lookahead = Unset
+          entry
+
+        case Unset =>
+          if !finished && advance() then next() else panic(m"the archive has no more entries")
 
       // Parse forward to the next real entry, first draining whatever of the
       // previous entry's body was not yet read, so the cursor stands at the
@@ -156,15 +158,15 @@ object Tarfile:
         var longLink: Optional[Text] = Unset
 
         while lookahead.absent && !finished do
-          val block = takeBlock(cursor)
+          takeBlock(cursor) match
+            case Unset =>
+              // The archive ended without its terminating zero blocks.
+              raise(TarError(TarError.Reason.TruncatedStream(512, 0)))
+              finished = true
 
-          if block.absent then
-            // The archive ended without its terminating zero blocks.
-            raise(TarError(TarError.Reason.TruncatedStream(512, 0)))
-            finished = true
-          else
-            val head = block.vouch
-            if TarHeader.isZeroBlock(head) then finished = true else
+            case head: Data if TarHeader.isZeroBlock(head) => finished = true
+
+            case head: Data =>
               val header = TarHeader.parse(head)
               val checksum = TarHeader.decodeOctal(header.checksum, t"checksum")
               TarHeader.verifyChecksum(head, checksum)
@@ -343,14 +345,12 @@ object Tarfile:
     ( using Tactic[TarError] )
   :   List[SparseSegment] =
 
-    if !hasMore then Nil else
-      val block = takeBlock(cursor)
-
-      if block.absent then
+    if !hasMore then Nil else takeBlock(cursor) match
+      case Unset =>
         raise(TarError(TarError.Reason.TruncatedStream(512, 0)))
         Nil
-      else
-        val head = block.vouch
+
+      case head: Data =>
         val builder = scala.collection.immutable.List.newBuilder[SparseSegment]
         var pos = 0
         var i = 0

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -898,23 +898,27 @@ object Cbor extends Cbor2, Dynamic:
     @scala.caps.unsafe.untrackedCaptures
     var offset: Int = 0
 
-    private inline def expect(count: Int): Unit raises CborError =
+    // These inline helpers take an explicit `Tactic` clause rather than `raises` sugar: the
+    // context-function result the sugar expands to synthesizes a closure per inline expansion,
+    // and from the 2026-07-17 upstream nightlies (#26547) a second expansion in the same
+    // method fails cc root-visibility against the first expansion's memoized root capability.
+    private inline def expect(count: Int)(using Tactic[CborError]): Unit =
       if data.length - offset < count then abort(CborError(Reason.Truncated(offset.toLong)))
 
     private inline def readByte(): Int =
       (data(offset)&0xFF).also(offset += 1)
 
-    private inline def readUInt8(): Int raises CborError =
+    private inline def readUInt8()(using Tactic[CborError]): Int =
       expect(1)
       readByte()
 
-    private inline def readUInt16(): Int raises CborError =
+    private inline def readUInt16()(using Tactic[CborError]): Int =
       expect(2)
       val pos = offset
       offset = pos + 2
       ((data(pos) & 0xFF) << 8) | (data(pos + 1) & 0xFF)
 
-    private inline def readUInt32(): Long raises CborError =
+    private inline def readUInt32()(using Tactic[CborError]): Long =
       expect(4)
       val pos = offset
       offset = pos + 4
@@ -923,7 +927,7 @@ object Cbor extends Cbor2, Dynamic:
         ((data(pos + 2) & 0xFFL) << 8) |
         (data(pos + 3) & 0xFFL)
 
-    private inline def readUInt64(): Long raises CborError =
+    private inline def readUInt64()(using Tactic[CborError]): Long =
       expect(8)
       val pos = offset
       offset = pos + 8
@@ -943,7 +947,7 @@ object Cbor extends Cbor2, Dynamic:
     // dominates real-world workloads (small integers, short strings, small
     // arrays/maps). The remaining cases dispatch through a `match` so the JVM
     // can compile them to a tableswitch.
-    private inline def readLength(info: Int, headOffset: Long): Long raises CborError =
+    private inline def readLength(info: Int, headOffset: Long)(using Tactic[CborError]): Long =
       if info < 24 then info.toLong
       else info match
         case 24 => readUInt8().toLong
@@ -966,7 +970,7 @@ object Cbor extends Cbor2, Dynamic:
       offset += length
       Array.freeze(result)
 
-    private inline def boundedLength(length: Long, headOffset: Long): Int raises CborError =
+    private inline def boundedLength(length: Long, headOffset: Long)(using Tactic[CborError]): Int =
       if length < 0 || length > Int.MaxValue then abort(CborError(Reason.Overflow(headOffset)))
       val count = length.toInt
       expect(count)
@@ -1025,7 +1029,8 @@ object Cbor extends Cbor2, Dynamic:
 
     private inline def decodeUtf8
       ( bytes: scala.Array[Byte], start: Int, length: Int, errorOffset: Long )
-    :   String raises CborError =
+      ( using Tactic[CborError] )
+    :   String =
 
       try new String(bytes, start, length, java.nio.charset.StandardCharsets.UTF_8)
       catch case _: Throwable => abort(CborError(Reason.InvalidUtf8(errorOffset)))

--- a/lib/breviloquence/src/staged/breviloquence.stagedInternal.scala
+++ b/lib/breviloquence/src/staged/breviloquence.stagedInternal.scala
@@ -101,7 +101,7 @@ object stagedInternal:
       val run = ctx.run
 
       if run == null then false else
-        val sources = run.nn.units.map(_.source.file.path).toSet
+        val sources = run.nn.units.map(_.source.path).toSet
         val position = symbol.pos
         position.exists { position => sources.contains(position.sourceFile.path) }
     catch case _: Exception => false

--- a/lib/burdock/src/core/burdock_repackage.scala
+++ b/lib/burdock/src/core/burdock_repackage.scala
@@ -120,7 +120,9 @@ def repackage(): Unit = application(scala.collection.immutable.Nil):
 
           . stdlib.to(List)
 
-      val tmpFile: Path on Linux = inputJar.parent.vouch/t"${inputJar.name}.tmp"
+      val tmpFile: Path on Linux =
+        inputJar.parent.or(panic(m"a jar file always has a parent directory"))
+        / t"${inputJar.name}.tmp"
 
       // Only animate on a real terminal; when stdout is redirected the carriage-return redraws
       // and cursor escapes would garble the output, so we suppress them and let the final summary

--- a/lib/camouflage/src/core/camouflage.Cache.scala
+++ b/lib/camouflage/src/core/camouflage.Cache.scala
@@ -60,6 +60,8 @@ class Cache[value](lifetime: Optional[Long]):
   def establish(block: => value): value = mutex:
     if expiry < jl.System.currentTimeMillis then value = Promise()
 
-    if value.ready then value().vouch else block.tap: result =>
-      value.offer(result)
-      expiry = lifetime.lay(Long.MaxValue)(_ + jl.System.currentTimeMillis)
+    // A present result is a completed promise; otherwise compute, offer and return it.
+    value().or:
+      block.tap: result =>
+        value.offer(result)
+        expiry = lifetime.lay(Long.MaxValue)(_ + jl.System.currentTimeMillis)

--- a/lib/capricious/src/test/capricious_test.scala
+++ b/lib/capricious/src/test/capricious_test.scala
@@ -45,25 +45,25 @@ object Tests extends Suite(m"Capricious Tests"):
           given Distribution = Gaussian(0.0, 1.0)
           List.fill(10000)(arbitrary[Double]())
 
-      . assert(_.mean.vouch === 0.0 +/- 0.02)
+      . assert(_.mean.lay(false)(_ === 0.0 +/- 0.02))
 
       test(m"Normal distribution standard deviation"):
         stochastic:
           given Distribution = Gaussian(0.0, 2.0)
           List.fill(10000)(arbitrary[Double]())
 
-      . assert(_.std.vouch === 2.0 +/- 0.05)
+      . assert(_.std.lay(false)(_ === 2.0 +/- 0.05))
 
       test(m"Gamma distribution mean"):
         stochastic:
           given distribution: Gamma = Gamma.approximate(100, 10)
           List.fill(100000)(arbitrary[Double]())
 
-      . assert(_.mean.vouch === 100.0 +/- 0.1)
+      . assert(_.mean.lay(false)(_ === 100.0 +/- 0.1))
 
       test(m"Gamma distribution standard deviation"):
         stochastic:
           given distribution: Gamma = Gamma.approximate(100, 10)
           List.fill(100000)(arbitrary[Double]())
 
-      . assert(_.std.vouch === 10.0 +/- 0.1)
+      . assert(_.std.lay(false)(_ === 10.0 +/- 0.1))

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -81,8 +81,8 @@ object Tests extends Suite(m"Cataclysm Tests"):
   def dim(n: Int, unit: Text): ValueToken = ValueToken.Dimension(n, unit, (n.toString+unit.s).tt)
 
   // ── value-matcher helpers ────────────────────────────────────────────────
-  def vm(property: Text, value: Text): Outcome =
-    SyntaxMatcher.check(PropertyDef.of(property).vouch, value)
+  def vm(property: Text, value: Text): Optional[Outcome] =
+    PropertyDef.of(property).let(SyntaxMatcher.check(_, value))
 
   def vmatch(grammar: Syntax, value: Text): Outcome = SyntaxMatcher.check(grammar, value)
 
@@ -325,7 +325,7 @@ object Tests extends Suite(m"Cataclysm Tests"):
       . assert(_ == List(rule(t"a", decl(t"--my-color", t"red"))))
 
       test(m"a known property's value grammar is loaded"):
-        PropertyDef.of(t"color").vouch.syntax
+        PropertyDef.of(t"color").let(_.syntax)
       . assert(_ == t"<color>")
 
       test(m"an unknown property has no definition"):

--- a/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
@@ -169,10 +169,16 @@ object Contrastable:
       case (Decomposition.Product(leftName, left, _), Decomposition.Product(rightName, right, _)) =>
         val name = if leftName == rightName then leftName else t"$leftName/$rightName"
 
+        // Products of different types may have differing field sets; a field absent on one
+        // side is compared against a blank placeholder (as in the sum case below), so it
+        // registers as a difference.
+        val keys = left.keys ++ right.keys
+        val missing = Decomposition.Primitive(t"", t"", Unset)
+
         Juxtaposition.Collation
           ( name,
-            left.keys.to(List).map: key =>
-              key -> juxtaposition(t"", left(key).vouch, right(key).vouch),
+            keys.to(List).map: key =>
+              key -> juxtaposition(t"", left(key).or(missing), right(key).or(missing)),
             leftName,
             rightName )
 

--- a/lib/delicious/src/scala/delicious.Reifier.scala
+++ b/lib/delicious/src/scala/delicious.Reifier.scala
@@ -34,13 +34,15 @@ package delicious
 
 import dotty.tools.dotc as dtd
 import dotty.tools.dotc.ast.tpd.TreeOps
+import dotty.tools.dotc.core.CompilationUnitInfo
 import dotty.tools.dotc.core.Contexts
 import dotty.tools.dotc.core.tasty.DottyUnpickler
+import dotty.tools.dotc.core.tasty.TastyUnpickler
 import dotty.tools.dotc.quoted.QuotesCache
 import dotty.tools.dotc.core.tasty.TreeUnpickler.UnpickleMode
 import dotty.tools.dotc.reporting.Reporter
 import dotty.tools.dotc.util.SourceFile
-import dotty.tools.io.NoAbstractFile
+import dotty.tools.io.VirtualFile
 
 import java.util as ju
 
@@ -141,13 +143,33 @@ class Reifier(classpath: LocalClasspath):
         // The decode is inlined at the argument: the Java decoder's fluid result adapts to
         // the unpickler's pure formal, where a named array value would charge its read
         // capability.
+        // `DottyUnpickler`'s constructor differs between the compiler streams (one reads the
+        // bytes from the file, the other takes them separately), so the same unpickling is
+        // spelled out through the section unpicklers, whose surface both streams share.
         val unpickler =
-          DottyUnpickler
-            ( NoAbstractFile, ju.Base64.getDecoder.nn.decode(tasty.s).nn.asInstanceOf[scala.Array[Byte]],
-              isBestEffortTasty = false, UnpickleMode.TypeTree )
+          TastyUnpickler
+            ( ju.Base64.getDecoder.nn.decode(tasty.s).nn.asInstanceOf[scala.Array[Byte]],
+              false )
 
-        unpickler.enter(scala.collection.immutable.Set.empty)
-        val tree = unpickler.tree
+        // The file exists only to give the compilation unit an associated name: its
+        // contents are never read (the unpickler above already has the bytes), but the
+        // decode is repeated inline because only a fluid Java result adapts to the pure
+        // formal, as above.
+        val info =
+          CompilationUnitInfo
+            ( VirtualFile
+                ( "<delicious>",
+                  ju.Base64.getDecoder.nn.decode(tasty.s).nn.asInstanceOf[scala.Array[Byte]] ) )
+          . nn
+        val positions = unpickler.unpickle(DottyUnpickler.PositionsSectionUnpickler())
+        val comments = unpickler.unpickle(DottyUnpickler.CommentsSectionUnpickler())
+
+        val treeUnpickler =
+          unpickler.unpickle(DottyUnpickler.TreeSectionUnpickler(info, positions, comments, false))
+          . get
+
+        treeUnpickler.enter(scala.collection.immutable.Set.empty)
+        val tree = treeUnpickler.unpickle(UnpickleMode.TypeTree).head
         tree.foreachSubTree { _ => () } // force trees and positions
 
         val quotes = scala.quoted.runtime.impl.QuotesImpl()

--- a/lib/dendrology/src/dag/dendrology.LaneDagDiagram.scala
+++ b/lib/dendrology/src/dag/dendrology.LaneDagDiagram.scala
@@ -273,11 +273,11 @@ object LaneDagDiagram:
     val widths = scala.Array.fill(maxCol)(2)
 
     rows.foreach: (tiles, optNode) =>
-      if optNode.present then
+      optNode.let: node =>
         val nodeIdx = tiles.indexOf(Node)
 
         if nodeIdx >= 0 then
-          val w = style.width(glyph(optNode.vouch))
+          val w = style.width(glyph(node))
           if w > widths(nodeIdx) then widths(nodeIdx) = w
 
     widths.iterator.to(List)

--- a/lib/denominative/src/core/denominative.bounds.scala
+++ b/lib/denominative/src/core/denominative.bounds.scala
@@ -45,6 +45,9 @@ import vacuous.*
 extension [countable: Countable](inline value: countable)
   inline def limit: Ordinal = countable.size(value).z
 
+// The receiver is not `inline`: an inline parameter is not an immutable path, so it cannot
+// brand `Ordinal in value.type` (the same constraint as `confine` and `within`).
+extension [countable: Countable](value: countable)
   inline def ult: Optional[Ordinal in value.type] =
     if countable.size(value) >= 1
     then (countable.size(value) - 1).z.asInstanceOf[Ordinal in value.type] else Unset

--- a/lib/denominative/src/core/denominative.bounds.scala
+++ b/lib/denominative/src/core/denominative.bounds.scala
@@ -32,20 +32,27 @@
                                                                                                   */
 package denominative
 
+import prepositional.*
 import vacuous.*
 
 // The bounding ordinals of any `Countable` value: `limit` is the exclusive upper bound (the ordinal
 // one past the last element), and `ult`/`pen`/`ant` are the ultimate/penultimate/antepenultimate
 // element ordinals (`Unset` when the value is too short). These are `Ordinal`-valued, so they live
-// with denominative rather than rudiments.
+// with denominative rather than rudiments. Each is *confined* to this value
+// (`Ordinal in value.type`, like `within` and `extent`): the presence check is the range proof,
+// so a subsequent deindexing returns a bare result. Sound for immutable receivers on stable
+// paths; a mutable countable that shrinks after the brand is minted invalidates it.
 extension [countable: Countable](inline value: countable)
   inline def limit: Ordinal = countable.size(value).z
 
-  inline def ult: Optional[Ordinal] =
-    if countable.size(value) >= 1 then (countable.size(value) - 1).z else Unset
+  inline def ult: Optional[Ordinal in value.type] =
+    if countable.size(value) >= 1
+    then (countable.size(value) - 1).z.asInstanceOf[Ordinal in value.type] else Unset
 
-  inline def pen: Optional[Ordinal] =
-    if countable.size(value) >= 1 then (countable.size(value) - 2).z else Unset
+  inline def pen: Optional[Ordinal in value.type] =
+    if countable.size(value) >= 2
+    then (countable.size(value) - 2).z.asInstanceOf[Ordinal in value.type] else Unset
 
-  inline def ant: Optional[Ordinal] =
-    if countable.size(value) >= 1 then (countable.size(value) - 3).z else Unset
+  inline def ant: Optional[Ordinal in value.type] =
+    if countable.size(value) >= 3
+    then (countable.size(value) - 3).z.asInstanceOf[Ordinal in value.type] else Unset

--- a/lib/denominative/src/test/denominative_test.scala
+++ b/lib/denominative/src/test/denominative_test.scala
@@ -483,11 +483,11 @@ object Tests extends Suite(m"Denominative Tests"):
       . assert(_ == Span.Mode.Offset)
 
       test(m"offset round-trips the start offset"):
-        span.offset.vouch
+        span.offset
       . assert(_ == 10.z)
 
       test(m"offset round-trips the length"):
-        span.length.vouch
+        span.length
       . assert(_ == 5)
 
       test(m"an offset span has no line"):
@@ -502,19 +502,19 @@ object Tests extends Suite(m"Denominative Tests"):
       . assert(_ == Span.Mode.Line)
 
       test(m"line round-trips the line"):
-        span.startLine.vouch
+        span.startLine
       . assert(_ == 3.z)
 
       test(m"line round-trips the column"):
-        span.startColumn.vouch
+        span.startColumn
       . assert(_ == 7.z)
 
       test(m"line round-trips the length"):
-        span.length.vouch
+        span.length
       . assert(_ == 4)
 
       test(m"line end column is start column plus length"):
-        span.endColumn.vouch
+        span.endColumn
       . assert(_ == 11.z)
 
       test(m"a line span is single-line"):
@@ -522,7 +522,7 @@ object Tests extends Suite(m"Denominative Tests"):
       . assert(identity(_))
 
       test(m"a line span spans one line"):
-        span.lineCount.vouch
+        span.lineCount
       . assert(_ == 1)
 
     suite(m"Span lines-mode tests"):
@@ -533,15 +533,15 @@ object Tests extends Suite(m"Denominative Tests"):
       . assert(_ == Span.Mode.Lines)
 
       test(m"lines round-trips the start line"):
-        span.startLine.vouch
+        span.startLine
       . assert(_ == 5.z)
 
       test(m"lines reports the inclusive end line"):
-        span.endLine.vouch
+        span.endLine
       . assert(_ == 7.z)
 
       test(m"lines round-trips the line count"):
-        span.lineCount.vouch
+        span.lineCount
       . assert(_ == 3)
 
       test(m"a lines span has no columns"):
@@ -556,19 +556,19 @@ object Tests extends Suite(m"Denominative Tests"):
       . assert(_ == Span.Mode.Area)
 
       test(m"area round-trips the start line"):
-        span.startLine.vouch
+        span.startLine
       . assert(_ == 2.z)
 
       test(m"area round-trips the start column"):
-        span.startColumn.vouch
+        span.startColumn
       . assert(_ == 4.z)
 
       test(m"area round-trips the end line"):
-        span.endLine.vouch
+        span.endLine
       . assert(_ == 6.z)
 
       test(m"area round-trips the end column"):
-        span.endColumn.vouch
+        span.endColumn
       . assert(_ == 9.z)
 
       test(m"a multi-line area is not single-line"):
@@ -576,7 +576,7 @@ object Tests extends Suite(m"Denominative Tests"):
       . assert(_ == false)
 
       test(m"area line count is inclusive"):
-        Span.area(10.z, 0.z, 13.z, 0.z).lineCount.vouch
+        Span.area(10.z, 0.z, 13.z, 0.z).lineCount
       . assert(_ == 4)
 
     suite(m"Span empty-mode tests"):
@@ -597,5 +597,5 @@ object Tests extends Suite(m"Denominative Tests"):
       . assert(identity(_))
 
       test(m"a large line number round-trips in line mode"):
-        Span.line(1000000.z, Prim, 0).startLine.vouch
+        Span.line(1000000.z, Prim, 0).startLine
       . assert(_ == 1000000.z)

--- a/lib/digression/src/ansi/digression_ansi.scala
+++ b/lib/digression/src/ansi/digression_ansi.scala
@@ -99,7 +99,9 @@ given stackTraceTeletype: (Text is Measurable) => (palette: StackTrace.Palette)
     val frame = row.frame
     val obj = frame.displaySegment.starts(t"Ξ")
     val methodCls = if obj then frame.displaySegment.skip(1) else frame.displaySegment
-    val color = packages(frame.method.prefix).vouch
+    // Every row's prefix was registered when `packages` was built from the same frames; an
+    // unregistered prefix falls back to the first accent colour.
+    val color = packages(frame.method.prefix).or(accent(0))
 
     if row.sameClass || plumbing(row)
     then e"${palette.subdue(color, 0.85)}(${frame.displayPrefix}.$methodCls)"

--- a/lib/dissonance/src/core/dissonance.Change.scala
+++ b/lib/dissonance/src/core/dissonance.Change.scala
@@ -47,6 +47,10 @@ sealed trait Change[+element] extends Product:
 sealed trait Edit[+element] extends Change[element]:
   def value: Optional[element]
 
+  // Mapping preserves presence (`let` maps a present value to a present value), but not the
+  // `Retained` brand: expressing `this.type & Retained`-conditional results here would entangle
+  // the ADT with the marker, so a mapped edit must be re-minted (`retained`) where the brand is
+  // still needed.
   override def map[element2](lambda: element => element2): Edit[element2] = this match
     case Par(left, right, value) => Par(left, right, value.let(lambda))
     case Del(left, value)        => Del(left, value.let(lambda))

--- a/lib/dissonance/src/core/dissonance.Diff.scala
+++ b/lib/dissonance/src/core/dissonance.Diff.scala
@@ -118,10 +118,14 @@ object Diff:
 
     recur(lines, 1, Nil, 0, 0, 0)
 
-  extension (diff: Diff[Text])
+  // Rendering a redraft reproduces every kept and deleted line verbatim, so it demands a `Diff`
+  // whose edits provably carry their values: `parse`d diffs (whose `Par`s are `Unset`) do not
+  // qualify; diffs from the Myers walk or a previous `resolve` do.
+  extension (diff: Diff[Text] & Retained)
     def redraft(context: Redraft.Context = Redraft.Context.Minimal): Redraft =
       Redraft.render(diff, context)
 
+  extension (diff: Diff[Text])
     def serialize: Chain[Text] = diff.chunks.flatMap:
       case Chunk(left, right, dels, inss) =>
         def range(start: Int, end: Int): Text =
@@ -184,10 +188,16 @@ case class Diff[element](edits: Edit[element]*):
 
           (subs: List[Change[element]])
         else
-          val delsSeq = Sequence.from(dels.stdlib.map(_.value.vouch))
-          val inssSeq = Sequence.from(inss.stdlib.map(_.value))
+          // This `Diff` may have been parsed, in which case its deletions carry no values; an
+          // absent value simply never compares similar, honestly degrading that pairing to a
+          // plain deletion and insertion instead of vouching for a value that is not there.
+          val delsSeq = Sequence.from(dels.stdlib.map(_.value))
+          val inssSeq = Sequence.from(inss.stdlib.map { ins => ins.value: Optional[element] })
 
-          val subs = dissonance.diff(delsSeq, inssSeq, similar).edits.toList.map:
+          val similar2: (Optional[element], Optional[element]) ->{similar} Boolean =
+            (left, right) => left.lay(false) { l => right.lay(false) { r => similar(l, r) } }
+
+          val subs = dissonance.diff(delsSeq, inssSeq, similar2).edits.toList.map:
             case Del(index, _) => Del(dels.stdlib(index).left, dels.stdlib(index).value)
             case Ins(index, _) => Ins(inss.stdlib(index).right, inss.stdlib(index).value)
 

--- a/lib/dissonance/src/core/dissonance.Redraft.scala
+++ b/lib/dissonance/src/core/dissonance.Redraft.scala
@@ -94,7 +94,7 @@ object Redraft:
     ( directives: List[Directive],
       original:   Sequence[Text],
       compare:    (Text, Text) -> Boolean )
-  :   (List[Edit[Text]], List[Anomaly]) =
+  :   (List[Edit[Text] & Retained], List[Anomaly]) =
 
     val n = original.length
 
@@ -105,7 +105,9 @@ object Redraft:
 
     var cursor = 0
     var right = 0
-    var edits: List[Edit[Text]] = Nil
+    // Every edit is constructed with its line (from `original` or the directive itself), so each
+    // is minted `Retained` at construction.
+    var edits: List[Edit[Text] & Retained] = Nil
     var matchers: List[Matcher] = Nil
     var anomalies: List[Anomaly] = Nil
 
@@ -113,7 +115,7 @@ object Redraft:
       var k = cursor
 
       while k < target do
-        edits = Par(k, right, original.stdlib(k)) :: edits
+        edits = Par(k, right, original.stdlib(k)).retained :: edits
         right += 1
         k += 1
 
@@ -121,19 +123,19 @@ object Redraft:
 
     def keep(index: Int, text: Text, line: Int): Unit =
       keepUpTo(index)
-      edits = Par(index, right, original.stdlib(index)) :: edits
+      edits = Par(index, right, original.stdlib(index)).retained :: edits
       matchers = Matcher(text, index, line) :: matchers
       right += 1
       cursor = index + 1
 
     def cut(index: Int, text: Text, line: Int): Unit =
       keepUpTo(index)
-      edits = Del(index, original.stdlib(index)) :: edits
+      edits = Del(index, original.stdlib(index)).retained :: edits
       matchers = Matcher(text, index, line) :: matchers
       cursor = index + 1
 
     def add(text: Text): Unit =
-      edits = Ins(right, text) :: edits
+      edits = Ins(right, text).retained :: edits
       right += 1
 
     directives.zipWithIndex.each: (directive, line) =>
@@ -189,17 +191,23 @@ object Redraft:
 
     (edits.reverse, anomalies.sort(_.line))
 
-  def render(diff: Diff[Text], context: Context): Redraft =
-    val original: Sequence[Text] = diff.edits.collect:
-      case Par(_, _, value) => value.vouch
-      case Del(_, value)    => value.vouch
+  // Demands a `Retained` diff: rendering reproduces every kept and deleted line verbatim, so
+  // presence is required in the type rather than vouched for edit-by-edit.
+  def render(diff: Diff[Text] & Retained, context: Context): Redraft =
+    val edits: List[Edit[Text] & Retained] = diff.retentions
 
-    . pipe(Sequence.from(_))
+    val original: Sequence[Text] = edits.bind: edit =>
+      edit match
+        case Par(_, _, _) | Del(_, _) => List(edit.kept)
+        case Ins(_, _)                => List[Text]()
 
-    val full: List[Directive] = diff.edits.to(List).bind:
-      case Par(_, _, value) => List(Directive.Keep(value.vouch))
-      case Del(_, value)    => List(Directive.Mark(value.vouch, insert = false))
-      case Ins(_, value)    => List(Directive.Mark(value, insert = true))
+    . pipe(list => Sequence.from(list.stdlib))
+
+    val full: List[Directive] = edits.bind: edit =>
+      edit match
+        case Par(_, _, _)  => List(Directive.Keep(edit.kept))
+        case Del(_, _)     => List(Directive.Mark(edit.kept, insert = false))
+        case Ins(_, value) => List(Directive.Mark(value, insert = true))
 
     // Promote any ambiguous primary `+`/`-` marker to the forced `>`/`<` spelling.
     def deambiguate(directives: List[Directive]): List[Directive] =
@@ -271,13 +279,13 @@ case class Redraft(directives: Redraft.Directive*):
   def serialize: Chain[Text] = directives.map(Redraft.render1).to(Chain)
 
   def resolve(original: Sequence[Text], compare: (Text, Text) -> Boolean = _ == _)
-  :   Diff[Text] raises RedraftError =
+  :   Diff[Text] & Retained raises RedraftError =
 
     val (edits, anomalies) = Redraft.analyze(directives.to(List), original, compare)
 
     anomalies match
       case anomaly :: _ => abort(RedraftError(anomaly.line, anomaly.text, anomaly.reason))
-      case Nil          => Diff(edits*)
+      case Nil          => Diff(edits*).retained
 
   def verify(original: Sequence[Text], compare: (Text, Text) -> Boolean = _ == _)
   :   List[Redraft.Anomaly] =

--- a/lib/dissonance/src/core/dissonance.Retained.scala
+++ b/lib/dissonance/src/core/dissonance.Retained.scala
@@ -58,14 +58,17 @@ extension [element](edit: Edit[element])
   // discipline as `occupied`: one check, here construction itself, recorded in the type.)
   def retained: edit.type & Retained = edit.asInstanceOf[edit.type & Retained]
 
-  // A single accessor that dispatches at compile time on the edit's type: an edit statically
-  // known to be `Retained` returns a bare `element` with no absence-handling; any other edit
-  // returns its `Optional` value unchanged. The declared return type is `Optional`, so
-  // non-reducing (e.g. generic) call sites are safe; a `Retained` edit narrows to a bare
-  // `element`.
+// A single accessor that dispatches at compile time on the edit's type: an edit statically
+// known to be `Retained` returns a bare `element` with no absence-handling; any other edit
+// returns its `Optional` value unchanged. The declared return type is `Optional`, so
+// non-reducing (e.g. generic) call sites are safe; a `Retained` edit narrows to a bare
+// `element`. The receiver's precise type is carried by the `editType` parameter (the same
+// shape as deindexing's `apply`): a term-singleton `edit.type` in the summonFrom pattern
+// sends implicit-scope computation through `wildApprox`, which crashes on the intersection.
+extension [element, editType <: Edit[element]](edit: editType)
   transparent inline def kept: Optional[element] = summonFrom:
-    case _: (edit.type <:< Retained) => edit.value.asInstanceOf[element]
-    case _                           => edit.value
+    case _: (`editType` <:< Retained) => edit.value.asInstanceOf[element]
+    case _                            => edit.value
 
 extension [element](diff: Diff[element])
   // The `Retained` producer for a whole `Diff`, sanctioned only where every edit passed to the

--- a/lib/dissonance/src/core/dissonance.Retained.scala
+++ b/lib/dissonance/src/core/dissonance.Retained.scala
@@ -30,65 +30,51 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package contingency
+package dissonance
 
-import scala.collection.mutable as scm
+import scala.compiletime.*
 
-import beneficence.*
-import rudiments.*
+import proscenium.compat.*
+
 import vacuous.*
 
-object Foci:
-  given default: [focus] => Foci[focus]:
-    override def active: Boolean = false
-    def length: Int = 0
-    def success: Boolean = false
-    def register(error: Exception): Unit = ()
+// A phantom marker recording a *proof of retention* in a value's type: producers which populate
+// every edit's `value` by construction (the Myers walk, redraft analysis) mint `& Retained` at
+// the construction site, and `kept` narrows `value` from `Optional[element]` to a bare `element`
+// on any edit whose type carries the proof, so absence-handling is discharged at compile time:
+//
+//     statically-proven `Retained` edits access their values directly
+//
+// A *structural refinement*, not a trait: refinements are erasure-transparent, so
+// `Edit[Text] & Retained` still erases to `Edit`. A nominal marker would erase intersections and
+// `self <: Retained` bounds to the marker's own class, inserting checkcasts that fail at
+// runtime — the underlying value never actually implements it. (The same technique as
+// rudiments' `Populated`, the non-emptiness proof.)
+type Retained = Any { type Retain = true }
 
+extension [element](edit: Edit[element])
+  // The `Retained` producer for a single edit: the cast *is* the mint, used only at a site where
+  // presence is established by construction — an edit whose `value` was just supplied. (The same
+  // discipline as `occupied`: one check, here construction itself, recorded in the type.)
+  def retained: edit.type & Retained = edit.asInstanceOf[edit.type & Retained]
 
-    def fold[accrual](initial: accrual)(lambda: (Optional[focus], accrual) => Exception ~> accrual)
-    :   accrual =
+  // A single accessor that dispatches at compile time on the edit's type: an edit statically
+  // known to be `Retained` returns a bare `element` with no absence-handling; any other edit
+  // returns its `Optional` value unchanged. The declared return type is `Optional`, so
+  // non-reducing (e.g. generic) call sites are safe; a `Retained` edit narrows to a bare
+  // `element`.
+  transparent inline def kept: Optional[element] = summonFrom:
+    case _: (edit.type <:< Retained) => edit.value.asInstanceOf[element]
+    case _                           => edit.value
 
-      initial
+extension [element](diff: Diff[element])
+  // The `Retained` producer for a whole `Diff`, sanctioned only where every edit passed to the
+  // constructor was itself `Retained` (the varargs field cannot carry the brand through, so it
+  // is re-established on the assembled value).
+  def retained: diff.type & Retained = diff.asInstanceOf[diff.type & Retained]
 
-
-    def supplement(count: Int, transform: Optional[focus] => Optional[focus]): Unit = ()
-
-trait Foci[focus] extends Findable:
-  // False only for the inert default instance, whose `register` and
-  // `supplement` discard everything: a hot decode loop may then skip its
-  // per-field `focus` wrapping (and the closure each wrap allocates)
-  // entirely, since no focus would ever be observed.
-  def active: Boolean = true
-  def length: Int
-  def success: Boolean
-  def register(error: Exception): Unit
-
-  def fold[accrual](initial: accrual)(lambda: (Optional[focus], accrual) => Exception ~> accrual)
-  :   accrual
-
-  // The transform returns `Optional`: the slots are themselves `Optional`, so demanding a
-  // bare focus forced partial callers to assert presence they could not prove.
-  def supplement(count: Int, transform: Optional[focus] => Optional[focus]): Unit
-  def tainted: Boolean = length > 0
-
-class TrackFoci[focus]() extends Foci[focus]:
-  private val errors: scm.ArrayBuffer[Exception] = scm.ArrayBuffer()
-  private val focuses: scm.ArrayBuffer[Optional[focus]] = scm.ArrayBuffer()
-
-  def length: Int = errors.length
-  def success: Boolean = length == 0
-
-  def register(error: Exception): Unit =
-    errors.append(error)
-    focuses.append(Unset)
-
-
-  def fold[accrual](initial: accrual)(lambda: (Optional[focus], accrual) => Exception ~> accrual)
-  :   accrual =
-
-    (0 until errors.length).fuse(initial)(lambda(focuses(next), state)(errors(next)))
-
-
-  def supplement(count: Int, transform: Optional[focus] => Optional[focus]): Unit =
-    for i <- (errors.length - count) until errors.length do focuses(i) = transform(focuses(i))
+extension [element](diff: Diff[element] & Retained)
+  // Transfers a `Diff`'s retention proof back to its edits: a `Diff & Retained` was assembled
+  // exclusively from retained edits, so re-minting each one discharges no new obligation.
+  def retentions: List[Edit[element] & Retained] =
+    diff.edits.to(List).asInstanceOf[List[Edit[element] & Retained]]

--- a/lib/dissonance/src/core/dissonance_core.scala
+++ b/lib/dissonance/src/core/dissonance_core.scala
@@ -128,12 +128,15 @@ def diff[element]
   ( leftSeries:  Sequence[element],
     rightSeries: Sequence[element],
     compare:     (element, element) => Boolean = { (a: element, b: element) => a == b } )
-:   Diff[element] =
+:   Diff[element] & Retained =
 
   val left = leftSeries.stdlib
   val right = rightSeries.stdlib
 
-  type Edits = List[Edit[element]]
+  // Every edit the backtrack constructs carries its element (`left(position)` or
+  // `right(rightPosition)`), so each is minted `Retained` at construction and the assembled
+  // `Diff` carries the proof.
+  type Edits = List[Edit[element] & Retained]
 
   @tailrec
   def count(position: Int, offset: Int): Int =
@@ -145,14 +148,14 @@ def diff[element]
 
   @tailrec
   def trace(deletes: Int, inserts: Int, focus: List[Int], rows: List[Array[Int]^{}])
-  :   Diff[element] =
+  :   Diff[element] & Retained =
 
     val delPos = if deletes == 0 then 0 else count(rows.head.readable(deletes - 1) + 1, inserts - deletes)
     val insPos = if inserts == 0 then 0 else count(rows.head.readable(deletes), inserts - deletes)
     val best = if deletes + inserts == 0 then count(0, 0) else delPos.max(insPos)
 
     if best == left.length && (best - deletes + inserts) == right.length
-    then Diff(backtrack(left.length - 1, deletes, rows, Nil)*)
+    then Diff(backtrack(left.length - 1, deletes, rows, Nil)*).retained
     else if inserts > 0 then trace(deletes + 1, inserts - 1, best :: focus, rows)
     else trace(0, deletes + 1, Nil, Array.from(focus.stdlib.reverse :+ best) :: rows)
 

--- a/lib/dissonance/src/core/dissonance_core.scala
+++ b/lib/dissonance/src/core/dissonance_core.scala
@@ -169,7 +169,7 @@ def diff[element]
     then
       backtrack
         ( position - 1, deletes, rows,
-          List.of(Par(position, rightPosition, left(position)) :: edits.stdlib) )
+          List.of(Par(position, rightPosition, left(position)).retained :: edits.stdlib) )
 
     else if deletes < rows.length && (deletes == 0 || ins >= del)
     then
@@ -177,20 +177,20 @@ def diff[element]
       then
         backtrack
           ( position, deletes, rows.tail,
-            List.of(Ins(rightPosition, right(rightPosition)) :: edits.stdlib) )
+            List.of(Ins(rightPosition, right(rightPosition)).retained :: edits.stdlib) )
       else
         backtrack
           ( position - 1, deletes, rows,
-          List.of(Par(position, rightPosition, left(position)) :: edits.stdlib) )
+          List.of(Par(position, rightPosition, left(position)).retained :: edits.stdlib) )
     else
       if position == del
       then
         backtrack
           ( del - 1, deletes - 1, rows.tail,
-            List.of(Del(position, left(position)) :: edits.stdlib) )
+            List.of(Del(position, left(position)).retained :: edits.stdlib) )
       else
         backtrack
           ( position - 1, deletes, rows,
-          List.of(Par(position, rightPosition, left(position)) :: edits.stdlib) )
+          List.of(Par(position, rightPosition, left(position)).retained :: edits.stdlib) )
 
   trace(0, 0, Nil, Nil)

--- a/lib/dissonance/src/core/soundness_dissonance_core.scala
+++ b/lib/dissonance/src/core/soundness_dissonance_core.scala
@@ -34,5 +34,5 @@ package soundness
 
 export
   dissonance
-  . { Change, Chunk, Del, Diff, diff, DiffError, Edit, Evolution, evolve, Ins, Par, RDiff, Redraft,
-      RedraftError, Sub, Tract }
+  . { Change, Chunk, Del, Diff, diff, DiffError, Edit, Evolution, evolve, Ins, kept, Par, RDiff,
+      Redraft, RedraftError, retained, Retained, retentions, Sub, Tract }

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -87,7 +87,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
       . assert(_ == List(t"hello.txt"))
 
     suite(m"Image config"):
-      val imageConfig = image.imageConfig.vouch
+      val imageConfig = image.imageConfig.or(panic(m"the fixture image always has a config"))
 
       test(m"an image built with layers carries an image config, not a wasm one"):
         (image.imageConfig.present, image.wasmConfig.present)
@@ -191,7 +191,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
 
       test(m"the image config round-trips"):
         archiveData.open[Image]() { handle ?=> handle.imageConfig }
-      . assert(_ == image.imageConfig.vouch)
+      . assert(_ == image.imageConfig)
 
       test(m"a layer's stored blob streams verbatim"):
         archiveData.open[Image]() { handle ?=> handle.compressed(image.manifest.layers.head).memoize.to[List] }
@@ -253,7 +253,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
             imports = List(t"wasi:io/streams@0.2.0"),
             target  = t"wasi:http/proxy@0.2.0" )
 
-      val wasmConfig = artifact.wasmConfig.vouch
+      val wasmConfig = artifact.wasmConfig.or(panic(m"the fixture artifact always has a wasm config"))
       val wasmLayer  = artifact.layers.head
 
       test(m"the artifact carries a wasm config, not an image config"):
@@ -285,7 +285,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
       . assert(_ == List(wasmLayer.digest))
 
       test(m"the component's exports, imports and target are recorded"):
-        wasmConfig.component.vouch
+        wasmConfig.component
       . assert:
           _ == WasmComponent
                 ( List(t"wasi:http/incoming-handler@0.2.0"),

--- a/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
+++ b/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
@@ -140,7 +140,10 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
     val nonce = new scala.Array[Byte](12)
     random.nextBytes(nonce)
 
-    val ciphertext = withKey: keyBytes =>
+    // Both `withKey` type arguments are explicit: inferring one on 3.10 instantiates `result`
+    // through the lambda's existential binder to a ResultCap-fresh array type, which the
+    // type-argument check rejects; an explicit argument takes the LocalCap path on both streams.
+    val ciphertext = withKey[scala.Array[Byte]]: keyBytes =>
       aes[scala.Array[Byte]](keyBytes, jc.Cipher.ENCRYPT_MODE, nonce)(_.doFinal(bytes).nn)
 
     ju.Arrays.fill(bytes, 0.toByte)
@@ -150,7 +153,7 @@ private[enigmatic] class VeiledHeapCloak extends Cloak, caps.SharedCapability:
     scala.caps.unsafe.unsafeAssumePure:
       new Secret:
         def uncloak[result](block: scala.Array[Byte] => result): result =
-          val cleartext = withKey: keyBytes =>
+          val cleartext = withKey[scala.Array[Byte]]: keyBytes =>
             aes[scala.Array[Byte]](keyBytes, jc.Cipher.DECRYPT_MODE, nonce)(_.doFinal(ciphertext).nn)
 
           try block(cleartext) finally ju.Arrays.fill(cleartext, 0.toByte)

--- a/lib/enigmatic/src/core/enigmatic.Pem.scala
+++ b/lib/enigmatic/src/core/enigmatic.Pem.scala
@@ -134,26 +134,25 @@ object Pem:
   :   Pem =
 
     val body = jl.StringBuilder()
-    var data: Optional[Data] = Unset
 
-    while data.absent do
+    def recur(): Data =
       nextLine(cursor).lay(abort(PemError(PemError.Reason.EndMissing))): line =>
         line.trim match
           case r"-----* *END $endLabel([ A-Z]+) *-----*" =>
-            data =
-              mitigate:
-                case SerializationError(_, _) => PemError(PemError.Reason.BadBase64)
+            mitigate:
+              case SerializationError(_, _) => PemError(PemError.Reason.BadBase64)
 
-              // `[Data]` stated, not inferred: the conformance check on a macro expansion
-              // dealiases opaque types, and `Data` is a transparent alias over an opaque one.
-              // Inferred, the two sides of the check were spelled differently — `Data` against
-              // its own dealiasing, `scala.Array[Byte]` — and did not match.
-              . protect[Data](body.toString.tt.deserialize[Base64])
+            // `[Data]` stated, not inferred: the conformance check on a macro expansion
+            // dealiases opaque types, and `Data` is a transparent alias over an opaque one.
+            // Inferred, the two sides of the check were spelled differently — `Data` against
+            // its own dealiasing, `scala.Array[Byte]` — and did not match.
+            . protect[Data](body.toString.tt.deserialize[Base64])
 
           case _ =>
             body.append(line.s)
+            recur()
 
-    Pem(label, data.vouch)
+    Pem(label, recur())
 
   // The next line of the input (excluding its terminator), or `Unset` at
   // end-of-stream. Only `\n` terminates a line, as the legacy `cut(t"\n")`

--- a/lib/escapade/src/core/escapade.Ansi.scala
+++ b/lib/escapade/src/core/escapade.Ansi.scala
@@ -203,7 +203,14 @@ object Ansi extends Ansi2:
 
   object Runtime:
     import unsafeExceptions.canThrowAny
-    private val complement = Map('[' -> ']', '(' -> ')', '{' -> '}', '<' -> '>', '«' -> '»')
+    // Total over the closed set of opening brackets admitted by the branches below.
+    private def complement(bracket: Char): Char = bracket match
+      case '[' => ']'
+      case '(' => ')'
+      case '{' => '}'
+      case '<' => '>'
+      case '«' => '»'
+      case _   => panic(m"the complement function covers every opening bracket")
 
     def initial: State = State()
 
@@ -218,8 +225,8 @@ object Ansi extends Ansi2:
               state.last = Unset
               closures(state, text.skip(1))
 
-            case '[' | '(' | '<' | '«' | '{' =>
-              state.pushStyleFrame(complement(text(Prim).vouch).vouch, transform)
+            case char @ ('[' | '(' | '<' | '«' | '{') =>
+              state.pushStyleFrame(complement(char), transform)
               state.last = Unset
               closures(state, text.skip(1))
 
@@ -234,8 +241,8 @@ object Ansi extends Ansi2:
               state.last = Unset
               closures(state, text.skip(1))
 
-            case '[' | '(' | '<' | '«' | '{' =>
-              state.pushLinkFrame(complement(text(Prim).vouch).vouch, url)
+            case char @ ('[' | '(' | '<' | '«' | '{') =>
+              state.pushLinkFrame(complement(char), url)
               state.last = Unset
               closures(state, text.skip(1))
 
@@ -249,8 +256,8 @@ object Ansi extends Ansi2:
               state.last = Unset
               closures(state, text.skip(1))
 
-            case '[' | '(' | '<' | '«' | '{' =>
-              state.pushEscapeFrame(complement(text(Prim).vouch).vouch, on, off)
+            case char @ ('[' | '(' | '<' | '«' | '{') =>
+              state.pushEscapeFrame(complement(char), on, off)
               state.last = Unset
               closures(state, text.skip(1))
 

--- a/lib/escapade/src/core/escapade.internal.scala
+++ b/lib/escapade/src/core/escapade.internal.scala
@@ -416,7 +416,9 @@ case class Teletype2(plain: Text, ansi: Array[escapade.internal.AnsiStyle]^{}):
   def render(using escapes: TerminalEscapes): Text =
     Text.build:
       def recur(current: AnsiStyle, index: Ordinal): Unit =
-        if index.n0 < plain.length then
+        // The presence of the character at `index` is the loop's bounds check; `ansi` shares
+        // `plain`'s extent by construction.
+        plain(index).lay(()): char =>
           val style = ansi.readUnchecked(index.n0)
 
           if style.changed then
@@ -430,7 +432,7 @@ case class Teletype2(plain: Text, ansi: Array[escapade.internal.AnsiStyle]^{}):
 
             val current2 = current.update(style)
 
-            append(plain(index).vouch)
+            append(char)
             recur(current2, index + 1)
           else
             recur(current, index + 1)

--- a/lib/escapade/src/test/escapade_test.scala
+++ b/lib/escapade/src/test/escapade_test.scala
@@ -60,6 +60,11 @@ object Tests extends Suite(m"Escapade tests"):
     def emulate(teletype: Teletype, width: Int = 80, height: Int = 4): Pty =
       Pty(width, height).consume(emit(teletype))
 
+    // Locates `text` in the PTY buffer and checks that every cell satisfies `predicate`;
+    // absence of the text fails the check honestly.
+    def styled(pty: Pty, text: Text)(predicate: Style => Boolean): Boolean =
+      pty.buffer.find(text).lay(false)(_.styles.all(predicate))
+
     // chroma values we'll reference repeatedly
     val red    = Red.chroma
     val yellow = Yellow.chroma
@@ -129,8 +134,8 @@ object Tests extends Suite(m"Escapade tests"):
 
       test(m"teletype substitution preserves styling"):
         val inner: Teletype = e"$Bold(bold)"
-        emulate(e"x${inner}y").buffer.find(t"bold").vouch.styles
-      . assert(_.all(_.bold))
+        styled(emulate(e"x${inner}y"), t"bold")(_.bold)
+      . assert(identity(_))
 
       test(m"non-stylize substitution does not consume bracket"):
         val n = 42
@@ -150,32 +155,32 @@ object Tests extends Suite(m"Escapade tests"):
 
     suite(m"Interpolator: brackets"):
       test(m"parenthesis bracket"):
-        emulate(e"$Bold(bold)").buffer.find(t"bold").vouch.styles
-      . assert(_.all(_.bold))
+        styled(emulate(e"$Bold(bold)"), t"bold")(_.bold)
+      . assert(identity(_))
 
       test(m"square bracket"):
-        emulate(e"$Bold[bold]").buffer.find(t"bold").vouch.styles
-      . assert(_.all(_.bold))
+        styled(emulate(e"$Bold[bold]"), t"bold")(_.bold)
+      . assert(identity(_))
 
       test(m"curly bracket"):
-        emulate(e"$Bold{bold}").buffer.find(t"bold").vouch.styles
-      . assert(_.all(_.bold))
+        styled(emulate(e"$Bold{bold}"), t"bold")(_.bold)
+      . assert(identity(_))
 
       test(m"angle bracket"):
-        emulate(e"$Bold<bold>").buffer.find(t"bold").vouch.styles
-      . assert(_.all(_.bold))
+        styled(emulate(e"$Bold<bold>"), t"bold")(_.bold)
+      . assert(identity(_))
 
       test(m"guillemet bracket"):
-        emulate(e"$Bold«bold»").buffer.find(t"bold").vouch.styles
-      . assert(_.all(_.bold))
+        styled(emulate(e"$Bold«bold»"), t"bold")(_.bold)
+      . assert(identity(_))
 
       test(m"mismatched closing bracket type is ignored as text"):
-        emulate(e"$Bold(a]b)").buffer.find(t"a]b").vouch.styles
-      . assert(_.all(_.bold))
+        styled(emulate(e"$Bold(a]b)"), t"a]b")(_.bold)
+      . assert(identity(_))
 
       test(m"mismatched closing bracket inside parens does not close span"):
-        emulate(e"$Bold(a]b)c").buffer.find(t"c").vouch.styles
-      . assert(_.all(!_.bold))
+        styled(emulate(e"$Bold(a]b)c"), t"c")(!_.bold)
+      . assert(identity(_))
 
     // ─── interpolator: escapes ────────────────────────────────────────────
 
@@ -347,40 +352,40 @@ object Tests extends Suite(m"Escapade tests"):
 
     suite(m"Nesting: stack restoration"):
       test(m"inner color overrides outer"):
-        emulate(e"${Fg(red)}(${Fg(yellow)}(yellow))").buffer.find(t"yellow").vouch.styles
-      . assert(_.all(_.foreground == yellow))
+        styled(emulate(e"${Fg(red)}(${Fg(yellow)}(yellow))"), t"yellow")(_.foreground == yellow)
+      . assert(identity(_))
 
       test(m"outer color restored after inner closes"):
-        emulate(e"${Fg(red)}(${Fg(yellow)}(yellow)red)").buffer.find(t"red").vouch.styles
-      . assert(_.all(_.foreground == red))
+        styled(emulate(e"${Fg(red)}(${Fg(yellow)}(yellow)red)"), t"red")(_.foreground == red)
+      . assert(identity(_))
 
       test(m"default restored after outermost closes"):
-        emulate(e"${Fg(red)}(${Fg(yellow)}(yellow)red)tail").buffer.find(t"tail").vouch.styles
-      . assert(_.all(_.foreground == white))
+        styled(emulate(e"${Fg(red)}(${Fg(yellow)}(yellow)red)tail"), t"tail")(_.foreground == white)
+      . assert(identity(_))
 
       test(m"three levels of nested color restore correctly"):
-        emulate(e"${Fg(red)}(${Fg(yellow)}(${Fg(green)}(g)y)r)x").buffer.find(t"x").vouch.styles
-      . assert(_.all(_.foreground == white))
+        styled(emulate(e"${Fg(red)}(${Fg(yellow)}(${Fg(green)}(g)y)r)x"), t"x")(_.foreground == white)
+      . assert(identity(_))
 
       test(m"middle color of three-deep stack restores correctly"):
-        emulate(e"${Fg(red)}(${Fg(yellow)}(${Fg(green)}(g)y)r)").buffer.find(t"y").vouch.styles
-      . assert(_.all(_.foreground == yellow))
+        styled(emulate(e"${Fg(red)}(${Fg(yellow)}(${Fg(green)}(g)y)r)"), t"y")(_.foreground == yellow)
+      . assert(identity(_))
 
       test(m"outer color of three-deep stack restores correctly"):
-        emulate(e"${Fg(red)}(${Fg(yellow)}(${Fg(green)}(g)y)r)").buffer.find(t"r").vouch.styles
-      . assert(_.all(_.foreground == red))
+        styled(emulate(e"${Fg(red)}(${Fg(yellow)}(${Fg(green)}(g)y)r)"), t"r")(_.foreground == red)
+      . assert(identity(_))
 
       test(m"nested bold and italic both apply"):
-        emulate(e"$Bold(b$Italic(bi)b)").buffer.find(t"bi").vouch.styles
-      . assert(_.all { s => s.bold && s.italic })
+        styled(emulate(e"$Bold(b$Italic(bi)b)"), t"bi") { s => s.bold && s.italic }
+      . assert(identity(_))
 
       test(m"italic removed after inner span ends but bold remains"):
-        emulate(e"$Bold(b$Italic(bi)b2)").buffer.find(t"b2").vouch.styles
-      . assert(_.all { s => s.bold && !s.italic })
+        styled(emulate(e"$Bold(b$Italic(bi)b2)"), t"b2") { s => s.bold && !s.italic }
+      . assert(identity(_))
 
       test(m"nested background restores outer background"):
-        emulate(e"${Bg(red)}(${Bg(blue)}(blue)red)").buffer.find(t"red").vouch.styles
-      . assert(_.all(_.background == red))
+        styled(emulate(e"${Bg(red)}(${Bg(blue)}(blue)red)"), t"red")(_.background == red)
+      . assert(identity(_))
 
       test(m"nested fg/bg combinations restore independently"):
         val out = emulate(e"${Fg(red)}(${Bg(blue)}(both)fg)tail")
@@ -445,13 +450,13 @@ object Tests extends Suite(m"Escapade tests"):
 
       test(m"append teletype preserves left styling"):
         val left = e"$Bold(bold)"
-        emulate(left.append(e"plain")).buffer.find(t"bold").vouch.styles
-      . assert(_.all(_.bold))
+        styled(emulate(left.append(e"plain")), t"bold")(_.bold)
+      . assert(identity(_))
 
       test(m"append teletype preserves right styling"):
         val right = e"$Bold(bold)"
-        emulate(e"plain".append(right)).buffer.find(t"bold").vouch.styles
-      . assert(_.all(_.bold))
+        styled(emulate(e"plain".append(right)), t"bold")(_.bold)
+      . assert(identity(_))
 
       test(m"+ operator behaves as append"):
         (e"a" + e"b").plain
@@ -476,13 +481,13 @@ object Tests extends Suite(m"Escapade tests"):
 
       test(m"dropChars preserves styling on remaining range"):
         val tt = e"$Bold(abcdef)".dropChars(2)
-        emulate(tt).buffer.find(t"cdef").vouch.styles
-      . assert(_.all(_.bold))
+        styled(emulate(tt), t"cdef")(_.bold)
+      . assert(identity(_))
 
       test(m"takeChars preserves styling on remaining range"):
         val tt = e"$Bold(abcdef)".takeChars(3)
-        emulate(tt).buffer.find(t"abc").vouch.styles
-      . assert(_.all(_.bold))
+        styled(emulate(tt), t"abc")(_.bold)
+      . assert(identity(_))
 
     // ─── Textual extension methods (from gossamer) ────────────────────────
 
@@ -759,7 +764,7 @@ object Tests extends Suite(m"Escapade tests"):
       . assert(_ == List(t""))
 
       test(m"cut preserves bold styling on parts"):
-        emulate(e"$Bold(a,b,c)").buffer.find(t"a,b,c").vouch.styles.all(_.bold)
+        styled(emulate(e"$Bold(a,b,c)"), t"a,b,c")(_.bold)
       . assert(_ == true)
 
     // ─── Joinable & Concatenable ──────────────────────────────────────────
@@ -775,7 +780,7 @@ object Tests extends Suite(m"Escapade tests"):
 
       test(m"join preserves nested styling"):
         val parts = scala.collection.immutable.List(e"$Bold(a)", e"plain", e"$Italic(c)")
-        emulate(parts.join(e",")).buffer.find(t"a").vouch.styles.all(_.bold)
+        styled(emulate(parts.join(e",")), t"a")(_.bold)
       . assert(_ == true)
 
       test(m"empty list joins to empty"):
@@ -825,12 +830,12 @@ object Tests extends Suite(m"Escapade tests"):
 
       test(m"first ribbon segment has correct background"):
         val pty = emulate(Ribbon(Bg(red), Bg(yellow)).fill(e"one", e"two"), width = 80)
-        pty.buffer.find(t"one").vouch.styles.all(_.background == red)
+        styled(pty, t"one")(_.background == red)
       . assert(_ == true)
 
       test(m"second ribbon segment has correct background"):
         val pty = emulate(Ribbon(Bg(red), Bg(yellow)).fill(e"one", e"two"), width = 80)
-        pty.buffer.find(t"two").vouch.styles.all(_.background == yellow)
+        styled(pty, t"two")(_.background == yellow)
       . assert(_ == true)
 
       test(m"zero-length ribbon with no parts is empty"):

--- a/lib/escritoire/src/core/escritoire.Grid.scala
+++ b/lib/escritoire/src/core/escritoire.Grid.scala
@@ -85,19 +85,19 @@ case class Grid[text](sections: List[TableSection[text]], style: TableStyle):
         case _ =>
           Chain()
 
-    def rule(above: Optional[Array[Int]^{}], below: Optional[Array[Int]^{}]): text =
-      val width = above.or(below).vouch.pipe: widths =>
-        widths.sum + style.cost(widths.length)
+    // Every rule adjoins at least one row of columns, whose shared `widths` it takes
+    // unconditionally; `above`/`below` say which side(s) those columns are on.
+    def rule(widths: Array[Int]^{}, above: Boolean, below: Boolean): text =
+      val width = widths.sum + style.cost(widths.length)
 
-      val ascenders =
-        above.let(_.readable.scan(0)(_ + _ + style.padding*2 + 1).to(sci.BitSet)).or(sci.BitSet())
+      def joints: sci.BitSet = widths.readable.scan(0)(_ + _ + style.padding*2 + 1).to(sci.BitSet)
 
-      val descenders =
-        below.let(_.readable.scan(0)(_ + _ + style.padding*2 + 1).to(sci.BitSet)).or(sci.BitSet())
+      val ascenders = if above then joints else sci.BitSet()
+      val descenders = if below then joints else sci.BitSet()
 
       val horizontal =
-        if above.absent then style.topLine
-        else if below.absent then style.bottomLine
+        if !above then style.topLine
+        else if !below then style.bottomLine
         else style.titleLine
 
       Textual:
@@ -126,13 +126,13 @@ case class Grid[text](sections: List[TableSection[text]], style: TableStyle):
 
     val topLine =
       if style.topLine.absent then Chain() else
-        Chain(rule(Unset, sections.stdlib.head.widths))
+        Chain(rule(sections.stdlib.head.widths, above = false, below = true))
 
-    val midRule = rule(sections.stdlib.head.widths, sections.stdlib.head.widths)
+    val midRule = rule(sections.stdlib.head.widths, above = true, below = true)
 
     val bottomLine =
       if style.bottomLine.absent then Chain() else
-        Chain(rule(sections.stdlib.head.widths, Unset))
+        Chain(rule(sections.stdlib.head.widths, above = true, below = false))
 
     val body =
       sections.stdlib.to(Chain).bind: section =>

--- a/lib/ethereal/src/core/ethereal.Installer.scala
+++ b/lib/ethereal/src/core/ethereal.Installer.scala
@@ -78,7 +78,8 @@ object Installer:
 
   def candidateTargets()(using service: DaemonService[?], diagnostics: Diagnostics)
     ( using Environment, System )
-  :   List[Path on Linux] logs DaemonLogEvent raises InstallError =
+    ( using Tactic[InstallError], (DaemonLogEvent is Loggable)^ )
+  :   List[Path on Linux] =
 
     mitigate:
       case PathError(_, _)     => InstallError(InstallError.Reason.Environment)

--- a/lib/exegesis/src/core/exegesis.LspConnection.scala
+++ b/lib/exegesis/src/core/exegesis.LspConnection.scala
@@ -68,13 +68,16 @@ extends JsonRpc, caps.ExclusiveCapability:
   // (as in `LspSession.client0`).
   private val channel: JsonRpc = caps.unsafe.unsafeAssumePure(this)
 
-  val lifecycle:  LspLifecycle  = channel.proxy[LspLifecycle]
-  val language:   LspLanguage   = channel.proxy[LspLanguage]
-  val navigation: LspNavigation = channel.proxy[LspNavigation]
-  val editing:    LspEditing    = channel.proxy[LspEditing]
-  val advanced:   LspAdvanced   = channel.proxy[LspAdvanced]
-  val workspace:  LspWorkspace  = channel.proxy[LspWorkspace]
-  val resolve:    LspResolve    = channel.proxy[LspResolve]
+  // The same confinement argument seals each proxy: the generated module's only capabilities
+  // are this connection and the Lsp object, both already reachable through the member that
+  // holds it, so the pure interface type loses nothing that is not confined here anyway.
+  val lifecycle:  LspLifecycle  = caps.unsafe.unsafeAssumePure(channel.proxy[LspLifecycle])
+  val language:   LspLanguage   = caps.unsafe.unsafeAssumePure(channel.proxy[LspLanguage])
+  val navigation: LspNavigation = caps.unsafe.unsafeAssumePure(channel.proxy[LspNavigation])
+  val editing:    LspEditing    = caps.unsafe.unsafeAssumePure(channel.proxy[LspEditing])
+  val advanced:   LspAdvanced   = caps.unsafe.unsafeAssumePure(channel.proxy[LspAdvanced])
+  val workspace:  LspWorkspace  = caps.unsafe.unsafeAssumePure(channel.proxy[LspWorkspace])
+  val resolve:    LspResolve    = caps.unsafe.unsafeAssumePure(channel.proxy[LspResolve])
 
   // A fault the server reports as an error response arrives as a `JsonRpcError` carrying the wire
   // code, which is exactly the vocabulary of `LspError.Reason`; a code outside the standard set is

--- a/lib/exegesis/src/test/exegesis.CaptureTests.scala
+++ b/lib/exegesis/src/test/exegesis.CaptureTests.scala
@@ -79,11 +79,11 @@ object CaptureTests extends Suite(m"Handle confinement tests"):
 
     test(m"the registry cannot escape the registration block"):
       demilitarize:
-        def attempt()(using Stdio, Monitor, Probate): LspRegistry =
+        def attempt()(using Stdio, Monitor, Probate): Optional[LspRegistry] =
           var stash: Optional[LspRegistry] = Unset
           Lsp.listen(t"escape"):
             stash = summon[LspRegistry]
-          stash.vouch
+          stash
     . assert(_.nonEmpty)
 
     // A pure snapshot taken from a handle may escape by design: only the handle is confined.

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -504,7 +504,7 @@ object Tests extends Suite(m"Exegesis Tests"):
       . assert(_ == TrafficFixture.request)
 
       test(m"an outbound message is observed as the response to the request"):
-        traffic.stdlib.last._2.as[Json].as[JsonRpc.Response].id.vouch.as[Int]
+        traffic.stdlib.last._2.as[Json].as[JsonRpc.Response].id.let(_.as[Int])
       . assert(_ == 0)
 
     suite(m"Client sessions"):

--- a/lib/exoskeleton/src/args/exoskeleton.Argument.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Argument.scala
@@ -73,11 +73,18 @@ case class Argument
       suggestion2
 
   def apply(): Text = format match
-    case Argument.Format.Full            => value
-    case Argument.Format.FlagSuffix      => value.skip(2)
-    case Argument.Format.CharFlag(index) => t"-${value(index + 1).or('-')}"
-    case Argument.Format.EqualityPrefix  => value.before(value.offsetOf("=").or(Prim))
-    case Argument.Format.EqualitySuffix  => value.after(value.offsetOf("=").or(Prim))
+    case Argument.Format.Full       => value
+    case Argument.Format.FlagSuffix => value.skip(2)
+
+    // The `val` gives the deindexing's skolem-dependent type a single widening point (`Char`):
+    // inlined directly into the interpolation, the `t` macro's resplice retypes the deindexing
+    // and mints a fresh, non-identical skolem (upstream #26563, from 3.9.0-RC5).
+    case Argument.Format.CharFlag(index) =>
+      val flag = value(index + 1).or('-')
+      t"-$flag"
+
+    case Argument.Format.EqualityPrefix => value.before(value.offsetOf("=").or(Prim))
+    case Argument.Format.EqualitySuffix => value.after(value.offsetOf("=").or(Prim))
 
   def prefix: Optional[Text] = cursor.let(value.keep(_))
   def suffix: Optional[Text] = cursor.let(value.skip(_))

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -41,6 +41,7 @@ import contingency.*
 import digression.*
 import distillate.*
 import eucalyptus.*
+import fulminate.*
 import galilei.*
 import gossamer.*
 import guillotine.*
@@ -113,7 +114,9 @@ extends Rig:
     unsafely:
       // `Fqcn.apply` rather than the `fqcn""` interpolator: the macro's synthesized tree
       // fails capture-variable unification when expanded in a capture-checked module.
-      val executor: Fqcn = safely(Fqcn(t"superlunary.Executor2")).vouch
+      val executor: Fqcn =
+        safely(Fqcn(t"superlunary.Executor2"))
+        . or(panic(m"the constant fully-qualified class name is well-formed"))
 
       val jarfile = supervise:
         unsafely:

--- a/lib/exoskeleton/src/rig/exoskeleton_rig.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton_rig.scala
@@ -56,7 +56,9 @@ extension (shell: Shell)
     . protect:
         given tmux: Tmux = Tmux(Uuid().show, summon[WorkingDirectory], width, height, shell)
 
-        val path = summon[Enclave.Tool].path.parent.vouch.encode
+        val path =
+          summon[Enclave.Tool].path.parent
+          . lay(abort(TmuxError(TmuxError.Reason.ExecFailed)))(_.encode)
 
         var psFile: Optional[Path on Linux] = Unset
 

--- a/lib/facsimile/src/core/facsimile.FontEmbedder.scala
+++ b/lib/facsimile/src/core/facsimile.FontEmbedder.scala
@@ -63,7 +63,8 @@ private[facsimile] object FontEmbedder:
 
     val baseFont = subset.lay(baseName): chars => t"${tag(baseName, chars)}+$baseName"
 
-    val unitsPerEm = safely(program.head.unitsPerEm.int).or(1000).max(1)
+    val units: Optional[Int] = safely(program.head.unitsPerEm.int)
+    val unitsPerEm = units.or(1000).max(1)
     def scaled(units: Int): Long = units.toLong*1000/unitsPerEm
 
     val fontFile =

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -241,8 +241,8 @@ extends caps.ExclusiveCapability:
   // A reference to the page at a position in the flattened page sequence, for destinations.
   private[facsimile] def pageReference(ordinal: Ordinal)(using Tactic[PdfError]): Optional[Cos.Ref] =
     val entries = pageEntries
-    if ordinal.n0 < 0 || ordinal.n0 >= entries.length then Unset
-    else entries(ordinal.n0.z).vouch(0).let(Cos.Ref(_, 0))
+    // The bounds check and the lookup are the same act: a confined ordinal deindexes bare.
+    entries.confine(ordinal.n0.z).let { position => entries(position)(0).let(Cos.Ref(_, 0)) }
 
   def trailer: Map[Text, Cos] = xref.trailer
 

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -563,7 +563,8 @@ extends caps.ExclusiveCapability:
             pipeline(steps, Stream(List(data).iterator))
 
   // Interprets a streaming plan, minting each duct at its `via` call site.
-  private def pipeline(steps: List[Filter.Step^], consume stream: (Stream[Data] over Credit)^)
+  private def pipeline[plan^]
+    ( steps: List[Filter.Step^{plan}], consume stream: (Stream[Data] over Credit)^ )
   :   (Stream[Data] over Credit)^ =
 
     steps match

--- a/lib/facsimile/src/test/facsimile_test.scala
+++ b/lib/facsimile/src/test/facsimile_test.scala
@@ -740,7 +740,7 @@ object Tests extends Suite(m"Facsimile tests"):
           scala.caps.unsafe.unsafeAssumeSeparate(doc.addResource(doc.page(Prim), t"Font", t"F1", font))
 
         PdfFile(fileBytes(path)).open[Pdf]():
-          pdf.page(Prim).fonts(t"F1").vouch.embedded.let(_.data.to[List])
+          pdf.page(Prim).fonts(t"F1").let(_.embedded).let(_.data.to[List])
       . assert(_ == fontProgram.to[List])
 
       test(m"content using an embedded font extracts as text"):
@@ -769,7 +769,7 @@ object Tests extends Suite(m"Facsimile tests"):
           scala.caps.unsafe.unsafeAssumeSeparate(doc.addResource(doc.page(Prim), t"Font", t"F1", font))
 
         PdfFile(fileBytes(path)).open[Pdf]():
-          pdf.page(Prim).fonts(t"F1").vouch match
+          pdf.page(Prim).fonts(t"F1") match
             case _: PdfFont.TrueType => true
             case _                   => false
       . assert(_ == true)
@@ -782,7 +782,7 @@ object Tests extends Suite(m"Facsimile tests"):
           scala.caps.unsafe.unsafeAssumeSeparate(doc.addResource(doc.page(Prim), t"Font", t"F1", font))
 
         PdfFile(fileBytes(path)).open[Pdf]():
-          pdf.page(Prim).fonts(t"F1").vouch.baseFont
+          pdf.page(Prim).fonts(t"F1").let(_.baseFont)
       . assert(_ == t"TestSans")
 
       test(m"the font descriptor carries the font's real metrics"):
@@ -822,8 +822,8 @@ object Tests extends Suite(m"Facsimile tests"):
           scala.caps.unsafe.unsafeAssumeSeparate(doc.addResource(doc.page(Prim), t"Font", t"F1", font))
 
         PdfFile(fileBytes(path)).open[Pdf]():
-          pdf.page(Prim).fonts(t"F1").vouch.baseFont
-      . assert(_.s.matches("[A-Z]{6}\\+TestSans"))
+          pdf.page(Prim).fonts(t"F1").let(_.baseFont)
+      . assert(_.lay(false)(_.s.matches("[A-Z]{6}\\+TestSans")))
 
       test(m"a subset program keeps used outlines and drops the rest"):
         val path = tempPdf(blankPage)
@@ -833,7 +833,7 @@ object Tests extends Suite(m"Facsimile tests"):
           scala.caps.unsafe.unsafeAssumeSeparate(doc.addResource(doc.page(Prim), t"Font", t"F1", font))
 
         PdfFile(fileBytes(path)).open[Pdf]():
-          pdf.page(Prim).fonts(t"F1").vouch.embedded.let: ttf =>
+          pdf.page(Prim).fonts(t"F1").let(_.embedded).let: ttf =>
             (ttf.glyf(1).empty, ttf.glyf(2).empty)
       . assert(_ == (false, true))
 
@@ -845,7 +845,7 @@ object Tests extends Suite(m"Facsimile tests"):
           scala.caps.unsafe.unsafeAssumeSeparate(doc.addResource(doc.page(Prim), t"Font", t"F1", font))
 
         PdfFile(fileBytes(path)).open[Pdf]():
-          pdf.page(Prim).fonts(t"F1").vouch.embedded.let: ttf =>
+          pdf.page(Prim).fonts(t"F1").let(_.embedded).let: ttf =>
             (ttf.glyf(1).empty, ttf.glyf(2).empty, ttf.glyf(3).composite)
       . assert(_ == (false, false, true))
 
@@ -1151,8 +1151,8 @@ object Tests extends Suite(m"Facsimile tests"):
     suite(m"Fonts"):
       test(m"a standard-14 font is recognized with its metrics"):
         PdfFile(contentPage(t"")).open():
-          val font = pdf.page(Prim).fonts(t"F1").vouch
-          (font.standard, font.width('A'))
+          pdf.page(Prim).fonts(t"F1").let: font =>
+            (font.standard, font.width('A'))
       . assert(_ == (PdfFont.Standard.Helvetica, 667.0))
 
       test(m"declared widths override standard metrics"):
@@ -1164,8 +1164,8 @@ object Tests extends Suite(m"Facsimile tests"):
             . in[Data] )
 
         PdfFile(doc).open():
-          val font = pdf.page(Prim).fonts(t"F1").vouch
-          (font.width('A'), font.width('B'))
+          pdf.page(Prim).fonts(t"F1").let: font =>
+            (font.width('A'), font.width('B'))
       . assert(_ == (800.0, 667.0))
 
       test(m"differences remap codes through glyph names"):
@@ -1177,7 +1177,7 @@ object Tests extends Suite(m"Facsimile tests"):
             . in[Data] )
 
         PdfFile(doc).open():
-          pdf.page(Prim).fonts(t"F1").vouch.decode(data('A', 'B', 0x93))
+          pdf.page(Prim).fonts(t"F1").let(_.decode(data('A', 'B', 0x93)))
       . assert(_ == t"éB“")
 
       test(m"a ToUnicode map takes precedence"):
@@ -1191,7 +1191,7 @@ object Tests extends Suite(m"Facsimile tests"):
             t"<< /Length ${cmap.length} >>\nstream\n$cmap\nendstream".in[Data] )
 
         PdfFile(doc).open():
-          pdf.page(Prim).fonts(t"F1").vouch.decode(data('A', 0x60, 0x61, 0x62))
+          pdf.page(Prim).fonts(t"F1").let(_.decode(data('A', 0x60, 0x61, 0x62)))
       . assert(_ == t"Bpqr")
 
       test(m"a Type0 font reads two-byte codes and CID widths"):
@@ -1205,8 +1205,8 @@ object Tests extends Suite(m"Facsimile tests"):
             . in[Data] )
 
         PdfFile(doc).open():
-          val font = pdf.page(Prim).fonts(t"F1").vouch
-          (font.codes(data(0, 10, 0, 11)), font.width(10), font.width(21), font.width(99))
+          pdf.page(Prim).fonts(t"F1").let: font =>
+            (font.codes(data(0, 10, 0, 11)), font.width(10), font.width(21), font.width(99))
       . assert(_ == (List(10, 11), 600.0, 500.0, 750.0))
 
     suite(m"Text extraction"):

--- a/lib/galilei/src/core/galilei.IoError.scala
+++ b/lib/galilei/src/core/galilei.IoError.scala
@@ -86,14 +86,24 @@ object IoError:
     case Operation.Delete   => m"delete"
     case Operation.Metadata => m"metadata"
 
+  private def describe
+    ( path:       Path,
+      operation:  Operation,
+      reason:     Reason,
+      filesystem: path.Plane is Filesystem )
+    ( using Diagnostics )
+  :   Message =
+
+    given path.Plane is Filesystem = filesystem
+    m"the $operation operation at ${path.encode} on ${filesystem.name} failed because $reason"
+
 case class IoError
   ( path:       Path,
     operation:  IoError.Operation,
     reason:     IoError.Reason,
     filesystem: path.Plane is Filesystem )
   ( using Diagnostics )
-extends Error
-  ( {
-      given path.Plane is Filesystem = filesystem
-      m"the $operation operation at ${path.encode} on ${filesystem.name} failed because $reason"
-    } )
+// The message is computed in a companion method: a local `given` alias in the super-argument
+// block is a lazy val whose initialization references `this` before the super constructor,
+// which the Scala.js linker rejects (the JVM tolerates it).
+extends Error(IoError.describe(path, operation, reason, filesystem))

--- a/lib/galilei/src/core/galilei.Windows.scala
+++ b/lib/galilei/src/core/galilei.Windows.scala
@@ -68,7 +68,7 @@ object Windows:
 
     def decode(text: Text): Drive raises PathError =
       if text.length >= 3 && text(Sec) == ':' && text(Ter) == '\\'
-      then Drive(text(Prim).vouch)
+      then text.prim.let(Drive(_)).or(abort(PathError(_.InvalidRoot)))
       else abort(PathError(_.InvalidRoot))
 
     def length(text: Text): Int raises PathError = 3

--- a/lib/galilei/src/wasi/galilei_wasi.scala
+++ b/lib/galilei/src/wasi/galilei_wasi.scala
@@ -209,7 +209,7 @@ package filesystemBackends:
 
               while !done do
                 val entry = stream.`read-directory-entry`.call[Optional[(U8, Text)]]()
-                if entry.absent then done = true else names = entry.vouch(1) :: names
+                entry.lay({ done = true })(pair => names = pair(1) :: names)
 
               streamHandle.dispose()
               names.stdlib.reverse.to(Chain)

--- a/lib/gesticulate/src/core/gesticulate.Multipart.scala
+++ b/lib/gesticulate/src/core/gesticulate.Multipart.scala
@@ -145,8 +145,11 @@ object Multipart:
           parts.drop(1).map: param =>
             param.cut(t"=", 2) match
               case List(key, value) =>
+                // `pen` is present only when `value` has at least two characters, so a lone
+                // `"` (which starts and ends with a quote) is left unstripped rather than
+                // miscomputed.
                 if value.starts(t"\"") && value.ends(t"\"")
-                then key -> value.segment(Sec thru value.pen.vouch)
+                then key -> value.pen.lay(value)((pen: Ordinal) => value.segment(Sec thru pen))
                 else key -> value
 
               case _ =>

--- a/lib/gesticulate/src/core/gesticulate.internal.scala
+++ b/lib/gesticulate/src/core/gesticulate.internal.scala
@@ -126,7 +126,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)

--- a/lib/gossamer/src/core/gossamer.Decimalizer.scala
+++ b/lib/gossamer/src/core/gossamer.Decimalizer.scala
@@ -66,7 +66,13 @@ extends DecimalConverter:
 
       val norm: Double = abs*(10 ** -baseScale)
       val digits: Int = significantFigures.or(decimalPlaces.let(1 + scale + _)).or(3)
-      val sign = (negative || plusSign.present) && double != 0.0
+      // The sign character and its presence are one value: the flag previously implied
+      // plusSign's presence from sixty lines away, which the write below had to assert.
+      val signChar: Optional[Char] =
+        if double == 0.0 then Unset
+        else if negative then minusSign else plusSign
+
+      val sign = signChar.present
 
       @tailrec
       def write
@@ -140,7 +146,7 @@ extends DecimalConverter:
           recur(next, bcd2, index + 1)
 
       val chars: scala.Array[Char]^ = recur(norm, 0L, 1)
-      if sign then chars(0) = (if negative then minusSign else plusSign.vouch)
+      signChar.let(chars(0) = _)
 
       Text(new String(chars))
     else if double.isNaN then

--- a/lib/hallucination/src/core/hallucination.Descriptor.scala
+++ b/lib/hallucination/src/core/hallucination.Descriptor.scala
@@ -84,6 +84,27 @@ case class Descriptor(entries: List[Descriptor.Entry]):
   def has(label: Text): Boolean = entries.exists(_.label == label)
   def hasAlpha: Boolean = has("alpha".tt)
 
+  // The channel positions of each colour model the layout might carry, resolved once per
+  // descriptor: present exactly when *every* channel of the group is present. The per-pixel
+  // operations below branch on these rather than on `has`, so a malformed layout (e.g. `red`
+  // without `green`) degrades to the next fallback path instead of panicking, and the
+  // per-pixel bodies perform no channel lookups and no allocation.
+  private lazy val rgbPositions: Optional[((Int, Int), (Int, Int), (Int, Int))] =
+    locate("red".tt).let: red =>
+      locate("green".tt).let: green =>
+        locate("blue".tt).let: blue =>
+          (red, green, blue)
+
+  private lazy val cmykPositions: Optional[((Int, Int), (Int, Int), (Int, Int), (Int, Int))] =
+    locate("cyan".tt).let: cyan =>
+      locate("magenta".tt).let: magenta =>
+        locate("yellow".tt).let: yellow =>
+          locate("key".tt).let: key =>
+            (cyan, magenta, yellow, key)
+
+  private lazy val alphaPosition: Optional[(Int, Int)] = locate("alpha".tt)
+  private lazy val greyPosition: Optional[(Int, Int)] = locate("grey".tt)
+
   private def component(word: Long, position: (Int, Int)): Int =
     val (shift, depth) = position
     ((word >>> shift)&((1L << depth) - 1)).toInt
@@ -94,37 +115,30 @@ case class Descriptor(entries: List[Descriptor.Entry]):
   // The opacity of the pixel in the unit interval: fully opaque if the layout has no alpha
   // channel.
   def alpha(word: Long): Double =
-    locate("alpha".tt).lay(1.0)(proportion(word, _))
+    alphaPosition.lay(1.0)(proportion(word, _))
 
-  // The colour of the pixel as `Srgb`, the runtime counterpart of `Pixel`'s `srgb`.
+  // The colour of the pixel as `Srgb`, the runtime counterpart of `Pixel`'s `srgb`. Tries
+  // RGB, then CMYK, then grey: an incomplete channel group falls through to the next model.
   def srgb(word: Long): Srgb =
-    if has("red".tt) then
-      Srgb
-        ( proportion(word, locate("red".tt).vouch),
-          proportion(word, locate("green".tt).vouch),
-          proportion(word, locate("blue".tt).vouch) )
-    else if has("cyan".tt) then
+    def grey: Srgb =
+      val luma = greyPosition.lay(0.0)(proportion(word, _))
+      Srgb(luma, luma, luma)
+
+    def cmyk: Srgb = cmykPositions.lay(grey): (cyan, magenta, yellow, key) =>
       Cmyk
-        ( proportion(word, locate("cyan".tt).vouch),
-          proportion(word, locate("magenta".tt).vouch),
-          proportion(word, locate("yellow".tt).vouch),
-          proportion(word, locate("key".tt).vouch) )
+        ( proportion(word, cyan),
+          proportion(word, magenta),
+          proportion(word, yellow),
+          proportion(word, key) )
 
       . to[Srgb]
-    else
-      val luma = locate("grey".tt).lay(0.0)(proportion(word, _))
-      Srgb(luma, luma, luma)
+
+    rgbPositions.lay(cmyk): (red, green, blue) =>
+      Srgb(proportion(word, red), proportion(word, green), proportion(word, blue))
 
   // Rescales the pixel to 24-bit RGB with the same rounding as `Pixel`'s `chroma`.
   def chroma(word: Long): Chroma =
-    if has("red".tt) then
-      def rescale(label: Text): Int =
-        val position = locate(label).vouch
-        val maximum = (1 << position(1)) - 1
-        (component(word, position)*255 + maximum/2)/maximum
-
-      Chroma(rescale("red".tt), rescale("green".tt), rescale("blue".tt))
-    else
+    def fromSrgb: Chroma =
       val color = srgb(word)
 
       Chroma
@@ -132,32 +146,33 @@ case class Descriptor(entries: List[Descriptor.Entry]):
           (color.green*255 + 0.5).toInt,
           (color.blue*255 + 0.5).toInt )
 
+    rgbPositions.lay(fromSrgb): (red, green, blue) =>
+      def rescale(position: (Int, Int)): Int =
+        val maximum = (1 << position(1)) - 1
+        (component(word, position)*255 + maximum/2)/maximum
+
+      Chroma(rescale(red), rescale(green), rescale(blue))
+
   // Packs a colour and an opacity into a pixel, the runtime counterpart of `Pixel`'s `apply`.
   def pack(color: Srgb, alpha: Double = 1.0): Long =
     def scale(proportion: Double, position: (Int, Int)): Long =
       val (shift, depth) = position
       ((proportion*((1L << depth) - 1) + 0.5).toLong) << shift
 
-    if has("red".tt) then
-      val opaque =
-        scale(color.red, locate("red".tt).vouch) +
-          scale(color.green, locate("green".tt).vouch) +
-          scale(color.blue, locate("blue".tt).vouch)
+    def grey: Long =
+      greyPosition.lay(0L): position =>
+        scale(color.red*0.299 + color.green*0.587 + color.blue*0.114, position)
 
-      locate("alpha".tt).lay(opaque): position => opaque + scale(alpha, position)
-
-    else if has("cyan".tt) then
+    def cmyk: Long = cmykPositions.lay(grey): (cyanPos, magentaPos, yellowPos, keyPos) =>
       val key = 1.0 - color.red.max(color.green).max(color.blue)
       val white = 1.0 - key
       val cyan = if white == 0.0 then 0.0 else (white - color.red)/white
       val magenta = if white == 0.0 then 0.0 else (white - color.green)/white
       val yellow = if white == 0.0 then 0.0 else (white - color.blue)/white
 
-      scale(cyan, locate("cyan".tt).vouch) +
-        scale(magenta, locate("magenta".tt).vouch) +
-        scale(yellow, locate("yellow".tt).vouch) +
-        scale(key, locate("key".tt).vouch)
+      scale(cyan, cyanPos) + scale(magenta, magentaPos) + scale(yellow, yellowPos) +
+        scale(key, keyPos)
 
-    else
-      locate("grey".tt).lay(0L): position =>
-        scale(color.red*0.299 + color.green*0.587 + color.blue*0.114, position)
+    rgbPositions.lay(cmyk): (red, green, blue) =>
+      val opaque = scale(color.red, red) + scale(color.green, green) + scale(color.blue, blue)
+      alphaPosition.lay(opaque): position => opaque + scale(alpha, position)

--- a/lib/hallucination/src/core/hallucination.JpegCodec.scala
+++ b/lib/hallucination/src/core/hallucination.JpegCodec.scala
@@ -532,8 +532,11 @@ private[hallucination] final class JpegDecoder(data: scala.IArray[Byte]) extends
       val luma = plane(y*stride + x) & 0xffL
       (luma << 16) | (luma << 8) | luma
 
-  private def colorRaster
-    ( frame: JpegFrame, planes: scala.Array[scala.Array[Byte]], width: Int, height: Int )
+  private def colorRaster[planeCaps^ <: {caps.any.only[caps.Unscoped]}]
+    ( frame:  JpegFrame,
+      planes: scala.Array[scala.Array[Byte]^{planeCaps}],
+      width:  Int,
+      height: Int )
     ( using Tactic[RasterError] )
   :   Raster =
 

--- a/lib/hallucination/src/core/hallucination.JpegCodec.scala
+++ b/lib/hallucination/src/core/hallucination.JpegCodec.scala
@@ -247,18 +247,28 @@ private[hallucination] final class JpegDecoder(data: scala.IArray[Byte]) extends
       if quantTables(components(check).quantizationTableIndex).absent then bad()
       check += 1
 
+    // The Huffman tables this scan reads, resolved once from the `Optional`-holding
+    // registries: the presence checks that formerly only validated the indices now surrender
+    // the tables themselves, so the per-block decoders receive proven values instead of
+    // re-deriving them. A slot is filled exactly when the scan's spectral band can read it —
+    // DC iff `spectralStart == 0`, AC iff `spectralEnd > 1`, which covers every AC read
+    // because `parseSos` guarantees `spectralStart < spectralEnd` (exclusive) — so an
+    // unfilled slot is never dereferenced.
+    val dcResolved = new scala.Array[JpegHuffmanTable](count)
+    val acResolved = new scala.Array[JpegHuffmanTable](count)
+
     if scan.spectralStart == 0 then
       var index = 0
 
       while index < count do
-        if dcTables(scan.dcTableIndices(index)).absent then bad()
+        dcResolved(index) = dcTables(scan.dcTableIndices(index)).lay(bad())(identity)
         index += 1
 
     if scan.spectralEnd > 1 then
       var index = 0
 
       while index < count do
-        if acTables(scan.acTableIndices(index)).absent then bad()
+        acResolved(index) = acTables(scan.acTableIndices(index)).lay(bad())(identity)
         index += 1
 
     val isInterleaved = count > 1
@@ -320,12 +330,12 @@ private[hallucination] final class JpegDecoder(data: scala.IArray[Byte]) extends
 
                   if scan.successiveHigh == 0 then
                     decodeBlock
-                      ( huffman, plane, base, scan.dcTableIndices(i), scan.acTableIndices(i),
+                      ( huffman, plane, base, dcResolved(i), acResolved(i),
                         scan.spectralStart, scan.spectralEnd, scan.successiveLow, eobRun,
                         dcPredictors, i )
                   else
                     decodeBlockRefine
-                      ( huffman, plane, base, scan.acTableIndices(i), scan.spectralStart,
+                      ( huffman, plane, base, acResolved(i), scan.spectralStart,
                         scan.spectralEnd, scan.successiveLow, eobRun )
 
                   hPos += 1
@@ -345,12 +355,14 @@ private[hallucination] final class JpegDecoder(data: scala.IArray[Byte]) extends
     marker
 
   // Section F.2.2: decodes the coefficients of one block on the first pass over its spectral band.
+  // `dcTable`/`acTable` were resolved by `decodeScan` for exactly the spectral bands that read
+  // them, and are touched only within those bands.
   private update def decodeBlock
     ( huffman:       JpegHuffmanDecoder^,
       coeff:         scala.Array[Int],
       base:          Int,
-      dcTableIndex:  Int,
-      acTableIndex:  Int,
+      dcTable:       JpegHuffmanTable,
+      acTable:       JpegHuffmanTable,
       spectralStart: Int,
       spectralEnd:   Int,
       successiveLow: Int,
@@ -361,7 +373,7 @@ private[hallucination] final class JpegDecoder(data: scala.IArray[Byte]) extends
   :   Unit =
 
     if spectralStart == 0 then
-      val value = huffman.decode(reader, dcTables(dcTableIndex).vouch)
+      val value = huffman.decode(reader, dcTable)
 
       val diff =
         if value == 0 then 0
@@ -375,7 +387,6 @@ private[hallucination] final class JpegDecoder(data: scala.IArray[Byte]) extends
 
     if index < spectralEnd && eobRun(0) > 0 then writable(eobRun)(0) -= 1
     else if index < spectralEnd then
-      val acTable = acTables(acTableIndex).vouch
       var continue = true
 
       while continue && index < spectralEnd do
@@ -403,12 +414,14 @@ private[hallucination] final class JpegDecoder(data: scala.IArray[Byte]) extends
               writable(coeff)(base + Unzigzag(index)) = huffman.receiveExtend(reader, s) << successiveLow
               index += 1
 
-  // Section G.1.2: refines coefficients on later (successive-approximation) passes.
+  // Section G.1.2: refines coefficients on later (successive-approximation) passes. `acTable`
+  // was resolved by `decodeScan` (an AC refinement scan always has `spectralEnd > 1`) and is
+  // read only on the AC branch.
   private update def decodeBlockRefine
     ( huffman:       JpegHuffmanDecoder^,
       coeff:         scala.Array[Int],
       base:          Int,
-      acTableIndex:  Int,
+      acTable:       JpegHuffmanTable,
       spectralStart: Int,
       spectralEnd:   Int,
       successiveLow: Int,
@@ -421,8 +434,6 @@ private[hallucination] final class JpegDecoder(data: scala.IArray[Byte]) extends
     if spectralStart == 0 then
       if huffman.getBits(reader, 1) == 1 then writable(coeff)(base) |= bit
     else
-      val acTable = acTables(acTableIndex).vouch
-
       if eobRun(0) > 0 then
         writable(eobRun)(0) -= 1
         refineNonZeroes(huffman, coeff, base, acTable, spectralStart, spectralEnd, 64, bit)
@@ -493,7 +504,15 @@ private[hallucination] final class JpegDecoder(data: scala.IArray[Byte]) extends
     var index = 0
 
     while index < frame.components.length do
-      planes(index) = renderPlane(frame.components(index), coefficients0.asInstanceOf[scala.Array[scala.Array[Int]]](index))
+      val component = frame.components(index)
+
+      // Each *scanned* component's quantization table was proven present by `decodeScan`; a
+      // frame component that no scan ever covered may still lack one, so resolve here, where
+      // the error convention is available.
+      val quant = quantTables(component.quantizationTableIndex).lay(bad())(identity)
+
+      val coeff = coefficients0.asInstanceOf[scala.Array[scala.Array[Int]]](index)
+      planes(index) = renderPlane(component, quant, coeff)
       index += 1
 
     val width = frame.imageWidth
@@ -503,8 +522,10 @@ private[hallucination] final class JpegDecoder(data: scala.IArray[Byte]) extends
     then grayscaleRaster(frame.components(0), planes(0), width, height)
     else colorRaster(frame, planes, width, height)
 
-  private update def renderPlane(component: JpegComponent, coeff: scala.Array[Int]): scala.Array[Byte] =
-    val quant = quantTables(component.quantizationTableIndex).vouch
+  private update def renderPlane
+    ( component: JpegComponent, quant: scala.Array[Int], coeff: scala.Array[Int] )
+  :   scala.Array[Byte] =
+
     val stride = component.blockWidth*8
     val plane = new scala.Array[Byte](stride*component.blockHeight*8)
     var blockY = 0
@@ -602,13 +623,15 @@ private[hallucination] final class JpegDecoder(data: scala.IArray[Byte]) extends
     else if count == 3 && matchesIdentifiers(frame, 1, 2, 3) then JpegColor.YCbCr
     else if count == 3 && matchesIdentifiers(frame, 82, 71, 66) then JpegColor.Rgb
     else if count == 3 && isJfif then JpegColor.YCbCr
-    else if adobeTransform.present then adobeColor(count)
-    else if count == 4 then JpegColor.Cmyk
-    else if count == 3 then JpegColor.YCbCr
-    else JpegColor.Unknown
+    else
+      adobeTransform.lay
+        ( if count == 4 then JpegColor.Cmyk
+          else if count == 3 then JpegColor.YCbCr
+          else JpegColor.Unknown )
+        ( adobeColor(count, _) )
 
   // The colour transform indicated by an Adobe APP14 marker.
-  private def adobeColor(count: Int): JpegColor = adobeTransform.vouch match
+  private def adobeColor(count: Int, transform: Int): JpegColor = transform match
     case 0 => if count == 3 then JpegColor.Rgb else JpegColor.Cmyk
     case 1 => JpegColor.YCbCr
     case _ => JpegColor.Ycck

--- a/lib/hallucination/src/core/hallucination.JpegUpsampler.scala
+++ b/lib/hallucination/src/core/hallucination.JpegUpsampler.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package hallucination
 
+import scala.caps
+
 import contingency.*
 import proscenium.compat.*
 
@@ -145,8 +147,8 @@ private[hallucination] final class JpegUpsampler private
     lineBuffers0.asInstanceOf[scala.Array[scala.Array[Byte]]](index)
 
   // Upsamples row `row` of every component to full width and interleaves via `colorConvert`.
-  def upsampleAndInterleaveRow
-    ( componentData: scala.Array[scala.Array[Byte]],
+  def upsampleAndInterleaveRow[componentCaps^ <: {caps.any.only[caps.Unscoped]}]
+    ( componentData: scala.Array[scala.Array[Byte]^{componentCaps}],
       row:           Int,
       output:        scala.Array[Byte],
       colorConvert:  JpegColorConverter )
@@ -163,9 +165,9 @@ private[hallucination] final class JpegUpsampler private
 
     colorConvert.convert(lineBuffers0, output)
 
-  private def upsampleRow
+  private def upsampleRow[inputCaps^ <: {caps.any.only[caps.Unscoped]}]
     ( kind:      Int,
-      input:     scala.Array[Byte],
+      input:     scala.Array[Byte]^{inputCaps},
       width:     Int,
       height:    Int,
       rowStride: Int,

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -143,7 +143,7 @@ object SourceCode:
     context0.setSetting(context0.settings.source, "future")
 
     given context: Contexts.Context =
-      context0.setCompilationUnit(CompilationUnit(source, mustExist = false)(using context0))
+      context0.setCompilationUnit(CompilationUnit(source, false)(using context0))
 
     val trees = Trees()
     val parser = Parsers.Parser(source)

--- a/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
+++ b/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
@@ -316,10 +316,7 @@ object Honeycomb:
                 ConstantType(StringConstant(tag.s)).asType.absolve match
                   case '[tag] => Expr.summon[(? >: value) is Renderable in (? >: tag)] match
                     case Some('{$renderable: Renderable}) =>
-                      // Widened eagerly: joining the branch types under capture
-                      // checking decorates the summoned evidence's skolem, which
-                      // then fails to unify (the macro only needs `Expr[Any]`).
-                      ('{$renderable.render($expr)}: Expr[Any])
+                      '{$renderable.render($expr)}
 
                     case _ => halt:
                       m"""
@@ -331,10 +328,7 @@ object Honeycomb:
                 ConstantType(StringConstant(tag.s)).asType.absolve match
                   case '[tag] => Expr.summon[(? >: value) is Renderable in (? >: tag)] match
                     case Some('{$renderable: Renderable}) =>
-                      // Widened eagerly: joining the branch types under capture
-                      // checking decorates the summoned evidence's skolem, which
-                      // then fails to unify (the macro only needs `Expr[Any]`).
-                      ('{$renderable.render($expr)}: Expr[Any])
+                      '{$renderable.render($expr)}
 
                     case _ =>
                       Expr.summon[(? >: value) is Showable] match

--- a/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
+++ b/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
@@ -62,7 +62,7 @@ object Honeycomb:
     import doms.html.whatwg
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)
@@ -267,7 +267,7 @@ object Honeycomb:
     import Html.Hole
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -1535,14 +1535,10 @@ object Html extends Tag.Container
 
               inline def infer(inline tag: Tag): Unit =
                 reset(mark)
-                // Use a direct `if inferred.absent` check rather than
-                // `dom.infer(...).let { ... }.or { ... }`: `Optional.let` is
-                // not inline, so the lambda body would capture the surrounding
-                // `focus` and `level` `var`s as `ObjectRef`s on every `<`
-                // entry, allocating two refs per element open.
-                val inferred: Optional[Tag] = dom.infer(parent, tag)
-
-                if inferred.absent then
+                // `lay` is inline, so neither branch closes over the
+                // surrounding `focus` and `level` `var`s: no `ObjectRef`
+                // allocation per `<` entry.
+                dom.infer(parent, tag).lay:
                   if parent.autoclose then close()
                   else if permissive then
                     warn(InadmissibleTag(content, parent.label))
@@ -1551,9 +1547,10 @@ object Html extends Tag.Container
                     if parent == root then empty() else close()
                   else
                     fail(InadmissibleTag(content, parent.label), mark)
-                else
-                  focus = inferred.vouch
-                  level = Level.Descend
+
+                . apply: inferred =>
+                    focus = inferred
+                    level = Level.Descend
 
               next()
 
@@ -1585,9 +1582,7 @@ object Html extends Tag.Container
                   focus = if parent.foreign then Tag.foreign(content, extra) else openTag
 
                   if !admit(content) then
-                    val inferred = dom.infer(parent, focus)
-
-                    if inferred.absent then
+                    dom.infer(parent, focus).lay:
                       if parent.autoclose then
                         reset(mark)
                         close()
@@ -1606,10 +1601,11 @@ object Html extends Tag.Container
                       else
                         reset(mark)
                         fail(InadmissibleTag(content, parent.label), mark)
-                    else
-                      reset(mark)
-                      focus = inferred.vouch
-                      level = Level.Descend
+
+                    . apply: inferred =>
+                        reset(mark)
+                        focus = inferred
+                        level = Level.Descend
                   else if focus.void then
                     empty()
                   else if (content == t"a" || content == t"nobr") &&
@@ -1677,10 +1673,8 @@ object Html extends Tag.Container
                 while i < pendingCount do
                   val label = state.pendingFormattingLabels(i)
                   val attrs = state.pendingFormattingAttrs(i)
-                  val cloneTag: Optional[Tag] = dom.elements(label)
 
-                  if cloneTag.present then
-                    val tag = cloneTag.vouch
+                  dom.elements(label).let: tag =>
                     state.push(tag)
                     val cloneChild = descend(tag, admissible, attrs)
                     state.pop()

--- a/lib/honeycomb/src/core/honeycomb.internal.scala
+++ b/lib/honeycomb/src/core/honeycomb.internal.scala
@@ -69,7 +69,7 @@ object internal:
     import doms.html.whatwg
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)
@@ -283,7 +283,7 @@ object internal:
     import Html.Hole
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)

--- a/lib/hyperbole/src/core/hyperbole.internal.scala
+++ b/lib/hyperbole/src/core/hyperbole.internal.scala
@@ -57,7 +57,11 @@ object internal:
     def serialize(tree: TastyTree): Expr[TastyTree] = tree match
       case TastyTree(tag, typeName, name, expr, source, nodes, param, term, definitional) =>
         val nodes2 = nodes.map(serialize(_))
-        val param2 = if param.absent then '{Unset} else Expr(param.vouch)
+        // A concrete-scrutinee match, not an Optional combinator: an inline lambda whose
+        // arms are quote literals crashes pickleQuotes (the aviation.internal caveat).
+        val param2 = param match
+          case Unset       => '{Unset}
+          case param: Text => Expr(param)
 
         ' {
             TastyTree

--- a/lib/hyperbole/src/test/hyperbole.StackTests.scala
+++ b/lib/hyperbole/src/test/hyperbole.StackTests.scala
@@ -81,23 +81,23 @@ object StackTests extends Suite(m"Stack-trace resolution tests"):
 
     // The frames below the fixture belong to the test framework and the JDK, so every test looks
     // at the topmost frame in the fixture's own file.
-    def frame(stackTrace: StackTrace): StackTrace.Frame =
-      stackTrace.frames.find(_.jvmClass.starts(t"hyperbole.")).optional.vouch
+    def frame(stackTrace: StackTrace): Optional[StackTrace.Frame] =
+      stackTrace.frames.find(_.jvmClass.starts(t"hyperbole.")).optional
 
     suite(m"Resolving as a trace is captured"):
       test(m"An imported resolver resolves frames at capture time"):
-        frame(captured(StackFixture.lambda())).source.let(_.definition)
+        frame(captured(StackFixture.lambda())).let(_.source).let(_.definition)
 
       . assert(_ == t"hyperbole.StackFixture.lambda.λ")
 
       test(m"Without an imported resolver, frames are left alone"):
-        frame(capture0(StackFixture.lambda())).source
+        frame(capture0(StackFixture.lambda())).lay(false)(_.source == Unset)
 
-      . assert(_ == Unset)
+      . assert(_ == true)
 
     suite(m"Locating the TASTy for a class"):
       test(m"A module class resolves through its top-level class"):
-        frame(capture(StackFixture.method())).source.let(_.path)
+        frame(capture(StackFixture.method())).let(_.source).let(_.path)
 
       . assert(_.let(_.ends(t"hyperbole.StackTests.scala")) == true)
 
@@ -109,58 +109,58 @@ object StackTests extends Suite(m"Stack-trace resolution tests"):
 
     suite(m"Naming the definition a frame was compiled from"):
       test(m"A method frame names the method"):
-        frame(capture(StackFixture.method())).source.let(_.definition)
+        frame(capture(StackFixture.method())).let(_.source).let(_.definition)
 
       . assert(_ == t"hyperbole.StackFixture.method")
 
       test(m"A lambda frame names the method containing it"):
-        frame(capture(StackFixture.lambda())).source.let(_.definition)
+        frame(capture(StackFixture.lambda())).let(_.source).let(_.definition)
 
       . assert(_ == t"hyperbole.StackFixture.lambda.λ")
 
       test(m"An extension method frame names the extension"):
-        frame(capture(1.extended)).source.let(_.definition)
+        frame(capture(1.extended)).let(_.source).let(_.definition)
 
       . assert(_ == t"hyperbole.hyperbole.StackTests⁆.extended")
 
       test(m"A default getter is named as `rewrite` would name it"):
-        frame(capture(StackFixture.defaulted())).source.let(_.definition)
+        frame(capture(StackFixture.defaulted())).let(_.source).let(_.definition)
 
       . assert(_ == t"hyperbole.StackFixture.defaultedδ₁")
 
       test(m"A lazy value's initializer names the value"):
-        frame(capture(StackFixture.lazily)).source.let(_.definition)
+        frame(capture(StackFixture.lazily)).let(_.source).let(_.definition)
 
       . assert(_ == t"hyperbole.StackFixture.lazily")
 
     suite(m"Classifying frames"):
       test(m"A lambda is classified as a lambda"):
-        frame(capture(StackFixture.lambda())).source.let(_.kind)
+        frame(capture(StackFixture.lambda())).let(_.source).let(_.kind)
 
       . assert(_ == Kind.Lambda)
 
       test(m"An extension method is classified as an extension"):
-        frame(capture(1.extended)).source.let(_.kind)
+        frame(capture(1.extended)).let(_.source).let(_.kind)
 
       . assert(_ == Kind.Extension)
 
       test(m"A default argument is classified as a default"):
-        frame(capture(StackFixture.defaulted())).source.let(_.kind)
+        frame(capture(StackFixture.defaulted())).let(_.source).let(_.kind)
 
       . assert(_ == Kind.Default)
 
       test(m"A lazy value's initializer is classified as an initializer"):
-        frame(capture(StackFixture.lazily)).source.let(_.kind)
+        frame(capture(StackFixture.lazily)).let(_.source).let(_.kind)
 
       . assert(_ == Kind.Initializer)
 
     suite(m"Quoting the source"):
       test(m"A frame carries the line of source it was compiled from"):
-        frame(capture(StackFixture.method())).source.let(_.code)
+        frame(capture(StackFixture.method())).let(_.source).let(_.code)
 
       . assert(_ == t"""def method(): Unit = throw Exception("method")""")
 
       test(m"The line quoted for a lambda is the line inside it"):
-        frame(capture(StackFixture.lambda())).source.let(_.code)
+        frame(capture(StackFixture.lambda())).let(_.source).let(_.code)
 
       . assert(_ == t"""throw Exception("lambda")""")

--- a/lib/jacinta/src/core/jacinta.Json.Parser.scala
+++ b/lib/jacinta/src/core/jacinta.Json.Parser.scala
@@ -59,9 +59,9 @@ private[jacinta] object Parser:
   // arrays are filled once during the parse and never mutated after, and typing them
   // immutable keeps `Raw` free of stateful members under separation checking.
   private[jacinta] type Raw =
-    Long | Int | Double | Bcd | String | Array[Any]^{} |
-      Array[Long]^{} | Array[Int]^{} |
-      Boolean | Json.JsonNull.type | Unset
+    ( Long | Int | Double | Bcd | String | Array[Any] |
+        Array[Long] | Array[Int] |
+        Boolean | Json.JsonNull.type | Unset )^{}
 
   private inline val NumZero       = 0
   private inline val NumInt        = 1
@@ -197,7 +197,7 @@ private[jacinta] object Parser:
     caps.unsafe.unsafeAssumePure(parser.parse())
 
   def parseTracked(source: Data, mode: NumberMode = NumberMode.Full)
-  :   (Raw, Array[Int]^{}) raises ParseError =
+  :   (Json.Ast, Json.PositionIndex) raises ParseError =
 
     val parser = borrow()
     parser.tracking = true
@@ -205,10 +205,10 @@ private[jacinta] object Parser:
     parser.holes = false
     parser.numberMode = mode
     val raw = caps.unsafe.unsafeAssumePure(parser.parse())
-    (raw, parser.rootIndex.nn)
+    (raw.asInstanceOf[Json.Ast], Json.PositionIndex(parser.rootIndex.nn))
 
   def parseTracked(input: Iterator[Data], mode: NumberMode)
-  :   (Raw, Array[Int]^{}) raises ParseError =
+  :   (Json.Ast, Json.PositionIndex) raises ParseError =
 
     val parser = borrow()
     parser.tracking = true
@@ -216,7 +216,7 @@ private[jacinta] object Parser:
     parser.holes = false
     parser.numberMode = mode
     val raw = caps.unsafe.unsafeAssumePure(parser.parse())
-    (raw, parser.rootIndex.nn)
+    (raw.asInstanceOf[Json.Ast], Json.PositionIndex(parser.rootIndex.nn))
 
   def parse(consume input: (Stream[Data] over Credit)^, mode: NumberMode): Raw raises ParseError =
     val parser = borrow()
@@ -229,7 +229,7 @@ private[jacinta] object Parser:
     caps.unsafe.unsafeAssumePure(parser.parse())
 
   def parseTracked(consume input: (Stream[Data] over Credit)^, mode: NumberMode)
-  :   (Raw, Array[Int]^{}) raises ParseError =
+  :   (Json.Ast, Json.PositionIndex) raises ParseError =
 
     val parser = borrow()
     parser.tracking = true
@@ -239,7 +239,7 @@ private[jacinta] object Parser:
     parser.holes = false
     parser.numberMode = mode
     val raw = caps.unsafe.unsafeAssumePure(parser.parse())
-    (raw, parser.rootIndex.nn)
+    (raw.asInstanceOf[Json.Ast], Json.PositionIndex(parser.rootIndex.nn))
 
 // The parser is a stateful capability: one exclusive owner per instance (guaranteed by
 // the per-thread pool), with every state-mutating method classified `update`. This unit

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -2840,5 +2840,5 @@ extends Dynamic, Topical, Original derives CanEqual:
 
     val result = decodable.decoded(this)
     val foci = summon[Foci[Json.Focus]]
-    foci.supplement(foci.length, _.let(decodable.position(this, _)).vouch)
+    foci.supplement(foci.length, _.let(decodable.position(this, _)))
     result

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -1795,14 +1795,12 @@ object Json extends Json2, Dynamic:
     def parseTracked(source: Data)(using mode: NumberMode)
     :   (Json.Ast, Json.PositionIndex) raises ParseError =
 
-      val (raw, ints) = Parser.parseTracked(source, mode)
-      (raw.asInstanceOf[Json.Ast], Json.PositionIndex(ints))
+      Parser.parseTracked(source, mode)
 
     def parseTracked(input: Iterator[Data])(using mode: NumberMode)
     :   (Json.Ast, Json.PositionIndex) raises ParseError =
 
-      val (raw, ints) = Parser.parseTracked(input, mode)
-      (raw.asInstanceOf[Json.Ast], Json.PositionIndex(ints))
+      Parser.parseTracked(input, mode)
 
     private[jacinta] def parse(consume input: (Stream[Data] over Credit)^)
       ( using mode: NumberMode, tactic: Tactic[ParseError] )
@@ -1814,8 +1812,7 @@ object Json extends Json2, Dynamic:
       ( using mode: NumberMode, tactic: Tactic[ParseError] )
     :   (Json.Ast, Json.PositionIndex) =
 
-      val (raw, ints) = Parser.parseTracked(input, mode)
-      (raw.asInstanceOf[Json.Ast], Json.PositionIndex(ints))
+      Parser.parseTracked(input, mode)
 
   def ast(value: Json.Ast): Json = new Json(value)
 

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -2718,8 +2718,8 @@ extends Dynamic, Topical, Original derives CanEqual:
             rightMap = rightMap.updated(rightAst.objectKey(i), rightAst.objectValue(i))
             i += 1
 
-          leftMap.keySet == rightMap.keySet && leftMap.keySet.forall: key =>
-            recur(leftMap(key).vouch, rightMap(key).vouch)
+          leftMap.stdlib.size == rightMap.stdlib.size && leftMap.stdlib.forall: (key, leftValue) =>
+            rightMap(key).lay(false)(recur(leftValue, _))
 
       def recur(left: Json.Ast, right: Json.Ast): Boolean = right.asMatchable match
         case right: Long => left.asMatchable match

--- a/lib/jacinta/src/core/jacinta.internal.scala
+++ b/lib/jacinta/src/core/jacinta.internal.scala
@@ -69,7 +69,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     def firstOrigin[tuple: Type]: Int = Type.of[tuple] match
@@ -213,10 +213,10 @@ object internal:
         val root = root0.asInstanceOf[TypeRepr]
         val element = elementType(position)
 
-        if element.absent
-        then halt(m"the schema position ${position.show} is not an indexable array type")
+        val elementJson = element.or:
+          halt(m"the schema position ${position.show} is not an indexable array type")
 
-        jsonType(element.vouch, root).asType.absolve match
+        jsonType(elementJson, root).asType.absolve match
           case '[type result <: Json; result] =>
             '{$self.selectIndex($idx).asInstanceOf[result]}
 
@@ -261,10 +261,10 @@ object internal:
             case Some(member) =>
               val element = elementType(position.memberType(member))
 
-              if element.absent
-              then halt(m"the field $name of ${position.show} is not an indexable array")
+              val elementJson = element.or:
+                halt(m"the field $name of ${position.show} is not an indexable array")
 
-              jsonType(element.vouch, root).asType.absolve match
+              jsonType(elementJson, root).asType.absolve match
                 case '[type result <: Json; result] =>
                   '{$self.selectField(${Expr(name)}).selectIndex($idx).asInstanceOf[result]}
 
@@ -673,7 +673,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)
@@ -1001,7 +1001,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)

--- a/lib/jacinta/src/schema/jacinta_schema.scala
+++ b/lib/jacinta/src/schema/jacinta_schema.scala
@@ -112,8 +112,7 @@ private def conform(schema: JsonSchema, ast: Json.Ast): Unit raises JsonError =
 
     case array: JsonSchema.Array =>
       if !ast.isArray then mismatch(JsonPrimitive.Array)
-      else if array.items.present then
-        val items = array.items.vouch
+      else array.items.lay(()): items =>
         var index = 0
         val length = ast.arrayLength
 

--- a/lib/jacinta/src/staged/jacinta.stagedInternal.scala
+++ b/lib/jacinta/src/staged/jacinta.stagedInternal.scala
@@ -86,7 +86,7 @@ object stagedInternal:
       val run = ctx.run
 
       if run == null then false else
-        val sources = run.nn.units.map(_.source.file.path).toSet
+        val sources = run.nn.units.map(_.source.path).toSet
         val position = symbol.pos
         position.exists { position => sources.contains(position.sourceFile.path) }
     catch case _: Exception => false

--- a/lib/jacinta/src/test/jacinta.PositionTests.scala
+++ b/lib/jacinta/src/test/jacinta.PositionTests.scala
@@ -177,13 +177,14 @@ object PositionTests extends Suite(m"Jacinta position-index tests"):
     suite(m"Subsequence property"):
       test(m"A nested object's descriptor slice has length == slot 0"):
         val json = Json.parseTracked(t"""{"a":{"b":42}}""")
-        val data = json.positionIndex.vouch.ints
-        val firstEntryOff = data(5)
-        val valueDescOff = firstEntryOff + 3
-        val valueSize = data(valueDescOff)
-        val slice = data.slice(valueDescOff, valueDescOff + valueSize)
-        slice.length == valueSize
-      . assert(identity)
+        json.positionIndex.let: index =>
+          val data = index.ints
+          val firstEntryOff = data(5)
+          val valueDescOff = firstEntryOff + 3
+          val valueSize = data(valueDescOff)
+          val slice = data.slice(valueDescOff, valueDescOff + valueSize)
+          slice.length == valueSize
+      . assert(_ == true)
 
     suite(m"Non-tracking mode"):
       test(m"Plain parse leaves positionIndex Unset"):
@@ -192,13 +193,13 @@ object PositionTests extends Suite(m"Jacinta position-index tests"):
 
     suite(m"Span derivation"):
       test(m"a position's span carries its line as a 0-based ordinal"):
-        at(2, 8, 3).span.startLine.vouch
+        at(2, 8, 3).span.startLine
       . assert(_ == 1.z)
 
       test(m"a position's span carries its column as a 0-based ordinal"):
-        at(2, 8, 3).span.startColumn.vouch
+        at(2, 8, 3).span.startColumn
       . assert(_ == 7.z)
 
       test(m"a position's span carries its length"):
-        at(2, 8, 3).span.length.vouch
+        at(2, 8, 3).span.length
       . assert(_ == 3)

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -563,7 +563,9 @@ object Protobuf extends Protobuf2:
       val numbers = fieldNumbers[derivation]
 
       value =>
-        val bytes = printed: printer =>
+        // The parameter ascription pins the lambda's type at each expansion site; without it,
+        // repeated expansions in one unit reuse a memoized capability root (#26547).
+        val bytes = printed: (printer: ProtobufPrinter^) =>
           fields(value):
             [field0] => fieldValue =>
               printer.field(numbers(label).vouch, contextual.encode(fieldValue))
@@ -574,7 +576,9 @@ object Protobuf extends Protobuf2:
       value =>
         variant(value):
           [variant <: derivation] => variantValue =>
-            val payload = printed(_.field(index + 1, contextual.encode(variantValue)))
+            // Parameter ascription pins the capability root per expansion, as in `conjunction`.
+            val payload = printed: (printer: ProtobufPrinter^) =>
+              printer.field(index + 1, contextual.encode(variantValue))
             Protobuf.Wire(WireType.Len, payload)
 
     inline def fieldNumbers[derivation <: Product: ProductReflection]: Map[Text, Int] =

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -560,7 +560,9 @@ object Protobuf extends Protobuf2:
     inline def conjunction[derivation <: Product: ProductReflection]
     :   derivation is Encodable in Protobuf =
 
-      val numbers = fieldNumbers[derivation]
+      val annotated: Map[Text, Set[field]] = infer[derivation is Annotated by field] match
+        case annotated: Annotated.Fields => annotated.fields
+        case _                           => Map()
 
       value =>
         // The parameter ascription pins the lambda's type at each expansion site; without it,
@@ -568,7 +570,11 @@ object Protobuf extends Protobuf2:
         val bytes = printed: (printer: ProtobufPrinter^) =>
           fields(value):
             [field0] => fieldValue =>
-              printer.field(numbers(label).vouch, contextual.encode(fieldValue))
+              // The number is computed exactly as `fieldNumbers` would, from this field's own
+              // label and index — no map lookup whose totality would need asserting.
+              printer.field
+                ( annotated(label).let(_.head.number).or(index + 1),
+                  contextual.encode(fieldValue) )
 
         Protobuf.Wire(WireType.Len, bytes)
 
@@ -581,23 +587,14 @@ object Protobuf extends Protobuf2:
               printer.field(index + 1, contextual.encode(variantValue))
             Protobuf.Wire(WireType.Len, payload)
 
-    inline def fieldNumbers[derivation <: Product: ProductReflection]: Map[Text, Int] =
-      val annotated: Map[Text, Set[field]] = infer[derivation is Annotated by field] match
-        case annotated: Annotated.Fields => annotated.fields
-        case _                           => Map()
-
-      val pairs =
-        contexts[derivation]():
-          [field0] => context =>
-            (label, annotated(label).let(_.head.number).or(index + 1))
-
-      Map.from(pairs.readable.toSeq)
 
   object DecodableDerivation extends Derivable[Decodable in Protobuf]:
     inline def conjunction[derivation <: Product: ProductReflection]
     :   (derivation is Decodable in Protobuf)^ =
 
-      val numbers = fieldNumbers[derivation]
+      val annotated: Map[Text, Set[field]] = infer[derivation is Annotated by field] match
+        case annotated: Annotated.Fields => annotated.fields
+        case _                           => Map()
 
       // The decode lambda closes over the resolution-scoped `Tactic` that `provide` summons
       // at the derivation site, sharing the instance's given-resolution lifetime; the fresh
@@ -608,7 +605,8 @@ object Protobuf extends Protobuf2:
 
           build[derivation]:
             [field0] => context =>
-              map(numbers(label).vouch).lay(default.or(context.decoded(Protobuf.Absent))): values =>
+              map(annotated(label).let(_.head.number).or(index + 1))
+              . lay(default.or(context.decoded(Protobuf.Absent))): values =>
                 context.decoded(Protobuf.Repeated(values)) }
 
     inline def disjunction[derivation: SumReflection]: (derivation is Decodable in Protobuf)^ =
@@ -625,19 +623,9 @@ object Protobuf extends Protobuf2:
 
             delegate(labels.stdlib(index)):
               [variant <: derivation] => context =>
-                context.decoded(Protobuf.Repeated(map(index + 1).vouch)) }
+                map(index + 1).lay(abort(ProtobufError(Reason.MissingField(index + 1)))): values =>
+                  context.decoded(Protobuf.Repeated(values)) }
 
-    inline def fieldNumbers[derivation <: Product: ProductReflection]: Map[Text, Int] =
-      val annotated: Map[Text, Set[field]] = infer[derivation is Annotated by field] match
-        case annotated: Annotated.Fields => annotated.fields
-        case _                           => Map()
-
-      val pairs =
-        contexts[derivation]():
-          [field0] => context =>
-            (label, annotated(label).let(_.head.number).or(index + 1))
-
-      Map.from(pairs.readable.toSeq)
 
 // A single Protocol Buffers wire value, tagged with its wire type — the `Form` of
 // `Encodable`/`Decodable in Protobuf`. `Repeated` carries every occurrence of a

--- a/lib/locomotion/src/staged/locomotion.stagedInternal.scala
+++ b/lib/locomotion/src/staged/locomotion.stagedInternal.scala
@@ -117,7 +117,7 @@ object stagedInternal:
       val run = ctx.run
 
       if run == null then false else
-        val sources = run.nn.units.map(_.source.file.path).toSet
+        val sources = run.nn.units.map(_.source.path).toSet
         val position = symbol.pos
         position.exists { position => sources.contains(position.sourceFile.path) }
     catch case _: Exception => false

--- a/lib/mandible/src/core/mandible_core.scala
+++ b/lib/mandible/src/core/mandible_core.scala
@@ -81,7 +81,8 @@ def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using T
       val code: Quotes ?=> Expr[Unit] = '{def _code(): Unit = $code0}
       staging.run(code)
       val classfile: Classfile = new Classfile(file.read[Data].readable)
-      classfile.methods.stdlib.find(_.name == t"_code$$1").map(_.bytecode).get.vouch.embed(codepoint)
+      classfile.methods.stdlib.find(_.name == t"_code$$1").optional.let(_.bytecode)
+      . lay(abort(BytecodeError(BytecodeError.Reason.ClassfileUnreadable)))(_.embed(codepoint))
 
 
 type BytecodePalette = Palette:

--- a/lib/mandible/src/lira/mandible.HostContracts.scala
+++ b/lib/mandible/src/lira/mandible.HostContracts.scala
@@ -63,7 +63,8 @@ object HostContracts:
       toolchain:  List[LiraManifest.Tool],
       allowMajor: Text -> Boolean            = { _ => false },
       sign:       LiraManifest -> LiraManifest = { manifest => manifest } )
-  :   List[(Text, Data)] raises LiraError raises DisciplineError =
+    ( using Tactic[LiraError], Tactic[DisciplineError] )
+  :   List[(Text, Data)] =
 
     val registry = Discipline.Registry(List(JsigDiscipline))
     val context = Discipline.Context(t"host")

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -102,26 +102,21 @@ object Tests extends Suite(m"Mandible tests"):
     classfileDisciplineTests()
     jvmProfileTests()
     test(m"Locate a known method on a classfile"):
-      val rewrite =
-        Classfile[StackTrace].let(_.methods.stdlib.find(_.name == t"rewrite").getOrElse(Unset)).vouch
-    . assert()
+      Classfile[StackTrace].let(_.methods.stdlib.find(_.name == t"rewrite").getOrElse(Unset))
+    . assert(_ != Unset)
 
     test(m"Disassemble a known method's bytecode"):
-      val bytecode =
-        Classfile[StackTrace]
-        . let(_.methods.stdlib.find(_.name == t"rewrite").getOrElse(Unset))
-        . let(_.bytecode)
-        . vouch
-      bytecode.instructions.size
+      Classfile[StackTrace]
+      . let(_.methods.stdlib.find(_.name == t"rewrite").getOrElse(Unset))
+      . let(_.bytecode)
+      . lay(0)(_.instructions.size)
     . assert(_ > 0)
 
     test(m"Bytecode carries declared maxStack and maxLocals"):
-      val bytecode =
-        Classfile[StackTrace]
-        . let(_.methods.stdlib.find(_.name == t"rewrite").getOrElse(Unset))
-        . let(_.bytecode)
-        . vouch
-      (bytecode.maxStack, bytecode.maxLocals)
+      Classfile[StackTrace]
+      . let(_.methods.stdlib.find(_.name == t"rewrite").getOrElse(Unset))
+      . let(_.bytecode)
+      . lay((-1, -1))(bytecode => (bytecode.maxStack, bytecode.maxLocals))
     . assert((s, l) => s >= 0 && l >= 0)
 
     test(m"Method descriptor parser handles primitives and references"):

--- a/lib/mosquito/src/test/mosquito_test.scala
+++ b/lib/mosquito/src/test/mosquito_test.scala
@@ -319,16 +319,18 @@ object Tests extends Suite(m"Mosquito tests"):
 
       test(m"M times M-inverse is identity (2x2)"):
         val m = Matrix[2, 2]((4.0, 7.0), (2.0, 6.0))
-        val product = m*m.inverse.vouch
-        val target = Matrix[2, 2]((1.0, 0.0), (0.0, 1.0))
-        product.elements.indices.map(i => math.abs(product.elements.readUnchecked(i) - target.elements.readUnchecked(i))).max
+        m.inverse.lay(Double.MaxValue): inverse =>
+          val product = m*inverse
+          val target = Matrix[2, 2]((1.0, 0.0), (0.0, 1.0))
+          product.elements.indices.map(i => math.abs(product.elements.readUnchecked(i) - target.elements.readUnchecked(i))).max
       . assert(_ < 0.000001)
 
       test(m"M times M-inverse is identity (3x3)"):
         val m = Matrix[3, 3]((1.0, 2.0, 3.0), (0.0, 1.0, 4.0), (5.0, 6.0, 0.0))
-        val product = m*m.inverse.vouch
-        val target = Matrix[3, 3]((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
-        product.elements.indices.map(i => math.abs(product.elements.readUnchecked(i) - target.elements.readUnchecked(i))).max
+        m.inverse.lay(Double.MaxValue): inverse =>
+          val product = m*inverse
+          val target = Matrix[3, 3]((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+          product.elements.indices.map(i => math.abs(product.elements.readUnchecked(i) - target.elements.readUnchecked(i))).max
       . assert(_ < 0.000001)
 
       test(m"Inverse of singular 3x3 matrix is Unset"):
@@ -600,22 +602,20 @@ object Tests extends Suite(m"Mosquito tests"):
 
     suite(m"Eigenvalues and eigenvectors"):
       test(m"Eigenvalues of 2x2 diagonal matrix"):
-        val sorted =
-          Matrix[2, 2]((2.0, 0.0), (0.0, 3.0)).eigenvalues.let(_.list.stdlib.sorted).vouch
-
-        math.abs(sorted(0) - 2.0) + math.abs(sorted(1) - 3.0)
+        Matrix[2, 2]((2.0, 0.0), (0.0, 3.0)).eigenvalues.let(_.list.stdlib.sorted)
+        . lay(Double.MaxValue): sorted =>
+            math.abs(sorted(0) - 2.0) + math.abs(sorted(1) - 3.0)
       . assert(_ < 0.000001)
 
       test(m"Eigenvalues of [[2, 1], [1, 2]] are 1 and 3"):
-        val sorted =
-          Matrix[2, 2]((2.0, 1.0), (1.0, 2.0)).eigenvalues.let(_.list.stdlib.sorted).vouch
-
-        math.abs(sorted(0) - 1.0) + math.abs(sorted(1) - 3.0)
+        Matrix[2, 2]((2.0, 1.0), (1.0, 2.0)).eigenvalues.let(_.list.stdlib.sorted)
+        . lay(Double.MaxValue): sorted =>
+            math.abs(sorted(0) - 1.0) + math.abs(sorted(1) - 3.0)
       . assert(_ < 0.000001)
 
       test(m"Eigenvalues of identity are all 1"):
-        val list = Matrix.identity[Double, 3].eigenvalues.let(_.list).vouch
-        list.map(v => math.abs(v - 1.0)).max
+        Matrix.identity[Double, 3].eigenvalues.let(_.list).lay(Double.MaxValue): list =>
+          list.map(v => math.abs(v - 1.0)).max
       . assert(_ < 0.000001)
 
       test(m"Eigensystem of non-symmetric matrix is Unset"):
@@ -624,56 +624,55 @@ object Tests extends Suite(m"Mosquito tests"):
 
       test(m"M * v = lambda * v for each eigenvector"):
         val mat = Matrix[2, 2]((2.0, 1.0), (1.0, 2.0))
-        val pair = mat.eigensystem.vouch
-        val vals = pair(0)
-        val vecs = pair(1)
-        val v0 = vecs.column(0)
-        val v1 = vecs.column(1)
-        val lambda0 = vals(0)
-        val lambda1 = vals(1)
-        val mv0 = mat*v0
-        val mv1 = mat*v1
-        val d0 = math.abs(mv0(0) - lambda0*v0(0)) + math.abs(mv0(1) - lambda0*v0(1))
-        val d1 = math.abs(mv1(0) - lambda1*v1(0)) + math.abs(mv1(1) - lambda1*v1(1))
-        math.max(d0, d1)
+        mat.eigensystem.lay(Double.MaxValue): pair =>
+          val vals = pair(0)
+          val vecs = pair(1)
+          val v0 = vecs.column(0)
+          val v1 = vecs.column(1)
+          val lambda0 = vals(0)
+          val lambda1 = vals(1)
+          val mv0 = mat*v0
+          val mv1 = mat*v1
+          val d0 = math.abs(mv0(0) - lambda0*v0(0)) + math.abs(mv0(1) - lambda0*v0(1))
+          val d1 = math.abs(mv1(0) - lambda1*v1(0)) + math.abs(mv1(1) - lambda1*v1(1))
+          math.max(d0, d1)
       . assert(_ < 0.000001)
 
       test(m"Eigenvectors are unit vectors"):
         val mat = Matrix[3, 3]((4.0, 1.0, 2.0), (1.0, 5.0, 3.0), (2.0, 3.0, 6.0))
-        val vecs = mat.eigenvectors.vouch
-        val norms = (0 until 3).map: column =>
-          math.abs(vecs.column(column).norm - 1.0)
+        mat.eigenvectors.lay(Double.MaxValue): vecs =>
+          val norms = (0 until 3).map: column =>
+            math.abs(vecs.column(column).norm - 1.0)
 
-        norms.max
+          norms.max
       . assert(_ < 0.000001)
 
     suite(m"Solve linear system"):
       test(m"Solve 2x2 system"):
         val mat = Matrix[2, 2]((2.0, 1.0), (1.0, 3.0))
         val rhs = Vector(3.0, 4.0)
-        val solution = mat.solve(rhs).vouch
-        math.abs(solution(0) - 1.0) + math.abs(solution(1) - 1.0)
+        mat.solve(rhs).lay(Double.MaxValue): solution =>
+          math.abs(solution(0) - 1.0) + math.abs(solution(1) - 1.0)
       . assert(_ < 0.000001)
 
       test(m"Solve identity system returns RHS"):
-        val solution = Matrix.identity[Double, 3].solve(Vector(7.0, 8.0, 9.0)).vouch
-        solution
+        Matrix.identity[Double, 3].solve(Vector(7.0, 8.0, 9.0))
       . assert(_ == Vector(7.0, 8.0, 9.0))
 
       test(m"Solve 3x3 system"):
         val mat = Matrix[3, 3]((1.0, 1.0, 1.0), (0.0, 2.0, 5.0), (2.0, 5.0, -1.0))
         val rhs = Vector(6.0, -4.0, 27.0)
-        val solution = mat.solve(rhs).vouch
-        val expected = Vector(5.0, 3.0, -2.0)
-        (0 until 3).map(i => math.abs(solution(i) - expected(i))).max
+        mat.solve(rhs).lay(Double.MaxValue): solution =>
+          val expected = Vector(5.0, 3.0, -2.0)
+          (0 until 3).map(i => math.abs(solution(i) - expected(i))).max
       . assert(_ < 0.000001)
 
       test(m"Solve verifies A * x = b"):
         val mat = Matrix[3, 3]((4.0, 1.0, 2.0), (1.0, 5.0, 3.0), (2.0, 3.0, 6.0))
         val rhs = Vector(7.0, 8.0, 9.0)
-        val solution = mat.solve(rhs).vouch
-        val recovered = mat*solution
-        (0 until 3).map(i => math.abs(recovered(i) - rhs(i))).max
+        mat.solve(rhs).lay(Double.MaxValue): solution =>
+          val recovered = mat*solution
+          (0 until 3).map(i => math.abs(recovered(i) - rhs(i))).max
       . assert(_ < 0.000001)
 
       test(m"Solve singular system returns Unset"):
@@ -682,6 +681,6 @@ object Tests extends Suite(m"Mosquito tests"):
 
       test(m"Solve requires row swap (zero in pivot)"):
         val mat = Matrix[2, 2]((0.0, 1.0), (1.0, 0.0))
-        val solution = mat.solve(Vector(2.0, 3.0)).vouch
-        math.abs(solution(0) - 3.0) + math.abs(solution(1) - 2.0)
+        mat.solve(Vector(2.0, 3.0)).lay(Double.MaxValue): solution =>
+          math.abs(solution(0) - 3.0) + math.abs(solution(1) - 2.0)
       . assert(_ < 0.000001)

--- a/lib/obligatory/src/json/obligatory.internal.scala
+++ b/lib/obligatory/src/json/obligatory.internal.scala
@@ -387,12 +387,21 @@ object internal:
             case '[result] => (Expr.summon[result is Json.Decodable], Expr.summon[Monitor]) match
               case (Some(decoder), Some(monitor)) =>
                 Some:
+                  // The tactic is constructed and passed explicitly rather than through
+                  // `unsafely: …`, whose block is a context function; each generated method would
+                  // re-elaborate that context-function type, and the fresh root capabilities minted
+                  // for its `ThrowTactic^`/`CanThrow` parameters are memoized from the first
+                  // method's expansion, so a later method's block fails to conform (upstream
+                  // #26547). A `ThrowTactic` throws in place — exactly `unsafely`'s behaviour for
+                  // a throwing tactic — so the semantics are unchanged.
                   ' {
-                      unsafely:
-                        val response =
-                          JsonRpc.outcome(JsonRpc.call($rpc, $methodName, $payload))(using $monitor)
+                      val tactic: ThrowTactic[JsonRpcError, result]^ = ThrowTactic()
 
-                        $decoder.decoded(response)
+                      val response =
+                        JsonRpc.outcome(JsonRpc.call($rpc, $methodName, $payload))
+                          ( using $monitor, tactic )
+
+                      $decoder.decoded(response)
                     }
 
                   . asTerm

--- a/lib/octogenarian/src/core/octogenarian.Git.scala
+++ b/lib/octogenarian/src/core/octogenarian.Git.scala
@@ -68,7 +68,7 @@ object Git:
     // observationally pure.
     caps.unsafe.unsafeAssumePure:
       iterator.filter: progress =>
-        (previous.absent || previous.vouch != progress).also { previous = progress }
+        previous.lay(true)(_ != progress).also { previous = progress }
 
   def progress(process: Job[?, ?]): Iterator[Progress] =
     import hieroglyph.charDecoders.utf8Decoder, hieroglyph.textSanitizers.substituteSanitizer

--- a/lib/octogenarian/src/core/octogenarian.GitRepo.scala
+++ b/lib/octogenarian/src/core/octogenarian.GitRepo.scala
@@ -217,17 +217,23 @@ case class GitRepo(gitDir: Path on Linux):
     var signature: List[Text]        = Nil
     var body:      List[Text] = Nil
 
+    // A commit is emitted only once all four mandatory headers have arrived; the
+    // nested `let`s both check and name them, so the emission reads bare values.
     def flush(): Unit =
-      if hash.present && tree.present && author.present && committer.present then unsafely:
-        commits +=
-          Commit
-            ( hash.vouch,
-              tree.vouch,
-              parents.reverse,
-              author.vouch,
-              committer.vouch,
-              parsePem(signature.join(t"\n")),
-              body.reverse )
+      hash.let: hash =>
+        tree.let: tree =>
+          author.let: author =>
+            committer.let: committer =>
+              unsafely:
+                commits +=
+                  Commit
+                    ( hash,
+                      tree,
+                      parents.reverse,
+                      author,
+                      committer,
+                      parsePem(signature.join(t"\n")),
+                      body.reverse )
 
     // A gpgsig block continues on the following one-space-indented lines.
     def indented(): List[Text] =

--- a/lib/octogenarian/src/core/octogenarian.Hunk.scala
+++ b/lib/octogenarian/src/core/octogenarian.Hunk.scala
@@ -35,10 +35,12 @@ package octogenarian
 import anticipation.*
 import dissonance.*
 
+// Edits are `Retained`: every hunk line carries its text, so `Patch.parse` mints the proof at
+// construction and `Patch.asDiff`'s result supports value-demanding operations (`redraft`).
 case class Hunk
   ( oldStart: Int,
     oldLines: Int,
     newStart: Int,
     newLines: Int,
     section:  Text,
-    edits:    List[Edit[Text]] )
+    edits:    List[Edit[Text] & Retained] )

--- a/lib/octogenarian/src/core/octogenarian.Patch.scala
+++ b/lib/octogenarian/src/core/octogenarian.Patch.scala
@@ -56,9 +56,10 @@ object Patch:
 
     files.to(List)
 
-  // Flattens every hunk's edits into a single Dissonance Diff[Text].
-  def asDiff(file: FileDiff): Diff[Text] =
-    Diff(file.hunks.stdlib.flatMap(_.edits.stdlib)*)
+  // Flattens every hunk's edits into a single Dissonance Diff[Text]. Assembled exclusively from
+  // `Retained` edits, so the `Diff` carries the proof.
+  def asDiff(file: FileDiff): Diff[Text] & Retained =
+    Diff(file.hunks.stdlib.flatMap(_.edits.stdlib)*).retained
 
   private def parseHunkRange(text: Text): (Int, Int) = text.cut(t",") match
     case List(start)        => (start.s.toInt, 1)
@@ -67,21 +68,21 @@ object Patch:
 
   private def parseFile(header: Text, body: List[Text]): FileDiff =
     case class State
-      ( oldPath:    Optional[Text]    = Unset,
-        newPath:    Optional[Text]    = Unset,
-        changeKind: ChangeKind        = ChangeKind.Modified,
-        hunks:      List[Hunk]        = Nil,
+      ( oldPath:    Optional[Text]               = Unset,
+        newPath:    Optional[Text]               = Unset,
+        changeKind: ChangeKind                   = ChangeKind.Modified,
+        hunks:      List[Hunk]                   = Nil,
         // Current hunk being read (with running line counters), if any.
-        hunk:       Optional[Hunk]    = Unset,
-        edits:      List[Edit[Text]]  = Nil,
-        oldLine:    Int               = 0,
-        newLine:    Int               = 0 ):
+        hunk:       Optional[Hunk]               = Unset,
+        edits:      List[Edit[Text] & Retained]  = Nil,
+        oldLine:    Int                          = 0,
+        newLine:    Int                          = 0 ):
 
       def closeHunk(): State =
         hunk.lay(this): h =>
           copy(hunks = h.copy(edits = edits.reverse) :: hunks, hunk = Unset, edits = Nil)
 
-      def push(edit: Edit[Text]): State = copy(edits = edit :: edits)
+      def push(edit: Edit[Text] & Retained): State = copy(edits = edit :: edits)
 
     val initial = header match
       case r"diff --git a/$old(.*) b/$nu(.*)" =>
@@ -131,14 +132,14 @@ object Patch:
       case other if state.hunk.present =>
         if other.starts(t"+") then
           val text = other.skip(1)
-          state.push(Ins(state.newLine, text)).copy(newLine = state.newLine + 1)
+          state.push(Ins(state.newLine, text).retained).copy(newLine = state.newLine + 1)
         else if other.starts(t"-") then
           val text = other.skip(1)
-          state.push(Del(state.oldLine, text)).copy(oldLine = state.oldLine + 1)
+          state.push(Del(state.oldLine, text).retained).copy(oldLine = state.oldLine + 1)
         else if other.starts(t" ") then
           val text = other.skip(1)
           val advanced = state.copy(oldLine = state.oldLine + 1, newLine = state.newLine + 1)
-          advanced.push(Par(state.oldLine, state.newLine, text))
+          advanced.push(Par(state.oldLine, state.newLine, text).retained)
         else
           state  // "\ No newline at end of file" or stray
 

--- a/lib/octogenarian/src/test/octogenarian_test.scala
+++ b/lib/octogenarian/src/test/octogenarian_test.scala
@@ -68,7 +68,8 @@ object Tests extends Suite(m"Octogenarian Tests"):
     // ----- Shared helpers -------------------------------------------------
 
     def freshDir(): Path on Linux =
-      val dir = temporaryDirectory[Path on Linux] / Uuid().show
+      val name: Text = Uuid().show
+      val dir = temporaryDirectory[Path on Linux] / name
       dir.create[Directory]()
       dir
 

--- a/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
+++ b/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
@@ -115,10 +115,16 @@ class Issuer
               val response: Optional[Http.Response] = if state.expired then Unset else
                 exchange.submit(Http.Post)(query.per(secret)(_.client_secret = _))
 
-              val json: Json = response.let(_.status) match
-                case Http.Ok           => response.vouch.receive[Json]
+              val json: Json = response match
+                case response: Http.Response if response.status == Http.Ok =>
+                  response.receive[Json]
 
-                case Http.Unauthorized | Unset =>
+                case response: Http.Response if response.status != Http.Unauthorized =>
+                  abort(OAuthError(OAuthError.Reason.Other))
+
+                // The token expired (no request was made) or was rejected: try the refresh
+                // token.
+                case _ =>
                   state.refresh.let: refresh =>
                     val query = Query.make(grant_type = t"refresh_token", refresh_token = refresh)
 
@@ -130,8 +136,6 @@ class Issuer
                       case _       => abort(OAuthError(OAuthError.Reason.Unauthorized))
 
                   . lest(OAuthError(OAuthError.Reason.Unauthorized))
-
-                case status            => abort(OAuthError(OAuthError.Reason.Other))
 
               import dynamicJsonAccess.enabled
 

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -335,7 +335,11 @@ object Tests extends Suite(m"Parasite tests"):
           val captured = juca.AtomicReference[Optional[Name[Async]]](Unset)
           val t = task(n"named")(captured.set(monitor.name))
           t.await()
-          captured.get().nn.vouch
+
+          // Bound at a val: the deindexed reference's RC5 typer skolem otherwise
+          // intersects the Optional union and vouch no longer sees an Optional.
+          val current: Optional[Name[Async]] = captured.get().nn
+          current.vouch
         . assert(_ == t"named")
 
       suite(m"Task error handling"):
@@ -1207,7 +1211,8 @@ object Tests extends Suite(m"Parasite tests"):
           val task = async:
             captured.set(monitor.stack)
           task.await()
-          captured.get().nn.vouch.contains(t"virtual")
+          val current: Optional[Text] = captured.get().nn
+          current.vouch.contains(t"virtual")
         . assert(_ == true)
 
         test(m"Nested workers' stack reflects nesting"):
@@ -1217,7 +1222,8 @@ object Tests extends Suite(m"Parasite tests"):
               captured.set(monitor.stack)
             inner.await()
           task.await()
-          captured.get().nn.vouch.contains(t"//")
+          val current: Optional[Text] = captured.get().nn
+          current.vouch.contains(t"//")
         . assert(_ == true)
 
       suite(m"Async names"):

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -337,10 +337,10 @@ object Tests extends Suite(m"Parasite tests"):
           t.await()
 
           // Bound at a val: the deindexed reference's RC5 typer skolem otherwise
-          // intersects the Optional union and vouch no longer sees an Optional.
+          // intersects the Optional union and the equality no longer sees an Optional.
           val current: Optional[Name[Async]] = captured.get().nn
-          current.vouch
-        . assert(_ == t"named")
+          current
+        . assert(_.lay(false)(_ == t"named"))
 
       suite(m"Task error handling"):
         test(m"Awaiting a cancelled task raises Cancelled"):
@@ -1212,7 +1212,7 @@ object Tests extends Suite(m"Parasite tests"):
             captured.set(monitor.stack)
           task.await()
           val current: Optional[Text] = captured.get().nn
-          current.vouch.contains(t"virtual")
+          current.lay(false)(_.contains(t"virtual"))
         . assert(_ == true)
 
         test(m"Nested workers' stack reflects nesting"):
@@ -1223,7 +1223,7 @@ object Tests extends Suite(m"Parasite tests"):
             inner.await()
           task.await()
           val current: Optional[Text] = captured.get().nn
-          current.vouch.contains(t"//")
+          current.lay(false)(_.contains(t"//"))
         . assert(_ == true)
 
       suite(m"Async names"):

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -154,10 +154,8 @@ private def readHandshake(input: (zephyrine.Stream[Data] over zephyrine.Credit)^
     recur(0)
 
   val demand = zephyrine.Credit(buffering.capacity(zephyrine.Substrate.Bytes))
-  var acc: Data = Data()
-  var result: Optional[Data] = Unset
 
-  while result.absent do input.refill(demand) match
+  def recur(acc: Data): Data = input.refill(demand) match
     case count: Int =>
       if count > 0 then
         val window = input.lend { region => range => region.materialize(range.capped(count)) }
@@ -166,15 +164,16 @@ private def readHandshake(input: (zephyrine.Stream[Data] over zephyrine.Credit)^
 
         if marker >= 0 then
           input.skip(marker + 4 - acc.length)
-          result = caps.unsafe.unsafeAssumePure(acc2.take(marker + 4))
+          acc2.take(marker + 4)
         else
           input.skip(count)
-          acc = acc2
+          recur(acc2)
+      else recur(acc)
 
     case _ =>
-      result = acc
+      acc
 
-  result.vouch
+  recur(Data())
 
 // Makes a `WsUrl` a Coaxial client transport, so a WebSocket client is just Coaxial's
 // own client loop: `url.react(initialState) { message => … }`, symmetric with the

--- a/lib/plutocrat/src/core/plutocrat.Luhn.scala
+++ b/lib/plutocrat/src/core/plutocrat.Luhn.scala
@@ -41,14 +41,21 @@ import vacuous.*
 
 object Luhn:
   def digit(number: Text): Int =
-    def recur(index: Int, sum: Int, odd: Boolean): Int =
-      if index < 0 then (10 - sum%10)%10 else
-        val n: Int = ((if odd then 2 else 1)*(number(index.z).vouch - '0')).toInt
-        recur(index - 1, sum + (if n > 9 then n - 9 else n), !odd)
+    var sum: Int = 0
+    var odd: Boolean = true
 
-    recur(number.length - 1, 0, true)
+    // `retrace` drives the last-to-first walk with ordinals confined to `number`, so each
+    // access is bare and the loop allocates nothing.
+    number.retrace: index =>
+      val n: Int = ((if odd then 2 else 1)*(number(index) - '0')).toInt
+      sum += (if n > 9 then n - 9 else n)
+      odd = !odd
 
+    (10 - sum%10)%10
+
+  // False for empty input: a last digit to check against is the first requirement.
   def check(number: Text): Boolean =
-    digit(number.skip(1, Rtl)) == number((number.length - 1).z).vouch - '0'
+    number.ult.lay(false): ult =>
+      digit(number.skip(1, Rtl)) == number(ult) - '0'
 
   def check(number: Long): Boolean = check(number.show)

--- a/lib/polaris/src/core/polaris.Bufferable.scala
+++ b/lib/polaris/src/core/polaris.Bufferable.scala
@@ -66,9 +66,12 @@ object Bufferable extends ProductDerivable[Bufferable]:
     def sextant(sextant: Sextant, value: derivation): Unit = buffer0(sextant, value)
 
   inline def conjunction[derivation <: Product: ProductReflection]: derivation is Bufferable =
+    // The sextant parameter is ascribed for the same reason as Debufferable.conjunction's:
+    // an inferred type adopts a memoized root capability from the unit's first expansion,
+    // failing any second expansion (upstream #26547).
     Join[derivation]
       ( contexts[derivation]() { [field] => _.width }.sum,
-        (sextant, value) => fields(value) { [field] => field => contextual.sextant(sextant, field) } )
+        (sextant: Sextant, value) => fields(value) { [field] => field => contextual.sextant(sextant, field) } )
 
 trait Bufferable extends Typeclass:
   def width: Int

--- a/lib/polaris/src/core/polaris.Debufferable.scala
+++ b/lib/polaris/src/core/polaris.Debufferable.scala
@@ -72,9 +72,13 @@ object Debufferable extends ProductDerivable[Debufferable]:
     def debuffer(sextant: Sextant): derivation = debuffer0(sextant)
 
   inline def conjunction[derivation <: Product: ProductReflection]: derivation is Debufferable =
+    // The lambda parameter is ascribed so its type is not inferred from the expected arrow:
+    // inferred, it adopts a memoized root capability minted by the unit's first expansion of
+    // this derivation, and any second expansion in the same unit fails the root-visibility
+    // check (upstream #26547, from 2026-07-17 nightlies).
     Join[derivation]
       ( contexts[derivation]() { [field] => _.width }.sum,
-        sextant => build { [field] => context => context.debuffer(sextant) } )
+        (sextant: Sextant) => build { [field] => context => context.debuffer(sextant) } )
 
 trait Debufferable extends Typeclass:
   def width: Int

--- a/lib/polysyllabic/src/core/polysyllabic.Hyphenation.scala
+++ b/lib/polysyllabic/src/core/polysyllabic.Hyphenation.scala
@@ -125,10 +125,7 @@ object Hyphenation:
       padded(i + 1) = if c >= 'A' && c <= 'Z' then (c + 32).toChar else c
       i += 1
 
-    val exception = hyphenation.exceptions(padded.raw, 1, length)
-
-    if !exception.absent then
-      val offsets: Array[Int]^{} = exception.vouch
+    hyphenation.exceptions(padded.raw, 1, length).let: offsets =>
       val filtered = Array[Int](offsets.length)
       var count = 0
 
@@ -140,22 +137,23 @@ object Hyphenation:
           count += 1
 
       exactCopy(filtered, count)
-    else
-      val scores = Array[Byte](paddedLength + 1)
-      walkCompact(padded.raw, paddedLength, hyphenation.patterns, scores.raw)
-      val breaks = Array[Int](length)
-      var count = 0
-      var p = if leftMin > 1 then leftMin else 1
-      val lastBreak = length - (if rightMin > 1 then rightMin else 1)
 
-      while p <= lastBreak do
-        if (scores(p + 1) & 1) == 1 then
-          breaks(count) = p
-          count += 1
+    . or:
+        val scores = Array[Byte](paddedLength + 1)
+        walkCompact(padded.raw, paddedLength, hyphenation.patterns, scores.raw)
+        val breaks = Array[Int](length)
+        var count = 0
+        var p = if leftMin > 1 then leftMin else 1
+        val lastBreak = length - (if rightMin > 1 then rightMin else 1)
 
-        p += 1
+        while p <= lastBreak do
+          if (scores(p + 1) & 1) == 1 then
+            breaks(count) = p
+            count += 1
 
-      exactCopy(breaks, count)
+          p += 1
+
+        exactCopy(breaks, count)
 
   // Walk the compact pattern trie from every starting position in `padded`,
   // merging each matched pattern's score array into `scores` via `max`. Uses
@@ -251,10 +249,7 @@ object Hyphenation:
       padded(i + 1) = if c >= 'A' && c <= 'Z' then (c + 32).toChar else c
       i += 1
 
-    val exception = hyphenation.exceptions(padded, 1, length)
-
-    if !exception.absent then
-      val offsets: Array[Int]^{} = exception.vouch
+    hyphenation.exceptions(padded, 1, length).let: offsets =>
       var count = 0
 
       offsets.iterate: index =>
@@ -265,11 +260,12 @@ object Hyphenation:
           count += 1
 
       count
-    else
-      // Zero the active prefix of the scores buffer so the running maxima
-      // start from 0 each call. `Arrays.fill` is a JIT intrinsic.
-      java.util.Arrays.fill(scores, 0, paddedLength + 1, 0.toByte)
-      trieWalkInto(padded, paddedLength, length, hyphenation, leftMin, rightMin, scores, breaks)
+
+    . or:
+        // Zero the active prefix of the scores buffer so the running maxima
+        // start from 0 each call. `Arrays.fill` is a JIT intrinsic.
+        java.util.Arrays.fill(scores, 0, paddedLength + 1, 0.toByte)
+        trieWalkInto(padded, paddedLength, length, hyphenation, leftMin, rightMin, scores, breaks)
 
   private inline def mergePattern
     ( scores: scala.Array[Byte]^, base: Int, pattern: Array[Byte]^{} )

--- a/lib/prescience/src/core/prescience.internal.scala
+++ b/lib/prescience/src/core/prescience.internal.scala
@@ -130,7 +130,7 @@ object internal:
       val run = ctx.run
 
       if run == null then false else
-        val sources = run.nn.units.map(_.source.file.path).toSet
+        val sources = run.nn.units.map(_.source.path).toSet
         val position = symbol.pos
         position.exists { position => sources.contains(position.sourceFile.path) }
     catch case _: Exception => false

--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -58,7 +58,7 @@ import termcaps.environmentTermcap
 import themes.solarizedTheme
 
 abstract class Suite(suiteName: Message) extends Testable(suiteName):
-  val suiteIo = safely(stdios.virtualMachineStdio).vouch
+  val suiteIo = safely(stdios.virtualMachineStdio).or(panic(m"the JVM stdio is always available"))
 
   private def makeRunner(selection: Selection): Runner[Report] =
     given stdio: Stdio = suiteIo

--- a/lib/probably/src/core/probably.Entry.scala
+++ b/lib/probably/src/core/probably.Entry.scala
@@ -101,8 +101,11 @@ final class Entry(val id: TestId, val kind: Entry.Kind):
       if !seen.has(value) then ticks0 = ticks0.updated(axis, seen :+ value)
 
     val address = coordinates.map(_(1))
-    if !cells0.defines(address) then cells0 = cells0.updated(address, Tally())
-    cells0(address).vouch
+
+    cells0(address).or:
+      val tally = Tally()
+      cells0 = cells0.updated(address, tally)
+      tally
 
   // The coordinate values of one axis in presentation order: first-appearance order for
   // discrete axes, numeric order for integral and decimal axes.

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -128,14 +128,16 @@ class TestsMap():
   private var tests: Ledger[TestId, ReportLine] = Ledger()
 
   def list: List[(TestId, ReportLine)] = mutex(tests.to[List])
-  def apply(testId: TestId): ReportLine = mutex(tests(testId).vouch)
+  def apply(testId: TestId): Optional[ReportLine] = mutex(tests(testId))
 
   def update(testId: TestId, reportLine: ReportLine) = mutex:
     tests = tests.updated(testId, reportLine)
 
   def getOrElseUpdate(testId: TestId, reportLine: => ReportLine): ReportLine = mutex:
-    if !tests.defines(testId) then tests = tests.updated(testId, reportLine)
-    tests(testId).vouch
+    tests(testId).or:
+      val line = reportLine
+      tests = tests.updated(testId, line)
+      line
 
 // The report's intermediate representation: a tree of suites (namespacing only), whose
 // leaves are uniform `Entry` values — one per named test, of any kind, holding that test's

--- a/lib/punctuation/src/core/punctuation.BlockParser.scala
+++ b/lib/punctuation/src/core/punctuation.BlockParser.scala
@@ -238,11 +238,8 @@ private[punctuation] final class BlockParser:
     while idx < openStack.length && continueLoop do
       openStack(idx) match
         case container: ContainerBuilder =>
-          val cont = container.tryContinue(remaining)
-
-          if cont.absent then continueLoop = false
-          else
-            remaining = cont.vouch
+          container.tryContinue(remaining).lay({ continueLoop = false }): cont =>
+            remaining = cont
             idx += 1
 
         case _: LeafBuilder => continueLoop = false

--- a/lib/punctuation/src/core/punctuation.InlineParser.scala
+++ b/lib/punctuation/src/core/punctuation.InlineParser.scala
@@ -327,24 +327,16 @@ private[punctuation] object InlineParser:
       InlineSupport.parseRefLabel(s, after, end) match
         case r: InlineSupport.RefLabelMatch =>
           val label = if r.label.s.isEmpty then bracketContent else r.label
-          val resolved = refs.lookup(label)
 
-          if resolved.present then
-            val ref = resolved.vouch
-            return LinkResolution(ref.destination, ref.title, r.end)
           // Per spec: when the `[label]` parses but the label doesn't
           // resolve, the link attempt fails entirely — don't fall back to
           // shortcut. The full-ref `[label]` is consumed by this attempt.
-          return Unset
+          return refs.lookup(label).let: ref =>
+            LinkResolution(ref.destination, ref.title, r.end)
 
         case _ =>
           ()  // fall through to shortcut
 
     // 3. Shortcut reference
-    val resolved = refs.lookup(bracketContent)
-
-    if resolved.present then
-      val ref = resolved.vouch
+    refs.lookup(bracketContent).let: ref =>
       LinkResolution(ref.destination, ref.title, after)
-    else
-      Unset

--- a/lib/punctuation/src/core/punctuation.InlineSupport.scala
+++ b/lib/punctuation/src/core/punctuation.InlineSupport.scala
@@ -246,9 +246,11 @@ private[punctuation] object InlineSupport:
     while i < n && (s.charAt(i) == ' ' || s.charAt(i) == '\t') do i += 1
     if i >= n then return Unset
 
-    val destResult = parseLinkDestination(s, i, n)
-    if destResult.absent then return Unset
-    val (destination, afterDest) = (destResult.vouch.dest, destResult.vouch.end)
+    val destMatch = parseLinkDestination(s, i, n) match
+      case dest: DestMatch => dest
+      case Unset           => return Unset
+
+    val (destination, afterDest) = (destMatch.dest, destMatch.end)
     i = afterDest
 
     val beforeWs = i
@@ -625,9 +627,11 @@ private[punctuation] object InlineSupport:
     i = skipLinkWhitespace(s, i, end)
     if i >= end then return Unset
 
-    val destResult = parseLinkDestination(s, i, end)
-    if destResult.absent then return Unset
-    val (destination, afterDest) = (destResult.vouch.dest, destResult.vouch.end)
+    val destMatch = parseLinkDestination(s, i, end) match
+      case dest: DestMatch => dest
+      case Unset           => return Unset
+
+    val (destination, afterDest) = (destMatch.dest, destMatch.end)
 
     // Compute both options up front: dest-only (no title) and dest+title.
     // Prefer dest+title if its trailing content is valid; otherwise fall

--- a/lib/quantitative/src/test/quantitative_test.scala
+++ b/lib/quantitative/src/test/quantitative_test.scala
@@ -399,16 +399,16 @@ object Tests extends Suite(m"Quantitative Tests"):
       . assert(_ == 6*Second)
 
       test(m"Average some values"):
-        List(1*Second, 2*Second, 3*Second).mean.vouch
-      . assert(_ == 2*Second)
+        List(1*Second, 2*Second, 3*Second).mean
+      . assert(_.lay(false)(_ == 2*Second))
 
       test(m"Variance of some values"):
-        List(1*Second, 2*Second, 3*Second).variance.vouch
-      . assert(_ == (2/3.0)*Second*Second)
+        List(1*Second, 2*Second, 3*Second).variance
+      . assert(_.lay(false)(_ == (2/3.0)*Second*Second))
 
       test(m"Standard deviation of some values"):
-        List(1*Second, 2*Second, 3*Second).std.vouch
-      . assert(_ == (2/3.0).sqrt*Second)
+        List(1*Second, 2*Second, 3*Second).std
+      . assert(_.lay(false)(_ == (2/3.0).sqrt*Second))
 
     suite(m"Prefix-scaled rendering"):
       sealed trait Information extends Dimension
@@ -486,11 +486,10 @@ object Tests extends Suite(m"Quantitative Tests"):
     suite(m"Bytecode shape"):
       import classloaders.threadContextClassloader
 
-      def methodBytecode(method: Text)(using Classloader): Bytecode =
+      def methodBytecode(method: Text)(using Classloader): Optional[Bytecode] =
         Classfile[Probes.type]
         . let(_.methods.find(_.name == method).getOrElse(Unset))
         . let(_.bytecode)
-        . vouch
 
       // True when the bytecode contains a virtual / interface dispatch to a
       // typeclass operation (`negate`, `add`, etc.). Virtual calls to a
@@ -544,63 +543,63 @@ object Tests extends Suite(m"Quantitative Tests"):
             case _                    => false
 
       test(m"Quantity negation has no virtual call to `negate`"):
-        callsTypeclassOp(methodBytecode(t"viaQuantity_negate"))
+        methodBytecode(t"viaQuantity_negate").lay(true)(callsTypeclassOp)
       . assert(_ == false)
 
       test(m"Quantity negation has no boxing"):
-        hasBoxing(methodBytecode(t"viaQuantity_negate"))
+        methodBytecode(t"viaQuantity_negate").lay(true)(hasBoxing)
       . assert(_ == false)
 
       test(m"Quantity negation contains the primitive `Dneg` instruction"):
-        containsDneg(methodBytecode(t"viaQuantity_negate"))
+        methodBytecode(t"viaQuantity_negate").lay(false)(containsDneg)
       . assert(_ == true)
 
       test(m"Quantity * Double contains the primitive `Dmul` instruction"):
-        containsDmul(methodBytecode(t"viaQuantity_mulScalar"))
+        methodBytecode(t"viaQuantity_mulScalar").lay(false)(containsDmul)
       . assert(_ == true)
 
       test(m"Quantity / Double contains the primitive `Ddiv` instruction"):
-        containsDdiv(methodBytecode(t"viaQuantity_divScalar"))
+        methodBytecode(t"viaQuantity_divScalar").lay(false)(containsDdiv)
       . assert(_ == true)
 
       test(m"Quantity * Double has no virtual call to `multiply`"):
-        callsTypeclassOp(methodBytecode(t"viaQuantity_mulScalar"))
+        methodBytecode(t"viaQuantity_mulScalar").lay(true)(callsTypeclassOp)
       . assert(_ == false)
 
       test(m"Quantity / Double has no virtual call to `divide`"):
-        callsTypeclassOp(methodBytecode(t"viaQuantity_divScalar"))
+        methodBytecode(t"viaQuantity_divScalar").lay(true)(callsTypeclassOp)
       . assert(_ == false)
 
       test(m"Quantity + Quantity contains the primitive `Dadd` instruction"):
-        containsDadd(methodBytecode(t"viaQuantity_addQ"))
+        methodBytecode(t"viaQuantity_addQ").lay(false)(containsDadd)
       . assert(_ == true)
 
       test(m"Quantity + Quantity has no virtual call to `add` or `op`"):
-        callsTypeclassOp(methodBytecode(t"viaQuantity_addQ"))
+        methodBytecode(t"viaQuantity_addQ").lay(true)(callsTypeclassOp)
       . assert(_ == false)
 
       test(m"Quantity - Quantity contains the primitive `Dsub` instruction"):
-        containsDsub(methodBytecode(t"viaQuantity_subQ"))
+        methodBytecode(t"viaQuantity_subQ").lay(false)(containsDsub)
       . assert(_ == true)
 
       test(m"Quantity - Quantity has no virtual call to `subtract` or `op`"):
-        callsTypeclassOp(methodBytecode(t"viaQuantity_subQ"))
+        methodBytecode(t"viaQuantity_subQ").lay(true)(callsTypeclassOp)
       . assert(_ == false)
 
       test(m"Quantity * Quantity contains the primitive `Dmul` instruction"):
-        containsDmul(methodBytecode(t"viaQuantity_mulQ"))
+        methodBytecode(t"viaQuantity_mulQ").lay(false)(containsDmul)
       . assert(_ == true)
 
       test(m"Quantity * Quantity has no virtual call to `multiply` or `op`"):
-        callsTypeclassOp(methodBytecode(t"viaQuantity_mulQ"))
+        methodBytecode(t"viaQuantity_mulQ").lay(true)(callsTypeclassOp)
       . assert(_ == false)
 
       test(m"Quantity / Quantity contains the primitive `Ddiv` instruction"):
-        containsDdiv(methodBytecode(t"viaQuantity_divQ"))
+        methodBytecode(t"viaQuantity_divQ").lay(false)(containsDdiv)
       . assert(_ == true)
 
       test(m"Quantity / Quantity has no virtual call to `divide` or `op`"):
-        callsTypeclassOp(methodBytecode(t"viaQuantity_divQ"))
+        methodBytecode(t"viaQuantity_divQ").lay(true)(callsTypeclassOp)
       . assert(_ == false)
 
 

--- a/lib/revolution/src/core/revolution.internal.scala
+++ b/lib/revolution/src/core/revolution.internal.scala
@@ -56,4 +56,4 @@ object internal:
     // components, which the opaque `List` alias makes awkward inside a quote.
     safely(versionText.tt.as[Semver]).or(halt(m"invalid semantic version"))
 
-    '{safely(${Expr(versionText)}.tt.as[Semver]).vouch}
+    '{safely(${Expr(versionText)}.tt.as[Semver]).or(panic(m"the version literal was validated at expansion"))}

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -221,6 +221,13 @@ extension [self](self: self)(using traversable: self is Traversable)
   inline def all(predicate: traversable.Operand => Boolean): Boolean =
     traversable.traverse(self).forall(predicate)
 
+// The `Populated` producer: one non-emptiness check, recorded in the type, so the operations
+// below are total on the result. The presence check *is* the proof, in the same way a confined
+// ordinal's range check is (`Ordinal in value.type`).
+extension [self](value: self)(using traversable: self is Traversable)
+  def occupied: Optional[self & Populated] =
+    if traversable.traverse(value).hasNext then value.asInstanceOf[self & Populated] else Unset
+
 // Operations that are partial on possibly-empty collections but *total* on receivers carrying a
 // `Populated` proof (obtained from `occupied`, whose bounds check is thereby discharged exactly
 // once). Stdlib members shadow these for stdlib receivers while the aliases remain transparent.

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -267,13 +267,9 @@ extension [value](iterables: Iterable[Iterable[value]])
     if iterables.nil then Iterable() else iterables.reduceLeft(_ ++ between ++ _)
 
 extension [value](iterable: Iterable[value])
-  // The `Result` of each numeric typeclass below is bound as an inferred type parameter (e.g.
-  // `to result` + `result =:= value`) rather than referenced path-dependently (`addable.Result =:=
-  // value`). Under capture checking the path-dependent form fails at the cross-package `export`
-  // forwarder (#1411); binding it as a type parameter keeps call sites unchanged.
-  transparent inline def total[result]
-    ( using addable:  value is Addable by value to result,
-            equality: result =:= value )
+  transparent inline def total
+    ( using addable:  value is Addable by value,
+            equality: addable.Result =:= value )
   :   Optional[value] =
 
     compiletime.summonFrom:
@@ -283,23 +279,23 @@ extension [value](iterable: Iterable[value])
         if iterable.nil then Unset else iterable.tail.foldLeft(iterable.head)(addable.add)
 
 
-  transparent inline def mean[addResult, divResult]
-    ( using addable:   value is Addable by value to addResult,
-            equality:  addResult =:= value,
-            divisible: value is Divisible by Double to divResult,
-            eqality2:  divResult =:= value )
+  transparent inline def mean
+    ( using addable:   value is Addable by value,
+            equality:  addable.Result =:= value,
+            divisible: value is Divisible by Double,
+            eqality2:  divisible.Result =:= value )
   :   Optional[value] =
 
     iterable.total.let(_/iterable.size.toDouble)
 
-  inline def mean2[subResult, addResult, divResult, add2Result]
-    ( using subtractable: value is Subtractable by value to subResult,
-            addable:      subResult is Addable by subResult to addResult,
-            equality:     addResult =:= subResult,
-            divisible:    subResult is Divisible by Double to divResult,
-            equality2:    divResult =:= subResult,
-            addable2:     value is Addable by divResult to add2Result,
-            equality3:    add2Result =:= value )
+  inline def mean2
+    ( using subtractable: value is Subtractable by value,
+            addable:      subtractable.Result is Addable by subtractable.Result,
+            equality:     addable.Result =:= subtractable.Result,
+            divisible:    subtractable.Result is Divisible by Double,
+            equality2:    divisible.Result =:= subtractable.Result,
+            addable2:     value is Addable by divisible.Result,
+            equality3:    addable2.Result =:= value )
   :   Optional[value] =
 
     if iterable.nil then Unset else
@@ -307,32 +303,32 @@ extension [value](iterable: Iterable[value])
 
       iterable.map(_ - arbitrary).total.let: total => arbitrary + total/iterable.size.toDouble
 
-  def variance[addResult, divResult, subResult, mulResult, add2Result, div2Result]
-    ( using addable:       value is Addable by value to addResult,
-            equality:      addResult =:= value,
-            divisible:     value is Divisible by Double to divResult,
-            equality2:     divResult =:= value,
-            subtractable:  value is Subtractable by value to subResult,
-            multiplicable: subResult is Multiplicable by subResult to mulResult,
-            addable2:      mulResult is Addable by mulResult to add2Result,
-            zeroic2:       mulResult is Zeroic,
-            equality3:     add2Result =:= mulResult,
-            divisible2:    mulResult is Divisible by Double to div2Result )
-  :   Optional[div2Result] =
+  def variance
+    ( using addable:       value is Addable by value,
+            equality:      addable.Result =:= value,
+            divisible:     value is Divisible by Double,
+            equality2:     divisible.Result =:= value,
+            subtractable:  value is Subtractable by value,
+            multiplicable: subtractable.Result is Multiplicable by subtractable.Result,
+            addable2:      multiplicable.Result is Addable by multiplicable.Result,
+            zeroic2:       multiplicable.Result is Zeroic,
+            equality3:     addable2.Result =:= multiplicable.Result,
+            divisible2:    multiplicable.Result is Divisible by Double )
+  :   Optional[divisible2.Result] =
 
     iterable.mean.let: mean =>
       iterable.map(_ - mean).map { value => value*value }.total/iterable.size.toDouble
 
 
-  def std[addResult, divResult, div2Result, mulResult]
-    ( using addable:       value is Addable by value to addResult,
-            equality:      addResult =:= value,
-            divisible:     value is Divisible by Double to divResult,
-            equality2:     divResult =:= value,
-            divisible2:    value is Divisible by value to div2Result,
-            equality3:     div2Result =:= Double,
-            multiplicable: value is Multiplicable by Double to mulResult,
-            equality4:     mulResult =:= value )
+  def std
+    ( using addable:       value is Addable by value,
+            equality:      addable.Result =:= value,
+            divisible:     value is Divisible by Double,
+            equality2:     divisible.Result =:= value,
+            divisible2:    value is Divisible by value,
+            equality3:     divisible2.Result =:= Double,
+            multiplicable: value is Multiplicable by Double,
+            equality4:     multiplicable.Result =:= value )
   :   Optional[value] =
 
     iterable.mean.let: mean0 =>
@@ -349,10 +345,10 @@ extension [value](iterable: Iterable[value])
       divisor*math.sqrt(sum/iterable.size.toDouble)
 
 
-  def product[mulResult]
+  def product
     ( using unital:        value is Unital,
-            multiplicable: value is Multiplicable by value to mulResult,
-            equality:      mulResult =:= value )
+            multiplicable: value is Multiplicable by value,
+            equality:      multiplicable.Result =:= value )
   :   value =
 
     iterable.foldLeft(unital.one)(multiplicable.multiply)

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -54,10 +54,17 @@ import vacuous.*
 
 export rudiments.internal.{Bytes, Digit}
 
-// The returned arrow declares its dependency on `recur` (`->{recur}`) rather than claiming a
-// pure result, which capture checking rejects (#1412); the knot is tied eta-delayed so `fn` is
-// only re-entered when the recursion is applied (the eager knot recursed unconditionally).
-def fixpoint[value](initial: value)(fn: (recur: value => value) ?=> value ->{recur} value): value =
+// The SAM trait names the knot's true aliasing: the recursion passed as `recur` captures the
+// recurrence itself (`->{this}`), and the result arrow declares its dependency on `recur`
+// rather than claiming purity (#1412). A context-function formal cannot express this (it
+// cannot name the function value inside its own type), so separation checking rightly rejects
+// that shape. Call sites still write `fixpoint(init) { recur ?=> ... }`: the context lambda
+// SAM-converts. The knot is tied eta-delayed, so `fn` is only re-entered when the recursion
+// is applied (the old eager knot recursed unconditionally).
+trait Recurrence[value]:
+  def apply(using recur: value ->{this} value): value ->{recur} value
+
+def fixpoint[value](initial: value)(fn: Recurrence[value]^): value =
   def recurrence(v: value): value = fn(using recurrence)(v)
   recurrence(initial)
 

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -54,10 +54,12 @@ import vacuous.*
 
 export rudiments.internal.{Bytes, Digit}
 
-// `fixpoint` was removed: it does not yet type-check under capture checking (the recursive
-// context function trips "Reference `recur` is not included in the allowed capture set") and
-// was unused. Issue #1412 tracks a capture-correct reformulation; the old definition is in
-// that issue and the git history.
+// The returned arrow declares its dependency on `recur` (`->{recur}`) rather than claiming a
+// pure result, which capture checking rejects (#1412); the knot is tied eta-delayed so `fn` is
+// only re-entered when the recursion is applied (the eager knot recursed unconditionally).
+def fixpoint[value](initial: value)(fn: (recur: value => value) ?=> value ->{recur} value): value =
+  def recurrence(v: value): value = fn(using recurrence)(v)
+  recurrence(initial)
 
 inline def probe[target]: Nothing = ${rudiments.internal.probe[target]}
 inline def typeName[target]: Text = ${rudiments.internal.name[target]}

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -61,10 +61,10 @@ export rudiments.internal.{Bytes, Digit}
 // that shape. Call sites still write `fixpoint(init) { recur ?=> ... }`: the context lambda
 // SAM-converts. The knot is tied eta-delayed, so `fn` is only re-entered when the recursion
 // is applied (the old eager knot recursed unconditionally).
-trait Recurrence[value]:
+trait Fixpoint[value]:
   def apply(using recur: value ->{this} value): value ->{recur} value
 
-def fixpoint[value](initial: value)(fn: Recurrence[value]^): value =
+def fixpoint[value](initial: value)(fn: Fixpoint[value]^): value =
   def recurrence(v: value): value = fn(using recurrence)(v)
   recurrence(initial)
 

--- a/lib/rudiments/src/core/soundness_rudiments_core.scala
+++ b/lib/rudiments/src/core/soundness_rudiments_core.scala
@@ -43,7 +43,7 @@ export
       give, immutable, indexBy, intercalate, javaInputStream, kib,
       longestTrain,
       Loop, loop, matchable, mean, mib, mutable, Mutex, next, ordinal, pipe, place, plus,
-      prior, probe, product, Recurrence, reflectClass, repeat, runs, runsBy, segment, Segmentable,
+      prior, probe, product, Fixpoint, reflectClass, repeat, runs, runsBy, segment, Segmentable,
       indexed, least, most, sift, snapshot, state, std, sumBy, tap, that, tib, to, total, tri, triple, tuple, twin,
       typed, typeName, unit, unwind, upsert, variance, waive, weave, when, yet, upon, context,
       mean2, unique, seek, where,

--- a/lib/rudiments/src/core/soundness_rudiments_core.scala
+++ b/lib/rudiments/src/core/soundness_rudiments_core.scala
@@ -38,7 +38,7 @@ export
   // dependent-typed inline extensions, which synthesized export forwarders break (the same
   // policy as zephyrine's `Region`/`Slate`). Consumers import them from `rudiments` directly.
   . { !!, &, all, also, and, annex, b, bi, Bijection, bijection, Bytes, bytes, collate, Counter,
-      DecimalConverter, Defaulting, Defaulting2, Digit, each, establish, Exit,
+      DecimalConverter, Defaulting, Defaulting2, Digit, each, establish, Exit, fixpoint,
       fuse, gib,
       give, immutable, indexBy, intercalate, javaInputStream, kib,
       longestTrain,

--- a/lib/rudiments/src/core/soundness_rudiments_core.scala
+++ b/lib/rudiments/src/core/soundness_rudiments_core.scala
@@ -43,7 +43,7 @@ export
       give, immutable, indexBy, intercalate, javaInputStream, kib,
       longestTrain,
       Loop, loop, matchable, mean, mib, mutable, Mutex, next, ordinal, pipe, place, plus,
-      prior, probe, product, reflectClass, repeat, runs, runsBy, segment, Segmentable,
+      prior, probe, product, Recurrence, reflectClass, repeat, runs, runsBy, segment, Segmentable,
       indexed, least, most, sift, snapshot, state, std, sumBy, tap, that, tib, to, total, tri, triple, tuple, twin,
       typed, typeName, unit, unwind, upsert, variance, waive, weave, when, yet, upon, context,
       mean2, unique, seek, where,

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -136,7 +136,7 @@ object Tests extends Suite(m"Rudiments Tests"):
       val array = Array.of(10, 20, 30)
 
       test(m"Plain `at` returns Optional"):
-        text(Prim).vouch
+        text(Prim)
       . assert(_ == 'h')
 
       test(m"`within` + confined `at` returns a bare element"):
@@ -431,35 +431,35 @@ object Tests extends Suite(m"Rudiments Tests"):
 
     suite(m"Mean tests"):
       test(m"Simple median"):
-        Iterable[Double](7, 25, 1, 24, 2, 3, 23, 4, 22, 5, 21).mean.vouch
-      . assert(_ === 12.454545 ± 0.00001)
+        Iterable[Double](7, 25, 1, 24, 2, 3, 23, 4, 22, 5, 21).mean
+      . assert(_.lay(false)(_ === 12.454545 ± 0.00001))
 
       test(m"Simple median, different pivot"):
-        Iterable[Double](25, 1, 24, 2, 3, 23, 4, 22, 5, 21, 7).mean.vouch
-      . assert(_ === 12.454545 ± 0.00001)
+        Iterable[Double](25, 1, 24, 2, 3, 23, 4, 22, 5, 21, 7).mean
+      . assert(_.lay(false)(_ === 12.454545 ± 0.00001))
 
       test(m"Simple median, even items"):
-        Iterable[Double](25, 1, 24, 2, 3, 23, 4, 22, 5, 21, 7, 8).mean.vouch
-      . assert(_ === 12.1 ± 0.1)
+        Iterable[Double](25, 1, 24, 2, 3, 23, 4, 22, 5, 21, 7, 8).mean
+      . assert(_.lay(false)(_ === 12.1 ± 0.1))
 
       test(m"Simple median, even items, different order"):
-        Iterable[Double](8, 25, 1, 24, 2, 3, 23, 4, 22, 5, 21, 7).mean.vouch
-      . assert(_ === 12.1 ± 0.1)
+        Iterable[Double](8, 25, 1, 24, 2, 3, 23, 4, 22, 5, 21, 7).mean
+      . assert(_.lay(false)(_ === 12.1 ± 0.1))
 
       test(m"Simple median, even items, different elements"):
-        Iterable[Double](10, 125, -1, 124, -2, -3, 123, -4, 122, -5, 121, 9).mean.vouch
-      . assert(_ === 51.6 ± 0.1)
+        Iterable[Double](10, 125, -1, 124, -2, -3, 123, -4, 122, -5, 121, 9).mean
+      . assert(_.lay(false)(_ === 51.6 ± 0.1))
 
       test(m"Mean of temperatures"):
-        Iterable(Fahrenheit(10), Fahrenheit(10), Fahrenheit(40)).mean2.vouch
+        Iterable(Fahrenheit(10), Fahrenheit(10), Fahrenheit(40)).mean2
       . assert(_ == Fahrenheit(20))
 
       test(m"Mean of even number of temperatures"):
-        Iterable(Celsius(40), Celsius(35), Celsius(45), Celsius(75)).mean2.vouch
+        Iterable(Celsius(40), Celsius(35), Celsius(45), Celsius(75)).mean2
       . assert(_ == Celsius(48.75))
 
       test(m"Mean of quantities"):
-        Iterable(10*Metre/Second, 30*Metre/Second, 5*Metre/Second, 20*Metre/Second).mean.vouch
+        Iterable(10*Metre/Second, 30*Metre/Second, 5*Metre/Second, 20*Metre/Second).mean
       . assert(_ == 16.25*Metre/Second)
 
     suite(m"bin tests"):
@@ -645,8 +645,8 @@ object Tests extends Suite(m"Rudiments Tests"):
         setInt.absent
       . assert(_ == false)
 
-      test(m"Unsafely vouch a set value"):
-        val x: Int = setInt.vouch
+      test(m"Assume a set value is present"):
+        val x: Int = unsafely(setInt.assume)
         x
       . assert(_ == 42)
 

--- a/lib/stenography/src/core/stenography.Syntax.scala
+++ b/lib/stenography/src/core/stenography.Syntax.scala
@@ -230,10 +230,9 @@ object Syntax:
     . group(_(0).name)
     . stdlib
     . view
-    . mapValues: bounds =>
-        bounds.length match
-          case 1 => bounds.prim.vouch(1)
-          case _ => Sequence('{', bounds.map(_(1)))
+    . mapValues:
+        case List(bound) => bound(1)
+        case bounds      => Sequence('{', bounds.map(_(1)))
 
     . to(scala.collection.immutable.Map)
 

--- a/lib/stratiform/src/binaryStaged/stratiform.bintelInternal.scala
+++ b/lib/stratiform/src/binaryStaged/stratiform.bintelInternal.scala
@@ -84,7 +84,7 @@ object bintelInternal:
       val run = ctx.run
 
       if run == null then false else
-        val sources = run.nn.units.map(_.source.file.path).toSet
+        val sources = run.nn.units.map(_.source.path).toSet
         val position = symbol.pos
         position.exists { position => sources.contains(position.sourceFile.path) }
     catch case _: Exception => false

--- a/lib/stratiform/src/core/stratiform.Stratiform.scala
+++ b/lib/stratiform/src/core/stratiform.Stratiform.scala
@@ -161,10 +161,10 @@ object Stratiform:
             case Some(member) =>
               val element = elementType(position.memberType(member))
 
-              if element.absent
-              then halt(m"the field $name of ${position.show} is not an indexable collection")
+              val elementTel = element.or:
+                halt(m"the field $name of ${position.show} is not an indexable collection")
 
-              telType(element.vouch, root).asType.absolve match
+              telType(elementTel, root).asType.absolve match
                 case '[type result <: Tel; result] =>
                   '{$self.selectRepeatedField(${Expr(name)}, $idx).asInstanceOf[result]}
 

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -4234,7 +4234,7 @@ object Tel extends Tel2:
               if tabulation.absent then parseSourceOrLiteralAtomIfPresent(compoundLeadingSpaces)
               else Unset
 
-            if extraAtom.present then pushAtom(extraAtom.vouch)
+            extraAtom.let(pushAtom(_))
 
             val children =
               if extraAtom.absent && tabulation.absent then parseChildren(indent) else EmptyBlocks
@@ -5525,7 +5525,7 @@ object Tel extends Tel2:
       val extraAtom: Optional[Tel.Atom] =
         if tabulated then Unset else parseSourceOrLiteralAtomIfPresent(spaces)
 
-      if extraAtom.present then pushAtom(extraAtom.vouch)
+      extraAtom.let(pushAtom(_))
 
       val children: Array[Tel.Block]^{} =
         if !tabulated && extraAtom.absent then parseChildren(indent)

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -913,51 +913,56 @@ object Tel extends Tel2:
 
               slot += 1
 
-          var next: Optional[Text] = reader.keyword(indent)
+          // The keyword loop is match-driven: the concrete-scrutinee match on the
+          // freshly-read keyword both ends the loop (on `Unset`) and names the
+          // `Text` once per iteration — no re-read of the slot, and no closure
+          // allocated per iteration.
+          var scanning = true
 
-          while next.present do
-            val found = indexOf(next.vouch)
+          while scanning do reader.keyword(indent) match
+            case Unset => scanning = false
 
-            if found < 0 then reader.skipEntry(indent)
-            else
-              val parsing = unwrap(entries.readUnchecked(found)(1))
+            case keyword: Text =>
+              val found = indexOf(keyword)
 
-              parsing match
-                case gathering: Gathering if parsing.repeatable =>
-                  // Every occurrence of a repeatable field accumulates, in
-                  // document order — the AST's gather-all semantics.
-                  val buffer = values(found) match
-                    case buffer: scala.collection.mutable.ListBuffer[?] =>
-                      buffer.asInstanceOf[scala.collection.mutable.ListBuffer[Any]]
+              if found < 0 then reader.skipEntry(indent)
+              else
+                val parsing = unwrap(entries.readUnchecked(found)(1))
 
-                    case _ =>
-                      val buffer = scala.collection.mutable.ListBuffer.empty[Any]
-                      values(found) = buffer
-                      buffer
+                parsing match
+                  case gathering: Gathering if parsing.repeatable =>
+                    // Every occurrence of a repeatable field accumulates, in
+                    // document order — the AST's gather-all semantics.
+                    val buffer = values(found) match
+                      case buffer: scala.collection.mutable.ListBuffer[?] =>
+                        buffer.asInstanceOf[scala.collection.mutable.ListBuffer[Any]]
 
-                  buffer +=
-                    ( if focused
+                      case _ =>
+                        val buffer = scala.collection.mutable.ListBuffer.empty[Any]
+                        values(found) = buffer
+                        buffer
+
+                    buffer +=
+                      ( if focused
+                        then focusing(foci, reader, Text(keys.readUnchecked(found))):
+                          gathering.parseElement(reader, indent)
+                        else gathering.parseElement(reader, indent) )
+
+                  case _ =>
+                    // A non-repeatable field keeps its first occurrence — the
+                    // AST's `field()` semantics — and skips the rest. When the
+                    // first fill came from a positional atom, the duplicate is
+                    // §20.2 step 5c's E308 (the atom wins).
+                    if !(values(found).asInstanceOf[AnyRef] eq AbsentSlot) then
+                      if atomFilled(found)
+                      then raise(TelError(TelError.Reason.NonRepeatableTooMany))(using tactic)
+
+                      reader.skipEntry(indent)
+                    else values(found) =
+                      if focused
                       then focusing(foci, reader, Text(keys.readUnchecked(found))):
-                        gathering.parseElement(reader, indent)
-                      else gathering.parseElement(reader, indent) )
-
-                case _ =>
-                  // A non-repeatable field keeps its first occurrence — the
-                  // AST's `field()` semantics — and skips the rest. When the
-                  // first fill came from a positional atom, the duplicate is
-                  // §20.2 step 5c's E308 (the atom wins).
-                  if !(values(found).asInstanceOf[AnyRef] eq AbsentSlot) then
-                    if atomFilled(found)
-                    then raise(TelError(TelError.Reason.NonRepeatableTooMany))(using tactic)
-
-                    reader.skipEntry(indent)
-                  else values(found) =
-                    if focused
-                    then focusing(foci, reader, Text(keys.readUnchecked(found))):
-                      entries.readUnchecked(found)(1).parse(reader, indent)
-                    else entries.readUnchecked(found)(1).parse(reader, indent)
-
-            next = reader.keyword(indent)
+                        entries.readUnchecked(found)(1).parse(reader, indent)
+                      else entries.readUnchecked(found)(1).parse(reader, indent)
 
           index = 0
 
@@ -4176,6 +4181,13 @@ object Tel extends Tel2:
         else
           Unset
 
+      // Hoisted from the row loop below: the header is fixed for the whole
+      // compound run, so the Optional is resolved once here and each row tests
+      // a bare reference (flow typing narrows it past the null check).
+      val tabulationHeader: Tel.Tabulation | Null = tabulation match
+        case tabulation: Tel.Tabulation => tabulation
+        case _                          => null
+
       // Compound loop.
       var keepLoop = true
       while keepLoop && !head.eof && !head.separator && !head.blank && head.indentLevels == indent
@@ -4187,8 +4199,8 @@ object Tel extends Tel2:
           // §16.2: validate tabulated rows BEFORE parseCompoundLine consumes
           // the row's bytes. validateTabulatedRowInline uses mark + cue so the
           // cursor remains parked at the row start for parseCompoundLine.
-          if tabulation.present then
-            validateTabulatedRowInline(compoundLeadingSpaces, tabulation.vouch, compoundLine)
+          if tabulationHeader != null then
+            validateTabulatedRowInline(compoundLeadingSpaces, tabulationHeader, compoundLine)
 
           // parseCompoundLine pushes the compound's inline atoms onto
           // scratchAtoms and deposits keyword + remark into the parser's

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -334,8 +334,7 @@ trait Tel2 extends Tel3:
                       val match0 = telVal.field(keyword)
 
                       if positional.isEmpty then
-                        if match0.absent then default.or(ctx.absent())
-                        else ctx.decoded(match0.vouch)
+                        match0.lay(default.or(ctx.absent()))(ctx.decoded(_))
                       else
                         // §20.2 step 5c: an inline atom plus a same-keyword
                         // child fills a non-repeatable member twice (E308).

--- a/lib/stratiform/src/core/stratiform.Tels.scala
+++ b/lib/stratiform/src/core/stratiform.Tels.scala
@@ -626,7 +626,7 @@ object Tels extends Tels2:
 
           case "sigil" =>
             val s = firstAtomText(c)
-            sigil = if s.absent then Unset else Optional(s.vouch.s.charAt(0))
+            sigil = s.let { text => if text.s.isEmpty then Unset else text.s.charAt(0) }
 
           case "record"   => records  += parseRecord(c)
           case "scalar"   => scalars  += parseScalar(c)

--- a/lib/stratiform/src/core/stratiform.internal.scala
+++ b/lib/stratiform/src/core/stratiform.internal.scala
@@ -82,7 +82,7 @@ object internal:
     // reverse-source order, so accumulating with cons gives source order
     // directly — no final reverse needed (mirrors jacinta.internal).
     def collectParts[tuple: Type](acc: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => collectParts[tail](TypeRepr.of[head].literal[String].vouch :: acc)
+      case '[head *: tail] => collectParts[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: acc)
       case _               => acc
 
     val parts = collectParts[parts](Nil)
@@ -247,7 +247,7 @@ object internal:
     import quotes.reflect.*
 
     def collectParts[tuple: Type](acc: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => collectParts[tail](TypeRepr.of[head].literal[String].vouch :: acc)
+      case '[head *: tail] => collectParts[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: acc)
       case _               => acc
 
     val parts = collectParts[parts](Nil)

--- a/lib/stratiform/src/staged/stratiform.stagedInternal.scala
+++ b/lib/stratiform/src/staged/stratiform.stagedInternal.scala
@@ -95,7 +95,7 @@ object stagedInternal:
       val run = ctx.run
 
       if run == null then false else
-        val sources = run.nn.units.map(_.source.file.path).toSet
+        val sources = run.nn.units.map(_.source.path).toSet
         val position = symbol.pos
         position.exists { position => sources.contains(position.sourceFile.path) }
     catch case _: Exception => false

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -418,7 +418,7 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
       // E308 is a property of a member's whole run, not of one node, so it is
       // raised outside every `focus` block: the entry has no focus at all and
       // takes the root one. `supplementPositions` must tolerate that rather
-      // than `vouch` on it.
+      // than assume it is present.
       test(m"A run-level E308 accrues at the root without panicking"):
         assignPositions(t"name Alice\nname Bob\nemail e\n", twoRequiredSchema).items
         . map { case (p, span) => (p.s, span.exists) }.to[Set]

--- a/lib/stratiform/src/test/stratiform.PositionTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionTests.scala
@@ -187,13 +187,13 @@ object PositionTests extends Suite(m"Stratiform position-index tests"):
 
     suite(m"Span derivation"):
       test(m"a position's span carries its line as a 0-based ordinal"):
-        at(2, 8, 3).span.startLine.vouch
+        at(2, 8, 3).span.startLine
       . assert(_ == 1.z)
 
       test(m"a position's span carries its column as a 0-based ordinal"):
-        at(2, 8, 3).span.startColumn.vouch
+        at(2, 8, 3).span.startColumn
       . assert(_ == 7.z)
 
       test(m"a position's span carries its length"):
-        at(2, 8, 3).span.length.vouch
+        at(2, 8, 3).span.length
       . assert(_ == 3)

--- a/lib/stratiform/src/test/stratiform.PositionalTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionalTests.scala
@@ -194,7 +194,7 @@ object PositionalTests extends Suite(m"Stratiform positional assignment tests"):
 
       test(m"a false Boolean is written, not omitted"):
         val doc = PFlags(false, false).encode
-        (doc.childCompounds.readable.length, doc.field(t"active").vouch.primaryAtom)
+        (doc.childCompounds.readable.length, doc.field(t"active").let(_.primaryAtom))
       . assert(_ == (2, t"false"))
 
       test(m"every Boolean combination round-trips through serialized text"):

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -745,7 +745,7 @@ object Tests extends Suite(m"Stratiform Tests"):
         // re-emits at the canonical two-space indent.
         val src = summon[CharEncoder].encoded(t"parent\n child Alice\n")
         val tel = Tel.parse(src, recoverSchema)
-        tel.document.vouch.show
+        tel.show
       . assert(_ == t"parent\n  child Alice\n")
 
       test(m"prefers shallower on tie"):
@@ -1377,21 +1377,21 @@ object Tests extends Suite(m"Stratiform Tests"):
         val tel    = doc("name Alice\n")
         val ptr    = Tel.Pointer.of(t"name")
         val result = Mutation(tel, Mutation.Op.UpdateAtom(ptr, 0, t"Bob"))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"name Bob\n")
 
       test(m"AttachRemark adds a remark to the targeted compound"):
         val tel    = doc("name Alice\n")
         val ptr    = Tel.Pointer.of(t"name")
         val result = Mutation(tel, Mutation.Op.AttachRemark(ptr, t"primary contact"))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"name Alice  # primary contact\n")
 
       test(m"RemoveRemark drops a previously attached remark"):
         val tel    = doc("name Alice  # noted\n")
         val ptr    = Tel.Pointer.of(t"name")
         val result = Mutation(tel, Mutation.Op.RemoveRemark(ptr))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"name Alice\n")
 
       test(m"Insert appends a child compound to the parent"):
@@ -1402,14 +1402,14 @@ object Tests extends Suite(m"Stratiform Tests"):
                            Unset, Array.empty)
         val ptr    = Tel.Pointer.of(t"contact")
         val result = Mutation(tel, Mutation.Op.Insert(ptr, newCompound))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"contact\n  name Alice\n  email alice@example.com\n")
 
       test(m"Delete removes the addressed compound"):
         val tel    = doc("name Alice\nemail alice@example.com\n")
         val ptr    = Tel.Pointer.of(t"email")
         val result = Mutation(tel, Mutation.Op.Delete(ptr))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"name Alice\n")
 
       test(m"InsertBefore places a new sibling before the target"):
@@ -1418,7 +1418,7 @@ object Tests extends Suite(m"Stratiform Tests"):
                       (t"a", Array.of(Tel.Atom.Inline(t"one", 1)), Unset, Array.empty)
         val ptr    = Tel.Pointer.of(t"b")
         val result = Mutation(tel, Mutation.Op.InsertBefore(ptr, a))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"a one\nb two\n")
 
       test(m"InsertAfter places a new sibling after the target"):
@@ -1427,7 +1427,7 @@ object Tests extends Suite(m"Stratiform Tests"):
                       (t"b", Array.of(Tel.Atom.Inline(t"two", 1)), Unset, Array.empty)
         val ptr    = Tel.Pointer.of(t"a")
         val result = Mutation(tel, Mutation.Op.InsertAfter(ptr, b))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"a one\nb two\n")
 
       test(m"Replace swaps a compound for a new one"):
@@ -1437,28 +1437,28 @@ object Tests extends Suite(m"Stratiform Tests"):
                             Unset, Array.empty)
         val ptr    = Tel.Pointer.of(t"name")
         val result = Mutation(tel, Mutation.Op.Replace(ptr, replacement))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"name Charlie\n")
 
       test(m"SetFlag places an inline atom on a childless compound (§22.2)"):
         val tel    = doc("opt\n")
         val ptr    = Tel.Pointer.of(t"opt")
         val result = Mutation(tel, Mutation.Op.SetFlag(ptr, t"enabled"))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"opt enabled\n")
 
       test(m"SetFlag extends an existing inline-atom line"):
         val tel    = doc("opts fast\n")
         val ptr    = Tel.Pointer.of(t"opts")
         val result = Mutation(tel, Mutation.Op.SetFlag(ptr, t"safe"))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"opts fast safe\n")
 
       test(m"SetFlag places a compound child when compound children exist"):
         val tel    = doc("opt\n  sub x\n")
         val ptr    = Tel.Pointer.of(t"opt")
         val result = Mutation(tel, Mutation.Op.SetFlag(ptr, t"enabled"))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"opt\n  sub x\n  enabled\n")
 
       test(m"SetFlag rejects a flag already present as an inline atom"):
@@ -1471,28 +1471,28 @@ object Tests extends Suite(m"Stratiform Tests"):
         val tel    = doc("opt\n  enabled\n")
         val ptr    = Tel.Pointer.of(t"opt")
         val result = Mutation(tel, Mutation.Op.UnsetFlag(ptr, t"enabled"))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"opt\n")
 
       test(m"UnsetFlag removes an inline-atom flag, preserving other atoms"):
         val tel    = doc("opts fast safe\n")
         val ptr    = Tel.Pointer.of(t"opts")
         val result = Mutation(tel, Mutation.Op.UnsetFlag(ptr, t"safe"))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"opts fast\n")
 
       test(m"UnsetFlag ignores a same-keyword compound that is not flag-shaped"):
         val tel    = doc("opt\n  enabled x\n")
         val ptr    = Tel.Pointer.of(t"opt")
         val result = Mutation(tel, Mutation.Op.UnsetFlag(ptr, t"enabled"))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"opt\n  enabled x\n")
 
       test(m"UnsetFlag of an absent flag is the identity (§22.2)"):
         val tel    = doc("opt\n")
         val ptr    = Tel.Pointer.of(t"opt")
         val result = Mutation(tel, Mutation.Op.UnsetFlag(ptr, t"missing"))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"opt\n")
 
       test(m"sequenced ops apply in order"):
@@ -1502,7 +1502,7 @@ object Tests extends Suite(m"Stratiform Tests"):
                       ( Mutation.Op.UpdateAtom(ptr, 0, t"Bob"),
                         Mutation.Op.AttachRemark(ptr, t"note") )
         val result = Mutation(tel, ops)
-        result.document.vouch.show
+        result.show
       . assert(_ == t"name Bob  # note\n")
 
       test(m"pointer with no match raises PointerNotFound"):
@@ -1514,13 +1514,13 @@ object Tests extends Suite(m"Stratiform Tests"):
       test(m"ReorderWithinGroup moves a same-keyword sibling"):
         val tel = doc("item a\nitem b\nitem c\n")
         val op  = Mutation.Op.ReorderWithinGroup(Tel.Pointer.Empty, t"item", 0, 2)
-        Mutation(tel, op).document.vouch.show
+        Mutation(tel, op).show
       . assert(_ == t"item b\nitem c\nitem a\n")
 
       test(m"ReorderWithinGroup with same old and new is a no-op"):
         val tel = doc("item a\nitem b\n")
         val op  = Mutation.Op.ReorderWithinGroup(Tel.Pointer.Empty, t"item", 1, 1)
-        Mutation(tel, op).document.vouch.show
+        Mutation(tel, op).show
       . assert(_ == t"item a\nitem b\n")
 
       test(m"ReorderWithinGroup with out-of-range index raises"):
@@ -1533,14 +1533,14 @@ object Tests extends Suite(m"Stratiform Tests"):
         val tel = doc("name Alice\nname Bob\nage 30\nage 31\n")
         val op  = Mutation.Op.ReorderGroups
                     (Tel.Pointer.Empty, t"name", t"age", Mutation.Placement.After)
-        Mutation(tel, op).document.vouch.show
+        Mutation(tel, op).show
       . assert(_ == t"age 30\nage 31\nname Alice\nname Bob\n")
 
       test(m"ReorderGroups before the current position is the identity (§22.2)"):
         val tel = doc("name Alice\nage 30\n")
         val op  = Mutation.Op.ReorderGroups
                     (Tel.Pointer.Empty, t"name", t"age", Mutation.Placement.Before)
-        Mutation(tel, op).document.vouch.show
+        Mutation(tel, op).show
       . assert(_ == t"name Alice\nage 30\n")
 
       test(m"ReorderGroups raises when a group is missing"):
@@ -1668,7 +1668,7 @@ object Tests extends Suite(m"Stratiform Tests"):
         val tel    = doc("note x\n")
         val ptr    = Tel.Pointer.of(t"note")
         val result = Mutation(tel, Mutation.Op.UpdateAtom(ptr, 0, crCollision))
-        result.document.vouch.show.read[Tel].childCompounds.readable.head.atoms.readable.head match
+        result.show.read[Tel].childCompounds.readable.head.atoms.readable.head match
           case Tel.Atom.Literal(_, text) => text
           case _                         => t""
       . assert(_ == crCollision)
@@ -1677,7 +1677,7 @@ object Tests extends Suite(m"Stratiform Tests"):
         val tel    = doc("a 1\n")
         val ptr    = Tel.Pointer.of(t"a")
         val result = Mutation(tel, Mutation.Op.RemoveRemark(ptr))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"a 1\n")
 
       test(m"Replace retains the original compound's remark (§22.2)"):
@@ -1686,28 +1686,28 @@ object Tests extends Suite(m"Stratiform Tests"):
                            (t"email", Array.of(Tel.Atom.Inline(t"b@x", 1)), Unset, Array.empty)
         val ptr    = Tel.Pointer.of(t"email")
         val result = Mutation(tel, Mutation.Op.Replace(ptr, replacement))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"email b@x  # personal\n")
 
       test(m"Delete removes an emptied block with its attached comments (§22.2)"):
         val tel    = doc("# note\na 1\n\nb 2\n")
         val ptr    = Tel.Pointer.of(t"a")
         val result = Mutation(tel, Mutation.Op.Delete(ptr))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"b 2\n")
 
       test(m"Insert takes the natural position after the last same-member compound"):
         val tel    = doc("a 1\na 2\n\nb 3\n")
         val nine   = Tel.Compound(t"a", Array.of(Tel.Atom.Inline(t"9", 1)), Unset, Array.empty)
         val result = Mutation(tel, Mutation.Op.Insert(Tel.Pointer.Empty, nine))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"a 1\na 2\na 9\n\nb 3\n")
 
       test(m"UpdateAtom preserves tabulation padding (§22.2 identity rule)"):
         val tel    = doc("# Name  # Age\nAlice   30\n")
         val ptr    = Tel.Pointer.of(t"Alice")
         val result = Mutation(tel, Mutation.Op.UpdateAtom(ptr, 0, t"31"))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"# Name  # Age\nAlice   31\n")
 
       test(m"UpdateAtom escalates a tab-before-LF value past source form (§22.2)"):
@@ -1724,21 +1724,21 @@ object Tests extends Suite(m"Stratiform Tests"):
         val tel    = doc("# Name  # Age\nAlice   30\n")
         val note   = Tel.Compound(t"note", Array.of(Tel.Atom.Inline(t"x", 1)), Unset, Array.empty)
         val result = Mutation(tel, Mutation.Op.InsertAfter(Tel.Pointer.of(t"Alice"), note))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"# Name  # Age\nAlice   30\n\nnote x\n")
 
       test(m"InsertBefore a tabulated row opens a new block before the table (§22.2)"):
         val tel    = doc("# Name  # Age\nAlice   30\n")
         val note   = Tel.Compound(t"note", Array.of(Tel.Atom.Inline(t"x", 1)), Unset, Array.empty)
         val result = Mutation(tel, Mutation.Op.InsertBefore(Tel.Pointer.of(t"Alice"), note))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"note x\n\n# Name  # Age\nAlice   30\n")
 
       test(m"InsertIntoBlock appends a re-padded row to a tabulated block"):
         val tel    = doc("# Name  # Age\nAlice   30\nBob     25\n")
         val row    = Revision.compound(t"Carol", t"40")
         val result = Mutation(tel, Mutation.Op.InsertIntoBlock(Tel.Pointer.Empty, 0, row))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"# Name  # Age\nAlice   30\nBob     25\nCarol   40\n")
 
       test(m"InsertIntoBlock rejects a row exceeding column capacity"):
@@ -1751,13 +1751,13 @@ object Tests extends Suite(m"Stratiform Tests"):
       test(m"ResizeTabulation shrinks offsets to the normative minimum (§22.2)"):
         val tel    = doc("# Name    # Age\nAl        30\n")
         val result = Mutation(tel, Mutation.Op.ResizeTabulation(Tel.Pointer.Empty, 0))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"# Name  # Age\nAl      30\n")
 
       test(m"ResizeTabulation of a nested block starts at twice the indent"):
         val tel    = doc("person\n  # Name    # Age\n  Al        30\n")
         val result = Mutation(tel, Mutation.Op.ResizeTabulation(Tel.Pointer.of(t"person"), 0))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"person\n  # Name  # Age\n  Al      30\n")
 
       test(m"ResizeTabulation accommodates planned rows, then InsertIntoBlock fits"):
@@ -1770,7 +1770,7 @@ object Tests extends Suite(m"Stratiform Tests"):
                          ( Mutation.Op.ResizeTabulation(Tel.Pointer.Empty, 0, Array.of(row)),
                            Mutation.Op.InsertIntoBlock(Tel.Pointer.Empty, 0, row) ) )
 
-        result.document.vouch.show
+        result.show
       . assert(_ == t"# Name       # Age\nAl           30\nChristopher  40\n")
 
       test(m"ResizeTabulation of a block without a tabulation is rejected"):
@@ -1783,7 +1783,7 @@ object Tests extends Suite(m"Stratiform Tests"):
         val tel = doc("# emails\ne 1\n\n# phones\np 2\n")
         val op  = Mutation.Op.ReorderGroups
                     (Tel.Pointer.Empty, t"p", t"e", Mutation.Placement.Before)
-        Mutation(tel, op).document.vouch.show
+        Mutation(tel, op).show
       . assert(_ == t"# phones\np 2\n\n# emails\ne 1\n")
 
       test(m"Construct over members: inline run, flags, and child fallback (§22.3)"):
@@ -1796,7 +1796,7 @@ object Tests extends Suite(m"Stratiform Tests"):
 
         val tel    = doc("")
         val result = Mutation(tel, Mutation.Op.Insert(Tel.Pointer.Empty, c))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"person  Alice Smith  active\n  bio\n      line1\n      line2\n")
 
       test(m"Construct over members: repeatable occurrences stay together (§22.3)"):
@@ -1808,7 +1808,7 @@ object Tests extends Suite(m"Stratiform Tests"):
 
         val tel    = doc("")
         val result = Mutation(tel, Mutation.Op.Insert(Tel.Pointer.Empty, c))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"opts a b\n  note x\n")
 
       test(m"Construct over members: an empty value becomes a bare-keyword child"):
@@ -1817,7 +1817,7 @@ object Tests extends Suite(m"Stratiform Tests"):
 
         val tel    = doc("")
         val result = Mutation(tel, Mutation.Op.Insert(Tel.Pointer.Empty, c))
-        result.document.vouch.show
+        result.show
       . assert(_ == t"entry\n  note\n")
 
     suite(m"Tel.fields repeated-keyword accessor"):
@@ -1861,7 +1861,7 @@ object Tests extends Suite(m"Stratiform Tests"):
         val original = doc("# header\nname Alice\nemail a@example.com\n")
         val lens = summon["email" is Lens from Tel onto Tel]
         val updated = lens.modify(original)(_ => Tel.scalar(t"b@example.com"))
-        updated.document.vouch.show
+        updated.show
       . assert(_ == t"# header\nname Alice\nemail b@example.com\n")
 
       test(m"a multi-step Revision log round-trips through the printer"):
@@ -1872,9 +1872,9 @@ object Tests extends Suite(m"Stratiform Tests"):
            ++ Revision.at(Tel.Pointer.Empty)
                   .insert(Revision.compound(t"email", t"b@example.com")) )
 
-        val printed   = edited.document.vouch.show
+        val printed   = edited.show
         val reparsed  = printed.s.tt.read[Tel]
-        reparsed.document.vouch.show
+        reparsed.show
       . assert(_ == t"name Bob\nemail b@example.com\n")
 
     suite(m"Tel.modify and Lens given"):
@@ -1935,7 +1935,7 @@ object Tests extends Suite(m"Stratiform Tests"):
       test(m"editing through an ordinal optic preserves surrounding formatting"):
         val original = doc("# header\ncontacts\n  contact alice\n  contact bob\n")
         val updated = original.lens(_.contacts(Sec) = Tel.scalar(t"carol"))
-        updated.document.vouch.show
+        updated.show
       . assert(_ == t"# header\ncontacts\n  contact alice\n  contact carol\n")
 
     suite(m"Revision DSL"):
@@ -1944,7 +1944,7 @@ object Tests extends Suite(m"Stratiform Tests"):
       test(m"single-op edit changes one atom"):
         val tel  = doc("name Alice\n")
         val edit = Revision.at(Tel.Pointer.of(t"name")).update(t"Bob")
-        tel.edited(edit).document.vouch.show
+        tel.edited(edit).show
       . assert(_ == t"name Bob\n")
 
       test(m"chained edits apply in order"):
@@ -1952,7 +1952,7 @@ object Tests extends Suite(m"Stratiform Tests"):
         val edit = Revision.at(Tel.Pointer.of(t"name")).update(t"Bob")
                 ++ Revision.at(Tel.Pointer.of(t"name")).attachRemark(t"note")
 
-        tel.edited(edit).document.vouch.show
+        tel.edited(edit).show
       . assert(_ == t"name Bob  # note\n")
 
       test(m"Revision.compound helper builds an inline-atom compound"):
@@ -1965,12 +1965,12 @@ object Tests extends Suite(m"Stratiform Tests"):
         val edit = Revision.at(Tel.Pointer.of(t"b")).delete
                 ++ Revision.at(Tel.Pointer.of(t"a")).insertAfter(Revision.compound(t"c", t"3"))
 
-        tel.edited(edit).document.vouch.show
+        tel.edited(edit).show
       . assert(_ == t"a 1\nc 3\n")
 
       test(m"noop edit returns the document unchanged"):
         val tel = doc("name Alice\n")
-        tel.edited(Revision.noop).document.vouch.show
+        tel.edited(Revision.noop).show
       . assert(_ == t"name Alice\n")
 
     suite(m"Opening documents"):

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -808,7 +808,7 @@ object Tests extends Suite(m"Stratiform Tests"):
 
       test(m"BadVersion error spans the malformed version phrase"):
         val span = capture[TelError](t"tel notaversion\n".read[Tel]).span
-        (span.startColumn.vouch.n1, span.length.vouch)
+        (span.startColumn.let(_.n1), span.length)
       . assert(_ == (5, 11))
 
       test(m"PragmaNotFirst error reports the misplaced pragma's line"):
@@ -825,7 +825,7 @@ object Tests extends Suite(m"Stratiform Tests"):
 
       test(m"TrailingSpaces error spans exactly the trailing spaces"):
         val span = capture[TelError](t"good\nbad   \n".read[Tel]).span
-        (span.startColumn.vouch.n1, span.length.vouch)
+        (span.startColumn.let(_.n1), span.length)
       . assert(_ == (4, 3))
 
       test(m"Validation error (Type.assign) leaves the span empty"):
@@ -1981,7 +1981,7 @@ object Tests extends Suite(m"Stratiform Tests"):
       . assert(_ == t"name Alice\n")
 
       test(m"Metadata reports the line endings under the Read grant"):
-        t"name Alice\r\n".open[Tel]() { handle ?=> handle.metadata.vouch.lineEndings }
+        t"name Alice\r\n".open[Tel]() { handle ?=> handle.metadata.let(_.lineEndings) }
       . assert(_ == Tel.LineEndings.Crlf)
 
       test(m"Mutating through a writable handle writes back on close"):

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -2080,7 +2080,8 @@ object Tests extends Suite(m"Stratiform Tests"):
       import galilei.filesystemOptions.deleteRecursively.enabled
 
       test(m"A file path opened Read & Write writes the mutation back"):
-        val dest: Path on Linux = (% / "tmp" / Uuid().show).on[Linux]
+        val name: Text = Uuid().show
+        val dest: Path on Linux = (% / "tmp" / name).on[Linux]
         dest.write(t"name Alice\n")
 
         dest.open[Tel](Read & Write): handle ?=>

--- a/lib/superlunary/src/core/superlunary.References.scala
+++ b/lib/superlunary/src/core/superlunary.References.scala
@@ -63,7 +63,13 @@ abstract class References():
   private var allocations: List[Transport] = Nil
 
   def update(expr: Expr[scala.Array[Object]]): Unit = ref = expr
-  def array: Expr[scala.Array[Object]] = ref.vouch
+
+  // A protocol invariant of the rig, not a local check: `references() = array` is always
+  // assigned inside the staged lambda before any `$value` conversion splices `array`. The
+  // binding happens in quote scope, so it cannot be a constructor argument without
+  // restructuring the staging protocol.
+  def array: Expr[scala.Array[Object]] =
+    ref.or(panic(m"the reference array is bound by the rig before any value is spliced"))
   def current: Int = allocations.length
   def allocate(value: => Transport): Int = allocations.length.also { allocations ::= value }
   inline def apply(): scala.Array[Object] = scala.Array.from[Object](allocations.reverse.toSeq)

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -349,19 +349,23 @@ object Http:
       def frame(data: Data): Iterator[Data] =
         Iterator(t"${Integer.toHexString(data.length).nn.tt}\r\n".in[Data], data, t"\r\n".in[Data])
 
-      if second.absent then
-        val data = first.or(Array.empty[Byte])
-        val text = head(t"Content-Length: ${data.length}")
-        Stream(if data.length == 0 then Iterator(text.in[Data]) else Iterator(text.in[Data], data))
-      else
-        val text = head(t"Transfer-Encoding: chunked")
+      (first, second) match
+        case (first: Data, second: Data) =>
+          val text = head(t"Transfer-Encoding: chunked")
 
-        Stream
-          ( Iterator(text.in[Data])
-            ++ frame(first.vouch)
-            ++ frame(second.vouch)
-            ++ Iterator.continually(pull()).takeWhile(_.present).flatMap { data => frame(data.vouch) }
-            ++ Iterator(t"0\r\n\r\n".in[Data]) )
+          Stream
+            ( Iterator(text.in[Data])
+              ++ frame(first)
+              ++ frame(second)
+              ++ Iterator.continually(pull()).takeWhile(_.present).flatMap(_.lay(Iterator())(frame))
+              ++ Iterator(t"0\r\n\r\n".in[Data]) )
+
+        case _ =>
+          val data = first.or(Array.empty[Byte])
+          val text = head(t"Content-Length: ${data.length}")
+
+          Stream:
+            if data.length == 0 then Iterator(text.in[Data]) else Iterator(text.in[Data], data)
 
     case class Head
       ( method: Method, version: Version, host: Host, target: Text, headers: List[Header] )
@@ -810,8 +814,7 @@ object Http:
 
           result
 
-        . takeWhile(_.present).map(_.vouch)
-
+        . takeWhile(_.present).flatMap(_.lay(Iterator())(Iterator(_)))
       def frame(data: Data): Iterator[Data] =
         Iterator(t"${Integer.toHexString(data.length).nn.tt}\r\n".in[Data], data, t"\r\n".in[Data])
 

--- a/lib/ultimatum/src/core/ultimatum.Form.scala
+++ b/lib/ultimatum/src/core/ultimatum.Form.scala
@@ -35,9 +35,29 @@ package ultimatum
 import proscenium.compat.*
 
 import denominative.*
+import prepositional.*
 import profanity.*
 import rudiments.*
 import vacuous.*
+
+object Form:
+  // One derived leaf of the live pane tree: the pane itself, the rectangle the last solve
+  // assigned it, and its focusable widget (present only for a `Pane.Widget`). Every
+  // per-leaf datum lives together, so per-entry access needs no agreement between
+  // parallel sequences.
+  private[ultimatum] case class Entry(pane: Pane, rect: Rect, focus: Optional[Focus])
+
+  // An immutable snapshot of one solved layout: the entries in frame order. A `Layout` is
+  // only ever constructed whole (and the `Form` re-assigns its single `layout` var
+  // atomically), so an index confined to `entries` (an `Ordinal in entries.type`) is
+  // proof of bounds for exactly the values it will access.
+  private[ultimatum] case class Layout(entries: Sequence[Entry]):
+    // The indices of the focusable entries, in leaf order, each already confined to
+    // `entries` — minted once at construction, sound because `entries` is immutable.
+    val focusables: Sequence[Ordinal in entries.type] =
+      val builder = scala.collection.immutable.Vector.newBuilder[Ordinal in entries.type]
+      entries.iterate { index => if entries(index).focus.present then builder += index }
+      Sequence.of(builder.result())
 
 // Drives an interactive layout. The pane tree is re-derived from its live
 // containers on every frame, so panes appended or inserted while the form runs
@@ -57,16 +77,16 @@ class Form
     throttle:     Long         = 0,
     debounce:     Long         = 0,
     scheduleWake: Long => Unit = _ => () ):
+  // The one immutable snapshot of the derived layout, re-assigned atomically by `refresh`.
   @scala.caps.unsafe.untrackedCaptures
-  private var leaves: Sequence[Pane] = Sequence()
-  @scala.caps.unsafe.untrackedCaptures
-  private var focuses: Sequence[Focus] = Sequence()
-  @scala.caps.unsafe.untrackedCaptures
-  private var focusLeaf: Sequence[Int] = Sequence()
+  private var layout: Form.Layout = Form.Layout(Sequence())
   @scala.caps.unsafe.untrackedCaptures
   private var focused: Optional[Focus] = Unset
+
+  // Whether `layout`'s geometry no longer describes the terminal (set by a resize): the
+  // next refresh must re-measure at the root width and repaint in full.
   @scala.caps.unsafe.untrackedCaptures
-  private var rects: Sequence[Rect] = Sequence()
+  private var staleGeometry: Boolean = false
   @scala.caps.unsafe.untrackedCaptures
   private var lastRedraw: Long = 0
   @scala.caps.unsafe.untrackedCaptures
@@ -98,43 +118,52 @@ class Form
     case _ =>
       ()
 
-  // Snapshot the live tree's leaves and focusables; keep focus on the same widget
-  // if it still exists, else fall back to the first.
-  private def rederive(): Unit =
+  // Snapshot the live tree's leaves; keep focus on the same widget if it still
+  // exists, else fall back to the first focusable.
+  private def rederive(): Sequence[Pane] =
     bind(pane)
-    leaves = Sequence.from(pane.leaves.stdlib)
-    focuses = leaves.collect { case Pane.Widget(_, focus) => focus }
+    val panes = Sequence.from(pane.leaves.stdlib)
 
-    focusLeaf = Sequence.from:
-      (0 until leaves.length).collect:
-        case i if leaves(i.z).vouch.isInstanceOf[Pane.Widget] => i
+    val stays = focused.lay(false): widget =>
+      panes.stdlib.exists:
+        case Pane.Widget(_, focus) => focus eq widget
+        case _                     => false
 
-    val stays = focused.lay(false): widget => focuses.indexWhere(_ eq widget) >= 0
+    if !stays then
+      focused = panes.stdlib.collectFirst { case Pane.Widget(_, focus) => focus }.optional
 
-    if !stays then focused = if focuses.isEmpty then Unset else focuses.prim.vouch
+    panes
 
-  private def focusIndex: Int = focused.lay(0): widget =>
-    val index = focuses.indexWhere(_ eq widget)
-    if index < 0 then 0 else index
+  // The position, within `layout.focusables`, of the focused widget (matched by
+  // identity, so focus survives insertions), defaulting to the first.
+  private def focusPosition(layout: Form.Layout): Int = focused.lay(0): widget =>
+    val position = layout.focusables.indexWhere: ordinal =>
+      layout.entries(ordinal).focus.lay(false)(_ eq widget)
+
+    if position < 0 then 0 else position
 
   // Project the panes to a frame, overriding each widget's minimum with the live
   // size its content needs at the width it last occupied (the root width on the
-  // first solve).
-  private def liveFrame: Frame =
-    val widths = if rects.nil then leaves.map(_ => root.width) else rects.map(_.width)
-    var index = -1
+  // first solve, or when the previous geometry is stale). The widths are threaded
+  // as an iterator aligned with the leaf walk, so no leaf count has to agree with
+  // any sequence: a source that runs dry (the live tree grew mid-frame) degrades
+  // to the root width.
+  private def liveFrame(previous: Form.Layout, stale: Boolean): Frame =
+    val widths: Iterator[Int] =
+      if stale then Iterator.empty else previous.entries.stdlib.iterator.map(_.rect.width)
+
+    def nextWidth(): Int = if widths.hasNext then widths.next() else root.width
 
     def project(node: Pane): Frame = node match
       case Pane.Branch(sizing, axis, panes) =>
         Frame.Split(sizing, axis, panes.contents.map(project).to[List])
 
       case Pane.Leaf(sizing, _) =>
-        index += 1
+        nextWidth()
         Frame.Cell(sizing)
 
       case Pane.Widget(sizing, widget) =>
-        index += 1
-        val (minWidth, minHeight) = widget.measure(widths(index.z).vouch)
+        val (minWidth, minHeight) = widget.measure(nextWidth())
 
         val grown = sizing.copy(minWidth = sizing.minWidth.max(minWidth),
             minHeight = sizing.minHeight.max(minHeight))
@@ -143,8 +172,14 @@ class Form
 
     project(pane)
 
-  private def solve(): Sequence[Rect] =
-    val frame = liveFrame
+  // Solve the snapshot's panes against the live root, pairing each pane with its
+  // solved rectangle (and its focus, for widgets) in one immutable `Layout`. The
+  // `zip` makes the pairing total by construction: there are no separate sequences
+  // whose lengths must silently agree.
+  private def solve(panes: Sequence[Pane], previous: Form.Layout, stale: Boolean)
+  :   Form.Layout =
+
+    val frame = liveFrame(previous, stale)
 
     val height = mode match
       case Occupancy.Fullscreen => root.height
@@ -155,49 +190,66 @@ class Form
       case screen: ScreenRoot => screen.reframe()
       case _                  => ()
 
-    Sequence.from(frame.arrange(Rect(0, 0, root.width, height)).cells.stdlib)
+    val rects = frame.arrange(Rect(0, 0, root.width, height)).cells
 
-  private def paint(index: Int): Unit =
-    val extent = FlowExtent(root, rects(index.z).vouch)
+    Form.Layout:
+      Sequence.from:
+        panes.stdlib.zip(rects.stdlib).map: (leaf, rect) =>
+          val focus: Optional[Focus] = leaf match
+            case Pane.Widget(_, focus) => focus
+            case _                     => Unset
 
-    leaves(index.z).vouch match
+          Form.Entry(leaf, rect, focus)
+
+  // Paint one leaf of a solved layout. The index is confined to `layout.entries`, so
+  // callers prove it in bounds (via `iterate`, `confine` or `focusables`) before it
+  // crosses this boundary; both accesses below are then total.
+  private def paint(layout: Form.Layout)(index: Ordinal in layout.entries.type): Unit =
+    val entry = layout.entries(index)
+    val extent = FlowExtent(root, entry.rect)
+
+    entry.pane match
       case Pane.Leaf(_, content) =>
         content(extent)
         extent.flush()
 
       case Pane.Widget(_, widget) =>
-        widget.render(extent, focusLeaf.indexOf(index) == focusIndex)
+        widget.render(extent, layout.focusables.indexOf(index) == focusPosition(layout))
 
       case _ =>
         ()
 
   // Re-derive, re-solve and repaint, then present. A change in the number of
-  // leaves (a pane was added or removed) forces a full repaint, clearing the
-  // screen in fullscreen so a removed panel leaves no residue; otherwise
-  // fullscreen repaints only the dirty cells and inline re-presents the block.
+  // leaves (a pane was added or removed) or stale geometry (a resize) forces a
+  // full repaint, clearing the screen in fullscreen so a removed panel leaves no
+  // residue; otherwise fullscreen repaints only the dirty cells and inline
+  // re-presents the block.
   private def refresh(changed: Set[Int]): Unit =
-    rederive()
+    val panes = rederive()
+    val previous = layout
+    val stale = staleGeometry || panes.length != previous.entries.length
+    staleGeometry = false
 
-    if leaves.length != rects.length then
+    if stale then
       mode match
         case Occupancy.Fullscreen => root.clear()
         case Occupancy.Inline     => ()
 
-      rects = Sequence()
-
-    val updated = solve()
+    val updated = solve(panes, previous, stale)
+    layout = updated
 
     mode match
       case Occupancy.Inline =>
-        rects = updated
-        (0 until rects.length).each(paint(_))
+        updated.entries.iterate(paint(updated)(_))
 
       case Occupancy.Fullscreen =>
-        val dirty = dirtyCells(rects, updated, changed)
-        rects = updated
-        dirty.each(paint(_))
+        val previousRects = if stale then Sequence() else previous.entries.map(_.rect)
+        val dirty = dirtyCells(previousRects, updated.entries.map(_.rect), changed)
+        dirty.each { index => updated.entries.confine(index.z).let(paint(updated)(_)) }
 
-    if focuses.nonEmpty then paint(focusLeaf(focusIndex.z).vouch)
+    updated.focusables.confine(focusPosition(updated).z).let: position =>
+      paint(updated)(updated.focusables(position))
+
     root.flush()
 
   // Repaint immediately, folding in any coalesced or pending-resize work. Used for
@@ -272,12 +324,20 @@ class Form
 
     while running && events.hasNext do events.next() match
       case Keypress.Tab =>
-        if focuses.nonEmpty then
+        val current = layout
+
+        if current.focusables.nonEmpty then
           // Repaint the panel losing focus too, so its focus indicator updates;
-          // the panel gaining focus is repainted by `refresh` (focused last).
-          val vacated = focusLeaf(focusIndex.z).vouch
-          focused = focuses(((focusIndex + 1)%focuses.length).z).vouch
-          requestRefresh(Set(vacated))
+          // the panel gaining focus is repainted by `refresh` (focused last). The
+          // wrap-around stays plain `Int` arithmetic until it is re-confined.
+          val position = focusPosition(current)
+          val next = (position + 1)%current.focusables.length
+
+          current.focusables.confine(position.z).let: vacated =>
+            current.focusables.confine(next.z).let: gaining =>
+              focused = current.entries(current.focusables(gaining)).focus
+              val vacatedEntry: Ordinal = current.focusables(vacated)
+              requestRefresh(Set(vacatedEntry.n0))
 
       case Keypress.Escape | Keypress.Ctrl('C' | 'D') =>
         running = false
@@ -302,12 +362,13 @@ class Form
       case TerminalInfo.CursorPosition(row, column) =>
         anchor = (row, column)
 
-      // A resize re-tiles to the new size; reset the rects so the whole layout is
-      // repainted against the live dimensions, and mark the resize so the next
-      // repaint clears the moved block (using the anchor reply, when one arrived).
-      // The repaint is debounced until the drag pauses; typing is unaffected.
+      // A resize re-tiles to the new size; mark the geometry stale so the whole
+      // layout is repainted against the live dimensions, and mark the resize so the
+      // next repaint clears the moved block (using the anchor reply, when one
+      // arrived). The repaint is debounced until the drag pauses; typing is
+      // unaffected.
       case _: TerminalInfo.WindowSize =>
-        rects = Sequence()
+        staleGeometry = true
         resizePending = true
         requestResizeRefresh()
 
@@ -324,16 +385,22 @@ class Form
         ()
 
       case event =>
-        if focuses.nonEmpty then
-          focuses(focusIndex.z).vouch.handle(event)
-          val changed = Set(focusLeaf(focusIndex.z).vouch)
+        val current = layout
 
-          // During a pending resize the widget's state updates immediately, but its
-          // repaint coalesces into the debounced resize flush: presenting now would
-          // draw against stale geometry and move the parked cursor out from under
-          // the anchor recovery. (A wake is always scheduled while `resizePending`.)
-          if resizePending then deferred = deferred.lay(changed)(_ ++ changed)
-          else requestRefresh(changed)
+        if current.focusables.nonEmpty then
+          current.focusables.confine(focusPosition(current).z).let: position =>
+            val ordinal = current.focusables(position)
+
+            current.entries(ordinal).focus.let: widget =>
+              widget.handle(event)
+              val changed = Set((ordinal: Ordinal).n0)
+
+              // During a pending resize the widget's state updates immediately, but its
+              // repaint coalesces into the debounced resize flush: presenting now would
+              // draw against stale geometry and move the parked cursor out from under
+              // the anchor recovery. (A wake is always scheduled while `resizePending`.)
+              if resizePending then deferred = deferred.lay(changed)(_ ++ changed)
+              else requestRefresh(changed)
 
     root match
       case inline: InlineRoot => inline.finish()

--- a/lib/ultimatum/src/core/ultimatum.Frame.scala
+++ b/lib/ultimatum/src/core/ultimatum.Frame.scala
@@ -34,7 +34,6 @@ package ultimatum
 
 import proscenium.compat.*
 
-import denominative.*
 import rudiments.*
 import vacuous.*
 
@@ -76,10 +75,31 @@ object Frame:
   // to exactly `available`.
   def distribute(fractions: List[Double], limits: List[Limits], available: Int): Sequence[Int] =
     val n = fractions.stdlib.length
-    val frac = Sequence.from(fractions.stdlib)
-    val min = Sequence.from(limits.stdlib.map(_.min))
-    val max = Sequence.from(limits.stdlib.map(_.max))
+
+    // The working state, hoisted once into index-aligned local arrays so every read in
+    // the fixed-point loops below is total `Array` indexing (`i` ranges over `0 until n`
+    // throughout). A `limits` list shorter than `fractions` (a violated caller contract)
+    // degrades to zero minima and unbounded maxima rather than a panic.
+    val frac = scala.Array.fill(n)(0.0)
+    val min = scala.Array.fill(n)(0)
+    val max = scala.Array.fill[Optional[Int]](n)(Unset)
     val pinned = scala.Array.fill[Optional[Int]](n)(Unset)
+
+    var index = 0
+    val fractionCells = fractions.stdlib.iterator
+
+    while index < n && fractionCells.hasNext do
+      frac(index) = fractionCells.next()
+      index += 1
+
+    index = 0
+    val limitCells = limits.stdlib.iterator
+
+    while index < n && limitCells.hasNext do
+      val limit = limitCells.next()
+      min(index) = limit.min
+      max(index) = limit.max
+      index += 1
 
     def poolAndWeight(): (Int, Double) =
       var used = 0
@@ -87,7 +107,7 @@ object Frame:
       var i = 0
 
       while i < n do
-        if pinned(i).present then used += pinned(i).vouch else weight += frac(i.z).vouch
+        pinned(i).let(used += _).or(weight += frac(i))
         i += 1
 
       ((available - used).max(0), weight)
@@ -101,13 +121,13 @@ object Frame:
 
       while i < n do
         if pinned(i).absent then
-          val ideal = if weight <= 0.0 then 0.0 else pool*frac(i.z).vouch/weight
+          val ideal = if weight <= 0.0 then 0.0 else pool*frac(i)/weight
 
-          if ideal < min(i.z).vouch then
-            pinned(i) = min(i.z).vouch
+          if ideal < min(i) then
+            pinned(i) = min(i)
             changed = true
           else
-            max(i.z).let: hi =>
+            max(i).let: hi =>
               if ideal > hi then
                 pinned(i) = hi
                 changed = true
@@ -121,9 +141,8 @@ object Frame:
     var i = 0
 
     while i < n do
-      if pinned(i).present then sizes(i) = pinned(i).vouch
-      else
-        val raw = if weight <= 0.0 then 0.0 else pool*frac(i.z).vouch/weight
+      pinned(i).let { size => sizes(i) = size }.or:
+        val raw = if weight <= 0.0 then 0.0 else pool*frac(i)/weight
         val floor = raw.toInt
         sizes(i) = floor
         remainders(i) = raw - floor
@@ -199,13 +218,16 @@ enum Frame:
         case Axis.File => rect.left
         case Axis.Rank => rect.top
 
-      val offsets = Sequence.from(sizes.stdlib.scanLeft(start)(_ + _))
+      val offsets = sizes.stdlib.scanLeft(start)(_ + _)
 
-      val placements = children.stdlib.zipWithIndex.map: (child, i) =>
-        val childRect = axis match
-          case Axis.File => Rect(offsets(i.z).vouch, rect.top, sizes(i.z).vouch, rect.height)
-          case Axis.Rank => Rect(rect.left, offsets(i.z).vouch, rect.width, sizes(i.z).vouch)
+      // Zip each child directly with its solved size and offset (`scanLeft` yields n + 1
+      // offsets; the zip truncates to the n children), so no re-indexing is needed.
+      val placements = children.stdlib.lazyZip(sizes.stdlib).lazyZip(offsets).map:
+        (child, size, offset) =>
+          val childRect = axis match
+            case Axis.File => Rect(offset, rect.top, size, rect.height)
+            case Axis.Rank => Rect(rect.left, offset, rect.width, size)
 
-        child.arrange(childRect)
+          child.arrange(childRect)
 
       Placement.Split(rect, List.of(placements))

--- a/lib/ultimatum/src/core/ultimatum.GridSurface.scala
+++ b/lib/ultimatum/src/core/ultimatum.GridSurface.scala
@@ -232,14 +232,17 @@ extends Board:
     snapshotTop = top
     snapshotColumns = columns
 
-  // Whether the snapshot really describes the screen region about to be presented: the
+  // The snapshot, when it really describes the screen region about to be presented: the
   // same absolute top, the same column clip and the same grid dimensions. Any geometry
-  // change means the diff would be against the wrong cells, so the caller must fall
-  // back to a full redraw.
-  protected def snapshotValid(top: Int, columns: Int, h: Int): Boolean =
-    snapshot.lay(false): snap =>
-      snapshotTop == top && snapshotColumns == columns
+  // change means a diff would be against the wrong cells, so the caller gets `Unset` and
+  // must fall back to a full redraw. The validator returns the validated screen itself
+  // (rather than a `Boolean`), so the caller threads the proof into the diffing present
+  // as a non-Optional parameter.
+  protected def snapshotValid(top: Int, columns: Int, h: Int): Optional[Screen[StyleWord]] =
+    snapshot.let: snap =>
+      if snapshotTop == top && snapshotColumns == columns
         && snap.height == h && snap.width == gridWidth
+      then snap else Unset
 
   // Whether the cell at `(c, r)` differs from the snapshot's. A cell is one grapheme
   // with one style; links never reach the grid (`putCell` always writes `t""`), so the
@@ -249,7 +252,8 @@ extends Board:
       || screen.style(c.z, r.z).raw != snap.style(c.z, r.z).raw
 
   // Diff the grid (drawn at absolute rows `top..top + h - 1`, clipped to `columns`)
-  // against the snapshot, appending one absolutely-addressed run per contiguous patch
+  // against `snap` — the validated snapshot, threaded in by the caller from
+  // `snapshotValid` — appending one absolutely-addressed run per contiguous patch
   // of changed cells: `cup` to the patch, its cells as SGR, and a style reset after any
   // run that emitted SGR (each run renders self-contained, like a full row today).
   // Returns the number of runs, so a caller can skip the write when nothing changed.
@@ -257,10 +261,10 @@ extends Board:
   // leading cell's style, so the two cells always change (or not) together; backing a
   // run up off a sentinel start is a defensive backstop.
   protected def emitDiffRuns
-    ( frame: StringBuilder, top: Int, columns: Int, h: Int, termcap: Termcap )
+    ( frame: StringBuilder, top: Int, columns: Int, h: Int, termcap: Termcap,
+      snap: Screen[StyleWord] )
   :   Int =
 
-    val snap = snapshot.vouch
     var runs = 0
     var r = 0
 
@@ -289,10 +293,13 @@ extends Board:
   // NOTHING is written — an identical frame is a true no-op. Otherwise the patches
   // land in one single write with the cursor hidden, so it never flashes across the
   // screen between runs (and nothing can interleave mid-frame).
-  protected def presentDiff(top: Int, columns: Int, h: Int)(using Stdio): Unit =
+  protected def presentDiff(top: Int, columns: Int, h: Int, snap: Screen[StyleWord])
+    ( using Stdio )
+  :   Unit =
+
     val termcap = summon[Stdio].termcap
     val body = StringBuilder()
-    val runs = emitDiffRuns(body, top, columns, h, termcap)
+    val runs = emitDiffRuns(body, top, columns, h, termcap, snap)
 
     val caretRow2 = (top + caretRow.min(h - 1)).max(1)
     val caretColumn2 = caretColumn.min(columns - 1).max(0) + 1

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -239,10 +239,12 @@ extends GridSurface(widthFn(), 0):
     // growth, shrink-clearing and resize-clearing.
     val dockTop = if topAnchored then 1 else (rows - h + 1).max(1)
 
-    if !invalidated && started && h == presentedRows && columns == presentedColumns
-      && dockTop == presentedTop && snapshotValid(dockTop, columns, h)
-    then presentDiff(dockTop, columns, h)
-    else flushDockedFull(rows, columns, h)
+    val validated =
+      if !invalidated && started && h == presentedRows && columns == presentedColumns
+        && dockTop == presentedTop
+      then snapshotValid(dockTop, columns, h) else Unset
+
+    validated.let(presentDiff(dockTop, columns, h, _)).or(flushDockedFull(rows, columns, h))
 
   private def flushDockedFull(rows: Int, columns: Int, h: Int): Unit =
     val resized = invalidated

--- a/lib/ultimatum/src/core/ultimatum.ScreenRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.ScreenRoot.scala
@@ -38,6 +38,7 @@ import escapade.*
 import gossamer.*
 import profanity.*
 import turbulence.*
+import vacuous.*
 
 object ScreenRoot:
   // Build a fullscreen root covering the whole terminal, reading its size live (so a
@@ -88,9 +89,12 @@ extends GridSurface(widthFn(), heightFn()):
   def flush(): Unit =
     val columns = gridWidth
     val h       = gridHeight
+    val validated = if invalidated then Unset else snapshotValid(1, columns, h)
 
-    if !invalidated && snapshotValid(1, columns, h) then presentDiff(1, columns, h)
-    else
+    validated.let: snap =>
+      presentDiff(1, columns, h, snap)
+
+    . or:
       invalidated = false
 
       val frame = StringBuilder()

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -207,10 +207,19 @@ def dirtyCells
     changed:  Set[Int] )
 :   Set[Int] =
 
-  val moved = (0 until current.length).filter: i =>
-    i >= previous.length || previous(i.z).vouch != current(i.z).vouch
+  // A hot per-frame path: iterate `current` with confined ordinals (`iterate` proves each
+  // index against `current`; `confine` re-proves it against `previous`, whose length may
+  // legitimately differ), so both reads are bare and nothing is bounds-checked twice. An
+  // index beyond `previous` is moved by definition.
+  val moved = scala.collection.immutable.Set.newBuilder[Int]
 
-  Set.from(moved) ++ changed
+  current.iterate: index =>
+    val dirty = previous.confine(index).lay(true): ordinal =>
+      previous(ordinal) != current(index)
+
+    if dirty then moved += (index: Ordinal).n0
+
+  Set.of(moved.result()) ++ changed
 
 // Solve `pane` against `root` once and paint each leaf's content into its
 // rectangle (no event loop). An `InlineRoot` is sized to the height its content

--- a/lib/urticose/src/core/urticose.EmailAddress.scala
+++ b/lib/urticose/src/core/urticose.EmailAddress.scala
@@ -115,7 +115,10 @@ object EmailAddress:
         try
           if text.ult.let(text(_)) != ']' then abort(EmailAddressError(UnclosedIpAddress))
           import strategies.throwUnsafely
-          val ipAddress = text.segment(index.next thru text.pen.vouch)
+
+          val ipAddress =
+            text.pen.lay(abort(EmailAddressError(UnclosedIpAddress))): (pen: Ordinal) =>
+              text.segment(index.next thru pen)
 
           if ipAddress.starts(t"IPv6:") then ipAddress.skip(5).as[Ipv6] else ipAddress.as[Ipv4]
         catch case error: IpAddressError => abort(EmailAddressError(InvalidDomain(error)))

--- a/lib/vacuous/src/core/soundness_vacuous_core.scala
+++ b/lib/vacuous/src/core/soundness_vacuous_core.scala
@@ -37,4 +37,4 @@ export
   . { absent, assume, compact, Concrete, Default, default, Distinct, Extractor,
       invite, javaOptional, lay, layGiven, let, letGiven, Mandatable, mask, only, optimizable,
       option, Optional, optional, Optionality, or, per, present, presume, puncture,
-      unless, Unsafe, Unset, UnsetError, vouch }
+      unless, Unsafe, Unset, UnsetError }

--- a/lib/vacuous/src/core/vacuous_core.scala
+++ b/lib/vacuous/src/core/vacuous_core.scala
@@ -63,17 +63,18 @@ transparent inline def invite[entity]: Optional[entity] = summonFrom:
 
 extension [value](iterable: Iterable[Optional[value]])
   transparent inline def compact: Iterable[value] =
-    iterable.filter(!_.absent).map(_.vouch)
+    iterable.filter(!_.absent).map(_.or(panic(m"the absent elements were filtered out")))
 
   // All-or-nothing: the whole list if every element is present, or `Unset` if any is
   // absent. One presence sweep, recorded by the result's type.
   def entire: Optional[List[value]] =
-    if iterable.exists(_.absent) then Unset else List.from(iterable.map(_.vouch))
+    if iterable.exists(_.absent) then Unset
+    else List.from(iterable.map(_.or(panic(m"absence was excluded by the sweep above"))))
 
 // As `compact` for a streaming source: absent elements are dropped as the iterator advances.
 extension [value](iterator: Iterator[Optional[value]])
   transparent inline def compact: Iterator[value] =
-    iterator.filter(!_.absent).map(_.vouch)
+    iterator.filter(!_.absent).map(_.or(panic(m"the absent elements were filtered out")))
 
 extension [value](option: Option[value])
   // Not `inline`: inlining a union `Optional[value]` result re-infers it per call site, where capture
@@ -100,7 +101,12 @@ extension [value](optional: Optional[value])(using Optionality[optional.type])
   inline def absent: Boolean = optional == Unset
   inline def present: Boolean = optional != Unset
 
-  inline def vouch: value = optional.or(panic(m"a value was vouched but was absent"))
+  // The foundation extraction, private to these combinators: after an `absent` test, the
+  // union's only remaining inhabitant is a `value`, so the cast is a no-op at runtime. Every
+  // combinator below discharges absence through this one point; user code never needs it,
+  // since `or`/`let`/`lay` express every honest consumption.
+  private inline def unsafeGet: value = optional.asInstanceOf[value]
+
 
   inline def mask(predicate: value => Boolean): Optional[value] =
     optional.let: value => if predicate(value) then Unset else value
@@ -109,21 +115,21 @@ extension [value](optional: Optional[value])(using Optionality[optional.type])
     optional.lay(ju.Optional.empty[value].nn)(ju.Optional.of(_).nn)
 
   def presume(using default: Default[value]): value = optional.or(default())
-  def option: Option[value] = if absent then None else Some(vouch)
+  def option: Option[value] = if absent then None else Some(unsafeGet)
   def assume(using absentValue: CanThrow[UnsetError]): value = optional.or(throw UnsetError())
 
   inline def lay[value2](inline alternative: => value2)(inline lambda: value => value2): value2 =
 
-    if absent then alternative else lambda(vouch)
+    if absent then alternative else lambda(unsafeGet)
 
 
   inline def layGiven[value2](inline alternative: => value2)(inline block: value ?=> value2)
   :   value2 =
 
-    if absent then alternative else block(using vouch)
+    if absent then alternative else block(using unsafeGet)
 
   def let[value2](lambda: value => value2): Optional[value2] =
-    if absent then Unset else lambda(vouch)
+    if absent then Unset else lambda(unsafeGet)
 
   inline def letGiven[value2](inline block: value ?=> value2): Optional[value2] =
-    if absent then Unset else block(using vouch)
+    if absent then Unset else block(using unsafeGet)

--- a/lib/vacuous/src/core/vacuous_core.scala
+++ b/lib/vacuous/src/core/vacuous_core.scala
@@ -65,6 +65,16 @@ extension [value](iterable: Iterable[Optional[value]])
   transparent inline def compact: Iterable[value] =
     iterable.filter(!_.absent).map(_.vouch)
 
+  // All-or-nothing: the whole list if every element is present, or `Unset` if any is
+  // absent. One presence sweep, recorded by the result's type.
+  def entire: Optional[List[value]] =
+    if iterable.exists(_.absent) then Unset else List.from(iterable.map(_.vouch))
+
+// As `compact` for a streaming source: absent elements are dropped as the iterator advances.
+extension [value](iterator: Iterator[Optional[value]])
+  transparent inline def compact: Iterator[value] =
+    iterator.filter(!_.absent).map(_.vouch)
+
 extension [value](option: Option[value])
   // Not `inline`: inlining a union `Optional[value]` result re-infers it per call site, where capture
   // checking stamps a spurious `^` when `value` is (or contains) a pure type such as `Text`.

--- a/lib/vicarious/src/core/vicarious.Catalog.scala
+++ b/lib/vicarious/src/core/vicarious.Catalog.scala
@@ -37,6 +37,7 @@ import proscenium.compat.*
 import scala.language.dynamics
 
 import beneficence.*
+import fulminate.*
 import vacuous.*
 
 object Catalog:
@@ -56,7 +57,7 @@ case class Catalog[key, value: ClassTag](values: Array[value]^{}) extends Findab
   def size: Int = values.length
 
   inline def apply(accessor: (`*`: Proxy[key, value, 0]) ?=> Proxy[key, value, ?]): value =
-    values(accessor(using Proxy(0)).id.vouch)
+    values(accessor(using Proxy(0)).id.or(panic(m"the Proxy phantom always assigns an id")))
 
   def map[value2: ClassTag](lambda: value => value2): Catalog[key, value2] =
     Catalog(values.map(lambda))

--- a/lib/wisteria/src/core/wisteria.SumDerivation.scala
+++ b/lib/wisteria/src/core/wisteria.SumDerivation.scala
@@ -181,7 +181,7 @@ object SumDerivation:
         [variant <: derivation] =>
           lambda[variant](_)
 
-      . vouch
+      . or(panic(m"a fallible fold either yields a variant or raises for the bad label"))
 
 
     protected transparent inline def variant[derivation](sum: derivation)
@@ -202,7 +202,7 @@ object SumDerivation:
       fold[derivation, Variants, Labels](sum, size, 0, false)(index == reflection.ordinal(sum)):
         [variant <: derivation] => variant => lambda[variant](variant)
 
-      . vouch
+      . or(panic(m"the sum's ordinal always identifies one of its variants"))
 
 
     private transparent inline def fold[derivation, variants <: Tuple, labels <: Tuple]

--- a/lib/wisteria/src/core/wisteria.internal.scala
+++ b/lib/wisteria/src/core/wisteria.internal.scala
@@ -1040,9 +1040,14 @@ object internal:
           case Nil       => selection
           case arguments => selection.appliedToTypes(arguments)
 
-    // Ascribed, not bare: the macro's declared result is `Optional[field]`, and a bare
-    // `'{Unset}` expands with the singleton type `Unset.type`. The conformance check on a
-    // macro expansion dealiases opaque types on both sides, but only reaches them through a
-    // `TypeRef`; a singleton hides `Unset`'s underlying type, so the expansion no longer
-    // conformed to the dealiased `Optional[field]`.
-    . map(_.asExprOf[field]).getOrElse('{Unset: Optional[field]})
+    // Both branches are ascribed, not bare: the macro's declared result is `Optional[field]`,
+    // and the conformance check on a macro expansion dealiases opaque types on both sides,
+    // but only reaches them through a `TypeRef`. A bare `'{Unset}` expands with the singleton
+    // type `Unset.type`, and a bare reference to a `<init>$default$n` getter expands with its
+    // term-reference type (a nullary-method `ExprType`, `@uncheckedVariance` included); either
+    // hides `Optional`'s underlying type, so the expansion no longer conformed to the
+    // dealiased `Optional[field]`.
+    . map: selection =>
+        '{${selection.asExprOf[field]}: Optional[field]}
+
+    . getOrElse('{Unset: Optional[field]})

--- a/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
+++ b/lib/xenophile/src/kotlin/xenophile.KotlinFacade.scala
@@ -536,10 +536,11 @@ object KotlinFacade:
 
             // Skip a property whose name a refined method already occupies.
             if propertyNames.contains(property.s) then accumulated else
-              val function = samFunctionType(parameter).vouch
-              val getter = Refinement(accumulated, property.s, function)
-              val signature = MethodType(List("value"))(_ => List(function), _ => TypeRepr.of[Unit])
-              Refinement(getter, s"${property.s}_=", signature)
+              samFunctionType(parameter).lay(accumulated): function =>
+                val getter = Refinement(accumulated, property.s, function)
+                val signature =
+                  MethodType(List("value"))(_ => List(function), _ => TypeRepr.of[Unit])
+                Refinement(getter, s"${property.s}_=", signature)
 
           case _ =>
             accumulated
@@ -875,12 +876,16 @@ object KotlinFacade:
       case parameter :: Nil => parameter
       case _                => Unset
 
-    val candidates = classSymbol.methodMember(setterName.s).filter(parameterOf(_).present)
+    // Find the setter and its parameter type in one pass, so the parameter accompanying the
+    // matched method is the very one the match examined.
+    def search(remaining: List[Symbol]): (Symbol, TypeRepr) = remaining match
+      case Nil => halt(m"xenophile: $className has no mutable property $property")
 
-    val method = candidates.find { m => parameterOf(m).lay(false)(satisfies(value, _)) }.getOrElse:
-      halt(m"xenophile: $className has no mutable property $property")
+      case method :: rest =>
+        parameterOf(method).lay(search(rest)): parameter =>
+          if satisfies(value, parameter) then (method, parameter) else search(rest)
 
-    val parameter = parameterOf(method).vouch
+    val (method, parameter) = search(classSymbol.methodMember(setterName.s))
     val call = Apply(Select(receiver(self, repr), method), List(adapted(value, parameter)))
 
     '{${call.asExpr}; ()}
@@ -1326,12 +1331,11 @@ object KotlinFacade:
 
       assign(pairs, 0, Map())
 
-    val absent = proscenium.List.of((0 until member.arity).filter(!provided.stdlib.contains(_)).toList)
+    // All-or-nothing: `entire` is present exactly when every position was provided.
+    (0 until member.arity).map(provided(_)).entire.lay:
+      val absent =
+        proscenium.List.of((0 until member.arity).filter(!provided.stdlib.contains(_)).toList)
 
-    if absent.isEmpty then
-      val ordered = (0 until member.arity).to(List).map { index => provided(index).vouch }
-      invocation(self, repr, className, field, ordered, prototype)
-    else
       val undefaulted = absent.filter: index =>
         !member.defaults.stdlib.lift(index).getOrElse(false)
 
@@ -1340,6 +1344,9 @@ object KotlinFacade:
         halt(m"xenophile: $className.$field requires arguments for: $names")
 
       bridgeCall(self, repr, className, member, provided, prototype)
+
+    . apply: ordered =>
+        invocation(self, repr, className, field, ordered.stdlib, prototype)
 
   // The facade of an `enum class` entry, a static field of the enum's own type.
   def enumEntry[kotlinType: Type](name: Expr[String])(using Quotes): Expr[Any] =
@@ -1430,8 +1437,11 @@ object KotlinFacade:
   def unwrapped(self: Expr[Facade])(using Quotes): Expr[Any] =
     import quotes.reflect.*
 
-    val transport = Map.of(Xenophile.refinements(self.asTerm.tpe.widen))(t"Transport")
+    // A concrete-scrutinee match rather than an Optional combinator: an inline lambda
+    // whose arms are quote literals crashes pickleQuotes (the aviation.internal caveat).
+    Xenophile.refinements(self.asTerm.tpe.widen).get(t"Transport") match
+      case scala.None => '{$self.raw}
 
-    if transport.absent then '{$self.raw} else
-      transport.vouch.asType.absolve match
-        case '[u] => '{$self.raw.asInstanceOf[u]}
+      case scala.Some(transport) =>
+        transport.asType.absolve match
+          case '[u] => '{$self.raw.asInstanceOf[u]}

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -287,21 +287,9 @@ object WasmInvoke extends Materializer:
           (arrayCarrier, decode)
 
         case _ =>
-          val payloadWit = optionPayload(witType)
-          val payloadScala = scalaPayload(scala)
-
-          if payloadWit.present && payloadScala.present then
-            val (innerCarrier, innerDecode) = decodeFor(payloadWit.vouch, payloadScala.vouch)
-
-            // `java.util.Optional` is nameable here, so ordinary quotes suffice; an absent
-            // value becomes `Unset`.
-            val decode: Expr[Any] => Expr[Any] = call =>
-              '{  val option = $call.asInstanceOf[java.util.Optional[Any]]
-                  if option.isPresent then ${innerDecode('{option.get})} else Unset  }
-
-            (optionClass.typeRef.appliedTo(List(innerCarrier)), decode)
-          else
-            witType match
+          // A def, not a closure: the alternative is shared by two absence paths below, and a
+          // tuple-resulted lambda here trips capture checking's freshness in the macro context.
+          def opaque(): (TypeRepr, Expr[Any] => Expr[Any]) = witType match
               case Foreign.Type.Named(name) if isHandle(scala) =>
                 handleDecode(name, scala)
 
@@ -329,6 +317,21 @@ object WasmInvoke extends Materializer:
                 then halt(m"xenophile: `invoke[Unit]` requires a WIT `result<…>` or void function")
                 else scala.asType.absolve match
                   case '[scala] => deriveResult[scala]
+
+          optionPayload(witType) match
+            case Unset => opaque()
+
+            case payloadWit: Foreign.Type =>
+              scalaPayload(scala).lay(opaque()): payloadScala =>
+                val (innerCarrier, innerDecode) = decodeFor(payloadWit, payloadScala)
+
+                // `java.util.Optional` is nameable here, so ordinary quotes suffice; an absent
+                // value becomes `Unset`.
+                val decode: Expr[Any] => Expr[Any] = call =>
+                  '{  val option = $call.asInstanceOf[java.util.Optional[Any]]
+                      if option.isPresent then ${innerDecode('{option.get})} else Unset  }
+
+                (optionClass.typeRef.appliedTo(List(innerCarrier)), decode)
 
     val (carrier, decode) = decodeFor(prototype.result, TypeRepr.of[result].dealias)
 
@@ -555,42 +558,8 @@ object WasmInvoke extends Materializer:
       (facade.typeRef, Apply(Select.unique(Ref(child.companionModule), "apply"), List(built)))
 
     def encodedArgument(value: Term, parameter: Foreign.Type): (TypeRepr, Term) =
-      val (carrier, encoded, alreadyOption) = value.tpe.widen.dealias match
-        // A `tuple<…>` (or a record, whose ABI it shares) argument with a matching Scala tuple:
-        // element-wise recursion, constructed as the scala-wasm `TupleN` of the element carriers —
-        // the mirror of the decode path. Nested tuples, `option<T>` and `WitCase` elements are
-        // handled by the per-element recursion into `encodedArgument`.
-        case valueType
-        if parameterTuple(parameter).let { es => isTuple(valueType, es.length) }.or(false) =>
-          val elements = parameterTuple(parameter).vouch
-
-          // Explicit loop, not a mapping lambda: minted quote capabilities must not leak into a
-          // closure's capture set (macro-under-cc precedent, rep/DECISIONS.md).
-          val encodedBuffer = List.newBuilder[(TypeRepr, Term)]
-          val indexed = elements.iterator.zipWithIndex
-
-          while indexed.hasNext do
-            val (element, index) = indexed.next()
-            val field = Select.unique(value, "_" + (index + 1).toString)
-            encodedBuffer += encodedArgument(field, element)
-
-          val encodedElements = encodedBuffer.result()
-          val carriers = encodedElements.map(_(0))
-
-          val tupleClass =
-            Symbol.requiredClass("scala.scalajs.wit.Tuple" + elements.length.toString)
-
-          val tupleCarrier = tupleClass.typeRef.appliedTo(carriers)
-
-          val constructed =
-            Apply
-              ( TypeApply
-                  ( Select.unique(Ref(tupleClass.companionModule), "apply"),
-                    carriers.map(Inferred(_)) ),
-                encodedElements.map(_(1)) )
-
-          (tupleCarrier, constructed, false)
-
+      // The non-tuple encodings, by the argument's Scala type.
+      def nonTuple(valueType: TypeRepr): (TypeRepr, Term, Boolean) = valueType match
         // A statically-absent argument (a bare `Unset` against an `option<T>` parameter, e.g. the
         // `option<request-options>` of `wasi:http`'s `handle`) needs no payload codec at all.
         case tpe if tpe =:= TypeRepr.of[Unset] =>
@@ -649,6 +618,42 @@ object WasmInvoke extends Materializer:
 
             val encoded = '{$encodable.encoded(${value.asExprOf[argument]}).value}.asTerm
             (carrierType(encodable), encoded, false)
+
+      val (carrier, encoded, alreadyOption) = parameterTuple(parameter) match
+        // A `tuple<…>` (or a record, whose ABI it shares) parameter with a matching Scala tuple:
+        // element-wise recursion, constructed as the scala-wasm `TupleN` of the element carriers —
+        // the mirror of the decode path. Nested tuples, `option<T>` and `WitCase` elements are
+        // handled by the per-element recursion into `encodedArgument`.
+        case elements: List[Foreign.Type] if isTuple(value.tpe.widen.dealias, elements.length) =>
+          // Explicit loop, not a mapping lambda: minted quote capabilities must not leak into a
+          // closure's capture set (macro-under-cc precedent, rep/DECISIONS.md).
+          val encodedBuffer = List.newBuilder[(TypeRepr, Term)]
+          val indexed = elements.iterator.zipWithIndex
+
+          while indexed.hasNext do
+            val (element, index) = indexed.next()
+            val field = Select.unique(value, "_" + (index + 1).toString)
+            encodedBuffer += encodedArgument(field, element)
+
+          val encodedElements = encodedBuffer.result()
+          val carriers = encodedElements.map(_(0))
+
+          val tupleClass =
+            Symbol.requiredClass("scala.scalajs.wit.Tuple" + elements.length.toString)
+
+          val tupleCarrier = tupleClass.typeRef.appliedTo(carriers)
+
+          val constructed =
+            Apply
+              ( TypeApply
+                  ( Select.unique(Ref(tupleClass.companionModule), "apply"),
+                    carriers.map(Inferred(_)) ),
+                encodedElements.map(_(1)) )
+
+          (tupleCarrier, constructed, false)
+
+        case _ =>
+          nonTuple(value.tpe.widen.dealias)
 
       // A plain (always-present) value against an `option<T>` parameter crosses as a present
       // `java.util.Optional`, and one against a `result<T, E>` parameter as an `Ok` (used by

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -1038,42 +1038,45 @@ object Xml extends Tag.Container
 
             index += 1
 
-          var label: Optional[Text] = reader.nextChild()
+          var scanning: Boolean = true
 
-          while label.present do
-            val found = indexOf(label.vouch)
+          while scanning do reader.nextChild() match
+            case Unset => scanning = false
 
-            if found < 0 then reader.skipElement()
-            else Xml.Parsable.unwrap(entries.readUnchecked(found)(1)) match
-              case gathering: Gathering if entries.readUnchecked(found)(1).repeatable =>
-                // Every occurrence of a repeatable field accumulates, in
-                // document order — the AST derivation's gather-all
-                // semantics.
-                val buffer = values(found) match
-                  case buffer: scm.ListBuffer[?] => buffer.asInstanceOf[scm.ListBuffer[Any]]
+            case label: Text =>
+              val found = indexOf(label)
 
-                  case _ =>
-                    val buffer = scm.ListBuffer.empty[Any]
-                    values(found) = buffer
-                    buffer
+              if found < 0 then reader.skipElement()
+              else Xml.Parsable.unwrap(entries.readUnchecked(found)(1)) match
+                case gathering: Gathering if entries.readUnchecked(found)(1).repeatable =>
+                  // Every occurrence of a repeatable field accumulates, in
+                  // document order — the AST derivation's gather-all
+                  // semantics.
+                  val buffer = values(found) match
+                    case buffer: scm.ListBuffer[?] => buffer.asInstanceOf[scm.ListBuffer[Any]]
 
-                buffer +=
-                  ( if focused
-                    then focus(descend(prior, keys.readUnchecked(found).tt))(gathering.parseElement(reader))
-                    else gathering.parseElement(reader) )
+                    case _ =>
+                      val buffer = scm.ListBuffer.empty[Any]
+                      values(found) = buffer
+                      buffer
 
-              case _ =>
-                // Unknown children are skipped, and a duplicate child keeps
-                // the first occurrence — the AST derivation's `HashMap`
-                // inserts only when the label is not yet present.
-                if !(values(found).asInstanceOf[AnyRef] eq AbsentSlot)
-                then reader.skipElement()
-                else values(found) =
-                  if focused
-                  then focus(descend(prior, keys.readUnchecked(found).tt))(entries.readUnchecked(found)(1).parse(reader))
-                  else entries.readUnchecked(found)(1).parse(reader)
+                  buffer +=
+                    ( if focused
+                      then focus(descend(prior, keys.readUnchecked(found).tt))(gathering.parseElement(reader))
+                      else gathering.parseElement(reader) )
 
-            label = reader.nextChild()
+                case _ =>
+                  // Unknown children are skipped, and a duplicate child keeps
+                  // the first occurrence — the AST derivation's `HashMap`
+                  // inserts only when the label is not yet present.
+                  if !(values(found).asInstanceOf[AnyRef] eq AbsentSlot)
+                  then reader.skipElement()
+                  else values(found) =
+                    if focused
+                    then focus(descend(prior, keys.readUnchecked(found).tt))(entries.readUnchecked(found)(1).parse(reader))
+                    else entries.readUnchecked(found)(1).parse(reader)
+
+
 
           index = 0
 
@@ -1954,8 +1957,9 @@ object Xml extends Tag.Container
                     val attrCount = data.readUnchecked(offset + 4)
                     val offSlot = offset + 6 + attrCount + childElementIndex
                     val childOff = data.readUnchecked(offSlot)
-                    val child = descendAst(element, name, ordinal).vouch
-                    walk(child, data, offset + childOff, segments, i + 1)
+
+                    descendAst(element, name, ordinal).let: child =>
+                      walk(child, data, offset + childOff, segments, i + 1)
 
                 case _ =>
                   Unset
@@ -2067,7 +2071,7 @@ object Xml extends Tag.Container
         case xml: Xml        => result.decoded(xml)
 
       val foci = summon[Foci[Xml.Focus]]
-      foci.supplement(foci.length, _.let(_.withPosition(document)).vouch)
+      foci.supplement(foci.length, _.let(_.withPosition(document)))
       decoded
 
   enum Hole:
@@ -3769,8 +3773,7 @@ object Xml extends Tag.Container
     private[xylophone] def directTextInt()(using Tactic[ParseError]): Optional[Int] =
       val value = directTextLong()
 
-      if value.absent then Unset else
-        val long = value.vouch
+      value.let: long =>
         if long >= Int.MinValue.toLong && long <= Int.MaxValue.toLong
         then Optional(long.toInt)
         else Unset

--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -70,7 +70,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)
@@ -359,7 +359,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     def firstOrigin[tuple: Type]: Int = Type.of[tuple] match
@@ -400,7 +400,7 @@ object internal:
     import Xml.Hole
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)

--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -1325,49 +1325,49 @@ object internal:
           case '[fieldType] =>
             val keyText: Expr[Text] = '{ $keys(${Expr(index)}).tt }
 
-            val valueSymbol =
-              Symbol.newVal(owner, "attr"+index, TypeRepr.of[Optional[Text]], Flags.EmptyFlags,
-                Symbol.noSymbol)
+            // The generated code tests presence and names the value with a single
+            // concrete-scrutinee match (the sanctioned check-then-extract shape),
+            // so each per-kind reader below takes the bound `Text` directly — no
+            // per-arm re-read of the slot. The match is inside the quote (runtime
+            // code), so no inline Optional combinator runs in macro position, and
+            // no closure is allocated on the parse path.
+            def step(value: Expr[Text]): Expr[Unit] =
+              val read: Expr[fieldType] = kinds(index) match
+                case IntK     => '{ Xml.intParsable.attribute($value)(using $tactic, $foci) }
+                                 . asExprOf[fieldType]
+                case LongK    => '{ Xml.longParsable.attribute($value)(using $tactic, $foci) }
+                                 . asExprOf[fieldType]
+                case DoubleK  => '{ Xml.doubleParsable.attribute($value)(using $tactic, $foci) }
+                                 . asExprOf[fieldType]
+                case FloatK   => '{ Xml.floatParsable.attribute($value)(using $tactic, $foci) }
+                                 . asExprOf[fieldType]
+                case BooleanK => '{ Xml.booleanParsable.attribute($value)(using $tactic, $foci) }
+                                 . asExprOf[fieldType]
+                case TextK    => value.asExprOf[fieldType]
+                case StringK  => '{ $value.s }.asExprOf[fieldType]
 
-            val valueDef =
-              ValDef(valueSymbol, Some('{ Attributes.fetch($attributes)($keyText) }.asTerm))
+                case InstanceK =>
+                  '{
+                    $instances(${Expr(index)}).asInstanceOf[fieldType is Xml.Field]
+                    . attribute($value)(using $tactic, $foci)
+                  }
 
-            val valueRef = Ref(valueSymbol).asExprOf[Optional[Text]]
+              val focused: Term =
+                '{ Xml.Parsable.focusing($foci, $keyText)($read) }.asTerm
 
-            val read: Expr[fieldType] = kinds(index) match
-              case IntK     => '{ Xml.intParsable.attribute($valueRef.vouch)(using $tactic, $foci) }
-                               . asExprOf[fieldType]
-              case LongK    => '{ Xml.longParsable.attribute($valueRef.vouch)(using $tactic, $foci) }
-                               . asExprOf[fieldType]
-              case DoubleK  => '{ Xml.doubleParsable.attribute($valueRef.vouch)(using $tactic, $foci) }
-                               . asExprOf[fieldType]
-              case FloatK   => '{ Xml.floatParsable.attribute($valueRef.vouch)(using $tactic, $foci) }
-                               . asExprOf[fieldType]
-              case BooleanK => '{ Xml.booleanParsable.attribute($valueRef.vouch)(using $tactic, $foci) }
-                               . asExprOf[fieldType]
-              case TextK    => '{ $valueRef.vouch }.asExprOf[fieldType]
-              case StringK  => '{ $valueRef.vouch.s }.asExprOf[fieldType]
-
-              case InstanceK =>
-                '{
-                  $instances(${Expr(index)}).asInstanceOf[fieldType is Xml.Field]
-                  . attribute($valueRef.vouch)(using $tactic, $foci)
-                }
-
-            val focused: Term =
-              '{ Xml.Parsable.focusing($foci, $keyText)($read) }.asTerm
+              Block
+                ( List
+                    ( Assign(Ref(slots(index)), focused),
+                      Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+                  unit )
+              . asExprOf[Unit]
 
             Some:
-              Block
-                ( List(valueDef),
-                  If
-                    ( '{ $valueRef.present }.asTerm,
-                      Block
-                        ( List
-                            ( Assign(Ref(slots(index)), focused),
-                              Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
-                          unit ),
-                      unit ) )
+              '{
+                Attributes.fetch($attributes)($keyText) match
+                  case value: Text => ${ step('{ value }) }
+                  case _           => ()
+              }.asTerm
 
       // One dispatch arm per child-matching field: read the value (with
       // focus bookkeeping), honoring the derived engine's semantics — a

--- a/lib/xylophone/src/staged/xylophone.stagedInternal.scala
+++ b/lib/xylophone/src/staged/xylophone.stagedInternal.scala
@@ -95,7 +95,7 @@ object stagedInternal:
       val run = ctx.run
 
       if run == null then false else
-        val sources = run.nn.units.map(_.source.file.path).toSet
+        val sources = run.nn.units.map(_.source.path).toSet
         val position = symbol.pos
         position.exists { position => sources.contains(position.sourceFile.path) }
     catch case _: Exception => false

--- a/lib/xylophone/src/test/xylophone.PositionTests.scala
+++ b/lib/xylophone/src/test/xylophone.PositionTests.scala
@@ -41,9 +41,9 @@ import parsing.trackPositions
 
 object PositionTests extends Suite(m"Xylophone position-index tests"):
 
-  private def line(p: Optional[Xml.Position]): Int = p.vouch.line.n1
-  private def col(p: Optional[Xml.Position]): Int = p.vouch.column.n1
-  private def len(p: Optional[Xml.Position]): Int = p.vouch.length.vouch
+  private def line(p: Optional[Xml.Position]): Optional[Int] = p.let(_.line.n1)
+  private def col(p: Optional[Xml.Position]): Optional[Int] = p.let(_.column.n1)
+  private def len(p: Optional[Xml.Position]): Optional[Int] = p.let(_.length)
 
   def run(): Unit =
     given XmlSchema = XmlSchema.Freeform

--- a/lib/yossarian/src/core/yossarian.Pty.scala
+++ b/lib/yossarian/src/core/yossarian.Pty.scala
@@ -571,14 +571,15 @@ case class Pty(buffer: Screen[Style], state: PtyState, output: Relay[Text]):
         writeGrapheme(Grapheme(input.segment(index.z till end.z).s))
         recur(end, Normal)
 
-      if index >= input.length
-      then Pty(buffer2,
-          state2.copy(cursor = cursor(), style = style, link = link, scrollTop = scrollTop,
-              scrollBottom = scrollBottom, pendingWrap = pendingWrap),
-          output = output)
-      else
-        val current: Char = input(index.z).vouch
+      // The presence of a character at `index` is the loop's bounds check; past the end of
+      // the input, the walk is complete.
+      input(index.z).lay:
+        Pty(buffer2,
+            state2.copy(cursor = cursor(), style = style, link = link, scrollTop = scrollTop,
+                scrollBottom = scrollBottom, pendingWrap = pendingWrap),
+            output = output)
 
+      . apply: current =>
         context match
           case Normal =>
             (current: @switch) match

--- a/lib/yossarian/src/core/yossarian.internal.scala
+++ b/lib/yossarian/src/core/yossarian.internal.scala
@@ -93,8 +93,7 @@ object internal:
     // First Char of the cell's grapheme, or ' ' for trailing-half cells.
     // Convenience accessor for narrow-ASCII assertions.
     def char(x: Ordinal, y: Ordinal): Char =
-      val grapheme = graphemeBuffer(offset(x, y)).text
-      if grapheme.nil then ' ' else grapheme(Prim).vouch
+      graphemeBuffer(offset(x, y)).text.prim.or(' ')
 
     // True if this cell is the trailing half of a wide grapheme stored in the
     // cell to the left.

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -5936,7 +5936,7 @@ extends Dynamic derives CanEqual:
     // `Tracked#as` (PR #1151).
     val foci = summon[Foci[Yaml.Focus]]
     val yaml = this
-    foci.supplement(foci.length, _.let(_.withPosition(yaml)).vouch)
+    foci.supplement(foci.length, _.let(_.withPosition(yaml)))
     result
 
   // Sequence indexing: `yaml(0)` returns the first element of a sequence,

--- a/lib/ypsiloid/src/core/ypsiloid.internal.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.internal.scala
@@ -100,7 +100,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     def firstOrigin[tuple: Type]: Int = Type.of[tuple] match
@@ -140,7 +140,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)
@@ -418,7 +418,7 @@ object internal:
     import quotes.reflect.*
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
-      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
     val parts = recur[parts](Nil)

--- a/lib/ypsiloid/src/test/ypsiloid.PositionTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.PositionTests.scala
@@ -165,17 +165,18 @@ object PositionTests extends Suite(m"Ypsiloid position-index tests"):
     suite(m"Subsequence property"):
       test(m"A nested mapping's descriptor slice has length == slot 0"):
         val yaml = t"{a: {b: 42}}".read[Yaml]
-        val data = yaml.positionIndex.vouch.ints
-        // Root composite header: [size, line, col, len, n=1, off_0, ...]
-        // The single entry's offset is at data(5), entry = [keyLine,
-        // keyColumn, keyLength, <valueDescriptor>]. The value descriptor
-        // starts at offset(0) + 3 from the root descriptor.
-        val firstEntryOff = data(5)
-        val valueDescOff = firstEntryOff + 3
-        val valueSize = data(valueDescOff)
-        val slice = data.slice(valueDescOff, valueDescOff + valueSize)
-        slice.length == valueSize
-      . assert(identity)
+        yaml.positionIndex.let: index =>
+          val data = index.ints
+          // Root composite header: [size, line, col, len, n=1, off_0, ...]
+          // The single entry's offset is at data(5), entry = [keyLine,
+          // keyColumn, keyLength, <valueDescriptor>]. The value descriptor
+          // starts at offset(0) + 3 from the root descriptor.
+          val firstEntryOff = data(5)
+          val valueDescOff = firstEntryOff + 3
+          val valueSize = data(valueDescOff)
+          val slice = data.slice(valueDescOff, valueDescOff + valueSize)
+          slice.length == valueSize
+      . assert(_ == true)
 
     suite(m"Non-tracking mode"):
       test(m"Default Tracking.Off leaves positionIndex Unset"):

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -491,11 +491,7 @@ extends caps.Mutable:
     var loaded = false
 
     while !loaded && !ended do
-      val chunk = load()
-
-      if chunk.absent then ended = true
-      else
-        val data = chunk.vouch
+      load().lay({ ended = true }): data =>
         val len = addressable.length(data)
 
         if len > 0 then

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -442,10 +442,10 @@ private def chunkIterator[medium](consume stream: (Stream[medium] over Credit)^)
           false
 
       def next(): medium =
-        if !hasNext then panic(m"the stream is exhausted")
-        val result = chunk.vouch
-        chunk = Unset
-        result
+        chunk
+        . lay(if !done && advance() then next() else panic(m"the stream is exhausted")): result =>
+            chunk = Unset
+            result
 
 private def recordIterator[record]
   ( consume stream: (Stream[Array[record]^{}] over Credit)^ )

--- a/lib/ziggurat/src/test/ziggurat_test.scala
+++ b/lib/ziggurat/src/test/ziggurat_test.scala
@@ -66,7 +66,8 @@ object Tests extends Suite(m"Ziggurat tests"):
     val tempDirs = scala.collection.mutable.ListBuffer.empty[Path on Linux]
 
     def tempDir(): Path on Linux =
-      val dir: Path on Linux = temporaryDirectory[Path on Linux] / Uuid().show
+      val name: Text = Uuid().show
+      val dir: Path on Linux = temporaryDirectory[Path on Linux] / name
       dir.create[Directory]()
       tempDirs += dir
       dir

--- a/lib/ziggurat/src/test/ziggurat_test.scala
+++ b/lib/ziggurat/src/test/ziggurat_test.scala
@@ -301,8 +301,7 @@ object Tests extends Suite(m"Ziggurat tests"):
 
     val winHost: Optional[Text] = safely(Environment.windowsHost[Text])
 
-    if winHost.present then
-      val host = winHost.vouch
+    winHost.let: host =>
       val winSshOk =
         safely(sh"ssh -o BatchMode=yes -o ConnectTimeout=5 $host echo ok".exec[Exit]()) == Exit.Ok
 


### PR DESCRIPTION
Nineteen small commits that make the same source tree compile on both Proscala streams — verified by full clean builds (12726/12726 targets, resolved compiler asserted) on trunk/3.9 (3.9.0-RC5 base, 28 patches → releasing as 3.9.0-RC5-p11) and trunk/3.10 (29 patches → 3.10.0-dev-p11).

Three groups:

**Restorations of honest code enabled by new compiler patches.** `fixpoint` returns, reformulated as a SAM-trait knot that names its aliasing (fixes #1412; the old eager knot also recursed unconditionally at runtime). The statistics methods' path-dependent `Result` evidence returns (the #1411 workaround is reverted; fixed by the `dependarg` patch). Honeycomb's element macro drops its `Expr[Any]` widenings (#1428, fixed by `returnavoid`), and ScalacEdges returns to the `CompilerError()` extractor (fixed by `boolunapply`).

**Adaptations to 3.10's stricter capture/separation checking**, each stating something inference left implicit: explicit `Tactic` clauses instead of doubly-nested `raises` sugar (breviloquence, ethereal, mandible), ascribed lambda parameters in shared derivations (polaris, locomotion), Unscoped-bounded capset variables in the JPEG upsampler, whole-union purity on jacinta's `Raw`, an explicit `ThrowTactic` in obligatory's RPC macro with the LSP proxies sealed under the file's existing confinement argument, and a val-bound deindexing in exoskeleton (upstream #26563).

**Tracking upstream 3.10 API drift** in the compiler-facing modules: null-safe `SourceFile.path` (beneficence plugin + seven staged-macro checks), the sanctioned `io.virtualDirectory` factory in anthology (backported to the 3.9 stream as `virtualdir`), an inlined `DottyUnpickler` body in delicious, and a positional argument in harlequin.

Resolves the Soundness side of #1410, #1411, #1412 and #1428 (details on each issue). Developed with LLM assistance (Claude); every change verified on both streams, most with standalone reproductions now in the proscala repo's docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)