### PR TITLE
Rename the section-key axis from world to realm

### DIFF
--- a/lib/degustation/src/lira/degustation.Tasty.scala
+++ b/lib/degustation/src/lira/degustation.Tasty.scala
@@ -57,7 +57,7 @@ object Tasty extends Discipline:
   // inherited member need not be re-atomized under each type that presents it. Classfile-level
   // linkage is the JVM ecosystem profile's, not this discipline's, so only the TASTy level is
   // certified here.
-  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"jvm", t"sjsir", t"nir"))
+  def domain: Discipline.Domain = Discipline.Domain.Realms(Set(t"jvm", t"sjsir", t"nir"))
   def keying: Discipline.Keying = Discipline.Keying.Declaration
 
   def guarantees(universe: Text): Set[Discipline.Guarantee] =

--- a/lib/degustation/src/test/degustation_test.scala
+++ b/lib/degustation/src/test/degustation_test.scala
@@ -355,7 +355,7 @@ object Tests extends Suite(m"Degustation Tests"):
 
       (lira.manifest.module,
        lira.manifest.api.stdlib.map(_.discipline),
-       lira.manifest.section.stdlib.map(_.world),
+       lira.manifest.section.stdlib.map(_.realm),
        lira.manifest.section.stdlib.forall(_.derivative.present),
        report.atomizations.stdlib.map(_.discipline))
     . assert(_ == (t"fixture-core", scala.List(t"tasty/1"), scala.List(t"jvm"), true,
@@ -396,15 +396,15 @@ object Tests extends Suite(m"Degustation Tests"):
             List(jvmInput, sjsInput),
             registry,
             toolchain = List(LiraBundle.tool[Universe.Classfile](t"3.9.0")),
-            classpath = { input => contextClasspath(input.world) } )
+            classpath = { input => contextClasspath(input.realm) } )
 
         val lira = Lira.read(bytes)
         val report = Verification.install(lira)
-        val sjsSection = lira.manifest.section.stdlib.find(_.world == t"sjsir")
+        val sjsSection = lira.manifest.section.stdlib.find(_.realm == t"sjsir")
 
-        (lira.manifest.section.stdlib.map(_.world),
-         report.materialized.stdlib.map(_(0).world),
-         report.materialized.stdlib.find(_(0).world == t"sjsir")
+        (lira.manifest.section.stdlib.map(_.realm),
+         report.materialized.stdlib.map(_(0).realm),
+         report.materialized.stdlib.find(_(0).realm == t"sjsir")
            . map(_(1).entries.stdlib.exists(_.path.text.s.endsWith(".sjsir"))))
       . assert(_ == (scala.List(t"jvm", t"sjsir"), scala.List(t"jvm", t"sjsir"),
           scala.Some(true)))

--- a/lib/mandible/src/lira/mandible.ClassfileDiscipline.scala
+++ b/lib/mandible/src/lira/mandible.ClassfileDiscipline.scala
@@ -59,7 +59,7 @@ object ClassfileDiscipline extends Discipline:
   // Classfiles exist in the `jvm` universe alone; `sjsir` and `nir` have no counterpart to
   // compare against, so the cross-section invariant (§9.6) is vacuous here and correctly so. A
   // single-universe domain is exactly the case §11.2 requirement 1 exempts from it.
-  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"jvm"))
+  def domain: Discipline.Domain = Discipline.Domain.Realms(Set(t"jvm"))
 
   // §11.2 requirement 4: a JVM call site names the receiver, not the declarer, so a type's
   // linkage surface includes members it inherits. Declaration keying would be unsound for a

--- a/lib/mandible/src/lira/mandible.JsigDiscipline.scala
+++ b/lib/mandible/src/lira/mandible.JsigDiscipline.scala
@@ -55,13 +55,13 @@ object JsigDiscipline extends Discipline:
 
   // Host contracts carried as signature stubs are the motivating case; the `jvm` inclusion
   // admits a library whose interface carrier genuinely is Java signatures.
-  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"jvm", t"host"))
+  def domain: Discipline.Domain = Discipline.Domain.Realms(Set(t"jvm", t"host"))
 
   // A call site names the receiver, so a type's contract surface includes what it presents —
   // sound here as it is for `classfile/1`, and required for the same reason.
   def keying: Discipline.Keying = Discipline.Keying.Membership
 
