### PR TITLE
Add spinners, progress bars and meters to Ultimatum, chosen by import

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2961,7 +2961,14 @@ object ultimatum extends Library:
   object core extends Component(profanity.core, escapade.core, yossarian.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
-  object demo extends Internal(core, ethereal.core, exoskeleton.completions):
+  // Gauges — spinners, progress bars, meters and step indicators — are a separate component so
+  // that the durations and byte quantities the transfer statuses need (`aviation`, `quantitative`)
+  // are not imposed on every `ultimatum.core` user. Only the `Fixture` and `Tick` hooks live in
+  // core.
+  object gauges extends Component(core, aviation.core, quantitative.units):
+    override def scalacOptions = Task:
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
+  object demo extends Internal(core, gauges, ethereal.core, exoskeleton.completions):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium")
     override def mainClass: Task.Simple[Option[String]] = Some("ultimatum.demo")
@@ -2995,7 +3002,7 @@ object ultimatum extends Library:
 
       new java.io.File(target.toString).setExecutable(true)
       PathRef(target)
-  object test extends Tests(core):
+  object test extends Tests(core, gauges):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions())
 

--- a/build.mill
+++ b/build.mill
@@ -751,7 +751,7 @@ object soundness extends Toolchain:
     hallucination.bmp, hallucination.gif, hallucination.jpeg, hallucination.png,
     hallucination.webp, hallucination.formats,
     ziggurat.core, ziggurat.packager,
-    ultimatum.core, xenophile.native, exoskeleton.args, exoskeleton.core):
+    ultimatum.core, ultimatum.gauges, xenophile.native, exoskeleton.args, exoskeleton.core):
     def summary = "Command-line applications: terminals, shells, files and processes"
 
   object data extends Bundle(caesura.core, dissonance.core, enigmatic.asn1, enigmatic.core,
@@ -1316,7 +1316,8 @@ object burdock extends Library:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object core
       extends Component(zeppelin.core, exoskeleton.core, revolution.core, telekinesis.jvm,
-                       jacinta.core, eucalyptus.core, fulminate.print, hellenism.core, boot):
+                       jacinta.core, eucalyptus.core, fulminate.print, hellenism.core, boot,
+                       ultimatum.gauges):
     override def scalaJs = false // packaging; depends on JVM-only `zeppelin`/`telekinesis`
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
     override def scalacOptions = Task:

--- a/lib/ultimatum/src/core/soundness_ultimatum_core.scala
+++ b/lib/ultimatum/src/core/soundness_ultimatum_core.scala
@@ -34,6 +34,17 @@ package soundness
 
 export ultimatum.{Rect, Extent, FlowExtent, InlineRoot, ScreenRoot, Sizing, Limits, Frame,
     Placement, Pane, Panes, Occupancy, BorderStyle, panel, stack, strip, border, layout, paint,
-    Focus,
+    Fixture, Focus, Tick,
     EditorField, MenuField, Form, dirtyCells, editor, menu, form, InlineAnchoring, InlineGrowth,
     InlineShrink}
+
+package inlineAnchoring:
+  export
+    ultimatum.inlineAnchoring
+    . { bottomDocked, topAnchored, topAfterResize, fullscreen, inline }
+
+package inlineGrowth:
+  export ultimatum.inlineGrowth.{scrollIntoScrollback, clampToScreen}
+
+package inlineShrink:
+  export ultimatum.inlineShrink.{redockBottom, keepTop}

--- a/lib/ultimatum/src/core/soundness_ultimatum_core.scala
+++ b/lib/ultimatum/src/core/soundness_ultimatum_core.scala
@@ -32,11 +32,12 @@
                                                                                                   */
 package soundness
 
-export ultimatum.{Rect, Extent, FlowExtent, InlineRoot, ScreenRoot, Sizing, Limits, Frame,
-    Placement, Pane, Panes, Occupancy, BorderStyle, panel, stack, strip, border, layout, paint,
-    Fixture, Focus, Tick,
-    EditorField, MenuField, Form, dirtyCells, editor, menu, form, InlineAnchoring, InlineGrowth,
-    InlineShrink}
+export
+  ultimatum
+  . { Arrangement, BorderStyle, dirtyCells, editor, EditorField, Extent, Fixture, FlowExtent,
+      Focus, form, Form, Frame, InlineAnchoring, InlineGrowth, InlineRoot, InlineShrink, layout,
+      Limits, menu, MenuField, Occupancy, paint, Pane, Panes, panel, Placement, Rect, ScreenRoot,
+      Sizing, stack, strip, Tick }
 
 package inlineAnchoring:
   export

--- a/lib/ultimatum/src/core/ultimatum.Arrangement.scala
+++ b/lib/ultimatum/src/core/ultimatum.Arrangement.scala
@@ -32,9 +32,9 @@
                                                                                                   */
 package ultimatum
 
-// The direction in which a split divides its space. `File` places children side
-// by side as columns, distributing width; `Rank` stacks them as rows,
-// distributing height. (Chess terminology: files run vertically, ranks
-// horizontally.)
-enum Axis:
-  case Rank, File
+// How a split arranges its children, and so which axis it divides. `Strip` places them side by
+// side, distributing width; `Stack` puts them one above another, distributing height. The names
+// match the `strip` and `stack` constructors that build each, so the value a split carries and the
+// call that produced it read the same.
+enum Arrangement:
+  case Stack, Strip

--- a/lib/ultimatum/src/core/ultimatum.Fixture.scala
+++ b/lib/ultimatum/src/core/ultimatum.Fixture.scala
@@ -32,77 +32,27 @@
                                                                                                   */
 package ultimatum
 
-import anticipation.*
-import denominative.*
-import gossamer.*
 import profanity.*
-import rudiments.*
-import spectacular.*
 import vacuous.*
 
-// A focusable element bound into an interactive layout. It owns mutable widget
-// state, renders itself onto whichever `Board` the driver gives it (so the
-// driver can move it to a new rectangle on re-layout), folds an event into its
-// state, and reports the intrinsic size its current content needs — the hook the
-// reactive layout uses to grow or shrink a panel.
-trait Focus extends Fixture:
-  def handle(event: TerminalEvent): Unit
+// Anything the layout can host as a live element: it owns mutable state, renders itself onto
+// whichever `Board` the driver gives it (so the driver can move it to a new rectangle on
+// re-layout), and reports the intrinsic size its current content needs — the hook the reactive
+// layout uses to grow or shrink a panel.
+// A fixture need not accept input; a gauge does not, and so stays out of the focus cycle. `Focus`
+// adds input handling on top.
+trait Fixture:
+  def render(canvas: Board^, focused: Boolean): Unit
+  def measure(width: Int): (Int, Int)
 
-// A focusable wrapping a `LineEditor`. Its intrinsic height is the number of
-// wrapped rows its current value occupies, so an editor that grows past one line
-// pushes the rest of the layout down.
-class EditorField(initial: LineEditor = LineEditor()) extends Focus:
-  @scala.caps.unsafe.untrackedCaptures
-  private var editor: LineEditor = initial
+  // How long, in milliseconds, until this fixture wants redrawing again irrespective of any change
+  // to its state; `Unset` for a fixture that changes only when its state does. A spinner returns
+  // its frame interval, and that is the whole of the animation contract: the driver takes the
+  // minimum over the live fixtures and arms one timer, or none at all when every fixture is
+  // static.
+  def period: Optional[Int] = Unset
 
-  def value: Text = editor.value
-
-  // The shared `Interaction` draws the editor and positions the caret; the
-  // hardware cursor is then shown only when this field has focus, so the caret
-  // appears in the focused editor and is hidden elsewhere.
-  def render(canvas: Board^, focused: Boolean): Unit =
-    given canvas0: (Board^{canvas}) = canvas
-    summon[Interaction[Text, LineEditor]].render(Unset, editor)
-    canvas.cursor(focused)
-
-  def handle(event: TerminalEvent): Unit = editor = editor.apply(event)
-
-  def measure(width: Int): (Int, Int) =
-    val rows = LineEditor.cursorPosition(editor.value, editor.value.length, width.max(1))._1 + 1
-    (0, rows)
-
-// A focusable wrapping a `SelectMenu`. Its intrinsic height is one row per
-// option.
-class MenuField[item: Showable](initial: SelectMenu[item]) extends Focus:
-  @scala.caps.unsafe.untrackedCaptures
-  private var menu: SelectMenu[item] = initial
-
-  def value: item = menu.current
-
-  // Renders the options with a focus-aware marker on the current selection: a
-  // pointer (`>`) when this field has focus, a dot (`·`) when it does not, so the
-  // selection is always visible but the focused menu is distinguished. The
-  // hardware cursor is kept hidden — a menu has no text caret.
-  def render(canvas: Board^, focused: Boolean): Unit =
-    given canvas0: (Board^{canvas}) = canvas
-    val cols = canvas.width.max(1)
-    canvas.move(Prim, Prim)
-    canvas.clear()
-    var row = 0
-
-    menu.options.each: option =>
-      canvas.move(Prim, row.z)
-
-      val marker =
-        if option != menu.current then t"   " else if focused then t" > " else t" · "
-
-      val line = t"$marker${option.show}"
-      canvas.put(line)
-      row += (line.length - 1)/cols + 1
-
-    canvas.flush()
-    canvas.cursor(false)
-
-  def handle(event: TerminalEvent): Unit = menu = menu.apply(event)
-
-  def measure(width: Int): (Int, Int) = (0, menu.options.stdlib.length)
+  // Install the running form's repaint trigger, so that a background change to this fixture's
+  // state wakes the event loop and appears immediately. The same contract `Panes.bindWake` has,
+  // and a no-op for a fixture whose state only ever changes in response to an event it was given.
+  private[ultimatum] def bindWake(wake: () => Unit): Unit = ()

--- a/lib/ultimatum/src/core/ultimatum.Form.scala
+++ b/lib/ultimatum/src/core/ultimatum.Form.scala
@@ -173,8 +173,8 @@ class Form
     def nextWidth(): Int = if widths.hasNext then widths.next() else root.width
 
     def project(node: Pane): Frame = node match
-      case Pane.Branch(sizing, axis, panes) =>
-        Frame.Split(sizing, axis, panes.contents.map(project).to[List])
+      case Pane.Branch(sizing, arrangement, panes) =>
+        Frame.Split(sizing, arrangement, panes.contents.map(project).to[List])
 
       case Pane.Leaf(sizing, _) =>
         nextWidth()
@@ -201,7 +201,7 @@ class Form
 
     val height = mode match
       case Occupancy.Fullscreen => root.height
-      case Occupancy.Inline     => frame.measure(Axis.Rank).min
+      case Occupancy.Inline     => frame.measure(Arrangement.Stack).min
 
     root match
       case inline: InlineRoot => inline.reframe(root.width, height)

--- a/lib/ultimatum/src/core/ultimatum.Form.scala
+++ b/lib/ultimatum/src/core/ultimatum.Form.scala
@@ -42,10 +42,18 @@ import vacuous.*
 
 object Form:
   // One derived leaf of the live pane tree: the pane itself, the rectangle the last solve
-  // assigned it, and its focusable widget (present only for a `Pane.Widget`). Every
+  // assigned it, and its live element (present only for a `Pane.Widget`). Every
   // per-leaf datum lives together, so per-entry access needs no agreement between
   // parallel sequences.
-  private[ultimatum] case class Entry(pane: Pane, rect: Rect, focus: Optional[Focus])
+  // `focus` is the same object as `fixture` whenever the fixture accepts input, and `Unset` when it
+  // does not — which is precisely what keeps a display-only fixture (a gauge) out of the focus
+  // cycle, since `focusables` is derived from `focus` alone. Both are recorded at `solve`, where
+  // the pane is matched anyway, rather than re-tested on each access.
+  private[ultimatum] case class Entry
+    ( pane:    Pane,
+      rect:    Rect,
+      fixture: Optional[Fixture],
+      focus:   Optional[Focus] )
 
   // An immutable snapshot of one solved layout: the entries in frame order. A `Layout` is
   // only ever constructed whole (and the `Form` re-assigns its single `layout` var
@@ -98,6 +106,12 @@ class Form
   @scala.caps.unsafe.untrackedCaptures
   private var resizePending: Boolean = false
 
+  // Whether an animation wake is already scheduled. One timer serves every animated fixture in the
+  // layout (armed at the shortest period any of them asks for), and it is re-armed by each
+  // repaint, so an animation costs exactly one pending wake however many spinners are on screen.
+  @scala.caps.unsafe.untrackedCaptures
+  private var animationPending: Boolean = false
+
   // The anchor reply (the parked cursor's position after the resize's reflow),
   // stashed when it decodes and handed to the inline root at the resize repaint;
   // dropped on every new WINCH so it can only describe the latest reflow.
@@ -109,11 +123,15 @@ class Form
   @scala.caps.unsafe.untrackedCaptures
   private var resizeGrace: Boolean = false
 
-  // Bind every container to the wake function so a mutation requests a repaint.
+  // Bind every container and every live element to the wake function, so a mutation — whether of
+  // the tree's shape or of an element's own state — requests a repaint.
   private def bind(node: Pane): Unit = node match
     case Pane.Branch(_, _, panes) =>
       panes.bindWake(wake)
       panes.contents.each(bind(_))
+
+    case Pane.Widget(_, fixture) =>
+      fixture.bindWake(wake)
 
     case _ =>
       ()
@@ -126,11 +144,11 @@ class Form
 
     val stays = focused.lay(false): widget =>
       panes.stdlib.exists:
-        case Pane.Widget(_, focus) => focus eq widget
-        case _                     => false
+        case Pane.Widget(_, fixture) => fixture eq widget
+        case _                       => false
 
     if !stays then
-      focused = panes.stdlib.collectFirst { case Pane.Widget(_, focus) => focus }.optional
+      focused = panes.stdlib.collectFirst { case Pane.Widget(_, focus: Focus) => focus }.optional
 
     panes
 
@@ -162,8 +180,8 @@ class Form
         nextWidth()
         Frame.Cell(sizing)
 
-      case Pane.Widget(sizing, widget) =>
-        val (minWidth, minHeight) = widget.measure(nextWidth())
+      case Pane.Widget(sizing, fixture) =>
+        val (minWidth, minHeight) = fixture.measure(nextWidth())
 
         val grown = sizing.copy(minWidth = sizing.minWidth.max(minWidth),
             minHeight = sizing.minHeight.max(minHeight))
@@ -195,11 +213,15 @@ class Form
     Form.Layout:
       Sequence.from:
         panes.stdlib.zip(rects.stdlib).map: (leaf, rect) =>
-          val focus: Optional[Focus] = leaf match
-            case Pane.Widget(_, focus) => focus
-            case _                     => Unset
+          val fixture: Optional[Fixture] = leaf match
+            case Pane.Widget(_, fixture) => fixture
+            case _                       => Unset
 
-          Form.Entry(leaf, rect, focus)
+          val focus: Optional[Focus] = leaf match
+            case Pane.Widget(_, focus: Focus) => focus
+            case _                            => Unset
+
+          Form.Entry(leaf, rect, fixture, focus)
 
   // Paint one leaf of a solved layout. The index is confined to `layout.entries`, so
   // callers prove it in bounds (via `iterate`, `confine` or `focusables`) before it
@@ -213,8 +235,8 @@ class Form
         content(extent)
         extent.flush()
 
-      case Pane.Widget(_, widget) =>
-        widget.render(extent, layout.focusables.indexOf(index) == focusPosition(layout))
+      case Pane.Widget(_, fixture) =>
+        fixture.render(extent, layout.focusables.indexOf(index) == focusPosition(layout))
 
       case _ =>
         ()
@@ -244,13 +266,48 @@ class Form
 
       case Occupancy.Fullscreen =>
         val previousRects = if stale then Sequence() else previous.entries.map(_.rect)
-        val dirty = dirtyCells(previousRects, updated.entries.map(_.rect), changed)
+
+        // An animated fixture is dirty by definition: its appearance depends on the clock, not on
+        // its rectangle or its state, so nothing else in `dirtyCells` would notice it changing.
+        val dirty = dirtyCells(previousRects, updated.entries.map(_.rect), changed ++ animated)
         dirty.each { index => updated.entries.confine(index.z).let(paint(updated)(_)) }
 
     updated.focusables.confine(focusPosition(updated).z).let: position =>
       paint(updated)(updated.focusables(position))
 
     root.flush()
+    rearm()
+
+  // The shortest redraw interval any live fixture asks for, or `Unset` when every fixture is
+  // static — in which case no timer is armed at all and the form stays purely event-driven.
+  private def animationPeriod: Optional[Int] =
+    var least: Int = Int.MaxValue
+    val current = layout
+
+    current.entries.iterate: index =>
+      least = least.min(current.entries(index).fixture.lay(Int.MaxValue)(_.period.or(Int.MaxValue)))
+
+    if least == Int.MaxValue then Unset else least
+
+  // Arm the animation timer, unless one is already armed or a resize wake already covers it (that
+  // wake will repaint, and the repaint re-arms). Armed after every refresh, so the timer stops of
+  // its own accord the moment the last animated fixture leaves the layout.
+  private def rearm(): Unit =
+    if !animationPending && !wakePending then animationPeriod.let: period =>
+      animationPending = true
+      scheduleWake(period.toLong)
+
+  // The indices of the entries whose fixture animates, and which therefore have to be repainted on
+  // every frame whether or not anything else about them changed.
+  private def animated: Set[Int] =
+    val builder = scala.collection.immutable.Set.newBuilder[Int]
+    val current = layout
+
+    current.entries.iterate: index =>
+      if current.entries(index).fixture.lay(false)(_.period.present)
+      then builder += (index: Ordinal).n0
+
+    Set.of(builder.result())
 
   // Repaint immediately, folding in any coalesced or pending-resize work. Used for
   // typing, focus changes and application redraws, which must stay responsive.
@@ -372,10 +429,14 @@ class Form
         resizePending = true
         requestResizeRefresh()
 
-      // An application redraw request (e.g. after a background layout change), or the
-      // scheduled wake for a debounced resize: repaint if the drag has gone quiet,
-      // else reschedule the wake for the rest of the debounce window.
+      // An application redraw request (e.g. after a background layout change), the scheduled wake
+      // for a debounced resize, or an animation tick: repaint if the drag has gone quiet, else
+      // reschedule the wake for the rest of the debounce window. An animation wake is consumed
+      // here — the repaint that follows re-arms it — so a layout that stops animating stops the
+      // timer of its own accord.
       case TerminalInfo.Redraw =>
+        animationPending = false
+
         if !resizePending then requestRefresh(Set())
         else if resizeDelay <= 0 then flushDeferred()
         else scheduleWake(resizeDelay)

--- a/lib/ultimatum/src/core/ultimatum.Frame.scala
+++ b/lib/ultimatum/src/core/ultimatum.Frame.scala
@@ -173,7 +173,7 @@ object Frame:
     Sequence.from(sizes.iterator)
 
 // A node in a layout tree: a `Cell` (a leaf panel that hosts content) or a
-// `Split` that divides its space among children along an `Axis`. Solving against
+// `Split` that divides its space among children along an `Arrangement`. Solving against
 // a root `Rect` runs two passes: a bottom-up MEASURE computing each node's (min,
 // max) on each axis (forcing a split's minimum up to the aggregate of its
 // children), then a top-down ARRANGE distributing space by fraction, fixing any
@@ -182,22 +182,22 @@ enum Frame:
   def sizing: Sizing
 
   case Cell(sizing: Sizing)
-  case Split(sizing: Sizing, axis: Axis, children: List[Frame])
+  case Split(sizing: Sizing, arrangement: Arrangement, children: List[Frame])
 
   // The resolved (min, max) of this frame along `axis`.
-  def measure(axis: Axis): Limits =
-    val own = axis match
-      case Axis.File => Limits(sizing.minWidth, sizing.maxWidth)
-      case Axis.Rank => Limits(sizing.minHeight, sizing.maxHeight)
+  def measure(arrangement: Arrangement): Limits =
+    val own = arrangement match
+      case Arrangement.Strip => Limits(sizing.minWidth, sizing.maxWidth)
+      case Arrangement.Stack => Limits(sizing.minHeight, sizing.maxHeight)
 
     this match
       case Cell(_) =>
         own
 
-      case Split(_, splitAxis, children) =>
-        val childLimits = children.map(_.measure(axis))
+      case Split(_, splitArrangement, children) =>
+        val childLimits = children.map(_.measure(arrangement))
 
-        if splitAxis == axis then Frame.alongLimits(own, childLimits)
+        if splitArrangement == arrangement then Frame.alongLimits(own, childLimits)
         else Frame.crossLimits(own, childLimits)
 
   // Solve this frame against a rectangle, producing a tree of placements.
@@ -205,18 +205,18 @@ enum Frame:
     case Cell(_) =>
       Placement.Cell(rect)
 
-    case Split(_, axis, children) =>
-      val available = axis match
-        case Axis.File => rect.width
-        case Axis.Rank => rect.height
+    case Split(_, arrangement, children) =>
+      val available = arrangement match
+        case Arrangement.Strip => rect.width
+        case Arrangement.Stack => rect.height
 
-      val limits = children.map(_.measure(axis))
+      val limits = children.map(_.measure(arrangement))
       val fractions = children.map(_.sizing.fraction)
       val sizes = Frame.distribute(fractions, limits, available)
 
-      val start = axis match
-        case Axis.File => rect.left
-        case Axis.Rank => rect.top
+      val start = arrangement match
+        case Arrangement.Strip => rect.left
+        case Arrangement.Stack => rect.top
 
       val offsets = sizes.stdlib.scanLeft(start)(_ + _)
 
@@ -224,9 +224,9 @@ enum Frame:
       // offsets; the zip truncates to the n children), so no re-indexing is needed.
       val placements = children.stdlib.lazyZip(sizes.stdlib).lazyZip(offsets).map:
         (child, size, offset) =>
-          val childRect = axis match
-            case Axis.File => Rect(offset, rect.top, size, rect.height)
-            case Axis.Rank => Rect(rect.left, offset, rect.width, size)
+          val childRect = arrangement match
+            case Arrangement.Strip => Rect(offset, rect.top, size, rect.height)
+            case Arrangement.Stack => Rect(rect.left, offset, rect.width, size)
 
           child.arrange(childRect)
 

--- a/lib/ultimatum/src/core/ultimatum.Pane.scala
+++ b/lib/ultimatum/src/core/ultimatum.Pane.scala
@@ -37,7 +37,7 @@ import rudiments.*
 // The content-bearing layout tree built by the `file`/`rank`/`panel` DSL. A
 // `Leaf` pairs a `Sizing` with deferred content (run later, once its rectangle
 // is known, with its `Extent` in context); a `Branch` splits its space among
-// children along an `Axis`. A pane projects to a pure `Frame` for solving (via
+// children along an `Arrangement`. A pane projects to a pure `Frame` for solving (via
 // `frame`) and yields its leaves in order (via `leaves`), so a solved
 // `Placement`'s cells line up one-to-one with the leaves.
 // A pane tree is pure: a `Leaf`'s deferred `content` is a *pure* function of its `Extent` (an
@@ -48,7 +48,7 @@ enum Pane:
 
   case Leaf(sizing: Sizing, content: Extent^ -> Unit)
   case Widget(sizing: Sizing, fixture: Fixture)
-  case Branch(sizing: Sizing, axis: Axis, panes: Panes)
+  case Branch(sizing: Sizing, arrangement: Arrangement, panes: Panes)
 
   // The pure layout structure, with content discarded, for the solver. A widget
   // contributes only its declared `Sizing` here; the interactive driver injects
@@ -59,8 +59,8 @@ enum Pane:
     case Leaf(sizing, _)   => Frame.Cell(sizing)
     case Widget(sizing, _) => Frame.Cell(sizing)
 
-    case Branch(sizing, axis, panes) =>
-      Frame.Split(sizing, axis, panes.contents.map(_.frame).to[List])
+    case Branch(sizing, arrangement, panes) =>
+      Frame.Split(sizing, arrangement, panes.contents.map(_.frame).to[List])
 
   // The leaves in frame order (left to right for files, top to bottom for ranks).
   def leaves: List[Pane] = this match
@@ -69,6 +69,8 @@ enum Pane:
 
   // A copy of this pane re-weighted for use as a child of a split.
   def weight(fraction: Double): Pane = this match
