### PR TITLE
Give every orphan given a deliberate home

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,6 +45,29 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Test assertions use fluent pattern (`. assert(_ == expectedValue)`)
 - Strong emphasis on compile-time type safety and immutability
 
+### Given placement (issue #1632)
+
+- A `given` goes in the **companion of its subject type** (or, failing that, the typeclass's
+  companion) whenever module layering permits, so it resolves through implicit scope with no
+  import. Companion-to-companion placement is equivalent for resolution; pick the companion
+  that avoids the unwanted dependency edge.
+- A given that **selects an implementation** (a policy, backend, format or style) goes in a
+  carefully-named package (`strategies`, `logging`, `alphabets`, `optics`, `teletypeables`,
+  `wasiApis`, …) and is imported decisively by name. Mirror the package as a `package <name>:`
+  block in the component's `soundness_*.scala` export file; blocks of the same name from
+  different libraries merge in the umbrella, so member names must be globally distinct.
+- A given that is single-canonical but structurally un-anchorable (subject owned elsewhere,
+  union/alias subject, or a platform component whose subject's companion is platform-neutral)
+  stays at package top level with a **unique, library-qualified name** (`tarPathOpenable`,
+  `terminalStdio`) and a comment explaining why; never a bare generic name, and never
+  anonymous — an unnameable given cannot be selectively imported or disambiguated.
+- Traps: `import p.*` does NOT import givens (use by-name imports or `given` selectors — a
+  sweep that replaces a by-name given import with a wildcard silently drops the given);
+  synthesized export forwarders lose capture-annotated refinements (hand-write delegating
+  givens, as `soundness_scintillate_server.scala` does); and a lexically-scoped given
+  (imported or same-package toplevel) outranks any companion given, which is what makes the
+  choice-package pattern override defaults.
+
 ## Workflow
 
 ### Before the first commit of any task

--- a/lib/ambience/src/wasi/ambience_wasi.scala
+++ b/lib/ambience/src/wasi/ambience_wasi.scala
@@ -46,7 +46,8 @@ import xenophile.*
 // The WIT definitions the navigation below is typechecked against, and which the `call`
 // materializer consults (at its downstream expansion site) for the function's module id.
 type WasiEnvironmentApi = Interface in Wit at "/ambience/environment.wit"
-given wasiEnvironmentApi: WasiEnvironmentApi = Interface[Wit](cp"/ambience/environment.wit")
+package wasiApis:
+  given wasiEnvironmentApi: WasiEnvironmentApi = Interface[Wit](cp"/ambience/environment.wit")
 
 package environments:
   // `inline`, so the `call` macro expands at the downstream summoning site: the Wasm Component

--- a/lib/ambience/src/wasi/soundness_ambience_wasi.scala
+++ b/lib/ambience/src/wasi/soundness_ambience_wasi.scala
@@ -32,10 +32,13 @@
                                                                                                   */
 package soundness
 
-export ambience.{WasiEnvironmentApi, wasiEnvironmentApi}
+export ambience.{WasiEnvironmentApi}
 
 package environments:
   export ambience.environments.wasiEnvironment
 
 package workingDirectories:
   export ambience.workingDirectories.wasiWorkingDirectory
+
+package wasiApis:
+  export ambience.wasiApis.wasiEnvironmentApi

--- a/lib/archimedes/src/core/archimedes.Math.scala
+++ b/lib/archimedes/src/core/archimedes.Math.scala
@@ -50,6 +50,7 @@ import rudiments.*
 import spectacular.*
 import turbulence.*
 import vacuous.*
+import contextual.*
 import xylophone.*
 import zephyrine.ParseError
 
@@ -170,6 +171,16 @@ object Math:
   private def fenced(inner: Mathml, open: Text, close: Text): Mathml =
     val stretchy = List(t"stretchy" -> t"true")
     Mrow(List(Mo(open, stretchy), inner, Mo(close, stretchy)))
+
+  // The `ergo""` interpolator: `ergo"(x↗y)"` parses an ergo shorthand literal into
+  // a `Math` value, checking it at compile time (see `internal.ergoInterpolator`). In the
+  // companion, so it is in `Math`'s implicit scope with no import.
+  inline given interpolable: Math is Interpolable:
+    transparent inline def interpolate[parts <: Tuple, origins <: Tuple]
+      ( inline insertions: Any* )
+    :   Math =
+
+      ${archimedes.internal.ergoInterpolator[parts]('insertions)}
 
 case class Math
   ( contents:   List[Mathml],

--- a/lib/archimedes/src/core/archimedes_core.scala
+++ b/lib/archimedes/src/core/archimedes_core.scala
@@ -53,15 +53,6 @@ extension [ValueType: Encodable in Math as encodable](value: ValueType)
 
   def mathml: Mathml = Mathml.atom(encodable.encoded(value))
 
-// The `ergo""` interpolator: `ergo"(x↗y)"` parses an ergo shorthand literal into
-// a `Math` value, checking it at compile time (see `internal.ergoInterpolator`).
-inline given ergoInterpolable: Math is Interpolable:
-  transparent inline def interpolate[parts <: Tuple, origins <: Tuple]
-    ( inline insertions: Any* )
-  :   Math =
-
-    ${archimedes.internal.ergoInterpolator[parts]('insertions)}
-
 extension (inline context: StringContext)
   transparent inline def ergo: Interpolation = interpolation[Math](context)
 

--- a/lib/aviation/src/wasi/aviation_wasi.scala
+++ b/lib/aviation/src/wasi/aviation_wasi.scala
@@ -43,7 +43,8 @@ import xenophile.*
 // The WIT definitions the navigation below is typechecked against, and which the `call`
 // materializer consults (at its downstream expansion site) for the function's module id.
 type WasiClockApi = Interface in Wit at "/aviation/clocks.wit"
-given wasiClockApi: WasiClockApi = Interface[Wit](cp"/aviation/clocks.wit")
+package wasiApis:
+  given wasiClockApi: WasiClockApi = Interface[Wit](cp"/aviation/clocks.wit")
 
 package clocks:
   // `inline`, so the `call` macro expands at the downstream summoning site: the Wasm Component

--- a/lib/aviation/src/wasi/soundness_aviation_wasi.scala
+++ b/lib/aviation/src/wasi/soundness_aviation_wasi.scala
@@ -32,7 +32,10 @@
                                                                                                   */
 package soundness
 
-export aviation.{WasiClockApi, wasiClockApi}
+export aviation.{WasiClockApi}
 
 package clocks:
   export aviation.clocks.{wasiMonotonicClock, wasiClock}
+
+package wasiApis:
+  export aviation.wasiApis.wasiClockApi

--- a/lib/bitumen/src/jvm/bitumen_jvm.scala
+++ b/lib/bitumen/src/jvm/bitumen_jvm.scala
@@ -53,7 +53,7 @@ given tarPathOpenable: [path: Abstractable across Paths to Text]
 =>  ( TarOpenable[path]^{tarTactic, streamTactic} ) =
   TarOpenable[path]
 
-given creatable: [path: Abstractable across Paths to Text]
+given tarPathCreatable: [path: Abstractable across Paths to Text]
 =>  (tactic: Tactic[TarError])
 =>  ( TarBuilder.TarCreatable[path]^{tactic} ) =
   TarBuilder.TarCreatable[path]

--- a/lib/bitumen/src/jvm/soundness_bitumen_jvm.scala
+++ b/lib/bitumen/src/jvm/soundness_bitumen_jvm.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export bitumen.{TarBuilder, TarOpenable, tarPathOpenable, creatable, from, extractTo}
+export bitumen.{TarBuilder, TarOpenable, tarPathOpenable, tarPathCreatable, from, extractTo}

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -226,6 +226,11 @@ object Cbor extends Cbor2, Dynamic:
   opaque type Ast = CborTypes
 
   object Ast:
+    // In the companion (implicit scope), so aggregating a CBOR stream needs no import.
+    given aggregable: (tactic: Tactic[CborError])
+    =>  ((Ast is Aggregable by Data)^{tactic}) =
+      source => Ast.parse(source.read[Data])
+
     val Sentinel: AnyRef = new Object
 
     // Reinterpret a pre-boxed reference as `Ast` without unbox/rebox. Safe

--- a/lib/breviloquence/src/core/breviloquence_parser.scala
+++ b/lib/breviloquence/src/core/breviloquence_parser.scala
@@ -40,6 +40,3 @@ import turbulence.*
 extension (cbor: Cbor.Ast.type)
   def parse(source: Array[Byte]^{}): Cbor.Ast raises CborError = Cbor.Parser.parse(source)
 
-given parserAggregable: (tactic: Tactic[CborError])
-=>  ((Cbor.Ast is Aggregable by Data)^{tactic}) =
-  source => Cbor.Ast.parse(source.read[Data])

--- a/lib/burdock/src/core/burdock_repackage.scala
+++ b/lib/burdock/src/core/burdock_repackage.scala
@@ -44,7 +44,7 @@ import exoskeleton.*
 import fulminate.*
 // `Message`'s `Printable` instance now lives in `fulminate.print`, outside `Message`'s implicit
 // scope, so printing a `Message` needs it imported by name.
-import fulminate.messagePrintable
+import fulminate.printables.messagePrintable
 import galilei.*
 import gossamer.*
 import hellenism.*, classloaders.threadContextClassloader

--- a/lib/caduceus/src/resend/caduceus_core.scala
+++ b/lib/caduceus/src/resend/caduceus_core.scala
@@ -38,7 +38,7 @@ import contingency.*
 import fulminate.*
 // `Message`'s `Printable` instance now lives in `fulminate.print`, outside `Message`'s implicit
 // scope, so printing a `Message` needs it imported by name.
-import fulminate.messagePrintable
+import fulminate.printables.messagePrintable
 import gesticulate.*
 import hieroglyph.*
 import jacinta.*

--- a/lib/caesura/src/core/caesura_core.scala
+++ b/lib/caesura/src/core/caesura_core.scala
@@ -112,31 +112,33 @@ private def parsedIterator[value](consume reader: DsvReader^, parsable: value is
 // name within a row; the `Sheet` opticals address the n-th row (`Ordinal`), every
 // row (`Each`), or rows matching a predicate (`Filter`). So
 // `sheet.lens(_(Sec).name = t"…")` updates the "name" column of the second row.
-private def cell(row: Dsv, name: String): Text =
-  row.columns.let(_(name.tt)).let: index => row.data.at(index.z)
-  . or(t"")
+package optics:
+  private def cell(row: Dsv, name: String): Text =
+    row.columns.let(_(name.tt)).let: index => row.data.at(index.z)
+    . or(t"")
 
-private def withCell(row: Dsv, name: String, value: Text): Dsv =
-  row.columns.let(_(name.tt)).lay(row): index => row.copy(data = row.data.updated(index, value))
+  private def withCell(row: Dsv, name: String, value: Text): Dsv =
+    row.columns.let(_(name.tt)).lay(row): index => row.copy(data = row.data.updated(index, value))
 
-given cellLens: [name <: Label: ValueOf] => (erased dynamicDsvEnabler: DynamicDsvEnabler)
-=>  name is Lens from Dsv onto Text =
-  Lens(cell(_, valueOf[name]), withCell(_, valueOf[name], _))
+  given cellLens: [name <: Label: ValueOf] => (erased dynamicDsvEnabler: DynamicDsvEnabler)
+  =>  name is Lens from Dsv onto Text =
+    Lens(cell(_, valueOf[name]), withCell(_, valueOf[name], _))
 
-given rowOptical: [element] => Ordinal is Optical from Sheet onto Dsv = ordinal =>
-  Optic: (origin, lambda) =>
-    origin.copy(rows = origin.rows.zipWithIndex.map: (row, index) =>
-      if index == ordinal.n0 then lambda(row) else row)
+  given rowOptical: [element] => Ordinal is Optical from Sheet onto Dsv = ordinal =>
+    Optic: (origin, lambda) =>
+      origin.copy(rows = origin.rows.zipWithIndex.map: (row, index) =>
+        if index == ordinal.n0 then lambda(row) else row)
 
-given rowEach: Each.type is Optical from Sheet onto Dsv = _ =>
-  Optic: (origin, lambda) => origin.copy(rows = origin.rows.map(lambda))
+  given rowEach: Each.type is Optical from Sheet onto Dsv = _ =>
+    Optic: (origin, lambda) => origin.copy(rows = origin.rows.map(lambda))
 
-// The `predicate` laundering is for the Scala.js pipeline, which — unlike the JVM pipeline —
-// rejects the `Optic`'s capture of `filter.predicate` against the required pure `Optic` type.
-// (Compiler divergence; see #1520 and the identical laundering in `panopticon.Optical.filter`.)
-given rowFilter: Filter[Dsv] is Optical from Sheet onto Dsv = filter =>
-  val predicate: Dsv -> Boolean = caps.unsafe.unsafeAssumePure(filter.predicate)
+  // The `predicate` laundering is for the Scala.js pipeline, which — unlike the JVM pipeline —
+  // rejects the `Optic`'s capture of `filter.predicate` against the required pure `Optic` type.
+  // (Compiler divergence; see #1520 and the identical laundering in `panopticon.Optical.filter`.)
+  given rowFilter: Filter[Dsv] is Optical from Sheet onto Dsv = filter =>
+    val predicate: Dsv -> Boolean = caps.unsafe.unsafeAssumePure(filter.predicate)
 
-  Optic: (origin, lambda) =>
-    origin.copy
-      ( rows = origin.rows.map { row => if predicate(row) then lambda(row) else row } )
+    Optic: (origin, lambda) =>
+      origin.copy
+        ( rows = origin.rows.map { row => if predicate(row) then lambda(row) else row } )
+

--- a/lib/caesura/src/core/soundness_caesura_core.scala
+++ b/lib/caesura/src/core/soundness_caesura_core.scala
@@ -46,3 +46,6 @@ package dsvRedesignations:
     caesura.dsvRedesignations
     . { capitalizedWordsRedesignation, lowerDottedRedesignation, lowerSlashedRedesignation,
         lowerWordsRedesignation, unchangedRedesignation }
+
+package optics:
+  export caesura.optics.{cellLens, rowEach, rowFilter, rowOptical}

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -36,7 +36,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
-import caesura.optics.*
+import caesura.optics.{cellLens, rowEach, rowFilter, rowOptical}
 
 given decimalizer: Decimalizer = Decimalizer(1)
 

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -36,6 +36,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
+import caesura.optics.*
 
 given decimalizer: Decimalizer = Decimalizer(1)
 

--- a/lib/capricious/src/wasi/capricious_wasi.scala
+++ b/lib/capricious/src/wasi/capricious_wasi.scala
@@ -44,7 +44,8 @@ import xenophile.*
 // The WIT definitions the navigation below is typechecked against, and which the `call`
 // materializer consults (at its downstream expansion site) for the function's module id.
 type WasiRandomApi = Interface in Wit at "/capricious/random.wit"
-given wasiRandomApi: WasiRandomApi = Interface[Wit](cp"/capricious/random.wit")
+package wasiApis:
+  given wasiRandomApi: WasiRandomApi = Interface[Wit](cp"/capricious/random.wit")
 
 package randomization:
   // `inline`, so the `call` macro expands at the downstream summoning site: the Wasm Component

--- a/lib/capricious/src/wasi/soundness_capricious_wasi.scala
+++ b/lib/capricious/src/wasi/soundness_capricious_wasi.scala
@@ -32,7 +32,10 @@
                                                                                                   */
 package soundness
 
-export capricious.{WasiRandom, WasiRandomApi, wasiRandomApi}
+export capricious.{WasiRandom, WasiRandomApi}
 
 package randomization:
   export capricious.randomization.wasiRandomization
+
+package wasiApis:
+  export capricious.wasiApis.wasiRandomApi

--- a/lib/cataclysm/src/core/cataclysm.Css.scala
+++ b/lib/cataclysm/src/core/cataclysm.Css.scala
@@ -34,8 +34,12 @@ package cataclysm
 
 import scala.language.dynamics
 
+import proscenium.compat.iterator
+
 import anticipation.*
 import contextual.*
+import contingency.*
+import fulminate.*
 import gesticulate.*
 import gossamer.*
 import parasite.*
@@ -47,6 +51,18 @@ import vacuous.*
 import zephyrine.*
 
 object Css:
+  // Reading a stylesheet accumulates every `CssError` (unknown property, invalid
+  // or unsupported value, …) instead of stopping at the first: the parse runs
+  // inside a `track`, and any errors are folded into a single `CssErrors` raised
+  // at the end. A fully-valid stylesheet yields the `Css` with nothing raised. In
+  // the companion, so aggregation resolves through implicit scope with no import.
+  given aggregable: (Tactic[CssErrors], Diagnostics) => Css is Aggregable by Text = source =>
+    track[Text](CssErrors(Nil)):
+      case error: CssError => accrual + error
+
+    . protect:
+        CssParser.parse(source.iterator)
+
   // Controls how a `Css` tree is serialized. `newlines` puts each rule and declaration on its own
   // indented line; `spaces` adds the cosmetic spaces (after `:` and before `{`). Bundled as
   // `formatting.standardCssFormatting` and `formatting.compactCssFormatting`.

--- a/lib/cataclysm/src/core/cataclysm_core.scala
+++ b/lib/cataclysm/src/core/cataclysm_core.scala
@@ -50,17 +50,6 @@ import vacuous.*
 extension (inline context: StringContext)
   transparent inline def css: Interpolation = interpolation[Css | Css.Style](context)
 
-// Reading a stylesheet accumulates every `CssError` (unknown property, invalid
-// or unsupported value, …) instead of stopping at the first: the parse runs
-// inside a `track`, and any errors are folded into a single `CssErrors` raised
-// at the end. A fully-valid stylesheet yields the `Css` with nothing raised.
-given cssAggregable: (Tactic[CssErrors], Diagnostics) => Css is Aggregable by Text = source =>
-  track[Text](CssErrors(Nil)):
-    case error: CssError => accrual + error
-
-  . protect:
-      CssParser.parse(source.iterator)
-
 // The class and id names referenced anywhere in a stylesheet, including inside
 // nested rules and the selector-list arguments of `:is()`/`:not()`/`:nth-…(of)`.
 extension (css: Css)

--- a/lib/cataclysm/src/core/soundness_cataclysm_core.scala
+++ b/lib/cataclysm/src/core/soundness_cataclysm_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export cataclysm.{Css, CssError, CssErrors, cssAggregable, SelectorList, Selector, Compound,
+export cataclysm.{Css, CssError, CssErrors, SelectorList, Selector, Compound,
     Simple, Combinator, AttributeMatcher, AttributeTest, Prefix, PseudoArgument,
     CssConvertible, Outcome, PropertyDef, SyntaxMatcher, ValueToken, Pixels, Rems, Exs, Chs,
     ViewportWidths,

--- a/lib/chiaroscuro/src/render/chiaroscuro_render.scala
+++ b/lib/chiaroscuro/src/render/chiaroscuro_render.scala
@@ -63,144 +63,146 @@ trait JuxtapositionPalette extends Palette:
   def positive: Color in Srgb
   def negative: Color in Srgb
 
-given juxtapositionTeletype: (measurable: Text is Measurable) => (palette: JuxtapositionPalette)
-=>  Juxtaposition is Teletypeable =
+package teletypeables:
+  given juxtapositionTeletype: (measurable: Text is Measurable) => (palette: JuxtapositionPalette)
+  =>  Juxtaposition is Teletypeable =
 
-  value =>
-    val subdued = Fg(palette.unaccented)
-    val fg = Fg(palette.foreground)
-    val positive = Fg(palette.positive)
-    val negative = Fg(palette.negative)
-    val informative = Fg(palette.informative)
-    val positiveBg = Bg(palette.subdue(palette.positive, 0.5))
-    val negativeBg = Bg(palette.subdue(palette.negative, 0.5))
+    value =>
+      val subdued = Fg(palette.unaccented)
+      val fg = Fg(palette.foreground)
+      val positive = Fg(palette.positive)
+      val negative = Fg(palette.negative)
+      val informative = Fg(palette.informative)
+      val positiveBg = Bg(palette.subdue(palette.positive, 0.5))
+      val negativeBg = Bg(palette.subdue(palette.negative, 0.5))
 
-    value match
-      case Juxtaposition.Collation(name, comparison, _, _) =>
-        import tableStyles.defaultTableStyle
-        val columns = 110
-        val length = comparison.stdlib.length
-        val topRule = e"\n$subdued(────┬${(t"─"*(length.min(columns)))}┬────)\n"
-        val midRule = e"$subdued(────┼${(t"─"*(length.min(columns)))}┼────)\n"
-        val bottomRule = e"$subdued(────┴${(t"─"*(length%columns))}┴────)\n"
+      value match
+        case Juxtaposition.Collation(name, comparison, _, _) =>
+          import tableStyles.defaultTableStyle
+          val columns = 110
+          val length = comparison.stdlib.length
+          val topRule = e"\n$subdued(────┬${(t"─"*(length.min(columns)))}┬────)\n"
+          val midRule = e"$subdued(────┼${(t"─"*(length.min(columns)))}┼────)\n"
+          val bottomRule = e"$subdued(────┴${(t"─"*(length%columns))}┴────)\n"
 
-        val penultimateRule = if length%columns == 0 then midRule else
-          val count = columns - length%columns - 1
-          e"$subdued(────┼${(t"─"*(length%columns))}┬${(t"─"*count)}┴────)\n"
+          val penultimateRule = if length%columns == 0 then midRule else
+            val count = columns - length%columns - 1
+            e"$subdued(────┼${(t"─"*(length%columns))}┬${(t"─"*count)}┴────)\n"
 
-        if comparison.all(_(1).singleChar) then
-          var topSum = 0
-          var bottomSum = 0
-          def pad(value: Text): Char = value(Prim).let(Unicode.visible).or(' ')
+          if comparison.all(_(1).singleChar) then
+            var topSum = 0
+            var bottomSum = 0
+            def pad(value: Text): Char = value(Prim).let(Unicode.visible).or(' ')
 
-          comparison.stdlib.grouped(columns).zipWithIndex.map: (comparison2, index) =>
-            val first = index == 0
-            val last = index == comparison.stdlib.length/columns
+            comparison.stdlib.grouped(columns).zipWithIndex.map: (comparison2, index) =>
+              val first = index == 0
+              val last = index == comparison.stdlib.length/columns
 
-            val observed = comparison2.map:
-              case (_, Same(char))            => e"$informative(${pad(char)})"
-              case (_, Different(char, _, _)) => e"$positiveBg(${pad(char)})"
-              case _                          => e""
+              val observed = comparison2.map:
+                case (_, Same(char))            => e"$informative(${pad(char)})"
+                case (_, Different(char, _, _)) => e"$positiveBg(${pad(char)})"
+                case _                          => e""
 
-            . join
+              . join
 
-            val expected = comparison2.map:
-              case (_, Same(char))            => e"$informative(${pad(char)})"
-              case (_, Different(_, char, _)) => e"$negativeBg(${pad(char)})"
-              case _                          => e""
+              val expected = comparison2.map:
+                case (_, Same(char))            => e"$informative(${pad(char)})"
+                case (_, Different(_, char, _)) => e"$negativeBg(${pad(char)})"
+                case _                          => e""
 
-            . join
+              . join
 
-            val margin1 = topSum.show.superscripts.pad(4, Rtl, ' ')
-            val margin2 = bottomSum.show.subscripts.pad(4, Rtl, ' ')
-            topSum += comparison2.sumBy(_(1).leftWidth)
-            bottomSum += comparison2.sumBy(_(1).rightWidth)
-            val margin3 = topSum.show.superscripts.pad(4, Ltr, ' ')
-            val margin4 = bottomSum.show.subscripts.pad(4, Ltr, ' ')
+              val margin1 = topSum.show.superscripts.pad(4, Rtl, ' ')
+              val margin2 = bottomSum.show.subscripts.pad(4, Rtl, ' ')
+              topSum += comparison2.sumBy(_(1).leftWidth)
+              bottomSum += comparison2.sumBy(_(1).rightWidth)
+              val margin3 = topSum.show.superscripts.pad(4, Ltr, ' ')
+              val margin4 = bottomSum.show.subscripts.pad(4, Ltr, ' ')
 
-            val leftEdge1 = if first then e"$fg($margin1)│" else e"$margin1 "
-            val leftEdge2 = if first then e"$fg($margin2)│" else e"$margin2 "
-            val rightEdge3 = if last then e"│$fg($margin3)" else e" $margin3"
-            val rightEdge4 = if last then e"│$fg($margin4)" else e" $margin4"
+              val leftEdge1 = if first then e"$fg($margin1)│" else e"$margin1 "
+              val leftEdge2 = if first then e"$fg($margin2)│" else e"$margin2 "
+              val rightEdge3 = if last then e"│$fg($margin3)" else e" $margin3"
+              val rightEdge4 = if last then e"│$fg($margin4)" else e" $margin4"
 
-            val line1 = e"$subdued($leftEdge1)$observed$subdued($rightEdge3)"
-            val line2 = e"$subdued($leftEdge2)$expected$subdued($rightEdge4)"
+              val line1 = e"$subdued($leftEdge1)$observed$subdued($rightEdge3)"
+              val line2 = e"$subdued($leftEdge2)$expected$subdued($rightEdge4)"
 
-            e"$line1\n$line2\n"
+              e"$line1\n$line2\n"
 
-          // The mapped lines only read the two summary buffers; laundered pure.
-          . to(Iterable).asInstanceOf[Iterable[Teletype]]
-          . join(topRule, midRule, penultimateRule, bottomRule)
+            // The mapped lines only read the two summary buffers; laundered pure.
+            . to(Iterable).asInstanceOf[Iterable[Teletype]]
+            . join(topRule, midRule, penultimateRule, bottomRule)
 
-        else
-          def children(comp: (Text, Juxtaposition)): List[(Text, Juxtaposition)] = comp(1) match
-            case Same(value)                           => Nil
-            case Different(left, right, difference)    => Nil
-
-            case Collation(_, comparison, left, right) =>
-              if comparison.all(_(1).singleChar) then Nil else comparison
-
-          case class Row(treeLine: Text, left: Teletype, right: Teletype, memo: Teletype)
-
-          given treeStyle: (Text is Textual) => TreeStyle[Row] = (tiles, row) =>
-            row.copy(treeLine = tiles.map(treeStyles.defaultTreeStyle.text(_)).join+row.treeLine)
-
-          def line(data: (Text, Juxtaposition)): Row =
-            def line(bullet: Text): Text = t"$bullet ${data(0)}"
-
-            data(1) match
-              case Same(v) =>
-                Row
-                  ( line(t"▪"),
-                    e"${Fg(palette.informative)}($v)",
-                    e"${Fg(palette.informative)}($v)",
-                    e"" )
-
-              case Different(left, right, difference) =>
-                Row
-                  ( line(t"▪"),
-                    e"${Fg(palette.positive)}($left)",
-                    e"${Fg(palette.negative)}($right)",
-                    difference.let(_.teletype).or(e"") )
+          else
+            def children(comp: (Text, Juxtaposition)): List[(Text, Juxtaposition)] = comp(1) match
+              case Same(value)                           => Nil
+              case Different(left, right, difference)    => Nil
 
               case Collation(_, comparison, left, right) =>
-                if comparison.all(_(1).singleChar)
-                then
-                  import proximities.levenshteinProximity
-                  import caseSensitivity.caseSensitive
-                  val distance = left.proximity(right).toInt
+                if comparison.all(_(1).singleChar) then Nil else comparison
 
+            case class Row(treeLine: Text, left: Teletype, right: Teletype, memo: Teletype)
+
+            given treeStyle: (Text is Textual) => TreeStyle[Row] = (tiles, row) =>
+              row.copy(treeLine = tiles.map(treeStyles.defaultTreeStyle.text(_)).join+row.treeLine)
+
+            def line(data: (Text, Juxtaposition)): Row =
+              def line(bullet: Text): Text = t"$bullet ${data(0)}"
+
+              data(1) match
+                case Same(v) =>
+                  Row
+                    ( line(t"▪"),
+                      e"${Fg(palette.informative)}($v)",
+                      e"${Fg(palette.informative)}($v)",
+                      e"" )
+
+                case Different(left, right, difference) =>
                   Row
                     ( line(t"▪"),
                       e"${Fg(palette.positive)}($left)",
                       e"${Fg(palette.negative)}($right)",
-                      e"lev = $distance" )
+                      difference.let(_.teletype).or(e"") )
 
-                else
-                  Row
-                    ( line(t"■"),
-                      e"${Fg(palette.informative)}($left)",
-                      e"${Fg(palette.informative)}($right)",
-                      e"" )
+                case Collation(_, comparison, left, right) =>
+                  if comparison.all(_(1).singleChar)
+                  then
+                    import proximities.levenshteinProximity
+                    import caseSensitivity.caseSensitive
+                    val distance = left.proximity(right).toInt
 
-          val table =
-            Scaffold[Row]
-              ( Column(e"$name")(_.treeLine),
-                Column(e"Expected", textAlign = TextAlignment.Left)(_.left),
-                Column(e"Observed")(_.right),
-                Column(e"Details")(_.memo.teletype) )
+                    Row
+                      ( line(t"▪"),
+                        e"${Fg(palette.positive)}($left)",
+                        e"${Fg(palette.negative)}($right)",
+                        e"lev = $distance" )
 
-          table
-          . tabulate(TreeDiagram.by(children(_))(comparison*).render(line).stdlib.to(List))
-          . grid(200)
-          . render
-          . join(e"\n")
+                  else
+                    Row
+                      ( line(t"■"),
+                        e"${Fg(palette.informative)}($left)",
+                        e"${Fg(palette.informative)}($right)",
+                        e"" )
 
-      case Different(left, right, difference) =>
-        val ws = if right.contains(Lf) then e"\n" else e" "
-        val ws2 = if left.contains(Lf) then e"\n" else e" "
+            val table =
+              Scaffold[Row]
+                ( Column(e"$name")(_.treeLine),
+                  Column(e"Expected", textAlign = TextAlignment.Left)(_.left),
+                  Column(e"Observed")(_.right),
+                  Column(e"Details")(_.memo.teletype) )
 
-        e"The result$ws$negative($right)${ws}did not equal$ws2$positive($left)"
+            table
+            . tabulate(TreeDiagram.by(children(_))(comparison*).render(line).stdlib.to(List))
+            . grid(200)
+            . render
+            . join(e"\n")
 
-      case Same(value) =>
-        e"The value $subdued($value) was expected"
+        case Different(left, right, difference) =>
+          val ws = if right.contains(Lf) then e"\n" else e" "
+          val ws2 = if left.contains(Lf) then e"\n" else e" "
+
+          e"The result$ws$negative($right)${ws}did not equal$ws2$positive($left)"
+
+        case Same(value) =>
+          e"The value $subdued($value) was expected"
+

--- a/lib/chiaroscuro/src/render/soundness_chiaroscuro_render.scala
+++ b/lib/chiaroscuro/src/render/soundness_chiaroscuro_render.scala
@@ -32,4 +32,7 @@
                                                                                                   */
 package soundness
 
-export chiaroscuro.{juxtapositionTeletype, JuxtapositionPalette}
+export chiaroscuro.{JuxtapositionPalette}
+
+package teletypeables:
+  export chiaroscuro.teletypeables.{juxtapositionTeletype}

--- a/lib/chiaroscuro/src/test/chiaroscuro_test.scala
+++ b/lib/chiaroscuro/src/test/chiaroscuro_test.scala
@@ -36,6 +36,7 @@ import soundness.*
 
 import proscenium.compat.*
 import textMetrics.uniformMetric
+import chiaroscuro.teletypeables.juxtapositionTeletype
 
 case class Person(name: Text, age: Int)
 case class Organization(name: Text, ceo: Person, staff: List[Person])

--- a/lib/coaxial/src/wasi/coaxial_wasi.scala
+++ b/lib/coaxial/src/wasi/coaxial_wasi.scala
@@ -58,10 +58,12 @@ import xenophile.*
 // materializer consults (at its downstream expansion site) for module ids, resource methods and
 // parameter types.
 type WasiSocketsApi = Interface in Wit at "/coaxial/sockets.wit"
-given wasiSocketsApi: WasiSocketsApi = Interface[Wit](cp"/coaxial/sockets.wit")
+package wasiApis:
+  given wasiSocketsApi: WasiSocketsApi = Interface[Wit](cp"/coaxial/sockets.wit")
 
 // The handles a connected TCP socket threads back to the backend: the readable and writable halves
 // of the connection, and the socket itself (kept so it can be shut down and dropped).
+
 private case class WasiExchange
   ( input:  WitHandle of "input-stream",
     output: WitHandle of "output-stream",

--- a/lib/coaxial/src/wasi/soundness_coaxial_wasi.scala
+++ b/lib/coaxial/src/wasi/soundness_coaxial_wasi.scala
@@ -32,7 +32,10 @@
                                                                                                   */
 package soundness
 
-export coaxial.{WasiSocketsApi, wasiSocketsApi}
+export coaxial.{WasiSocketsApi}
 
 package socketBackends:
   export coaxial.socketBackends.wasi
+
+package wasiApis:
+  export coaxial.wasiApis.wasiSocketsApi

--- a/lib/digression/src/ansi/digression_ansi.scala
+++ b/lib/digression/src/ansi/digression_ansi.scala
@@ -76,134 +76,137 @@ object StackTracePalette:
     def accent4:    Color in Srgb = hex(0xfeae00)
     def accent5:    Color in Srgb = hex(0xaefe00)
 
-given exceptionTeletype: (Text is Measurable, StackTrace.Resolver) => Exception is Teletypeable =
-  exception => summon[StackTrace is Teletypeable].teletype(StackTrace(exception))
+// The styled renderings, imported decisively: `import digression.teletypeables.*`.
+package teletypeables:
+  given exceptionTeletype: (Text is Measurable, StackTrace.Resolver) => Exception is Teletypeable =
+    exception => summon[StackTrace is Teletypeable].teletype(StackTrace(exception))
 
-given stackTraceTeletype: (Text is Measurable) => (palette: StackTracePalette)
-=>  StackTrace is Teletypeable = stack =>
+  given stackTraceTeletype: (Text is Measurable) => (palette: StackTracePalette)
+  =>  StackTrace is Teletypeable = stack =>
 
-  // A static match, not `selectDynamic(s"accent$n")`: structural selection reflects through
-  // `Class.getMethod`, unsupported on Scala Native (and these are real trait members anyway).
-  def accent(level: Int): Color in Srgb = (level % 5) + 1 match
-    case 1 => palette.accent1
-    case 2 => palette.accent2
-    case 3 => palette.accent3
-    case 4 => palette.accent4
-    case _ => palette.accent5
+    // A static match, not `selectDynamic(s"accent$n")`: structural selection reflects through
+    // `Class.getMethod`, unsupported on Scala Native (and these are real trait members anyway).
+    def accent(level: Int): Color in Srgb = (level % 5) + 1 match
+      case 1 => palette.accent1
+      case 2 => palette.accent2
+      case 3 => palette.accent3
+      case 4 => palette.accent4
+      case _ => palette.accent5
 
-  def dedup[element](todo: List[element], seen: Set[element] = Set(), done: List[element] = Nil)
-  :   List[element] =
+    def dedup[element](todo: List[element], seen: Set[element] = Set(), done: List[element] = Nil)
+    :   List[element] =
 
-    todo match
-      case Nil          => done.reverse
+      todo match
+        case Nil          => done.reverse
 
-      case head :: tail =>
-        if seen.has(head) then dedup(tail, seen, done)
-        else dedup(tail, seen + head, head :: done)
+        case head :: tail =>
+          if seen.has(head) then dedup(tail, seen, done)
+          else dedup(tail, seen + head, head :: done)
 
-  val packages: Map[Text, Color in Srgb] =
-    Map.from:
-      dedup[Text](stack.frames.map(_.method.prefix), Set(), Nil).stdlib
-      . zipWithIndex.map: (prefix, index) =>
-          prefix -> accent(index)
+    val packages: Map[Text, Color in Srgb] =
+      Map.from:
+        dedup[Text](stack.frames.map(_.method.prefix), Set(), Nil).stdlib
+        . zipWithIndex.map: (prefix, index) =>
+            prefix -> accent(index)
 
-  val fullClass = e"$Italic(${stack.component}.$Bold(${stack.className}))"
-  val init = e"${palette.message}($fullClass): ${stack.message}"
+    val fullClass = e"$Italic(${stack.component}.$Bold(${stack.className}))"
+    val init = e"${palette.message}($fullClass): ${stack.message}"
 
-  case class Row(frame: StackTrace.Frame, sameClass: Boolean, sameFile: Boolean)
+    case class Row(frame: StackTrace.Frame, sameClass: Boolean, sameFile: Boolean)
 
-  val rows: List[Row] =
-    List.of:
-      stack.frames.fold((List.empty[Row].stdlib, t"", t"")):
-        case ((acc, lastClass, lastFile), frame) =>
-          val sameClass = frame.displayClass == lastClass
-          val sameFile = frame.file == lastFile
-          (Row(frame, sameClass, sameFile) :: acc, frame.displayClass, frame.file)
+    val rows: List[Row] =
+      List.of:
+        stack.frames.fold((List.empty[Row].stdlib, t"", t"")):
+          case ((acc, lastClass, lastFile), frame) =>
+            val sameClass = frame.displayClass == lastClass
+            val sameFile = frame.file == lastFile
+            (Row(frame, sameClass, sameFile) :: acc, frame.displayClass, frame.file)
 
-      . _1.reverse
+        . _1.reverse
 
-  // A frame the compiler generated—a bridge, a forwarder, an initializer—is rarely what the
-  // reader is looking for, so it stays legible but recedes.
-  def plumbing(row: Row): Boolean = row.frame.source.lay(false)(_.kind.plumbing)
+    // A frame the compiler generated—a bridge, a forwarder, an initializer—is rarely what the
+    // reader is looking for, so it stays legible but recedes.
+    def plumbing(row: Row): Boolean = row.frame.source.lay(false)(_.kind.plumbing)
 
-  def classCell(row: Row): Teletype =
-    val frame = row.frame
-    val obj = frame.displaySegment.starts(t"Ξ")
-    val methodCls = if obj then frame.displaySegment.skip(1) else frame.displaySegment
-    // Every row's prefix was registered when `packages` was built from the same frames; an
-    // unregistered prefix falls back to the first accent colour.
-    val color = packages(frame.method.prefix).or(accent(0))
+    def classCell(row: Row): Teletype =
+      val frame = row.frame
+      val obj = frame.displaySegment.starts(t"Ξ")
+      val methodCls = if obj then frame.displaySegment.skip(1) else frame.displaySegment
+      // Every row's prefix was registered when `packages` was built from the same frames; an
+      // unregistered prefix falls back to the first accent colour.
+      val color = packages(frame.method.prefix).or(accent(0))
 
-    if row.sameClass || plumbing(row)
-    then e"${palette.subdue(color, 0.85)}(${frame.displayPrefix}.$methodCls)"
-    else
-      e"${palette.subdue(color, 0.5)}(${frame.displayPrefix}.$Bold($color($methodCls)))"
+      if row.sameClass || plumbing(row)
+      then e"${palette.subdue(color, 0.85)}(${frame.displayPrefix}.$methodCls)"
+      else
+        e"${palette.subdue(color, 0.5)}(${frame.displayPrefix}.$Bold($color($methodCls)))"
 
-  def dotCell(row: Row): Teletype =
-    // A resolved frame names a chain of source definitions, which is joined with dots however
-    // the chain happens to have been compiled.
-    val resolved = row.frame.source.present
-    val ch = if resolved || row.frame.displaySegment.starts(t"Ξ") then t"." else t"⌗"
-    e"${palette.separator}($ch)"
+    def dotCell(row: Row): Teletype =
+      // A resolved frame names a chain of source definitions, which is joined with dots however
+      // the chain happens to have been compiled.
+      val resolved = row.frame.source.present
+      val ch = if resolved || row.frame.displaySegment.starts(t"Ξ") then t"." else t"⌗"
+      e"${palette.separator}($ch)"
 
-  def methodCell(row: Row): Teletype =
-    val color = if plumbing(row) then palette.subdue(palette.method, 0.85) else palette.method
-    e"$color(${row.frame.displayMethod})"
+    def methodCell(row: Row): Teletype =
+      val color = if plumbing(row) then palette.subdue(palette.method, 0.85) else palette.method
+      e"$color(${row.frame.displayMethod})"
 
-  def codeCell(row: Row): Teletype =
-    e"${palette.subdue(palette.file, 0.7)}(${row.frame.source.let(_.code).or(t"")})"
+    def codeCell(row: Row): Teletype =
+      e"${palette.subdue(palette.file, 0.7)}(${row.frame.source.let(_.code).or(t"")})"
 
-  def fileCell(row: Row): Teletype =
-    val color = if row.sameFile then palette.subdue(palette.file, 0.85) else palette.file
-    e"$color(${row.frame.file})"
+    def fileCell(row: Row): Teletype =
+      val color = if row.sameFile then palette.subdue(palette.file, 0.85) else palette.file
+      e"$color(${row.frame.file})"
 
-  def lineCell(row: Row): Teletype =
-    e"${palette.line}(${row.frame.line.let(_.show).or(t"")})"
+    def lineCell(row: Row): Teletype =
+      e"${palette.line}(${row.frame.line.let(_.show).or(t"")})"
 
-  val scaffold =
-    Scaffold[Row]
-      ( Column(e"")(_ => e"${palette.separator}(at)"),
-        Column(e"", textAlign = TextAlignment.Right)(classCell),
-        Column(e"")(dotCell),
-        Column(e"")(methodCell),
-        Column(e"", textAlign = TextAlignment.Right)(fileCell),
-        Column(e"")(_ => e"${palette.separator}(:)"),
-        Column(e"", textAlign = TextAlignment.Right)(lineCell),
-        // The quoted source is the first thing to go when the terminal is too narrow for it:
-        // everything else in the row is needed to identify the frame at all.
-        Column(e"", sizing = columnar.Collapsible(0.5))(codeCell) )
+    val scaffold =
+      Scaffold[Row]
+        ( Column(e"")(_ => e"${palette.separator}(at)"),
+          Column(e"", textAlign = TextAlignment.Right)(classCell),
+          Column(e"")(dotCell),
+          Column(e"")(methodCell),
+          Column(e"", textAlign = TextAlignment.Right)(fileCell),
+          Column(e"")(_ => e"${palette.separator}(:)"),
+          Column(e"", textAlign = TextAlignment.Right)(lineCell),
+          // The quoted source is the first thing to go when the terminal is too narrow for it:
+          // everything else in the row is needed to identify the frame at all.
+          Column(e"", sizing = columnar.Collapsible(0.5))(codeCell) )
 
-  given style: TableStyle =
-    TableStyle
-      ( padding    = 0,
-        topLine    = Unset,
-        bottomLine = Unset,
-        titleLine  = Unset,
-        sideLines  = BoxLine.Blank,
-        innerLines = BoxLine.Blank,
-        charset    = LineCharset.Default )
+    given style: TableStyle =
+      TableStyle
+        ( padding    = 0,
+          topLine    = Unset,
+          bottomLine = Unset,
+          titleLine  = Unset,
+          sideLines  = BoxLine.Blank,
+          innerLines = BoxLine.Blank,
+          charset    = LineCharset.Default )
 
-  import columnAttenuation.ignoreAttenuation
+    import columnAttenuation.ignoreAttenuation
 
-  val grid = scaffold.tabulate(rows).grid(200)
-  val dataOnly = grid.copy(sections = grid.sections.tail)
-  val tableLines = List.from(dataOnly.render.stdlib)
+    val grid = scaffold.tabulate(rows).grid(200)
+    val dataOnly = grid.copy(sections = grid.sections.tail)
+    val tableLines = List.from(dataOnly.render.stdlib)
 
-  val allLines = init :: (tableLines: List[Teletype])
-  val root = (allLines: Iterable[Teletype]).join(e"\n")
+    val allLines = init :: (tableLines: List[Teletype])
+    val root = (allLines: Iterable[Teletype]).join(e"\n")
 
-  stack.cause.lay(root): cause => e"$root\n${palette.message}(caused by:)\n$cause"
+    stack.cause.lay(root): cause => e"$root\n${palette.message}(caused by:)\n$cause"
 
-given frameTeletype: (Text is Measurable) => (palette: StackTracePalette)
-=>  StackTrace.Frame is Teletypeable = frame =>
+  given frameTeletype: (Text is Measurable) => (palette: StackTracePalette)
+  =>  StackTrace.Frame is Teletypeable = frame =>
 
-  val className = e"${palette.method}(${frame.displayClass.fit(40, Rtl)})"
-  val method = e"${palette.method}(${frame.method.method.fit(40)})"
-  val file = e"${palette.file}(${frame.file.fit(18, Rtl)})"
-  val line = e"${palette.line}(${frame.line.let(_.show).or(t"?")})"
-  e"$className${palette.separator}( ⌗ )$method $file${palette.separator}(:)$line"
+    val className = e"${palette.method}(${frame.displayClass.fit(40, Rtl)})"
+    val method = e"${palette.method}(${frame.method.method.fit(40)})"
+    val file = e"${palette.file}(${frame.file.fit(18, Rtl)})"
+    val line = e"${palette.line}(${frame.line.let(_.show).or(t"?")})"
+    e"$className${palette.separator}( ⌗ )$method $file${palette.separator}(:)$line"
 
-given methodTeletype: (palette: StackTracePalette) => StackTrace.Method is Teletypeable = method =>
-  val className = e"${palette.method}(${method.className})"
-  val methodName = e"${palette.method}(${method.method})"
-  e"$className${palette.separator}( ⌗ )$methodName"
+  given methodTeletype: (palette: StackTracePalette) => StackTrace.Method is Teletypeable = method =>
+    val className = e"${palette.method}(${method.className})"
+    val methodName = e"${palette.method}(${method.method})"
+    e"$className${palette.separator}( ⌗ )$methodName"
+

--- a/lib/digression/src/ansi/soundness_digression_ansi.scala
+++ b/lib/digression/src/ansi/soundness_digression_ansi.scala
@@ -32,5 +32,7 @@
                                                                                                   */
 package soundness
 
-export digression.{exceptionTeletype, frameTeletype, methodTeletype, StackTracePalette,
-    stackTraceTeletype}
+export digression.StackTracePalette
+
+package teletypeables:
+  export digression.teletypeables.{exceptionTeletype, frameTeletype, methodTeletype, stackTraceTeletype}

--- a/lib/escapade/src/graphics/escapade_graphics.scala
+++ b/lib/escapade/src/graphics/escapade_graphics.scala
@@ -43,14 +43,16 @@ import rudiments.*
 import spectacular.*
 import vacuous.*
 
-given graphical: [graphical: Graphical] => graphical is Teletypeable = graphic =>
-  TeletypeBuilder().build:
-    for y <- 0 until (graphical.height(graphic) - 1) by 2 do
-      for x <- 0 until graphical.width(graphic)
-      do
-        val fg = graphical.pixel(graphic, x, y)
-        val bg = graphical.pixel(graphic, x, y + 1)
-        val styled = TextStyle(fg, bg).styleWord
-        append(Teletype(t"▀", Array.of(styled, 0L)))
+package teletypeables:
+  given graphical: [graphical: Graphical] => graphical is Teletypeable = graphic =>
+    TeletypeBuilder().build:
+      for y <- 0 until (graphical.height(graphic) - 1) by 2 do
+        for x <- 0 until graphical.width(graphic)
+        do
+          val fg = graphical.pixel(graphic, x, y)
+          val bg = graphical.pixel(graphic, x, y + 1)
+          val styled = TextStyle(fg, bg).styleWord
+          append(Teletype(t"▀", Array.of(styled, 0L)))
 
-      append(e"\n")
+        append(e"\n")
+

--- a/lib/escapade/src/graphics/soundness_escapade_graphics.scala
+++ b/lib/escapade/src/graphics/soundness_escapade_graphics.scala
@@ -32,4 +32,5 @@
                                                                                                   */
 package soundness
 
-export escapade.graphical
+package teletypeables:
+  export escapade.teletypeables.{graphical}

--- a/lib/escapade/src/io/escapade_io.scala
+++ b/lib/escapade/src/io/escapade_io.scala
@@ -43,18 +43,20 @@ import zephyrine.*
 
 // Teletype values are records, so their streams travel on the boxed medium
 // (windows of `Array[Teletype]^{}`); each record prints as it arrives.
-given out: Stdio => Out.type is Writable by (Array[Teletype]^{}) = new Writable:
-  type Self = Out.type
-  type Operand = Array[Teletype]^{}
+package writables:
+  given out: Stdio => Out.type is Writable by (Array[Teletype]^{}) = new Writable:
+    type Self = Out.type
+    type Operand = Array[Teletype]^{}
 
-  def write(target: Self, stream: (Stream[Array[Teletype]^{}] over Credit)^): Unit =
-    stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Array[Teletype]^{}] over Credit)^]
-    . records.each(Out.print(_))
+    def write(target: Self, stream: (Stream[Array[Teletype]^{}] over Credit)^): Unit =
+      stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Array[Teletype]^{}] over Credit)^]
+      . records.each(Out.print(_))
 
-given err: Stdio => Err.type is Writable by (Array[Teletype]^{}) = new Writable:
-  type Self = Err.type
-  type Operand = Array[Teletype]^{}
+  given err: Stdio => Err.type is Writable by (Array[Teletype]^{}) = new Writable:
+    type Self = Err.type
+    type Operand = Array[Teletype]^{}
 
-  def write(target: Self, stream: (Stream[Array[Teletype]^{}] over Credit)^): Unit =
-    stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Array[Teletype]^{}] over Credit)^]
-    . records.each(Err.print(_))
+    def write(target: Self, stream: (Stream[Array[Teletype]^{}] over Credit)^): Unit =
+      stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Array[Teletype]^{}] over Credit)^]
+      . records.each(Err.print(_))
+

