### PR TITLE
Check `sh""` interpolators at compile time, with positioned errors

### DIFF
--- a/lib/guillotine/src/core/guillotine.Sh.scala
+++ b/lib/guillotine/src/core/guillotine.Sh.scala
@@ -52,10 +52,21 @@ object Sh:
   enum Context:
     case Awaiting, Unquoted, Quotes2, Quotes1
 
-  case class State(current: Context, escape: Boolean, arguments: sci.List[Text])
+  // `offset` counts characters consumed so far in "value space", where each substitution
+  // occupies exactly one position (matching `Runtime.skip`); `quoteStart` records the offset of
+  // the opening quote of the current `Quotes1`/`Quotes2` context, so that errors over
+  // unterminated quotes can be positioned at the quote that was never closed.
+  case class State
+    ( current: Context,
+      escape: Boolean,
+      arguments: sci.List[Text],
+      offset: Int = 0,
+      quoteStart: Int = -1 )
+
   case class Parameters(params: Text*)
 
-  case class ShError(detail: Message) extends Exception(s"guillotine: ${detail.text.s}")
+  case class ShError(detail: Message, offset: Int)
+  extends Exception(s"guillotine: ${detail.text.s}")
 
   object Runtime:
     import unsafeExceptions.canThrowAny
@@ -64,13 +75,13 @@ object Sh:
     def complete(state: State): Command =
       val arguments = state.current match
         case Quotes2 =>
-          throw ShError(m"the double quotes have not been closed")
+          throw ShError(m"this double quote is never closed", state.quoteStart)
 
         case Quotes1 =>
-          throw ShError(m"the single quotes have not been closed")
+          throw ShError(m"this single quote is never closed", state.quoteStart)
 
         case _ if state.escape =>
-          throw ShError(m"cannot terminate with an escape character")
+          throw ShError(m"a command cannot end with an escape character", state.offset - 1)
 
         case _ =>
           state.arguments
@@ -82,66 +93,78 @@ object Sh:
 
     def insert(state: State, value: Parameters): State = value.params.toList match
       case head :: tail =>
-        if state.escape
-        then throw ShError(m"escaping with '\\' is not allowed immediately before a substitution")
+        if state.escape then
+          throw ShError
+            ( m"an escape character cannot appear immediately before a substitution",
+              state.offset - 1 )
 
-        state.absolve match
-          case State(Awaiting, false, arguments) =>
+        val state2 = state.absolve match
+          case State(Awaiting, false, arguments, _, _) =>
             State(Unquoted, false, arguments ++ ((head :: tail): sci.List[Text]))
 
-          case State(Unquoted, false, arguments :+ last) =>
+          case State(Unquoted, false, arguments :+ last, _, _) =>
             State(Unquoted, false, arguments ++ ((t"$last$head" :: tail): sci.List[Text]))
 
-          case State(Quotes1, false, arguments :+ last) =>
+          case State(Quotes1, false, arguments :+ last, _, _) =>
             State(Quotes1, false, arguments :+ ((t"$last$head" :: tail): sci.List[Text]).join(t" "))
 
-          case State(Quotes2, false, arguments :+ last) =>
+          case State(Quotes2, false, arguments :+ last, _, _) =>
             State(Quotes2, false, arguments :+ ((t"$last$head" :: tail): sci.List[Text]).join(t" "))
 
+        state2.copy(offset = state.offset + 1, quoteStart = state.quoteStart)
+
       case _ =>
-        state
+        state.copy(offset = state.offset + 1)
 
     private def chars(text: Text): scala.Seq[Char] = text.chars.toSeq
 
     def parse(current: State, text: Text): State = chars(text).fuse(current):
-      (state, next).absolve match
-        case (State(Awaiting, _, arguments), ' ') => State(Awaiting, false, arguments)
+      val step = (state, next).absolve match
+        case (State(Awaiting, _, arguments, _, _), ' ') =>
+          State(Awaiting, false, arguments)
 
-          case (State(Quotes1, false, more :+ current), '\\') =>
-            State(Quotes1, false, more :+ t"$current\\")
+        case (State(Quotes1, false, more :+ current, _, _), '\\') =>
+          State(Quotes1, false, more :+ t"$current\\")
 
-          case (State(context, false, arguments), '\\') =>
-            State(context, true, arguments)
+        case (State(context, false, arguments, _, _), '\\') =>
+          State(context, true, arguments)
 
-          case (State(Unquoted, _, arguments), ' ') =>
-            State(Awaiting, false, arguments)
+        case (State(Unquoted, _, arguments, _, _), ' ') =>
+          State(Awaiting, false, arguments)
 
-          case (State(Quotes1, _, arguments), '\'') =>
-            State(Unquoted, false, arguments)
+        case (State(Quotes1, _, arguments, _, _), '\'') =>
+          State(Unquoted, false, arguments)
 