-    case Leaf(sizing, content)       => Leaf(sizing.copy(fraction = fraction), content)
-    case Widget(sizing, fixture)     => Widget(sizing.copy(fraction = fraction), fixture)
-    case Branch(sizing, axis, panes) => Branch(sizing.copy(fraction = fraction), axis, panes)
+    case Leaf(sizing, content)   => Leaf(sizing.copy(fraction = fraction), content)
+    case Widget(sizing, fixture) => Widget(sizing.copy(fraction = fraction), fixture)
+
+    case Branch(sizing, arrangement, panes) =>
+      Branch(sizing.copy(fraction = fraction), arrangement, panes)

--- a/lib/ultimatum/src/core/ultimatum.Pane.scala
+++ b/lib/ultimatum/src/core/ultimatum.Pane.scala
@@ -47,7 +47,7 @@ enum Pane:
   def sizing: Sizing
 
   case Leaf(sizing: Sizing, content: Extent^ -> Unit)
-  case Widget(sizing: Sizing, focus: Focus)
+  case Widget(sizing: Sizing, fixture: Fixture)
   case Branch(sizing: Sizing, axis: Axis, panes: Panes)
 
   // The pure layout structure, with content discarded, for the solver. A widget
@@ -70,5 +70,5 @@ enum Pane:
   // A copy of this pane re-weighted for use as a child of a split.
   def weight(fraction: Double): Pane = this match
     case Leaf(sizing, content)       => Leaf(sizing.copy(fraction = fraction), content)
-    case Widget(sizing, focus)       => Widget(sizing.copy(fraction = fraction), focus)
+    case Widget(sizing, fixture)     => Widget(sizing.copy(fraction = fraction), fixture)
     case Branch(sizing, axis, panes) => Branch(sizing.copy(fraction = fraction), axis, panes)

--- a/lib/ultimatum/src/core/ultimatum.Tick.scala
+++ b/lib/ultimatum/src/core/ultimatum.Tick.scala
@@ -32,77 +32,19 @@
                                                                                                   */
 package ultimatum
 
-import anticipation.*
-import denominative.*
-import gossamer.*
-import profanity.*
-import rudiments.*
-import spectacular.*
-import vacuous.*
+object Tick:
+  val zero: Tick = Tick(0, 0L)
 
-// A focusable element bound into an interactive layout. It owns mutable widget
-// state, renders itself onto whichever `Board` the driver gives it (so the
-// driver can move it to a new rectangle on re-layout), folds an event into its
-// state, and reports the intrinsic size its current content needs — the hook the
-// reactive layout uses to grow or shrink a panel.
-trait Focus extends Fixture:
-  def handle(event: TerminalEvent): Unit
+  def at(elapsed: Long, period: Int): Tick =
+    Tick(if period <= 0 then 0 else (elapsed/period).toInt, elapsed)
 
-// A focusable wrapping a `LineEditor`. Its intrinsic height is the number of
-// wrapped rows its current value occupies, so an editor that grows past one line
-// pushes the rest of the layout down.
-class EditorField(initial: LineEditor = LineEditor()) extends Focus:
-  @scala.caps.unsafe.untrackedCaptures
-  private var editor: LineEditor = initial
-
-  def value: Text = editor.value
-
-  // The shared `Interaction` draws the editor and positions the caret; the
-  // hardware cursor is then shown only when this field has focus, so the caret
-  // appears in the focused editor and is hidden elsewhere.
-  def render(canvas: Board^, focused: Boolean): Unit =
-    given canvas0: (Board^{canvas}) = canvas
-    summon[Interaction[Text, LineEditor]].render(Unset, editor)
-    canvas.cursor(focused)
-
-  def handle(event: TerminalEvent): Unit = editor = editor.apply(event)
-
-  def measure(width: Int): (Int, Int) =
-    val rows = LineEditor.cursorPosition(editor.value, editor.value.length, width.max(1))._1 + 1
-    (0, rows)
-
-// A focusable wrapping a `SelectMenu`. Its intrinsic height is one row per
-// option.
-class MenuField[item: Showable](initial: SelectMenu[item]) extends Focus:
-  @scala.caps.unsafe.untrackedCaptures
-  private var menu: SelectMenu[item] = initial
-
-  def value: item = menu.current
-
-  // Renders the options with a focus-aware marker on the current selection: a
-  // pointer (`>`) when this field has focus, a dot (`·`) when it does not, so the
-  // selection is always visible but the focused menu is distinguished. The
-  // hardware cursor is kept hidden — a menu has no text caret.
-  def render(canvas: Board^, focused: Boolean): Unit =
-    given canvas0: (Board^{canvas}) = canvas
-    val cols = canvas.width.max(1)
-    canvas.move(Prim, Prim)
-    canvas.clear()
-    var row = 0
-
-    menu.options.each: option =>
-      canvas.move(Prim, row.z)
-
-      val marker =
-        if option != menu.current then t"   " else if focused then t" > " else t" · "
-
-      val line = t"$marker${option.show}"
-      canvas.put(line)
-      row += (line.length - 1)/cols + 1
-
-    canvas.flush()
-    canvas.cursor(false)
-
-  def handle(event: TerminalEvent): Unit = menu = menu.apply(event)
-
-  def measure(width: Int): (Int, Int) = (0, menu.options.stdlib.length)
+// The animation clock reading handed to a design each time it is drawn. `index` counts whole
+// animation periods since the gauge started — the frame number a spinner indexes its glyph cycle
+// with — and `elapsed` is monotonic milliseconds since it started.
+// Passing the reading in, rather than letting a design read a clock, is what keeps every design a
+// pure function of its status and its tick: a test drives one by handing it a literal `Tick`
+// instead of waiting.
+case class Tick(index: Int, elapsed: Long):
+  // Where this reading falls within the current period, as a fraction in `[0, 1)`; the dial a
+  // design uses when it wants a continuous sweep rather than a discrete frame.
+  def phase(period: Int): Double = if period <= 0 then 0.0 else (elapsed%period).toDouble/period

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -167,6 +167,16 @@ def form(mode: Occupancy = Occupancy.Fullscreen)(pane: Pane)
   // A container mutation wakes the loop by putting a redraw event on the spool.
   val wake = () => terminal.events.put(TerminalInfo.Redraw)
 
+  // A deferred repaint, woken after `delay` milliseconds (plus a small margin so it lands past the
+  // window it was waiting for). Both modes need one: inline mode uses it for the debounced resize
+  // repaint, and both use it as the animation tick for gauges.
+  val scheduleWake = (delay: Long) =>
+    async:
+      snooze((delay + 16).toDouble*Milli(Second))
+      terminal.events.put(TerminalInfo.Redraw)
+
+    ()
+
   mode match
     case Occupancy.Fullscreen =>
       // The feature body and its terminal argument are the same single-owner session.
@@ -180,18 +190,13 @@ def form(mode: Occupancy = Occupancy.Fullscreen)(pane: Pane)
         val root = ScreenRoot(terminal)
         root.cursor(false)
 
-        try Form(root, mode, pane, wake).run(terminal.eventIterator()) finally root.finish()
+        // No throttle or debounce: a fullscreen resize repaints immediately (the alternate screen
+        // has no scrollback to protect), but the wake is still supplied, for the animation tick.
+        try
+          Form(root, mode, pane, wake, 0, 0, scheduleWake).run(terminal.eventIterator())
+        finally root.finish()
 
     case Occupancy.Inline =>
-      // A deferred resize repaint is woken by posting a `Redraw` after the remaining
-      // window (plus a small margin so it lands past it).
-      val scheduleWake = (delay: Long) =>
-        async:
-          snooze((delay + 16).toDouble*Milli(Second))
-          terminal.events.put(TerminalInfo.Redraw)
-
-        ()
-
       // Resize repaints are throttled to ~10/second and debounced by 50 ms of quiet,
       // so a drag must pause before the block is redrawn; typing stays immediate.
       Form(InlineRoot(terminal), mode, pane, wake, 100, 50, scheduleWake)

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -87,16 +87,16 @@ def menu[item: Showable]
 
 // A split whose children sit side by side as columns (distributing width): a
 // strip of panes across the terminal, on the `File` axis.
-def strip(panes: Pane*): Pane = Pane.Branch(Sizing(), Axis.File, Panes(panes*))
+def strip(panes: Pane*): Pane = Pane.Branch(Sizing(), Arrangement.Strip, Panes(panes*))
 
 // A column split over a live container, whose children can change while running.
-def strip(panes: Panes): Pane = Pane.Branch(Sizing(), Axis.File, panes)
+def strip(panes: Panes): Pane = Pane.Branch(Sizing(), Arrangement.Strip, panes)
 
 // A split whose children stack as rows (distributing height), on the `Rank` axis.
-def stack(panes: Pane*): Pane = Pane.Branch(Sizing(), Axis.Rank, Panes(panes*))
+def stack(panes: Pane*): Pane = Pane.Branch(Sizing(), Arrangement.Stack, Panes(panes*))
 
 // A row split over a live container, whose children can change while running.
-def stack(panes: Panes): Pane = Pane.Branch(Sizing(), Axis.Rank, panes)
+def stack(panes: Panes): Pane = Pane.Branch(Sizing(), Arrangement.Stack, panes)
 
 // Wrap `child` in a box-drawing border. Each requested side becomes a thin leaf
 // panel whose content is regenerated from its solved size, so an edge always
@@ -231,7 +231,7 @@ def dirtyCells
 // needs and presented at the cursor; any other canvas fills its own height.
 def paint(root: Board^, pane: Pane): Unit =
   val height = root match
-    case _: InlineRoot => pane.frame.measure(Axis.Rank).min
+    case _: InlineRoot => pane.frame.measure(Arrangement.Stack).min
     case _             => root.height
 
   root match

--- a/lib/ultimatum/src/demo/ultimatum_demo.scala
+++ b/lib/ultimatum/src/demo/ultimatum_demo.scala
@@ -35,10 +35,18 @@ package ultimatum
 import soundness.*
 
 import backstops.silentBackstop
-import probates.cancelProbate
+import bars.smoothBar
+import counters.paddedCounter
 import executives.completions
+import gaugeGlyphs.unicodeGlyphs
 import interpreters.posixInterpreter
+import palettes.emberGaugePalette
+import probates.cancelProbate
+import processions.checklistProcession
+import sparklines.blockSparkline
+import spinners.brailleDotsSpinner
 import strategies.throwUnsafely
+import textMetrics.eastAsianScriptsMetric
 import threading.platformThreading
 
 // A medium-complexity fullscreen layout demonstrating the framework: a title bar
@@ -67,6 +75,18 @@ def demo(): Unit = cli:
 //   │             │ ┌─ activity ┐                            │
 //   │             │ └───────────┘                            │
 //   └─────────────────────── status ────────────────────────┘
+// A pipeline part-way through: one step done, one running (which is what the checklist animates),
+// and two still to come.
+private def steps: Procession =
+  val stages =
+    Sequence
+      ( Step(t"resolve", Standing.Succeeded),
+        Step(t"compile", Standing.Running),
+        Step(t"test", Standing.Pending),
+        Step(t"publish", Standing.Pending) )
+
+  Procession(stages)
+
 private def demoLayout: Pane =
   // A rounded border around the menu; the menu itself is 20 wide, so the bordered
   // sidebar is 22.
@@ -74,13 +94,19 @@ private def demoLayout: Pane =
     menu(List(t"Overview", t"Compose", t"Activity", t"Settings"), t"Overview",
         minWidth = 20, maxWidth = 20)
 
+  // A column of gauges, each keyed on a different status type and each picking up its design from
+  // the imports at the top of this file. The spinner and the checklist animate; the bar, counter
+  // and sparkline change only when their `Reading` does.
   val activity = border():
-    panel(minHeight = 6):
-      Out.println(t"Recent activity")
-      Out.println(t"")
-      Out.println(t"  • Demo started")
-      Out.println(t"  • Four panes tiled")
-      Out.println(t"  • Tab moves focus, Esc quits")
+    stack
+      ( panel(minHeight = 1, maxHeight = 1)(Out.print(t"  Activity")),
+        gauge(Reading(Captioned[Busy](Busy(), t"resolving")), minHeight = 1, maxHeight = 1),
+        gauge(Reading(Captioned[Fraction](Fraction(0.62), t"compiling")), minHeight = 1,
+            maxHeight = 1),
+        gauge(Reading(Reckoning(17, 120)), minHeight = 1, maxHeight = 1),
+        gauge(Reading(Series(Sequence(2.0, 5.0, 3.0, 8.0, 6.0, 9.0, 4.0))), minHeight = 1,
+            maxHeight = 1),
+        gauge(Reading(steps)) )
 
   // A bottom-only border draws a single rule under the heading, a separator with
   // no corners or sides.

--- a/lib/ultimatum/src/gauges/soundness_ultimatum_gauges.scala
+++ b/lib/ultimatum/src/gauges/soundness_ultimatum_gauges.scala
@@ -30,24 +30,75 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package burdock
+package soundness
 
-import escapade.*
-import hieroglyph.*
-import ultimatum.*
+export
+  ultimatum
+  . { Bar, Busy, Byte, Bytes, CaptionLayout, Captioned, Checklist, Countdown, Dial, Elapsed, Facet,
+      Fraction, gauge, Gaugeable, GaugePalette, gaugeLine, gaugeRows, Gauging, Gradient,
+      Information, Inlay, Magnitude, Meter, Procession, Reading, Reckoning, Series, Sparkline,
+      Spinner, Standing, Step, Transfer, whilst }
 
-import gaugeGlyphs.unicodeGlyphs
-import palettes.emberGaugePalette
-import textMetrics.uniformMetric
+// Every given is exported by name: a wildcard would silently drop them, since `import p.*` does not
+// import givens.
 
-// The repackager's progress bar. The drawing is `ultimatum`'s: this fixes the width, the design and
-// the palette, and leaves the in-place redrawing to the command-line entry point.
-// It was its own implementation until the gauge facility existed; keeping the same `render`
-// signature means the call site is unchanged, and the smooth eighth-block design and the ember
-// colours are the ones it always had.
-object ProgressBar:
-  val width: Int = 40
+package spinners:
+  export
+    ultimatum.spinners
+    . { aestheticSpinner, arcSpinner, arrowDoubleSpinner, arrowSpinner, balloonSpinner,
+        binarySpinner, bounceSpinner, bouncingBallSpinner, bouncingBarSpinner, boxSpinner,
+        brailleDotsSpinner, brailleGrowSpinner, brailleSnakeSpinner, brailleWaveSpinner,
+        circleHalfSpinner, circlePulseSpinner, circleQuadrantSpinner, clockSpinner,
+        crossStarSpinner, dotsScrollSpinner, dqpbSpinner, earthSpinner, growingBarSpinner,
+        growingBlockSpinner, hamburgerSpinner, hourglassSpinner, hourglassThinSpinner, layerSpinner,
+        lineSpinner, moonPhaseSpinner, noiseSpinner, pipeSpinner, pointsSpinner, pulseSpinner,
+        shuttleSpinner, squareCornerSpinner, starSpinner, toggleRoundSpinner, toggleSpinner,
+        toggleSquareSpinner, triangleSpinner }
 
-  // Renders `fraction` (clamped by `Fraction`) as a `width`-cell bar.
-  def render(fraction: Double): Teletype =
-    gaugeLine(Fraction(fraction), width)(using bars.smoothBar)
+package bars:
+  export
+    ultimatum.bars
+    . { arrowheadBar, asciiBar, blockBar, brailleBar, capsuleBar, dotBar, equalsBar, fineBar,
+        gradientBar, markerBar, percentageBar, pipBar, railBar, risingBar, segmentedBar, shadedBar,
+        smoothBar, squareBar }
+
+package meters:
+  export
+    ultimatum.meters
+    . { asciiMeter, batteryMeter, bulletMeter, columnMeter, needleMeter, thermometerMeter }
+
+package sparklines:
+  export ultimatum.sparklines.{asciiSparkline, blockSparkline, dotSparkline, tallSparkline}
+
+package counters:
+  export
+    ultimatum.counters
+    . { decimalTransferCounter, paddedCounter, percentageCounter, plainCounter, rateTransferCounter,
+        scaledCounter, terseTransferCounter, transferCounter, wordCounter }
+
+package standings:
+  export
+    ultimatum.standings
+    . { asciiStanding, heavyStanding, squareStanding, tickStanding, wordStanding }
+
+package processions:
+  export
+    ultimatum.processions
+    . { beadProcession, breadcrumbProcession, checklistProcession, numberedProcession,
+        ribbonProcession }
+
+package palettes:
+  export
+    ultimatum.palettes
+    . { ansiSixteenGaugePalette, emberGaugePalette, monochromeGaugePalette, oceanicGaugePalette,
+        plumGaugePalette, signalGaugePalette, slateGaugePalette, solarizedDarkGaugePalette,
+        solarizedLightGaugePalette, verdantGaugePalette }
+
+package captions:
+  export ultimatum.captions.{leadingCaption, spacedCaption, trailingCaption, truncatedCaption}
+
+package gaugeGlyphs:
+  export ultimatum.gaugeGlyphs.{asciiGlyphs, brailleGlyphs, emojiGlyphs, unicodeGlyphs}
+
+package informationPrefixes:
+  export ultimatum.informationPrefixes.{binaryBytes, decimalBytes}

--- a/lib/ultimatum/src/gauges/ultimatum.Bar.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Bar.scala
@@ -1,0 +1,218 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import denominative.*
+import escapade.*
+import gossamer.*
+import rudiments.*
+import spectacular.*
+import symbolism.*
+import vacuous.*
+
+object Bar:
+  // The characters a filled bar is drawn from. `partials` are the intermediate widths of the
+  // boundary cell, in ascending order and excluding `full`; supplying them is what makes a bar
+  // advance by a fraction of a cell rather than jumping a whole one at a time. An empty `partials`
+  // gives a bar that steps cell by cell.
+  case class Glyphs
+    ( full:     Text,
+       partials: Text           = t"",
+       empty:    Text           = t" ",
+       leftCap:  Optional[Text] = Unset,
+       rightCap: Optional[Text] = Unset,
+       tip:      Optional[Text] = Unset )
+
+  // The intrinsic width every bar prefers, matching the width the repackager's bar has always had.
+  val defaultColumns: Int = 40
+
+  // The shades a bar collapses to when it has one cell: enough to tell nearly-done from
+  // barely-started, which is all one cell can honestly say.
+  private val shades: Text = t"░▒▓█"
+  private val asciiShades: Text = t".:*#"
+
+// How a proportion is drawn. Four shapes cover the catalogue: a bar that fills, a marker that
+// travels along a track, a run of discrete pips, and a bare figure.
+// Degradation is implemented here, once, rather than in each of the eighteen designs: a bar
+// re-quantizes to whatever width it is given, drops its end caps when they no longer earn their
+// cells, falls through to a percentage at four cells, and to a single shade glyph at one.
+enum Bar:
+  case Filled(glyphs: Bar.Glyphs, columns: Int, gradient: Boolean)
+  case Marker(track: Text, marker: Text, columns: Int)
+  case Segmented(pip: Text, hollow: Text, gap: Text, pips: Int)
+  case Numeric
+
+  def columnCount: Int = this match
+    case Filled(_, columns, _)      => columns
+    case Marker(_, _, columns)      => columns
+    case Segmented(_, _, gap, pips) => pips + (if gap == t"" then 0 else pips - 1)
+    case Numeric                    => 4
+
+  def gaugeable(using gauging: Gauging): Fraction is Gaugeable = new Gaugeable:
+    type Self = Fraction
+    override def minWidth(status: Fraction): Int = 1
+    override def columns(status: Fraction): Int = columnCount
+
+    def rows(status: Fraction, tick: Tick, width: Int): List[Teletype] =
+      List(Bar.this.draw(status, width, gauging))
+
+  // Draw at exactly `width` cells.
+  def draw(fraction: Fraction, width: Int, gauging: Gauging): Teletype =
+    val palette = gauging.palette
+    val ascii = !gauging.permits(Gaugeable.Glyphs.Unicode)
+
+    if width <= 0 then Teletype(t"")
+    else if width == 1 then
+      // One cell can still carry the magnitude, as a shade.
+      val shades = if ascii then Bar.asciiShades else Bar.shades
+      val index = (fraction.value*shades.length).toInt.min(shades.length - 1).max(0)
+      val glyph = Teletype(shades.at(index.z).let(_.show).or(t" "))
+
+      gauging.tint(palette.lengthwise(fraction.value))(glyph)
+
+    else if width < 4 then
+      // Too narrow for a bar, wide enough for a figure: right-align the percentage into the cells
+      // available, dropping its most significant digits last.
+      val text = Magnitude.percentage(fraction)
+      val trimmed = if text.length <= width then text else text.skip(text.length - width)
+      gauging.tint(palette.caption)(Teletype(trimmed))
+
+    else
+      this match
+        case Numeric =>
+          val text = Magnitude.percentage(fraction)
+          val padding = width - text.length
+          val body = gauging.tint(palette.caption)(Teletype(text))
+          if padding > 0 then e"${t" "*padding}$body" else body
+
+        case Segmented(pip, hollow, gap, pips) =>
+          // Fit as many pips as the width allows, so a segmented bar thins out rather
+          // than clipping.
+          val separator = if gap == t"" then 0 else 1
+          val count = ((width + separator)/(1 + separator)).min(pips).max(1)
+          val lit = (fraction.value*count).toInt.min(count)
+
+          val cells = (0 until count).map: index =>
+            val glyph = if index < lit then pip else hollow
+            val color = if index < lit then palette.fill else palette.track
+            gauging.tint(color)(Teletype(glyph))
+
+          pad(cells.reduceLeft { (l, r) => e"$l${t" "*separator}$r" }, width, gauging)
+
+        case Marker(track, marker, _) =>
+          // A head travelling along a rail: no fill, so it reads as a position rather
+          // than an amount.
+          val position = (fraction.value*(width - 1)).toInt.min(width - 1).max(0)
+          val before = gauging.tint(palette.track)(Teletype(track*position))
+          val head = gauging.tint(palette.leadingEdge)(Teletype(marker))
+          val after = gauging.tint(palette.track)(Teletype(track*(width - position - 1)))
+          e"$before$head$after"
+
+        case Filled(glyphs, _, gradient) =>
+          val leftCap = glyphs.leftCap
+          val caps = (if leftCap.present then 1 else 0) + (if glyphs.rightCap.present then 1 else 0)
+
+          // The caps are the first thing to go: below eight cells they cost a fifth of the bar.
+          val capped = width >= 8 && caps > 0
+          val inner = if capped then width - caps else width
+          val body = fill(fraction, inner, glyphs, gradient, gauging)
+
+          if !capped then body else
+            def cap(glyph: Optional[Text]): Teletype =
+              glyph.lay(e""): text => gauging.tint(palette.track)(Teletype(text))
+
+            e"${cap(leftCap)}$body${cap(glyphs.rightCap)}"
+
+  // The filled region itself, at exactly `inner` cells. Cell accounting is exact — full cells, plus
+  // at most one boundary cell, plus empty cells, always sums to `inner` — so the bar never changes
+  // width as it fills.
+  private def fill
+    ( fraction: Fraction,
+       inner:    Int,
+       glyphs:   Bar.Glyphs,
+       gradient: Boolean,
+       gauging:  Gauging )
+  :   Teletype =
+
+    val palette = gauging.palette
+    val steps = glyphs.partials.length + 1
+    val total = (fraction.value*inner*steps).toInt.max(0).min(inner*steps)
+
+    // A tip glyph replaces the last filled cell for as long as the bar is neither empty nor full —
+    // the classic `[===>  ]`. It is a different idea from a partial: a partial says *how much* of
+    // the boundary cell is filled, whereas a tip just marks where the fill has got to, and so must
+    // be present at every intermediate value rather than only at the sub-cell steps.
+    val (whole, boundary) = glyphs.tip.lay:
+      val whole = total/steps
+      val remainder = total%steps
+
+      val partial: Optional[Text] =
+        if remainder == 0 then Unset else glyphs.partials.at((remainder - 1).z).let(_.show)
+
+      (whole, partial)
+
+    . apply: tip =>
+        val filledCells = (fraction.value*inner).toInt.max(0).min(inner)
+        val complete = filledCells == 0 || filledCells == inner
+
+        if complete then (filledCells, Unset) else (filledCells - 1, tip)
+
+    val used = whole + (if boundary.present then 1 else 0)
+
+    // A gradient bar colours each cell by where it sits along the bar; a plain one uses two runs.
+    val filled =
+      if !gradient then gauging.tint(palette.fill)(Teletype(glyphs.full*whole))
+      else if whole == 0 then e"" else
+        (0 until whole)
+        . map: index =>
+            val position = if inner <= 1 then 0.0 else index.toDouble/(inner - 1)
+            gauging.tint(palette.lengthwise(position))(Teletype(glyphs.full))
+
+        . reduceLeft: (left, right) => e"$left$right"
+
+    val edge = boundary.lay(e""): glyph => gauging.tint(palette.leadingEdge)(Teletype(glyph))
+
+    val blank = Teletype(glyphs.empty*(inner - used).max(0))
+
+    // A track drawn with spaces is only visible as a background; one with its own glyph is drawn
+    // in the track colour instead, so both kinds of design read correctly on any terminal.
+    val rest =
+      if glyphs.empty == t" " then gauging.wash(palette.track)(blank)
+      else gauging.tint(palette.track)(blank)
+
+    e"$filled$edge$rest"
+
+  private def pad(content: Teletype, width: Int, gauging: Gauging): Teletype =
+    val used = gauging.cells(content.plain)
+    if used >= width then content else e"$content${t" "*(width - used)}"

