### PR TITLE
Add R64 and R32, word-sized exact rational types, to Hypotenuse

### DIFF
--- a/lib/archimedes/src/core/archimedes.Math.scala
+++ b/lib/archimedes/src/core/archimedes.Math.scala
@@ -42,6 +42,7 @@ import contingency.*
 import gossamer.*
 import hieroglyph.*
 import honeycomb.Html
+import hypotenuse.*
 import honeycomb.Renderable
 import mosquito.*
 import prepositional.*
@@ -122,6 +123,19 @@ object Math:
   given text:       Text is Encodable in Math       = value => Math(Mtext(value))
   given identical:  Mathml is Encodable in Math     = node => Math(List(node))
   given self:       Math is Encodable in Math       = identity(_)
+
+  // Rationals render as `<mfrac>`, collapsing to a plain `<mn>` for whole values, with
+  // the sign hoisted out as an `<mo>`.
+  given r64: R64 is Encodable in Math = value => rationalMathml(value.numerator, value.denominator)
+  given r32: R32 is Encodable in Math = value => rationalMathml(value.numerator, value.denominator)
+
+  private def rationalMathml(numerator: Long, denominator: Long): Math =
+    if denominator == 0L then Math(Mtext(t"NaR")) else
+      val body =
+        if denominator == 1L then Mn(math.abs(numerator).toString.tt)
+        else Mfrac(Mn(math.abs(numerator).toString.tt), Mn(denominator.toString.tt))
+
+      if numerator < 0L then Math(Mrow(List(Mo(t"−"), body))) else Math(body)
 
   // Wraps the encoder lambda in a class (rather than an inline function value) to
   // avoid inline-given code bloat, mirroring quantitative's `ShowableQuantity`. It

--- a/lib/archimedes/src/test/archimedes_test.scala
+++ b/lib/archimedes/src/test/archimedes_test.scala
@@ -52,6 +52,15 @@ object Tests extends Suite(m"Archimedes tests"):
         Mfrac(Mn(t"1"), Mn(t"2")).xml.show
       .assert(_ == t"<mfrac><mn>1</mn><mn>2</mn></mfrac>")
 
+      test(m"Render a rational as a fraction"):
+        R64(-3, 4).math.xml.show
+      .assert(_ == t"""<math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mo>−</mo>"""
+          + t"<mfrac><mn>3</mn><mn>4</mn></mfrac></mrow></math>")
+
+      test(m"Render a whole rational as a number"):
+        R32(7).math.xml.show
+      .assert(_ == t"""<math xmlns="http://www.w3.org/1998/Math/MathML"><mn>7</mn></math>""")
+
       test(m"Render a token with an attribute"):
         Mi(t"x", List(t"mathvariant" -> t"italic")).xml.show
       .assert(_ == t"""<mi mathvariant="italic">x</mi>""")

--- a/lib/baroque/src/test/baroque_test.scala
+++ b/lib/baroque/src/test/baroque_test.scala
@@ -54,6 +54,22 @@ object Tests extends Suite(m"Baroque tests"):
       Complex(0, 3).show
     . assert(_ == t"3ℐ")
 
+    test(m"Show a rational complex number"):
+      Complex(R64(1, 2), R64(1, 3)).show
+    . assert(_ == t"1/2 + 1/3ℐ")
+
+    test(m"Add rational complex numbers"):
+      Complex(R64(1, 2), R64(1, 3)) + Complex(R64(1, 3), R64(1, 6))
+    . assert(_ == Complex(R64(5, 6), R64(1, 2)))
+
+    test(m"Multiply rational complex numbers"):
+      Complex(R64(1, 2), R64(1, 3))*Complex(R64(2, 3), R64(3, 4))
+    . assert(_ == Complex(R64(1, 12), R64(43, 72)))
+
+    test(m"Divide rational complex numbers"):
+      Complex(R64(1, 2), R64(1, 3))/Complex(R64(1), R64(0))
+    . assert(_ == Complex(R64(1, 2), R64(1, 3)))
+
     test(m"Show a quantity complex number"):
       val re = 1.0*Metre/Second
       val im = Metre*9.0/Second

--- a/lib/hypotenuse/src/core/hypotenuse.RationalError.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.RationalError.scala
@@ -30,17 +30,12 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package hypotenuse
 
-export
-  hypotenuse
-  . { %%, **, /-, <, <=, >, >=, abs, acos, asin, atan, B16, B32, B64, B8, base32, bin,
-      binary, bits, ceiling, CheckOverflow, Commensurable, cos, cosh, decrement, DivisionByZero,
-      DivisionError, erf, euler, exp, expm1, exponent, F32, F64, finite, floor, gcd, goldenRatio,
-      hex, hyp, increment, infinite, int, lcm, ln, log10, log1p, long, mantissa, nan, octal,
-      Orderable, OverflowError, pi, predecessor, rawBits, round, S16, S32, S64, S8, scalb, short,
-      signum, sin, sinh, successor, tan, U16, U32, U64, U8, ulp, π, φ, min, minimize, minimum,
-      max, maximize, maximum, median, Decimal, DecimalError, R32, R64, RationalError }
+import scala.language.experimental.into
 
-package arithmeticOptions:
-  export hypotenuse.arithmeticOptions.{division, overflow, rationalDivision}
+import anticipation.*
+import fulminate.*
+
+case class RationalError(text: Text)(using Diagnostics)
+extends Error(741, 0)(m"$text is not a representable rational number")