-          case (State(Quotes2, false, arguments), '"') =>
-            State(Unquoted, false, arguments)
+        case (State(Quotes2, false, arguments, _, _), '"') =>
+          State(Unquoted, false, arguments)
 
-          case (State(Unquoted, false, arguments), '"') =>
-            State(Quotes2, false, arguments)
+        case (State(Unquoted, false, arguments, _, _), '"') =>
+          State(Quotes2, false, arguments)
 
-          case (State(Unquoted, false, arguments), '\'') =>
-            State(Quotes1, false, arguments)
+        case (State(Unquoted, false, arguments, _, _), '\'') =>
+          State(Quotes1, false, arguments)
 
-          case (State(Awaiting, false, arguments), '"') =>
-            State(Quotes2, false, arguments :+ t"")
+        case (State(Awaiting, false, arguments, _, _), '"') =>
+          State(Quotes2, false, arguments :+ t"")
 
-          case (State(Awaiting, false, arguments), '\'') =>
-            State(Quotes1, false, arguments :+ t"")
+        case (State(Awaiting, false, arguments, _, _), '\'') =>
+          State(Quotes1, false, arguments :+ t"")
 
-          case (State(Awaiting, _, arguments), char) =>
-            State(Unquoted, false, arguments :+ t"$char")
+        case (State(Awaiting, _, arguments, _, _), char) =>
+          State(Unquoted, false, arguments :+ t"$char")
 
-          case (State(context, _, sci.Nil), char) =>
-            State(context, false, sci.List(t"$char"))
+        case (State(context, _, sci.Nil, _, _), char) =>
+          State(context, false, sci.List(t"$char"))
 
-          case (State(context, _, more :+ current), char) =>
-            State(context, false, more :+ t"$current$char")
+        case (State(context, _, more :+ current, _, _), char) =>
+          State(context, false, more :+ t"$current$char")
+
+      val entering =
+        (step.current == Quotes1 || step.current == Quotes2) && step.current != state.current
+
+      step.copy
+        ( offset = state.offset + 1,
+          quoteStart = if entering then state.offset else state.quoteStart )
 
   given nothing: Insertion[Parameters, Nothing] = value => Parameters(t"")
   given text: Insertion[Parameters, Text] = value => Parameters(value)

--- a/lib/guillotine/src/core/guillotine.internal.scala
+++ b/lib/guillotine/src/core/guillotine.internal.scala
@@ -58,11 +58,79 @@ object internal:
     val insertionExprs: List[Expr[Any]] = insertions.absolve match
       case Varargs(exprs) => exprs.toList
 
-    def rethrow[result](block: => result): result =
-      try block catch case error: Sh.ShError => halt(error.detail)
+    // Recover each literal part's source-file range from the `StringContext.apply(...)` term,
+    // so that parse errors can be positioned at the offending character within the literal. The
+    // walk is permissive about the surrounding tree shape; if the collected literals don't match
+    // the resolved parts, positions fall back to the whole macro expansion.
+    def collectLiterals(term: Term, acc: List[(Int, Int)]): List[(Int, Int)] = term match
+      case Literal(StringConstant(_)) => (term.pos.start, term.pos.end) :: acc
+      case Inlined(_, _, body)        => collectLiterals(body, acc)
+      case Typed(body, _)             => collectLiterals(body, acc)
+      case Block(_, expr)             => collectLiterals(expr, acc)
 
-    val checkState = Sh.Runtime.initial
-    rethrow(Sh.Runtime.parse(checkState, parts.head.tt))
+      case Apply(fn, args) =>
+        val withFn = collectLiterals(fn, acc)
+        args.foldLeft(withFn): (acc2, arg) => collectLiterals(arg, acc2)
+
+      case Repeated(elems, _) => elems.foldLeft(acc): (acc2, elem) => collectLiterals(elem, acc2)
+      case _                  => acc
+
+    val collected = collectLiterals(context.asTerm, Nil).reverse
+
+    val partOrigins: List[(Int, Int)] =
+      if collected.length == parts.length then collected else List.fill(parts.length)((0, 0))
+
+    val macroPos = Position.ofMacroExpansion
+    val sourceFile = macroPos.sourceFile
+
+    val sourceContent: Option[String] = sourceFile.content match
+      case Some(content: String) => Some(content)
+      case _                     => None
+
+    // Per part, precompute the value→source offset mapping (accounting for `$$` and `\uHHHH`
+    // escapes, whose source spelling is longer than their value).
+    val perPart: Seq[((String, Int), Int -> Int)] =
+      parts.zip(partOrigins).map: (part, origin) =>
+        val srcStart = origin(0)
+
+        val mapping: Int -> Int = sourceContent match
+          case Some(content) if srcStart > 0 && srcStart < content.length =>
+            val upper = (srcStart + part.length*6 + 16).min(content.length)
+            Interpolation.buildMapping(content.substring(srcStart, upper).nn, part)
+
+          case _ =>
+            identity
+
+        ((part, srcStart), mapping)
+
+      . toIndexedSeq
+
+    // Map a parser offset (in "value space", where each substitution occupies one position, as
+    // in `Sh.Runtime.insert`) to a source-file position.
+    def position(offset: Int, length: Int): Position =
+      var acc = 0
+      var i = 0
+
+      while i < perPart.length do
+        val ((part, srcStart), mapping) = perPart(i)
+
+        if offset < acc + part.length && srcStart > 0 then
+          val inPart = offset - acc
+          val endIn = (inPart + length.max(1)).min(part.length)
+          val rawStart = (srcStart + mapping(inPart)).max(srcStart)
+          val rawEnd = (srcStart + mapping(endIn)).max(rawStart + 1)
+          return Position(sourceFile, rawStart, rawEnd)
+
+        acc += part.length + 1
+        i += 1
+
+      macroPos
+
+    def rethrow[result](block: => result): result =
+      try block
+      catch case error: Sh.ShError => halt(error.detail, position(error.offset, 1))
+
+    var checkState = rethrow(Sh.Runtime.parse(Sh.Runtime.initial, parts.head.tt))
 
     var runtimeExpr: Expr[Sh.State] =
       '{Sh.Runtime.parse(Sh.Runtime.initial, ${Expr(parts.head)}.tt)}