--- a/lib/ultimatum/src/gauges/ultimatum.Busy.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Busy.scala
@@ -1,0 +1,53 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+// Work in progress whose extent is unknown: the status a spinner shows. It carries only a counter,
+// advanced by the caller when it has something to report, so that a spinner can be driven by
+// progress as well as by the clock; a design that ignores it animates from its `Tick` alone.
+object Busy:
+  def apply(tick: Int = 0): Busy = tick.max(0)
+
+  // The default design, used when nothing is imported. Braille dots are the one spinner most
+  // people expect, they occupy a single cell, and they degrade to `-\|/` on an ASCII terminal.
+  // Any `import spinners.…` outranks this, being lexically scoped.
+  given gaugeable: Gauging => Busy is Gaugeable = spinners.brailleDotsSpinner
+
+opaque type Busy = Int
+
+extension (busy: Busy)
+  def tick: Int = busy
+  def next: Busy = busy + 1
+
+  // The frame to show, for a design with `count` frames.
+  def phase(count: Int): Int = if count <= 0 then 0 else busy%count

--- a/lib/ultimatum/src/gauges/ultimatum.CaptionLayout.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.CaptionLayout.scala
@@ -30,24 +30,46 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package burdock
+package ultimatum
 
+import anticipation.*
 import escapade.*
-import hieroglyph.*
-import ultimatum.*
+import gossamer.*
+import symbolism.*
 
-import gaugeGlyphs.unicodeGlyphs
-import palettes.emberGaugePalette
-import textMetrics.uniformMetric
+object CaptionLayout:
+  // The no-import default: the label follows the gauge, one space away.
+  given default: CaptionLayout = CaptionLayout(1, true, true)
 
-// The repackager's progress bar. The drawing is `ultimatum`'s: this fixes the width, the design and
-// the palette, and leaves the in-place redrawing to the command-line entry point.
-// It was its own implementation until the gauge facility existed; keeping the same `render`
-// signature means the call site is unchanged, and the smooth eighth-block design and the ember
-// colours are the ones it always had.
-object ProgressBar:
-  val width: Int = 40
+// Where a caption sits relative to the gauge it labels, and what happens when there is not room for
+// both. `elide` shortens the caption rather than squeezing the gauge, which is the right priority:
+// a half-drawn bar misreports the thing it is measuring, whereas a shortened label is merely
+// terser.
+case class CaptionLayout(gap: Int, trailing: Boolean, elide: Boolean):
+  // How many cells the gauge itself gets. The caption is allowed at most half the row before it
+  // starts costing the gauge cells — so a long label shortens rather than crowding out the thing it
+  // labels, and a short one still leaves an elastic bar the rest of the row.
+  def gaugeWidth(preferred: Int, caption: Text, width: Int, gauging: Gauging): Int =
+    val wanted = gauging.cells(caption)
+    val allowance = if elide then wanted.min(width/2) else wanted
+    (width - gap - allowance).max(0).min(preferred)
 
-  // Renders `fraction` (clamped by `Fraction`) as a `width`-cell bar.
-  def render(fraction: Double): Teletype =
-    gaugeLine(Fraction(fraction), width)(using bars.smoothBar)
+  def compose(gauge: Teletype, gaugeWidth: Int, caption: Text, width: Int, gauging: Gauging)
+  :   Teletype =
+
+    val room = width - gaugeWidth - gap
+    val label = if !elide then caption else shorten(caption, room, gauging)
+    val text = gauging.tint(gauging.palette.caption)(Teletype(label))
+    val spacer = t" "*gap.max(0)
+
+    val composed =
+      if room <= 0 then gauge else if trailing then e"$gauge$spacer$text" else e"$text$spacer$gauge"
+
+    val used = gauging.cells(composed.plain)
+    if used >= width then composed else e"$composed${t" "*(width - used)}"
+
+  private def shorten(caption: Text, room: Int, gauging: Gauging): Text =
+    if room <= 0 then t""
+    else if gauging.cells(caption) <= room then caption
+    else if room == 1 then t"…"
+    else t"${caption.keep(room - 1)}…"

--- a/lib/ultimatum/src/gauges/ultimatum.Captioned.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Captioned.scala
@@ -33,6 +33,39 @@
 package ultimatum
 
 import anticipation.*
+import escapade.*
+import vacuous.*
+
+object Captioned:
+  // Derived from whatever design the underlying status already has, rather than choosing one: the
+  // caption's placement is the only style decision here, and that comes from `CaptionLayout`. So
+  // this is structural, lives in the companion, and needs no import.
+  given gaugeable: [status: Gaugeable as design]
+  =>  ( layout: CaptionLayout, gauging: Gauging )
+  =>  Captioned[status] is Gaugeable =
+
+    new Gaugeable:
+      type Self = Captioned[status]
+      override def period: Optional[Int] = design.period
+      override def minWidth(status: Self): Int = design.minWidth(status.status)
+
+      override def columns(status: Self): Int =
+        design.columns(status.status) + layout.gap + gauging.cells(status.caption)
+
+      override def height(status: Self, width: Int): Int =
+        design.height(status.status, width)
+
+      def rows(status: Self, tick: Tick, width: Int): List[Teletype] =
+        val gaugeWidth =
+          layout.gaugeWidth(design.columns(status.status), status.caption, width, gauging)
+
+        val drawn = design.rows(status.status, tick, gaugeWidth)
+
+        // Only the first row carries the caption; a multi-row design keeps its shape below it.
+        val captioned = drawn.stdlib.zipWithIndex.map: (row, index) =>
+          if index > 0 then row else layout.compose(row, gaugeWidth, status.caption, width, gauging)
+
+        List.of(captioned.toList)
 
 // Any status with a label beside it: `⠹ resolving dependencies`, `████░░ copying`. Generic over
 // what it labels, so one design serves every status type — and its given derives from the

--- a/lib/ultimatum/src/gauges/ultimatum.Captioned.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Captioned.scala
@@ -1,0 +1,41 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+
+// Any status with a label beside it: `⠹ resolving dependencies`, `████░░ copying`. Generic over
+// what it labels, so one design serves every status type — and its given derives from the
+// underlying design rather than choosing one, so it is structural, not a style, and needs no
+// import.
+case class Captioned[status](status: status, caption: Text)

--- a/lib/ultimatum/src/gauges/ultimatum.Checklist.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Checklist.scala
@@ -1,0 +1,158 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import escapade.*
+import gossamer.*
+import symbolism.*
+import vacuous.*
+
+object Checklist:
+  // The frames the running step's marker cycles through, so that a checklist shows which step is
+  // working rather than merely which is next.
+  private val working: Text = t"⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+  private val asciiWorking: Text = t"-\\|/"
+
+// How a run of steps is drawn. These differ in *height* — `Rows` is one row per step, the rest are
+// a single row — which is why `Procession` has no default: the choice changes the layout around it,
+// so it is the caller's.
+enum Checklist:
+  case Rows, Breadcrumb, Beads, Numbered, Ribbon
+
+  def gaugeable(using gauging: Gauging): Procession is Gaugeable = new Gaugeable:
+    type Self = Procession
+
+    // Only a design that shows a working step needs the clock.
+    override def period: Optional[Int] = Checklist.this match
+      case Rows | Beads => 80
+      case _            => Unset
+
+    override def minWidth(status: Procession): Int = 3
+
+    override def height(status: Procession, width: Int): Int = Checklist.this match
+      case Rows => status.count.max(1)
+      case _    => 1
+
+    def rows(status: Procession, tick: Tick, width: Int): List[Teletype] =
+      Checklist.this.draw(status, tick, width, gauging)
+
+  def draw(procession: Procession, tick: Tick, width: Int, gauging: Gauging): List[Teletype] =
+    val palette = gauging.palette
+    val plain = !gauging.permits(Gaugeable.Glyphs.Unicode)
+
+    // The running step's marker, animated; every other standing keeps its static glyph.
+    def marker(standing: Standing): Text =
+      val frames = if plain then Checklist.asciiWorking else Checklist.working
+      val count = frames.length
+
+      standing match
+        case Standing.Running   => frames.s.charAt(tick.index.abs%count).toString.tt
+        case Standing.Succeeded => if plain then t"+" else t"✓"
+        case Standing.Failed    => if plain then t"x" else t"✗"
+        case Standing.Warned    => t"!"
+        case Standing.Skipped   => if plain then t"-" else t"‑"
+        case Standing.Pending   => if plain then t"." else t"·"
+
+    def pad(content: Teletype): Teletype =
+      val used = gauging.cells(content.plain)
+      if used >= width then content else e"$content${t" "*(width - used)}"
+
+    def clip(text: Text, cells: Int): Text =
+      if text.length <= cells then text
+      else if cells <= 1 then t"…"
+      else t"${text.keep(cells - 1)}…"
+
+    this match
+      case Rows =>
+        // One row per step: the canonical multi-row widget, and the one that makes the layout grow
+        // as steps are appended.
+        val steps = procession.steps.stdlib.map: step =>
+          val glyph = gauging.tint(palette.colorOf(step.standing))(Teletype(marker(step.standing)))
+          val faded = step.standing == Standing.Succeeded || step.standing == Standing.Skipped
+          val color = if faded then palette.muted else palette.caption
+          val name = gauging.tint(color)(Teletype(clip(step.name, (width - 2).max(1))))
+
+          pad(e"$glyph $name")
+
+        if steps.isEmpty then List(pad(e"")) else List.of(steps.toList)
+
+      case Numbered =>
+        val name = procession.current.lay(t"")(_.name)
+        val position = t"[${procession.position}/${procession.count}]"
+        val label = clip(name, (width - position.length - 1).max(0))
+
+        val marker = gauging.tint(palette.muted)(Teletype(position))
+        val text = gauging.tint(palette.caption)(Teletype(label))
+
+        List(pad(e"$marker $text"))
+
+      case Beads =>
+        // A compact chain: one bead per step, joined by a rule. Fixed at `2n - 1` cells.
+        val link = if plain then t"-" else t"━"
+
+        val beads = procession.steps.stdlib.zipWithIndex.map: (step, index) =>
+          val glyph = step.standing match
+            case Standing.Pending => if plain then t"o" else t"○"
+            case Standing.Running => if plain then t"*" else t"◐"
+            case _                => if plain then t"@" else t"●"
+
+          val bead = gauging.tint(palette.colorOf(step.standing))(Teletype(glyph))
+          if index == 0 then bead else e"${gauging.tint(palette.track)(Teletype(link))}$bead"
+
+        if beads.isEmpty then List(pad(e"")) else
+          List(pad(beads.reduceLeft { (left, right) => e"$left$right" }))
+
+      case Breadcrumb =>
+        val separator = if plain then t">" else t"›"
+
+        val crumbs = procession.steps.stdlib.map: step =>
+          val faded = step.standing == Standing.Pending
+          val color = if faded then palette.track else palette.colorOf(step.standing)
+          gauging.tint(color)(Teletype(step.name))
+
+        if crumbs.isEmpty then List(pad(e"")) else
+          val joined = crumbs.reduceLeft: (left, right) =>
+            e"$left ${gauging.tint(palette.muted)(Teletype(separator))} $right"
+
+          List(pad(joined))
+
+      case Ribbon =>
+        // Powerline: `escapade.Ribbon` already draws the separators and picks a legible foreground
+        // per segment, so this is only a matter of choosing the backgrounds.
+        val names = procession.steps.stdlib.map: step => Teletype(step.name)
+
+        if names.isEmpty then List(pad(e"")) else
+          // Qualified: this enum's own `Ribbon` case shadows the one from escapade.
+          val colors = palette.steps(names.length).stdlib.map(Bg(_))
+          List(pad(escapade.Ribbon(colors*).fill(names*)))

--- a/lib/ultimatum/src/gauges/ultimatum.Countdown.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Countdown.scala
@@ -1,0 +1,47 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import aviation.*
+import quantitative.*
+import symbolism.*
+
+// Time left. Clamped at zero, so a deadline that has passed reads as `0s` rather than as a
+// negative interval.
+object Countdown:
+  def apply(duration: Duration): Countdown =
+    if duration.value < 0 then 0.0*Second else duration
+
+  extension (countdown: Countdown) def duration: Duration = countdown
+
+opaque type Countdown = Duration

--- a/lib/ultimatum/src/gauges/ultimatum.Dial.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Dial.scala
@@ -1,0 +1,167 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import denominative.*
+import escapade.*
+import gossamer.*
+import proscenium.compat.*
+import rudiments.*
+import spectacular.*
+import symbolism.*
+import vacuous.*
+
+object Dial:
+  private val levels: Text = t"▁▂▃▄▅▆▇█"
+
+// How a bounded reading is drawn. A meter is not progress — it can fall as well as rise — so these
+// designs mark the scale, and colour the reading by where it sits on it rather than by how far it
+// has come.
+// They differ in *height* as well as width (a thermometer is a column), which is why `Meter` has no
+// default design: the choice changes the layout, so it belongs to the caller.
+enum Dial:
+  case Battery, Thermometer, Needle, Bullet, Column, Ascii
+
+  def columnCount: Int = this match
+    case Battery     => 8
+    case Thermometer => 1
+    case Needle      => 12
+    case Bullet      => 20
+    case Column      => 1
+    case Ascii       => 10
+
+  def rowCount: Int = this match
+    case Thermometer => 5
+    case _           => 1
+
+  def gaugeable(using gauging: Gauging): Meter is Gaugeable = new Gaugeable:
+    type Self = Meter
+    override def elastic: Boolean = Dial.this != Column && Dial.this != Thermometer
+    override def minWidth(status: Meter): Int = if rowCount > 1 then 1 else 3
+    override def columns(status: Meter): Int = columnCount
+    override def height(status: Meter, width: Int): Int = rowCount
+
+    def rows(status: Meter, tick: Tick, width: Int): List[Teletype] =
+      Dial.this.draw(status, width, gauging)
+
+  def draw(meter: Meter, width: Int, gauging: Gauging): List[Teletype] =
+    val palette = gauging.palette
+    val fraction = meter.fraction
+    val plain = !gauging.permits(Gaugeable.Glyphs.Unicode)
+
+    def level(fraction: Fraction): Text =
+      val index = (fraction.value*Dial.levels.length).toInt.min(Dial.levels.length - 1).max(0)
+      Dial.levels.at(index.z).let(_.show).or(t" ")
+
+    def pad(content: Teletype): Teletype =
+      val used = gauging.cells(content.plain)
+      if used >= width then content else e"$content${t" "*(width - used)}"
+
+    this match
+      case Column =>
+        // One cell: the reading as a height, coloured by severity.
+        List(gauging.tint(palette.severity(fraction.value))(Teletype(level(fraction))))
+
+      case Thermometer =>
+        // A column read from the bottom up, with a bulb beneath it. The top filled cell is a
+        // partial, so the reading moves smoothly rather than a fifth at a time.
+        val stem = rowCount - 1
+        val total = fraction.value*stem
+        val color = palette.severity(fraction.value)
+
+        val cells = (0 until stem).map: row =>
+          val fromTop = stem - 1 - row
+          val filled = (total - fromTop).max(0.0).min(1.0)
+
+          if filled <= 0 then gauging.tint(palette.track)(Teletype(t"░"))
+          else gauging.tint(color)(Teletype(level(Fraction(filled))))
+
+        List.of(cells.toList) :+ gauging.tint(color)(Teletype(if plain then t"o" else t"◍"))
+
+      case Battery =>
+        // Caps, cells and a terminal nub. A battery reddens as it *empties*, so the severity ramp
+        // is read backwards.
+        val inner = (width - 3).max(1)
+        val lit = (fraction.value*inner).toInt.min(inner)
+        val color = palette.severity(1 - fraction.value)
+        val body = gauging.tint(color)(Teletype((if plain then t"#" else t"█")*lit))
+        val empty = if plain then t"-" else t"░"
+        val rest = gauging.tint(palette.track)(Teletype(empty*(inner - lit)))
+
+        if plain then List(pad(e"[$body$rest]"))
+        else
+          val nub = gauging.tint(color)(Teletype(t"╸"))
+          val left = gauging.tint(palette.track)(Teletype(t"▐"))
+          val right = gauging.tint(palette.track)(Teletype(t"▌"))
+
+          List(pad(e"$left$body$rest$right$nub"))
+
+      case Needle =>
+        // A tick travelling along a scale, with the ends marked: a position on a range, with no
+        // suggestion that the space behind it has been filled.
+        val span = (width - 2).max(1)
+        val at = (fraction.value*(span - 1)).toInt.min(span - 1).max(0)
+        val rail = if plain then t"-" else t"─"
+        val head = if plain then t"|" else t"┃"
+        val cap = if plain then t"+" else t"╷"
+        val before = gauging.tint(palette.track)(Teletype(rail*at))
+        val after = gauging.tint(palette.track)(Teletype(rail*(span - at - 1)))
+        val marker = gauging.tint(palette.severity(fraction.value))(Teletype(head))
+        val ends = gauging.tint(palette.muted)(Teletype(cap))
+
+        List(pad(e"$ends$before$marker$after$ends"))
+
+      case Bullet =>
+        // A measure drawn over a qualitative track: the bands say what counts as low, fair and
+        // high, so the reading is interpretable without a legend.
+        val lit = (fraction.value*width).toInt.min(width)
+
+        val cells = (0 until width).map: index =>
+          val band = index.toDouble/width.max(1)
+
+          if index < lit then gauging.tint(palette.severity(fraction.value))(Teletype(t"█"))
+          else if plain then gauging.tint(palette.track)(Teletype(t"-"))
+          else
+            val shade = if band < 0.5 then t"░" else if band < 0.8 then t"▒" else t"▓"
+            gauging.tint(palette.track)(Teletype(shade))
+
+        List(pad(cells.reduceLeft { (l, r) => e"$l$r" }))
+
+      case Ascii =>
+        val inner = (width - 2).max(1)
+        val lit = (fraction.value*inner).toInt.min(inner)
+        val body = gauging.tint(palette.severity(fraction.value))(Teletype(t"#"*lit))
+        val rest = gauging.tint(palette.track)(Teletype(t"-"*(inner - lit)))
+
+        List(pad(e"[$body$rest]"))

--- a/lib/ultimatum/src/gauges/ultimatum.Elapsed.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Elapsed.scala
@@ -1,0 +1,49 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import aviation.*
+import quantitative.*
+import symbolism.*
+
+// Time spent so far. A distinct type from `Countdown` — rather than both being `Duration` — for
+// exactly the reason the whole facility is keyed on the status type: they want different designs,
+// and a duration counting up should not be able to pick up the design for one counting down.
+object Elapsed:
+  def apply(duration: Duration): Elapsed = duration
+
+  // In the companion, so that it does not compete at the top level with `Countdown`'s identically
+  // shaped accessor; the companion is in the opaque type's implicit scope, so it resolves anyway.
+  extension (elapsed: Elapsed) def duration: Duration = elapsed
+
+opaque type Elapsed = Duration

--- a/lib/ultimatum/src/gauges/ultimatum.Facet.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Facet.scala
@@ -1,0 +1,94 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import escapade.*
+import gossamer.*
+import symbolism.*
+
+object Facet:
+  // A part whose width is fixed by its own content.
+  def fixed(shed: Int, content: Teletype)(using gauging: Gauging): Facet =
+    Facet(shed, gauging.cells(content.plain), false, _ => content)
+
+  // The part that absorbs whatever width is left. At most one facet in a row may be flexible; it
+  // is never shed, because a row that has dropped its gauge is not worth drawing.
+  def flexible(minWidth: Int)(render: Int -> Teletype): Facet =
+    Facet(Int.MinValue, minWidth, true, render)
+
+  // Lay `facets` out into exactly `width` cells, separated by `gap` spaces: drop parts in
+  // descending `shed` order until what remains fits, then hand the surplus to the flexible part.
+  // This is escritoire's column-negotiation idea — a declared minimum, a droppable part, a
+  // flexible remainder — without its binary search on slack: a gauge's parts have exact widths and
+  // never reflow, so one greedy pass is exact, and there is no gas budget to run out of.
+  // Total by construction: below every minimum, the result is `width` spaces.
+  def solve(facets: List[Facet], width: Int, gap: Int = 1)(using gauging: Gauging): Teletype =
+    def extent(kept: scala.List[Facet]): Int =
+      kept.map(_.minWidth).sum + gap*(kept.length - 1).max(0)
+
+    // Shed the most expendable part first; ties keep source order, so a row degrades the same way
+    // every time rather than flickering between two arrangements at a boundary.
+    def shed(kept: scala.List[Facet]): scala.List[Facet] =
+      if extent(kept) <= width || kept.length <= 1 then kept else
+        val worst = kept.filter(!_.flexible).map(_.shed).maxOption
+
+        worst.map: value =>
+          val index = kept.indexWhere: facet => !facet.flexible && facet.shed == value
+
+          if index < 0 then kept else shed(kept.patch(index, scala.Nil, 1))
+
+        . getOrElse(kept)
+
+    val kept = shed(facets.stdlib.toList)
+
+    if kept.isEmpty || extent(kept) > width then Teletype(t" "*width.max(0)) else
+      val surplus = width - extent(kept)
+
+      val parts = kept.map: facet =>
+        facet.render(facet.minWidth + (if facet.flexible then surplus else 0))
+
+      val joined = parts.reduceLeft: (left, right) =>
+        e"$left${t" "*gap}$right"
+
+      val used = gauging.cells(joined.plain)
+
+      if used >= width then joined else e"$joined${t" "*(width - used)}"
+
+// One horizontal part of a composite gauge row — a caption, the bar itself, a percentage, a rate,
+// an estimate. `shed` orders the parts by how readily they are given up when the row will not fit:
+// the highest value goes first. `render` is handed the width the part actually got, which for the
+// flexible part is more than its minimum.
+// `render` is a *pure* function of the width the part got: a design captures nothing, so that the
+// pane tree it ends up inside stays pure under capture checking.
+case class Facet(shed: Int, minWidth: Int, flexible: Boolean, render: Int -> Teletype)

--- a/lib/ultimatum/src/gauges/ultimatum.Fraction.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Fraction.scala
@@ -1,0 +1,60 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import vacuous.*
+
+// A proportion of work completed, in `[0, 1]`: the status a progress bar shows. Clamped on
+// construction, so that no design has to defend against a fraction outside its range, and
+// `Unset` for work whose total is not yet known — which every bar renders as an indeterminate
+// sweep rather than as zero.
+object Fraction:
+  def apply(value: Double): Fraction = if value.isNaN then 0.0 else value.max(0.0).min(1.0)
+
+  def of(done: Long, total: Long): Fraction =
+    if total <= 0 then Fraction(0.0) else Fraction(done.toDouble/total)
+
+  // Work in flight whose total is unknown.
+  val indeterminate: Optional[Fraction] = Unset
+
+  // The default design: the smooth eighth-block bar, which is what a Soundness progress bar has
+  // always looked like. Every candidate bar is one row and says the same thing, so a default is
+  // safe here in a way it is not for a meter or a procession.
+  given gaugeable: Gauging => Fraction is Gaugeable = bars.smoothBar
+
+opaque type Fraction = Double
+
+extension (fraction: Fraction)
+  def value: Double = fraction
+  def percentage: Int = (fraction*100).toInt
+  def complete: Boolean = fraction >= 1.0