--- a/lib/escapade/src/io/soundness_escapade_io.scala
+++ b/lib/escapade/src/io/soundness_escapade_io.scala
@@ -32,4 +32,6 @@
                                                                                                   */
 package soundness
 
-export escapade.{err, out}
+
+package writables:
+  export escapade.writables.{err, out}

--- a/lib/ethereal/src/core/ethereal.DaemonLogEvent.scala
+++ b/lib/ethereal/src/core/ethereal.DaemonLogEvent.scala
@@ -38,6 +38,9 @@ import guillotine.*
 import profanity.*
 
 object DaemonLogEvent:
+  // In the companion, so transcription resolves through implicit scope with no import.
+  given transcribable: Message transcribes DaemonLogEvent = _.communicate
+
   given communicable: DaemonLogEvent is Communicable =
     case WriteExecutable(location) => m"writing the executable to $location"
     case Shutdown                  => m"shutting down"

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -80,8 +80,6 @@ import filesystemOptions.dereferenceSymlinks.enabled
 
 import filesystemBackends.virtualMachine
 
-given daemonLogEvent: Message transcribes DaemonLogEvent = _.communicate
-
 def service[bus <: Matchable](using service: DaemonService[bus]): DaemonService[bus]^{service} =
   service
 

--- a/lib/ethereal/src/core/soundness_ethereal_core.scala
+++ b/lib/ethereal/src/core/soundness_ethereal_core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export
   ethereal
