### PR TITLE
Add Vivisection, a session-based debugger speaking JDWP directly

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -786,7 +786,8 @@ object soundness extends Toolchain:
     harlequin.md, harlequin.ansi, austronesian.core, anthology.linker, anthology.link, anthology.nir,
     anthology.lira,
     anthology.`scala`, exegesis.core, hellenism.jvm, delicious.core, delicious.`scala`,
-    delicious.ansi, anthology.kotlin, anthology.oci, anthology.xeq, hyperbole.stacks):
+    delicious.ansi, anthology.kotlin, anthology.oci, anthology.xeq, hyperbole.stacks,
+    vivisection.core):
     def summary = "Developer tools: compilers, build tooling, source analysis and version control"
 
   object web extends Bundle(archimedes.core, cacophony.core, cataclysm.core, coaxial.core, coaxial.jvm, cosmopolite.core, gesticulate.core,
@@ -3061,6 +3062,22 @@ object vicarious extends Library:
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions())
 
+object vivisection extends Library:
+  // A from-scratch JDWP debugger client: coaxial sockets carry the wire protocol, guillotine
+  // launches the debuggee, digression supplies SMAP-aware line translation, and parasite runs
+  // the reply-correlation and event-dispatch pumps.
+  object core extends Component(coaxial.jvm, guillotine.core, aperture.core, digression.core,
+      parasite.core, zephyrine.core, gossamer.core):
+    override def scalaJs = false // debugs JVMs over TCP; depends on JVM-only `guillotine`
+    override def scalaNative = false // JDWP is a JVM protocol; forks JVMs via `guillotine`
+    override def scalacOptions = Task:
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
+  // The offline suite drives the protocol against a scripted fake VM over an in-memory duplex;
+  // the live suite launches real JVMs under the jdwp agent.
+  object test extends Tests(core, eucalyptus.core, ambience.core):
+    override def scalacOptions = Task:
+      settings.sep(super.scalacOptions())
+
 object wisteria extends Library:
   object core extends Component(contingency.core, vicarious.core):
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
@@ -3278,7 +3295,8 @@ val allLibraries: Seq[Library] = Seq(
   proscenium, punctuation, quantitative, querencia, reliquary, revolution, rudiments, savagery,
   scintillate, sedentary, serpentine, spectacular, stenography, stratiform, superlunary,
   surveillance, symbolism, synesthesia, tarantula, telekinesis, turbulence, typonym,
-  ultimatum, ulysses, umbrageous, urticose, vacuous, vexillology, vicarious, wisteria, xenophile, xylophone,
+  ultimatum, ulysses, umbrageous, urticose, vacuous, vexillology, vicarious, vivisection,
+  wisteria, xenophile, xylophone,
   yossarian, ypsiloid, zephyrine, zeppelin, ziggurat
 )
 

--- a/doc/errors/601.md
+++ b/doc/errors/601.md
@@ -1,0 +1,25 @@
+# `SN-601` — `DebuggerError`
+
+Raised when a debug session cannot be established, or when the debuggee VM replies to a JDWP
+command with an error code. The subcode is the JDWP error constant the VM returned, or a negative
+value for a fault local to the debugger (a failed handshake, or a lost connection).
+
+## Cause
+
+Vivisection speaks the Java Debug Wire Protocol to a debuggee JVM. This error covers a debuggee
+that refuses or drops the connection, a handshake that is not echoed, and any command the VM
+rejects — an invalid identifier, a thread that is not suspended, a VM that has already died, and
+the rest of the JDWP error constants.
+
+## Example message
+
+```
+[↯SN-601] the JDWP action failed because the thread was not suspended
+```
+
+## Resolution
+
+Most JDWP error constants indicate that the command referred to state that has since changed —
+a frame that has returned, an object that has been collected, or a thread that has resumed. Re-read
+the relevant state after the VM last suspended before issuing the command again. A `Disconnected`
+reason means the transport itself failed; check that the debuggee is still running and reachable.

--- a/lib/vivisection/doc/basics.md
+++ b/lib/vivisection/doc/basics.md
@@ -1,0 +1,7 @@
+### The JDWP protocol vocabulary
+
+The `Jdwp` object holds a Scala-native model of the Java Debug Wire Protocol: identifier types
+(`Jdwp.ObjectId`, `Jdwp.ThreadId`, …, all tagged views of the same opaque `Jdwp.Ref`), a
+`Jdwp.Location`, tagged `Jdwp.Value`s, event-request `Jdwp.Modifier`s, and the composite
+`Jdwp.Event`s a suspended VM sends back. `Jdwp.Reader` and `Jdwp.Writer` are hand-written
+big-endian codecs, aware of the identifier sizes negotiated with the VM at the start of a session.

--- a/lib/vivisection/doc/features.md
+++ b/lib/vivisection/doc/features.md
@@ -1,0 +1,5 @@
+- implements the JDWP wire protocol from scratch over a socket, with no `com.sun.jdi` dependency
+- launches a debuggee under the jdwp agent, or attaches to a running JVM
+- presents a capability-scoped debug session: breakpoints, stepping, threads and frames
+- correlates requests and replies asynchronously, so many commands may be in flight at once
+- decodes composite events into a typed event stream

--- a/lib/vivisection/doc/intro.md
+++ b/lib/vivisection/doc/intro.md
@@ -1,0 +1,6 @@
+_Vivisection_ is a session-based debugger for the JVM, designed for Scala rather than adapted from
+a Java debugger. It speaks the JDWP wire protocol directly over a socket, launches or attaches to a
+debuggee, and drives breakpoints, stepping, variable inspection and expression evaluation through a
+capability-scoped session. Frames, variables and values are translated back into the terms the
+programmer wrote — decoding compiled names through TASTy, stepping through `inline` expansions, and
+rendering values through their static types rather than their erased runtime representation.

--- a/lib/vivisection/doc/name.md
+++ b/lib/vivisection/doc/name.md
@@ -1,0 +1,2 @@
+__Vivisection__ is the examination of a living subject; this library examines a running program
+from the inside, while it executes.

--- a/lib/vivisection/doc/slogan.md
+++ b/lib/vivisection/doc/slogan.md
@@ -1,0 +1,1 @@
+A Scala-native debugger, spoken in the language you wrote

--- a/lib/vivisection/doc/status.md
+++ b/lib/vivisection/doc/status.md
@@ -1,0 +1,1 @@
+embryonic

--- a/lib/vivisection/src/core/soundness_vivisection_core.scala
+++ b/lib/vivisection/src/core/soundness_vivisection_core.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export vivisection.Jdwp
+
+export vivisection.{ObjectId, ThreadId, ThreadGroupId, StringId, ClassLoaderId, ReferenceTypeId,
+    MethodId, FieldId, FrameId}

--- a/lib/vivisection/src/core/soundness_vivisection_core.scala
+++ b/lib/vivisection/src/core/soundness_vivisection_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export vivisection.Jdwp
+export vivisection.{Jdwp, Debugger}
 
 export vivisection.{ObjectId, ThreadId, ThreadGroupId, StringId, ClassLoaderId, ReferenceTypeId,
     MethodId, FieldId, FrameId}

--- a/lib/vivisection/src/core/vivisection.Debug.scala
+++ b/lib/vivisection/src/core/vivisection.Debug.scala
@@ -30,9 +30,30 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package vivisection
 
-export vivisection.{Jdwp, Debugger, Debug}
+import scala.caps
 
-export vivisection.{ObjectId, ThreadId, ThreadGroupId, StringId, ClassLoaderId, ReferenceTypeId,
-    MethodId, FieldId, FrameId}
+import anticipation.*
+import contingency.*
+import proscenium.*
+
+// A live debug session: the capability lent inside `target.session { debug ?=> … }`. Sealed
+// (`ExclusiveCapability`), so it cannot outlive the session that lends it. Its operations are the
+// programmer-facing surface over the wire-level `Jdwp.Connection` it wraps.
+class Debug private[vivisection] (connection: Jdwp.Connection) extends caps.ExclusiveCapability:
+  def version()(using Tactic[Debugger.Error]): Jdwp.Version = connection.version()
+  def threads()(using Tactic[Debugger.Error]): List[ThreadId] = connection.allThreads()
+  def suspend()(using Tactic[Debugger.Error]): Unit = connection.suspendAll()
+  def resume()(using Tactic[Debugger.Error]): Unit = connection.resumeAll()
+
+  def suspend(thread: ThreadId)(using Tactic[Debugger.Error]): Unit =
+    connection.suspendThread(thread)
+
+  def resume(thread: ThreadId)(using Tactic[Debugger.Error]): Unit =
+    connection.resumeThread(thread)
+
+  def name(thread: ThreadId)(using Tactic[Debugger.Error]): Text = connection.threadName(thread)
+
+  def frames(thread: ThreadId)(using Tactic[Debugger.Error]): List[(FrameId, Jdwp.Location)] =
+    connection.frames(thread, 0, connection.frameCount(thread))

--- a/lib/vivisection/src/core/vivisection.Debug.scala
+++ b/lib/vivisection/src/core/vivisection.Debug.scala
@@ -57,3 +57,34 @@ class Debug private[vivisection] (connection: Jdwp.Connection) extends caps.Excl
 
   def frames(thread: ThreadId)(using Tactic[Debugger.Error]): List[(FrameId, Jdwp.Location)] =
     connection.frames(thread, 0, connection.frameCount(thread))
+
+  // The event stream: every composite the (suspending or running) VM sends back. This is the
+  // primitive; a caller drains it and reacts, or awaits a particular event. Reading it consumes
+  // the events as they arrive.
+  def events: Chain[Jdwp.Event.Composite] = connection.composites.lazyList
+
+  // Sets a breakpoint at a resolved location, returning the request id used to `clear` it. The VM
+  // reports each hit as a `Breakpoint` event on `events`, suspending per the given policy.
+  def breakpoint(location: Jdwp.Location, policy: Jdwp.SuspendPolicy = Jdwp.SuspendPolicy.All)
+    ( using Tactic[Debugger.Error] )
+  :   Int =
+
+    val modifiers: List[Jdwp.Modifier] = List(Jdwp.Modifier.LocationOnly(location))
+    connection.eventRequestSet(Jdwp.EventKind.Breakpoint, policy, modifiers)
+
+  // Requests a single step on a thread; the VM reports it as a `SingleStep` event on `events`.
+  def step
+    ( thread: ThreadId,
+      depth:  Jdwp.StepDepth = Jdwp.StepDepth.Over,
+      size:   Jdwp.StepSize = Jdwp.StepSize.Line )
+    ( using Tactic[Debugger.Error] )
+  :   Int =
+
+    val modifiers: List[Jdwp.Modifier] =
+      List(Jdwp.Modifier.Step(thread, size, depth), Jdwp.Modifier.Count(1))
+
+    connection.eventRequestSet(Jdwp.EventKind.SingleStep, Jdwp.SuspendPolicy.EventThread, modifiers)
+
+  // Cancels a previously-set event request.
+  def clear(kind: Jdwp.EventKind, request: Int)(using Tactic[Debugger.Error]): Unit =
+    connection.eventRequestClear(kind, request)

--- a/lib/vivisection/src/core/vivisection.Debuggee.scala
+++ b/lib/vivisection/src/core/vivisection.Debuggee.scala
@@ -30,9 +30,111 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package vivisection
 
-export vivisection.{Jdwp, Debugger, Debuggee, Debug}
+import java.net as jn
 