-  def guarantees(world: Text): Set[Discipline.Guarantee] =
+  def guarantees(realm: Text): Set[Discipline.Guarantee] =
     Set(Discipline.Guarantee.Recompilation)
 
   // `.sig` is the JDK's own spelling for signature classfiles; the format is the classfile

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -509,7 +509,7 @@ object Tests extends Suite(m"Mandible tests"):
 
     // --- jsig/1 and host contracts ------------------------------------------------------------
 
-    test(m"jsig claims signature files and classfiles in both its worlds"):
+    test(m"jsig claims signature files and classfiles in both its realms"):
       val data = Array.freeze(Array[Byte](0))
 
       (JsigDiscipline.claims(TreePath(t"java.base/java/lang/Object.sig"), data),

--- a/lib/reliquary/res/test/reliquary/lira.tel
+++ b/lib/reliquary/res/test/reliquary/lira.tel
@@ -1,8 +1,8 @@
 tel 1.0
 
-# The `lira` manifest schema (LIRA specification §14: `jvm | sjsir | nir | host` worlds,
+# The `lira` manifest schema (LIRA specification §14: `jvm | sjsir | nir | host` realms,
 # optional numeric-only `version`, dependencies scoped by universe and integration or
-# `build`-pinned, sections keyed by world and integration with `derivative` hashes and host
+# `build`-pinned, sections keyed by realm and integration with `derivative` hashes and host
 # `requires` records, `resource` claims for the resource/1 discipline, and ecosystem `profile`
 # claims). This document is the canonical mirror of the hand-encoded `LiraSchemas.lira`;
 # reliquary's test suite asserts the two are structurally identical and pins this document's
@@ -50,7 +50,7 @@ record Requires
   field uses Hash optional
 
 record Section
-  select World
+  select Realm
   field integration Identifier optional
   field tree Hash
   field delete String optional repeatable
@@ -98,7 +98,7 @@ scalar TreePath
 scalar Guarantee
   validate guarantee
 
-select World
+select Realm
   variant jvm Flag
   variant sjsir Flag
   variant nir Flag

--- a/lib/reliquary/src/core/reliquary.Buildpath.scala
+++ b/lib/reliquary/src/core/reliquary.Buildpath.scala
@@ -265,7 +265,7 @@ case class Buildpath(releases: List[LiraManifest]):
             if target != universe && !joins.stdlib.contains(target)
             then abort(LiraError(Reason.AbsentDependency(dependency.module)))
 
-            if !candidate.section.stdlib.exists(_.world == target)
+            if !candidate.section.stdlib.exists(_.realm == target)
             then abort(LiraError(Reason.AbsentDependency(dependency.module)))
 
           if !requirementMet(dependency, candidate)
@@ -289,7 +289,7 @@ case class Buildpath(releases: List[LiraManifest]):
       val served = serving(universe, manifest.module)
 
       manifest.section.stdlib.filter: section =>
-        section.world == served
+        section.realm == served
         && section.integration.option == assignment(manifest.module).option
 
   // The host-contract modules the selected sections' `requires` records name — the modules rule

--- a/lib/reliquary/src/core/reliquary.CapabilityDiscipline.scala
+++ b/lib/reliquary/src/core/reliquary.CapabilityDiscipline.scala
@@ -59,14 +59,14 @@ object CapabilityDiscipline extends Discipline:
 
   def claims(path: TreePath, data: Data): Boolean = path.text == t"capabilities"
 
-  // The single world `{host}`: capability listings describe environments, never libraries, and
+  // The single realm `{host}`: capability listings describe environments, never libraries, and
   // L127 rejects a library release that declares this discipline.
-  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"host"))
+  def domain: Discipline.Domain = Discipline.Domain.Realms(Set(t"host"))
   def keying: Discipline.Keying = Discipline.Keying.Declaration
 
   // Presence, on the same terms as `resource/1` — the recompilation level for content addressed
   // by name, and the only level "the command exists" can mean.
-  def guarantees(world: Text): Set[Discipline.Guarantee] =
+  def guarantees(realm: Text): Set[Discipline.Guarantee] =
     Set(Discipline.Guarantee.Recompilation)
 
   private def malformed(detail: Text): DisciplineError =

--- a/lib/reliquary/src/core/reliquary.Discipline.scala
+++ b/lib/reliquary/src/core/reliquary.Discipline.scala
@@ -40,27 +40,27 @@ import vacuous.*
 
 object Discipline:
   // What a compiler-based discipline needs beyond the content itself: which section is being
-  // atomized — its world and, where the release offers alternative dependency vectors (§9.5),
+  // atomized — its realm and, where the release offers alternative dependency vectors (§9.5),
   // its integration — and the dependency classpath materialized from the buildpath (entries as
   // textual paths, so the core stays platform-light). The classpath is a property of the
   // integration, which is why atomization is per-section and not per-universe.
   case class Context