--- a/lib/ultimatum/src/gauges/ultimatum.GaugePalette.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.GaugePalette.scala
@@ -1,0 +1,110 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import iridescence.*
+import prepositional.*
+
+object GaugePalette:
+  // The `rgb"…"` interpolator yields a `Chroma` — a packed 24-bit integer — whereas a palette's
+  // roles are `Color in Srgb`, so hex literals are converted here rather than at every one of the
+  // hundred-odd places a palette names a colour.
+  def hue(chroma: Chroma): Color in Srgb =
+    Srgb(((chroma.red)&255)/255.0, chroma.green/255.0, chroma.blue/255.0)
+
+  // The no-import default, chosen from what the terminal can actually render: a caller who imports
+  // nothing gets colour that works where they are, and a caller who names a palette has asserted
+  // they know what their terminal does. Any `import palettes.…` outranks this, because a
+  // lexically-scoped given beats a companion one.
+  given adaptive: (termcap: Termcap) => GaugePalette = termcap.color match
+    // Qualified: `import iridescence.*` above brings `iridescence.palettes` into scope under the
+    // same name. The two blocks merge in the `soundness` umbrella, so a user still writes
+    // `import palettes.emberGaugePalette` and gets this one.
+    case ColorDepth.NoColor | ColorDepth.Indexed8 => ultimatum.palettes.monochromeGaugePalette
+    case ColorDepth.Indexed16 | ColorDepth.Cube4  => ultimatum.palettes.ansiSixteenGaugePalette
+    case ColorDepth.Cube6 | ColorDepth.TrueColor  => ultimatum.palettes.slateGaugePalette
+
+// The colours a gauge draws with, named by the role each plays rather than by hue, so that one
+// design renders under any palette and one palette serves every design.
+// A real trait, not a structural refinement of `Palette`: structural member selection goes through
+// `iridescence.Palette.selectDynamic` — runtime reflection, which Scala Native does not support —
+// whereas these are ordinary virtual calls. `chiaroscuro.JuxtapositionPalette` and
+// `probably.TestPalette` are declared this way for the same reason.
+// Extending `Palette` brings `background`, `foreground`, `subdue`, `accent` and the pairwise `mix`
+// with it, which is how most palettes below derive their track from their fill.
+trait GaugePalette extends Palette:
+  type Form = Srgb
+
+  // The unfilled part of a bar, the hollow pips, the arc a dial's needle sweeps.
+  def track: Color in Srgb
+
+  // The filled part.
+  def fill: Color in Srgb
+
+  // The boundary cell of a bar and the head of a marker: brighter than `fill`, so that the bar
+  // reads as moving even in a still screenshot.
+  def leadingEdge: Color in Srgb
+
+  // Labels and captions.
+  def caption: Color in Srgb
+
+  // Present but not competing: completed steps, elapsed times, units.
+  def muted: Color in Srgb
+
+  def success: Color in Srgb
+  def warning: Color in Srgb
+  def danger: Color in Srgb
+
+  // The fill interpolated along a bar's length — `position` is 0 at the left edge and 1 at the
+  // right. Only a gradient design consults it; the default is the plain two-stop ramp from the
+  // fill to the leading edge.
+  def lengthwise: Gradient = Gradient(fill, leadingEdge)
+
+  // The fill as a function of the *value* rather than the position: held at `success` across the
+  // lower half, then climbing through `warning` to `danger`. What a battery or a load meter uses.
+  def severity: Gradient = Gradient(success, success, warning, danger)
+
+  // One background per step, for a ribbon of stages.
+  def steps(count: Int): Sequence[Color in Srgb] =
+    Sequence.from:
+      (0 until count).map: index =>
+        lengthwise(if count <= 1 then 0.0 else index.toDouble/(count - 1))
+
+  def colorOf(standing: Standing): Color in Srgb = standing match
+    case Standing.Succeeded => success
+    case Standing.Failed    => danger
+    case Standing.Warned    => warning
+    case Standing.Skipped   => muted
+    case Standing.Pending   => track
+    case Standing.Running   => leadingEdge

--- a/lib/ultimatum/src/gauges/ultimatum.Gaugeable.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Gaugeable.scala
@@ -1,0 +1,134 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import denominative.*
+import escapade.*
+import prepositional.*
+import profanity.*
+import vacuous.*
+
+object Gaugeable:
+  // How adventurous a design may be with its character repertoire. Every design in the catalogue
+  // carries an ASCII rendering as well as its preferred one, so importing `asciiGlyphs` degrades
+  // the whole catalogue at once — the single import a caller writing to a dumb terminal, a log
+  // capture or a CI transcript needs.
+  // `Emoji` is separate from `Unicode` because emoji are the only glyphs that occupy two cells,
+  // and a terminal that renders them at one cell will shear every row that uses them.
+  object Glyphs:
+    // The no-import default: the BMP box-drawing and block glyphs, which every modern terminal
+    // has, and no emoji.
+    given default: Glyphs = Unicode
+
+  enum Glyphs:
+    case Ascii, Unicode, Braille, Emoji
+
+  // Binds a pure design to a live `Reading` and to the form's repaint machinery — the adapter
+  // through which a gauge becomes something the layout can host.
+  // The design is summoned where the pane is built, so the palette, glyph repertoire and metric it
+  // captured are the ones the *user's* imports chose, not the driver's.
+  class Fixture[status: Gaugeable as design](reading: Reading[status]) extends ultimatum.Fixture:
+    // Monotonic, so that a spinner does not jump when the system clock is stepped; and per-gauge,
+    // so that two spinners started at different moments stay independently phased.
+    @scala.caps.unsafe.untrackedCaptures
+    private val started: Long = System.nanoTime
+
+    private def tick: Tick =
+      Tick.at((System.nanoTime - started)/1000000L, design.period.or(1000))
+
+    override def period: Optional[Int] = design.period
+
+    private[ultimatum] override def bindWake(wake: () => Unit): Unit = reading.bindWake(wake)
+
+    // The width reported is the design's preferred width, which the solver treats as a minimum;
+    // an elastic design will be given more if the layout has it, and `rows` is told what it got.
+    def measure(width: Int): (Int, Int) =
+      val status = reading()
+      (design.columns(status), design.height(status, width.max(1)))
+
+    def render(canvas: Board^, focused: Boolean): Unit =
+      val status = reading()
+      val width = canvas.width
+
+      if width >= design.minWidth(status) then
+        var row = 0
+        val lines = design.rows(status, tick, width).stdlib.iterator
+
+        while lines.hasNext && row < canvas.height do
+          canvas.move(Prim, row.z)
+          canvas.put(lines.next())
+          row += 1
+
+      canvas.flush()
+
+  // A design occupying exactly one row, which is nearly all of them.
+  abstract class Row[status] extends Gaugeable:
+    type Self = status
+    def row(status: status, tick: Tick, width: Int): Teletype
+
+    def rows(status: status, tick: Tick, width: Int): List[Teletype] =
+      List(row(status, tick, width))
+
+// A design for rendering a value of type `Self` as a terminal gauge: a one-cell spinner, a
+// full-width progress bar, a multi-row checklist. The *status type is the key*, so importing a
+// different choice package substitutes a different design for the same application code, with no
+// other edit.
+// Rendering is pure — a status, a clock reading and a width map to styled rows — so a design
+// captures nothing, sits safely inside a pane tree (which must stay pure under capture checking),
+// and is testable by calling it. Everything effectful lives in the two adapters,
+// `Gaugeable.Fixture` and `Inlay`.
+trait Gaugeable extends Typeclass:
+  // How long, in milliseconds, until the design wants redrawing irrespective of its status;
+  // `Unset` for a design that changes only when its status does. A spinner returns its frame
+  // interval. `Form` takes the minimum over the live gauges and arms a single timer.
+  def period: Optional[Int] = Unset
+
+  // The narrowest width at which this design renders something meaningful. Given less, the driver
+  // draws nothing rather than something broken.
+  def minWidth(status: Self): Int = 1
+
+  // The width the design would like. A bar is happy with whatever it is given, so this is its
+  // preferred size; a spinner is exactly this wide and no wider.
+  def columns(status: Self): Int = minWidth(status)
+
+  // The rows the design occupies at `width` cells: one for a spinner or a bar, one per step for a
+  // checklist, two for a dial. This is what lets a gauge push the rest of the layout around.
+  def height(status: Self, width: Int): Int = 1
+
+  // Whether the design should take all the width it is offered (a bar) or be held at `columns` (a
+  // spinner, a status glyph, a counter).
+  def elastic: Boolean = true
+
+  // Render at exactly `width` cells. Every row must measure exactly `width` under the ambient
+  // metric, and there must be exactly `height(status, width)` of them.
+  def rows(status: Self, tick: Tick, width: Int): List[Teletype]

--- a/lib/ultimatum/src/gauges/ultimatum.Gauging.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Gauging.scala
@@ -1,0 +1,81 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import escapade.*
+import hieroglyph.*
+import iridescence.*
+import prepositional.*
+
+object Gauging:
+  // Assembled from three separately-importable givens, so that a caller overrides any one axis —
+  // the colours, the character repertoire, the width metric — without having to name the other
+  // two. This is what keeps "which design", "which palette" and "which glyphs" three orthogonal
+  // imports rather than one combinatorial choice.
+  given assembled: (palette0:  GaugePalette,
+                    glyphs0:   Gaugeable.Glyphs,
+                    metric0:   Text is Measurable)
+  =>  Gauging =
+    new Gauging:
+      val palette = palette0
+      val glyphs = glyphs0
+      val metric = metric0
+
+// The ambient rendering context a design captures when its `given` is summoned: which colours to
+// draw in, which glyphs it may use, and how to measure a string's width in cells.
+// A design takes this as a parameter of its `given` rather than of its `rows` method, following
+// `urticose`'s `urlTeletype` and `chiaroscuro`'s `juxtapositionTeletype`: resolution then happens
+// where the user summons the design, so the user's imports decide the appearance.
+trait Gauging:
+  def palette: GaugePalette
+  def glyphs: Gaugeable.Glyphs
+  def metric: Text is Measurable
+
+  // Colour a fragment, or leave it alone. Threading every tint through here means a design never
+  // writes an escape directly, and a palette that declines to colour a role costs nothing.
+  def tint(color: Color in Srgb)(text: Teletype): Teletype = e"${Fg(color)}($text)"
+  def wash(color: Color in Srgb)(text: Teletype): Teletype = e"${Bg(color)}($text)"
+
+  // Whether this context permits `glyphs`, so a design can pick its best available rendering.
+  // The repertoires nest: braille implies unicode, and emoji implies both.
+  def permits(required: Gaugeable.Glyphs): Boolean = required match
+    case Gaugeable.Glyphs.Ascii   => true
+    case Gaugeable.Glyphs.Unicode => glyphs != Gaugeable.Glyphs.Ascii
+    case Gaugeable.Glyphs.Emoji   => glyphs == Gaugeable.Glyphs.Emoji
+
+    case Gaugeable.Glyphs.Braille =>
+      glyphs == Gaugeable.Glyphs.Braille || glyphs == Gaugeable.Glyphs.Emoji
+
+  // The display width of `text` in cells, under whichever metric is in scope.
+  def cells(text: Text): Int = metric.width(text)

--- a/lib/ultimatum/src/gauges/ultimatum.Gradient.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Gradient.scala
@@ -1,0 +1,64 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import iridescence.*
+import prepositional.*
+
+object Gradient:
+  def apply(stops: (Color in Srgb)*): Gradient = Gradient(Sequence(stops*))
+
+// An N-stop colour ramp over sRGB. `iridescence` supplies only a pairwise interpolation
+// (`Palette.mix`), so this builds the ramp piecewise from it: the stops are evenly spaced, and a
+// repeated stop consequently flattens that part of the ramp — which is how a severity ramp holds
+// one colour across the whole lower half before it starts to climb.
+// This is a general facility, and a candidate to move into `iridescence` alongside `Spectrum`; it
+// is local for now so that adding it does not touch a module everything else depends on.
+case class Gradient(stops: Sequence[Color in Srgb]):
+  def apply(position: Double): Color in Srgb =
+    val count = stops.stdlib.length
+
+    if count == 0 then Srgb(0.0, 0.0, 0.0) else if count == 1 then stops.stdlib.head else
+      val scaled = position.max(0.0).min(1.0)*(count - 1)
+      val index = scaled.toInt.min(count - 2)
+      val balance = scaled - index
+      val left = stops.stdlib(index).to[Srgb]
+      val right = stops.stdlib(index + 1).to[Srgb]
+
+      def channel(from: Double, to: Double): Double = from*(1 - balance) + to*balance
+
+      val red = channel(left.red, right.red)
+      val green = channel(left.green, right.green)
+      val blue = channel(left.blue, right.blue)
+
+      Srgb(red, green, blue)

--- a/lib/ultimatum/src/gauges/ultimatum.Information.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Information.scala
@@ -1,0 +1,60 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import gossamer.*
+import prepositional.*
+import quantitative.*
+
+// The information dimension, and the byte as its unit. `quantitative` declares the seven SI base
+// dimensions and no more, so every byte quantity in the tree has so far been a local, ad-hoc
+// declaration; this is the shared one, introduced here because the transfer statuses need it.
+// It is a candidate to move into `quantitative` proper once something outside ultimatum wants it.
+sealed trait Information extends Dimension
+
+sealed trait Bytes[power <: Nat] extends Units[power, Information]
+
+val Byte: MetricUnit[Bytes[1]] = MetricUnit(1.0)
+
+// Single-canonical, and structurally un-anchorable: the subject is a type declared in this file
+// but the typeclass belongs to `quantitative`, so there is no companion for it to live in. Named
+// distinctly for that reason, per the given-placement rules.
+given informationDesignation: Designation[Bytes[1]] = () => t"B"
+
+// How a byte quantity is scaled for display. Neither is a default: `1.5 MB` and `1.43 MiB` are the
+// same quantity written under different conventions, and which one is right depends on what is
+// being measured — so the caller picks.
+package informationPrefixes:
+  given binaryBytes: (Prefixes on Bytes[1]) = Prefixes(List(Kibi, Mebi, Gibi, Tebi))
+  given decimalBytes: (Prefixes on Bytes[1]) = Prefixes(List(Kilo, Mega, Giga, Tera))

--- a/lib/ultimatum/src/gauges/ultimatum.Inlay.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Inlay.scala
@@ -30,24 +30,95 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package burdock
+package ultimatum
 
+import anticipation.*
 import escapade.*
-import hieroglyph.*
-import ultimatum.*
+import gossamer.*
+import parasite.*
+import quantitative.*
+import symbolism.*
+import turbulence.*
+import vacuous.*
 
-import gaugeGlyphs.unicodeGlyphs
-import palettes.emberGaugePalette
-import textMetrics.uniformMetric
+// A gauge drawn live at the cursor, with no form and no layout: the shape a command-line tool
+// wants when it has one thing to report. Each frame is redrawn in place, the animation is one
+// background task snoozing the design's own period, and `finish` erases the block.
+// Every design works here unchanged, because a design is a pure function of status, tick and width
+// — this class supplies the three and does the writing.
+class Inlay[status: Gaugeable as design]
+  ( reading: Reading[status], width: Optional[Int] = Unset )
+  ( using stdio: Stdio, monitor: Monitor, probate: Probate ):
 
-// The repackager's progress bar. The drawing is `ultimatum`'s: this fixes the width, the design and
-// the palette, and leaves the in-place redrawing to the command-line entry point.
-// It was its own implementation until the gauge facility existed; keeping the same `render`
-// signature means the call site is unchanged, and the smooth eighth-block design and the ember
-// colours are the ones it always had.
-object ProgressBar:
-  val width: Int = 40
+  @scala.caps.unsafe.untrackedCaptures
+  private val started: Long = System.nanoTime
 
-  // Renders `fraction` (clamped by `Fraction`) as a `width`-cell bar.
-  def render(fraction: Double): Teletype =
-    gaugeLine(Fraction(fraction), width)(using bars.smoothBar)
+  // How many rows the last frame occupied, so the next one knows how far to move back up.
+  @scala.caps.unsafe.untrackedCaptures
+  private var drawn: Int = 0
+
+  @scala.caps.unsafe.untrackedCaptures
+  private var running: Boolean = false
+
+  private def columns: Int = width.or(stdio.termcap.width.max(1))
+
+  private def tick: Tick =
+    Tick.at((System.nanoTime - started)/1000000L, design.period.or(1000))
+
+  // Draw one frame over the last one. Each row is erased to the end of the line as it is written,
+  // so a frame that is shorter than its predecessor leaves no residue.
+  private def paint(): Unit =
+    val rows = design.rows(reading(), tick, columns).stdlib
+    rewind()
+    var index = 0
+
+    while index < rows.length do
+      Out.print(e"${rows(index)}${csi.el()}")
+      if index < rows.length - 1 then Out.print(t"\n")
+      index += 1
+
+    drawn = rows.length
+
+  // Back to the first column of the block's first row.
+  private def rewind(): Unit =
+    if drawn > 1 then Out.print(csi.cuu(drawn - 1))
+    Out.print(t"\r")
+
+  // Paint once, and — if the design animates — keep painting until `finish`. A design with no
+  // period is drawn once here and thereafter only when its `Reading` changes and calls back.
+  def start(): Unit =
+    reading.bindWake: () => paint()
+    paint()
+
+    design.period.let: period =>
+      running = true
+
+      // The repaint task captures this `Inlay`, which also owns the `Monitor` the task is spawned
+      // against, and separation checking rejects the overlap. They are the same single-owner
+      // session: the task is started here, stopped by `finish`, and touches nothing else — so the
+      // assertion is local and its scope is the object's own lifetime. (`form` makes the same
+      // assertion, for the same reason, around the alternate-screen session.)
+      scala.caps.unsafe.unsafeAssumeSeparate:
+        async:
+          while running do
+            snooze(period.toDouble*Milli(Second))
+            if running then paint()
+
+        ()
+
+  // Erase the block and leave the cursor where it started, so whatever the caller prints next
+  // begins on a clean line.
+  def finish(): Unit =
+    running = false
+    reading.bindWake: () => ()
+    rewind()
+    var index = 0
+
+    while index < drawn do
+      Out.print(csi.el())
+      if index < drawn - 1 then Out.print(t"\n")
+      index += 1
+
+    if drawn > 1 then Out.print(csi.cuu(drawn - 1))
+    Out.print(t"\r")
+    drawn = 0

--- a/lib/ultimatum/src/gauges/ultimatum.Magnitude.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Magnitude.scala
@@ -1,0 +1,78 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import gossamer.*
+import spectacular.*
+
+// Compact renderings of the numbers that appear beside a gauge, where every cell is contested and
+// a full-precision figure would crowd out the bar itself.
+object Magnitude:
+  // A duration as the two largest units that carry information: `41s`, `2m41s`, `1h04m`, `3d02h`.
+  // Never more than two, and never a leading zero unit, so the field stays narrow and stops
+  // jittering once it is past a minute.
+  def interval(seconds: Double): Text =
+    val total = seconds.max(0.0).toLong
+
+    if total < 60 then t"${total}s" else
+      val minutes = total/60
+      val hours = minutes/60
+      val days = hours/24
+
+      if minutes < 60 then t"${minutes}m${pad(total%60)}s"
+      else if hours < 24 then t"${hours}h${pad(minutes%60)}m"
+      else t"${days}d${pad(hours%24)}h"
+
+  // A count, abbreviated once it stops being readable at a glance: `947`, `1.2k`, `15k`, `3.4M`.
+  def count(value: Long): Text =
+    if value < 1000 then value.show
+    else if value < 1000000 then scaled(value, 1000.0, t"k")
+    else if value < 1000000000L then scaled(value, 1000000.0, t"M")
+    else scaled(value, 1000000000.0, t"G")
+
+  // A percentage, always three cells wide (`  0%` … `100%` less its sign), so a bar's right-hand
+  // figure never shifts as it fills.
+  def percentage(fraction: Fraction): Text =
+    val value = fraction.percentage
+    if value >= 100 then t"100%" else if value >= 10 then t" $value%" else t"  $value%"
+
+  private def pad(value: Long): Text = if value < 10 then t"0$value" else value.show
+
+  // One decimal place below ten, none above: `1.2k` but `15k`, so the field is at most four cells.
+  private def scaled(value: Long, divisor: Double, suffix: Text): Text =
+    val scale = value/divisor
+
+    if scale >= 10 then t"${scale.toLong}$suffix" else
+      val tenths = (scale*10).toLong
+      t"${tenths/10}.${tenths%10}$suffix"

--- a/lib/ultimatum/src/gauges/ultimatum.Magnitude.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Magnitude.scala
@@ -67,6 +67,38 @@ object Magnitude:
     val value = fraction.percentage
     if value >= 100 then t"100%" else if value >= 10 then t" $value%" else t"  $value%"
 
+  // A byte count in the largest prefix that leaves a figure above one: `947 B`, `4.01 MiB`,
+  // `1.20 GB`. `binary` selects the 1024-based prefixes (`KiB`) over the 1000-based ones (`kB`);
+  // the two describe the same quantity under different conventions, and which is right depends on
+  // what is being measured, so the design says which it means rather than assuming.
+  def bytes(value: Double, binary: Boolean): Text =
+    val step = if binary then 1024.0 else 1000.0
+
+    val units: scala.Array[Text] =
+      if binary then scala.Array(t"B", t"KiB", t"MiB", t"GiB", t"TiB")
+      else scala.Array(t"B", t"kB", t"MB", t"GB", t"TB")
+
+    var size = value.max(0.0)
+    var index = 0
+
+    while size >= step && index < units.length - 1 do
+      size /= step
+      index += 1
+
+    t"${figure(size)} ${units(index)}"
+
+  // A transfer rate, in the same prefixes.
+  def rate(bytesPerSecond: Double, binary: Boolean): Text = t"${bytes(bytesPerSecond, binary)}/s"
+
+  // Three significant figures below ten, otherwise whole units: enough precision to see movement,
+  // narrow enough not to crowd the bar.
+  private def figure(value: Double): Text =
+    if value >= 100 then value.toLong.show
+    else if value >= 10 then t"${(value*10).toLong/10}.${(value*10).toLong%10}"
+    else
+      val hundredths = (value*100).toLong
+      t"${hundredths/100}.${pad(hundredths%100)}"
+
   private def pad(value: Long): Text = if value < 10 then t"0$value" else value.show
 
   // One decimal place below ten, none above: `1.2k` but `15k`, so the field is at most four cells.

--- a/lib/ultimatum/src/gauges/ultimatum.Meter.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Meter.scala
@@ -1,0 +1,45 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+// A reading on a bounded scale: a battery's charge, a temperature, a load average, a signal level.
+// Distinct from `Fraction` because the bounds are part of the datum — a meter shows where a value
+// sits between them, and its design may mark the scale — and because a meter is not progress: it
+// can fall as well as rise.
+object Meter:
+  def apply(value: Double): Meter = Meter(value, 0.0, 1.0)
+
+case class Meter(value: Double, minimum: Double, maximum: Double):
+  def fraction: Fraction =
+    val span = maximum - minimum
+    if span <= 0 then Fraction(0.0) else Fraction((value - minimum)/span)

--- a/lib/ultimatum/src/gauges/ultimatum.Procession.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Procession.scala
@@ -1,0 +1,46 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import vacuous.*
+
+// An ordered run of steps: the status a checklist, a breadcrumb or a ribbon of stages shows. The
+// designs for it differ in *height* — a checklist is one row per step, a breadcrumb is one row
+// altogether — which is exactly why it has no default design: the choice changes the layout, so it
+// belongs to the caller.
+case class Procession(steps: Sequence[Step]):
+  def current: Optional[Step] = steps.stdlib.find(_.standing == Standing.Running).optional
+  def count: Int = steps.stdlib.length
+
+  // How many steps are no longer waiting — the numerator of `[3/7]`.
+  def position: Int = steps.stdlib.count(_.standing != Standing.Pending)

--- a/lib/ultimatum/src/gauges/ultimatum.Reading.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Reading.scala
@@ -59,7 +59,11 @@ class Reading[status](initial: status):
 
   // Paired with `apply`, this gives assignment syntax: `reading() = Fraction(0.42)`.
   def update(status: status): Unit =