-export vivisection.{ObjectId, ThreadId, ThreadGroupId, StringId, ClassLoaderId, ReferenceTypeId,
-    MethodId, FieldId, FrameId}
+import scala.caps
+
+import ambience.*
+import anticipation.*, abstractables.durationAbstractable
+import coaxial.*
+import contingency.*
+import fulminate.*
+import gigantism.*
+import gossamer.*
+import guillotine.*
+import parasite.*
+import proscenium.*
+import rudiments.*
+import spectacular.*
+import urticose.*
+import vacuous.*
+
+// A launch target: a JVM to start under the JDWP agent and then debug. `target.session { debug ?=>
+// … }` forks the process with the agent listening, waits for it to bind its port, attaches, and
+// lends a `Debug`; the debuggee is killed when the block ends.
+object Debuggee:
+  private val interval: Long = 50L*1000L*1000L
+  private val attempts: Int = 200
+
+  // A plain-socket readiness probe. With `server=y` the agent binds before `main` runs, so a
+  // successful connect means it is ready to be attached to. The connection is dropped before any
+  // handshake, which the OpenJDK agent tolerates and re-listens after.
+  private def listening(port: Int): Boolean =
+    try
+      val socket = jn.Socket()
+      socket.connect(jn.InetSocketAddress("localhost", port), 200)
+      socket.close()
+      true
+    catch case _: Throwable => false
+
+  class Sessional
+    ( using online:     Online,
+            monitor:    Monitor,
+            probate:    Probate,
+            backend:    SocketBackend,
+            options:    Every[SocketOption.Tcp],
+            asyncError: Tactic[Async.Error],
+            working:    WorkingDirectory,
+            loggable:   (SocketEvent is Loggable)^,
+            exec:       (Exec.Event is Loggable)^,
+            tactic:     Tactic[Debugger.Error],
+            note:       Diagnostics )
+  extends aperture.Sessional:
+    type Self = Debuggee
+    type Result = Debug^
+
+    def session[result](target: Debuggee)(lambda: (session: Debug^) ?=> result): result =
+      given Diagnostics = note
+
+      val launchFailed = Debugger.Error(Debugger.Error.Reason.Disconnected, t"could not launch")
+      val badPort = Debugger.Error(Debugger.Error.Reason.Disconnected, t"the port was invalid")
+      val unresponsive = Debugger.Error(Debugger.Error.Reason.Disconnected, t"never listened")
+
+      given execTactic: (Tactic[Exec.Error]^) = tactic.contramap(_ => launchFailed)
+      given portTactic: (Tactic[Port.Error]^) = tactic.contramap(_ => badPort)
+
+      val job = target.agented.fork[Exit]()
+
+      try
+        def waitFor(remaining: Int): Unit =
+          if listening(target.port) then ()
+          else if remaining <= 0 then abort(unresponsive)
+          else
+            snooze(interval)
+            waitFor(remaining - 1)
+
+        waitFor(attempts)
+
+        // Connected directly (not via `Debugger(endpoint).session`): delegating would rebuild the
+        // socket `Connectable` from the captured `online`, whose capture set `.duplex` rejects.
+        // `connect` returns a plain `Duplex`, so `online` never has to flow into an empty set.
+        val endpoint = Endpoint(t"localhost", Port[Tcp](target.port))
+        val duplex = summon[(Endpoint[Tcp.Port] is Connectable)^].connect(endpoint, Unset)
+
+        try Jdwp.Connection.exchange(duplex): connection => lambda(using new Debug(connection))
+        finally duplex.close()
+      finally job.abort()
+
+  given sessional: ( online:     Online,
+                     monitor:    Monitor,
+                     probate:    Probate,
+                     backend:    SocketBackend,
+                     options:    Every[SocketOption.Tcp],
+                     asyncError: Tactic[Async.Error],
+                     working:    WorkingDirectory,
+                     loggable:   (SocketEvent is Loggable)^,
+                     exec:       (Exec.Event is Loggable)^,
+                     tactic:     Tactic[Debugger.Error],
+                     note:       Diagnostics )
+  =>  ( Sessional^{online, monitor, asyncError, loggable, exec, tactic, caps.any} ) = Sessional()
+
+case class Debuggee(command: Command, port: Int = 5005, suspended: Boolean = true):
+  // The command with the jdwp agent option inserted just after the executable.
+  private[vivisection] def agented: Command =
+    val wait = if suspended then t"y" else t"n"
+    val flag = t"-agentlib:jdwp=transport=dt_socket,server=y,suspend=$wait,address=*:$port"
+    val args = command.arguments
+
+    Command((args.take(1) ++ (flag +: args.drop(1)))*)

--- a/lib/vivisection/src/core/vivisection.Debugger.scala
+++ b/lib/vivisection/src/core/vivisection.Debugger.scala
@@ -35,10 +35,15 @@ package vivisection
 import anticipation.*
 import fulminate.*
 import proscenium.*
+import urticose.*
 
-// The failures a debug session can raise: a transport-level fault local to the debugger, or a JDWP
-// error code returned by the debuggee VM in reply to a command.
+// An attach target: a debuggee JVM already listening for a JDWP connection on a TCP endpoint. The
+// `Sessional` that connects, exchanges the handshake and lends a `Debug` is still to come — opening
+// the duplex from within a lent session runs into the capture-checking shape the coaxial TCP
+// `Connectable` given imposes. Its companion carries the session error type.
 object Debugger:
+  def apply(endpoint: Endpoint[TcpPort]): Debugger = new Debugger(endpoint)
+
   object Error:
     object Reason:
       // Hand-written rather than derived: an unrecognized code becomes `Other`, so decoding a
@@ -130,3 +135,5 @@ object Debugger:
 
   case class Error(reason: Error.Reason, detail: Text)(using Diagnostics)
   extends fulminate.Error(601, reason.number)(m"the JDWP action failed because $reason: $detail")
+
+class Debugger(val endpoint: Endpoint[TcpPort])

--- a/lib/vivisection/src/core/vivisection.Debugger.scala
+++ b/lib/vivisection/src/core/vivisection.Debugger.scala
@@ -1,0 +1,131 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package vivisection
+
+import anticipation.*
+import fulminate.*
+import proscenium.*
+
+// The failures a debug session can raise: a transport-level fault local to the debugger, or a JDWP
+// error code returned by the debuggee VM in reply to a command.
+object Debugger:
+  object Error:
+    object Reason:
+      // Hand-written rather than derived: an unrecognized code becomes `Other`, so decoding a
+      // reply's error code is total and the number the VM sent is never lost. `Disconnected`
+      // carries −1 because it originates here, not from the VM.
+      def apply(code: Int): Reason = code match
+        case 10    => InvalidThread
+        case 11    => InvalidThreadGroup
+        case 13    => ThreadNotSuspended
+        case 14    => ThreadSuspended
+        case 20    => InvalidObject
+        case 21    => InvalidClass
+        case 22    => ClassNotPrepared
+        case 23    => InvalidMethod
+        case 24    => InvalidLocation
+        case 25    => InvalidField
+        case 30    => InvalidFrame
+        case 31    => NoMoreFrames
+        case 32    => OpaqueFrame
+        case 34    => TypeMismatch
+        case 35    => InvalidSlot
+        case 41    => NotFound
+        case 99    => NotImplemented
+        case 100   => NullPointer
+        case 101   => AbsentInformation
+        case 102   => InvalidEventType
+        case 103   => IllegalArgument
+        case 112   => VmDead
+        case 113   => Internal
+        case 502   => AlreadyInvoking
+        case code0 => Other(code0)
+
+    given communicable: Reason is Communicable =
+      case Reason.InvalidThread      => m"the thread identifier was invalid"
+      case Reason.InvalidThreadGroup => m"the thread-group identifier was invalid"
+      case Reason.ThreadNotSuspended => m"the thread was not suspended"
+      case Reason.ThreadSuspended    => m"the thread was already suspended"
+      case Reason.InvalidObject      => m"the object identifier was invalid"
+      case Reason.InvalidClass       => m"the class identifier was invalid"
+      case Reason.ClassNotPrepared   => m"the class had not been prepared"
+      case Reason.InvalidMethod      => m"the method identifier was invalid"
+      case Reason.InvalidLocation    => m"the location was invalid"
+      case Reason.InvalidField       => m"the field identifier was invalid"
+      case Reason.InvalidFrame       => m"the frame identifier was invalid"
+      case Reason.NoMoreFrames       => m"there were no more frames on the stack"
+      case Reason.OpaqueFrame        => m"the frame was opaque (native)"
+      case Reason.TypeMismatch       => m"the value did not match the expected type"
+      case Reason.InvalidSlot        => m"the local-variable slot was invalid"
+      case Reason.NotFound           => m"the requested item was not found"
+      case Reason.NotImplemented     => m"the VM does not implement this command"
+      case Reason.NullPointer        => m"a null pointer was encountered"
+      case Reason.AbsentInformation  => m"the debug information was absent"
+      case Reason.InvalidEventType   => m"the event type was invalid"
+      case Reason.IllegalArgument    => m"an argument was illegal"
+      case Reason.VmDead             => m"the virtual machine had died"
+      case Reason.Internal           => m"the virtual machine reported an internal error"
+      case Reason.AlreadyInvoking    => m"a method was already being invoked on the thread"
+      case Reason.Disconnected       => m"the connection to the debuggee was lost"
+      case Reason.Other(code0)       => m"the VM reported error code $code0"
+
+    enum Reason(val number: Int) extends Clarification:
+      case InvalidThread extends Reason(10)
+      case InvalidThreadGroup extends Reason(11)
+      case ThreadNotSuspended extends Reason(13)
+      case ThreadSuspended extends Reason(14)
+      case InvalidObject extends Reason(20)
+      case InvalidClass extends Reason(21)
+      case ClassNotPrepared extends Reason(22)
+      case InvalidMethod extends Reason(23)
+      case InvalidLocation extends Reason(24)
+      case InvalidField extends Reason(25)
+      case InvalidFrame extends Reason(30)
+      case NoMoreFrames extends Reason(31)
+      case OpaqueFrame extends Reason(32)
+      case TypeMismatch extends Reason(34)
+      case InvalidSlot extends Reason(35)
+      case NotFound extends Reason(41)
+      case NotImplemented extends Reason(99)
+      case NullPointer extends Reason(100)
+      case AbsentInformation extends Reason(101)
+      case InvalidEventType extends Reason(102)
+      case IllegalArgument extends Reason(103)
+      case VmDead extends Reason(112)
+      case Internal extends Reason(113)
+      case AlreadyInvoking extends Reason(502)
+      case Disconnected extends Reason(-1)
+      case Other(code0: Int) extends Reason(code0)
+
+  case class Error(reason: Error.Reason, detail: Text)(using Diagnostics)
+  extends fulminate.Error(601, reason.number)(m"the JDWP action failed because $reason: $detail")

--- a/lib/vivisection/src/core/vivisection.Debugger.scala
+++ b/lib/vivisection/src/core/vivisection.Debugger.scala
@@ -69,6 +69,7 @@ object Debugger:
         case 112   => VmDead
         case 113   => Internal
         case 502   => AlreadyInvoking
+        case -1    => Disconnected
         case code0 => Other(code0)
 
     given communicable: Reason is Communicable =

--- a/lib/vivisection/src/core/vivisection.Debugger.scala
+++ b/lib/vivisection/src/core/vivisection.Debugger.scala
@@ -32,17 +32,53 @@
                                                                                                   */
 package vivisection
 
-import anticipation.*
-import fulminate.*
-import proscenium.*
-import urticose.*
+import scala.caps
 
