### PR TITLE
Lift the spine of the build out from under gossamer

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1233,7 +1233,8 @@ object austronesian extends Library:
   object test extends Tests(core)
 
 object aviation extends Library:
-  object core extends Component(abacist.core, quantitative.units, cosmopolite.core):
+  object core extends Component(abacist.core, quantitative.units, cosmopolite.core,
+      contextual.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium")
   // WASI-backed monotonic clock: a `MonotonicClock` given whose reading is a Wasm Component Model
@@ -1576,13 +1577,12 @@ object denominative extends Library:
       settings.sep(super.scalacOptions())
 
 object digression extends Library:
-  object core extends Component(contingency.core, iridescence.core,
-      spectacular.core):
+  object core extends Component(contingency.core, spectacular.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // Rendering stack traces as ANSI tables, which is why `escapade.core` used to need both
   // `escritoire` and `digression`.
-  object ansi extends Component(core, escapade.core, escritoire.core):
+  object ansi extends Component(core, escapade.core, escritoire.core, iridescence.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object test extends Tests(core, ansi):
@@ -1971,7 +1971,8 @@ object geodesy extends Library:
       settings.sep(super.scalacOptions())
 
 object gesticulate extends Library:
-  object core extends Component(gossamer.core, anticipation.html, anticipation.path,
+  object core extends Component(gossamer.core, contextual.core, anticipation.html,
+      anticipation.path,
     turbulence.core, zephyrine.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
@@ -2021,7 +2022,7 @@ object graffiti extends Library:
       settings.sep(super.scalacOptions())
 
 object guillotine extends Library:
-  object core extends Component(turbulence.core, ambience.core):
+  object core extends Component(turbulence.core, ambience.core, contextual.core):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
@@ -2356,7 +2357,7 @@ object urticose extends Library:
   object core extends Component(gossamer.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
-  object url extends Component(anticipation.url, serpentine.core, core):
+  object url extends Component(anticipation.url, serpentine.core, contextual.core, core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // `Url` styling, which is all that `urticose` needed `escapade` (and hence `iridescence`) for.
@@ -3120,6 +3121,7 @@ object querencia extends Library:
 
 object xylophone extends Library:
   object core extends Component(zephyrine.core, adversaria.core, typonym.core, wisteria.core,
+      contextual.core,
       panopticon.core, turbulence.core, serpentine.core, gossamer.lexicon):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
@@ -3140,7 +3142,7 @@ object xylophone extends Library:
     def mvnDeps = Seq(mvn"org.scala-lang.modules::scala-xml:2.4.0")
 
 object yossarian extends Library:
-  object core extends Component(gossamer.core, turbulence.core):
+  object core extends Component(gossamer.core, turbulence.core, anticipation.color):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object test extends Tests(core):

--- a/build.mill
+++ b/build.mill
@@ -1578,7 +1578,7 @@ object denominative extends Library:
       settings.sep(super.scalacOptions())
 
 object digression extends Library:
-  object core extends Component(contingency.core, spectacular.core):
+  object core extends Component(contingency.core, spectacular.core, distillate.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // Rendering stack traces as ANSI tables, which is why `escapade.core` used to need both
@@ -1599,7 +1599,7 @@ object dissonance extends Library:
       settings.sep(super.scalacOptions())
 
 object distillate extends Library:
-  object core extends Component(digression.core, inimitable.core, wisteria.core):
+  object core extends Component(wisteria.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object test extends Tests(core, urticose.url)
@@ -1674,7 +1674,7 @@ object enigmatic extends Library:
     override def nativeModuleDeps = super.nativeModuleDeps :+ xenophile.scalanative.native
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
-  object test extends Tests(core, cose, openssl, x509):
+  object test extends Tests(core, cose, openssl, x509, gossamer.codec):
     // Not `settings.cc`: the suite's `NoPadding` tests trip the tactic-capturing
     // padding given (pure `using cipher` params can't accept capturing evidence
     // yet); `CaptureTests` opts into capture checking per-file instead. `-Ycc-new`
@@ -2193,7 +2193,7 @@ object imperial extends Library:
       settings.sep(super.scalacOptions())
 
 object inimitable extends Library:
-  object core extends Component(contingency.core, spectacular.core):
+  object core extends Component(distillate.core, contingency.core, spectacular.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object test extends Tests(core):
@@ -2717,7 +2717,8 @@ object sedentary extends Library:
       settings.sep(super.scalacOptions())
 
 object serpentine extends Library:
-  object core extends Component(nomenclature.core, anticipation.path, anticipation.print):
+  object core extends Component(nomenclature.core, anticipation.path, anticipation.print,
+      inimitable.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // The platform types (`Linux`, `Windows`, …) that the path-algebra tests exercise now live in

--- a/build.mill
+++ b/build.mill
@@ -726,7 +726,7 @@ object soundness extends Toolchain:
   object base extends Bundle(ambience.core, aperture.core, aviation.core, contextual.core,
     contingency.core, denominative.core, digression.core, diuretic.core, fulminate.core,
     hieroglyph.core, adversaria.core, turbulence.core, turbulence.stdio, eucalyptus.core,
-    gossamer.core, gossamer.lexicon,
+    gossamer.core, gossamer.codec, gossamer.lexicon,
     fulminate.print,
     inimitable.core, iridescence.core, kaleidoscope.core, mercator.core, nomenclature.core,
     nomenclature.lexicon,
@@ -1059,7 +1059,8 @@ object adversaria extends Library:
       settings.sep(super.scalacOptions())
 
 object ambience extends Library:
-  object core extends Component(anticipation.path, anticipation.print, gossamer.core):
+  object core extends Component(anticipation.path, anticipation.print, gossamer.core,
+      distillate.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // WASI-backed environment: an `Environment` given whose variables come from a Wasm Component
@@ -1505,7 +1506,7 @@ object corpuscular extends Library:
       settings.sep(super.scalacOptions())
 
 object cosmopolite extends Library:
-  object core extends Component(gossamer.core):
+  object core extends Component(distillate.core, gossamer.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object test extends Tests(core):
@@ -1963,7 +1964,7 @@ object geodesy extends Library:
   object angle extends Component(hypotenuse.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
-  object core extends Component(angle, gossamer.core):
+  object core extends Component(distillate.core, angle, gossamer.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object test extends Tests(core, angle):
@@ -1999,7 +2000,14 @@ object gnossienne extends Library:
       settings.sep(super.scalacOptions())
 
 object gossamer extends Library:
-  object core extends Component(hieroglyph.core, kaleidoscope.core, spectacular.core, hypotenuse.core, distillate.core):
+  object core extends Component(hieroglyph.core, kaleidoscope.core, spectacular.core,
+      hypotenuse.core):
+    override def scalacOptions = Task:
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
+  // Decoding `Text` from bytes and naming enum cases: gossamer's only uses of distillate,
+  // and so the component that keeps distillate (with digression, inimitable and wisteria
+  // behind it) out of the closure of everything that merely handles text.
+  object codec extends Component(core, distillate.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // Word-lookup structures — an Aho-Corasick `Dictionary` and a fuzzy-search `Lexicon` — which
@@ -2266,7 +2274,7 @@ object legerdemain extends Library:
   // The `Query` type and its `Parametric` typeclass: the form-encoded half of the library, with
   // no HTML in it. `telekinesis` needs only this, so keeping it out of `core` takes the whole
   // HTML/XML stack off the HTTP-client path.
-  object query extends Component(gossamer.core):
+  object query extends Component(gossamer.core, distillate.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object core extends Component(honeycomb.core, anamnesis.core, query):
@@ -2354,7 +2362,7 @@ object mosquito extends Library:
       settings.sep(super.scalacOptions())
 
 object urticose extends Library:
-  object core extends Component(gossamer.core):
+  object core extends Component(distillate.core, gossamer.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object url extends Component(anticipation.url, serpentine.core, contextual.core, core):
@@ -2369,7 +2377,7 @@ object urticose extends Library:
       settings.sep(super.scalacOptions())
 
 object nomenclature extends Library:
-  object core extends Component(gossamer.core):
+  object core extends Component(gossamer.core, distillate.core):
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
@@ -2567,7 +2575,7 @@ object probably extends Library:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // The scoverage `Invoker`'s initializer needs `SecureRandom` (absent on Scala Native), so
   // the measurement-file lookup is split by platform (`coverage-jvm`/`coverage-native`).
-  object coverage extends Component(dendrology.tree):
+  object coverage extends Component(distillate.core, digression.core, dendrology.tree):
     override def sources = Task.Sources(moduleDir, moduleDir / os.up / "coverage-jvm")
     override def nativeSources = Task.Sources(moduleDir, moduleDir / os.up / "coverage-native")
     override def scalacOptions = Task:

--- a/lib/digression/src/ansi/digression_ansi.scala
+++ b/lib/digression/src/ansi/digression_ansi.scala
@@ -45,10 +45,41 @@ import rudiments.*
 import spectacular.*
 import vacuous.*
 
+trait StackTracePalette extends iridescence.Palette:
+  type Form = Srgb
+  def message:   Color in Srgb
+  def file:      Color in Srgb
+  def method:    Color in Srgb
+  def line:      Color in Srgb
+  def separator: Color in Srgb
+  def accent1:   Color in Srgb
+  def accent2:   Color in Srgb
+  def accent3:   Color in Srgb
+  def accent4:   Color in Srgb
+  def accent5:   Color in Srgb
+
+object StackTracePalette:
+  private def hex(n: Int): Color in Srgb =
+    Srgb(((n >> 16) & 255)/255.0, ((n >> 8) & 255)/255.0, (n & 255)/255.0)
+
+  given default: StackTracePalette = new StackTracePalette:
+    def background: Color in Srgb = hex(0x000000)
+    def foreground: Color in Srgb = hex(0xffffff)
+    def message:    Color in Srgb = hex(0xffffff)
+    def file:       Color in Srgb = hex(0x5f9e9f)
+    def method:     Color in Srgb = hex(0xabcfdf)
+    def line:       Color in Srgb = hex(0x47d1cc)
+    def separator:  Color in Srgb = hex(0x808080)
+    def accent1:    Color in Srgb = hex(0xf84020)
+    def accent2:    Color in Srgb = hex(0xd88600)
+    def accent3:    Color in Srgb = hex(0xfefe00)
+    def accent4:    Color in Srgb = hex(0xfeae00)
+    def accent5:    Color in Srgb = hex(0xaefe00)
+
 given exceptionTeletype: (Text is Measurable, StackTrace.Resolver) => Exception is Teletypeable =
   exception => summon[StackTrace is Teletypeable].teletype(StackTrace(exception))
 
-given stackTraceTeletype: (Text is Measurable) => (palette: StackTrace.Palette)
+given stackTraceTeletype: (Text is Measurable) => (palette: StackTracePalette)
 =>  StackTrace is Teletypeable = stack =>
 
   // A static match, not `selectDynamic(s"accent$n")`: structural selection reflects through
@@ -163,7 +194,7 @@ given stackTraceTeletype: (Text is Measurable) => (palette: StackTrace.Palette)
 
   stack.cause.lay(root): cause => e"$root\n${palette.message}(caused by:)\n$cause"
 
-given frameTeletype: (Text is Measurable) => (palette: StackTrace.Palette)
+given frameTeletype: (Text is Measurable) => (palette: StackTracePalette)
 =>  StackTrace.Frame is Teletypeable = frame =>
 
   val className = e"${palette.method}(${frame.displayClass.fit(40, Rtl)})"
@@ -172,7 +203,7 @@ given frameTeletype: (Text is Measurable) => (palette: StackTrace.Palette)
   val line = e"${palette.line}(${frame.line.let(_.show).or(t"?")})"
   e"$className${palette.separator}( ⌗ )$method $file${palette.separator}(:)$line"
 
-given methodTeletype: (palette: StackTrace.Palette) => StackTrace.Method is Teletypeable = method =>
+given methodTeletype: (palette: StackTracePalette) => StackTrace.Method is Teletypeable = method =>
   val className = e"${palette.method}(${method.className})"
   val methodName = e"${palette.method}(${method.method})"
   e"$className${palette.separator}( ⌗ )$methodName"

--- a/lib/digression/src/ansi/soundness_digression_ansi.scala
+++ b/lib/digression/src/ansi/soundness_digression_ansi.scala
@@ -32,4 +32,5 @@
                                                                                                   */
 package soundness
 
-export digression.{exceptionTeletype, frameTeletype, methodTeletype, stackTraceTeletype}
+export digression.{exceptionTeletype, frameTeletype, methodTeletype, StackTracePalette,
+    stackTraceTeletype}

--- a/lib/digression/src/core/digression.Fqcn.scala
+++ b/lib/digression/src/core/digression.Fqcn.scala
@@ -34,14 +34,23 @@ package digression
 
 import proscenium.compat.*
 
+import scala.caps
+
 import anticipation.*
 import denominative.*
 import contingency.*
+import distillate.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
 
 object Fqcn:
+  // Decoding a `Fqcn` from `Text`, in `Fqcn`'s own companion rather than distillate's
+  // `Decodable`, so that distillate need not depend on digression.
+  given decodable: (tactic: Tactic[FqcnError]^)
+  =>  ((Fqcn is Decodable in Text)^{tactic, caps.any}) =
+    Fqcn(_)
+
   def valid(char: Char): Boolean =
     char >= 'A' && char <= 'Z' || char >= 'a' && char <= 'z' || char >= '0' && char <= '9' ||
       char == '_' || char == '$'

--- a/lib/digression/src/core/digression.StackTrace.scala
+++ b/lib/digression/src/core/digression.StackTrace.scala
@@ -34,7 +34,6 @@ package digression
 
 import anticipation.*
 import fulminate.*
-import iridescence.*
 import prepositional.*
 import proscenium.compat.*
 import rudiments.*
@@ -131,36 +130,6 @@ object StackTrace:
         s"$msg\n  at $classPad$className$dot$method$methodPad $file:$line$code".tt
 
     stack.cause.lay(root): cause => s"$root\ncaused by:\n$cause".tt
-
-  trait Palette extends iridescence.Palette:
-    type Form = Srgb
-    def message:   Color in Srgb
-    def file:      Color in Srgb
-    def method:    Color in Srgb
-    def line:      Color in Srgb
-    def separator: Color in Srgb
-    def accent1:   Color in Srgb
-    def accent2:   Color in Srgb
-    def accent3:   Color in Srgb
-    def accent4:   Color in Srgb
-    def accent5:   Color in Srgb
-
-  private def hex(n: Int): Color in Srgb =
-    Srgb(((n >> 16) & 255)/255.0, ((n >> 8) & 255)/255.0, (n & 255)/255.0)
-
-  given defaultPalette: StackTrace.Palette = new Palette:
-    def background: Color in Srgb = hex(0x000000)
-    def foreground: Color in Srgb = hex(0xffffff)
-    def message:    Color in Srgb = hex(0xffffff)
-    def file:       Color in Srgb = hex(0x5f9e9f)
-    def method:     Color in Srgb = hex(0xabcfdf)
-    def line:       Color in Srgb = hex(0x47d1cc)
-    def separator:  Color in Srgb = hex(0x808080)
-    def accent1:    Color in Srgb = hex(0xf84020)
-    def accent2:    Color in Srgb = hex(0xd88600)
-    def accent3:    Color in Srgb = hex(0xfefe00)
-    def accent4:    Color in Srgb = hex(0xfeae00)
-    def accent5:    Color in Srgb = hex(0xaefe00)
 
   val legend: Map[Text, Text] =
     Map

--- a/lib/distillate/src/core/distillate.Decodable.scala
+++ b/lib/distillate/src/core/distillate.Decodable.scala
@@ -40,8 +40,6 @@ import scala.caps
 
 import anticipation.*
 import contingency.*
-import digression.*
-import inimitable.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -58,11 +56,6 @@ object Decodable extends Decodable2:
     text =>
       try Integer.parseInt(text.s) catch case _: NumberFormatException =>
         abort(NumberError(text, Int, NumberError.Reason.Unparseable))
-
-  given fqcn: (tactic: Tactic[FqcnError]^) => ((Fqcn is Decodable in Text)^{tactic, caps.any}) =
-    Fqcn(_)
-  given uuid: (tactic: Tactic[UuidError]^) => ((Uuid is Decodable in Text)^{tactic, caps.any}) =
-    Uuid.parse(_)
 
   given byte: (tactic: Tactic[NumberError]^)
   =>  ((Byte is Decodable in Text)^{tactic, caps.any}) =

--- a/lib/gossamer/src/codec/gossamer_codec.scala
+++ b/lib/gossamer/src/codec/gossamer_codec.scala
@@ -30,31 +30,35 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package gossamer
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, blank, BoundsError,
-      broken, build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, chomp,
-      contains, count, cut, Cuttable, Decimalizer, ends, erase, extract, fill, fit,
-      from,
-      fuzzy, Grapheme, init, join, Joinable, kebab, keep, length, lines, lower,
-      Ltr, Numerous, ossify, pad, pascal, plain, Proximity, proximity, Pue, pue, punycode,
-      RangeError, reversibleTextual, Rtl, search, offsetOf, SimpleTExtractor, skip, slices, snake, snip,
-      spaced, starts, sub, subscripts, superscripts, sysData, t, tail, text,
-      TextBuilder,
-      Textual, tr, trim, txt, uncamel, uncapitalize, unkebab, unsnake, upper, upto, urlDecode,
-      urlEncode, utf16, utf8, pinpoint, words, Writing, WritingBuilder, a, justify, punch }
+import proscenium.compat.*
 
-package decimalConverters:
-  export gossamer.decimalConverters.javaDecimalConverter
+import scala.reflect
 
-package proximities:
-  export gossamer.proximities.jaroProximity
-  export gossamer.proximities.jaroWinklerProximity
-  export gossamer.proximities.prefixProximity
-  export gossamer.proximities.levenshteinProximity
-  export gossamer.proximities.normalizedLevenshteinProximity
+import anticipation.*
+import distillate.*
+import hieroglyph.*
+import prepositional.*
 
-package caseSensitivity:
-  export gossamer.caseSensitivity.{caseInsensitive, caseSensitive, smartCase}
+// The distillate-facing half of gossamer: decoding `Text` from bytes, and naming enum cases
+// in the usual capitalisation styles. Splitting it out is what keeps `distillate` — and with
+// it digression, inimitable and wisteria — out of the closure of every module that only needs
+// text.
+
+// Character decoding as a `Decodable`, so `data.as[Text]` decodes bytes to text through the
+// `CharDecoder` in scope — the counterpart of `Text is Encodable in Data` (a `CharEncoder`).
+given textDecodable: (decoder: CharDecoder) => Text is Decodable in Data = decoder.decoded(_)
+
+package enumIdentification:
+  given kebabCaseIdentifiable: [enumeration <: reflect.Enum] => enumeration is Identifiable =
+    Identifiable(_.uncamel.stdlib.kebab, _.unkebab.stdlib.pascal)
+
+  given snakeCaseIdentifiable: [enumeration <: reflect.Enum] => enumeration is Identifiable =
+    Identifiable(_.uncamel.stdlib.snake, _.unsnake.stdlib.pascal)
+
+  given pascalCaseIdentifiable: [enumeration <: reflect.Enum] => enumeration is Identifiable =
+    Identifiable(identity(_), identity(_))
+
+  given camelCaseIdentifiable: [enumeration <: reflect.Enum] => enumeration is Identifiable =
+    Identifiable(_.uncamel.stdlib.camel, _.unsnake.stdlib.pascal)

--- a/lib/gossamer/src/codec/soundness_gossamer_codec.scala
+++ b/lib/gossamer/src/codec/soundness_gossamer_codec.scala
@@ -32,29 +32,10 @@
                                                                                                   */
 package soundness
 
-export
-  gossamer
-  . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, blank, BoundsError,
-      broken, build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, chomp,
-      contains, count, cut, Cuttable, Decimalizer, ends, erase, extract, fill, fit,
-      from,
-      fuzzy, Grapheme, init, join, Joinable, kebab, keep, length, lines, lower,
-      Ltr, Numerous, ossify, pad, pascal, plain, Proximity, proximity, Pue, pue, punycode,
-      RangeError, reversibleTextual, Rtl, search, offsetOf, SimpleTExtractor, skip, slices, snake, snip,
-      spaced, starts, sub, subscripts, superscripts, sysData, t, tail, text,
-      TextBuilder,
-      Textual, tr, trim, txt, uncamel, uncapitalize, unkebab, unsnake, upper, upto, urlDecode,
-      urlEncode, utf16, utf8, pinpoint, words, Writing, WritingBuilder, a, justify, punch }
+export gossamer.textDecodable
 
-package decimalConverters:
-  export gossamer.decimalConverters.javaDecimalConverter
-
-package proximities:
-  export gossamer.proximities.jaroProximity
-  export gossamer.proximities.jaroWinklerProximity
-  export gossamer.proximities.prefixProximity
-  export gossamer.proximities.levenshteinProximity
-  export gossamer.proximities.normalizedLevenshteinProximity
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{caseInsensitive, caseSensitive, smartCase}
+package enumIdentification:
+  export gossamer.enumIdentification.kebabCaseIdentifiable
+  export gossamer.enumIdentification.pascalCaseIdentifiable
+  export gossamer.enumIdentification.snakeCaseIdentifiable
+  export gossamer.enumIdentification.camelCaseIdentifiable

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -50,7 +50,6 @@ import scala.reflect.*
 
 import anticipation.*
 import denominative.*
-import distillate.*
 import fulminate.*
 import hieroglyph.*
 import hypotenuse.*
@@ -118,10 +117,6 @@ extension (inline context: StringContext)
 
 extension (context: StringContext)
   def t = SimpleTExtractor(context.parts.head.tt)
-
-// Character decoding as a `Decodable`, so `data.as[Text]` decodes bytes to text through the
-// `CharDecoder` in scope — the counterpart of `Text is Encodable in Data` (a `CharEncoder`).
-given textDecodable: (decoder: CharDecoder) => Text is Decodable in Data = decoder.decoded(_)
 
 extension (bytes: Data)
   def utf8: Text = String(Array.unsafeJvm(bytes), "UTF-8").tt
@@ -610,19 +605,6 @@ extension (builder: StringBuilder)
 package decimalConverters:
   given javaDecimalConverter: DecimalConverter:
     def decimalize(double: Double): Text = double.toString.tt
-
-package enumIdentification:
-  given kebabCaseIdentifiable: [enumeration <: reflect.Enum] => enumeration is Identifiable =
-    Identifiable(_.uncamel.stdlib.kebab, _.unkebab.stdlib.pascal)
-
-  given snakeCaseIdentifiable: [enumeration <: reflect.Enum] => enumeration is Identifiable =
-    Identifiable(_.uncamel.stdlib.snake, _.unsnake.stdlib.pascal)
-
-  given pascalCaseIdentifiable: [enumeration <: reflect.Enum] => enumeration is Identifiable =
-    Identifiable(identity(_), identity(_))
-
-  given camelCaseIdentifiable: [enumeration <: reflect.Enum] => enumeration is Identifiable =
-    Identifiable(_.uncamel.stdlib.camel, _.unsnake.stdlib.pascal)
 
 package caseSensitivity:
   given caseSensitive: CaseSensitivity = _ == _

--- a/lib/inimitable/src/core/inimitable.Uuid.scala
+++ b/lib/inimitable/src/core/inimitable.Uuid.scala
@@ -34,8 +34,11 @@ package inimitable
 
 import java.util as ju
 
+import scala.caps
+
 import anticipation.*
 import contingency.*
+import distillate.*
 import fulminate.*
 import prepositional.*
 import rudiments.*
@@ -43,6 +46,12 @@ import spectacular.*
 import vacuous.*
 
 object Uuid extends Extractor[Text, Uuid]:
+  // Decoding a `Uuid` from `Text`, kept in `Uuid`'s companion for the same reason as
+  // `Fqcn.decodable`: distillate need not depend on inimitable.
+  given decodable: (tactic: Tactic[UuidError]^)
+  =>  ((Uuid is Decodable in Text)^{tactic, caps.any}) =
+    Uuid.parse(_)
+
   // In `Uuid`'s own companion rather than `Showable`'s, so that `spectacular` need not depend on
   // `inimitable`; being companion-to-companion, this is the same implicit scope as before.
   given showable: Uuid is Showable = _.text

--- a/lib/probably/src/core/probably.AnsiRenderer.scala
+++ b/lib/probably/src/core/probably.AnsiRenderer.scala
@@ -134,7 +134,7 @@ private[probably] object AnsiRenderer:
       e"$sign${datum(inner)}"
 
   private def accent(level: Int): Color in Srgb =
-    val stackPalette = summon[StackTrace.Palette]
+    val stackPalette = summon[StackTracePalette]
 
     (level%5) + 1 match
       case 1 => stackPalette.accent1
@@ -352,7 +352,7 @@ private[probably] object AnsiRenderer:
         title.let: id => Out.println(e"$Bold(${Fg(palette.foreground)}(${id.name}))")
 
         val max = frames.stdlib.map(_.samples).maxOption.getOrElse(0L)
-        val stackPalette = summon[StackTrace.Palette]
+        val stackPalette = summon[StackTracePalette]
 
         // The digression convention: packages in first-appearance order take the accent
         // colours cyclically, exactly as coloured stack traces do.


### PR DESCRIPTION
`gossamer.core` has fan-in 44, so everything beneath it is compiled by most of the tree — and what sat beneath it turned out to rest on a handful of relocatable givens. Three legs, each independently verified: the stack-trace palette moves from `digression.core` to `digression.ansi`, where stack traces are actually rendered; gossamer's five distillate-facing givens become a new `gossamer.codec`; and the `Fqcn` and `Uuid` text decoders move into their own types' companions, inverting distillate's edges to digression and inimitable. Together these take the critical path from 26 components to 23 and remove distillate, digression, iridescence and geodesy from the deepest chain entirely.

## Release notes

Two changes are visible in source. The stack-trace palette is now `digression.StackTracePalette` rather than `StackTrace.Palette`, and lives in the `digression.ansi` component; it could not keep its old name, since a second `object StackTrace` in the package is illegal. Gossamer's `textDecodable` given and the `enumIdentification` instances now live in a new `gossamer.codec` component — code using them through the `soundness` umbrella is unaffected, but a project depending on `gossamer.core` directly and decoding `Text` from bytes will need to add it. Every other given keeps its implicit scope, so no call site needs a new import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)