-    ( world:       Text,
+    ( realm:       Text,
       integration: Optional[Text] = Unset,
       classpath:   List[Text]     = List() )
 
-  // The worlds a discipline atomizes at all (§11.2, requirement 1): universes, and possibly the
-  // `host` world (hosts.md). A universal discipline atomizes whatever world it is given — which
-  // is `dts/1`'s case, and brings host contracts within its reach; a world-specific one names
-  // its worlds, and the cross-section invariant (§9.6) is vacuous outside them. Claiming
-  // nothing in a world outside the domain is not the same as claiming content atomless.
+  // The realms a discipline atomizes at all (§11.2, requirement 1): universes, and possibly the
+  // `host` realm (hosts.md). A universal discipline atomizes whatever realm it is given — which
+  // is `dts/1`'s case, and brings host contracts within its reach; a realm-specific one names
+  // its realms, and the cross-section invariant (§9.6) is vacuous outside them. Claiming
+  // nothing in a realm outside the domain is not the same as claiming content atomless.
   enum Domain:
     case Universal
-    case Worlds(names: Set[Text])
+    case Realms(names: Set[Text])
 
-    def covers(world: Text): Boolean = this match
+    def covers(realm: Text): Boolean = this match
       case Universal     => true
-      case Worlds(names) => names.stdlib.contains(world)
+      case Realms(names) => names.stdlib.contains(realm)
 
   // Whether an atom's key names the type that *declares* a member, or every type that *presents*
   // it after inheritance (§11.2, requirement 4). Declaration keying is sound exactly where every
@@ -95,7 +95,7 @@ object Discipline:
 
       val results = all.stdlib.map: discipline =>
         val (claimed, rest) =
-          if !discipline.domain.covers(context.world) then (scala.Nil, remaining)
+          if !discipline.domain.covers(context.realm) then (scala.Nil, remaining)
           else remaining.partition: (path, data) => discipline.claims(path, data)
 
         remaining = rest

--- a/lib/reliquary/src/core/reliquary.EcosystemProfile.scala
+++ b/lib/reliquary/src/core/reliquary.EcosystemProfile.scala
@@ -46,7 +46,7 @@ object EcosystemProfile:
   // is handed, because a profile that checks structural invariants over a universe's content
   // (§11.6, clause 2) needs exactly what a discipline over that universe would need.
   case class Section
-    ( world:       Text,
+    ( realm:       Text,
       content:     List[(TreePath, Data)],
       integration: Optional[Text] = Unset,
       classpath:   List[Text]     = List() )
@@ -59,8 +59,8 @@ object EcosystemProfile:
     ( sections: List[Section],
       manifest: Optional[LiraManifest] = Unset ):
 
-    def section(world: Text): Optional[Section] =
-      sections.stdlib.find { section => section.world == world }.getOrElse(Unset)
+    def section(realm: Text): Optional[Section] =
+      sections.stdlib.find { section => section.realm == realm }.getOrElse(Unset)
 
   // A predicate failure, at the guarantee level it breaks. A profile reports what it found; the
   // audit below decides whether the release accounted for it.

--- a/lib/reliquary/src/core/reliquary.LiraManifest.scala
+++ b/lib/reliquary/src/core/reliquary.LiraManifest.scala
@@ -252,11 +252,11 @@ object LiraManifest:
           label = field(fields, t"label") )
 
     val section = top.filter(_.keyword == t"section").map: compound =>
-      val world = texts(compound) match
-        case scala.collection.immutable.Vector(world) => world
+      val realm = texts(compound) match
+        case scala.collection.immutable.Vector(realm) => realm
 
         case _ =>
-          abort(bad(t"a section needs exactly one world"))
+          abort(bad(t"a section needs exactly one realm"))
 
       val fields = children(compound)
 
@@ -270,7 +270,7 @@ object LiraManifest:
             uses    = field(subfields, t"uses").let(hash(_)) )
 
       Section