-// An attach target: a debuggee JVM already listening for a JDWP connection on a TCP endpoint. The
-// `Sessional` that connects, exchanges the handshake and lends a `Debug` is still to come — opening
-// the duplex from within a lent session runs into the capture-checking shape the coaxial TCP
-// `Connectable` given imposes. Its companion carries the session error type.
+import anticipation.*
+import coaxial.*
+import contingency.*
+import fulminate.*
+import parasite.*
+import proscenium.*
+import spectacular.*
+
+// An attach target: a debuggee JVM already listening for a JDWP connection, wrapping a connectable
+// endpoint (typically an `Endpoint[TcpPort]`). `target.session { debug ?=> … }` connects, exchanges
+// the handshake, negotiates identifier sizes, and lends a `Debug` for the block. Its companion
+// carries the session error type.
 object Debugger:
-  def apply(endpoint: Endpoint[TcpPort]): Debugger = new Debugger(endpoint)
+  def apply[endpoint](endpoint: endpoint): Debugger[endpoint] = new Debugger(endpoint)
+
+  // Generic over the connectable endpoint, so the socket `Connectable` is resolved at the caller's
+  // site through the context bound — the only shape whose capture set lines up with `.duplex`. (A
+  // `Connectable` captured as a field, rebuilt from a captured `Online`, does not: the `Online`
+  // cannot flow into the empty capture set `.duplex` requires.)
+  class Sessional[endpoint: {Connectable, Showable}]
+    ( using monitor:    Monitor,
+            probate:    Probate,
+            asyncError: Tactic[Async.Error],
+            loggable:   (SocketEvent is Loggable)^,
+            tactic:     Tactic[Error],
+            note:       Diagnostics )
+  extends aperture.Sessional:
+    type Self = Debugger[endpoint]
+    type Result = Debug^
+
+    def session[result](target: Debugger[endpoint])(lambda: (session: Debug^) ?=> result)
+    :   result =
+
+      target.endpoint.duplex: duplex =>
+        Jdwp.Connection.exchange(duplex): connection => lambda(using new Debug(connection))
+
+  given sessional: [endpoint: {Connectable, Showable}]
+  =>  ( monitor:    Monitor,
+        probate:    Probate,
+        asyncError: Tactic[Async.Error],
+        loggable:   (SocketEvent is Loggable)^,
+        tactic:     Tactic[Error],
+        note:       Diagnostics )
+  =>  ( Sessional[endpoint]^{monitor, asyncError, loggable, tactic, caps.any} ) =
+    Sessional[endpoint]()
 
   object Error:
     object Reason:
@@ -136,4 +172,4 @@ object Debugger:
   case class Error(reason: Error.Reason, detail: Text)(using Diagnostics)
   extends fulminate.Error(601, reason.number)(m"the JDWP action failed because $reason: $detail")
 
-class Debugger(val endpoint: Endpoint[TcpPort])
+class Debugger[endpoint](val endpoint: endpoint)

--- a/lib/vivisection/src/core/vivisection.Jdwp.scala
+++ b/lib/vivisection/src/core/vivisection.Jdwp.scala
@@ -35,10 +35,22 @@ package vivisection
 import java.io as ji
 import java.lang as jl
 import java.nio.charset as jnc
+import java.util.concurrent.atomic as juca
+
+import scala.caps
+import scala.collection.concurrent as scc
 
 import anticipation.*
+import coaxial.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import parasite.*
 import proscenium.*
 import spectacular.*
+import turbulence.*
+import vacuous.*
+import zephyrine.*
 
 // A Scala-native model of the Java Debug Wire Protocol (JDWP). The names mirror the specification's
 // so that this file can be read against it: command sets and commands keep their published numbers,
@@ -457,6 +469,10 @@ object Jdwp:
         case Modifier.Step(thread, size, depth) =>
           threadId(thread).int(size.id).int(depth.id)
 
+    def bytes(data: Data): Writer =
+      out.write(Array.unsafeJvm(data))
+      this
+
     def data: Data = Array.unsafeFrozen(out.toByteArray.nn)
 
   // The events a suspended (or running) VM sends back, decoded from a Composite command. Only the
@@ -530,3 +546,193 @@ object Jdwp:
         signature: Text, status: Int)
 
     case Unknown(kind: Int, request: Int)
+
+  // A complete JDWP packet. The 4-byte length prefix counts the whole packet, header included; the
+  // `flags` high bit marks a reply, which carries a 2-byte error code where a command carries a
+  // 1-byte command set and a 1-byte command.
+  object Packet:
+    val headerLength: Int = 11
+
+    private def payload(bytes: Data): Data =
+      val length = bytes.length - headerLength
+      val array = Array.scratch[Byte](length)
+      var index = 0
+
+      while index < length do
+        array(index) = bytes.readUnchecked(headerLength + index)
+        index += 1
+
+      Array.unsafeFrozen(array)
+
+    // Frames an outgoing command packet.
+    def command(id: Int, set: Int, command: Int, body: Data): Data =
+      val writer = Writer(IdSizes.bootstrap)
+      writer.int(headerLength + body.length)
+      writer.int(id)
+      writer.byte(0)
+      writer.byte(set.toByte)
+      writer.byte(command.toByte)
+      writer.bytes(body)
+      writer.data
+
+    // Frames a reply packet (used by the test harness's fake VM). A non-zero `code` is an error.
+    def reply(id: Int, code: Int, body: Data): Data =
+      val writer = Writer(IdSizes.bootstrap)
+      writer.int(headerLength + body.length)
+      writer.int(id)
+      writer.byte(0x80.toByte)
+      writer.short(code.toShort)
+      writer.bytes(body)
+      writer.data
+
+    // Decodes one complete packet (exactly its own `length` bytes).
+    def decode(bytes: Data): Packet =
+      val reader = Reader(bytes, IdSizes.bootstrap)
+      reader.int()
+      val id = reader.int()
+      val flags = reader.byte() & 0xff
+      val body = payload(bytes)
+
+      if (flags & 0x80) != 0 then Packet(id, flags, reader.short() & 0xffff, 0, 0, body)
+      else Packet(id, flags, 0, reader.byte() & 0xff, reader.byte() & 0xff, body)
+
+  case class Packet(id: Int, flags: Int, code: Int, commandSet: Int, command: Int, body: Data):
+    def reply: Boolean = (flags & 0x80) != 0
+
+  // A live JDWP connection: the wire-level client that frames and correlates packets over a duplex
+  // byte channel. Not itself the debug session capability — `Debug` owns one of these — but sealed
+  // (`ExclusiveCapability`) so it cannot be shared past the session it serves. The reader task only
+  // fulfils promises and enqueues composites; command handlers run elsewhere, so a handler issuing
+  // a further command never blocks the reader that must deliver its reply.
+  object Connection:
+    // The outcome of a command, as a dedicated type rather than an `Either[Int, Data]`: a `Left`
+    // with `Nothing` in the payload slot flows into the mutable-classified `Data` position and
+    // crashes the fork's read-only capture adaptation, so the reply channel avoids it entirely.
+    enum Reply:
+      case Ok(data: Data)
+      case Failed(code: Int)
+
+    // Reads a big-endian 32-bit integer from a raw byte array at the given offset.
+    private def int32(bytes: scala.Array[Byte], offset: Int): Int =
+      ((bytes(offset) & 0xff) << 24) | ((bytes(offset + 1) & 0xff) << 16) |
+        ((bytes(offset + 2) & 0xff) << 8) | (bytes(offset + 3) & 0xff)
+
+    // Opens a connection over an already-connected duplex: exchanges the handshake, starts the
+    // writer and reader pumps, negotiates identifier sizes, lends the connection, and tears
+    // everything down afterwards. Modelled on `exegesis.LspSessional.exchange`.
+    private[vivisection] def exchange[result](duplex: Duplex)(lambda: Connection => result)
+      ( using monitor: Monitor, probate: Probate, diagnostics: Diagnostics )
+      ( using Tactic[Debugger.Error] )
+    :   result =
+
+      duplex.send(Stream(Jdwp.Handshake))
+
+      // Sealed: the connection captures this session's monitor and diagnostics, which an honest
+      // `Connection^` would hide from the pumps that serve it. It is a local of this method, lent
+      // to `lambda` and dead once `lambda` returns.
+      val connection: Connection = caps.unsafe.unsafeAssumePure(Connection(diagnostics))
+
+      // A single writer drains outgoing packets so writes never interleave.
+      val writer: Task[Unit] = async:
+        connection.outgoing.lazyList.stdlib.foreach: packet => duplex.send(Stream(packet))
+
+      // The reader owns the read side: it is minted and consumed here, which also keeps the caller
+      // thread off the channel's first (blocking) refill before the writer has started.
+      val reader: Task[Unit] = async:
+        val source = duplex.source
+        val accumulator = ji.ByteArrayOutputStream()
+        var handshaken = false
+
+        source.toProgression.stdlib.iterator.foreach: chunk =>
+          accumulator.write(Array.unsafeJvm(chunk))
+          val bytes = accumulator.toByteArray.nn
+          var offset = 0
+          var advancing = true
+
+          while advancing do
+            advancing = false
+
+            if !handshaken then
+              if bytes.length - offset >= Jdwp.Handshake.length then
+                offset += Jdwp.Handshake.length
+                handshaken = true
+                advancing = true
+            else if bytes.length - offset >= Packet.headerLength then
+              val length = int32(bytes, offset)
+
+              if length >= Packet.headerLength && bytes.length - offset >= length then
+                val packet = Array.scratch[Byte](length)
+                java.lang.System.arraycopy(bytes, offset, packet, 0, length)
+                connection.dispatch(Packet.decode(Array.unsafeFrozen(packet)))
+                offset += length
+                advancing = true
+
+          accumulator.reset()
+          accumulator.write(bytes, offset, bytes.length - offset)
+
+        connection.disconnect()
+
+      try
+        connection.negotiate()
+        lambda(connection)
+      finally
+        reader.cancel()
+        writer.cancel()
+
+  class Connection private[vivisection] (note: Diagnostics) extends caps.ExclusiveCapability:
+    private val counter: juca.AtomicInteger = juca.AtomicInteger(0)
+    private val pending: scc.TrieMap[Int, Promise[Connection.Reply]] = scc.TrieMap()
+    private[vivisection] val outgoing: Relay[Data] = Relay()
+    private[vivisection] val composites: Relay[Event.Composite] = Relay()
+
+    @scala.caps.unsafe.untrackedCaptures
+    private var sizes0: IdSizes = IdSizes.bootstrap
+
+    def sizes: IdSizes = sizes0
+
+    // Routes a decoded packet: a reply fulfils its pending promise (with the error code, or the
+    // payload); a Composite command (command set 64, command 100) is enqueued for the dispatcher.
+    private[vivisection] def dispatch(packet: Packet): Unit =
+      if packet.reply then pending.remove(packet.id).foreach: promise =>
+        promise.offer:
+          if packet.code != 0 then Connection.Reply.Failed(packet.code)
+          else Connection.Reply.Ok(packet.body)
+      else if packet.commandSet == 64 && packet.command == 100 then
+        composites.put(Event.composite(Reader(packet.body, sizes0)))
+
+    // Fails every in-flight request and ends the event stream when the channel closes.
+    private[vivisection] def disconnect(): Unit =
+      pending.values.foreach(_.offer(Connection.Reply.Failed(-1)))
+      pending.clear()
+      composites.stop()
+
+    // The one seam every command goes through: allocate an id, frame the request, await the reply,
+    // and hand back a reader over its payload (raising the VM's error code on failure).
+    def request(set: Int, command: Int)(write: Writer => Unit)
+      ( using Tactic[Debugger.Error], Monitor )
+    :   Reader =
+
+      val id = counter.getAndIncrement()
+      val writer = Writer(sizes0)
+      write(writer)
+      val promise = Promise[Connection.Reply]()
+      pending(id) = promise
+      outgoing.put(Packet.command(id, set, command, writer.data))
+
+      given Diagnostics = note
+
+      // A cancelled or interrupted await is reported as a lost connection (code −1). An error is
+      // raised recoverably, then an empty reader returned, so no `Nothing`-typed expression reaches
+      // the reply position.
+      safely(promise.await()).or(Connection.Reply.Failed(-1)) match
+        case Connection.Reply.Ok(data) =>
+          Reader(data, sizes0)
+
+        case Connection.Reply.Failed(code) =>
+          raise(Debugger.Error(Debugger.Error.Reason(code), t"command ($set, $command)"))
+          Reader(Array.empty[Byte], sizes0)
+
+    // VirtualMachine (command set 1): negotiate the identifier sizes the rest of the session needs.
+    private[vivisection] def negotiate()(using Tactic[Debugger.Error], Monitor): Unit =
+      val reader = request(1, 7)(_ => ())
+      sizes0 = IdSizes(reader.int(), reader.int(), reader.int(), reader.int(), reader.int())