-    current = status
+    // A status is data — a fraction, a count, a list of steps — but `status` is an unbounded type
+    // parameter, so the compiler cannot know that and will not let it into an untracked field.
+    // `Reading` is not a capability (a pane tree holding one must stay pure, as `Panes` does), so
+    // the alternative would be to make it `caps.Mutable` and lose that.
+    current = caps.unsafe.unsafeAssumePure(status)
     onChange()
 
   def amend(lambda: status => status): Unit = update(lambda(current))

--- a/lib/ultimatum/src/gauges/ultimatum.Reading.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Reading.scala
@@ -1,0 +1,65 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import scala.caps
+
+// A mutable cell holding a gauge's current status. Assigning to it publishes the new value and
+// wakes the running form, so a gauge updated from a background task repaints at once — the same
+// contract a `Panes` mutation has.
+// The status itself is plain data (a pane tree stays pure); the one effectful field is the
+// installed repaint callback.
+class Reading[status](initial: status):
+  @scala.caps.unsafe.untrackedCaptures
+  private var current: status = initial
+
+  // A no-op until the cell is bound into a running form.
+  @scala.caps.unsafe.untrackedCaptures
+  private var onChange: () -> Unit = () => ()
+
+  // Install the running form's repaint trigger. As in `Panes.bindWake`, the callback genuinely
+  // captures the form's event loop and escapes into this longer-lived cell — a growing capture set
+  // that capture checking cannot yet express. It is sound by construction for the same reasons: it
+  // is re-bound on every `run` (so it never references a finished form) and is only ever called
+  // from a mutation while that form is live. Hence the single, localised `unsafeAssumePure`.
+  private[ultimatum] def bindWake(wake: () => Unit): Unit =
+    onChange = caps.unsafe.unsafeAssumePure(wake)
+
+  def apply(): status = current
+
+  // Paired with `apply`, this gives assignment syntax: `reading() = Fraction(0.42)`.
+  def update(status: status): Unit =
+    current = status
+    onChange()
+
+  def amend(lambda: status => status): Unit = update(lambda(current))

--- a/lib/ultimatum/src/gauges/ultimatum.Reckoning.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Reckoning.scala
@@ -32,7 +32,59 @@
                                                                                                   */
 package ultimatum
 
+import anticipation.*
+import escapade.*
+import gossamer.*
+import spectacular.*
+import symbolism.*
 import vacuous.*
+
+object Reckoning:
+  // How a count is written. `Padded` right-aligns the numerator to the total's digit count so the
+  // field does not jitter as it counts up — the difference between a figure that can be read while
+  // it changes and one that cannot.
+  enum Counter:
+    case Plain, Padded, Words, Percentage, Scaled
+
+    def write(reckoning: Reckoning): Text =
+      val done = reckoning.done.show
+
+      this match
+        case Plain      => reckoning.total.lay(done): total => t"$done/$total"
+        case Words      => reckoning.total.lay(done): total => t"$done of $total"
+        case Percentage => reckoning.fraction.lay(t"  ?%")(Magnitude.percentage(_))
+
+        case Scaled =>
+          val scaled = Magnitude.count(reckoning.done)
+          reckoning.total.lay(scaled): total => t"$scaled/${Magnitude.count(total)}"
+
+        // The numerator is right-aligned to the total's digit count, so the field does not jitter
+        // as it counts up.
+        case Padded =>
+          reckoning.total.lay(done): total =>
+            t"${t" "*(total.show.length - done.length).max(0)}$done/$total"
+
+    def gaugeable(using gauging: Gauging): Reckoning is Gaugeable = new Gaugeable:
+      type Self = Reckoning
+      override def elastic: Boolean = false
+      override def minWidth(status: Reckoning): Int = 1
+      override def columns(status: Reckoning): Int = gauging.cells(write(status))
+
+      def rows(status: Reckoning, tick: Tick, width: Int): List[Teletype] =
+        val text = write(status)
+        val used = gauging.cells(text)
+        val body = gauging.tint(gauging.palette.caption)(Teletype(text))
+
+        // Too narrow to write the count: drop the leading characters rather than the trailing
+        // ones, so the numerator (which is what changes) survives longest.
+        val fitted =
+          if used <= width then e"$body${t" "*(width - used)}"
+          else gauging.tint(gauging.palette.caption)(Teletype(text.skip(used - width)))
+
+        List(fitted)
+
+  // The default: `17/120` is not a style question.
+  given gaugeable: Gauging => Reckoning is Gaugeable = counters.plainCounter
 
 // A count of work done against a total that may not be known yet: `17/120`, or just `17` while the
 // total is still being discovered. The status a counter shows, and the one most jobs actually have

--- a/lib/ultimatum/src/gauges/ultimatum.Reckoning.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Reckoning.scala
@@ -1,0 +1,44 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import vacuous.*
+
+// A count of work done against a total that may not be known yet: `17/120`, or just `17` while the
+// total is still being discovered. The status a counter shows, and the one most jobs actually have
+// to hand.
+case class Reckoning(done: Long, total: Optional[Long] = Unset):
+  def fraction: Optional[Fraction] = total.let: total =>
+    if total <= 0 then Fraction(0.0) else Fraction(done.toDouble/total)
+
+  def remaining: Optional[Long] = total.let: total => (total - done).max(0L)

--- a/lib/ultimatum/src/gauges/ultimatum.Series.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Series.scala
@@ -1,0 +1,54 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import vacuous.*
+
+// A run of samples over time, shown as a sparkline. `floor` and `ceiling` fix the scale when it
+// should stay put between frames — a sparkline that rescales itself every tick makes a steady
+// signal look erratic — and are otherwise taken from the samples.
+case class Series
+  ( samples: Sequence[Double],
+    floor:   Optional[Double] = Unset,
+    ceiling: Optional[Double] = Unset ):
+
+  def lower: Double = floor.or(samples.stdlib.minOption.getOrElse(0.0))
+  def upper: Double = ceiling.or(samples.stdlib.maxOption.getOrElse(1.0))
+
+  // The samples mapped onto `[0, 1]`. A flat series maps to zero rather than dividing by nothing.
+  def normalized: Sequence[Fraction] =
+    val span = upper - lower
+
+    Sequence.from:
+      samples.stdlib.map: sample =>
+        if span <= 0 then Fraction(0.0) else Fraction((sample - lower)/span)

--- a/lib/ultimatum/src/gauges/ultimatum.Sparkline.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Sparkline.scala
@@ -30,24 +30,79 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package burdock
+package ultimatum
 
+import anticipation.*
+import denominative.*
 import escapade.*
-import hieroglyph.*
-import ultimatum.*
+import gossamer.*
+import rudiments.*
+import spectacular.*
+import symbolism.*
+import vacuous.*
 
-import gaugeGlyphs.unicodeGlyphs
-import palettes.emberGaugePalette
-import textMetrics.uniformMetric
+object Sparkline:
+  // Ascending block heights: the standard eight-level ramp.
+  private val blocks: Text = t"▁▂▃▄▅▆▇█"
+  private val dots: Text = t"⣀⠤⠒⠉"
+  private val ascii: Text = t"_.-^"
 
-// The repackager's progress bar. The drawing is `ultimatum`'s: this fixes the width, the design and
-// the palette, and leaves the in-place redrawing to the command-line entry point.
-// It was its own implementation until the gauge facility existed; keeping the same `render`
-// signature means the call site is unchanged, and the smooth eighth-block design and the ember
-// colours are the ones it always had.
-object ProgressBar:
-  val width: Int = 40
+  // Reduce `samples` to exactly `width` values by taking the maximum of each group. A sparkline
+  // narrower than its series must drop information; taking the maximum keeps the peaks, whereas
+  // truncating would silently show only the oldest samples and misrepresent the shape.
+  def decimate(samples: Sequence[Fraction], width: Int): Sequence[Fraction] =
+    val count = samples.stdlib.length
 
-  // Renders `fraction` (clamped by `Fraction`) as a `width`-cell bar.
-  def render(fraction: Double): Teletype =
-    gaugeLine(Fraction(fraction), width)(using bars.smoothBar)
+    if count <= width || width <= 0 then samples else
+      Sequence.from:
+        (0 until width).map: cell =>
+          val from = cell*count/width
+          val to = (((cell + 1)*count/width).max(from + 1)).min(count)
+          Fraction(samples.stdlib.slice(from, to).map(_.value).max)
+
+// How a run of samples is drawn. `Blocks` gives eight levels in one row; `Tall` stacks two rows for
+// sixteen; `Dots` and `Ascii` trade resolution for a narrower character repertoire.
+enum Sparkline:
+  case Blocks, Tall, Dots, Ascii
+
+  def rowCount: Int = this match
+    case Tall => 2
+    case _    => 1
+
+  def gaugeable(using gauging: Gauging): Series is Gaugeable = new Gaugeable:
+    type Self = Series
+    override def minWidth(status: Series): Int = 1
+    override def columns(status: Series): Int = status.samples.stdlib.length.max(1)
+    override def height(status: Series, width: Int): Int = rowCount
+
+    def rows(status: Series, tick: Tick, width: Int): List[Teletype] =
+      Sparkline.this.draw(status, width, gauging)
+
+  def draw(series: Series, width: Int, gauging: Gauging): List[Teletype] =
+    val values = Sparkline.decimate(series.normalized, width)
+    val ascii = !gauging.permits(Gaugeable.Glyphs.Unicode)
+
+    // A design whose glyphs are unavailable falls back to the ASCII ramp rather than to nothing.
+    val ramp = this match
+      case Ascii             => Sparkline.ascii
+      case _ if ascii        => Sparkline.ascii
+      case Dots              => Sparkline.dots
+      case Blocks | Tall     => Sparkline.blocks
+
+    def cell(fraction: Fraction, ramp: Text): Teletype =
+      val index = (fraction.value*ramp.length).toInt.min(ramp.length - 1).max(0)
+      val glyph = ramp.at(index.z).let(_.show).or(t" ")
+      gauging.tint(gauging.palette.lengthwise(fraction.value))(Teletype(glyph))
+
+    def row(pick: Fraction -> Fraction): Teletype =
+      val drawn = values.stdlib.map: value => cell(pick(value), ramp)
+      val body = if drawn.isEmpty then e"" else drawn.reduceLeft: (l, r) => e"$l$r"
+      val used = gauging.cells(body.plain)
+      if used >= width then body else e"$body${t" "*(width - used)}"
+
+    if this != Tall || ascii then List(row { value => value }) else
+      // Two rows give sixteen levels: the upper row shows the top half of the range and the lower
+      // row the bottom, so a tall sparkline resolves detail a single row would flatten.
+      val upper = row: value => Fraction((value.value*2 - 1).max(0.0))
+      val lower = row: value => Fraction((value.value*2).min(1.0))
+      List(upper, lower)

--- a/lib/ultimatum/src/gauges/ultimatum.Spinner.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Spinner.scala
@@ -1,0 +1,110 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import escapade.*
+import gossamer.*
+import symbolism.*
+import vacuous.*
+
+object Spinner:
+  // Build from a run of single-cell frames written as one string — `⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏` — split by code
+  // point, which is how nearly every design in the catalogue is declared.
+  def each
+    ( frames:     Text,
+       interval:   Int             = 80,
+       repertoire: Gaugeable.Glyphs = Gaugeable.Glyphs.Unicode,
+       narrower:   Optional[Spinner] = Unset )
+  :   Spinner =
+
+    Spinner(codepoints(frames), interval, 1, repertoire, narrower)
+
+  // Split by code point rather than by `Char`, so that an astral frame (an emoji clock face) is one
+  // frame and not two halves of a surrogate pair. Frames that are themselves multi-codepoint
+  // clusters have to be given explicitly, as a `Sequence`.
+  private def codepoints(text: Text): Sequence[Text] =
+    val builder = scala.collection.immutable.Vector.newBuilder[Text]
+    val string = text.s
+    var index = 0
+
+    while index < string.length do
+      val codepoint = string.codePointAt(index)
+      val width = java.lang.Character.charCount(codepoint)
+      builder += string.substring(index, index + width).nn.tt
+      index += width
+
+    Sequence.of(builder.result())
+
+// A cyclic run of frames, shown one at a time. `columns` is how wide every frame is (they must
+// agree, or the row would shear as it animates), `repertoire` is the least adventurous character
+// set that can render it, and `narrower` is what to fall back to when this design will not fit or
+// is not permitted — the chain that lets an emoji design degrade to a BMP one and a wide marquee to
+// a single spinning cell.
+case class Spinner
+  ( frames:     Sequence[Text],
+    interval:   Int               = 80,
+    columns:    Int               = 1,
+    repertoire: Gaugeable.Glyphs  = Gaugeable.Glyphs.Unicode,
+    narrower:   Optional[Spinner] = Unset ):
+
+  // The first design in this one's fallback chain that fits `width` and is permitted here.
+  def fit(width: Int, gauging: Gauging): Optional[Spinner] =
+    if columns <= width && gauging.permits(repertoire) then this
+    else narrower.lay(Unset: Optional[Spinner])(_.fit(width, gauging))
+
+  // The narrowest design in the chain, which is what the layout is told this gauge needs.
+  def leastColumns(gauging: Gauging): Int =
+    narrower.lay(columns)(_.leastColumns(gauging).min(columns))
+
+  def gaugeable(using gauging: Gauging): Busy is Gaugeable = new Gaugeable:
+    type Self = Busy
+    override def period: Optional[Int] = interval
+    override def elastic: Boolean = false
+    override def minWidth(status: Busy): Int = leastColumns(gauging)
+    override def columns(status: Busy): Int = leastColumns(gauging)
+
+    def rows(status: Busy, tick: Tick, width: Int): List[Teletype] =
+      val chosen = fit(width, gauging)
+
+      val frame = chosen.lay(Teletype(t" "*width.max(0))): spinner =>
+        val count = spinner.frames.stdlib.length
+
+        val index = (tick.index + status.tick).abs
+        val glyph = if count == 0 then t" " else spinner.frames.stdlib(index%count)
+
+        val padding = width - spinner.columns
+        val body = gauging.tint(gauging.palette.fill)(Teletype(glyph))
+        if padding > 0 then e"$body${t" "*padding}" else body
+
+      List(frame)

--- a/lib/ultimatum/src/gauges/ultimatum.Standing.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Standing.scala
@@ -1,0 +1,39 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+// How one unit of work has turned out — or has not yet. Kept separate from the glyphs that show
+// it, so that the same vocabulary serves a one-cell status marker, a checklist row and a colour
+// lookup in a palette.
+enum Standing:
+  case Pending, Running, Succeeded, Failed, Warned, Skipped

--- a/lib/ultimatum/src/gauges/ultimatum.Standing.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Standing.scala
@@ -32,6 +32,61 @@
                                                                                                   */
 package ultimatum
 
+import anticipation.*
+import escapade.*
+import gossamer.*
+import symbolism.*
+import vacuous.*
+
+object Standing:
+  // The six glyphs one design uses for the six standings, and the engine that draws them. A
+  // standing is carried by its glyph first and its colour second, so that the distinction survives
+  // a monochrome terminal and a redirected stream.
+  case class Marks
+    ( succeeded:  Text,
+      failed:     Text,
+      warned:     Text,
+      skipped:    Text,
+      running:    Text,
+      pending:    Text,
+      columns:    Int              = 1,
+      repertoire: Gaugeable.Glyphs = Gaugeable.Glyphs.Unicode,
+      narrower:   Optional[Marks]  = Unset ):
+
+    def apply(standing: Standing): Text = standing match
+      case Standing.Succeeded => succeeded
+      case Standing.Failed    => failed
+      case Standing.Warned    => warned
+      case Standing.Skipped   => skipped
+      case Standing.Running   => running
+      case Standing.Pending   => pending
+
+    // The first design in the fallback chain that fits and is permitted.
+    def fit(width: Int, gauging: Gauging): Optional[Marks] =
+      if columns <= width && gauging.permits(repertoire) then this
+      else narrower.lay(Unset: Optional[Marks])(_.fit(width, gauging))
+
+    def leastColumns: Int = narrower.lay(columns)(_.leastColumns.min(columns))
+
+    // Draw one standing, padded to `width`.
+    def draw(standing: Standing, width: Int, gauging: Gauging): Teletype =
+      fit(width, gauging).lay(Teletype(t" "*width.max(0))): marks =>
+        val glyph = gauging.tint(gauging.palette.colorOf(standing))(Teletype(marks(standing)))
+        val padding = width - marks.columns
+        if padding > 0 then e"$glyph${t" "*padding}" else glyph
+
+    def gaugeable(using gauging: Gauging): Standing is Gaugeable = new Gaugeable:
+      type Self = Standing
+      override def elastic: Boolean = false
+      override def minWidth(status: Standing): Int = leastColumns
+      override def columns(status: Standing): Int = leastColumns
+
+      def rows(status: Standing, tick: Tick, width: Int): List[Teletype] =
+        List(draw(status, width, gauging))
+
+  // The default marks, used when nothing is imported: the near-universal tick and cross.
+  given gaugeable: Gauging => Standing is Gaugeable = standings.tickStanding
+
 // How one unit of work has turned out — or has not yet. Kept separate from the glyphs that show
 // it, so that the same vocabulary serves a one-cell status marker, a checklist row and a colour
 // lookup in a palette.

--- a/lib/ultimatum/src/gauges/ultimatum.Step.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Step.scala
@@ -1,0 +1,40 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import vacuous.*
+
+// One named stage of a multi-stage process, with how it has turned out and an optional note (the
+// error, the artifact, the duration) shown beside it where the design has room.
+case class Step(name: Text, standing: Standing, detail: Optional[Text] = Unset)

--- a/lib/ultimatum/src/gauges/ultimatum.Transfer.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Transfer.scala
@@ -1,0 +1,60 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import aviation.*
+import quantitative.*
+import symbolism.*
+import vacuous.*
+
+// Bytes moved against bytes to move, with the time it has taken. The rate and the estimate are
+// *derived*, never stored, so a caller cannot hand a design an inconsistent triple — the commonest
+// bug in hand-rolled transfer displays, where the percentage and the ETA disagree.
+// It has no default design: whether to show a rate, whether to show an estimate, and whether to
+// count in `MB` or `MiB` are three editorial decisions, and a silent default would be wrong about
+// half the time.
+case class Transfer
+  ( moved:   Quantity[Bytes[1]],
+    total:   Optional[Quantity[Bytes[1]]] = Unset,
+    elapsed: Duration                     = 0.0*Second ):
+
+  def rate: Quantity[Bytes[1] & Seconds[-1]] =
+    if elapsed.value <= 0 then 0.0*Byte/Second else moved/elapsed
+
+  def fraction: Optional[Fraction] = total.let: total =>
+    if total.value <= 0 then Fraction(0.0) else Fraction(moved.value/total.value)
+
+  // How long the rest should take at the rate so far; `Unset` while nothing has moved (when any
+  // estimate would be a fabrication) or while the total is unknown.
+  def estimate: Optional[Duration] = total.lay(Unset: Optional[Duration]): total =>
+    if rate.value <= 0 then Unset else ((total - moved).value/rate.value)*Second

--- a/lib/ultimatum/src/gauges/ultimatum_gauges.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges.scala
@@ -30,24 +30,67 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package burdock
+package ultimatum
 
+import anticipation.*
 import escapade.*
-import hieroglyph.*
-import ultimatum.*
+import gossamer.*
+import parasite.*
+import symbolism.*
+import turbulence.*
+import vacuous.*
 
-import gaugeGlyphs.unicodeGlyphs
-import palettes.emberGaugePalette
-import textMetrics.uniformMetric
+// A leaf panel hosting a live gauge. The design is the `Gaugeable` given for `status` in scope
+// here, so which one is used is decided by the caller's imports at this line, not by the driver.
+// The gauge reports its design's intrinsic size on every solve, so it grows and shrinks with the
+// layout and re-negotiates on each resize; a gauge whose design animates also drives the form's
+// frame clock.
+def gauge[status: Gaugeable as design]
+  ( reading:   Reading[status],
+    fraction:  Double        = 1.0,
+    minWidth:  Int           = 0,
+    maxWidth:  Optional[Int] = Unset,
+    minHeight: Int           = 0,
+    maxHeight: Optional[Int] = Unset )
+:   Pane =
 
-// The repackager's progress bar. The drawing is `ultimatum`'s: this fixes the width, the design and
-// the palette, and leaves the in-place redrawing to the command-line entry point.
-// It was its own implementation until the gauge facility existed; keeping the same `render`
-// signature means the call site is unchanged, and the smooth eighth-block design and the ember
-// colours are the ones it always had.
-object ProgressBar:
-  val width: Int = 40
+  val preferred = design.columns(reading())
 
-  // Renders `fraction` (clamped by `Fraction`) as a `width`-cell bar.
-  def render(fraction: Double): Teletype =
-    gaugeLine(Fraction(fraction), width)(using bars.smoothBar)
+  // An inelastic design (a spinner, a status glyph) is pinned to its own width, so it does not
+  // stretch across the terminal; an elastic one takes whatever the solver gives it.
+  val width: Optional[Int] = if design.elastic then maxWidth else preferred
+
+  val sizing =
+    Sizing(fraction, minWidth.max(design.minWidth(reading())), width, minHeight, maxHeight)
+
+  Pane.Widget(sizing, Gaugeable.Fixture(reading))
+
+// One frame of `status` as styled rows — the pure entry point, for a caller doing its own drawing.
+def gaugeRows[status: Gaugeable as design]
+  ( status: status, width: Int, tick: Tick = Tick.zero )
+:   List[Teletype] =
+
+  design.rows(status, tick, width)
+
+// One frame as a single line, which is what a bar, a spinner or a counter renders to. A multi-row
+// design yields only its first row here; use `gaugeRows` for those.
+def gaugeLine[status: Gaugeable as design]
+  ( status: status, width: Int, tick: Tick = Tick.zero )
+:   Teletype =
+
+  design.rows(status, tick, width).stdlib.headOption.getOrElse(Teletype(t" "*width.max(0)))
+
+// Show a gauge at the cursor for the duration of `block`, then erase it. The animation runs in one
+// background task that redraws in place at the design's own period; a design with no period is
+// drawn once and then only when its `Reading` changes.
+// This is the standalone path — no form, no layout — and it shares every design with the embedded
+// one.
+def whilst[status: Gaugeable as design, result]
+  ( reading: Reading[status], width: Optional[Int] = Unset )
+  ( block: => result )
+  ( using Stdio, Monitor, Probate )
+:   result =
+
+  val inlay = Inlay(reading, width)
+  inlay.start()
+  try block finally inlay.finish()