-        ( world       = world,
+        ( realm       = realm,
           integration = field(fields, t"integration"),
           tree        = hash(required(fields, t"tree")),
           delete      = List.from(repeated(fields, t"delete").map(TreePath(_))),
@@ -342,7 +342,7 @@ case class LiraManifest
 
   // A release carrying a `host` section is a host contract (§9.4, hosts.md §4) — recognizable
   // from its manifest alone, which is what makes L137 checkable at resolution time.
-  def hostContract: Boolean = section.stdlib.exists(_.world == t"host")
+  def hostContract: Boolean = section.stdlib.exists(_.realm == t"host")
 
   // The canonical text of the whole file's manifest part: directive, pragma, one blank line,
   // then the compounds in schema order, LF-terminated. Deterministic; `Lira.read` accepts any
@@ -409,7 +409,7 @@ case class LiraManifest
     delta.let: delta => lines += s"delta ${LiraHash.text(delta)}"
 
     section.stdlib.foreach: section =>
-      lines += s"section ${section.world}"
+      lines += s"section ${section.realm}"
       section.integration.let: id => lines += s"  integration $id"
       lines += s"  tree ${LiraHash.text(section.tree)}"
       section.delete.stdlib.foreach: path => lines += s"  delete ${path.text}"

--- a/lib/reliquary/src/core/reliquary.LiraRealm.scala
+++ b/lib/reliquary/src/core/reliquary.LiraRealm.scala
@@ -36,20 +36,20 @@ import anticipation.*
 import gossamer.*
 import vacuous.*
 
-object LiraWorld:
-  def parse(keyword: Text): Optional[LiraWorld] = keyword.s match
+object LiraRealm:
+  def parse(keyword: Text): Optional[LiraRealm] = keyword.s match
     case "jvm"   => Jvm
     case "sjsir" => Sjsir
     case "nir"   => Nir
     case "host"  => Host
     case _       => Unset
 
-// The worlds of the base `lira` schema (§9.4): the three universes of the motivating ecosystem —
-// the library-composition worlds a section's content belongs to — and `host`, the one world that
+// The realms of the base `lira` schema (§9.4): the three universes of the motivating ecosystem —
+// the library-composition realms a section's content belongs to — and `host`, the one realm that
 // is not a universe, holding a host contract's capability content (hosts.md). The universe
 // vocabulary is open — universes beyond these arrive as TEL schema layers, and sections of
-// unknown worlds are held opaque and never materialized.
-enum LiraWorld:
+// unknown realms are held opaque and never materialized.
+enum LiraRealm:
   case Jvm, Sjsir, Nir, Host
 
   def keyword: Text = this match
@@ -58,6 +58,6 @@ enum LiraWorld:
     case Nir   => t"nir"
     case Host  => t"host"
 
-  // Whether independently-published libraries compose in this world: true of every world except
+  // Whether independently-published libraries compose in this realm: true of every realm except
   // `host`, whose sections are never materialized onto any artifact path (§13.5).
   def universe: Boolean = this != Host

--- a/lib/reliquary/src/core/reliquary.LiraSchemas.scala
+++ b/lib/reliquary/src/core/reliquary.LiraSchemas.scala
@@ -43,9 +43,9 @@ import vacuous.*
 // canonical `.tel` document (at `res/test/reliquary/`) verbatim; the test suite asserts the two
 // stay in agreement and pins each schema's signature as a golden value.
 //
-// The schemas encode the LIRA specification's §14: worlds are `jvm | sjsir | nir | host` — the
-// three universes of the motivating ecosystem, and the one world that is not a universe, which
-// holds a host contract's content (hosts.md); a `Section` is keyed by world and integration
+// The schemas encode the LIRA specification's §14: realms are `jvm | sjsir | nir | host` — the
+// three universes of the motivating ecosystem, and the one realm that is not a universe, which
+// holds a host contract's content (hosts.md); a `Section` is keyed by realm and integration
 // (§9.5), may carry a `derivative` hash (its canonical derived JAR), and may carry `requires`
 // records naming the host contracts its code assumes; a `version` is optional (a release
 // without one is a development release) and strictly numeric; a `Dependency` may be scoped to
@@ -167,7 +167,7 @@ object LiraSchemas:
         field("uses", hash, required = Loose)),
 
       record("Section",
-        selectRef("World"),
+        selectRef("Realm"),
         field("integration", identifier, required = Loose),
         field("tree", hash),
         field("delete", string, required = Loose, repeatable = Loose),
@@ -196,7 +196,7 @@ object LiraSchemas:
       scalar("TreePath", "tree-path"),
       scalar("Guarantee", "guarantee")),
     selects  = Array.of(
-      select("World",
+      select("Realm",
         variant("jvm"),
         variant("sjsir"),
         variant("nir"),
@@ -293,7 +293,7 @@ object LiraSchemas:
   // The BASE-256 schema signatures of the six canonical documents, pinned as golden values (the
   // test suite recomputes each from its `res/test/reliquary/*.tel` mirror and checks agreement).
   // A conforming document of each schema carries its signature on the pragma line.
-  val liraSignature:  Text = t"ϗƤҚЂЫǑmӪwUKΎ5ύ9ẈGÅЖӸψðΩȦӂSẓῩҚӂЊHk"
+  val liraSignature:  Text = t"ῘΔìẅḍβlίZOǒžAζȉḠẌLŠῺẃȕЊTȧGƜ2ДNΫΫA"
   val treeSignature:  Text = t"ǨẙơẗỵclϋẁЫĥᾸMôĮẍOώżӯάǢЗĆӸkҚțȐωǢέӫ"
   val atomsSignature: Text = t"2ӪççÃ5AḟǑXϋƤzᾱĺHϕЂẌǒEẂẁĮί9ḀẘΊÐιЪp"
   val usesSignature:  Text = t"şşCȧOӖGҐΪḍḋjΊӁῚƟȐЌĥέȦЬƜδĻĘ1Ȑḟ6ӟÔḍ"

--- a/lib/reliquary/src/core/reliquary.Section.scala
+++ b/lib/reliquary/src/core/reliquary.Section.scala
@@ -35,22 +35,22 @@ package reliquary
 import anticipation.*
 import vacuous.*
 
-// One compiled view of a release (§9), keyed by world and integration: a world keyword (kept
+// One compiled view of a release (§9), keyed by realm and integration: a realm keyword (kept
 // textual so sections of unknown, layered universes survive as opaque data), the integration
 // realized (§9.5; absent where the release declares none, which is the single implicit
 // integration), the tree blob's hash, the overlay-delete list, the canonical derivative
 // artifact's hash (§13.6), and the host requirements this section's code assumes of its
 // environment (hosts.md §6).
 case class Section
-  ( world:       Text,
+  ( realm:       Text,
     integration: Optional[Text] = Unset,
     tree:        Data,
     delete:      List[TreePath] = List(),
     derivative:  Optional[Data] = Unset,
     requires:    List[LiraManifest.Requires] = List() ):
 
-  def known: Optional[LiraWorld] = LiraWorld.parse(world)
+  def known: Optional[LiraRealm] = LiraRealm.parse(realm)
 
   // The key that must be unique within a release (L131), and by which a consumer selects a
   // section once an assignment has chosen an integration (§13.5).
-  def key: (Text, Optional[Text]) = (world, integration)
+  def key: (Text, Optional[Text]) = (realm, integration)

--- a/lib/reliquary/src/core/reliquary.Verification.scala
+++ b/lib/reliquary/src/core/reliquary.Verification.scala
@@ -57,7 +57,7 @@ object Verification:
 
     def tree(universe: Text, integration: Optional[Text]): Optional[LiraTree] =
       materialized.stdlib.find: pair =>
-        pair(0).world == universe && pair(0).integration.option == integration.option
+        pair(0).realm == universe && pair(0).integration.option == integration.option
 
       . map(_(1)).getOrElse(Unset)
 
@@ -190,7 +190,7 @@ object Verification:
         abort(LiraError(Reason.UnimplementedClaim(id)))
 
     val registry = Discipline.Registry(List.from(resolved), manifest.resource)
-    val universes = manifest.section.stdlib.map(_.world).toSet
+    val universes = manifest.section.stdlib.map(_.realm).toSet
 
     resolved.foreach: discipline =>
       if !universes.exists(discipline.domain.covers)
@@ -216,7 +216,7 @@ object Verification:
 
       val context =
         Discipline.Context
-          (section.world, section.integration, classpath(section.world,
+          (section.realm, section.integration, classpath(section.realm,
               section.integration))
 
       (section, summary(registry.atomize(content, context)))
@@ -228,7 +228,7 @@ object Verification:
 
       computed.drop(1).foreach: (section, other) =>
         if other != root
-        then abort(LiraError(Reason.ApiDivergence(t"${section.world} differs from the root")))
+        then abort(LiraError(Reason.ApiDivergence(t"${section.realm} differs from the root")))
 
   // Step 4's sibling for profiles (§11.6, L128/L130). `install` stays language-blind, exactly as
   // it does for re-atomization and lineage-step grading, and this recovers the per-section
@@ -246,7 +246,7 @@ object Verification:
         (entry.path, report.blobstore.resolve(entry.blob))
 
       EcosystemProfile.Section
-        (section.world, content, section.integration, classpath(section.world,
+        (section.realm, content, section.integration, classpath(section.realm,
             section.integration))
 
     EcosystemProfile.Evidence(List.from(sections), manifest)

--- a/lib/reliquary/src/core/soundness_reliquary_core.scala
+++ b/lib/reliquary/src/core/soundness_reliquary_core.scala
@@ -36,5 +36,5 @@ export reliquary.{Atom, AtomClass, Atomization, AtomReference, AtomsBlob, Blob, 
     Blobstore, Buildpath, CapabilityDiscipline, Discipline, DisciplineError, EcosystemProfile,
     Grade, Lineage, Lira, LiraAdvisory,
     LiraDelta, LiraError, LiraHash, LiraManifest, LiraPayload, LiraSchemas, LiraTree,
-    LiraValidators, LiraWorld, ManifestSigning, OpaqueDiscipline, Overlay, Publication,
+    LiraValidators, LiraRealm, ManifestSigning, OpaqueDiscipline, Overlay, Publication,
     Replacement, Section, Snapshot, TreeEntry, TreePath, UsesBlob, Verification, Versioning}

--- a/lib/reliquary/src/derive/reliquary.Derivative.scala
+++ b/lib/reliquary/src/derive/reliquary.Derivative.scala
@@ -95,6 +95,6 @@ object Derivative:
   def verify(manifest: LiraManifest, report: Verification.Report): Unit raises LiraError =
     manifest.section.stdlib.foreach: section =>
       section.derivative.let: declared =>
-        report.tree(section.world, section.integration).let: tree =>
+        report.tree(section.realm, section.integration).let: tree =>
           if Blob.compare(hash(tree, report.blobstore), declared) != 0
-          then abort(LiraError(Reason.BadDerivative(section.world)))
+          then abort(LiraError(Reason.BadDerivative(section.realm)))

--- a/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
+++ b/lib/reliquary/src/derive/reliquary.LiraAssembler.scala
@@ -49,12 +49,12 @@ import errorDiagnostics.emptyDiagnostics
 // assembles the complete `.lira` file. Everything here is deterministic for fixed inputs.
 object LiraAssembler:
 
-  // One cell of the (world × integration) matrix (§9.5). `integration` is absent where the
+  // One cell of the (realm × integration) matrix (§9.5). `integration` is absent where the
   // release declares none, which is its single implicit integration. `requires` names the host
   // contracts this section's code assumes (hosts.md §6) — authorial, so it arrives as input
   // rather than being computed.
   case class SectionInput
-    ( world:       Text,
+    ( realm:       Text,
       content:     List[(TreePath, Data)],
       integration: Optional[Text] = Unset,
       requires:    List[LiraManifest.Requires] = List() )
@@ -100,8 +100,8 @@ object LiraAssembler:
     val registry = Discipline.Registry(disciplines.declared, resource)
 
     val atomized = inputs.map: input =>
-      val context = Discipline.Context(input.world, input.integration, classpath(input))
-      (input.world, registry.atomize(input.content, context))
+      val context = Discipline.Context(input.realm, input.integration, classpath(input))
+      (input.realm, registry.atomize(input.content, context))
 
     // The same per-section view a discipline is given, for the profile predicates below. Built
     // here so that a profile checking structural invariants over a universe's content (§11.6,
@@ -109,7 +109,7 @@ object LiraAssembler:
     val profileSections = List.from:
       inputs.map: input =>
         EcosystemProfile.Section
-          (input.world, input.content, input.integration, classpath(input))
+          (input.realm, input.content, input.integration, classpath(input))
 
     // L125: an `export` or `track` declaration must be effective — a declared path that resolves
     // to no item in any section, or that some other discipline claims, is an assembly-time
@@ -136,7 +136,7 @@ object LiraAssembler:
     // atomization of nothing is not a claim about anything. The rule quantifies over the
     // *declared* disciplines: `resource/1` and `opaque/1` are the registry's own and universal,
     // so the question never arises for them.
-    val universes = inputs.map(_.world).toSet
+    val universes = inputs.map(_.realm).toSet
 
     registry.declared.stdlib.foreach: discipline =>
       if !universes.exists(discipline.domain.covers)
@@ -185,7 +185,7 @@ object LiraAssembler:
 
       val section =
         Section
-          ( world       = input.world,
+          ( realm       = input.realm,
             integration = input.integration,
             tree        = LiraHash(LiraHash.Domain.Blob, tree.encode),
             delete      = delete,

--- a/lib/reliquary/src/derive/reliquary.Materializer.scala
+++ b/lib/reliquary/src/derive/reliquary.Materializer.scala
@@ -62,7 +62,7 @@ object Materializer:
     // `host` sections are never materialized onto any artifact path (§13.5): a host contract's
     // content describes the environment and joins nothing.
     if universe == t"host"
-    then abort(LiraError(Reason.BadHostContract(t"the host world derives no artifacts")))
+    then abort(LiraError(Reason.BadHostContract(t"the host realm derives no artifacts")))
 
     val path = Buildpath(liras.map(_.manifest))
     val (assignment, _) = path.resolved(universe)

--- a/lib/reliquary/src/test/reliquary_test.scala
+++ b/lib/reliquary/src/test/reliquary_test.scala
@@ -724,7 +724,7 @@ object Tests extends Suite(m"Reliquary Tests"):
     suite(m"Container and verification"):
       test(m"an assembled lira reads back and verifies"):
         val report = Verification.install(Lira.read(makeLira()))
-        report.materialized.stdlib.map { pair => pair(0).world }
+        report.materialized.stdlib.map { pair => pair(0).realm }
       . assert(_ == scala.List(t"jvm", t"sjsir"))
 
       test(m"resource/1 atomizes exports by name and tracks content"):
@@ -981,7 +981,7 @@ object Tests extends Suite(m"Reliquary Tests"):
 
       test(m"the sjsir overlay materializes without the deleted classfile"):
         val report = Verification.install(Lira.read(makeLira()))
-        val sjsir = report.materialized.stdlib.find { pair => pair(0).world == t"sjsir" }
+        val sjsir = report.materialized.stdlib.find { pair => pair(0).realm == t"sjsir" }
 
         sjsir.map { pair => pair(1).entries.map(_.path.text).stdlib }
       . assert(_ == scala.Some(scala.List(t"a/A.sjsir", t"a/A.tasty")))
@@ -1877,7 +1877,7 @@ object Tests extends Suite(m"Reliquary Tests"):
         val evidence = Verification.evidence(lira.manifest, report)
 
         evidence.sections.stdlib.map: section =>
-          (section.world, section.content.stdlib.map(_(0).text))
+          (section.realm, section.content.stdlib.map(_(0).text))
 
       . assert(_ == scala.List(
           (t"jvm", scala.List(t"a/A.class", t"a/A.special")),
@@ -1887,7 +1887,7 @@ object Tests extends Suite(m"Reliquary Tests"):
         val scoped = new Discipline:
           def id: Text = t"scoped/1"
           def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".class")
-          def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"jvm"))
+          def domain: Discipline.Domain = Discipline.Domain.Realms(Set(t"jvm"))
           def keying: Discipline.Keying = Discipline.Keying.Membership
 
           def guarantees(universe: Text): Set[Discipline.Guarantee] =
@@ -1965,7 +1965,7 @@ object Tests extends Suite(m"Reliquary Tests"):
 
         val lira = Lira.read(bytes)
         Verification.install(lira)
-        (lira.manifest.hostContract, lira.manifest.section.stdlib.map(_.world))
+        (lira.manifest.hostContract, lira.manifest.section.stdlib.map(_.realm))
       . assert(_ == (true, scala.List(t"host")))
 
       // L135's four exclusions, each on a hand-built manifest, since the assembler itself

--- a/lib/xenophile/src/lira/xenophile.CHeaderDiscipline.scala
+++ b/lib/xenophile/src/lira/xenophile.CHeaderDiscipline.scala
@@ -43,17 +43,17 @@ import errorDiagnostics.emptyDiagnostics
 
 // The `cheader/1` discipline, adapted to reliquary's SPI: the declared surface of an
 // environment-supplied shared library, carried as C headers and atomized per `cheader.md`. Its
-// domain is the single world `{host}` — FFI is a host assumption, and the header describes what
+// domain is the single realm `{host}` — FFI is a host assumption, and the header describes what
 // the environment provides, never what a library on the buildpath supplies.
 object CHeaderDiscipline extends Discipline:
   def id: Text = t"cheader/1"
 
   def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".h")
 
-  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"host"))
+  def domain: Discipline.Domain = Discipline.Domain.Realms(Set(t"host"))
   def keying: Discipline.Keying = Discipline.Keying.Declaration
 
-  def guarantees(world: Text): Set[Discipline.Guarantee] =
+  def guarantees(realm: Text): Set[Discipline.Guarantee] =
     Set(Discipline.Guarantee.Recompilation)
 
   def atomize(content: List[(TreePath, Data)], context: Discipline.Context)

--- a/lib/xenophile/src/lira/xenophile.KotlinMetadataDiscipline.scala
+++ b/lib/xenophile/src/lira/xenophile.KotlinMetadataDiscipline.scala
@@ -62,12 +62,12 @@ object KotlinMetadataDiscipline extends Discipline:
 
   // `{jvm, host}`: the metadata rides in JVM classfiles, and the `host` inclusion admits
   // contracts carried as API-stub classfiles — the anticipated Android surface (hosts.md §3).
-  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"jvm", t"host"))
+  def domain: Discipline.Domain = Discipline.Domain.Realms(Set(t"jvm", t"host"))
 
   // Membership, as `classfile.md` §6: a Kotlin call site resolves members through the receiver.
   def keying: Discipline.Keying = Discipline.Keying.Membership
 
-  def guarantees(world: Text): Set[Discipline.Guarantee] =
+  def guarantees(realm: Text): Set[Discipline.Guarantee] =
     Set(Discipline.Guarantee.Recompilation)
 
   def atomize(content: List[(TreePath, Data)], context: Discipline.Context)

--- a/lib/xenophile/src/lira/xenophile.WebIdlDiscipline.scala
+++ b/lib/xenophile/src/lira/xenophile.WebIdlDiscipline.scala
@@ -42,7 +42,7 @@ import rudiments.*
 import errorDiagnostics.emptyDiagnostics
 
 // The `webidl/1` discipline, adapted to reliquary's SPI: the Web IDL of a browser host
-// contract, atomized per `webidl.md`. Its domain is the single world `{host}` — a browser is a
+// contract, atomized per `webidl.md`. Its domain is the single realm `{host}` — a browser is a
 // host, not a universe, and a `js`-universe library's carrier is `.d.ts` — so a release
 // carrying it is a host contract (L135) and L127 rejects a library that declares it.
 object WebIdlDiscipline extends Discipline:
@@ -50,12 +50,12 @@ object WebIdlDiscipline extends Discipline:
 
   def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".idl")
 
-  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"host"))
+  def domain: Discipline.Domain = Discipline.Domain.Realms(Set(t"host"))
   def keying: Discipline.Keying = Discipline.Keying.Declaration
 
   // Recompilation, for consumers type-checking against declarations generated from the IDL;
   // there is no linkage in a browser to protect, and behavior is never certified (§18).
-  def guarantees(world: Text): Set[Discipline.Guarantee] =
+  def guarantees(realm: Text): Set[Discipline.Guarantee] =
     Set(Discipline.Guarantee.Recompilation)
 
   def atomize(content: List[(TreePath, Data)], context: Discipline.Context)

--- a/lib/xenophile/src/lira/xenophile.WitDiscipline.scala
+++ b/lib/xenophile/src/lira/xenophile.WitDiscipline.scala
@@ -49,10 +49,10 @@ object WitDiscipline extends Discipline:
 
   def claims(path: TreePath, data: Data): Boolean = path.text.s.endsWith(".wit")
 
-  def domain: Discipline.Domain = Discipline.Domain.Worlds(Set(t"host", t"component"))
+  def domain: Discipline.Domain = Discipline.Domain.Realms(Set(t"host", t"component"))
   def keying: Discipline.Keying = Discipline.Keying.Declaration
 
-  def guarantees(world: Text): Set[Discipline.Guarantee] =
+  def guarantees(realm: Text): Set[Discipline.Guarantee] =
     Set(Discipline.Guarantee.Recompilation)
 
   def atomize(content: List[(TreePath, Data)], context: Discipline.Context)


### PR DESCRIPTION
The LIRA specification renames the axis a section is keyed by: `world` was a WIT
term of art, and cosmological intuition puts worlds inside universes, which is
backwards — every universe is a realm, and so are the two realms that are not
universes, `host` and `app`.

Reliquary follows the vocabulary: `LiraWorld` becomes `LiraRealm`,
`Section.world` and `Discipline.Context.world` become `.realm`, and
`Domain.Worlds` becomes `Domain.Realms`, with the discipline implementations in
mandible, degustation and xenophile following. WIT's own `world` is left alone
wherever it appears — it is the term the spec renamed away from, not a second
name for the same thing.

The `lira` schema's `select World` becomes `select Realm`, which changes that
schema's signature — carried on the pragma line of every conforming document —
so its pinned golden value is updated. The other five schemas are untouched.

Not in this PR: the `app` realm variant and the `artifact` field/`Artifact`
record the specification adds alongside the rename.

Reliquary, Degustation, Mandible and Xenophile suites: 495 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)