--- a/lib/hypotenuse/src/core/hypotenuse.rationalInternal.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.rationalInternal.scala
@@ -1,0 +1,1280 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package hypotenuse
+
+import proscenium.compat.*
+
+import scala.caps
+import scala.math
+import scala.reflect.ClassTag
+import scala.util.FromDigits
+
+import java.lang.{Double as JDouble, Long as JLong}
+
+import anticipation.*
+import contingency.*
+import prepositional.*
+import rudiments.*
+import symbolism.*
+import vacuous.*
+
+// Exact rational numbers in a single machine word: `R64` over `Long` and `R32` over `Int`.
+//
+// The magnitude is a position in the Stern–Brocot tree, stored as the value's canonical
+// continued fraction [a₀; a₁, …, aₖ] (with aₖ ≥ 2): a sentinel 1 bit, then the Elias-gamma
+// codes of a₀+1, a₁, …, aₖ, most significant term first. The top bit of the word is the
+// sign; an all-zero magnitude is zero when positive, and NaR — "not a rational", the result
+// of division by zero — when negative (`Long.MinValue`/`Int.MinValue`). NaR propagates
+// through arithmetic and compares as unordered, like `Double.NaN`.
+//
+// Gamma-coding the terms (rather than storing the tree path's steps unary) makes the cost
+// of a term logarithmic in its size: with the 62 payload bits of `R64`, integers reach
+// 2³¹−2 and unit fractions 1/(2³¹−1), while the deepest all-ones chains bound every decoded
+// numerator and denominator below 2⁴⁴. `R32`'s 30 payload bits reach ±32766 and 1/32767,
+// with numerators and denominators below 2²¹. Every rational whose numerator and
+// denominator are at most 2²⁴ (R64) or 2¹¹ (R32) is exactly representable.
+//
+// Every value is canonical: each rational has exactly one encoding, already in lowest
+// terms, so bit-equality is value-equality and no gcd normalization exists anywhere. When
+// an exact result needs more than the payload budget, the encoder keeps the longest prefix
+// of its continued fraction that fits, reducing the final term where possible — the result
+// is a convergent or semiconvergent of the exact value, the best rational approximation
+// among all rationals of no greater denominator (at term granularity; not global
+// round-to-nearest).
+//
+// The opaque types and their operations are confined to `rationalInternal` — the pattern of
+// `internal`'s numeric types — so the representation stays hidden even from the rest of
+// this package, keeping companion-scope given resolution intact everywhere outside.
+export rationalInternal.{R32, R64}
+
+object rationalInternal:
+  // The `caps.Pure` bounds make purity visible outside the opaque scope, so collections of
+  // rationals never box their elements with a fresh capture set (the `ultimatum.Fraction`
+  // pattern).
+  opaque type R64 <: Matchable & caps.Pure = Long & caps.Pure
+  opaque type R32 <: Matchable & caps.Pure = Int & caps.Pure
+
+  // `caps.Pure` is an erased marker, so each type still erases to its representation; the
+  // casts are runtime no-ops that let the capture checker treat a rational as pure.
+  private inline def r64(value: Long): R64 = value.asInstanceOf[R64]
+  private inline def r32(value: Int): R32 = value.asInstanceOf[R32]
+
+  // Any continued-fraction term of at least 2³¹ overflows every payload budget, so a term
+  // this size acts as a saturating sentinel: emitting it ends term generation, and the
+  // encoder's truncation replaces it with the largest term that fits.
+  private val Cap: Long = 0x80000000L
+
+  private val Budget64: Int = 62
+  private val Budget32: Int = 30
+
+  // Terms all cost at least one bit, so no encoding ever reads beyond the budget's worth of
+  // terms; the generators below stop early once the budget is exceeded.
+  private val TermLimit: Int = 96
+
+  // The Elias-gamma code of b ≥ 1 is ⌊log₂ b⌋ zeros followed by the binary of b.
+  private def gammaLength(term: Long): Int = 2*(63 - JLong.numberOfLeadingZeros(term)) + 1
+
+  // The stored code for term i is the gamma code of a₀+1 at the head — a₀ may be zero for
+  // values below one — and of aᵢ elsewhere.
+  private def stored(terms: scala.Array[Long], index: Int): Long =
+    if index == 0 then terms(0) + 1 else terms(index)
+
+  // Packs continued-fraction terms into a magnitude word: a sentinel 1, then each term's
+  // gamma code. When the terms overrun the budget, the final kept term is reduced to the
+  // largest value that fits (a semiconvergent) or dropped (the previous convergent), and a
+  // trailing term of 1 is merged upward — […, x, 1] = […, x+1] — to keep the encoding
+  // canonical.
+  private def encodeMagnitude(terms: scala.Array[Long]^, count0: Int, budget: Int): Long =
+    var used = 0
+    var fit = 0
+
+    while fit < count0 && used + gammaLength(stored(terms, fit)) <= budget do
+      used += gammaLength(stored(terms, fit))
+      fit += 1
+
+    var count = count0
+
+    if fit < count0 then
+      val remaining = budget - used
+      val most = if remaining <= 0 then 0L else (1L << (remaining + 1)/2) - 1
+      val reduced = math.min(stored(terms, fit) - 1, most)
+
+      if reduced >= (if fit == 0 then 2L else 1L) then
+        terms(fit) = if fit == 0 then reduced - 1 else reduced
+        count = fit + 1
+      else count = fit
+
+    var settled = false
+
+    while !settled do
+      if count == 0 then return 0L
+      else if count == 1 then
+        if terms(0) == 0L then return 0L else settled = true
+      else if terms(count - 1) >= 2L then
+        var length = 0
+        var i = 0
+
+        while i < count do
+          length += gammaLength(stored(terms, i))
+          i += 1
+
+        if length <= budget then settled = true else count -= 1
+      else
+        terms(count - 2) += 1
+        count -= 1
+
+    var accumulator = 1L
+    var i = 0
+
+    while i < count do
+      val code = stored(terms, i)
+      accumulator = (accumulator << gammaLength(code)) | code
+      i += 1
+
+    accumulator
+
+  // Reads the gamma-coded terms back out of a nonzero magnitude, recovering the a-values.
+  private def decodeTerms(magnitude: Long, terms: scala.Array[Long]^): Int =
+    var position = 62 - JLong.numberOfLeadingZeros(magnitude)
+    var count = 0
+
+    while position >= 0 do
+      var zeros = 0
+
+      while (magnitude >> position & 1L) == 0L do
+        zeros += 1
+        position -= 1
+
+      var value = 0L
+      var i = zeros + 1
+
+      while i > 0 do
+        value = (value << 1) | (magnitude >> position & 1L)
+        position -= 1
+        i -= 1
+
+      terms(count) = if count == 0 then value - 1 else value
+      count += 1
+
+    count
+
+  // Folds continued-fraction terms into the numerator and denominator by the continuant
+  // recurrence; both stay below 2⁴⁴ for any encodable term sequence.
+  private def continuants(terms: scala.Array[Long], count: Int): (Long, Long) =
+    var numerator = 1L
+    var numerator0 = 0L
+    var denominator = 0L
+    var denominator0 = 1L
+    var i = 0
+
+    while i < count do
+      val term = terms(i)
+      val nextNumerator = term*numerator + numerator0
+      val nextDenominator = term*denominator + denominator0
+      numerator0 = numerator
+      denominator0 = denominator
+      numerator = nextNumerator
+      denominator = nextDenominator
+      i += 1
+
+    (numerator, denominator)
+
+  // The Euclidean algorithm, appending continued-fraction terms from `offset` and
+  // saturating at `Cap`; the final term of an exact run is always at least 2, so the output
+  // is canonical without adjustment.
+  private def euclidean(numerator: Long, denominator: Long, terms: scala.Array[Long]^, offset: Int)
+  :   Int =
+    var high = numerator
+    var low = denominator
+    var count = offset
+
+    while low != 0L && count < TermLimit do
+      val quotient = high/low
+
+      if quotient >= Cap then
+        terms(count) = Cap
+        count += 1
+        low = 0L
+      else
+        terms(count) = quotient
+        count += 1
+        val remainder = high%low
+        high = low
+        low = remainder
+
+    count
+
+  private def encodeFraction(numerator: Long, denominator: Long, budget: Int): Long =
+    if numerator == 0L then 0L else
+      val terms = new scala.Array[Long](TermLimit)
+      encodeMagnitude(terms, euclidean(numerator, denominator, terms, 0), budget)
+
+  // Wide intermediates — cross-products of decoded R64 fractions reach 2⁸⁸, and the square
+  // comparisons in `sqrtMagnitude` 2¹³¹ — are fixed six-limb little-endian arrays in base
+  // 2³¹, so every limb product fits comfortably in a `Long` on any platform.
+  private val Limbs: Int = 6
+  private val LimbMask: Long = 0x7fffffffL
+
+  private def limbsClear(limbs: scala.Array[Long]^): Unit =
+    var i = 0
+
+    while i < Limbs do
+      limbs(i) = 0L
+      i += 1
+
+  private def limbsFromLong(limbs: scala.Array[Long]^, value: Long): Unit =
+    limbsClear(limbs)
+    limbs(0) = value & LimbMask
+    limbs(1) = (value >>> 31) & LimbMask
+    limbs(2) = value >>> 62
+
+  private def limbsToLong(limbs: scala.Array[Long]): Long =
+    limbs(0) | (limbs(1) << 31) | (limbs(2) << 62)
+
+  private def limbsBitLength(limbs: scala.Array[Long]): Int =
+    var top = Limbs - 1
+    while top >= 0 && limbs(top) == 0L do top -= 1
+    if top < 0 then 0 else 31*top + (64 - JLong.numberOfLeadingZeros(limbs(top)))
+
+  private def limbsCompare(left: scala.Array[Long], right: scala.Array[Long]): Int =
+    var i = Limbs - 1
+    var result = 0
+
+    while i >= 0 && result == 0 do
+      if left(i) != right(i) then result = if left(i) < right(i) then -1 else 1
+      i -= 1
+
+    result
+
+  private def limbsAdd(into: scala.Array[Long]^, addend: scala.Array[Long]): Unit =
+    var carry = 0L
+    var i = 0
+
+    while i < Limbs do
+      val sum = into(i) + addend(i) + carry
+      into(i) = sum & LimbMask
+      carry = sum >>> 31
+      i += 1
+
+  // Subtraction of a smaller-or-equal value from a larger.
+  private def limbsSubtract(into: scala.Array[Long]^, subtrahend: scala.Array[Long]): Unit =
+    var borrow = 0L
+    var i = 0
+
+    while i < Limbs do
+      val difference = into(i) - subtrahend(i) - borrow
+
+      if difference < 0L then
+        into(i) = difference + (1L << 31)
+        borrow = 1L
+      else
+        into(i) = difference
+        borrow = 0L
+
+      i += 1
+
+  private def limbsCopy(source: scala.Array[Long], target: scala.Array[Long]^): Unit =
+    var i = 0
+
+    while i < Limbs do
+      target(i) = source(i)
+      i += 1
+
+  // The product of two nonnegative `Long`s, by 31-bit pieces; column accumulations stay far
+  // below the `Long` range before the final carry pass.
+  private def limbsMultiply(left: Long, right: Long, into: scala.Array[Long]^): Unit =
+    limbsClear(into)
+    var i = 0
+
+    while i < 3 do
+      val piece = i match
+        case 0 => left & LimbMask
+        case 1 => (left >>> 31) & LimbMask
+        case _ => left >>> 62
+
+      if piece != 0L then
+        var j = 0
+
+        while j < 3 do
+          val other = j match
+            case 0 => right & LimbMask
+            case 1 => (right >>> 31) & LimbMask
+            case _ => right >>> 62
+
+          if other != 0L then
+            val product = piece*other
+            into(i + j) += product & LimbMask
+            into(i + j + 1) += product >>> 31
+
+          j += 1
+
+      i += 1
+
+    var carry = 0L
+    var k = 0
+
+    while k < Limbs do
+      val sum = into(k) + carry
+      into(k) = sum & LimbMask
+      carry = sum >>> 31
+      k += 1
+
+  // A wide value times a nonnegative `Long`, for the square-times-operand comparisons in
+  // `sqrtMagnitude`; the true product never exceeds the six-limb capacity there.
+  private def limbsMultiplyByLong(limbs: scala.Array[Long], value: Long, into: scala.Array[Long]^)
+  :   Unit =
+    limbsClear(into)
+    var j = 0
+
+    while j < 3 do
+      val piece = j match
+        case 0 => value & LimbMask
+        case 1 => (value >>> 31) & LimbMask
+        case _ => value >>> 62
+
+      if piece != 0L then
+        var i = 0
+
+        while i + j < Limbs do
+          val product = limbs(i)*piece
+          into(i + j) += product & LimbMask
+          if i + j + 1 < Limbs then into(i + j + 1) += product >>> 31
+          i += 1
+
+      j += 1
+
+    var carry = 0L
+    var k = 0
+
+    while k < Limbs do
+      val sum = into(k) + carry
+      into(k) = sum & LimbMask
+      carry = sum >>> 31
+      k += 1
+
+  // Exact division of a wide value by a `Long` divisor whose quotient is known to fit in a
+  // `Long`, as arises from the surd recurrence in `sqrtMagnitude`.
+  private def limbsDivideByLong(limbs: scala.Array[Long], divisor: Long): Long =
+    var remainder = 0L
+    var quotient = 0L
+    var i = Limbs - 1
+
+    while i >= 0 do
+      val current = (remainder << 31) | limbs(i)
+      quotient = (quotient << 31) | (current/divisor)
+      remainder = current%divisor
+      i -= 1
+
+    quotient
+
+  // Restoring binary division of one wide value by another, leaving the remainder in
+  // `remainder`. Quotients of 2³² or more saturate to `Cap`, which ends term generation, so
+  // the returned quotient always fits easily in a `Long`.
+  private def limbsDivide
+    ( dividend:  scala.Array[Long],
+      divisor:   scala.Array[Long],
+      remainder: scala.Array[Long]^ )
+  :   Long =
+
+    val excess = limbsBitLength(dividend) - limbsBitLength(divisor)
+    if excess >= 32 then Cap else
+      limbsClear(remainder)
+      var quotient = 0L
+      var i = limbsBitLength(dividend) - 1
+
+      while i >= 0 do
+        var carry = (dividend(i/31) >> i%31) & 1L
+        var k = 0
+
+        while k < Limbs do
+          val shifted = (remainder(k) << 1) | carry
+          carry = shifted >>> 31
+          remainder(k) = shifted & LimbMask
+          k += 1
+
+        quotient <<= 1
+
+        if limbsCompare(remainder, divisor) >= 0 then
+          limbsSubtract(remainder, divisor)
+          quotient |= 1L
+
+        i -= 1
+
+      quotient
+
+  // The Euclidean algorithm over wide values, switching to `Long` arithmetic as soon as
+  // both operands fit; the common factors of an unreduced pair cancel in the remainders, so
+  // no gcd reduction is needed first.
+  private def euclideanWide
+    ( numerator: scala.Array[Long]^, denominator: scala.Array[Long]^, terms: scala.Array[Long]^ )
+  :   Int =
+
+    val remainder = new scala.Array[Long](Limbs)
+    var count = 0
+    var finished = false
+
+    while !finished && count < TermLimit do
+      if limbsBitLength(denominator) == 0 then finished = true
+      else if limbsBitLength(numerator) <= 62 && limbsBitLength(denominator) <= 62 then
+        count = euclidean(limbsToLong(numerator), limbsToLong(denominator), terms, count)
+        finished = true
+      else
+        val quotient = limbsDivide(numerator, denominator, remainder)
+
+        if quotient >= Cap then
+          terms(count) = Cap
+          count += 1
+          finished = true
+        else
+          terms(count) = quotient
+          count += 1
+          limbsCopy(denominator, numerator)
+          limbsCopy(remainder, denominator)
+
+    count
+
+  // The floor of the square root of a wide value, by binary search; the root always fits
+  // well within a `Long`.
+  private def limbsSquareRoot(value: scala.Array[Long]): Long =
+    val square = new scala.Array[Long](Limbs)
+    var low = 0L
+    var high = 1L << math.min(62, limbsBitLength(value)/2 + 1)
+
+    while high - low > 1L do
+      val middle = low + (high - low)/2
+      limbsMultiply(middle, middle, square)
+      if limbsCompare(square, value) <= 0 then low = middle else high = middle
+
+    low
+
+  // The magnitude word of √(n/d) for a canonical positive fraction: exact when nd is a
+  // perfect square — which for coprime n and d is exactly when both are — and otherwise the
+  // periodic surd recurrence for (P + √N)/Q generates terms until the budget truncates.
+  private def sqrtMagnitude(numerator: Long, denominator: Long, budget: Int): Long =
+    val wide = new scala.Array[Long](Limbs)
+    limbsMultiply(numerator, denominator, wide)
+    val root = limbsSquareRoot(wide)
+    val square = new scala.Array[Long](Limbs)
+    limbsMultiply(root, root, square)
+
+    if limbsCompare(square, wide) == 0 then encodeFraction(root, denominator, budget) else
+      val terms = new scala.Array[Long](TermLimit)
+      val work = new scala.Array[Long](Limbs)
+      var p = 0L
+      var q = denominator
+      var count = 0
+      var length = 0
+      var capped = false
+
+      while !capped && length <= budget + 2 && count < TermLimit do
+        var term = (p + root)/q
+        val candidate = (term + 1L)*q - p
+
+        if candidate <= root then term += 1L
+        else if candidate == root + 1L then
+          limbsMultiply(candidate, candidate, square)
+          if limbsCompare(square, wide) < 0 then term += 1L
+
+        if term >= Cap then
+          terms(count) = Cap
+          count += 1
+          capped = true
+        else
+          terms(count) = term
+          length += gammaLength(stored(terms, count))
+          count += 1
+          val p2 = term*q - p
+          limbsMultiply(p2, p2, square)
+          limbsCopy(wide, work)
+          limbsSubtract(work, square)
+          q = limbsDivideByLong(work, q)
+          p = p2
+
+      encodeMagnitude(terms, count, budget)
+
+  // The best encodable approximation of a positive, finite `Double`: exactly m·2ᵉ, with the
+  // power of two folded into whichever side of the fraction it belongs.
+  private def doubleMagnitude(value: Double, budget: Int): Long =
+    val bits = JDouble.doubleToLongBits(value)
+    val rawExponent = (bits >>> 52 & 0x7ffL).toInt
+    var mantissa = if rawExponent == 0 then bits & 0xfffffffffffffL
+                   else bits & 0xfffffffffffffL | (1L << 52)
+    var exponent = if rawExponent == 0 then -1074 else rawExponent - 1075
+    val shift = JLong.numberOfTrailingZeros(mantissa)
+    mantissa >>>= shift
+    exponent += shift
+    val width = 64 - JLong.numberOfLeadingZeros(mantissa)
+    val terms = new scala.Array[Long](TermLimit)
+
+    if exponent >= 0 then
+      if width + exponent > 32 then
+        terms(0) = Cap
+        encodeMagnitude(terms, 1, budget)
+      else encodeFraction(mantissa << exponent, 1L, budget)
+    else if -exponent <= 62 then encodeFraction(mantissa, 1L << -exponent, budget)
+    else if -exponent - width >= 32 then
+      terms(0) = 0L
+      terms(1) = Cap
+      encodeMagnitude(terms, 2, budget)
+    else
+      val wideNumerator = new scala.Array[Long](Limbs)
+      val wideDenominator = new scala.Array[Long](Limbs)
+      limbsFromLong(wideNumerator, mantissa)
+      limbsClear(wideDenominator)
+      wideDenominator(-exponent/31) = 1L << -exponent%31
+      encodeMagnitude(terms, euclideanWide(wideNumerator, wideDenominator, terms), budget)
+
+  // Decoding a nonzero magnitude to its canonical fraction.
+  private def fractionOf(magnitude: Long): (Long, Long) =
+    val terms = new scala.Array[Long](TermLimit)
+    continuants(terms, decodeTerms(magnitude, terms))
+
+  // Signed addition of two decoded fractions over wide intermediates, for R64.
+  private def addWide
+    ( leftNegative:  Boolean, leftNumerator: Long, leftDenominator: Long,
+      rightNegative: Boolean, rightNumerator: Long, rightDenominator: Long,
+      budget:        Int )
+  :   (Boolean, Long) =
+
+    val cross = new scala.Array[Long](Limbs)
+    val cross2 = new scala.Array[Long](Limbs)
+    val wideDenominator = new scala.Array[Long](Limbs)
+    limbsMultiply(leftNumerator, rightDenominator, cross)
+    limbsMultiply(rightNumerator, leftDenominator, cross2)
+    limbsMultiply(leftDenominator, rightDenominator, wideDenominator)
+    val terms = new scala.Array[Long](TermLimit)
+
+    if leftNegative == rightNegative then
+      limbsAdd(cross, cross2)
+      (leftNegative, encodeMagnitude(terms, euclideanWide(cross, wideDenominator, terms), budget))
+    else limbsCompare(cross, cross2) match
+      case 0 => (false, 0L)
+
+      case order =>
+        if order > 0 then
+          limbsSubtract(cross, cross2)
+          ( leftNegative,
+            encodeMagnitude(terms, euclideanWide(cross, wideDenominator, terms), budget) )
+        else
+          limbsSubtract(cross2, cross)
+          ( rightNegative,
+            encodeMagnitude(terms, euclideanWide(cross2, wideDenominator, terms), budget) )
+
+  // Multiplication or division of two decoded fractions over wide intermediates, for R64.
+  private def multiplyWide(numerator: Long, factor: Long, denominator: Long, divisor: Long,
+                           budget: Int): Long =
+    val wideNumerator = new scala.Array[Long](Limbs)
+    val wideDenominator = new scala.Array[Long](Limbs)
+    limbsMultiply(numerator, factor, wideNumerator)
+    limbsMultiply(denominator, divisor, wideDenominator)
+    val terms = new scala.Array[Long](TermLimit)
+    encodeMagnitude(terms, euclideanWide(wideNumerator, wideDenominator, terms), budget)
+
+  // Saturation bound for parsed digit strings; values this size already encode to the
+  // largest representable integer.
+  private val Saturated: Long = 1L << 62
+
+  // The grammar `[+|-] digits [. digits] [(e|E) [+|-] digits]` or `[+|-] digits / digits`,
+  // with the value returned as a sign and a saturating fraction; `Unset` for anything else.
+  // A zero denominator is well-formed — `1/0` — and builds NaR downstream.
+  private def parsedRational(text: Text): Optional[(Boolean, Long, Long)] =
+    val input: String = text.s
+    val length = input.length
+    var index = 0
+    var negative = false
+
+    if index < length && (input.charAt(index) == '+' || input.charAt(index) == '-') then
+      if input.charAt(index) == '-' then negative = true
+      index += 1
+
+    var numerator = 0L
+    var digits = false
+
+    while index < length && input.charAt(index).isDigit do
+      numerator = math.min(numerator*10 + (input.charAt(index) - '0'), Saturated)
+      digits = true
+      index += 1
+
+    if !digits then Unset
+    else if index < length && input.charAt(index) == '/' then
+      index += 1
+      var denominator = 0L
+      var digits2 = false
+
+      while index < length && input.charAt(index).isDigit do
+        denominator = math.min(denominator*10 + (input.charAt(index) - '0'), Saturated)
+        digits2 = true
+        index += 1
+
+      if digits2 && index == length then (negative, numerator, denominator) else Unset
+    else
+      var scale = 0
+
+      if index < length && input.charAt(index) == '.' then
+        index += 1
+        var digits2 = false
+
+        while index < length && input.charAt(index).isDigit do
+          if numerator < Saturated && scale < 18 then
+            numerator = numerator*10 + (input.charAt(index) - '0')
+            scale += 1
+
+          digits2 = true
+          index += 1
+
+        if !digits2 then return Unset
+
+      var exponent = 0
+
+      if index < length && (input.charAt(index) == 'e' || input.charAt(index) == 'E') then
+        index += 1
+        var exponentNegative = false
+
+        if index < length && (input.charAt(index) == '+' || input.charAt(index) == '-') then
+          if input.charAt(index) == '-' then exponentNegative = true
+          index += 1
+
+        if index >= length || !input.charAt(index).isDigit then return Unset
+
+        while index < length && input.charAt(index).isDigit do
+          exponent = math.min(exponent*10 + (input.charAt(index) - '0'), 999)
+          index += 1
+
+        if exponentNegative then exponent = -exponent
+
+      if index != length then Unset else
+        scale -= exponent
+
+        while scale < 0 do
+          numerator = math.min(numerator*10, Saturated)
+          scale += 1
+
+        var denominator = 1L
+
+        while scale > 0 do
+          if denominator < Saturated/10 then denominator *= 10
+          else if numerator > 1L then numerator /= 10
+          scale -= 1
+
+        (negative, numerator, denominator)
+
+  private def render(negative: Boolean, numerator: Long, denominator: Long): Text =
+    val builder = StringBuilder()
+    if negative then builder.append('-')
+    builder.append(numerator.toString)
+
+    if denominator != 1L then
+      builder.append('/')
+      builder.append(denominator.toString)
+
+    builder.toString.tt
+
+  private def widen32(word: Int): R64 =
+    if word == Int.MinValue then r64(Long.MinValue)
+    else if word == 0 then r64(0L)
+    else
+      val (numerator, denominator) = fractionOf((word & Int.MaxValue).toLong)
+      val magnitude = encodeFraction(numerator, denominator, Budget64)
+      r64(if word < 0 then magnitude | Long.MinValue else magnitude)
+
+  private def narrow64(word: Long): R32 =
+    if word == Long.MinValue then r32(Int.MinValue)
+    else if word == 0L then r32(0)
+    else
+      val (numerator, denominator) = fractionOf(word & Long.MaxValue)
+      val magnitude = encodeFraction(numerator, denominator, Budget32)
+      if magnitude == 0L then r32(0)
+      else r32(magnitude.toInt | (if word < 0L then Int.MinValue else 0))
+
+  object R64:
+    final val Zero: R64 = r64(0L)
+    final val One: R64 = r64(encodeFraction(1L, 1L, Budget64))
+    final val Nar: R64 = r64(Long.MinValue)
+    final val Max: R64 = r64(encodeFraction(0x7ffffffeL, 1L, Budget64))
+    final val Min: R64 = r64(Max | Long.MinValue)
+
+    inline given underlying: Underlying[R64, Long] = caps.unsafe.unsafeErasedValue
+    inline given canEqual: CanEqual[R64, R64] = caps.unsafe.unsafeErasedValue
+
+    // `R64` dealiases to `Long` here, so arrays of it — as `mosquito`'s `Matrix` builds —
+    // are primitive `long[]`s.
+    given classTag: ClassTag[R64] = summon[ClassTag[Long]].asInstanceOf[ClassTag[R64]]
+
+    private def build(negative: Boolean, numerator: Long, denominator: Long): R64 =
+      if denominator == 0L then r64(Long.MinValue)
+      else if numerator == 0L then r64(0L)
+      else
+        val magnitude = encodeFraction(numerator, denominator, Budget64)
+        if magnitude == 0L then r64(0L)
+        else if negative then r64(magnitude | Long.MinValue)
+        else r64(magnitude)
+
+    private def clamped(value: Long): Long =
+      if value == Long.MinValue then Long.MaxValue else math.abs(value)
+
+    def apply(value: Int): R64 = apply(value.toLong, 1L)
+    def apply(value: Long): R64 = apply(value, 1L)
+
+    def apply(numerator: Long, denominator: Long): R64 =
+      build(numerator < 0L ^ denominator < 0L, clamped(numerator), clamped(denominator))
+
+    def apply(value: Double): R64 =
+      if !JDouble.isFinite(value) then Nar
+      else if value == 0.0 then Zero
+      else
+        val magnitude = doubleMagnitude(math.abs(value), Budget64)
+        if magnitude == 0L then r64(0L)
+        else if value < 0.0 then r64(magnitude | Long.MinValue)
+        else r64(magnitude)
+
+    def parse(text: Text): R64 raises RationalError =
+      if text.s == "NaR" then Nar else parsedRational(text) match
+        case value: (Boolean, Long, Long) => build(value(0), value(1), value(2))
+        case _                            => abort(RationalError(text))
+
+    // The signed three-way comparison behind `Orderable`, with NaR below everything; the
+    // relational operators themselves treat NaR as unordered.
+    def comparison(left: R64, right: R64): Int =
+      if left == right then 0
+      else if left == Long.MinValue then -1
+      else if right == Long.MinValue then 1
+      else if left == 0L then (if right > 0L then -1 else 1)
+      else if right == 0L then (if left > 0L then 1 else -1)
+      else if left < 0L && right > 0L then -1
+      else if left > 0L && right < 0L then 1
+      else
+        val (leftNumerator, leftDenominator) = fractionOf(left & Long.MaxValue)
+        val (rightNumerator, rightDenominator) = fractionOf(right & Long.MaxValue)
+        val cross = new scala.Array[Long](Limbs)
+        val cross2 = new scala.Array[Long](Limbs)
+        limbsMultiply(leftNumerator, rightDenominator, cross)
+        limbsMultiply(rightNumerator, leftDenominator, cross2)
+        val order = limbsCompare(cross, cross2)
+        if left < 0L then -order else order
+
+    given orderable: R64 is Orderable:
+      inline def compare
+          (inline left: R64, inline right: R64, inline strict: Boolean, inline greater: Boolean)
+      :   Boolean =
+        if left == Long.MinValue || right == Long.MinValue then false else
+          val result = comparison(left, right)
+
+          if greater then (if strict then result > 0 else result >= 0)
+          else (if strict then result < 0 else result <= 0)
+
+    // `val ratio: R64 = 0.35` under `genericNumberLiterals`: decimal literals convert
+    // exactly — 0.35 is 7/20 — whenever the fraction fits the payload.
+    given fromDigits: FromDigits.Decimal[R64] = digits =>
+      parsedRational(digits.tt) match
+        case value: (Boolean, Long, Long) => build(value(0), value(1), value(2))
+        case _                            => throw FromDigits.MalformedNumber(digits)
+
+    given textualizable: R64 is Textualizable = value => value.text
+
+    private def negation(value: R64): R64 =
+      if value == 0L || value == Long.MinValue then value else r64(value ^ Long.MinValue)
+
+    private def sum(left: R64, right: R64): R64 =
+      if left == Long.MinValue || right == Long.MinValue then r64(Long.MinValue)
+      else if left == 0L then right
+      else if right == 0L then left
+      else
+        val (leftNumerator, leftDenominator) = fractionOf(left & Long.MaxValue)
+        val (rightNumerator, rightDenominator) = fractionOf(right & Long.MaxValue)
+
+        val (negative, magnitude) = addWide
+          ( left < 0L, leftNumerator, leftDenominator,
+            right < 0L, rightNumerator, rightDenominator,
+            Budget64 )
+
+        if magnitude == 0L then r64(0L)
+        else if negative then r64(magnitude | Long.MinValue)
+        else r64(magnitude)
+
+    private def product(left: R64, right: R64, inverted: Boolean): R64 =
+      if left == Long.MinValue || right == Long.MinValue then r64(Long.MinValue)
+      else if inverted && right == 0L then r64(Long.MinValue)
+      else if left == 0L || right == 0L then r64(0L)
+      else
+        val (leftNumerator, leftDenominator) = fractionOf(left & Long.MaxValue)
+        val (rightNumerator, rightDenominator) = fractionOf(right & Long.MaxValue)
+
+        val magnitude =
+          if inverted
+          then multiplyWide(leftNumerator, rightDenominator, leftDenominator, rightNumerator,
+                            Budget64)
+          else multiplyWide(leftNumerator, rightNumerator, leftDenominator, rightDenominator,
+                            Budget64)
+
+        if magnitude == 0L then r64(0L)
+        else if left < 0L ^ right < 0L then r64(magnitude | Long.MinValue)
+        else r64(magnitude)
+
+    // Statistical operations skolemize the element type they work over, and `Self` is
+    // invariant in a typeclass, so — as `abacist`'s `Quanta` does — the arithmetic givens
+    // take any subtype of R64 as `Self`, with `refine` casting the computed word back.
+    private def refine[self](value: R64): self = value.asInstanceOf[self]
+
+    // The standard arithmetic operators come from symbolism, so `+`, `-`, `*`, `/`, prefix
+    // negation and `sqrt` resolve through the generic operators without any R64-specific
+    // exports.
+    given addable: [self <: R64] => self is Addable:
+      type Operand = self
+      type Result = self
+
+      def add(augend: self, addend: self): self = refine(sum(augend, addend))
+
+    given subtractable: [self <: R64] => self is Subtractable:
+      type Operand = self
+      type Result = self
+
+      def subtract(minuend: self, subtrahend: self): self =
+        refine(sum(minuend, negation(subtrahend)))
+
+    given multiplicable: [self <: R64] => self is Multiplicable:
+      type Operand = self
+      type Result = self
+
+      def multiply(multiplicand: self, multiplier: self): self =
+        refine(product(multiplicand, multiplier, false))
+
+    // Division is total: division by zero gives NaR, which propagates like `Double.NaN`.
+    given divisible: [self <: R64] => self is Divisible:
+      type Operand = self
+      type Result = self
+
+      def divide(dividend: self, divisor: self): self = refine(product(dividend, divisor, true))
+
+    given negatable: [self <: R64] => self is Negatable to self =
+      operand => refine(negation(operand))
+
+    // The lower bound stops a `(? <: value) is Zeroic` search — as `total` makes —
+    // collapsing `self` to `Nothing`, whose `zero` would throw on the cast.
+    given zeroic: [self >: R64 <: R64] => self is Zeroic:
+      inline def zero: self = refine(Zero)
+
+    given unital: [self >: R64 <: R64] => self is Unital = () => refine(One)
+
+    // The best representable approximation of the square root: exact whenever the operand
+    // is the square of a representable rational, and NaR for negative operands.
+    given rootable: R64 is Rootable[2]:
+      type Result = R64
+
+      def root(value: R64): R64 =
+        if value < 0L then r64(Long.MinValue)
+        else if value == 0L then r64(0L)
+        else
+          val (numerator, denominator) = fractionOf(value & Long.MaxValue)
+          r64(sqrtMagnitude(numerator, denominator, Budget64))
+
+    // Statistical operations divide and rescale by `Double`s — collection sizes, exact
+    // halves — which convert to rationals exactly, so `mean`, `median` and `variance` stay
+    // exact for exact inputs.
+    given divisibleDouble: [self <: R64] => self is Divisible:
+      type Operand = Double
+      type Result = self
+
+      def divide(dividend: self, divisor: Double): self =
+        refine(product(dividend, R64(divisor), true))
+
+    given multiplicableDouble: [self <: R64] => self is Multiplicable:
+      type Operand = Double
+      type Result = self
+
+      def multiply(multiplicand: self, multiplier: Double): self =
+        refine(product(multiplicand, R64(multiplier), false))
+
+    // Destructuring through symbolism's `/:` extractor: `case n /: d => …`.
+    given quotient: R64 is Quotient:
+      type Topic = Long
+      type Transport = Long
+
+      def decompose(division: R64): scala.Option[(Long, Long)] =
+        if division == Long.MinValue then scala.None
+        else scala.Some((division.numerator, division.denominator))
+
+    // Implicit conversions exist only where exact, matching `F64`'s exclusion of `Long`;
+    // the two extremes `Int.MaxValue` and `Int.MinValue` round by one to ±(2³¹−2).
+    inline given intConversion: Conversion[Int, R64]:
+      def apply(value: Int): R64 = R64(value.toLong, 1L)
+
+    inline given shortConversion: Conversion[Short, R64]:
+      def apply(value: Short): R64 = R64(value.toLong, 1L)
+
+    inline given byteConversion: Conversion[Byte, R64]:
+      def apply(value: Byte): R64 = R64(value.toLong, 1L)
+
+    // Widening from `R32` is always exact.
+    inline given r32Conversion: Conversion[R32, R64]:
+      def apply(value: R32): R64 = widen32(value)
+
+    extension (left: R64)
+      def numerator: Long =
+        if left == Long.MinValue || left == 0L then 0L else
+          val (numerator, _) = fractionOf(left & Long.MaxValue)
+          if left < 0L then -numerator else numerator
+
+      // NaR has denominator 0, the unique word without one.
+      def denominator: Long =
+        if left == Long.MinValue then 0L
+        else if left == 0L then 1L
+        else
+          val (_, denominator) = fractionOf(left & Long.MaxValue)
+          denominator
+
+      def signum: Int =
+        if left == Long.MinValue || left == 0L then 0 else if left < 0L then -1 else 1
+
+      def nar: Boolean = left == Long.MinValue
+      def abs: R64 = if left == Long.MinValue then left else r64(left & Long.MaxValue)
+      def whole: Boolean = left.denominator == 1L
+
+      def reciprocal: R64 =
+        if left == Long.MinValue || left == 0L then r64(Long.MinValue) else
+          val (numerator, denominator) = fractionOf(left & Long.MaxValue)
+          val magnitude = encodeFraction(denominator, numerator, Budget64)
+          if magnitude == 0L then r64(0L)
+          else if left < 0L then r64(magnitude | Long.MinValue)
+          else r64(magnitude)
+
+      def floor: R64 =
+        if left == Long.MinValue || left == 0L then left else
+          val (numerator, denominator) = fractionOf(left & Long.MaxValue)
+
+          if left > 0L then build(false, numerator/denominator, 1L)
+          else build(true, numerator/denominator + (if numerator%denominator == 0L then 0L else 1L),
+                     1L)
+
+      def ceiling: R64 =
+        if left == Long.MinValue || left == 0L then left else
+          val (numerator, denominator) = fractionOf(left & Long.MaxValue)
+
+          if left < 0L then build(true, numerator/denominator, 1L)
+          else build(false, numerator/denominator + (if numerator%denominator == 0L then 0L else 1L),
+                     1L)
+
+      // Half-up rounding, matching `math.round` on `Double`.
+      def round: Long =
+        if left == Long.MinValue || left == 0L then 0L else
+          val (numerator, denominator) = fractionOf(left & Long.MaxValue)
+          val signed = if left < 0L then -numerator else numerator
+          math.floorDiv(2L*signed + denominator, 2L*denominator)
+
+      // Numerator and denominator are both below 2⁵³, so the quotient is correctly rounded.
+      def double: Double =
+        if left == Long.MinValue then Double.NaN
+        else if left == 0L then 0.0
+        else
+          val (numerator, denominator) = fractionOf(left & Long.MaxValue)
+          val quotient = numerator.toDouble/denominator.toDouble
+          if left < 0L then -quotient else quotient
+
+      def text: Text =
+        if left == Long.MinValue then "NaR".tt
+        else if left == 0L then "0".tt
+        else
+          val (numerator, denominator) = fractionOf(left & Long.MaxValue)
+          render(left < 0L, numerator, denominator)
+
+      // The best `R32` approximation; exact whenever the value fits `R32`'s budget.
+      def r32: R32 = narrow64(left)
+
+  object R32:
+    final val Zero: R32 = r32(0)
+    final val One: R32 = r32(encodeFraction(1L, 1L, Budget32).toInt)
+    final val Nar: R32 = r32(Int.MinValue)
+    final val Max: R32 = r32(encodeFraction(0x7ffeL, 1L, Budget32).toInt)
+    final val Min: R32 = r32(Max | Int.MinValue)
+
+    inline given underlying: Underlying[R32, Int] = caps.unsafe.unsafeErasedValue
+    inline given canEqual: CanEqual[R32, R32] = caps.unsafe.unsafeErasedValue
+
+    // `R32` dealiases to `Int` here, so arrays of it are primitive `int[]`s.
+    given classTag: ClassTag[R32] = summon[ClassTag[Int]].asInstanceOf[ClassTag[R32]]
+
+    private def build(negative: Boolean, numerator: Long, denominator: Long): R32 =
+      if denominator == 0L then r32(Int.MinValue)
+      else if numerator == 0L then r32(0)
+      else
+        val magnitude = encodeFraction(numerator, denominator, Budget32)
+        if magnitude == 0L then r32(0)
+        else if negative then r32(magnitude.toInt | Int.MinValue)
+        else r32(magnitude.toInt)
+
+    private def clamped(value: Long): Long =
+      if value == Long.MinValue then Long.MaxValue else math.abs(value)
+
+    def apply(value: Int): R32 = apply(value.toLong, 1L)
+    def apply(value: Long): R32 = apply(value, 1L)
+
+    def apply(numerator: Long, denominator: Long): R32 =
+      build(numerator < 0L ^ denominator < 0L, clamped(numerator), clamped(denominator))
+
+    def apply(value: Double): R32 =
+      if !JDouble.isFinite(value) then Nar
+      else if value == 0.0 then Zero
+      else
+        val magnitude = doubleMagnitude(math.abs(value), Budget32)
+        if magnitude == 0L then r32(0)
+        else if value < 0.0 then r32(magnitude.toInt | Int.MinValue)
+        else r32(magnitude.toInt)
+
+    def parse(text: Text): R32 raises RationalError =
+      if text.s == "NaR" then Nar else parsedRational(text) match
+        case value: (Boolean, Long, Long) => build(value(0), value(1), value(2))
+        case _                            => abort(RationalError(text))
+
+    // The signed three-way comparison behind `Orderable`, with NaR below everything; the
+    // relational operators themselves treat NaR as unordered. Decoded numerators and
+    // denominators stay below 2²¹, so the cross-products need only `Long`s.
+    def comparison(left: R32, right: R32): Int =
+      if left == right then 0
+      else if left == Int.MinValue then -1
+      else if right == Int.MinValue then 1
+      else if left == 0 then (if right > 0 then -1 else 1)
+      else if right == 0 then (if left > 0 then 1 else -1)
+      else if left < 0 && right > 0 then -1
+      else if left > 0 && right < 0 then 1
+      else
+        val (leftNumerator, leftDenominator) = fractionOf((left & Int.MaxValue).toLong)
+        val (rightNumerator, rightDenominator) = fractionOf((right & Int.MaxValue).toLong)
+        val order = JLong.compare(leftNumerator*rightDenominator, rightNumerator*leftDenominator)
+        if left < 0 then -order else order
+
+    given orderable: R32 is Orderable:
+      inline def compare
+          (inline left: R32, inline right: R32, inline strict: Boolean, inline greater: Boolean)
+      :   Boolean =
+        if left == Int.MinValue || right == Int.MinValue then false else
+          val result = comparison(left, right)
+
+          if greater then (if strict then result > 0 else result >= 0)
+          else (if strict then result < 0 else result <= 0)
+
+    given fromDigits: FromDigits.Decimal[R32] = digits =>
+      parsedRational(digits.tt) match
+        case value: (Boolean, Long, Long) => build(value(0), value(1), value(2))
+        case _                            => throw FromDigits.MalformedNumber(digits)
+
+    given textualizable: R32 is Textualizable = value => value.text
+
+    private def negation(value: R32): R32 =
+      if value == 0 || value == Int.MinValue then value else r32(value ^ Int.MinValue)
+
+    private def sum(left: R32, right: R32): R32 =
+      if left == Int.MinValue || right == Int.MinValue then r32(Int.MinValue)
+      else if left == 0 then right
+      else if right == 0 then left
+      else
+        val (leftNumerator, leftDenominator) = fractionOf((left & Int.MaxValue).toLong)
+        val (rightNumerator, rightDenominator) = fractionOf((right & Int.MaxValue).toLong)
+        val cross = leftNumerator*rightDenominator
+        val cross2 = rightNumerator*leftDenominator
+        val denominator = leftDenominator*rightDenominator
+        val negative = left < 0
+
+        if left < 0 == right < 0 then build(negative, cross + cross2, denominator)
+        else if cross == cross2 then r32(0)
+        else if cross > cross2 then build(negative, cross - cross2, denominator)
+        else build(right < 0, cross2 - cross, denominator)
+
+    private def product(left: R32, right: R32, inverted: Boolean): R32 =
+      if left == Int.MinValue || right == Int.MinValue then r32(Int.MinValue)
+      else if inverted && right == 0 then r32(Int.MinValue)
+      else if left == 0 || right == 0 then r32(0)
+      else
+        val (leftNumerator, leftDenominator) = fractionOf((left & Int.MaxValue).toLong)
+        val (rightNumerator, rightDenominator) = fractionOf((right & Int.MaxValue).toLong)
+
+        val (numerator, denominator) =
+          if inverted then (leftNumerator*rightDenominator, leftDenominator*rightNumerator)
+          else (leftNumerator*rightNumerator, leftDenominator*rightDenominator)
+
+        build(left < 0 ^ right < 0, numerator, denominator)
+
+    // Statistical operations skolemize the element type they work over, and `Self` is
+    // invariant in a typeclass, so — as `abacist`'s `Quanta` does — the arithmetic givens
+    // take any subtype of R32 as `Self`, with `refine` casting the computed word back.
+    private def refine[self](value: R32): self = value.asInstanceOf[self]
+
+    // The standard arithmetic operators come from symbolism, so `+`, `-`, `*`, `/`, prefix
+    // negation and `sqrt` resolve through the generic operators without any R32-specific
+    // exports.
+    given addable: [self <: R32] => self is Addable:
+      type Operand = self
+      type Result = self
+
+      def add(augend: self, addend: self): self = refine(sum(augend, addend))
+
+    given subtractable: [self <: R32] => self is Subtractable:
+      type Operand = self
+      type Result = self
+
+      def subtract(minuend: self, subtrahend: self): self =
+        refine(sum(minuend, negation(subtrahend)))
+
+    given multiplicable: [self <: R32] => self is Multiplicable:
+      type Operand = self
+      type Result = self
+
+      def multiply(multiplicand: self, multiplier: self): self =
+        refine(product(multiplicand, multiplier, false))
+
+    // Division is total: division by zero gives NaR, which propagates like `Double.NaN`.
+    given divisible: [self <: R32] => self is Divisible:
+      type Operand = self
+      type Result = self
+
+      def divide(dividend: self, divisor: self): self = refine(product(dividend, divisor, true))
+
+    given negatable: [self <: R32] => self is Negatable to self =
+      operand => refine(negation(operand))
+
+    // The lower bound stops a `(? <: value) is Zeroic` search — as `total` makes —
+    // collapsing `self` to `Nothing`, whose `zero` would throw on the cast.
+    given zeroic: [self >: R32 <: R32] => self is Zeroic:
+      inline def zero: self = refine(Zero)
+
+    given unital: [self >: R32 <: R32] => self is Unital = () => refine(One)
+
+    // The best representable approximation of the square root: exact whenever the operand
+    // is the square of a representable rational, and NaR for negative operands.
+    given rootable: R32 is Rootable[2]:
+      type Result = R32
+
+      def root(value: R32): R32 =
+        if value < 0 then r32(Int.MinValue)
+        else if value == 0 then r32(0)
+        else
+          val (numerator, denominator) = fractionOf((value & Int.MaxValue).toLong)
+          r32(sqrtMagnitude(numerator, denominator, Budget32).toInt)
+
+    given divisibleDouble: [self <: R32] => self is Divisible:
+      type Operand = Double
+      type Result = self
+
+      def divide(dividend: self, divisor: Double): self =
+        refine(product(dividend, R32(divisor), true))
+
+    given multiplicableDouble: [self <: R32] => self is Multiplicable:
+      type Operand = Double
+      type Result = self
+
+      def multiply(multiplicand: self, multiplier: Double): self =
+        refine(product(multiplicand, R32(multiplier), false))
+
+    // Destructuring through symbolism's `/:` extractor: `case n /: d => …`.
+    given quotient: R32 is Quotient:
+      type Topic = Long
+      type Transport = Long
+
+      def decompose(division: R32): scala.Option[(Long, Long)] =
+        if division == Int.MinValue then scala.None
+        else scala.Some((division.numerator, division.denominator))
+
+    // Implicit conversions exist only where exact; the two extremes `Short.MaxValue` and
+    // `Short.MinValue` round by one to ±32766.
+    inline given shortConversion: Conversion[Short, R32]:
+      def apply(value: Short): R32 = R32(value.toLong, 1L)
+
+    inline given byteConversion: Conversion[Byte, R32]:
+      def apply(value: Byte): R32 = R32(value.toLong, 1L)
+
+    extension (left: R32)
+      def numerator: Long =
+        if left == Int.MinValue || left == 0 then 0L else
+          val (numerator, _) = fractionOf((left & Int.MaxValue).toLong)
+          if left < 0 then -numerator else numerator
+
+      // NaR has denominator 0, the unique word without one.
+      def denominator: Long =
+        if left == Int.MinValue then 0L
+        else if left == 0 then 1L
+        else
+          val (_, denominator) = fractionOf((left & Int.MaxValue).toLong)
+          denominator
+
+      def signum: Int = if left == Int.MinValue || left == 0 then 0 else if left < 0 then -1 else 1
+      def nar: Boolean = left == Int.MinValue
+      def abs: R32 = if left == Int.MinValue then left else r32(left & Int.MaxValue)
+      def whole: Boolean = left.denominator == 1L
+
+      def reciprocal: R32 =
+        if left == Int.MinValue || left == 0 then r32(Int.MinValue) else
+          val (numerator, denominator) = fractionOf((left & Int.MaxValue).toLong)
+          val magnitude = encodeFraction(denominator, numerator, Budget32)
+          if magnitude == 0L then r32(0)
+          else if left < 0 then r32(magnitude.toInt | Int.MinValue)
+          else r32(magnitude.toInt)
+
+      def floor: R32 =
+        if left == Int.MinValue || left == 0 then left else
+          val (numerator, denominator) = fractionOf((left & Int.MaxValue).toLong)
+
+          if left > 0 then build(false, numerator/denominator, 1L)
+          else build(true, numerator/denominator + (if numerator%denominator == 0L then 0L else 1L),
+                     1L)
+
+      def ceiling: R32 =
+        if left == Int.MinValue || left == 0 then left else
+          val (numerator, denominator) = fractionOf((left & Int.MaxValue).toLong)
+
+          if left < 0 then build(true, numerator/denominator, 1L)
+          else build(false, numerator/denominator + (if numerator%denominator == 0L then 0L else 1L),
+                     1L)
+
+      // Half-up rounding, matching `math.round` on `Double`.
+      def round: Long =
+        if left == Int.MinValue || left == 0 then 0L else
+          val (numerator, denominator) = fractionOf((left & Int.MaxValue).toLong)
+          val signed = if left < 0 then -numerator else numerator
+          math.floorDiv(2L*signed + denominator, 2L*denominator)
+
+      // Numerator and denominator are both below 2⁵³, so the quotient is correctly rounded.
+      def double: Double =
+        if left == Int.MinValue then Double.NaN
+        else if left == 0 then 0.0
+        else
+          val (numerator, denominator) = fractionOf((left & Int.MaxValue).toLong)
+          val quotient = numerator.toDouble/denominator.toDouble
+          if left < 0 then -quotient else quotient
+
+      def text: Text =
+        if left == Int.MinValue then "NaR".tt
+        else if left == 0 then "0".tt
+        else
+          val (numerator, denominator) = fractionOf((left & Int.MaxValue).toLong)
+          render(left < 0, numerator, denominator)
+
+      // Widening to `R64` is always exact.
+      def r64: R64 = widen32(left)

