### PR TITLE
Compile with -Xjsr45 on the 3.9.0-RC5-p13 toolchain

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -54,10 +54,10 @@ object settings:
   //      https://github.com/propensive/proscala/releases; each release ships a single
   //      `proscala-<tag>.tar.gz` asset whose contents are a `lib` directory (the unversioned core
   //      jars plus the versioned third-party jars). The `toolchain` module below downloads
-  //      `SOUNDNESS_SCALA_RELEASE` (default `3.9.0-RC5-p11`, the latest in the 3.9.0 stream) and
+  //      `SOUNDNESS_SCALA_RELEASE` (default `3.9.0-RC5-p13`, the latest in the 3.9.0 stream) and
   //      extracts it into a shared cache, exposing its jars to every coursier resolution — no
   //      local compiler build and no publishing step needed. Switch streams by setting
-  //      `SOUNDNESS_SCALA_RELEASE` (e.g. `3.10.0-dev-p11`).
+  //      `SOUNDNESS_SCALA_RELEASE` (e.g. `3.10.0-dev-p13`).
   //
   //   2. Local (fork developers). Point `SOUNDNESS_SCALA_HOME` at a `make`-built `release`
   //      directory to use its `release/lib` jars directly instead of downloading. After
@@ -72,7 +72,7 @@ object settings:
   // coincide (earlier releases shipped jars built as e.g. `3.9.0-RC1-propensive`). Override the
   // coordinate with `SOUNDNESS_SCALA_VERSION`.
   val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC5-p11")
-  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC5-p11")
+  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC5-p13")
   // Empty by default → download `scalaRelease`. Set to a local `release` directory to use its
   // `release/lib` jars directly (fork-developer mode).
   val scalaHome = sys.env.getOrElse("SOUNDNESS_SCALA_HOME", "")
@@ -121,6 +121,9 @@ object settings:
     "-Wconf:src=.*synesthesia.McpServer.*&msg=match may not be exhaustive:s",
     // "-Wsafe-init",
     "-Xmax-inlines", "32",
+    // Emit JSR-45 SMAPs (SourceDebugExtension) mapping inlined code back to its source, so
+    // hyperbole's stack-trace resolver can expand and name each frame's inline chain.
+    "-Xjsr45",
     //"-Ycc-new",
     "-Yno-flexible-types",
     "-Yexplicit-nulls",


### PR DESCRIPTION
Soundness now compiles with Proscala's `-Xjsr45` flag, so every class it produces carries a JSR-45 SMAP mapping inlined code back to the source it was written in; combined with the inline-chain rendering Digression gained earlier, a stack trace through Soundness's own inline-heavy code now names each level of inlining instead of collapsing it into a single call-site line.

The toolchain moves from `3.9.0-RC5-p11` to `3.9.0-RC5-p13`. `-p12` introduced `-Xjsr45` but emitted each compilation unit's entire SMAP into every one of its classes; on a codebase that inlines as heavily as this one that came to 4.5 GB of debug information across 13,222 classfiles, which broke the Scala Native link and the staged Exoskeleton builds. `-p13` emits only the part each class uses, which brings the same information down to 38 MB.

No source changes are needed to benefit: the flag is a build setting, and the debug information is additional — bytecode semantics are unchanged. A stack trace rendered through hyperbole's resolver now looks like:

```
  at Thrower.run  Thrower.scala:3
       ↳ inlined from ThrowerA.fail (A.scala:3)
       ↳ inlined from ThrowerB.outer (B.scala:3)
```

Developed with LLM assistance (Claude Code), reviewed by hand.