-  . { Assembler, cli, Client, DaemonEvent, DaemonLogEvent, daemonLogEvent, DaemonService, Installer,
+  . { Assembler, cli, Client, DaemonEvent, DaemonLogEvent, DaemonService, Installer,
       LazyEnvironment, Runners, service, Stdin, TerminalMode, Upgrade, UpgradeError }
 
 package workingDirectories:

--- a/lib/exoskeleton/src/core/exoskeleton_core.scala
+++ b/lib/exoskeleton/src/core/exoskeleton_core.scala
@@ -44,7 +44,7 @@ import digression.*
 // The stack-trace renderers live in `digression.ansi`, not in `StackTrace`'s companion, so they
 // are not in implicit scope; without this import `.teletype` on a stack trace falls back to
 // escapade's generic `Showable` renderer.
-import digression.{exceptionTeletype, frameTeletype, methodTeletype, stackTraceTeletype}
+import digression.teletypeables.{exceptionTeletype, frameTeletype, methodTeletype, stackTraceTeletype}
 import distillate.*
 import escapade.*
 import fulminate.*

--- a/lib/fulminate/src/print/fulminate_print.scala
+++ b/lib/fulminate/src/print/fulminate_print.scala
@@ -38,4 +38,6 @@ import anticipation.*
 // which every module in the tree depends on — does not also carry `anticipation.print`. It is
 // not in `Message`'s implicit scope from here, so it must be imported; `Printable` has no
 // generic fallback, so a call site which forgets fails to compile rather than degrading.
-given messagePrintable: Message is Printable = (message, termcap) => message.text
+package printables:
+  given messagePrintable: Message is Printable = (message, termcap) => message.text
+

--- a/lib/fulminate/src/print/soundness_fulminate_print.scala
+++ b/lib/fulminate/src/print/soundness_fulminate_print.scala
@@ -32,4 +32,5 @@
                                                                                                   */
 package soundness
 
-export fulminate.messagePrintable
+package printables:
+  export fulminate.printables.{messagePrintable}

--- a/lib/galilei/src/wasi/galilei_wasi.scala
+++ b/lib/galilei/src/wasi/galilei_wasi.scala
@@ -54,7 +54,8 @@ import IoError.{Operation, Reason}
 // materializer consults (at its downstream expansion site) for module ids, resource methods and
 // parameter types.
 type WasiFilesystemApi = Interface in Wit at "/galilei/filesystem.wit"
-given wasiFilesystemApi: WasiFilesystemApi = Interface[Wit](cp"/galilei/filesystem.wit")
+package wasiApis:
+  given wasiFilesystemApi: WasiFilesystemApi = Interface[Wit](cp"/galilei/filesystem.wit")
 
 package filesystemBackends:
   // A `FilesystemBackend` over `wasi:filesystem`. WASI filesystems are capability-based: the host

--- a/lib/galilei/src/wasi/soundness_galilei_wasi.scala
+++ b/lib/galilei/src/wasi/soundness_galilei_wasi.scala
@@ -32,7 +32,10 @@
                                                                                                   */
 package soundness
 
-export galilei.{WasiFilesystemApi, wasiFilesystemApi}
+export galilei.{WasiFilesystemApi}
 
 package filesystemBackends:
   export galilei.filesystemBackends.wasi
+
+package wasiApis:
+  export galilei.wasiApis.wasiFilesystemApi

--- a/lib/graffiti/src/core/soundness_graffiti_core.scala
+++ b/lib/graffiti/src/core/soundness_graffiti_core.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package soundness
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
+export graffiti.{Archetype, Headline, hdir, TopMenu, urlText, VersoPanel, RectoPanel,
+    FoldableRectoPanel,
     Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
     ThemeColor, Favicon, Canonical, StandardMetadata, Dashboard}

--- a/lib/jacinta/src/optics/jacinta_optics.scala
+++ b/lib/jacinta/src/optics/jacinta_optics.scala
@@ -44,75 +44,79 @@ import vacuous.*
 
 // The panopticon lens and optic instances for `Json`. These are the only reason `jacinta.core`
 // needed panopticon, so they live here instead of in `Json`'s companion. That takes them out of
-// `Json`'s implicit scope, so a call site using `json.lens(…)` must import them; panopticon's
-// generic `deref` lens only applies to `Product` types, and `Json` is not one, so a missing
-// import is a compile error rather than a silent change of behaviour.
+// `Json`'s implicit scope, so a call site using `json.lens(…)` must import them — decisively,
+// from the `optics` package (`import jacinta.optics.*`, or `import soundness.optics.*`, where
+// every library's optics merge); panopticon's generic `deref` lens only applies to `Product`
+// types, and `Json` is not one, so a missing import is a compile error rather than a silent
+// change of behaviour.
 
-given jsonLens: [name <: Label: ValueOf] => (erased dynamicJsonEnabler: DynamicJsonEnabler) => (tactic: Tactic[JsonError])
-=>  ((name is Lens from Json onto Json)^{tactic}) =
+package optics:
+  given jsonLens: [name <: Label: ValueOf] => (erased dynamicJsonEnabler: DynamicJsonEnabler) => (tactic: Tactic[JsonError])
+  =>  ((name is Lens from Json onto Json)^{tactic}) =
 
-  Lens(_.selectField(valueOf[name]), (json, value) => json.modify(valueOf[name], value))
+    Lens(_.selectField(valueOf[name]), (json, value) => json.modify(valueOf[name], value))
 
-given jsonOrdinalOptical: [element] => Ordinal is Optical from Json onto Json =
-  ordinal =>
+  given jsonOrdinalOptical: [element] => Ordinal is Optical from Json onto Json =
+    ordinal =>
+      Optic: (origin, lambda) =>
+        if origin.root.isArray then
+          val n = origin.root.arrayLength
+
+          if n <= ordinal.n0 then origin else Json.ast:
+            val updated = Array[Any](n)
+            var i = 0
+
+            while i < n do
+              updated(i) =
+                if i == ordinal.n0
+                then lambda(Json.ast(origin.root.arrayElement(i))).root
+                else origin.root.arrayElement(i)
+
+              i += 1
+
+            Json.Ast.arr(Array.freeze(updated))
+        else
+          origin
+
+  // `Each` applies the transform to every array element; `Filter` to those matching
+  // its predicate. Both rebuild the array immutably and no-op on non-arrays.
+  given jsonEachOptical: Each.type is Optical from Json onto Json = _ =>
     Optic: (origin, lambda) =>
       if origin.root.isArray then
         val n = origin.root.arrayLength
 
-        if n <= ordinal.n0 then origin else Json.ast:
+        Json.ast:
           val updated = Array[Any](n)
           var i = 0
 
           while i < n do
-            updated(i) =
-              if i == ordinal.n0
-              then lambda(Json.ast(origin.root.arrayElement(i))).root
-              else origin.root.arrayElement(i)
-
+            updated(i) = lambda(Json.ast(origin.root.arrayElement(i))).root
             i += 1
 
           Json.Ast.arr(Array.freeze(updated))
       else
         origin
 
-// `Each` applies the transform to every array element; `Filter` to those matching
-// its predicate. Both rebuild the array immutably and no-op on non-arrays.
-given jsonEachOptical: Each.type is Optical from Json onto Json = _ =>
-  Optic: (origin, lambda) =>
-    if origin.root.isArray then
-      val n = origin.root.arrayLength
+  // The `predicate` laundering is for the Scala.js pipeline, which — unlike the JVM
+  // pipeline — rejects the `Optic`'s capture of `filter.predicate` against the required
+  // pure `Optic` type. (Compiler divergence; see #1520 and `caesura`'s `rowFilter`.)
+  given jsonFilterOptical: Filter[Json] is Optical from Json onto Json = filter =>
+    val predicate: Json -> Boolean = caps.unsafe.unsafeAssumePure(filter.predicate)
 
-      Json.ast:
-        val updated = Array[Any](n)
-        var i = 0
+    Optic: (origin, lambda) =>
+      if origin.root.isArray then
+        val n = origin.root.arrayLength
 
-        while i < n do
-          updated(i) = lambda(Json.ast(origin.root.arrayElement(i))).root
-          i += 1
+        Json.ast:
+          val updated = Array[Any](n)
+          var i = 0
 
-        Json.Ast.arr(Array.freeze(updated))
-    else
-      origin
+          while i < n do
+            val element = Json.ast(origin.root.arrayElement(i))
+            updated(i) = (if predicate(element) then lambda(element) else element).root
+            i += 1
 
-// The `predicate` laundering is for the Scala.js pipeline, which — unlike the JVM
-// pipeline — rejects the `Optic`'s capture of `filter.predicate` against the required
-// pure `Optic` type. (Compiler divergence; see #1520 and `caesura`'s `rowFilter`.)
-given jsonFilterOptical: Filter[Json] is Optical from Json onto Json = filter =>
-  val predicate: Json -> Boolean = caps.unsafe.unsafeAssumePure(filter.predicate)
+          Json.Ast.arr(Array.freeze(updated))
+      else
+        origin
 
-  Optic: (origin, lambda) =>
-    if origin.root.isArray then
-      val n = origin.root.arrayLength
-
-      Json.ast:
-        val updated = Array[Any](n)
-        var i = 0
-
-        while i < n do
-          val element = Json.ast(origin.root.arrayElement(i))
-          updated(i) = (if predicate(element) then lambda(element) else element).root
-          i += 1
-
-        Json.Ast.arr(Array.freeze(updated))
-    else
-      origin

--- a/lib/jacinta/src/optics/soundness_jacinta_optics.scala
+++ b/lib/jacinta/src/optics/soundness_jacinta_optics.scala
@@ -32,4 +32,5 @@
                                                                                                   */
 package soundness
 
-export jacinta.{jsonEachOptical, jsonFilterOptical, jsonLens, jsonOrdinalOptical}
+package optics:
+  export jacinta.optics.{jsonEachOptical, jsonFilterOptical, jsonLens, jsonOrdinalOptical}

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -36,7 +36,7 @@ import soundness.*
 
 // The `Json` lens and optic instances live in `jacinta.optics` now, outside `Json`'s implicit
 // scope, so they must be imported by name.
-import jacinta.{jsonEachOptical, jsonFilterOptical, jsonLens, jsonOrdinalOptical}
+import jacinta.optics.*
 import proscenium.compat.*
 
 import scala.language.dynamics

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -36,7 +36,7 @@ import soundness.*
 
 // The `Json` lens and optic instances live in `jacinta.optics` now, outside `Json`'s implicit
 // scope, so they must be imported by name.
-import jacinta.optics.*
+import jacinta.optics.{jsonEachOptical, jsonFilterOptical, jsonLens, jsonOrdinalOptical}
 import proscenium.compat.*
 
 import scala.language.dynamics

--- a/lib/legerdemain/src/query/legerdemain.Query.scala
+++ b/lib/legerdemain/src/query/legerdemain.Query.scala
@@ -98,7 +98,13 @@ object Query extends Dynamic:
     case given ProductReflection[`value` & Product] =>
       EncodableDerivation.conjunction[value & Product].asInstanceOf[value is Encodable in Query]
 
-  given showable: Query is Showable =
+  // The URL-encoded form, agreeing with `encodable` and `queryString`: `Query.show` must
+  // not disagree with `Query.encode` (#1500). The debug rendering lives in `inspectable`.
+  given showable: Query is Showable = _.queryString
+
+  // Declared explicitly because `Inspectable`'s derivation prefers `Encodable in Text`
+  // over `Showable`, which would otherwise render `.inspect` URL-encoded too.
+  given inspectable: Query is Inspectable =
     _.values.map { case (key, value) => t"$key = \"${value}\"" }.join(t", ")
 
   inline given decodable: [value] => value is Decodable in Query =

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -58,6 +58,13 @@ import crypto.permitDeprecatedCrypto
 import providers.javaStdlibProvider
 
 object Message:
+  // A formal `Message is Ingressive`, so the raw `Message` type satisfies the
+  // `Ingressive` requirement `webSocket` places on its message type. A `Message`
+  // channel is decoded by identity — the reader already produced the `Message` — so
+  // this is never actually applied; it could not recover the Text/Binary distinction
+  // from raw bytes anyway. In the companion, so it resolves with no import.
+  given ingressive: Message is Ingressive = Message.Binary(_)
+
   // A `Message` serialises to a complete (unmasked) WebSocket frame, so it can
   // flow through Coaxial's `Control.Reply`/`Conclude` and be written verbatim.
   given transmissible: Message is Transmissible =

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -62,13 +62,6 @@ import alphabets.base64Standard
 import crypto.permitDeprecatedCrypto
 import providers.javaStdlibProvider
 
-// A formal `Message is Ingressive`, so the raw `Message` type satisfies the
-// `Ingressive` requirement `webSocket` places on its message type. A `Message`
-// channel is decoded by identity — the reader already produced the `Message` — so
-// this is never actually applied; it could not recover the Text/Binary distinction
-// from raw bytes anyway.
-given messageIngressive: Message is Ingressive = Message.Binary(_)
-
 // `true` exactly when the message type is the raw `Message`. A match type reduces
 // by subtyping — `Message` matches the first case, any other (e.g. `Ping over Json`)
 // falls through to `false` — and `constValue` reads it back as a literal at the
@@ -106,7 +99,7 @@ inline def webSocket[state](initial: state = ())[message]
 // Text frame. Every `Transmissible` in perihelion yields a complete frame, so the
 // send path is uniform: the server spools it verbatim; a client masks it once at the
 // `Channel` boundary.
-given transmissible: [transport, value]
+given overTransmissible: [transport, value]
 =>  ( format: transport is Encodable in Text, codec: value is Encodable in transport )
 =>  CharEncoder
 =>  (value over transport) is Transmissible =
@@ -116,7 +109,7 @@ given transmissible: [transport, value]
 // `Tactic`-conditional and don't resolve as nested given constraints, so we
 // require a `Tactic[Hazard]` directly (satisfied by `strategies.throwUnsafely`;
 // `Tactic` is contravariant) and summon them in the body, where it is in scope.
-given ingressive: [transport, value]
+given overIngressive: [transport, value]
 =>  ( format: transport is Decodable in Text, codec: value is Decodable in transport )
 =>  ( CharDecoder, Tactic[Hazard] )
 =>  (value over transport) is Ingressive =

--- a/lib/perihelion/src/core/soundness_perihelion_core.scala
+++ b/lib/perihelion/src/core/soundness_perihelion_core.scala
@@ -32,9 +32,9 @@
                                                                                                   */
 package soundness
 
-// The MathML element types (`Mi`, `Mrow`, `Token`, `Layout`, `Ms`, …) are nested inside the
-// `Mathml` object (as `Mathml.Mi`, `Mathml.Mrow`, …) rather than exported flat, so their generic
-// names do not collide with unrelated modules in the `soundness` namespace. Import
-// `soundness.Mathml.*` for the bare element names where MathML is being authored by hand.
-export archimedes.{Math, Mathml, Display, MathmlError, MathmlParser, MathmlReader, mathmlNamespace,
-    Ergo, ErgoError, ergo, mathml, math, Cell, cell, draw}
+export perihelion.{Frame, Masking, Message, Websocket, WebsocketError, WebsocketEvent,
+    WsConnection, WsSessional, WsUrl, overIngressive, overTransmissible, webSocket}
+
+// `wsClient` and `wsSessional` are deliberately not exported: their types carry
+// capture-annotated refinements, which synthesized export forwarders lose (see the note in
+// soundness_scintillate_server.scala). Import them by name: `import perihelion.wsClient`.

--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -43,7 +43,7 @@ import digression.*
 // The stack-trace renderers live in `digression.ansi`, not in `StackTrace`'s companion, so they
 // are not in implicit scope; without this import `.teletype` on a stack trace falls back to
 // escapade's generic `Showable` renderer.
-import digression.{exceptionTeletype, frameTeletype, methodTeletype, stackTraceTeletype}
+import digression.teletypeables.{exceptionTeletype, frameTeletype, methodTeletype, stackTraceTeletype}
 import escapade.*
 import fulminate.*
 import gossamer.*

--- a/lib/probably/src/core/probably.AnsiRenderer.scala
+++ b/lib/probably/src/core/probably.AnsiRenderer.scala
@@ -43,7 +43,7 @@ import digression.*
 // The stack-trace renderers live in `digression.ansi`, not in `StackTrace`'s companion, so they
 // are not in implicit scope; without this import `.teletype` on a stack trace falls back to
 // escapade's generic `Showable` renderer.
-import digression.{exceptionTeletype, frameTeletype, methodTeletype, stackTraceTeletype}
+import digression.teletypeables.{exceptionTeletype, frameTeletype, methodTeletype, stackTraceTeletype}
 import distillate.*
 import escapade.*
 import escritoire.*, columnAttenuation.ignoreAttenuation
@@ -63,7 +63,8 @@ import tableStyles.defaultTableStyle
 // `Juxtaposition`'s renderer lives in `chiaroscuro.render`, not in the enum's companion, so it
 // is not in implicit scope. Without this import `cmp.teletype` below silently resolves to
 // escapade's generic `Showable` fallback and prints the value instead of the difference table.
-import chiaroscuro.juxtapositionTeletype
+import chiaroscuro.teletypeables.juxtapositionTeletype
+import probably.decimalizers.fourDecimalPlaces
 
 // The full-colour renderer: tables, ribbons, banner, sparklines, histograms and coverage,
 // plus GitHub Actions annotations when running there. All content decisions live in

--- a/lib/probably/src/core/probably.Axis.scala
+++ b/lib/probably/src/core/probably.Axis.scala
@@ -42,6 +42,8 @@ import distillate.*
 import gossamer.*
 import prepositional.*
 import spectacular.*
+
+import decimalizers.fourDecimalPlaces
 import vacuous.*
 
 object Axable:

--- a/lib/probably/src/core/probably.TerseRenderer.scala
+++ b/lib/probably/src/core/probably.TerseRenderer.scala
@@ -53,6 +53,8 @@ import vacuous.*
 import Format.measurable
 import tableStyles.minimalTableStyle
 
+import probably.decimalizers.fourDecimalPlaces
+
 // The plain-text renderer, for machine-adjacent environments (Claude Code): the same
 // document as the colour renderer, with word statuses, minimal tables and no banner.
 private[probably] object TerseRenderer:

--- a/lib/probably/src/core/probably_core.scala
+++ b/lib/probably/src/core/probably_core.scala
@@ -43,7 +43,10 @@ import nomenclature.*
 import prepositional.*
 import symbolism.*
 
-given decimalizer: Decimalizer = Decimalizer(4)
+// The default four-decimal-place rendering for numeric comparisons, imported
+// decisively rather than silently supplied by `import probably.*`.
+package decimalizers:
+  given fourDecimalPlaces: Decimalizer = Decimalizer(4)
 
 export Baseline.Compare.{Min, Mean, Max}
 export Baseline.Metric.{Cadential, Temporal}
@@ -53,9 +56,11 @@ export Baseline.Mode.{Arithmetic, Geometric}
 // imported, without a separate `import Probing.nominative` in every suite.
 export Probing.nominative
 
-// A real trait, not a structural refinement of `Palette`: structural member selection goes
-// through `iridescence.Palette.selectDynamic` — runtime reflection, which Scala Native does not
-// support — whereas these are ordinary virtual calls.
+  // A real trait, not a structural refinement of `Palette`: structural member selection goes
+  // through `iridescence.Palette.selectDynamic` — runtime reflection, which Scala Native does not
+  // support — whereas these are ordinary virtual calls.
+
+
 trait TestPalette extends JuxtapositionPalette:
   type Form = Srgb
   def warning: Color in Srgb

--- a/lib/profanity/src/core/profanity_core.scala
+++ b/lib/profanity/src/core/profanity_core.scala
@@ -41,7 +41,11 @@ import parasite.*
 import rudiments.*
 import turbulence.*
 
-given stdio: (terminal: Terminal) => Stdio = terminal.stdio
+// The canonical way a `Terminal` supplies the standard streams; a single instance, not a
+// choice, so it is a named toplevel given rather than a `stdios`-style package (which would
+// also be ambiguous with turbulence's `stdios` under two wildcard imports).
+given terminalStdio: (terminal: Terminal) => Stdio = terminal.stdio
+
 
 
 def interactive[result](block: (terminal: Terminal) ?=> result)

--- a/lib/profanity/src/core/soundness_profanity_core.scala
+++ b/lib/profanity/src/core/soundness_profanity_core.scala
@@ -35,7 +35,7 @@ package soundness
 export
   profanity
   . { Board, Console, CtrlChar, DismissError, Interaction, interactive, Interactivity, Keyboard,
-      Keypress, LineEditor, Question, SelectMenu, Interrupt, SignalResponse, stdio,
+      Keypress, LineEditor, Question, SelectMenu, Interrupt, SignalResponse,
       Terminal, TerminalError, TerminalEvent, TerminalFeature, TerminalInfo, TerminalBoard,
       InlineBoard, UnixSignal, WindowsSignal }
 
@@ -47,3 +47,5 @@ package terminalFeatures:
     profanity.terminalFeatures
     . { bracketedPasteFeature, focusReportingFeature, mouseTrackingFeature, alternateScreenFeature,
         kittyKeyboardFeature, backgroundColorFeature, terminalSizeFeature }
+
+export profanity.terminalStdio

--- a/lib/punctuation/src/ansi/punctuation_ansi.scala
+++ b/lib/punctuation/src/ansi/punctuation_ansi.scala
@@ -83,7 +83,7 @@ extension (markdown: Markdown of Layout)
 // `termcapDefinitions` leave the default `Int.MaxValue`, which would otherwise
 // produce mile-wide thematic-break rules), renders to a `Teletype`, then
 // emits ANSI escapes through the existing `Teletype is Printable` given.
-given (Hyphenation, Every[TeletypeFormattable], MarkdownPalette)
+given markdownPrintable: (Hyphenation, Every[TeletypeFormattable], MarkdownPalette)
 =>  (Markdown of Layout) is Printable =
 
   (markdown, termcap) =>

--- a/lib/stratiform/src/optics/soundness_stratiform_optics.scala
+++ b/lib/stratiform/src/optics/soundness_stratiform_optics.scala
@@ -32,4 +32,5 @@
                                                                                                   */
 package soundness
 
-export stratiform.{telEachOptical, telLens, telOrdinalOptical}
+package optics:
+  export stratiform.optics.{telEachOptical, telLens, telOrdinalOptical}

--- a/lib/stratiform/src/optics/stratiform_optics.scala
+++ b/lib/stratiform/src/optics/stratiform_optics.scala
@@ -51,27 +51,29 @@ import vacuous.*
 // routes through `Tel.modify`, which replaces an existing child
 // compound with the same kebab-case keyword in place or appends a
 // new one. Mirrors jacinta's lens given.
-given telLens: [name <: Label: ValueOf] => (erased dynamicTelEnabler: DynamicTelEnabler) => Tactic[TelError]
-=>  name is Lens from Tel onto Tel =
-  Lens(_.selectField(valueOf[name]), _.modify(valueOf[name], _))
+package optics:
+  given telLens: [name <: Label: ValueOf] => (erased dynamicTelEnabler: DynamicTelEnabler) => Tactic[TelError]
+  =>  name is Lens from Tel onto Tel =
+    Lens(_.selectField(valueOf[name]), _.modify(valueOf[name], _))
 
-// Positional optics over a node's child compounds (TEL has no positional arrays,
-// but a compound's children are ordered — this mirrors the read-side
-// `applyDynamic(field)(index)`). `Ordinal` addresses the n-th child; `Each` every
-// child. The transform's result keeps the original child's keyword, so a positional
-// update preserves the field identity while replacing its value/children.
-// (`rewrap`/`rebuild` are package-level pure helpers — see `stratiform_core.scala`.)
+  // Positional optics over a node's child compounds (TEL has no positional arrays,
+  // but a compound's children are ordered — this mirrors the read-side
+  // `applyDynamic(field)(index)`). `Ordinal` addresses the n-th child; `Each` every
+  // child. The transform's result keeps the original child's keyword, so a positional
+  // update preserves the field identity while replacing its value/children.
+  // (`rewrap`/`rebuild` are package-level pure helpers — see `stratiform_core.scala`.)
 
-given telOrdinalOptical: [element] => Ordinal is Optical from Tel onto Tel = ordinal =>
-  Optic: (origin, lambda) =>
-    if ordinal.n0 < 0 || ordinal.n0 >= origin.childCompounds.length then origin
-    else rebuild
-      ( origin,
-        Tel.withChildCompound
-         ( origin.subtree.children, ordinal.n0, c => rewrap(c, lambda(Tel.make(c))) ) )
+  given telOrdinalOptical: [element] => Ordinal is Optical from Tel onto Tel = ordinal =>
+    Optic: (origin, lambda) =>
+      if ordinal.n0 < 0 || ordinal.n0 >= origin.childCompounds.length then origin
+      else rebuild
+        ( origin,
+          Tel.withChildCompound
+           ( origin.subtree.children, ordinal.n0, c => rewrap(c, lambda(Tel.make(c))) ) )
 
-given telEachOptical: Each.type is Optical from Tel onto Tel = _ =>
-  Optic: (origin, lambda) =>
-    rebuild
-      ( origin,
-        Tel.mapChildCompounds(origin.subtree.children, c => rewrap(c, lambda(Tel.make(c)))) )
+  given telEachOptical: Each.type is Optical from Tel onto Tel = _ =>
+    Optic: (origin, lambda) =>
+      rebuild
+        ( origin,
+          Tel.mapChildCompounds(origin.subtree.children, c => rewrap(c, lambda(Tel.make(c)))) )
+

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -52,7 +52,7 @@ import panopticon.*
 
 // The `Tel` lens and optic instances live in `stratiform.optics` now, outside `Tel`'s implicit
 // scope, so they must be imported by name.
-import stratiform.optics.*
+import stratiform.optics.{telEachOptical, telLens, telOrdinalOptical}
 import prepositional.*
 import probably.*
 import rudiments.*

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -52,7 +52,7 @@ import panopticon.*
 
 // The `Tel` lens and optic instances live in `stratiform.optics` now, outside `Tel`'s implicit
 // scope, so they must be imported by name.
-import stratiform.{telEachOptical, telLens, telOrdinalOptical}
+import stratiform.optics.*
 import prepositional.*
 import probably.*
 import rudiments.*

--- a/lib/telekinesis/src/wasi/soundness_telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/soundness_telekinesis_wasi.scala
@@ -32,7 +32,10 @@
                                                                                                   */
 package soundness
 
-export telekinesis.{WasiHttpApi, wasiHttpApi}
+export telekinesis.{WasiHttpApi}
 
 package httpBackends:
   export telekinesis.httpBackends.wasi
+
+package wasiApis:
+  export telekinesis.wasiApis.wasiHttpApi

--- a/lib/telekinesis/src/wasi/telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/telekinesis_wasi.scala
@@ -55,7 +55,8 @@ import zephyrine.*
 // materializer consults (at its downstream expansion site) for module ids, resource methods and
 // parameter types.
 type WasiHttpApi = Interface in Wit at "/telekinesis/http.wit"
-given wasiHttpApi: WasiHttpApi = Interface[Wit](cp"/telekinesis/http.wit")
+package wasiApis:
+  given wasiHttpApi: WasiHttpApi = Interface[Wit](cp"/telekinesis/http.wit")
 
 package httpBackends:
   // An `Http.Backend` over `wasi:http/outgoing-handler`: the request is assembled from

--- a/lib/turbulence/src/wasi/soundness_turbulence_wasi.scala
+++ b/lib/turbulence/src/wasi/soundness_turbulence_wasi.scala
@@ -32,7 +32,10 @@
                                                                                                   */
 package soundness
 
-export turbulence.{WasiCliApi, wasiCliApi}
+export turbulence.{WasiCliApi}
 
 package stdios:
   export turbulence.stdios.wasiStdio
+
+package wasiApis:
+  export turbulence.wasiApis.wasiCliApi

--- a/lib/turbulence/src/wasi/turbulence_wasi.scala
+++ b/lib/turbulence/src/wasi/turbulence_wasi.scala
@@ -50,7 +50,8 @@ import xenophile.*
 // The WIT definitions the navigation below is typechecked against, and which the `call`
 // materializer consults (at its downstream expansion site) for module ids and resource methods.
 type WasiCliApi = Interface in Wit at "/turbulence/cli.wit"
-given wasiCliApi: WasiCliApi = Interface[Wit](cp"/turbulence/cli.wit")
+package wasiApis:
+  given wasiCliApi: WasiCliApi = Interface[Wit](cp"/turbulence/cli.wit")
 
 package stdios:
   // A `Stdio` whose standard streams go through the WASI stream resources: each write obtains the

--- a/lib/urticose/src/ansi/soundness_urticose_ansi.scala
+++ b/lib/urticose/src/ansi/soundness_urticose_ansi.scala
@@ -32,4 +32,7 @@
                                                                                                   */
 package soundness
 
-export urticose.{urlTeletype, UrlPalette}
+export urticose.{UrlPalette}
+
+package teletypeables:
+  export urticose.teletypeables.{urlTeletype}

--- a/lib/urticose/src/ansi/urticose_ansi.scala
+++ b/lib/urticose/src/ansi/urticose_ansi.scala
@@ -46,5 +46,7 @@ type UrlPalette = Palette:
 // draw in the ANSI stack. Note that `escapade` supplies a generic `Teletypeable` fallback for
 // any `Showable` type, so a call site which does not import this given still compiles — and
 // renders the URL unstyled.
-given urlTeletype: [scheme <: Label] => (palette: UrlPalette) => Url[scheme] is Teletypeable =
-  url => e"$Underline(${Fg(palette.link)}(${url.show}))"
+package teletypeables:
+  given urlTeletype: [scheme <: Label] => (palette: UrlPalette) => Url[scheme] is Teletypeable =
+    url => e"$Underline(${Fg(palette.link)}(${url.show}))"
+

--- a/lib/urticose/src/test/urticose_test.scala
+++ b/lib/urticose/src/test/urticose_test.scala
@@ -37,7 +37,7 @@ import soundness.*
 import proscenium.compat.*
 import fulminate.errorDiagnostics.stackTracesDiagnostics
 import strategies.throwUnsafely
-import urticose.urlTeletype
+import urticose.teletypeables.urlTeletype
 
 object Tests extends Suite(m"Urticose tests"):
   given palette: UrlPalette = new Palette:

--- a/lib/xylophone/src/core/soundness_xylophone_core.scala
+++ b/lib/xylophone/src/core/soundness_xylophone_core.scala
@@ -41,3 +41,6 @@ export
 
 package formatting:
   export xylophone.formatting.{compactXmlFormatting, indentedXmlFormatting}
+
+package optics:
+  export xylophone.optics.{xmlEachOptical, xmlLens, xmlOrdinalOptical}

--- a/lib/xylophone/src/core/xylophone_core.scala
+++ b/lib/xylophone/src/core/xylophone_core.scala
@@ -117,15 +117,16 @@ private def updateChildElements(xml: Xml, select: Int => Boolean, lambda: Xml =>
     case other =>
       other
 
-given lens: [name <: Label: ValueOf] => (erased dynamicXmlEnabler: DynamicXmlEnabler)
-=>  name is Lens from Xml onto Xml =
-  Lens(_.applyDynamic(valueOf[name])(Prim), replaceNamedChild(_, valueOf[name], _))
+package optics:
+  given xmlLens: [name <: Label: ValueOf] => (erased dynamicXmlEnabler: DynamicXmlEnabler)
+  =>  name is Lens from Xml onto Xml =
+    Lens(_.applyDynamic(valueOf[name])(Prim), replaceNamedChild(_, valueOf[name], _))
 
-given ordinalOptical: [element] => Ordinal is Optical from Xml onto Xml = ordinal =>
-  Optic: (origin, lambda) => updateChildElements(origin, _ == ordinal.n0, lambda)
+  given xmlOrdinalOptical: [element] => Ordinal is Optical from Xml onto Xml = ordinal =>
+    Optic: (origin, lambda) => updateChildElements(origin, _ == ordinal.n0, lambda)
 
-given eachOptical: Each.type is Optical from Xml onto Xml = _ =>
-  Optic: (origin, lambda) => updateChildElements(origin, _ => true, lambda)
+  given xmlEachOptical: Each.type is Optical from Xml onto Xml = _ =>
+    Optic: (origin, lambda) => updateChildElements(origin, _ => true, lambda)
 
 package formatting:
   given compactXmlFormatting: Xml.Formatting = Xml.Formatting(Unset, trailingNewline = false)

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -40,7 +40,7 @@ import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import threading.virtualThreading
 import probates.cancelProbate
-import xylophone.optics.*
+import xylophone.optics.{xmlEachOptical, xmlLens, xmlOrdinalOptical}
 
 case class Worker(name: Text, age: Int)
 case class Firm(name: Text, ceo: Worker)

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -40,6 +40,7 @@ import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import threading.virtualThreading
 import probates.cancelProbate
+import xylophone.optics.*
 
 case class Worker(name: Text, age: Int)
 case class Firm(name: Text, ceo: Worker)

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -56,7 +56,7 @@ import hypotenuse.Bcd
 import panopticon.*
 import prepositional.*
 import rudiments.*
-import spectacular.show
+import spectacular.{show, Showable}
 import turbulence.*
 import vacuous.*
 import wisteria.*
@@ -295,6 +295,9 @@ trait Yaml2:
           discriminable.rewrite(variantNames(label).or(label), contextual.encode(value))
 
 object Yaml extends Yaml2, Dynamic:
+  // In the companion (implicit scope), delegating to the block emitter in the package.
+  given showable: Formatting => Yaml is Showable = unseal(_).show
+
   // Controls how a `Yaml` value is serialized. YAML's block style is fixed and round-trip-
   // constrained, so this currently carries no options; importing `formatting.blockYamlFormatting`
   // enables `.show` and HTTP encoding, and this is the place to add options later.
@@ -375,6 +378,10 @@ object Yaml extends Yaml2, Dynamic:
     def withPosition(yaml: Yaml): Focus = copy(position = yaml.locate(pointer))
 
   object Ast extends Format:
+    // In `Ast`'s companion (implicit scope), delegating to the block emitter in the
+    // package; bring a `Yaml.Formatting` into scope to enable `.show`.
+    given showable: (formatting: Formatting) => Ast is Showable = renderAst(_)
+
     def name: Text = "YAML"
 
     case class Position

--- a/lib/ypsiloid/src/core/ypsiloid_core.scala
+++ b/lib/ypsiloid/src/core/ypsiloid_core.scala
@@ -56,7 +56,9 @@ import zephyrine.*
 // even-length `Array[Any]^{}` of alternating key/value; a sequence is an odd-length `Array[Any]^{}`
 // (trailing `arrayPad` sentinel when the item count is even). Mirrors jacinta's `Json.Ast`
 // `Showable`. Bring a `Yaml.Formatting` into scope to enable `.show` and HTTP encoding.
-given astShowable: (formatting: Yaml.Formatting) => Yaml.Ast is Showable = yaml =>
+// The `Showable` instances themselves live in the `Yaml` and `Yaml.Ast` companions, in
+// implicit scope; this is only the emitter.
+private[ypsiloid] def renderAst(yaml: Yaml.Ast)(using formatting: Yaml.Formatting): Text =
   val spaces: Text =
     t"                                                                "
 
@@ -196,8 +198,6 @@ given astShowable: (formatting: Yaml.Formatting) => Yaml.Ast is Showable = yaml 
       producer.put("\n")
     else
       block(yaml, 0)
-
-given showable: Yaml.Formatting => Yaml is Showable = Yaml.unseal(_).show
 
 extension (inline context: StringContext)
   transparent inline def y: Interpolation = interpolation[Yaml](context)

--- a/src/test/soundness.Tests.scala
+++ b/src/test/soundness.Tests.scala
@@ -143,6 +143,7 @@ object Tests extends Suite(m"Soundness tests"):
     synesthesia.Tests()
     symbolism.Tests()
     tarantula.Tests()
+    telekinesis.Tests()
     typonym.Tests()
     ultimatum.Tests()
     ulysses.Tests()
@@ -164,5 +165,5 @@ object Tests extends Suite(m"Soundness tests"):
 
 object FailingTests extends Suite(m"Failing tests"):
   def run(): Unit =
-    telekinesis.Tests()
     // turbulence.Tests() - deadlock
+    ()

--- a/tests/wasm/http/Main.scala
+++ b/tests/wasm/http/Main.scala
@@ -10,7 +10,7 @@ import gossamer.*
 import hieroglyph.*, charEncoders.utf8Encoder
 import prepositional.*
 import spectacular.*
-import telekinesis.*, telekinesis.wasiHttpApi
+import telekinesis.*, telekinesis.wasiApis.wasiHttpApi
 import vacuous.*
 import zephyrine.*
 

--- a/tests/wasm/src/Main.scala
+++ b/tests/wasm/src/Main.scala
@@ -22,12 +22,12 @@ import strategies.throwUnsafely
 object Main extends Run:
 
   private def scenarioEnv(): ambience.Environment =
-    import ambience.wasiEnvironmentApi
+    import ambience.wasiApis.wasiEnvironmentApi
     import ambience.environments.wasiEnvironment
     summon[ambience.Environment]
 
   private def stdio(scenario: Text): Unit =
-    import turbulence.{Stdio, wasiCliApi}
+    import turbulence.Stdio, turbulence.wasiApis.wasiCliApi
     import turbulence.stdios.wasiStdio
     import anticipation.termcapDefinitions.basicTermcap
 
@@ -39,7 +39,7 @@ object Main extends Run:
     io.printErr(("stderr: " + received + "\n").tt)
 
   private def clock(): Unit =
-    import aviation.{monotonic, wasiClockApi}
+    import aviation.monotonic, aviation.wasiApis.wasiClockApi
     import aviation.clocks.wasiMonotonicClock
 
     val first = monotonic()
@@ -47,7 +47,7 @@ object Main extends Run:
     System.out.nn.println("clock: ok")
 
   private def random(): Unit =
-    import capricious.{arbitrary, stochastic, wasiRandomApi}
+    import capricious.{arbitrary, stochastic}, capricious.wasiApis.wasiRandomApi
     import capricious.randomization.wasiRandomization
 
     stochastic:
@@ -56,7 +56,7 @@ object Main extends Run:
       System.out.nn.println(if first != second then "random: ok" else "random: suspicious")
 
   private def fs(): Unit =
-    import galilei.{FilesystemBackend, Linux, OpenFlag, wasiFilesystemApi}
+    import galilei.{FilesystemBackend, Linux, OpenFlag}, galilei.wasiApis.wasiFilesystemApi
     import galilei.filesystemBackends.wasi
     import serpentine.*
 
@@ -77,7 +77,7 @@ object Main extends Run:
     System.out.nn.println("fs: " + content.s)
 
   private def tcp(environment: ambience.Environment): Unit =
-    import coaxial.{SocketBackend, wasiSocketsApi}
+    import coaxial.SocketBackend, coaxial.wasiApis.wasiSocketsApi
     import coaxial.socketBackends.wasi
     import urticose.{Endpoint, Port, Tcp}
 
@@ -90,7 +90,7 @@ object Main extends Run:
     backend.hangUp(exchange)
 
   private def http(environment: ambience.Environment): Unit =
-    import telekinesis.{Http, wasiHttpApi}
+    import telekinesis.Http, telekinesis.wasiApis.wasiHttpApi
     import telekinesis.httpBackends.wasi
     import zephyrine.Stream
 


### PR DESCRIPTION
Issue #1632 asked for the orphan top-level `given` definitions to be relocated. A fresh inventory found 74 of them across 37 libraries, and this PR gives each one a deliberate home under a single rule: a given belongs in the companion of its subject type (implicit scope) when module layering permits; a given that selects an implementation belongs in a carefully-named package, imported decisively; and a single-canonical instance that cannot be anchored keeps a unique, library-qualified toplevel name with a comment saying why. The 35 that remain toplevel are all in the last category. The rule and its traps are now recorded in CLAUDE.md.

Along the way this resolves #1500, whose diagnosis dissolved on inspection: there was no umbrella-vs-per-module implicit-scope difference — the URL-encoded `Query is Showable` was dropped when `Query` moved to legerdemain, and the umbrella "passed" because `telekinesis.Tests()` sat in a suite nothing invokes. `Query.show` now agrees with `Query.encode`, the debug rendering is an explicit `Inspectable`, and the telekinesis suite is back in the attested run.

## Release notes

Givens that select an implementation now live in named packages and need a by-name import: the lens/optic instances of jacinta, xylophone, caesura and stratiform (`import soundness.optics.*` — xylophone's are renamed `xmlLens`, `xmlOrdinalOptical`, `xmlEachOptical`); the styled stack-trace, URL and juxtaposition renderings (`teletypeables`); escapade's `out`/`err` (`writables`); fulminate's `messagePrintable` (`printables`); the seven `wasi*Api` values (`wasiApis`); and probably's four-decimal default (`decimalizers.fourDecimalPlaces`). Several givens are renamed: bitumen's `creatable` → `tarPathCreatable`, profanity's `stdio` → `terminalStdio`, perihelion's `transmissible`/`ingressive` → `overTransmissible`/`overIngressive`. Companion moves are invisible to callers — those givens now resolve with no import at all. `import soundness.*` users are unaffected throughout, since wildcards never imported givens; note that a *wildcard* over the new packages does not import the givens either — import them by name. `Query.show` now renders the URL-encoded form; use `.inspect` for the debug rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)