--- a/lib/hypotenuse/src/core/hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse_core.scala
@@ -544,6 +544,22 @@ extension [left](inline left: left)
     if left >= right then left else right
 
 package arithmeticOptions:
+  // Importing one of these lexically outranks the companion `divisible`, so `a/b` on
+  // rationals yields a `Double` in that scope — which is what lets `std` (whose variance
+  // must divide to `Double`) resolve for rational collections.
+  object rationalDivision:
+    given r64: R64 is Divisible:
+      type Operand = R64
+      type Result = Double
+
+      def divide(dividend: R64, divisor: R64): Double = dividend.double/divisor.double
+
+    given r32: R32 is Divisible:
+      type Operand = R32
+      type Result = Double
+
+      def divide(dividend: R32, divisor: R32): Double = dividend.double/divisor.double
+
   object division:
     inline given unchecked: DivisionByZero:
       type Wrap[result] = result

--- a/lib/hypotenuse/src/test/hypotenuse_test.scala
+++ b/lib/hypotenuse/src/test/hypotenuse_test.scala
@@ -652,3 +652,268 @@ object Tests extends Suite(m"Hypotenuse tests"):
           Decimal.comparison(Decimal.parse(value.text), value) == 0
 
       . assert(_.forall(identity))
+
+    suite(m"R64 tests"):
+      import strategies.throwUnsafely
+
+      def gcd(a: Long, b: Long): Long = if b == 0L then a else gcd(b, a%b)
+
+      test(m"one half renders as 1/2"):
+        R64(1, 2).text
+      . assert(_ == t"1/2")
+
+      test(m"whole values render without a denominator"):
+        R64(7, 1).text
+      . assert(_ == t"7")
+
+      test(m"negative values render with a leading minus"):
+        R64(-5, 3).text
+      . assert(_ == t"-5/3")
+
+      test(m"zero renders as 0"):
+        R64(0).text
+      . assert(_ == t"0")
+
+      test(m"encoding is canonical, so equal values are bit-equal"):
+        R64(6, 4)
+      . assert(_ == R64(3, 2))
+
+      test(m"a negative denominator moves the sign"):
+        R64(5, -3)
+      . assert(_ == R64(-5, 3))
+
+      test(m"division by zero is NaR"):
+        R64(1, 0).nar
+      . assert(identity)
+
+      test(m"355/113 round-trips through its encoding"):
+        (R64(355, 113).numerator, R64(355, 113).denominator)
+      . assert(_ == (355L, 113L))
+
+      test(m"the largest integer is 2³¹−2"):
+        R64(2147483646L).numerator
+      . assert(_ == 2147483646L)
+
+      test(m"the smallest positive fraction is 1/(2³¹−1)"):
+        R64(1, 2147483647L).denominator
+      . assert(_ == 2147483647L)
+
+      test(m"Long.MaxValue saturates to the largest integer"):
+        R64(Long.MaxValue)
+      . assert(_ == R64(2147483646L))
+
+      test(m"integer literals convert"):
+        val value: R64 = 42
+        value
+      . assert(_ == R64(42))
+
+      test(m"decimal literals convert exactly"):
+        val value: R64 = 3.14
+        (value.numerator, value.denominator)
+      . assert(_ == (157L, 50L))
+
+      test(m"differential arithmetic against exact fractions"):
+        val random = scala.util.Random(19283746L)
+
+        (0 until 500).map: _ =>
+          val a = random.nextLong(4097L) - 2048L
+          val b = random.nextLong(2048L) + 1L
+          val c = random.nextLong(4097L) - 2048L
+          val d = random.nextLong(2048L) + 1L
+          val left = R64(a, b)
+          val right = R64(c, d)
+
+          val sums = left + right == R64(a*d + c*b, b*d)
+          val differences = left - right == R64(a*d - c*b, b*d)
+          val products = left*right == R64(a*c, b*d)
+          val quotients = c == 0L || left/right == R64(a*d, b*c)
+
+          val comparisons =
+            R64.comparison(left, right).sign == java.lang.Long.compare(a*d, c*b).sign
+
+          sums && differences && products && quotients && comparisons
+
+      . assert(_.forall(identity))
+
+      test(m"an unrepresentable result rounds to a semiconvergent"):
+        R64(2000000011L, 2000000010L)
+      . assert(_ == R64(1073741824L, 1073741823L))
+
+      test(m"NaR propagates through addition"):
+        (R64.Nar + R64(1)).nar
+      . assert(identity)
+
+      test(m"NaR propagates through multiplication"):
+        (R64.Nar*R64(2)).nar
+      . assert(identity)
+
+      test(m"NaR comparisons are all false"):
+        !(R64.Nar < R64(1)) && !(R64.Nar > R64(1)) && !(R64.Nar <= R64(1))
+          && !(R64.Nar >= R64(1))
+      . assert(identity)
+
+      test(m"square roots of perfect squares are exact"):
+        R64(9).sqrt
+      . assert(_ == R64(3))
+
+      test(m"square roots of square fractions are exact"):
+        R64(9, 4).sqrt
+      . assert(_ == R64(3, 2))
+
+      test(m"the square root of two approximates √2 to full depth"):
+        val root = R64(2).sqrt
+        (math.abs(root.double - math.sqrt(2.0)) < 1e-13, root.denominator > 1000000L)
+      . assert(_ == (true, true))
+
+      test(m"the square root of a negative value is NaR"):
+        R64(-1).sqrt.nar
+      . assert(identity)
+
+      test(m"mean of rationals is exact"):
+        List(R64(1, 2), R64(1, 3), R64(1, 6)).mean
+      . assert(_.lay(false)(_ == R64(1, 3)))
+
+      test(m"median of rationals"):
+        List(R64(1, 2), R64(1, 3), R64(1, 6)).median
+      . assert(_.lay(false)(_ == R64(1, 3)))
+
+      test(m"variance of rationals is exact"):
+        List(R64(1), R64(2), R64(3)).variance
+      . assert(_.lay(false)(_ == R64(2, 3)))
+
+      test(m"std resolves with the rationalDivision import"):
+        import arithmeticOptions.rationalDivision.r64
+        List(R64(1), R64(2), R64(3)).std
+      . assert(_.lay(false) { value => math.abs(value.double - math.sqrt(2.0/3.0)) < 1e-12 })
+
+      test(m"rationals destructure into numerator and denominator"):
+        R64(3, 4) match
+          case n /: d => (n, d)
+          case _      => (0L, 0L)
+      . assert(_ == (3L, 4L))
+
+      test(m"floor of a negative fraction"):
+        R64(-3, 2).floor
+      . assert(_ == R64(-2))
+
+      test(m"ceiling of a fraction"):
+        R64(3, 2).ceiling
+      . assert(_ == R64(2))
+
+      test(m"rounding is half-up"):
+        (R64(5, 2).round, R64(-5, 2).round)
+      . assert(_ == (3L, -2L))
+
+      test(m"reciprocal of zero is NaR"):
+        R64.Zero.reciprocal.nar
+      . assert(identity)
+
+      test(m"reciprocal swaps numerator and denominator"):
+        R64(-3, 4).reciprocal
+      . assert(_ == R64(-4, 3))
+
+      test(m"double conversion is exact for representables"):
+        R64(1, 2).double
+      . assert(_ == 0.5)
+
+      test(m"doubles convert to exact rationals when possible"):
+        R64(0.375)
+      . assert(_ == R64(3, 8))
+
+      test(m"parse reads fraction notation"):
+        R64.parse(t"-5/3")
+      . assert(_ == R64(-5, 3))
+
+      test(m"parse reads NaR"):
+        R64.parse(t"NaR").nar
+      . assert(identity)
+
+      test(m"text round-trips through parse"):
+        val random = scala.util.Random(87654321L)
+
+        (0 until 200).map: _ =>
+          val value = R64(random.nextLong(4097L) - 2048L, random.nextLong(2048L) + 1L)
+          R64.parse(value.text) == value
+
+      . assert(_.forall(identity))
+
+      test(m"random encodings decode to the reduced fraction"):
+        val random = scala.util.Random(1029384756L)
+
+        (0 until 300).map: _ =>
+          val a = random.nextLong(4096L) + 1L
+          val b = random.nextLong(4096L) + 1L
+          val divisor = gcd(a, b)
+          val value = R64(a, b)
+          value.numerator == a/divisor && value.denominator == b/divisor
+
+      . assert(_.forall(identity))
+
+    suite(m"R32 tests"):
+
+      test(m"encoding is canonical, so equal values are bit-equal"):
+        R32(6, 4)
+      . assert(_ == R32(3, 2))
+
+      test(m"division by zero is NaR"):
+        R32(1, 0).nar
+      . assert(identity)
+
+      test(m"the largest integer is 2¹⁵−2"):
+        R32(32766).numerator
+      . assert(_ == 32766L)
+
+      test(m"32767 saturates to the largest integer"):
+        R32(32767)
+      . assert(_ == R32(32766))
+
+      test(m"the smallest positive fraction is 1/(2¹⁵−1)"):
+        R32(1, 32767).denominator
+      . assert(_ == 32767L)
+
+      test(m"differential arithmetic against exact fractions"):
+        val random = scala.util.Random(56473829L)
+
+        (0 until 500).map: _ =>
+          val a = random.nextLong(65L) - 32L
+          val b = random.nextLong(32L) + 1L
+          val c = random.nextLong(65L) - 32L
+          val d = random.nextLong(32L) + 1L
+          val left = R32(a, b)
+          val right = R32(c, d)
+
+          val sums = left + right == R32(a*d + c*b, b*d)
+          val differences = left - right == R32(a*d - c*b, b*d)
+          val products = left*right == R32(a*c, b*d)
+          val quotients = c == 0L || left/right == R32(a*d, b*c)
+
+          val comparisons =
+            R32.comparison(left, right).sign == java.lang.Long.compare(a*d, c*b).sign
+
+          sums && differences && products && quotients && comparisons
+
+      . assert(_.forall(identity))
+
+      test(m"square roots of square fractions are exact"):
+        R32(9, 4).sqrt
+      . assert(_ == R32(3, 2))
+
+      test(m"mean of rationals is exact"):
+        List(R32(1, 2), R32(1, 3), R32(1, 6)).mean
+      . assert(_.lay(false)(_ == R32(1, 3)))
+
+      test(m"widening to R64 is exact"):
+        R32(3, 4).r64
+      . assert(_ == R64(3, 4))
+
+      test(m"narrowing a representable value is exact"):
+        R64(3, 4).r32
+      . assert(_ == R32(3, 4))
+
+      test(m"narrowing saturates large integers"):
+        R64(2147483645L).r32
+      . assert(_ == R32(32766))
+
+      test(m"NaR survives narrowing and widening"):
+        (R64.Nar.r32.nar, R32.Nar.r64.nar)
+      . assert(_ == (true, true))