@@ -79,8 +147,8 @@ object internal:
             Expr.summon[Insertion[Sh.Parameters, tpe]].getOrElse:
               halt(m"can't substitute ${TypeRepr.of[tpe].show} into a sh-interpolator")
 
-          rethrow(Sh.Runtime.skip(checkState))
-          rethrow(Sh.Runtime.parse(checkState, nextPart.tt))
+          checkState = rethrow(Sh.Runtime.skip(checkState))
+          checkState = rethrow(Sh.Runtime.parse(checkState, nextPart.tt))
 
           val current = runtimeExpr
 

--- a/lib/guillotine/src/test/guillotine_test.scala
+++ b/lib/guillotine/src/test/guillotine_test.scala
@@ -172,6 +172,62 @@ object Tests extends Suite(m"Guillotine tests"):
         sh"cat $path"
       . assert(_ == Command(t"cat", t"/etc/hosts"))
 
+    suite(m"Compile-time checking"):
+      test(m"unterminated single quote is a compile error"):
+        demilitarize:
+          sh"echo 'Hello world"
+        . map(_.message)
+      . assert(_.headOption.exists(_.contains("single quote")))
+
+      test(m"unterminated single quote focus is the opening quote"):
+        demilitarize:
+          sh"echo 'Hello world"
+        . map(_.focus)
+      . assert(_ == List("'"))
+
+      test(m"unterminated double quote is a compile error"):
+        demilitarize:
+          sh"""echo "Hello"""
+        . map(_.message)
+      . assert(_.headOption.exists(_.contains("double quote")))
+
+      test(m"unterminated double quote focus is the opening quote"):
+        demilitarize:
+          sh"""echo "Hello"""
+        . map(_.focus)
+      . assert(_ == List("\""))
+
+      test(m"trailing escape character is a compile error"):
+        demilitarize:
+          sh"""echo \"""
+        . map(_.message)
+      . assert(_.headOption.exists(_.contains("escape character")))
+
+      test(m"trailing escape character focus is the backslash"):
+        demilitarize:
+          sh"""echo \"""
+        . map(_.focus)
+      . assert(_ == List("\\"))
+
+      test(m"escape character before a substitution is a compile error"):
+        val file = t"file"
+        demilitarize:
+          sh"""ls \$file"""
+        . map(_.message)
+      . assert(_.headOption.exists(_.contains("substitution")))
+
+      test(m"quote opened after a substitution is positioned correctly"):
+        val flags = t"-la"
+        demilitarize:
+          sh"ls $flags 'unclosed"
+        . map(_.focus)
+      . assert(_ == List("'"))
+
+      test(m"a well-formed command produces no compile errors"):
+        demilitarize:
+          sh"""echo 'Hello world' "a b c" plain"""
+      . assert(_ == Nil)
+
     suite(m"Showable, Inspectable, equality"):
       test(m"render simple command"):
         (sh"echo Hello World": Command).inspect


### PR DESCRIPTION
The `sh` interpolator's compile-time checking pass was inert — the check state was bound once and every parse result discarded — so malformed shell literals such as an unterminated quote compiled cleanly and crashed at runtime. The checking pass now runs for real, and parse errors are reported at compile time with a source span on the offending character, using the same value→source offset translation as Xylophone's interpolator.

## Release notes

Malformed `sh""` literals are now compile errors rather than runtime exceptions. An unterminated quote, a trailing escape character, or an escape character immediately before a substitution is reported by the compiler with a caret on the offending character:
```
[error] example.scala:6:11
  sh"echo 'Hello world"
          ^
this single quote is never closed
```
Error messages have also been reworded for clarity, and positioning is exact even when the problem character appears after a substitution, in a triple-quoted literal, or beyond `$$`/`\uHHHH` escapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)