--- a/lib/vivisection/src/core/vivisection.Jdwp.scala
+++ b/lib/vivisection/src/core/vivisection.Jdwp.scala
@@ -1,0 +1,459 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package vivisection
+
+import java.io as ji
+import java.lang as jl
+import java.nio.charset as jnc
+
+import anticipation.*
+import proscenium.*
+import spectacular.*
+
+// A Scala-native model of the Java Debug Wire Protocol (JDWP). The names mirror the specification's
+// so that this file can be read against it: command sets and commands keep their published numbers,
+// event and error kinds keep their published names, and the identifier types keep the sizes the VM
+// negotiates. Nothing here touches a socket — `Jdwp.Reader` and `Jdwp.Writer` marshal to and from a
+// materialised `Data` payload, and `Jdwp.Connection` (elsewhere) frames and correlates packets.
+object Jdwp:
+  // The 14 bytes each end sends, and expects back, before any packet flows.
+  val Handshake: Data =
+    Array.unsafeFrozen("JDWP-Handshake".getBytes(jnc.StandardCharsets.US_ASCII).nn)
+
+  // Every JDWP identifier is an integer that fits a `Long`, but the wire width of each *kind* of
+  // identifier is negotiated per connection (`VirtualMachine.IDSizes`). `Ref` is one opaque
+  // integer tagged by a phantom kind, so a `ThreadId` can never be passed where a `FieldId` is
+  // wanted, while a `ThreadId` still widens to an `ObjectId` (a thread *is* an object in JDWP).
+  opaque type Ref[+kind <: Ref.Kind] = Long
+
+  object Ref:
+    sealed trait Kind
+    sealed trait Object extends Kind
+    sealed trait Thread extends Object
+    sealed trait Group extends Object
+    sealed trait Str extends Object
+    sealed trait Loader extends Object
+    sealed trait Type extends Kind
+    sealed trait Method extends Kind
+    sealed trait Field extends Kind
+    sealed trait Frame extends Kind
+
+    def apply[kind <: Kind](long: Long): Ref[kind] = long
+
+    // The JDWP null object: identifier zero. `absent` tests for it.
+    def empty[kind <: Kind]: Ref[kind] = 0L
+
+    given showable: [kind <: Kind] => Ref[kind] is Showable = ref => ref.long.show
+
+    given equality: [kind <: Kind] => CanEqual[Ref[kind], Ref[kind]] = CanEqual.derived
+
+  extension [kind <: Ref.Kind](ref: Ref[kind])
+    def long: Long = ref
+    def absent: Boolean = ref == 0L
+
+  // The five negotiated identifier widths, in bytes (each 1..8). `objectId` also sizes strings,
+  // threads, thread groups, class loaders, class objects and arrays; `referenceTypeId` sizes
+  // class, interface and array-type identifiers.
+  object IdSizes:
+    // Used only to decode the fixed-layout IDSizes reply itself, which carries no identifiers.
+    val bootstrap: IdSizes = IdSizes(8, 8, 8, 8, 8)
+
+  case class IdSizes(field: Int, method: Int, objectId: Int, referenceType: Int, frame: Int)
+
+  // A byte tag classifying a reference type as a class, interface or array.
+  object TypeTag:
+    def apply(id: Byte): TypeTag = id match
+      case 1 => Class
+      case 2 => Interface
+      case 3 => Array
+      case _ => Class
+
+  enum TypeTag(val id: Byte):
+    case Class     extends TypeTag(1)
+    case Interface extends TypeTag(2)
+    case Array     extends TypeTag(3)
+
+  // How much of the VM to suspend when an event fires.
+  object SuspendPolicy:
+    def apply(id: Byte): SuspendPolicy = id match
+      case 0 => None
+      case 1 => EventThread
+      case 2 => All
+      case _ => None
+
+  enum SuspendPolicy(val id: Byte):
+    case None        extends SuspendPolicy(0)
+    case EventThread extends SuspendPolicy(1)
+    case All         extends SuspendPolicy(2)
+
+  // The kinds of event a request may ask for, and that a composite event reports.
+  object EventKind:
+    def apply(id: Int): EventKind = id match
+      case 1   => SingleStep
+      case 2   => Breakpoint
+      case 3   => FramePop
+      case 4   => Exception
+      case 5   => UserDefined
+      case 6   => ThreadStart
+      case 7   => ThreadDeath
+      case 8   => ClassPrepare
+      case 9   => ClassUnload
+      case 10  => ClassLoad
+      case 20  => FieldAccess
+      case 21  => FieldModified
+      case 40  => MethodEntry
+      case 41  => MethodExit
+      case 90  => VmStart
+      case 99  => VmDeath
+      case id0 => Other(id0)
+
+  enum EventKind(val id: Int):
+    case SingleStep    extends EventKind(1)
+    case Breakpoint    extends EventKind(2)
+    case FramePop      extends EventKind(3)
+    case Exception     extends EventKind(4)
+    case UserDefined   extends EventKind(5)
+    case ThreadStart   extends EventKind(6)
+    case ThreadDeath   extends EventKind(7)
+    case ClassPrepare  extends EventKind(8)
+    case ClassUnload   extends EventKind(9)
+    case ClassLoad     extends EventKind(10)
+    case FieldAccess   extends EventKind(20)
+    case FieldModified extends EventKind(21)
+    case MethodEntry   extends EventKind(40)
+    case MethodExit    extends EventKind(41)
+    case VmStart       extends EventKind(90)
+    case VmDeath       extends EventKind(99)
+    case Other(id0: Int) extends EventKind(id0)
+
+  // The direction and grain of a single-step request.
+  enum StepDepth(val id: Int):
+    case Into extends StepDepth(0)
+    case Over extends StepDepth(1)
+    case Out  extends StepDepth(2)
+
+  enum StepSize(val id: Int):
+    case Min  extends StepSize(0)
+    case Line extends StepSize(1)
+
+  // A tag byte identifying the runtime type of a value on the wire.
+  object Tag:
+    def apply(id: Char): Tag = id match
+      case '[' => ArrayTag
+      case 'B' => ByteTag
+      case 'C' => CharTag
+      case 'L' => ObjectTag
+      case 'F' => FloatTag
+      case 'D' => DoubleTag
+      case 'I' => IntTag
+      case 'J' => LongTag
+      case 'S' => ShortTag
+      case 'V' => VoidTag
+      case 'Z' => BooleanTag
+      case 's' => StringTag
+      case 't' => ThreadTag
+      case 'g' => GroupTag
+      case 'l' => LoaderTag
+      case 'c' => ClassTag0
+      case _   => ObjectTag
+
+    // The tags whose wire payload is an objectID rather than an inline primitive.
+    def isObject(tag: Tag): Boolean = tag match
+      case ArrayTag | ObjectTag | StringTag | ThreadTag | GroupTag | LoaderTag | ClassTag0 => true
+      case _                                                                               => false
+
+  enum Tag(val id: Char):
+    case ArrayTag   extends Tag('[')
+    case ByteTag    extends Tag('B')
+    case CharTag    extends Tag('C')
+    case ObjectTag  extends Tag('L')
+    case FloatTag   extends Tag('F')
+    case DoubleTag  extends Tag('D')
+    case IntTag     extends Tag('I')
+    case LongTag    extends Tag('J')
+    case ShortTag   extends Tag('S')
+    case VoidTag    extends Tag('V')
+    case BooleanTag extends Tag('Z')
+    case StringTag  extends Tag('s')
+    case ThreadTag  extends Tag('t')
+    case GroupTag   extends Tag('g')
+    case LoaderTag  extends Tag('l')
+    case ClassTag0  extends Tag('c')
+
+  // An executable location: a reference type, one of its methods, and a code index within it.
+  case class Location(tag: TypeTag, cls: ReferenceTypeId, method: MethodId, index: Long)
+
+  // A tagged value read from or written to a frame slot, field, or array. Primitives are decoded
+  // eagerly; references stay as identifiers for the semantics layer to interpret.
+  enum Value:
+    case OfByte(byte: Byte)
+    case OfChar(char: Char)
+    case OfDouble(double: Double)
+    case OfFloat(float: Float)
+    case OfInt(int: Int)
+    case OfLong(long: Long)
+    case OfShort(short: Short)
+    case OfBoolean(boolean: Boolean)
+    case Reference(tag: Tag, id: ObjectId)
+    case Void
+
+  // The modifiers that constrain an event request. The trailing number is the JDWP modkind.
+  enum Modifier(val kind: Byte):
+    case Count(count: Int) extends Modifier(1)
+    case ThreadOnly(thread: ThreadId) extends Modifier(3)
+    case ClassOnly(cls: ReferenceTypeId) extends Modifier(4)
+    case ClassMatch(pattern: Text) extends Modifier(5)
+    case ClassExclude(pattern: Text) extends Modifier(6)
+    case LocationOnly(location: Location) extends Modifier(7)
+    case ExceptionOnly(cls: ReferenceTypeId, caught: Boolean, uncaught: Boolean) extends Modifier(8)
+    case Step(thread: ThreadId, size: StepSize, depth: StepDepth) extends Modifier(10)
+    case SourceNameMatch(pattern: Text) extends Modifier(12)
+
+  // Selected reply structures, decoded by the command methods on `Jdwp.Connection`.
+  case class Version(description: Text, major: Int, minor: Int, vmVersion: Text, vmName: Text)
+  case class ClassInfo(tag: TypeTag, cls: ReferenceTypeId, signature: Text, status: Int)
+  case class MethodInfo(method: MethodId, name: Text, signature: Text, modifiers: Int)
+  case class LineEntry(index: Long, line: Int)
+  case class LineTable(start: Long, end: Long, lines: List[LineEntry])
+  case class SlotInfo(index: Long, name: Text, signature: Text, length: Int, slot: Int)
+  case class VariableTable(argCount: Int, slots: List[SlotInfo])
+
+  // The capabilities a VM advertises (`VirtualMachine.CapabilitiesNew`); only the flags this
+  // library consults are named, the rest are carried positionally as needed.
+  case class Capabilities(canGetSourceDebugExtension: Boolean, canUseSourceNameFilters: Boolean)
+
+  // JDWP strings are JNI *modified* UTF-8: the null character is `C0 80`, and characters outside
+  // the basic multilingual plane arrive as two three-byte sequences (a surrogate pair), which we
+  // pass through as the two chars they encode. A strict UTF-8 decoder would reject both forms.
+  private[vivisection] def decodeModifiedUtf8(bytes: Data, offset: Int, length: Int): Text =
+    val builder = jl.StringBuilder()
+    var index = offset
+    val end = offset + length
+
+    while index < end do
+      val first = bytes.readUnchecked(index) & 0xff
+
+      if first < 0x80 then
+        builder.append(first.toChar)
+        index += 1
+      else if (first & 0xe0) == 0xc0 then
+        val second = bytes.readUnchecked(index + 1) & 0xff
+        builder.append((((first & 0x1f) << 6) | (second & 0x3f)).toChar)
+        index += 2
+      else
+        val second = bytes.readUnchecked(index + 1) & 0xff
+        val third = bytes.readUnchecked(index + 2) & 0xff
+        builder.append((((first & 0x0f) << 12) | ((second & 0x3f) << 6) | (third & 0x3f)).toChar)
+        index += 3
+
+    builder.toString.nn.tt
+
+  private[vivisection] def encodeModifiedUtf8(text: Text): scala.Array[Byte] =
+    val string = text.s
+    val buffer = ji.ByteArrayOutputStream()
+    var index = 0
+
+    while index < string.length do
+      val char = string.charAt(index).toInt
+
+      if char >= 0x01 && char <= 0x7f then buffer.write(char)
+      else if char <= 0x7ff then
+        buffer.write(0xc0 | (char >> 6))
+        buffer.write(0x80 | (char & 0x3f))
+      else
+        buffer.write(0xe0 | (char >> 12))
+        buffer.write(0x80 | ((char >> 6) & 0x3f))
+        buffer.write(0x80 | (char & 0x3f))
+
+      index += 1
+
+    buffer.toByteArray.nn
+
+  // Decodes a JDWP packet payload. Big-endian throughout; identifier reads consult the negotiated
+  // `sizes`. Stateful and single-threaded — one reader decodes one reply or one event, in order.
+  class Reader(data: Data, sizes: IdSizes) extends scala.caps.Mutable:
+    private var position: Int = 0
+
+    def remaining: Int = data.length - position
+
+    private update def next(): Int =
+      val byte = data.readUnchecked(position) & 0xff
+      position += 1
+      byte
+
+    update def byte(): Byte = next().toByte
+    update def boolean(): Boolean = next() != 0
+    update def short(): Short = ((next() << 8) | next()).toShort
+    update def char(): Char = ((next() << 8) | next()).toChar
+    update def int(): Int = (next() << 24) | (next() << 16) | (next() << 8) | next()
+    update def long(): Long = (int().toLong << 32) | (int().toLong & 0xffffffffL)
+    update def float(): Float = jl.Float.intBitsToFloat(int())
+    update def double(): Double = jl.Double.longBitsToDouble(long())
+
+    update def id(width: Int): Long =
+      var accumulator = 0L
+      var count = 0
+
+      while count < width do
+        accumulator = (accumulator << 8) | next().toLong
+        count += 1
+
+      accumulator
+
+    update def objectId(): ObjectId = Ref(id(sizes.objectId))
+    update def threadId(): ThreadId = Ref(id(sizes.objectId))
+    update def threadGroupId(): ThreadGroupId = Ref(id(sizes.objectId))
+    update def stringId(): StringId = Ref(id(sizes.objectId))
+    update def classLoaderId(): ClassLoaderId = Ref(id(sizes.objectId))
+    update def referenceTypeId(): ReferenceTypeId = Ref(id(sizes.referenceType))
+    update def methodId(): MethodId = Ref(id(sizes.method))
+    update def fieldId(): FieldId = Ref(id(sizes.field))
+    update def frameId(): FrameId = Ref(id(sizes.frame))
+
+    update def string(): Text =
+      val length = int()
+      val text = Jdwp.decodeModifiedUtf8(data, position, length)
+      position += length
+      text
+
+    update def location(): Location =
+      Location(TypeTag(byte()), referenceTypeId(), methodId(), long())
+
+    update def value(): Value = untaggedValue(Tag(next().toChar))
+
+    update def untaggedValue(tag: Tag): Value = tag match
+      case Tag.ByteTag    => Value.OfByte(byte())
+      case Tag.CharTag    => Value.OfChar(char())
+      case Tag.DoubleTag  => Value.OfDouble(double())
+      case Tag.FloatTag   => Value.OfFloat(float())
+      case Tag.IntTag     => Value.OfInt(int())
+      case Tag.LongTag    => Value.OfLong(long())
+      case Tag.ShortTag   => Value.OfShort(short())
+      case Tag.BooleanTag => Value.OfBoolean(boolean())
+      case Tag.VoidTag    => Value.Void
+      case reference      => Value.Reference(reference, objectId())
+
+  // Marshals a JDWP packet payload. Fluent: each write returns the writer. `data` snapshots the
+  // accumulated bytes.
+  class Writer(sizes: IdSizes):
+    private val out = ji.ByteArrayOutputStream()
+
+    def byte(value: Byte): Writer = { out.write(value.toInt & 0xff); this }
+    def boolean(value: Boolean): Writer = byte(if value then 1 else 0)
+
+    def short(value: Short): Writer =
+      out.write((value >> 8) & 0xff)
+      out.write(value & 0xff)
+      this
+
+    def char(value: Char): Writer =
+      out.write((value >> 8) & 0xff)
+      out.write(value & 0xff)
+      this
+
+    def int(value: Int): Writer =
+      out.write((value >> 24) & 0xff)
+      out.write((value >> 16) & 0xff)
+      out.write((value >> 8) & 0xff)
+      out.write(value & 0xff)
+      this
+
+    def long(value: Long): Writer =
+      int((value >>> 32).toInt)
+      int(value.toInt)
+
+    def float(value: Float): Writer = int(jl.Float.floatToIntBits(value))
+    def double(value: Double): Writer = long(jl.Double.doubleToLongBits(value))
+
+    def id(width: Int, value: Long): Writer =
+      var shift = (width - 1)*8
+
+      while shift >= 0 do
+        out.write(((value >>> shift) & 0xff).toInt)
+        shift -= 8
+
+      this
+
+    def objectId(ref: ObjectId): Writer = id(sizes.objectId, ref.long)
+    def threadId(ref: ThreadId): Writer = id(sizes.objectId, ref.long)
+    def threadGroupId(ref: ThreadGroupId): Writer = id(sizes.objectId, ref.long)
+    def stringId(ref: StringId): Writer = id(sizes.objectId, ref.long)
+    def classLoaderId(ref: ClassLoaderId): Writer = id(sizes.objectId, ref.long)
+    def referenceTypeId(ref: ReferenceTypeId): Writer = id(sizes.referenceType, ref.long)
+    def methodId(ref: MethodId): Writer = id(sizes.method, ref.long)
+    def fieldId(ref: FieldId): Writer = id(sizes.field, ref.long)
+    def frameId(ref: FrameId): Writer = id(sizes.frame, ref.long)
+
+    def string(text: Text): Writer =
+      val encoded = Jdwp.encodeModifiedUtf8(text)
+      int(encoded.length)
+      out.write(encoded)
+      this
+
+    def location(location: Location): Writer =
+      byte(location.tag.id)
+      referenceTypeId(location.cls)
+      methodId(location.method)
+      long(location.index)
+
+    def value(value: Value): Writer = value match
+      case Value.OfByte(byte0)       => byte(Tag.ByteTag.id.toByte).byte(byte0)
+      case Value.OfChar(char0)       => byte(Tag.CharTag.id.toByte).char(char0)
+      case Value.OfDouble(double0)   => byte(Tag.DoubleTag.id.toByte).double(double0)
+      case Value.OfFloat(float0)     => byte(Tag.FloatTag.id.toByte).float(float0)
+      case Value.OfInt(int0)         => byte(Tag.IntTag.id.toByte).int(int0)
+      case Value.OfLong(long0)       => byte(Tag.LongTag.id.toByte).long(long0)
+      case Value.OfShort(short0)     => byte(Tag.ShortTag.id.toByte).short(short0)
+      case Value.OfBoolean(boolean0) => byte(Tag.BooleanTag.id.toByte).boolean(boolean0)
+      case Value.Void                => byte(Tag.VoidTag.id.toByte)
+      case Value.Reference(tag, id0) => byte(tag.id.toByte).objectId(id0)
+
+    def modifier(modifier: Modifier): Writer =
+      byte(modifier.kind)
+
+      modifier match
+        case Modifier.Count(count)          => int(count)
+        case Modifier.ThreadOnly(thread)    => threadId(thread)
+        case Modifier.ClassOnly(cls)        => referenceTypeId(cls)
+        case Modifier.ClassMatch(pattern)   => string(pattern)
+        case Modifier.ClassExclude(pattern) => string(pattern)
+        case Modifier.LocationOnly(loc)     => location(loc)
+        case Modifier.SourceNameMatch(pat)  => string(pat)
+
+        case Modifier.ExceptionOnly(cls, caught, uncaught) =>
+          referenceTypeId(cls).boolean(caught).boolean(uncaught)
+
+        case Modifier.Step(thread, size, depth) =>
+          threadId(thread).int(size.id).int(depth.id)
+
+    def data: Data = Array.unsafeFrozen(out.toByteArray.nn)