--- a/lib/mosquito/src/test/mosquito_test.scala
+++ b/lib/mosquito/src/test/mosquito_test.scala
@@ -257,6 +257,16 @@ object Tests extends Suite(m"Mosquito tests"):
         m1/2
       . assert(_ == Matrix[2, 3]((0, 1, 1), (2, 2, 3)))
 
+    suite(m"Rational elements"):
+      test(m"Dot product of rational vectors"):
+        Vector(R64(1, 2), R64(1, 3)).dot(Vector(R64(2), R64(3)))
+      . assert(_ == R64(2))
+
+      test(m"Multiply rational matrices"):
+        val left = Matrix[2, 2]((R32(1, 2), R32(1, 3)), (R32(1, 4), R32(1, 5)))
+        left*Matrix[2, 2]((R32(2), R32(0)), (R32(0), R32(2)))
+      . assert(_ == Matrix[2, 2]((R32(1), R32(2, 3)), (R32(1, 2), R32(2, 5))))
+
     suite(m"Determinant"):
       test(m"Determinant of 2x2 matrix"):
         Matrix[2, 2]((1, 2), (3, 4)).determinant


### PR DESCRIPTION
Hypotenuse gains two new first-class number types, `R64` and `R32`: exact rational numbers packed into a single `Long` or `Int` using a Stern–Brocot encoding — a sign bit and the value's canonical continued fraction, gamma-coded — so every rational has exactly one representation, already in lowest terms, and equality is bit-equality. They come with the full symbolism typeclass surface, so complex numbers, vectors, matrices, MathML rendering and the rudiments statistical operations all work through the existing generic instances.