--- a/lib/ultimatum/src/gauges/ultimatum_gauges_bars.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges_bars.scala
@@ -1,0 +1,105 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import gossamer.*
+
+// Determinate progress bars, keyed on `Fraction`. Import one by name to choose it; with no import,
+// `Fraction`'s companion supplies the smooth eighth-block bar.
+// Each is a `Bar` value, so width negotiation, sub-cell quantization and the fall through to a
+// percentage and then to a single shade are shared by all of them rather than reimplemented
+// eighteen times.
+package bars:
+  // Full, partials, empty. Where `empty` is a space, the track shows as a background colour; where
+  // it is a glyph, the track is drawn in the track colour instead.
+  private def filled(full: Text, partials: Text, empty: Text): Bar =
+    Bar.Filled(Bar.Glyphs(full, partials, empty), Bar.defaultColumns, false)
+
+  // The eighth-width left blocks: each is one eighth wider than the last, so the bar's right edge
+  // advances by a fraction of a cell rather than jumping a whole one.
+  private val eighths: Text = t"▏▎▍▌▋▊▉"
+
+  given smoothBar: Gauging => Fraction is Gaugeable = filled(t"█", eighths, t" ").gaugeable
+  given blockBar: Gauging => Fraction is Gaugeable = filled(t"█", t"", t"░").gaugeable
+  given shadedBar: Gauging => Fraction is Gaugeable = filled(t"█", t"░▒▓", t" ").gaugeable
+
+  // The boundary cell rises rather than widens: a different reading of the same fraction, and the
+  // one to use when the bar is short.
+  given risingBar: Gauging => Fraction is Gaugeable = filled(t"█", t"▁▂▃▄▅▆▇", t" ").gaugeable
+
+  given fineBar: Gauging => Fraction is Gaugeable = filled(t"━", t"╸", t"━").gaugeable
+  given dotBar: Gauging => Fraction is Gaugeable = filled(t"●", t"", t"·").gaugeable
+  given railBar: Gauging => Fraction is Gaugeable = filled(t"━", t"╸", t"─").gaugeable
+  given squareBar: Gauging => Fraction is Gaugeable = filled(t"■", t"", t"□").gaugeable
+
+  given brailleBar: Gauging => Fraction is Gaugeable =
+    filled(t"⣿", t"⡀⡄⡆⡇⣇⣧⣷", t"⣀").gaugeable
+
+  // Capped bars: the caps mark the extent, so a partly-filled bar in a wide column still reads as
+  // a proportion of something. They are the first cells given up when the column narrows.
+  given capsuleBar: Gauging => Fraction is Gaugeable =
+    Bar.Filled(Bar.Glyphs(t"█", eighths, t"░", t"▕", t"▏"), Bar.defaultColumns, false).gaugeable
+
+  given asciiBar: Gauging => Fraction is Gaugeable =
+    Bar.Filled(Bar.Glyphs(t"#", t"", t"-", t"[", t"]"), Bar.defaultColumns, false).gaugeable
+
+  given equalsBar: Gauging => Fraction is Gaugeable =
+    Bar.Filled(Bar.Glyphs(t"=", t"", t" ", t"[", t"]"), Bar.defaultColumns, false).gaugeable
+
+  // The classic `[===>    ]`. The arrowhead is a tip rather than a partial: it marks where the
+  // fill has reached at every intermediate value, instead of appearing only on the sub-cell steps.
+  given arrowheadBar: Gauging => Fraction is Gaugeable =
+    val glyphs = Bar.Glyphs(t"=", t"", t" ", t"[", t"]", tip = t">")
+    Bar.Filled(glyphs, Bar.defaultColumns, false).gaugeable
+
+  // The fill colour is taken from the palette's lengthwise ramp per cell, so the bar carries a
+  // gradient along its length rather than one flat colour.
+  given gradientBar: Gauging => Fraction is Gaugeable =
+    Bar.Filled(Bar.Glyphs(t"█", eighths, t" "), Bar.defaultColumns, true).gaugeable
+
+  // Discrete pips rather than a continuous fill: coarser, but legible at a glance and countable,
+  // which a smooth bar is not.
+  given segmentedBar: Gauging => Fraction is Gaugeable =
+    Bar.Segmented(t"▰", t"▱", t"", 20).gaugeable
+
+  given pipBar: Gauging => Fraction is Gaugeable = Bar.Segmented(t"●", t"○", t" ", 10).gaugeable
+
+  // A head travelling along a rail, with nothing filled behind it: a position rather than an
+  // amount, for something that scrubs back and forth.
+  given markerBar: Gauging => Fraction is Gaugeable =
+    Bar.Marker(t"─", t"◆", Bar.defaultColumns).gaugeable
+
+  // The figure alone, for a column with no room for anything else — and the design every other bar
+  // degrades into.
+  given percentageBar: Gauging => Fraction is Gaugeable = Bar.Numeric.gaugeable

--- a/lib/ultimatum/src/gauges/ultimatum_gauges_captions.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges_captions.scala
@@ -30,24 +30,18 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package burdock
+package ultimatum
 
-import escapade.*
-import hieroglyph.*
-import ultimatum.*
+// Where a label sits relative to the gauge it labels. Orthogonal to which design is used and to
+// which palette colours it, so a caption can be moved without touching either.
+package captions:
+  // The label follows the gauge, one space away — the default, also supplied by `CaptionLayout`'s
+  // companion so that a captioned gauge works with no import.
+  given trailingCaption: CaptionLayout = CaptionLayout(1, true, true)
 
-import gaugeGlyphs.unicodeGlyphs
-import palettes.emberGaugePalette
-import textMetrics.uniformMetric
+  given leadingCaption: CaptionLayout = CaptionLayout(1, false, true)
+  given spacedCaption: CaptionLayout = CaptionLayout(2, true, true)
 
-// The repackager's progress bar. The drawing is `ultimatum`'s: this fixes the width, the design and
-// the palette, and leaves the in-place redrawing to the command-line entry point.
-// It was its own implementation until the gauge facility existed; keeping the same `render`
-// signature means the call site is unchanged, and the smooth eighth-block design and the ember
-// colours are the ones it always had.
-object ProgressBar:
-  val width: Int = 40
-
-  // Renders `fraction` (clamped by `Fraction`) as a `width`-cell bar.
-  def render(fraction: Double): Teletype =
-    gaugeLine(Fraction(fraction), width)(using bars.smoothBar)
+  // Never shorten the label, even where that leaves the gauge less room than it wants: for a
+  // caption whose exact text matters more than the bar beside it.
+  given truncatedCaption: CaptionLayout = CaptionLayout(1, true, false)

--- a/lib/ultimatum/src/gauges/ultimatum_gauges_counters.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges_counters.scala
@@ -30,24 +30,63 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package burdock
+package ultimatum
 
+import anticipation.*
 import escapade.*
-import hieroglyph.*
-import ultimatum.*
+import gossamer.*
+import spectacular.*
+import vacuous.*
 
-import gaugeGlyphs.unicodeGlyphs
-import palettes.emberGaugePalette
-import textMetrics.uniformMetric
+// Figures rather than pictures: counts for a `Reckoning`, and a composed report for a `Transfer`.
+// Import one by name; `Reckoning` has a default, `Transfer` deliberately does not.
+package counters:
+  given plainCounter: Gauging => Reckoning is Gaugeable = Reckoning.Counter.Plain.gaugeable
+  given paddedCounter: Gauging => Reckoning is Gaugeable = Reckoning.Counter.Padded.gaugeable
+  given wordCounter: Gauging => Reckoning is Gaugeable = Reckoning.Counter.Words.gaugeable
+  given scaledCounter: Gauging => Reckoning is Gaugeable = Reckoning.Counter.Scaled.gaugeable
 
-// The repackager's progress bar. The drawing is `ultimatum`'s: this fixes the width, the design and
-// the palette, and leaves the in-place redrawing to the command-line entry point.
-// It was its own implementation until the gauge facility existed; keeping the same `render`
-// signature means the call site is unchanged, and the smooth eighth-block design and the ember
-// colours are the ones it always had.
-object ProgressBar:
-  val width: Int = 40
+  given percentageCounter: Gauging => Reckoning is Gaugeable =
+    Reckoning.Counter.Percentage.gaugeable
 
-  // Renders `fraction` (clamped by `Fraction`) as a `width`-cell bar.
-  def render(fraction: Double): Teletype =
-    gaugeLine(Fraction(fraction), width)(using bars.smoothBar)
+  // The moved/total figures, the rate and the estimate, in descending order of what a reader can
+  // do without: at a narrow width the estimate goes first, then the rate, leaving the figures.
+  // `Transfer` has no default design, so choosing one of these is also choosing whether to show a
+  // rate at all — which is the editorial decision the absent default was reserving for the caller.
+  private def report(showRate: Boolean, showEstimate: Boolean, binary: Boolean)
+    ( using gauging: Gauging )
+  :   Transfer is Gaugeable =
+
+    new Gaugeable:
+      type Self = Transfer
+      override def minWidth(status: Transfer): Int = 3
+
+      def rows(status: Transfer, tick: Tick, width: Int): List[Teletype] =
+        val palette = gauging.palette
+
+        def caption(text: Text): Teletype = gauging.tint(palette.caption)(Teletype(text))
+        def muted(text: Text): Teletype = gauging.tint(palette.muted)(Teletype(text))
+
+        val moved = Magnitude.bytes(status.moved.value, binary)
+
+        val figures = status.total.lay(moved): total =>
+          t"$moved/${Magnitude.bytes(total.value, binary)}"
+
+        val parts = scala.collection.mutable.ListBuffer[Facet]()
+        parts += Facet.fixed(0, caption(figures))
+
+        if showRate then parts += Facet.fixed(2, muted(Magnitude.rate(status.rate.value, binary)))
+
+        if showEstimate then status.estimate.let: remaining =>
+          parts += Facet.fixed(3, muted(t"${Magnitude.interval(remaining.value)} left"))
+
+        List(Facet.solve(List.of(parts.toList), width))
+
+  // Binary prefixes (`4.01 MiB`), the convention for anything counted in blocks on a disk or a
+  // wire.
+  given transferCounter: Gauging => Transfer is Gaugeable = report(true, true, true)
+  given rateTransferCounter: Gauging => Transfer is Gaugeable = report(true, false, true)
+  given terseTransferCounter: Gauging => Transfer is Gaugeable = report(false, false, true)
+
+  // Decimal prefixes (`4.20 MB`), the convention a drive manufacturer and a network operator use.
+  given decimalTransferCounter: Gauging => Transfer is Gaugeable = report(true, true, false)

--- a/lib/ultimatum/src/gauges/ultimatum_gauges_glyphs.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges_glyphs.scala
@@ -1,0 +1,49 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+// Which characters the designs may use. Importing one of these degrades or promotes the whole
+// catalogue at once, rather than requiring a different design to be chosen for each gauge.
+package gaugeGlyphs:
+  // Seven-bit output only: safe in a log capture, a CI transcript, or a terminal whose font is
+  // unknown. Every design has an ASCII rendering, so nothing disappears.
+  given asciiGlyphs: Gaugeable.Glyphs = Gaugeable.Glyphs.Ascii
+
+  // Box-drawing and block glyphs: the default, and universal on modern terminals.
+  given unicodeGlyphs: Gaugeable.Glyphs = Gaugeable.Glyphs.Unicode
+
+  // Also braille, which packs two to four samples into a cell but needs a font that has it.
+  given brailleGlyphs: Gaugeable.Glyphs = Gaugeable.Glyphs.Braille
+
+  // Also emoji, which are two cells wide and need a terminal that agrees they are.
+  given emojiGlyphs: Gaugeable.Glyphs = Gaugeable.Glyphs.Emoji

--- a/lib/ultimatum/src/gauges/ultimatum_gauges_meters.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges_meters.scala
@@ -30,24 +30,16 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package burdock
+package ultimatum
 
-import escapade.*
-import hieroglyph.*
-import ultimatum.*
-
-import gaugeGlyphs.unicodeGlyphs
-import palettes.emberGaugePalette
-import textMetrics.uniformMetric
-
-// The repackager's progress bar. The drawing is `ultimatum`'s: this fixes the width, the design and
-// the palette, and leaves the in-place redrawing to the command-line entry point.
-// It was its own implementation until the gauge facility existed; keeping the same `render`
-// signature means the call site is unchanged, and the smooth eighth-block design and the ember
-// colours are the ones it always had.
-object ProgressBar:
-  val width: Int = 40
-
-  // Renders `fraction` (clamped by `Fraction`) as a `width`-cell bar.
-  def render(fraction: Double): Teletype =
-    gaugeLine(Fraction(fraction), width)(using bars.smoothBar)
+// Readings on a bounded scale. A meter can fall as well as rise, so these designs mark the scale
+// and colour the reading by where it sits on it.
+// `Meter` has no default design: a battery, a thermometer and a bullet chart are not substitutable,
+// and two of them are not even the same height.
+package meters:
+  given batteryMeter: Gauging => Meter is Gaugeable = Dial.Battery.gaugeable
+  given thermometerMeter: Gauging => Meter is Gaugeable = Dial.Thermometer.gaugeable
+  given needleMeter: Gauging => Meter is Gaugeable = Dial.Needle.gaugeable
+  given bulletMeter: Gauging => Meter is Gaugeable = Dial.Bullet.gaugeable
+  given columnMeter: Gauging => Meter is Gaugeable = Dial.Column.gaugeable
+  given asciiMeter: Gauging => Meter is Gaugeable = Dial.Ascii.gaugeable

--- a/lib/ultimatum/src/gauges/ultimatum_gauges_palettes.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges_palettes.scala
@@ -1,0 +1,178 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import iridescence.*
+import prepositional.*
+
+import ultimatum.GaugePalette.hue
+
+// Which colours a gauge draws in — an axis entirely separate from which design it uses, so that
+// swapping either is one import and neither disturbs the other.
+// These merge into the umbrella's existing `palettes` block (iridescence contributes only traits
+// there), so every member is suffixed to keep the names distinct across the whole of `soundness`.
+package palettes:
+  // Hue-free: the terminal's own two colours and a half-tone between them. The only palette that
+  // is honestly correct on a monochrome terminal, and the one to reach for when a gauge's output
+  // may be read as text.
+  given monochromeGaugePalette: GaugePalette:
+    val background  = Srgb(0.0, 0.0, 0.0)
+    val foreground  = Srgb(1.0, 1.0, 1.0)
+    val track       = Srgb(0.25, 0.25, 0.25)
+    val fill        = Srgb(0.75, 0.75, 0.75)
+    val leadingEdge = Srgb(1.0, 1.0, 1.0)
+    val caption     = Srgb(0.85, 0.85, 0.85)
+    val muted       = Srgb(0.45, 0.45, 0.45)
+    val success     = Srgb(1.0, 1.0, 1.0)
+    val warning     = Srgb(0.7, 0.7, 0.7)
+    val danger      = Srgb(1.0, 1.0, 1.0)
+
+  // Only colours a sixteen-colour terminal actually has: each is that terminal's canonical value,
+  // so even the 256-cube approximation lands on a shade it can display rather than between two.
+  given ansiSixteenGaugePalette: GaugePalette:
+    val background  = Srgb(0.0, 0.0, 0.0)
+    val foreground  = Srgb(0.898, 0.898, 0.898)
+    val track       = Srgb(0.333, 0.333, 0.333)
+    val fill        = Srgb(0.0, 0.0, 0.804)
+    val leadingEdge = Srgb(0.333, 0.333, 1.0)
+    val caption     = Srgb(0.898, 0.898, 0.898)
+    val muted       = Srgb(0.333, 0.333, 0.333)
+    val success     = Srgb(0.0, 0.804, 0.0)
+    val warning     = Srgb(0.804, 0.804, 0.0)
+    val danger      = Srgb(0.804, 0.0, 0.0)
+
+  // Solarized's own values, spelled out rather than mixed in from `iridescence.Solarized`: that
+  // trait is a `Theme`, and a theme's obligations (a luminosity, a colour list, a spectrum) have
+  // nothing to do with a palette's roles.
+  given solarizedDarkGaugePalette: GaugePalette:
+    val background  = Srgb(0.000, 0.169, 0.212)
+    val foreground  = Srgb(0.992, 0.965, 0.890)
+    val track       = Srgb(0.027, 0.212, 0.259)
+    val fill        = Srgb(0.149, 0.545, 0.824)
+    val leadingEdge = Srgb(0.165, 0.631, 0.596)
+    val caption     = Srgb(0.576, 0.631, 0.631)
+    val muted       = Srgb(0.345, 0.431, 0.459)
+    val success     = Srgb(0.522, 0.600, 0.000)
+    val warning     = Srgb(0.710, 0.537, 0.000)
+    val danger      = Srgb(0.863, 0.196, 0.184)
+
+  given solarizedLightGaugePalette: GaugePalette:
+    val background  = Srgb(0.992, 0.965, 0.890)
+    val foreground  = Srgb(0.000, 0.169, 0.212)
+    val track       = Srgb(0.933, 0.910, 0.835)
+    val fill        = Srgb(0.149, 0.545, 0.824)
+    val leadingEdge = Srgb(0.424, 0.443, 0.769)
+    val caption     = Srgb(0.396, 0.482, 0.514)
+    val muted       = Srgb(0.576, 0.631, 0.631)
+    val success     = Srgb(0.522, 0.600, 0.000)
+    val warning     = Srgb(0.796, 0.294, 0.086)
+    val danger      = Srgb(0.863, 0.196, 0.184)
+
+  // The house palette: the repackager's orange on its own deep brown, which is what a Soundness
+  // progress bar has always looked like.
+  given emberGaugePalette: GaugePalette:
+    val background  = hue(rgb"#1a0a00")
+    val foreground  = hue(rgb"#ffe6d0")
+    val track       = hue(rgb"#3b1700")
+    val fill        = hue(rgb"#ff7d26")
+    val leadingEdge = hue(rgb"#ffc16b")
+    val caption     = hue(rgb"#ffd9b3")
+    val muted       = hue(rgb"#8a5230")
+    val success     = hue(rgb"#8fd14f")
+    val warning     = hue(rgb"#ffc857")
+    val danger      = hue(rgb"#e5484d")
+
+  // Cool and low-contrast, for a gauge that will sit on screen for hours.
+  given oceanicGaugePalette: GaugePalette:
+    val background  = hue(rgb"#0b1c22")
+    val foreground  = hue(rgb"#d6eef2")
+    val track       = hue(rgb"#123640")
+    val fill        = hue(rgb"#2aa9a3")
+    val leadingEdge = hue(rgb"#7fe3d8")
+    val caption     = hue(rgb"#9fc9d1")
+    val muted       = hue(rgb"#3f6b74")
+    val success     = hue(rgb"#4fd18b")
+    val warning     = hue(rgb"#e8b04b")
+    val danger      = hue(rgb"#ef5f6b")
+
+  given verdantGaugePalette: GaugePalette:
+    val background  = hue(rgb"#0d1a0f")
+    val foreground  = hue(rgb"#e3f2e4")
+    val track       = hue(rgb"#1d3520")
+    val fill        = hue(rgb"#5ab552")
+    val leadingEdge = hue(rgb"#a4e05a")
+    val caption     = hue(rgb"#c2ddc3")
+    val muted       = hue(rgb"#456b47")
+    val success     = hue(rgb"#7ee081")
+    val warning     = hue(rgb"#e6c344")
+    val danger      = hue(rgb"#e05252")
+
+  given plumGaugePalette: GaugePalette:
+    val background  = hue(rgb"#170f1f")
+    val foreground  = hue(rgb"#efe4f7")
+    val track       = hue(rgb"#2d1c3d")
+    val fill        = hue(rgb"#9a5cd0")
+    val leadingEdge = hue(rgb"#d79cf5")
+    val caption     = hue(rgb"#cbb4dc")
+    val muted       = hue(rgb"#5b4270")
+    val success     = hue(rgb"#6fd3a0")
+    val warning     = hue(rgb"#e2b23c")
+    val danger      = hue(rgb"#e2506b")
+
+  // Cool greys with one blue accent: the fill is the only saturated colour on screen, so the eye
+  // goes to the progress and to nothing else.
+  given slateGaugePalette: GaugePalette:
+    val background  = hue(rgb"#14171c")
+    val foreground  = hue(rgb"#dfe3ea")
+    val track       = hue(rgb"#242a33")
+    val fill        = hue(rgb"#4c8ef7")
+    val leadingEdge = hue(rgb"#8fbcff")
+    val caption     = hue(rgb"#a7b0be")
+    val muted       = hue(rgb"#4a5261")
+    val success     = hue(rgb"#3ecf8e")
+    val warning     = hue(rgb"#e3b341")
+    val danger      = hue(rgb"#f0616d")
+
+  // Maximum separation between the three report colours, for CI logs read at a glance.
+  given signalGaugePalette: GaugePalette:
+    val background  = hue(rgb"#000000")
+    val foreground  = hue(rgb"#ffffff")
+    val track       = hue(rgb"#333333")
+    val fill        = hue(rgb"#00b3ff")
+    val leadingEdge = hue(rgb"#7fdcff")
+    val caption     = hue(rgb"#ffffff")
+    val muted       = hue(rgb"#767676")
+    val success     = hue(rgb"#00c853")
+    val warning     = hue(rgb"#ffab00")
+    val danger      = hue(rgb"#ff1744")

--- a/lib/ultimatum/src/gauges/ultimatum_gauges_processions.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges_processions.scala
@@ -30,24 +30,18 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package burdock
+package ultimatum
 
-import escapade.*
-import hieroglyph.*
-import ultimatum.*
+// Multi-step processes. `checklistProcession` is one row per step and animates the running one;
+// the rest fit on a single row.
+// `Procession` has no default design, because these differ in height: choosing one decides how much
+// of the layout the gauge takes, which is not a decision a library should make silently.
+package processions:
+  given checklistProcession: Gauging => Procession is Gaugeable = Checklist.Rows.gaugeable
+  given breadcrumbProcession: Gauging => Procession is Gaugeable = Checklist.Breadcrumb.gaugeable
+  given beadProcession: Gauging => Procession is Gaugeable = Checklist.Beads.gaugeable
+  given numberedProcession: Gauging => Procession is Gaugeable = Checklist.Numbered.gaugeable
 
-import gaugeGlyphs.unicodeGlyphs
-import palettes.emberGaugePalette
-import textMetrics.uniformMetric
-
-// The repackager's progress bar. The drawing is `ultimatum`'s: this fixes the width, the design and
-// the palette, and leaves the in-place redrawing to the command-line entry point.
-// It was its own implementation until the gauge facility existed; keeping the same `render`
-// signature means the call site is unchanged, and the smooth eighth-block design and the ember
-// colours are the ones it always had.
-object ProgressBar:
-  val width: Int = 40
-
-  // Renders `fraction` (clamped by `Fraction`) as a `width`-cell bar.
-  def render(fraction: Double): Teletype =
-    gaugeLine(Fraction(fraction), width)(using bars.smoothBar)
+  // Powerline. Renders as tofu without a patched font, and no `Termcap` can tell us whether one is
+  // installed, so this is opt-in and never a default.
+  given ribbonProcession: Gauging => Procession is Gaugeable = Checklist.Ribbon.gaugeable

--- a/lib/ultimatum/src/gauges/ultimatum_gauges_sparklines.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges_sparklines.scala
@@ -30,24 +30,15 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package burdock
+package ultimatum
 
-import escapade.*
-import hieroglyph.*
-import ultimatum.*
-
-import gaugeGlyphs.unicodeGlyphs
-import palettes.emberGaugePalette
-import textMetrics.uniformMetric
-
-// The repackager's progress bar. The drawing is `ultimatum`'s: this fixes the width, the design and
-// the palette, and leaves the in-place redrawing to the command-line entry point.
-// It was its own implementation until the gauge facility existed; keeping the same `render`
-// signature means the call site is unchanged, and the smooth eighth-block design and the ember
-// colours are the ones it always had.
-object ProgressBar:
-  val width: Int = 40
-
-  // Renders `fraction` (clamped by `Fraction`) as a `width`-cell bar.
-  def render(fraction: Double): Teletype =
-    gaugeLine(Fraction(fraction), width)(using bars.smoothBar)
+// Runs of samples drawn as a miniature chart. A sparkline narrower than its series is decimated by
+// taking the maximum of each group, never truncated: a truncated sparkline would show only the
+// oldest samples while looking like the whole series.
+// `Series` has no default design, because the choice sets the vertical resolution — eight levels or
+// four, one row or two — and that changes what the reader can actually see in the data.
+package sparklines:
+  given blockSparkline: Gauging => Series is Gaugeable = Sparkline.Blocks.gaugeable
+  given tallSparkline: Gauging => Series is Gaugeable = Sparkline.Tall.gaugeable
+  given dotSparkline: Gauging => Series is Gaugeable = Sparkline.Dots.gaugeable
+  given asciiSparkline: Gauging => Series is Gaugeable = Sparkline.Ascii.gaugeable