--- a/lib/vivisection/src/core/vivisection.Jdwp.scala
+++ b/lib/vivisection/src/core/vivisection.Jdwp.scala
@@ -301,26 +301,27 @@ object Jdwp:
 
   // Decodes a JDWP packet payload. Big-endian throughout; identifier reads consult the negotiated
   // `sizes`. Stateful and single-threaded — one reader decodes one reply or one event, in order.
-  class Reader(data: Data, sizes: IdSizes) extends scala.caps.Mutable:
+  class Reader(data: Data, sizes: IdSizes):
+    @scala.caps.unsafe.untrackedCaptures
     private var position: Int = 0
 
     def remaining: Int = data.length - position
 
-    private update def next(): Int =
+    private def next(): Int =
       val byte = data.readUnchecked(position) & 0xff
       position += 1
       byte
 
-    update def byte(): Byte = next().toByte
-    update def boolean(): Boolean = next() != 0
-    update def short(): Short = ((next() << 8) | next()).toShort
-    update def char(): Char = ((next() << 8) | next()).toChar
-    update def int(): Int = (next() << 24) | (next() << 16) | (next() << 8) | next()
-    update def long(): Long = (int().toLong << 32) | (int().toLong & 0xffffffffL)
-    update def float(): Float = jl.Float.intBitsToFloat(int())
-    update def double(): Double = jl.Double.longBitsToDouble(long())
+    def byte(): Byte = next().toByte
+    def boolean(): Boolean = next() != 0
+    def short(): Short = ((next() << 8) | next()).toShort
+    def char(): Char = ((next() << 8) | next()).toChar
+    def int(): Int = (next() << 24) | (next() << 16) | (next() << 8) | next()
+    def long(): Long = (int().toLong << 32) | (int().toLong & 0xffffffffL)
+    def float(): Float = jl.Float.intBitsToFloat(int())
+    def double(): Double = jl.Double.longBitsToDouble(long())
 
-    update def id(width: Int): Long =
+    def id(width: Int): Long =
       var accumulator = 0L
       var count = 0
 
@@ -330,28 +331,28 @@ object Jdwp:
 
       accumulator
 
-    update def objectId(): ObjectId = Ref(id(sizes.objectId))
-    update def threadId(): ThreadId = Ref(id(sizes.objectId))
-    update def threadGroupId(): ThreadGroupId = Ref(id(sizes.objectId))
-    update def stringId(): StringId = Ref(id(sizes.objectId))
-    update def classLoaderId(): ClassLoaderId = Ref(id(sizes.objectId))
-    update def referenceTypeId(): ReferenceTypeId = Ref(id(sizes.referenceType))
-    update def methodId(): MethodId = Ref(id(sizes.method))
-    update def fieldId(): FieldId = Ref(id(sizes.field))
-    update def frameId(): FrameId = Ref(id(sizes.frame))
+    def objectId(): ObjectId = Ref(id(sizes.objectId))
+    def threadId(): ThreadId = Ref(id(sizes.objectId))
+    def threadGroupId(): ThreadGroupId = Ref(id(sizes.objectId))
+    def stringId(): StringId = Ref(id(sizes.objectId))
+    def classLoaderId(): ClassLoaderId = Ref(id(sizes.objectId))
+    def referenceTypeId(): ReferenceTypeId = Ref(id(sizes.referenceType))
+    def methodId(): MethodId = Ref(id(sizes.method))
+    def fieldId(): FieldId = Ref(id(sizes.field))
+    def frameId(): FrameId = Ref(id(sizes.frame))
 