### Exact rational arithmetic in one machine word

```scala
val third: R64 = R64(1, 3)          // exact 1/3
val pi: R64 = 3.14159               // decimal literals are exact: 314159/100000
third + R64(1, 6)                   // R64(1, 2) — exact, canonical
R64(1)/R64(0)                       // NaR: division by zero propagates like NaN
R64(9, 4).sqrt                      // R64(3, 2) — exact for perfect squares
```

`R64` represents integers to ±(2³¹−2), unit fractions to 1/(2³¹−1), and every fraction with numerator and denominator up to 2²⁴; `R32` is the half-width version (±32766, exact to 2¹¹). When an exact result would not fit, it rounds to a convergent or semiconvergent of the true value — the best rational approximation among all rationals of no greater denominator. Division by zero yields the NaN-like `NaR` ("not a rational"), which propagates through arithmetic and compares as unordered.

Rationals destructure with `case n /: d`, convert exactly between widths (`r32.r64` always; `r64.r32` rounding), and provide `floor`, `ceiling`, `round`, `reciprocal`, `numerator`, `denominator` and friends. `Complex[R64]` (baroque) and rational `Vector`s and `Matrix`es (mosquito) work out of the box, rendering as proper `<mfrac>` fractions in MathML (archimedes). The statistical operations are exact: `List(R64(1, 2), R64(1, 3), R64(1, 6)).mean` is precisely `R64(1, 3)`; `std`, which must divide to `Double`, is enabled by `import arithmeticOptions.rationalDivision.r64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)