--- a/lib/ultimatum/src/gauges/ultimatum_gauges_spinners.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges_spinners.scala
@@ -1,0 +1,194 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import anticipation.*
+import gossamer.*
+
+// Indeterminate activity indicators, keyed on `Busy`. Import one by name to choose it; with no
+// import at all, `Busy`'s companion supplies the braille dots.
+// Every design names the least adventurous repertoire that can draw it and, where it is wide or
+// exotic, what to fall back to — so the catalogue degrades as a whole under `asciiGlyphs`, and in
+// a narrow column, without the caller choosing a different design.
+package spinners:
+  import Gaugeable.Glyphs.{Ascii, Emoji, Unicode}
+
+  // The ASCII designs, which are also the ends of most fallback chains.
+  private val line: Spinner = Spinner.each(t"-\\|/", 130, Ascii)
+  private val quadrant: Spinner = Spinner.each(t"◴◷◶◵", 120, Unicode, line)
+  private val arc: Spinner = Spinner.each(t"◜◠◝◞◡◟", 100, Unicode, line)
+  private val pulse: Spinner = Spinner.each(t"█▓▒░▒▓", 100, Unicode, line)
+  private val circles: Spinner = Spinner.each(t"◌○◎◉●◉◎○", 120, Unicode, line)
+  private val halves: Spinner = Spinner.each(t"◐◓◑◒", 120, Unicode, line)
+  private val hourglass: Spinner = Spinner.each(t"⧖⧗", 500, Unicode, line)
+
+  given lineSpinner: Gauging => Busy is Gaugeable = line.gaugeable
+  given crossStarSpinner: Gauging => Busy is Gaugeable = Spinner.each(t"+x*", 120, Ascii).gaugeable
+  given dqpbSpinner: Gauging => Busy is Gaugeable = Spinner.each(t"dqpb", 100, Ascii).gaugeable
+  given bounceSpinner: Gauging => Busy is Gaugeable = Spinner.each(t".oO°Oo.", 120, Ascii).gaugeable
+
+  given balloonSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t" .oO@* ", 140, Ascii).gaugeable
+
+  // Braille: the densest single-cell animations there are, and the ones most terminals show best.
+  given brailleDotsSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", 80, Unicode, line).gaugeable
+
+  given brailleSnakeSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"⣾⣽⣻⢿⡿⣟⣯⣷", 80, Unicode, line).gaugeable
+
+  given brailleWaveSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"⠁⠂⠄⡀⢀⠠⠐⠈", 90, Unicode, line).gaugeable
+
+  given brailleGrowSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"⠋⠙⠚⠞⠖⠦⠴⠲⠳⠓", 80, Unicode, line).gaugeable
+
+  // Circles, arcs and quadrants.
+  given arcSpinner: Gauging => Busy is Gaugeable = arc.gaugeable
+  given circleQuadrantSpinner: Gauging => Busy is Gaugeable = quadrant.gaugeable
+  given circleHalfSpinner: Gauging => Busy is Gaugeable = halves.gaugeable
+  given circlePulseSpinner: Gauging => Busy is Gaugeable = circles.gaugeable
+
+  given squareCornerSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"◰◳◲◱", 120, Unicode, line).gaugeable
+
+  given triangleSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"◢◣◤◥", 120, Unicode, line).gaugeable
+
+  given pipeSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"┤┘┴└├┌┬┐", 100, Unicode, line).gaugeable
+
+  given boxSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"▖▘▝▗", 120, Unicode, line).gaugeable
+
+  // Arrows and stars.
+  given arrowSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"←↖↑↗→↘↓↙", 100, Unicode, line).gaugeable
+
+  given arrowDoubleSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"⇐⇖⇑⇗⇒⇘⇓⇙", 100, Unicode, line).gaugeable
+
+  given starSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"✶✸✹✺✹✷", 70, Unicode, line).gaugeable
+
+  given hamburgerSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"☱☲☴", 100, Unicode, line).gaugeable
+
+  // Shading and growth: an amount of ink rather than a shape, so they read as effort.
+  given noiseSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"▓▒░", 100, Unicode, line).gaugeable
+
+  given pulseSpinner: Gauging => Busy is Gaugeable = pulse.gaugeable
+
+  given growingBarSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"▏▎▍▌▋▊▉█▉▊▋▌▍▎", 90, Unicode, line).gaugeable
+
+  given growingBlockSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"▁▃▄▅▆▇█▇▆▅▄▃", 90, Unicode, line).gaugeable
+
+  given layerSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"-=≡", 150, Ascii).gaugeable
+
+  // Toggles: two states, slow, for something that is alive rather than working.
+  given toggleSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"⊶⊷", 250, Unicode, line).gaugeable
+
+  given toggleSquareSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"▫▪", 250, Unicode, line).gaugeable
+
+  given toggleRoundSpinner: Gauging => Busy is Gaugeable =
+    Spinner.each(t"⦾⦿", 250, Unicode, line).gaugeable
+
+  // Hourglasses: the only single-cell designs that say "waiting" rather than "working".
+  given hourglassThinSpinner: Gauging => Busy is Gaugeable = hourglass.gaugeable
+
+  // Multi-cell designs. Each falls back to a single cell, so a narrow column still animates.
+  given pointsSpinner: Gauging => Busy is Gaugeable =
+    Spinner(Sequence(t"∙∙∙", t"●∙∙", t"∙●∙", t"∙∙●"), 125, 3, Unicode, line).gaugeable
+
+  given dotsScrollSpinner: Gauging => Busy is Gaugeable =
+    Spinner(Sequence(t"   ", t".  ", t".. ", t"..."), 200, 3, Ascii, line).gaugeable
+
+  given binarySpinner: Gauging => Busy is Gaugeable =
+    val frames =
+      Sequence(t"010010", t"001100", t"100101", t"111010", t"111101", t"010111", t"101011",
+          t"111000", t"110011", t"110101")
+
+    Spinner(frames, 80, 6, Ascii, line).gaugeable
+
+  given bouncingBarSpinner: Gauging => Busy is Gaugeable =
+    val frames =
+      Sequence(t"[    ]", t"[=   ]", t"[==  ]", t"[=== ]", t"[ ===]", t"[  ==]", t"[   =]",
+          t"[    ]", t"[   =]", t"[  ==]", t"[ ===]", t"[====]", t"[=== ]", t"[==  ]", t"[=   ]")
+
+    Spinner(frames, 80, 6, Ascii, line).gaugeable
+
+  given bouncingBallSpinner: Gauging => Busy is Gaugeable =
+    val frames =
+      Sequence(t"( ●    )", t"(  ●   )", t"(   ●  )", t"(    ● )", t"(     ●)", t"(    ● )",
+          t"(   ●  )", t"(  ●   )", t"( ●    )", t"(●     )")
+
+    Spinner(frames, 80, 8, Unicode, line).gaugeable
+
+  given aestheticSpinner: Gauging => Busy is Gaugeable =
+    val frames =
+      Sequence(t"▰▱▱▱▱▱▱", t"▰▰▱▱▱▱▱", t"▰▰▰▱▱▱▱", t"▰▰▰▰▱▱▱", t"▰▰▰▰▰▱▱", t"▰▰▰▰▰▰▱",
+          t"▰▰▰▰▰▰▰", t"▱▱▱▱▱▱▱")
+
+    Spinner(frames, 120, 7, Unicode, line).gaugeable
+
+  given shuttleSpinner: Gauging => Busy is Gaugeable =
+    val frames = Sequence(t"▸▹▹▹▹", t"▹▸▹▹▹", t"▹▹▸▹▹", t"▹▹▹▸▹", t"▹▹▹▹▸")
+
+    Spinner(frames, 120, 5, Unicode, line).gaugeable
+
+  // Emoji: two cells wide, and only where the terminal has said it can render them. Each falls
+  // back to the BMP design that means the same thing, which is also the ASCII path.
+  given clockSpinner: Gauging => Busy is Gaugeable =
+    val frames =
+      Sequence(t"🕛", t"🕐", t"🕑", t"🕒", t"🕓", t"🕔", t"🕕", t"🕖", t"🕗", t"🕘", t"🕙", t"🕚")
+
+    Spinner(frames, 100, 2, Emoji, quadrant).gaugeable
+
+  given moonPhaseSpinner: Gauging => Busy is Gaugeable =
+    val frames = Sequence(t"🌑", t"🌒", t"🌓", t"🌔", t"🌕", t"🌖", t"🌗", t"🌘")
+
+    Spinner(frames, 80, 2, Emoji, circles).gaugeable
+
+  given earthSpinner: Gauging => Busy is Gaugeable =
+    Spinner(Sequence(t"🌍", t"🌎", t"🌏"), 180, 2, Emoji, halves).gaugeable
+
+  given hourglassSpinner: Gauging => Busy is Gaugeable =
+    val frames = Sequence(t"⏳", t"⌛")
+
+    Spinner(frames, 500, 2, Emoji, hourglass).gaugeable

--- a/lib/ultimatum/src/gauges/ultimatum_gauges_standings.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges_standings.scala
@@ -30,24 +30,34 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package burdock
+package ultimatum
 
-import escapade.*
-import hieroglyph.*
-import ultimatum.*
+import anticipation.*
+import gossamer.*
 
-import gaugeGlyphs.unicodeGlyphs
-import palettes.emberGaugePalette
-import textMetrics.uniformMetric
+// One-cell (or one-word) markers for a `Standing`. Import one by name; with no import, `Standing`'s
+// companion supplies the tick and cross.
+// Every design carries the standing in its *glyph*, not only in its colour, so that it survives a
+// monochrome terminal, a redirected stream and a reader who cannot distinguish red from green.
+package standings:
+  import Gaugeable.Glyphs.{Ascii, Unicode}
 
-// The repackager's progress bar. The drawing is `ultimatum`'s: this fixes the width, the design and
-// the palette, and leaves the in-place redrawing to the command-line entry point.
-// It was its own implementation until the gauge facility existed; keeping the same `render`
-// signature means the call site is unchanged, and the smooth eighth-block design and the ember
-// colours are the ones it always had.
-object ProgressBar:
-  val width: Int = 40
+  private val ascii: Standing.Marks =
+    Standing.Marks(t"+", t"x", t"!", t"-", t"*", t".", 1, Ascii)
 
-  // Renders `fraction` (clamped by `Fraction`) as a `width`-cell bar.
-  def render(fraction: Double): Teletype =
-    gaugeLine(Fraction(fraction), width)(using bars.smoothBar)
+  given asciiStanding: Gauging => Standing is Gaugeable = ascii.gaugeable
+
+  given tickStanding: Gauging => Standing is Gaugeable =
+    Standing.Marks(t"✓", t"✗", t"!", t"‑", t"⠋", t"·", 1, Unicode, ascii).gaugeable
+
+  given heavyStanding: Gauging => Standing is Gaugeable =
+    Standing.Marks(t"✔", t"✘", t"⚠", t"⊘", t"◐", t"◌", 1, Unicode, ascii).gaugeable
+
+  given squareStanding: Gauging => Standing is Gaugeable =
+    Standing.Marks(t"■", t"▨", t"▩", t"□", t"▤", t"·", 1, Unicode, ascii).gaugeable
+
+  // Words rather than glyphs, for a transcript that will be read rather than watched. Four cells,
+  // so a column of them aligns.
+  given wordStanding: Gauging => Standing is Gaugeable =
+    Standing.Marks(t"  ok", t"FAIL", t"warn", t"skip", t" run", t"   …", 4, Unicode, ascii)
+    . gaugeable

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -133,12 +133,12 @@ object Tests extends Suite(m"Ultimatum Tests"):
       def strip(children: Frame*): Frame = Frame.Split(Sizing(), ultimatum.Arrangement.Strip, children.to(List))
       def stack(children: Frame*): Frame = Frame.Split(Sizing(), ultimatum.Arrangement.Stack, children.to(List))
 
-      test(m"fractions divide the axis proportionally"):
+      test(m"fractions divide the arrangement proportionally"):
         val frame = strip(cell(Sizing(2.0)), cell(Sizing(3.0)), cell(Sizing(4.0)))
         frame.arrange(Rect(0, 0, 90, 10)).cells
       . assert(_ == List(Rect(0, 0, 20, 10), Rect(20, 0, 30, 10), Rect(50, 0, 40, 10)))
 
-      test(m"largest-remainder rounding fills the axis exactly"):
+      test(m"largest-remainder rounding fills the arrangement exactly"):
         val frame = strip(cell(Sizing(2.0)), cell(Sizing(3.0)), cell(Sizing(4.0)))
         frame.arrange(Rect(0, 0, 100, 1)).cells.map(_.width)
       . assert(_ == List(22, 33, 45))
@@ -163,7 +163,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         frame.measure(ultimatum.Arrangement.Strip)
       . assert(_ == Limits(10, Unset))
 
-      test(m"file children fill the cross axis (full height)"):
+      test(m"file children fill the cross arrangement (full height)"):
         val frame = strip(cell(Sizing(1.0)), cell(Sizing(1.0)))
         frame.arrange(Rect(0, 0, 8, 4)).cells
       . assert(_ == List(Rect(0, 0, 4, 4), Rect(4, 0, 4, 4)))
@@ -1015,6 +1015,267 @@ object Tests extends Suite(m"Ultimatum Tests"):
         val bordered = border()(panel(minWidth = 3, minHeight = 2)(())).frame
         (bordered.measure(ultimatum.Arrangement.Strip).min, bordered.measure(ultimatum.Arrangement.Stack).min)
       . assert(_ == (5, 4))
+
+    suite(m"Gauge designs"):
+      import gaugeGlyphs.unicodeGlyphs
+      import palettes.emberGaugePalette
+      import textMetrics.uniformMetric
+
+      // A design's plain text is what it draws; the styling is the palette's business and is
+      // asserted separately.
+      def draw[status: Gaugeable as design](status: status, width: Int, tick: Tick = Tick.zero)
+      :   Text =
+
+        design.rows(status, tick, width).stdlib.map(_.plain).mkString("\n").tt
+
+      test(m"a half-full smooth bar fills exactly half its cells"):
+        draw(Fraction(0.5), 10)(using bars.smoothBar)
+      . assert(_ == t"█████     ")
+
+      test(m"an eighth-block bar advances by a fraction of a cell"):
+        draw(Fraction(0.05), 10)(using bars.smoothBar)
+      . assert(_ == t"▌         ")
+
+      test(m"a full bar leaves no empty cells"):
+        draw(Fraction(1.0), 8)(using bars.smoothBar)
+      . assert(_ == t"████████")
+
+      test(m"an empty bar draws no filled cells"):
+        draw(Fraction(0.0), 8)(using bars.smoothBar)
+      . assert(_ == t"        ")
+
+      test(m"a block bar draws its own track glyph"):
+        draw(Fraction(0.5), 8)(using bars.blockBar)
+      . assert(_ == t"████░░░░")
+
+      test(m"an ASCII bar keeps its caps and fills between them"):
+        draw(Fraction(0.5), 10)(using bars.asciiBar)
+      . assert(_ == t"[####----]")
+
+      test(m"an arrowhead bar puts the boundary cell at the head of the fill"):
+        draw(Fraction(0.5), 10)(using bars.arrowheadBar)
+      . assert(_ == t"[===>    ]")
+
+      test(m"a segmented bar lights whole pips"):
+        draw(Fraction(0.5), 20)(using bars.segmentedBar)
+      . assert(_ == t"▰▰▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱")
+
+      test(m"a marker bar shows a position, with nothing filled behind it"):
+        draw(Fraction(0.5), 9)(using bars.markerBar)
+      . assert(_ == t"────◆────")
+
+      test(m"a bar too narrow for caps drops them and still fills"):
+        draw(Fraction(0.5), 6)(using bars.asciiBar)
+      . assert(_ == t"###---")
+
+      test(m"a bar degrades to a percentage when it cannot be drawn"):
+        draw(Fraction(0.42), 3)(using bars.smoothBar)
+      . assert(_ == t"42%")
+
+      test(m"a bar degrades to a single shade glyph at one cell"):
+        draw(Fraction(0.9), 1)(using bars.smoothBar)
+      . assert(_ == t"█")
+
+      test(m"the percentage design pads to a stable width as it fills"):
+        (draw(Fraction(0.07), 4)(using bars.percentageBar),
+            draw(Fraction(1.0), 4)(using bars.percentageBar))
+      . assert(_ == (t"  7%", t"100%"))
+
+      test(m"a spinner advances one frame per period"):
+        (0 to 3).map(index => draw(Busy(), 1, Tick.at(index*80, 80))(using
+            spinners.brailleDotsSpinner)).mkString.tt
+      . assert(_ == t"⠋⠙⠹⠸")
+
+      test(m"a spinner cycles back to its first frame"):
+        draw(Busy(), 1, Tick.at(10*80, 80))(using spinners.brailleDotsSpinner)
+      . assert(_ == t"⠋")
+
+      test(m"the status's own counter advances the spinner too"):
+        draw(Busy(2), 1, Tick.zero)(using spinners.brailleDotsSpinner)
+      . assert(_ == t"⠹")
+
+      test(m"a spinner declares its frame interval as its animation period"):
+        summon[Busy is Gaugeable](using spinners.brailleDotsSpinner).period
+      . assert(_ == 80)
+
+      test(m"a bar declares no animation period"):
+        summon[Fraction is Gaugeable](using bars.smoothBar).period
+      . assert(_ == Unset)
+
+      test(m"a wide spinner falls back to a narrower design in a narrow column"):
+        draw(Busy(), 1, Tick.zero)(using spinners.bouncingBarSpinner)
+      . assert(_ == t"-")
+
+      test(m"a multi-cell spinner draws at its full width when it fits"):
+        draw(Busy(1), 6, Tick.zero)(using spinners.bouncingBarSpinner)
+      . assert(_ == t"[=   ]")
+
+    suite(m"Gauge glyph repertoires"):
+      import palettes.emberGaugePalette
+      import textMetrics.uniformMetric
+
+      def draw[status: Gaugeable as design](status: status, width: Int): Text =
+        design.rows(status, Tick.zero, width).stdlib.map(_.plain).mkString("\n").tt
+
+      test(m"an emoji spinner renders as emoji when they are permitted"):
+        import gaugeGlyphs.emojiGlyphs
+        draw(Busy(), 2)(using spinners.moonPhaseSpinner)
+      . assert(_ == t"🌑")
+
+      test(m"an emoji spinner falls back to its BMP sibling when they are not"):
+        import gaugeGlyphs.unicodeGlyphs
+        draw(Busy(), 2)(using spinners.moonPhaseSpinner)
+      . assert(_ == t"◌ ")
+
+      test(m"under ASCII glyphs every spinner degrades to seven-bit output"):
+        import gaugeGlyphs.asciiGlyphs
+        draw(Busy(), 2)(using spinners.brailleDotsSpinner).s.forall(_ < 128)
+      . assert(_ == true)
+
+      test(m"under ASCII glyphs a bar degrades to seven-bit output"):
+        import gaugeGlyphs.asciiGlyphs
+        draw(Fraction(0.5), 1)(using bars.smoothBar).s.forall(_ < 128)
+      . assert(_ == true)
+
+    suite(m"Gauge width invariants"):
+      import gaugeGlyphs.unicodeGlyphs
+      import palettes.emberGaugePalette
+      import textMetrics.uniformMetric
+
+      // Every design must render exactly the width it was given, at every width: a design that is
+      // one cell out corrupts the row beside it, and there is no other way to catch that across a
+      // catalogue this size.
+      val designs: scala.List[(Text, Int => Text)] =
+        scala.List
+         ( (t"smoothBar", width => bars.smoothBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"blockBar", width => bars.blockBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"shadedBar", width => bars.shadedBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"risingBar", width => bars.risingBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"fineBar", width => bars.fineBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"dotBar", width => bars.dotBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"railBar", width => bars.railBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"squareBar", width => bars.squareBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"brailleBar", width => bars.brailleBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"capsuleBar", width => bars.capsuleBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"asciiBar", width => bars.asciiBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"equalsBar", width => bars.equalsBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"arrowheadBar", width => bars.arrowheadBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"gradientBar", width => bars.gradientBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"segmentedBar", width => bars.segmentedBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"pipBar", width => bars.pipBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"markerBar", width => bars.markerBar.rows(Fraction(0.37), Tick.zero, width)),
+           (t"percentageBar", width => bars.percentageBar.rows(Fraction(0.37), Tick.zero, width)) )
+        . map: (name, render) =>
+            (name, (width: Int) => render(width).stdlib.head.plain)
+
+      test(m"every bar renders exactly the width it is given, from 1 to 120 cells"):
+        designs.flatMap: (name, render) =>
+          (1 to 120).flatMap: width =>
+            val drawn = render(width)
+            if drawn.length == width then scala.Nil else scala.List((name, width, drawn.length))
+      . assert(_ == scala.Nil)
+
+      test(m"every bar renders one row"):
+        scala.List
+         ( bars.smoothBar.rows(Fraction(0.5), Tick.zero, 20).stdlib.length,
+           bars.segmentedBar.rows(Fraction(0.5), Tick.zero, 20).stdlib.length,
+           bars.percentageBar.rows(Fraction(0.5), Tick.zero, 20).stdlib.length )
+      . assert(_ == scala.List(1, 1, 1))
+
+      test(m"a bar's output is stable for a fixed tick"):
+        val once = bars.smoothBar.rows(Fraction(0.37), Tick.zero, 30).stdlib.head.plain
+        val twice = bars.smoothBar.rows(Fraction(0.37), Tick.zero, 30).stdlib.head.plain
+        (once, twice)
+      . assert((a, b) => a == b)
+
+    suite(m"Facet shedding"):
+      import gaugeGlyphs.unicodeGlyphs
+      import palettes.emberGaugePalette
+      import textMetrics.uniformMetric
+
+      // A caption that goes first, a bar that stretches, and a figure that goes last.
+      def row(width: Int): Text =
+        Facet.solve
+         ( List
+            ( Facet.fixed(2, Teletype(t"compiling")),
+              Facet.flexible(4)(w => Teletype(t"="*w)),
+              Facet.fixed(1, Teletype(t"42%")) ),
+           width )
+        . plain
+
+      test(m"a wide row keeps every facet and stretches the flexible one"):
+        row(24)
+      . assert(_ == t"compiling ========== 42%")
+
+      test(m"a narrower row sheds the most expendable facet first"):
+        row(12)
+      . assert(_ == t"======== 42%")
+
+      test(m"a narrower row still sheds in shed order"):
+        row(8)
+      . assert(_ == t"==== 42%")
+
+      test(m"the flexible facet is never shed"):
+        row(4)
+      . assert(_ == t"====")
+
+      test(m"a row below every minimum is blank rather than corrupt"):
+        row(2)
+      . assert(_ == t"  ")
+
+      test(m"a solved row is always exactly the width it was given"):
+        (1 to 60).map(row(_).length).toList.filter(_ != 0)
+      . assert(_ == (1 to 60).toList)
+
+    suite(m"Gauges in a layout"):
+      def render(width: Int, height: Int)(pane: Pane): Text =
+        given Stdio = Stdio(null, null, null, termcapDefinitions.basicTermcap)
+        val root = FlowExtent(TerminalBoard(width, height), Rect(0, 0, width, height))
+        paint(root, pane)
+        root.render
+
+      import gaugeGlyphs.unicodeGlyphs
+      import palettes.emberGaugePalette
+      import textMetrics.uniformMetric
+
+      test(m"a gauge fixture paints its bar into the rectangle it is given"):
+        given Stdio = Stdio(null, null, null, termcapDefinitions.basicTermcap)
+        val flow = FlowExtent(TerminalBoard(10, 1), Rect(0, 0, 10, 1))
+        Gaugeable.Fixture(Reading(Fraction(0.3)))(using bars.blockBar).render(flow, false)
+        flow.render
+      . assert(_ == t"███░░░░░░░")
+
+      test(m"a gauge reports its design's preferred width to the solver"):
+        Gaugeable.Fixture(Reading(Fraction(0.5)))(using bars.smoothBar).measure(80)
+      . assert(_ == (40, 1))
+
+      test(m"a spinner reports a single cell and does not stretch"):
+        Gaugeable.Fixture(Reading(Busy()))(using spinners.brailleDotsSpinner).measure(80)
+      . assert(_ == (1, 1))
+
+      test(m"a gauge is not focusable, so it stays out of the focus cycle"):
+        Gaugeable.Fixture(Reading(Busy()))(using spinners.brailleDotsSpinner)
+        . isInstanceOf[Focus]
+      . assert(_ == false)
+
+      test(m"an updated reading is what the next paint draws"):
+        given Stdio = Stdio(null, null, null, termcapDefinitions.basicTermcap)
+        val reading = Reading(Fraction(0.0))
+        val fixture = Gaugeable.Fixture(reading)(using bars.blockBar)
+        val flow = FlowExtent(TerminalBoard(8, 1), Rect(0, 0, 8, 1))
+        reading() = Fraction(0.5)
+        fixture.render(flow, false)
+        flow.render
+      . assert(_ == t"████░░░░")
+
+      test(m"a bar in a stack is painted at the width the solver gave it"):
+        render(8, 2):
+          stack
+           ( panel(minHeight = 1, maxHeight = 1)(Out.print(t"job")),
+             Pane.Widget
+              ( Sizing(minHeight = 1, maxHeight = 1),
+                Gaugeable.Fixture(Reading(Fraction(0.5)))(using bars.blockBar) ) )
+      . assert(_ == t"job     \n████░░░░")
 
 // A test-only root `Board` that paints into a fixed in-memory grid but reports a
 // settable size, so a layout can be re-tiled to a smaller `width`/`height` and

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -130,8 +130,8 @@ object Tests extends Suite(m"Ultimatum Tests"):
 
     suite(m"Layout solver"):
       def cell(sizing: Sizing): Frame = Frame.Cell(sizing)