-    update def string(): Text =
+    def string(): Text =
       val length = int()
       val text = Jdwp.decodeModifiedUtf8(data, position, length)
       position += length
       text
 
-    update def location(): Location =
+    def location(): Location =
       Location(TypeTag(byte()), referenceTypeId(), methodId(), long())
 
-    update def value(): Value = untaggedValue(Tag(next().toChar))
+    def value(): Value = untaggedValue(Tag(next().toChar))
 
-    update def untaggedValue(tag: Tag): Value = tag match
+    def untaggedValue(tag: Tag): Value = tag match
       case Tag.ByteTag    => Value.OfByte(byte())
       case Tag.CharTag    => Value.OfChar(char())
       case Tag.DoubleTag  => Value.OfDouble(double())
@@ -457,3 +458,75 @@ object Jdwp:
           threadId(thread).int(size.id).int(depth.id)
 
     def data: Data = Array.unsafeFrozen(out.toByteArray.nn)
+
+  // The events a suspended (or running) VM sends back, decoded from a Composite command. Only the
+  // kinds this debugger requests are modelled in full; an unrecognized kind terminates decoding of
+  // the enclosing composite, since its payload length is unknown and the stream cannot be resynced
+  // within the packet (the next packet is unaffected, being length-framed).
+  object Event:
+    case class Composite(policy: SuspendPolicy, events: List[Event])
+
+    def composite(reader: Reader): Composite =
+      val policy = SuspendPolicy(reader.byte())
+      val count = reader.int()
+
+      // Builds the list in order; an unrecognized event kind ends the list, since its unknown
+      // payload length prevents locating the next event within this composite.
+      def decode(remaining: Int): List[Event] =
+        if remaining <= 0 then Nil else
+          val event = one(reader)
+
+          event match
+            case Unknown(_, _) => event :: Nil
+            case _             => event :: decode(remaining - 1)
+
+      Composite(policy, decode(count))
+
+    private def one(reader: Reader): Event =
+      val kind = EventKind(reader.byte() & 0xff)
+      val request = reader.int()
+
+      kind match
+        case EventKind.VmStart      => VmStart(request, reader.threadId())
+        case EventKind.VmDeath      => VmDeath(request)
+        case EventKind.ThreadStart  => ThreadStart(request, reader.threadId())
+        case EventKind.ThreadDeath  => ThreadDeath(request, reader.threadId())
+        case EventKind.Breakpoint   => Breakpoint(request, reader.threadId(), reader.location())
+        case EventKind.SingleStep   => SingleStep(request, reader.threadId(), reader.location())
+        case EventKind.MethodEntry  => MethodEntry(request, reader.threadId(), reader.location())
+        case EventKind.MethodExit   => MethodExit(request, reader.threadId(), reader.location())
+
+        case EventKind.Exception =>
+          val thread = reader.threadId()
+          val location = reader.location()
+          val exception = reader.objectId()
+          val catchLocation = reader.location()
+          Thrown(request, thread, location, exception, catchLocation)
+
+        case EventKind.ClassPrepare =>
+          val thread = reader.threadId()
+          val tag = TypeTag(reader.byte())
+          val cls = reader.referenceTypeId()
+          val signature = reader.string()
+          val status = reader.int()
+          ClassPrepared(request, thread, tag, cls, signature, status)
+
+        case other => Unknown(other.id, request)
+
+  enum Event:
+    case VmStart(request: Int, thread: ThreadId)
+    case VmDeath(request: Int)
+    case ThreadStart(request: Int, thread: ThreadId)
+    case ThreadDeath(request: Int, thread: ThreadId)
+    case Breakpoint(request: Int, thread: ThreadId, location: Location)
+    case SingleStep(request: Int, thread: ThreadId, location: Location)
+    case MethodEntry(request: Int, thread: ThreadId, location: Location)
+    case MethodExit(request: Int, thread: ThreadId, location: Location)
+
+    case Thrown(request: Int, thread: ThreadId, location: Location, exception: ObjectId,
+        catchLocation: Location)
+
+    case ClassPrepared(request: Int, thread: ThreadId, tag: TypeTag, cls: ReferenceTypeId,
+        signature: Text, status: Int)
+
+    case Unknown(kind: Int, request: Int)

--- a/lib/vivisection/src/core/vivisection.Jdwp.scala
+++ b/lib/vivisection/src/core/vivisection.Jdwp.scala
@@ -722,10 +722,9 @@ object Jdwp:
 
       given Diagnostics = note
 
-      // The session's monitor is passed to `await` explicitly rather than as a `given`, which would
-      // hide `this`. A cancelled or interrupted await is reported as a lost connection (code −1); an
-      // error is raised recoverably, then an empty reader returned, so no `Nothing`-typed expression
-      // reaches the reply position.
+      // The monitor is passed to `await` explicitly, not as a `given` (which would hide `this`). A
+      // cancelled await becomes a lost connection; an error is raised recoverably and an empty
+      // reader returned, so no `Nothing`-typed expression reaches the reply position.
       safely(promise.await()(using monitor)).or(Connection.Reply.Failed(-1)) match
         case Connection.Reply.Ok(data) =>
           Reader(data, sizes0)

--- a/lib/vivisection/src/core/vivisection.Jdwp.scala
+++ b/lib/vivisection/src/core/vivisection.Jdwp.scala
@@ -630,7 +630,7 @@ object Jdwp:
       // Sealed: the connection captures this session's monitor and diagnostics, which an honest
       // `Connection^` would hide from the pumps that serve it. It is a local of this method, lent
       // to `lambda` and dead once `lambda` returns.
-      val connection: Connection = caps.unsafe.unsafeAssumePure(Connection(diagnostics))
+      val connection: Connection = caps.unsafe.unsafeAssumePure(Connection(monitor, diagnostics))
 
       // A single writer drains outgoing packets so writes never interleave.
       val writer: Task[Unit] = async:
@@ -679,7 +679,8 @@ object Jdwp:
         reader.cancel()
         writer.cancel()
 
-  class Connection private[vivisection] (note: Diagnostics) extends caps.ExclusiveCapability:
+  class Connection private[vivisection] (monitor: Monitor, note: Diagnostics)
+  extends caps.ExclusiveCapability:
     private val counter: juca.AtomicInteger = juca.AtomicInteger(0)
     private val pending: scc.TrieMap[Int, Promise[Connection.Reply]] = scc.TrieMap()
     private[vivisection] val outgoing: Relay[Data] = Relay()
@@ -709,7 +710,7 @@ object Jdwp:
     // The one seam every command goes through: allocate an id, frame the request, await the reply,
     // and hand back a reader over its payload (raising the VM's error code on failure).
     def request(set: Int, command: Int)(write: Writer => Unit)
-      ( using Tactic[Debugger.Error], Monitor )
+      ( using Tactic[Debugger.Error] )
     :   Reader =
 
       val id = counter.getAndIncrement()
@@ -721,10 +722,11 @@ object Jdwp:
 
       given Diagnostics = note
 
-      // A cancelled or interrupted await is reported as a lost connection (code −1). An error is
-      // raised recoverably, then an empty reader returned, so no `Nothing`-typed expression reaches
-      // the reply position.
-      safely(promise.await()).or(Connection.Reply.Failed(-1)) match
+      // The session's monitor is passed to `await` explicitly rather than as a `given`, which would
+      // hide `this`. A cancelled or interrupted await is reported as a lost connection (code −1); an
+      // error is raised recoverably, then an empty reader returned, so no `Nothing`-typed expression
+      // reaches the reply position.
+      safely(promise.await()(using monitor)).or(Connection.Reply.Failed(-1)) match
         case Connection.Reply.Ok(data) =>
           Reader(data, sizes0)
 
@@ -733,7 +735,7 @@ object Jdwp:
           Reader(Array.empty[Byte], sizes0)
 
     // VirtualMachine (command set 1): negotiate the identifier sizes the rest of the session needs.
-    private[vivisection] def negotiate()(using Tactic[Debugger.Error], Monitor): Unit =
+    private[vivisection] def negotiate()(using Tactic[Debugger.Error]): Unit =
       val reader = request(1, 7)(_ => ())
       sizes0 = IdSizes(reader.int(), reader.int(), reader.int(), reader.int(), reader.int())
 
@@ -749,39 +751,39 @@ object Jdwp:
 
     // Issues a command whose reply carries no data of interest, discarding the reader.
     private def command(set: Int, cmd: Int)(write: Writer => Unit)
-      ( using Tactic[Debugger.Error], Monitor )
+      ( using Tactic[Debugger.Error] )
     :   Unit =
 
       request(set, cmd)(write)
       ()
 
     // VirtualMachine (command set 1).
-    def version()(using Tactic[Debugger.Error], Monitor): Version =
+    def version()(using Tactic[Debugger.Error]): Version =
       val reader = request(1, 1)(_ => ())
       Version(reader.string(), reader.int(), reader.int(), reader.string(), reader.string())
 
-    def allThreads()(using Tactic[Debugger.Error], Monitor): List[ThreadId] =
+    def allThreads()(using Tactic[Debugger.Error]): List[ThreadId] =
       val reader = request(1, 4)(_ => ())
       list(reader.int()): () => reader.threadId()
 
-    def suspendAll()(using Tactic[Debugger.Error], Monitor): Unit = command(1, 8)(_ => ())
-    def resumeAll()(using Tactic[Debugger.Error], Monitor): Unit = command(1, 9)(_ => ())
-    def dispose()(using Tactic[Debugger.Error], Monitor): Unit = command(1, 6)(_ => ())
+    def suspendAll()(using Tactic[Debugger.Error]): Unit = command(1, 8)(_ => ())
+    def resumeAll()(using Tactic[Debugger.Error]): Unit = command(1, 9)(_ => ())
+    def dispose()(using Tactic[Debugger.Error]): Unit = command(1, 6)(_ => ())
 
     // ReferenceType (command set 2).
-    def signature(cls: ReferenceTypeId)(using Tactic[Debugger.Error], Monitor): Text =
+    def signature(cls: ReferenceTypeId)(using Tactic[Debugger.Error]): Text =
       request(2, 1)(_.referenceTypeId(cls)).string()
 
-    def sourceFile(cls: ReferenceTypeId)(using Tactic[Debugger.Error], Monitor): Text =
+    def sourceFile(cls: ReferenceTypeId)(using Tactic[Debugger.Error]): Text =
       request(2, 7)(_.referenceTypeId(cls)).string()
 
     def sourceDebugExtension(cls: ReferenceTypeId)
-      ( using Tactic[Debugger.Error], Monitor )
+      ( using Tactic[Debugger.Error] )
     :   Text =
 
       request(2, 12)(_.referenceTypeId(cls)).string()
 
-    def methods(cls: ReferenceTypeId)(using Tactic[Debugger.Error], Monitor): List[MethodInfo] =
+    def methods(cls: ReferenceTypeId)(using Tactic[Debugger.Error]): List[MethodInfo] =
       val reader = request(2, 5)(_.referenceTypeId(cls))
 
       list(reader.int()): () =>
@@ -789,7 +791,7 @@ object Jdwp:
 
     // Method (command set 6).
     def lineTable(cls: ReferenceTypeId, method: MethodId)
-      ( using Tactic[Debugger.Error], Monitor )
+      ( using Tactic[Debugger.Error] )
     :   LineTable =
 
       val reader = request(6, 1)(_.referenceTypeId(cls).methodId(method))
@@ -800,20 +802,20 @@ object Jdwp:
       LineTable(start, end, lines)
 
     // ThreadReference (command set 11).
-    def threadName(thread: ThreadId)(using Tactic[Debugger.Error], Monitor): Text =
+    def threadName(thread: ThreadId)(using Tactic[Debugger.Error]): Text =
       request(11, 1)(_.threadId(thread)).string()
 
-    def suspendThread(thread: ThreadId)(using Tactic[Debugger.Error], Monitor): Unit =
+    def suspendThread(thread: ThreadId)(using Tactic[Debugger.Error]): Unit =
       command(11, 2)(_.threadId(thread))
 
-    def resumeThread(thread: ThreadId)(using Tactic[Debugger.Error], Monitor): Unit =
+    def resumeThread(thread: ThreadId)(using Tactic[Debugger.Error]): Unit =
       command(11, 3)(_.threadId(thread))
 
-    def frameCount(thread: ThreadId)(using Tactic[Debugger.Error], Monitor): Int =
+    def frameCount(thread: ThreadId)(using Tactic[Debugger.Error]): Int =
       request(11, 7)(_.threadId(thread)).int()
 
     def frames(thread: ThreadId, start: Int, length: Int)
-      ( using Tactic[Debugger.Error], Monitor )
+      ( using Tactic[Debugger.Error] )
     :   List[(FrameId, Location)] =
 
       val reader = request(11, 6): writer => writer.threadId(thread).int(start).int(length)
@@ -821,7 +823,7 @@ object Jdwp:
 
     // EventRequest (command set 15). `set` returns the request id used to `clear` it later.
     def eventRequestSet(kind: EventKind, policy: SuspendPolicy, modifiers: List[Modifier])
-      ( using Tactic[Debugger.Error], Monitor )
+      ( using Tactic[Debugger.Error] )
     :   Int =
 
       request(15, 1): writer =>
@@ -831,7 +833,7 @@ object Jdwp:
       . int()
 
     def eventRequestClear(kind: EventKind, request0: Int)
-      ( using Tactic[Debugger.Error], Monitor )
+      ( using Tactic[Debugger.Error] )
     :   Unit =
 
       command(15, 2)(_.byte(kind.id.toByte).int(request0))

--- a/lib/vivisection/src/core/vivisection.Jdwp.scala
+++ b/lib/vivisection/src/core/vivisection.Jdwp.scala
@@ -736,3 +736,102 @@ object Jdwp:
     private[vivisection] def negotiate()(using Tactic[Debugger.Error], Monitor): Unit =
       val reader = request(1, 7)(_ => ())
       sizes0 = IdSizes(reader.int(), reader.int(), reader.int(), reader.int(), reader.int())
+
+    // Reads `count` items in sequence. A helper rather than `map` over a range, because the reads
+    // are ordered side effects and must run strictly left to right.
+    private def list[element](count: Int)(read: () => element): List[element] =
+      def recur(remaining: Int): List[element] =
+        if remaining <= 0 then Nil else
+          val head = read()
+          head :: recur(remaining - 1)
+
+      recur(count)
+
+    // Issues a command whose reply carries no data of interest, discarding the reader.
+    private def command(set: Int, cmd: Int)(write: Writer => Unit)
+      ( using Tactic[Debugger.Error], Monitor )
+    :   Unit =
+
+      request(set, cmd)(write)
+      ()
+
+    // VirtualMachine (command set 1).
+    def version()(using Tactic[Debugger.Error], Monitor): Version =
+      val reader = request(1, 1)(_ => ())
+      Version(reader.string(), reader.int(), reader.int(), reader.string(), reader.string())
+
+    def allThreads()(using Tactic[Debugger.Error], Monitor): List[ThreadId] =
+      val reader = request(1, 4)(_ => ())
+      list(reader.int()): () => reader.threadId()
+
+    def suspendAll()(using Tactic[Debugger.Error], Monitor): Unit = command(1, 8)(_ => ())
+    def resumeAll()(using Tactic[Debugger.Error], Monitor): Unit = command(1, 9)(_ => ())
+    def dispose()(using Tactic[Debugger.Error], Monitor): Unit = command(1, 6)(_ => ())
+
+    // ReferenceType (command set 2).
+    def signature(cls: ReferenceTypeId)(using Tactic[Debugger.Error], Monitor): Text =
+      request(2, 1)(_.referenceTypeId(cls)).string()
+
+    def sourceFile(cls: ReferenceTypeId)(using Tactic[Debugger.Error], Monitor): Text =
+      request(2, 7)(_.referenceTypeId(cls)).string()
+
+    def sourceDebugExtension(cls: ReferenceTypeId)
+      ( using Tactic[Debugger.Error], Monitor )
+    :   Text =
+
+      request(2, 12)(_.referenceTypeId(cls)).string()
+
+    def methods(cls: ReferenceTypeId)(using Tactic[Debugger.Error], Monitor): List[MethodInfo] =
+      val reader = request(2, 5)(_.referenceTypeId(cls))
+
+      list(reader.int()): () =>
+        MethodInfo(reader.methodId(), reader.string(), reader.string(), reader.int())
+
+    // Method (command set 6).
+    def lineTable(cls: ReferenceTypeId, method: MethodId)
+      ( using Tactic[Debugger.Error], Monitor )
+    :   LineTable =
+
+      val reader = request(6, 1)(_.referenceTypeId(cls).methodId(method))
+      val start = reader.long()
+      val end = reader.long()
+      val lines = list(reader.int()): () => LineEntry(reader.long(), reader.int())
+
+      LineTable(start, end, lines)
+
+    // ThreadReference (command set 11).
+    def threadName(thread: ThreadId)(using Tactic[Debugger.Error], Monitor): Text =
+      request(11, 1)(_.threadId(thread)).string()
+
+    def suspendThread(thread: ThreadId)(using Tactic[Debugger.Error], Monitor): Unit =
+      command(11, 2)(_.threadId(thread))
+
+    def resumeThread(thread: ThreadId)(using Tactic[Debugger.Error], Monitor): Unit =
+      command(11, 3)(_.threadId(thread))
+
+    def frameCount(thread: ThreadId)(using Tactic[Debugger.Error], Monitor): Int =
+      request(11, 7)(_.threadId(thread)).int()
+
+    def frames(thread: ThreadId, start: Int, length: Int)
+      ( using Tactic[Debugger.Error], Monitor )
+    :   List[(FrameId, Location)] =
+
+      val reader = request(11, 6): writer => writer.threadId(thread).int(start).int(length)
+      list(reader.int()): () => (reader.frameId(), reader.location())
+
+    // EventRequest (command set 15). `set` returns the request id used to `clear` it later.
+    def eventRequestSet(kind: EventKind, policy: SuspendPolicy, modifiers: List[Modifier])
+      ( using Tactic[Debugger.Error], Monitor )
+    :   Int =
+
+      request(15, 1): writer =>
+        writer.byte(kind.id.toByte).byte(policy.id).int(modifiers.stdlib.length)
+        modifiers.stdlib.foreach(writer.modifier)
+
+      . int()
+
+    def eventRequestClear(kind: EventKind, request0: Int)
+      ( using Tactic[Debugger.Error], Monitor )
+    :   Unit =
+
+      command(15, 2)(_.byte(kind.id.toByte).int(request0))

--- a/lib/vivisection/src/core/vivisection_core.scala
+++ b/lib/vivisection/src/core/vivisection_core.scala
@@ -1,0 +1,46 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package vivisection
+
+// The negotiated-width JDWP identifiers, as distinct phantom-tagged views of one opaque integer.
+// Named for the specification's identifier types; `ThreadId`/`StringId`/… widen to `ObjectId`
+// because in JDWP a thread, string, class loader and array all *are* objects.
+type ObjectId        = Jdwp.Ref[Jdwp.Ref.Object]
+type ThreadId        = Jdwp.Ref[Jdwp.Ref.Thread]
+type ThreadGroupId   = Jdwp.Ref[Jdwp.Ref.Group]
+type StringId        = Jdwp.Ref[Jdwp.Ref.Str]
+type ClassLoaderId   = Jdwp.Ref[Jdwp.Ref.Loader]
+type ReferenceTypeId = Jdwp.Ref[Jdwp.Ref.Type]
+type MethodId        = Jdwp.Ref[Jdwp.Ref.Method]
+type FieldId         = Jdwp.Ref[Jdwp.Ref.Field]
+type FrameId         = Jdwp.Ref[Jdwp.Ref.Frame]

--- a/lib/vivisection/src/test/vivisection_test.scala
+++ b/lib/vivisection/src/test/vivisection_test.scala
@@ -240,3 +240,39 @@ object Tests extends Suite(m"Vivisection tests"):
           debug.version()
 
     . assert(_.vmName == t"FakeVM")
+
+    test(m"a session sets a breakpoint and reads the hit from the event stream"):
+      supervise:
+        val (vmSide, clientSide) = Duplex.pair()
+
+        val vm = async:
+          val incoming = vmSide.source.toProgression.stdlib.iterator
+          vmSide.send(Stream(incoming.next()))
+
+          val idSizes = Jdwp.Packet.decode(incoming.next())
+          val idBody = Jdwp.Writer(sizes).int(8).int(8).int(8).int(8).int(8).data
+          vmSide.send(Stream(Jdwp.Packet.reply(idSizes.id, 0, idBody)))
+
+          // The EventRequest.Set for the breakpoint; reply with request id 1.
+          val request = Jdwp.Packet.decode(incoming.next())
+          vmSide.send(Stream(Jdwp.Packet.reply(request.id, 0, Jdwp.Writer(sizes).int(1).data)))
+
+          // A Composite command (command set 64, command 100) carrying one Breakpoint event.
+          val event = Jdwp.Writer(sizes)
+          event.byte(Jdwp.SuspendPolicy.All.id)
+          event.int(1)
+          event.byte(Jdwp.EventKind.Breakpoint.id.toByte)
+          event.int(1)
+          event.objectId(Jdwp.Ref(5L))
+          event.location(location)
+          vmSide.send(Stream(Jdwp.Packet.command(999, 64, 100, event.data)))
+
+        Debugger(Attach(clientSide)).session: debug ?=>
+          debug.breakpoint(location)
+          debug.events.stdlib.head.events
+
+    . assert:
+        case Jdwp.Event.Breakpoint(request, thread, where) :: Nil =>
+          request == 1 && thread.long == 5L && where == location
+        case _ =>
+          false

--- a/lib/vivisection/src/test/vivisection_test.scala
+++ b/lib/vivisection/src/test/vivisection_test.scala
@@ -37,7 +37,17 @@ import soundness.*
 import errorDiagnostics.stackTracesDiagnostics
 import threading.platformThreading
 import probates.awaitProbate
+import logging.silentLogging
 import strategies.throwUnsafely
+
+case class Attach(duplex: Duplex)
+
+object Attach:
+  given connectable: (Attach is Connectable) = new Connectable:
+    type Self = Attach
+    def connect(attach: Attach, interface: Optional[MacAddress]): Duplex = attach.duplex
+
+  given showable: Attach is Showable = _ => t"attach"
 
 object Tests extends Suite(m"Vivisection tests"):
   def run(): Unit =
@@ -205,3 +215,28 @@ object Tests extends Suite(m"Vivisection tests"):
 
     . assert(_.vmName == t"FakeVM")
 