-      def strip(children: Frame*): Frame = Frame.Split(Sizing(), ultimatum.Axis.File, children.to(List))
-      def stack(children: Frame*): Frame = Frame.Split(Sizing(), ultimatum.Axis.Rank, children.to(List))
+      def strip(children: Frame*): Frame = Frame.Split(Sizing(), ultimatum.Arrangement.Strip, children.to(List))
+      def stack(children: Frame*): Frame = Frame.Split(Sizing(), ultimatum.Arrangement.Stack, children.to(List))
 
       test(m"fractions divide the axis proportionally"):
         val frame = strip(cell(Sizing(2.0)), cell(Sizing(3.0)), cell(Sizing(4.0)))
@@ -160,7 +160,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
 
       test(m"a container's minimum is forced up to the sum of its children's"):
         val frame = strip(cell(Sizing(1.0, minWidth = 5)), cell(Sizing(1.0, minWidth = 5)))
-        frame.measure(ultimatum.Axis.File)
+        frame.measure(ultimatum.Arrangement.Strip)
       . assert(_ == Limits(10, Unset))
 
       test(m"file children fill the cross axis (full height)"):
@@ -1013,7 +1013,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
 
       test(m"a full border adds one cell on every side to the minimum size"):
         val bordered = border()(panel(minWidth = 3, minHeight = 2)(())).frame
-        (bordered.measure(ultimatum.Axis.File).min, bordered.measure(ultimatum.Axis.Rank).min)
+        (bordered.measure(ultimatum.Arrangement.Strip).min, bordered.measure(ultimatum.Arrangement.Stack).min)
       . assert(_ == (5, 4))
 
 // A test-only root `Board` that paints into a fixed in-memory grid but reports a

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -1022,76 +1022,79 @@ object Tests extends Suite(m"Ultimatum Tests"):
       import textMetrics.uniformMetric
 
       // A design's plain text is what it draws; the styling is the palette's business and is
-      // asserted separately.
-      def draw[status: Gaugeable as design](status: status, width: Int, tick: Tick = Tick.zero)
-      :   Text =
+      // asserted separately. Deliberately monomorphic: these tests live in `package ultimatum`,
+      // where the opaque status types are transparent, so a generic helper would infer the
+      // underlying `Double` from a literal and then fail to match the design.
+      def bar(design: Fraction is Gaugeable)(value: Fraction, width: Int): Text =
+        design.rows(value, Tick.zero, width).stdlib.map(_.plain).mkString("\n").tt
 
-        design.rows(status, tick, width).stdlib.map(_.plain).mkString("\n").tt
+      def spin(design: Busy is Gaugeable)(value: Busy, width: Int, tick: Tick = Tick.zero): Text =
+        design.rows(value, tick, width).stdlib.map(_.plain).mkString("\n").tt
 
       test(m"a half-full smooth bar fills exactly half its cells"):
-        draw(Fraction(0.5), 10)(using bars.smoothBar)
+        bar(bars.smoothBar)(Fraction(0.5), 10)
       . assert(_ == t"█████     ")
 
       test(m"an eighth-block bar advances by a fraction of a cell"):
-        draw(Fraction(0.05), 10)(using bars.smoothBar)
+        bar(bars.smoothBar)(Fraction(0.05), 10)
       . assert(_ == t"▌         ")
 
       test(m"a full bar leaves no empty cells"):
-        draw(Fraction(1.0), 8)(using bars.smoothBar)
+        bar(bars.smoothBar)(Fraction(1.0), 8)
       . assert(_ == t"████████")
 
       test(m"an empty bar draws no filled cells"):
-        draw(Fraction(0.0), 8)(using bars.smoothBar)
+        bar(bars.smoothBar)(Fraction(0.0), 8)
       . assert(_ == t"        ")
 
       test(m"a block bar draws its own track glyph"):
-        draw(Fraction(0.5), 8)(using bars.blockBar)
+        bar(bars.blockBar)(Fraction(0.5), 8)
       . assert(_ == t"████░░░░")
 
       test(m"an ASCII bar keeps its caps and fills between them"):
-        draw(Fraction(0.5), 10)(using bars.asciiBar)
+        bar(bars.asciiBar)(Fraction(0.5), 10)
       . assert(_ == t"[####----]")
 
       test(m"an arrowhead bar puts the boundary cell at the head of the fill"):
-        draw(Fraction(0.5), 10)(using bars.arrowheadBar)
+        bar(bars.arrowheadBar)(Fraction(0.5), 10)
       . assert(_ == t"[===>    ]")
 
       test(m"a segmented bar lights whole pips"):
-        draw(Fraction(0.5), 20)(using bars.segmentedBar)
+        bar(bars.segmentedBar)(Fraction(0.5), 20)
       . assert(_ == t"▰▰▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱")
 
       test(m"a marker bar shows a position, with nothing filled behind it"):
-        draw(Fraction(0.5), 9)(using bars.markerBar)
+        bar(bars.markerBar)(Fraction(0.5), 9)
       . assert(_ == t"────◆────")
 
       test(m"a bar too narrow for caps drops them and still fills"):
-        draw(Fraction(0.5), 6)(using bars.asciiBar)
+        bar(bars.asciiBar)(Fraction(0.5), 6)
       . assert(_ == t"###---")
 
       test(m"a bar degrades to a percentage when it cannot be drawn"):
-        draw(Fraction(0.42), 3)(using bars.smoothBar)
+        bar(bars.smoothBar)(Fraction(0.42), 3)
       . assert(_ == t"42%")
 
       test(m"a bar degrades to a single shade glyph at one cell"):
-        draw(Fraction(0.9), 1)(using bars.smoothBar)
+        bar(bars.smoothBar)(Fraction(0.9), 1)
       . assert(_ == t"█")
 
       test(m"the percentage design pads to a stable width as it fills"):
-        (draw(Fraction(0.07), 4)(using bars.percentageBar),
-            draw(Fraction(1.0), 4)(using bars.percentageBar))
+        (bar(bars.percentageBar)(Fraction(0.07), 4),
+            bar(bars.percentageBar)(Fraction(1.0), 4))
       . assert(_ == (t"  7%", t"100%"))
 
       test(m"a spinner advances one frame per period"):
-        (0 to 3).map(index => draw(Busy(), 1, Tick.at(index*80, 80))(using
-            spinners.brailleDotsSpinner)).mkString.tt
+        val design = spinners.brailleDotsSpinner
+        (0 to 3).map { index => spin(design)(Busy(), 1, Tick.at(index*80, 80)) }.mkString.tt
       . assert(_ == t"⠋⠙⠹⠸")
 
       test(m"a spinner cycles back to its first frame"):
-        draw(Busy(), 1, Tick.at(10*80, 80))(using spinners.brailleDotsSpinner)
+        spin(spinners.brailleDotsSpinner)(Busy(), 1, Tick.at(10*80, 80))
       . assert(_ == t"⠋")
 
       test(m"the status's own counter advances the spinner too"):
-        draw(Busy(2), 1, Tick.zero)(using spinners.brailleDotsSpinner)
+        spin(spinners.brailleDotsSpinner)(Busy(2), 1, Tick.zero)
       . assert(_ == t"⠹")
 
       test(m"a spinner declares its frame interval as its animation period"):
@@ -1103,38 +1106,41 @@ object Tests extends Suite(m"Ultimatum Tests"):
       . assert(_ == Unset)
 
       test(m"a wide spinner falls back to a narrower design in a narrow column"):
-        draw(Busy(), 1, Tick.zero)(using spinners.bouncingBarSpinner)
+        spin(spinners.bouncingBarSpinner)(Busy(), 1, Tick.zero)
       . assert(_ == t"-")
 
       test(m"a multi-cell spinner draws at its full width when it fits"):
-        draw(Busy(1), 6, Tick.zero)(using spinners.bouncingBarSpinner)
+        spin(spinners.bouncingBarSpinner)(Busy(1), 6, Tick.zero)
       . assert(_ == t"[=   ]")
 
     suite(m"Gauge glyph repertoires"):
       import palettes.emberGaugePalette
       import textMetrics.uniformMetric
 
-      def draw[status: Gaugeable as design](status: status, width: Int): Text =
-        design.rows(status, Tick.zero, width).stdlib.map(_.plain).mkString("\n").tt
+      def bar(design: Fraction is Gaugeable)(value: Fraction, width: Int): Text =
+        design.rows(value, Tick.zero, width).stdlib.map(_.plain).mkString("\n").tt
+
+      def spin(design: Busy is Gaugeable)(value: Busy, width: Int): Text =
+        design.rows(value, Tick.zero, width).stdlib.map(_.plain).mkString("\n").tt
 
       test(m"an emoji spinner renders as emoji when they are permitted"):
         import gaugeGlyphs.emojiGlyphs
-        draw(Busy(), 2)(using spinners.moonPhaseSpinner)
+        spin(spinners.moonPhaseSpinner)(Busy(), 2)
       . assert(_ == t"🌑")
 
       test(m"an emoji spinner falls back to its BMP sibling when they are not"):
         import gaugeGlyphs.unicodeGlyphs
-        draw(Busy(), 2)(using spinners.moonPhaseSpinner)
+        spin(spinners.moonPhaseSpinner)(Busy(), 2)
       . assert(_ == t"◌ ")
 
       test(m"under ASCII glyphs every spinner degrades to seven-bit output"):
         import gaugeGlyphs.asciiGlyphs
-        draw(Busy(), 2)(using spinners.brailleDotsSpinner).s.forall(_ < 128)
+        spin(spinners.brailleDotsSpinner)(Busy(), 2).s.forall(_ < 128)
       . assert(_ == true)
 
       test(m"under ASCII glyphs a bar degrades to seven-bit output"):
         import gaugeGlyphs.asciiGlyphs
-        draw(Fraction(0.5), 1)(using bars.smoothBar).s.forall(_ < 128)
+        bar(bars.smoothBar)(Fraction(0.5), 1).s.forall(_ < 128)
       . assert(_ == true)
 
     suite(m"Gauge width invariants"):
@@ -1241,29 +1247,32 @@ object Tests extends Suite(m"Ultimatum Tests"):
       test(m"a gauge fixture paints its bar into the rectangle it is given"):
         given Stdio = Stdio(null, null, null, termcapDefinitions.basicTermcap)
         val flow = FlowExtent(TerminalBoard(10, 1), Rect(0, 0, 10, 1))
-        Gaugeable.Fixture(Reading(Fraction(0.3)))(using bars.blockBar).render(flow, false)
+        Gaugeable.Fixture(Reading[Fraction](Fraction(0.3)))(using bars.blockBar).render(flow, false)
         flow.render
       . assert(_ == t"███░░░░░░░")
 
       test(m"a gauge reports its design's preferred width to the solver"):
-        Gaugeable.Fixture(Reading(Fraction(0.5)))(using bars.smoothBar).measure(80)
+        Gaugeable.Fixture(Reading[Fraction](Fraction(0.5)))(using bars.smoothBar).measure(80)
       . assert(_ == (40, 1))
 
       test(m"a spinner reports a single cell and does not stretch"):
-        Gaugeable.Fixture(Reading(Busy()))(using spinners.brailleDotsSpinner).measure(80)
+        Gaugeable.Fixture(Reading[Busy](Busy()))(using spinners.brailleDotsSpinner).measure(80)
       . assert(_ == (1, 1))
 
       test(m"a gauge is not focusable, so it stays out of the focus cycle"):
-        Gaugeable.Fixture(Reading(Busy()))(using spinners.brailleDotsSpinner)
+        Gaugeable.Fixture(Reading[Busy](Busy()))(using spinners.brailleDotsSpinner)
         . isInstanceOf[Focus]
       . assert(_ == false)
 
       test(m"an updated reading is what the next paint draws"):
         given Stdio = Stdio(null, null, null, termcapDefinitions.basicTermcap)
-        val reading = Reading(Fraction(0.0))
+        // Qualified: this file is `package ultimatum` but imports `soundness.*`, so a bare
+        // `Fraction` is the umbrella's alias, through which the opaque type's purity is not
+        // visible and the assignment would not typecheck.
+        val reading = Reading(ultimatum.Fraction(0.0))
         val fixture = Gaugeable.Fixture(reading)(using bars.blockBar)
         val flow = FlowExtent(TerminalBoard(8, 1), Rect(0, 0, 8, 1))
-        reading() = Fraction(0.5)
+        reading() = ultimatum.Fraction(0.5)
         fixture.render(flow, false)
         flow.render
       . assert(_ == t"████░░░░")
@@ -1274,8 +1283,177 @@ object Tests extends Suite(m"Ultimatum Tests"):
            ( panel(minHeight = 1, maxHeight = 1)(Out.print(t"job")),
              Pane.Widget
               ( Sizing(minHeight = 1, maxHeight = 1),
-                Gaugeable.Fixture(Reading(Fraction(0.5)))(using bars.blockBar) ) )
+                Gaugeable.Fixture(Reading[Fraction](Fraction(0.5)))(using bars.blockBar) ) )
       . assert(_ == t"job     \n████░░░░")
+
+    suite(m"Meters, sparklines, counters and processions"):
+      import gaugeGlyphs.unicodeGlyphs
+      import palettes.emberGaugePalette
+      import textMetrics.uniformMetric
+
+      def plain[status](design: status is Gaugeable)(value: status, width: Int): Text =
+        design.rows(value, Tick.zero, width).stdlib.map(_.plain).mkString("\n").tt
+
+      test(m"a column meter shows a bounded reading as one cell"):
+        plain(meters.columnMeter)(Meter(0.5), 1)
+      . assert(_ == t"▅")
+
+      test(m"a meter reads against its own bounds, not against zero to one"):
+        plain(meters.columnMeter)(Meter(50.0, 0.0, 100.0), 1)
+      . assert(_ == t"▅")
+
+      test(m"an ASCII meter fills between its brackets"):
+        plain(meters.asciiMeter)(Meter(0.5), 10)
+      . assert(_ == t"[####----]")
+
+      test(m"a thermometer is a column of its own height"):
+        plain(meters.thermometerMeter)(Meter(1.0), 1).cut(t"\n").length
+      . assert(_ == 5)
+
+      test(m"a block sparkline draws one cell per sample"):
+        plain(sparklines.blockSparkline)(Series(Sequence(0.0, 0.5, 1.0)), 3)
+      . assert(_ == t"▁▅█")
+
+      test(m"a sparkline auto-scales to the range of its samples"):
+        plain(sparklines.blockSparkline)(Series(Sequence(10.0, 20.0)), 2)
+      . assert(_ == t"▁█")
+
+      test(m"fixed bounds keep a sparkline's scale still between frames"):
+        plain(sparklines.blockSparkline)(Series(Sequence(0.0, 5.0), 0.0, 10.0), 2)
+      . assert(_ == t"▁▅")
+
+      // Decimation, not truncation: a narrow sparkline keeps the peaks rather than showing only
+      // the oldest samples.
+      test(m"a sparkline narrower than its series keeps the peaks"):
+        plain(sparklines.blockSparkline)(Series(Sequence(0.0, 1.0, 0.0, 0.0)), 2)
+      . assert(_ == t"█▁")
+
+      test(m"a plain counter writes done over total"):
+        plain(counters.plainCounter)(Reckoning(17, 120), 7)
+      . assert(_ == t"17/120 ")
+
+      test(m"a counter with no total writes only what is done"):
+        plain(counters.plainCounter)(Reckoning(17), 2)
+      . assert(_ == t"17")
+
+      // The numerator is right-aligned to the total's width, so the field does not jitter.
+      test(m"a padded counter holds its width as it counts up"):
+        (plain(counters.paddedCounter)(Reckoning(7, 120), 7),
+            plain(counters.paddedCounter)(Reckoning(117, 120), 7))
+      . assert(_ == (t"  7/120", t"117/120"))
+
+      test(m"a scaled counter abbreviates large figures"):
+        plain(counters.scaledCounter)(Reckoning(1200, 8400), 9)
+      . assert(_ == t"1.2k/8.4k")
+
+      test(m"a tick standing is a single coloured glyph"):
+        plain(standings.tickStanding)(Standing.Succeeded, 1)
+      . assert(_ == t"✓")
+
+      test(m"an ASCII standing stays within seven bits"):
+        plain(standings.asciiStanding)(Standing.Failed, 1)
+      . assert(_ == t"x")
+
+      test(m"a word standing pads to a fixed width so a column aligns"):
+        (plain(standings.wordStanding)(Standing.Succeeded, 4),
+            plain(standings.wordStanding)(Standing.Failed, 4))
+      . assert(_ == (t"  ok", t"FAIL"))
+
+      val steps =
+        Procession
+         ( Sequence
+            ( Step(t"resolve", Standing.Succeeded),
+              Step(t"compile", Standing.Running),
+              Step(t"publish", Standing.Pending) ) )
+
+      test(m"a checklist is one row per step"):
+        plain(processions.checklistProcession)(steps, 12).cut(t"\n").length
+      . assert(_ == 3)
+
+      test(m"a checklist marks each step by its standing"):
+        plain(processions.checklistProcession)(steps, 9)
+      . assert(_ == t"✓ resolve\n⠋ compile\n· publish")
+
+      test(m"a numbered procession counts the steps that have started"):
+        plain(processions.numberedProcession)(steps, 14)
+      . assert(_ == t"[2/3] compile ")
+
+      test(m"a bead procession is a chain of two cells per step, less one"):
+        plain(processions.beadProcession)(steps, 5)
+      . assert(_ == t"●━◐━○")
+
+      test(m"a breadcrumb procession joins the steps on one row"):
+        plain(processions.breadcrumbProcession)(steps, 29)
+      . assert(_ == t"resolve › compile › publish  ")
+
+      test(m"a checklist declares an animation period; a breadcrumb does not"):
+        (processions.checklistProcession.period, processions.breadcrumbProcession.period)
+      . assert(_ == (80, Unset))
+
+    suite(m"Captioned gauges"):
+      import gaugeGlyphs.unicodeGlyphs
+      import palettes.emberGaugePalette
+      import textMetrics.uniformMetric
+
+      def plain[status](design: status is Gaugeable)(value: status, width: Int): Text =
+        design.rows(value, Tick.zero, width).stdlib.map(_.plain).mkString("\n").tt
+
+      test(m"a caption follows the gauge it labels"):
+        import bars.blockBar
+        plain(summon[Captioned[ultimatum.Fraction] is Gaugeable])(Captioned(ultimatum.Fraction(0.5), t"copying"), 12)
+      . assert(_ == t"██░░░ copyi…")
+
+      // Both degradations compose: the caption is cut to its half-row allowance, and the three
+      // cells that leaves the bar are too few to draw one, so it falls through to a figure.
+      test(m"a narrow captioned gauge elides the label and degrades the bar"):
+        import bars.blockBar
+        plain(summon[Captioned[ultimatum.Fraction] is Gaugeable])(Captioned(ultimatum.Fraction(0.5), t"copying"), 8)
+      . assert(_ == t"50% cop…")
+
+      test(m"a leading caption precedes the gauge"):
+        import bars.blockBar
+        import captions.leadingCaption
+        plain(summon[Captioned[ultimatum.Fraction] is Gaugeable])(Captioned(ultimatum.Fraction(0.5), t"go"), 8)
+      . assert(_ == t"go ██░░░")
+
+      test(m"a captioned spinner inherits the spinner's animation period"):
+        import spinners.brailleDotsSpinner
+        summon[Captioned[Busy] is Gaugeable].period
+      . assert(_ == 80)
+
+    suite(m"The form's frame clock"):
+      import gaugeGlyphs.unicodeGlyphs
+      import palettes.emberGaugePalette
+      import textMetrics.uniformMetric
+
+      // `scheduleWake` is a constructor parameter, so the ticker is tested by recording what it is
+      // asked to schedule — no sleeping, and nothing timing-dependent.
+      def wakes(pane: Pane): List[Long] =
+        given Stdio = Stdio(null, null, null, termcapDefinitions.basicTermcap)
+        val recorded = scala.collection.mutable.ListBuffer[Long]()
+        val root = ScreenRoot(20, 3)
+        Form(root, Occupancy.Fullscreen, pane, () => (), 0, 0, delay => { recorded += delay; () })
+        . run(scala.Iterator(Keypress.Escape))
+
+        List.of(recorded.toList)
+
+      test(m"a layout containing a spinner arms a wake at the design's period"):
+        wakes(gauge(Reading(ultimatum.Busy()))(using spinners.brailleDotsSpinner)).stdlib.headOption
+      . assert(_ == Some(80L))
+
+      test(m"a layout of static panels arms no wake at all"):
+        wakes(panel()(Out.print(t"still"))).stdlib.length
+      . assert(_ == 0)
+
+      test(m"a bar alone does not animate"):
+        wakes(gauge(Reading(ultimatum.Fraction(0.5)))(using bars.smoothBar)).stdlib.length
+      . assert(_ == 0)
+
+      test(m"the shortest period wins when several gauges animate"):
+        val fast = gauge(Reading(ultimatum.Busy()))(using spinners.starSpinner)
+        val slow = gauge(Reading(ultimatum.Busy()))(using spinners.toggleSpinner)
+        wakes(stack(fast, slow)).stdlib.headOption
+      . assert(_ == Some(70L))
 
 // A test-only root `Board` that paints into a fixed in-memory grid but reports a
 // settable size, so a layout can be re-tiled to a smaller `width`/`height` and


### PR DESCRIPTION
Ultimatum can now show live status: spinners, progress bars, meters, sparklines, counters
and step indicators, embedded in a layout or drawn on their own at the cursor. A gauge is
keyed on the type of the thing it displays, so the design, the colours and the character
repertoire are three separate imports and none of them disturbs the others. Every design
negotiates its own width with the layout on each frame, shedding parts and falling back to
coarser renderings as the terminal narrows, and a design that animates drives a single
frame clock shared by the whole form.

## Gauges

A gauge displays a *status*, and the design is the `Gaugeable` given for that status type
in scope where the gauge is built. With nothing imported you get sensible defaults:

```scala
Out.println(e"${Fraction(0.42)}")           // a smooth eighth-block bar
Out.println(e"${Reckoning(17, 120)}")       // 17/120
Out.println(e"${Standing.Succeeded} built") // ✓ built
```

Importing a different design changes the appearance and nothing else:

```scala
import bars.arrowheadBar        // [========>          ]
import spinners.moonPhaseSpinner
```

Colour is an independent axis, and so is the character repertoire:

```scala
import palettes.solarizedDarkGaugePalette
import gaugeGlyphs.asciiGlyphs   // seven-bit output, for a log or a dumb terminal
```

There are around forty spinners, eighteen bars, six meters, four sparklines, nine counters,
five status markers and five step indicators, and ten palettes.

## In a layout

`gauge` builds a pane. It reports its design's intrinsic size on every solve, so it grows
and shrinks with the layout; a `Reading` updated from a background task repaints at once;
and a gauge is not focusable, so TAB skips it.

```scala
val progress = Reading(Fraction(0.0))

form(Occupancy.Inline):
  stack
    ( gauge(Reading(Captioned[Busy](Busy(), t"resolving"))),
      gauge(progress),
      gauge(Reading(steps)) )   // a checklist, one row per step

progress() = Fraction(0.5)      // repaints immediately
```

## Standalone

`whilst` shows a gauge at the cursor for the duration of a block and erases it afterwards;
`gaugeLine` renders one frame for a caller doing its own drawing.

```scala
whilst(Reading(Busy())):
  slowThing()
```

## Degradation

A bar re-quantizes to whatever width it is given, drops its end caps below eight cells,
falls through to a percentage at four and to a single shade glyph at one. A composite row
sheds its parts in a declared order, so a transfer that reads
`14.2 MiB/512 MiB · 3.1 MiB/s · 2m41s left` at eighty cells keeps only the figures at
thirty. A sparkline narrower than its series is decimated by taking the maximum of each
group, never truncated, because a truncated sparkline shows only the oldest samples while
looking like the whole series. Emoji designs fall back to their BMP siblings where the
terminal cannot show them, and every design has an ASCII rendering.

## Breaking change

`ultimatum.Axis` is now `ultimatum.Arrangement`, and its cases `File` and `Rank` are now
`Strip` and `Stack`, matching the `strip` and `stack` constructors that build them. The old
name collided with `probably.Axis`, which meant ultimatum's could not be exported into the
`soundness` package at all; it now is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