+    test(m"a full attach session connects, handshakes and reads the VM version"):
+      supervise:
+        val (vmSide, clientSide) = Duplex.pair()
+
+        val vm = async:
+          val incoming = vmSide.source.toProgression.stdlib.iterator
+          vmSide.send(Stream(incoming.next()))
+
+          val idSizes = Jdwp.Packet.decode(incoming.next())
+          val idBody = Jdwp.Writer(sizes).int(8).int(8).int(8).int(8).int(8).data
+          vmSide.send(Stream(Jdwp.Packet.reply(idSizes.id, 0, idBody)))
+
+          val version = Jdwp.Packet.decode(incoming.next())
+
+          val versionBody =
+            Jdwp.Writer(sizes).string(t"a fake VM").int(1).int(8).string(t"1.8.0")
+              .string(t"FakeVM").data
+
+          vmSide.send(Stream(Jdwp.Packet.reply(version.id, 0, versionBody)))
+
+        // A fake attach target whose `Connectable` hands back the client end of the pair.
+        Debugger(Attach(clientSide)).session: debug ?=>
+          debug.version()
+
+    . assert(_.vmName == t"FakeVM")

--- a/lib/vivisection/src/test/vivisection_test.scala
+++ b/lib/vivisection/src/test/vivisection_test.scala
@@ -1,0 +1,175 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package vivisection
+
+import soundness.*
+
+object Tests extends Suite(m"Vivisection tests"):
+  def run(): Unit =
+    val sizes = Jdwp.IdSizes.bootstrap
+
+    def roundtrip[value](write: Jdwp.Writer => Unit)(read: Jdwp.Reader => value): value =
+      val writer = Jdwp.Writer(sizes)
+      write(writer)
+      read(Jdwp.Reader(writer.data, sizes))
+
+    test(m"byte round-trips"):
+      roundtrip(_.byte(0x7f.toByte))(_.byte())
+    . assert(_ == 0x7f.toByte)
+
+    test(m"negative byte round-trips"):
+      roundtrip(_.byte((-3).toByte))(_.byte())
+    . assert(_ == (-3).toByte)
+
+    test(m"boolean round-trips"):
+      roundtrip(_.boolean(true))(_.boolean())
+    . assert(_ == true)
+
+    test(m"short round-trips"):
+      roundtrip(_.short(0x1234.toShort))(_.short())
+    . assert(_ == 0x1234.toShort)
+
+    test(m"int round-trips"):
+      roundtrip(_.int(0x12345678))(_.int())
+    . assert(_ == 0x12345678)
+
+    test(m"negative int round-trips"):
+      roundtrip(_.int(-1))(_.int())
+    . assert(_ == -1)
+
+    test(m"long round-trips"):
+      roundtrip(_.long(0x0123456789abcdefL))(_.long())
+    . assert(_ == 0x0123456789abcdefL)
+
+    test(m"char round-trips"):
+      roundtrip(_.char('Z'))(_.char())
+    . assert(_ == 'Z')
+
+    test(m"ASCII string round-trips"):
+      roundtrip(_.string(t"HelloJDWP"))(_.string())
+    . assert(_ == t"HelloJDWP")
+
+    test(m"string with embedded null round-trips"):
+      roundtrip(_.string(t"a\u0000b"))(_.string())
+    . assert(_ == t"a\u0000b")
+
+    test(m"multi-byte string round-trips"):
+      roundtrip(_.string(t"caf\u00e9"))(_.string())
+    . assert(_ == t"caf\u00e9")
+
+    val eightByteSizes = Jdwp.IdSizes(8, 8, 8, 8, 8)
+    val fourByteSizes = Jdwp.IdSizes(4, 4, 4, 4, 4)
+
+    def idRoundtrip(idSizes: Jdwp.IdSizes): Long =
+      val writer = Jdwp.Writer(idSizes)
+      writer.objectId(Jdwp.Ref(0x0a0b0c0dL))
+      Jdwp.Reader(writer.data, idSizes).objectId().long
+
+    test(m"objectId round-trips at 8-byte width"):
+      idRoundtrip(eightByteSizes)
+    . assert(_ == 0x0a0b0c0dL)
+
+    test(m"objectId round-trips at 4-byte width"):
+      idRoundtrip(fourByteSizes)
+    . assert(_ == 0x0a0b0c0dL)
+
+    val location = Jdwp.Location(Jdwp.TypeTag.Class, Jdwp.Ref(11L), Jdwp.Ref(22L), 33L)
+
+    test(m"location round-trips"):
+      roundtrip(_.location(location))(_.location())
+    . assert(_ == location)
+
+    test(m"int value round-trips"):
+      roundtrip(_.value(Jdwp.Value.OfInt(999)))(_.value())
+    . assert(_ == Jdwp.Value.OfInt(999))
+
+    test(m"boolean value round-trips"):
+      roundtrip(_.value(Jdwp.Value.OfBoolean(true)))(_.value())
+    . assert(_ == Jdwp.Value.OfBoolean(true))
+
+    test(m"object reference value round-trips"):
+      val value = Jdwp.Value.Reference(Jdwp.Tag.ObjectTag, Jdwp.Ref(77L))
+      roundtrip(_.value(value))(_.value())
+    . assert(_ == Jdwp.Value.Reference(Jdwp.Tag.ObjectTag, Jdwp.Ref(77L)))
+
+    test(m"void value round-trips"):
+      roundtrip(_.value(Jdwp.Value.Void))(_.value())
+    . assert(_ == Jdwp.Value.Void)
+
+    test(m"command packet decodes to its fields"):
+      val body = Jdwp.Writer(sizes).int(42).data
+      Jdwp.Packet.decode(Jdwp.Packet.command(7, 1, 9, body))
+    . assert: packet =>
+        packet.id == 7 && !packet.reply && packet.commandSet == 1 && packet.command == 9
+
+    test(m"reply packet decodes with its error code"):
+      Jdwp.Packet.decode(Jdwp.Packet.reply(7, 13, Jdwp.Writer(sizes).data))
+    . assert: packet =>
+        packet.id == 7 && packet.reply && packet.code == 13
+
+    test(m"composite event decodes a breakpoint"):
+      val writer = Jdwp.Writer(sizes)
+      writer.byte(Jdwp.SuspendPolicy.All.id)
+      writer.int(1)
+      writer.byte(Jdwp.EventKind.Breakpoint.id.toByte)
+      writer.int(55)
+      writer.objectId(Jdwp.Ref(88L))
+      writer.location(location)
+      Jdwp.Event.composite(Jdwp.Reader(writer.data, sizes)).events
+
+    . assert:
+        case Jdwp.Event.Breakpoint(request, thread, where) :: Nil =>
+          request == 55 && thread.long == 88L && where == location
+        case _ =>
+          false
+
+    test(m"composite event stops at an unrecognized kind"):
+      val writer = Jdwp.Writer(sizes)
+      writer.byte(Jdwp.SuspendPolicy.None.id)
+      writer.int(2)
+      writer.byte(200.toByte)
+      writer.int(1)
+      Jdwp.Event.composite(Jdwp.Reader(writer.data, sizes)).events
+
+    . assert:
+        case Jdwp.Event.Unknown(kind, request) :: Nil => kind == 200 && request == 1
+        case _                                         => false
+
+    test(m"error reason decodes a known JDWP code"):
+      Debugger.Error.Reason(13)
+    . assert(_ == Debugger.Error.Reason.ThreadNotSuspended)
+
+    test(m"error reason decodes an unknown code as Other"):
+      Debugger.Error.Reason(9999)
+    . assert(_ == Debugger.Error.Reason.Other(9999))
+

--- a/lib/vivisection/src/test/vivisection_test.scala
+++ b/lib/vivisection/src/test/vivisection_test.scala
@@ -34,6 +34,11 @@ package vivisection
 
 import soundness.*
 
+import errorDiagnostics.stackTracesDiagnostics
+import threading.platformThreading
+import probates.awaitProbate
+import strategies.throwUnsafely
+
 object Tests extends Suite(m"Vivisection tests"):
   def run(): Unit =
     val sizes = Jdwp.IdSizes.bootstrap
@@ -172,4 +177,31 @@ object Tests extends Suite(m"Vivisection tests"):
     test(m"error reason decodes an unknown code as Other"):
       Debugger.Error.Reason(9999)
     . assert(_ == Debugger.Error.Reason.Other(9999))
+
+    test(m"a session handshakes, negotiates id sizes, and reads the VM version"):
+      supervise:
+        val (vmSide, clientSide) = Duplex.pair()
+
+        // A scripted fake VM: echo the handshake, answer IDSizes, then answer Version. Chunk
+        // boundaries survive `Duplex.pair`, so each command arrives as its own chunk.
+        val vm = async:
+          val incoming = vmSide.source.toProgression.stdlib.iterator
+          vmSide.send(Stream(incoming.next()))
+
+          val idSizes = Jdwp.Packet.decode(incoming.next())
+          val idBody = Jdwp.Writer(sizes).int(8).int(8).int(8).int(8).int(8).data
+          vmSide.send(Stream(Jdwp.Packet.reply(idSizes.id, 0, idBody)))
+
+          val version = Jdwp.Packet.decode(incoming.next())
+
+          val versionBody =
+            Jdwp.Writer(sizes).string(t"a fake VM").int(1).int(8).string(t"1.8.0")
+              .string(t"FakeVM").data
+
+          vmSide.send(Stream(Jdwp.Packet.reply(version.id, 0, versionBody)))
+
+        Jdwp.Connection.exchange(clientSide): connection =>
+          connection.version()
+
+    . assert(_.vmName == t"FakeVM")
 

--- a/src/test/soundness.Tests.scala
+++ b/src/test/soundness.Tests.scala
@@ -152,6 +152,7 @@ object Tests extends Suite(m"Soundness tests"):
     vexillology.Tests()
     vacuous.Tests()
     vicarious.Tests()
+    vivisection.Tests()
     jacinta.RecordsTests()
     jacinta.ValidationTests()
     wisteria.Tests()


### PR DESCRIPTION
Vivisection is a new library: a session-based debugger for the JVM that speaks the Java Debug Wire Protocol directly over a socket, with no dependency on `com.sun.jdi`. It attaches to a JVM already listening for a debugger, or launches one under the agent, and lends a capability-scoped `Debug` session for the duration of a block — from which you can inspect threads and stack frames, suspend and resume execution, set breakpoints, request steps, and react to the events the VM streams back.

## Vivisection

A Scala-native JVM debugger. It implements the JDWP wire protocol from scratch over a `coaxial` socket — no `com.sun.jdi`, and no build server in the path.

Attach to a JVM that is already listening for a debugger:

```scala
import soundness.*

Debugger(endpoint).session: debug ?=>
  debug.version()   // the VM's version banner
  debug.threads()   // its live threads
  debug.suspend()   // suspend every thread
```

…or launch one under the agent and debug it, killing it when the block ends:

```scala
Debuggee(sh"java -cp $classpath com.example.Main").session: debug ?=>
  debug.resume()
```

Set breakpoints and react to the events the VM streams back:

```scala
Debugger(endpoint).session: debug ?=>
  debug.breakpoint(location)
  debug.resume()
  debug.events.each: composite =>
    composite.events.each:
      case Jdwp.Event.Breakpoint(request, thread, where) => // …handle the hit
      case _                                              => ()
```

This is the foundation: the wire protocol, the connection with its asynchronous pumps, the attach and launch sessions, breakpoints, stepping and the event stream are in place and tested. TASTy-decoded stack frames, typeclass-driven value rendering, and compile-based expression evaluation are planned follow-ups.
