### PR TITLE
Implement the full XPath 1.0 language in Xylophone

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -3169,7 +3169,7 @@ object querencia extends Library:
 object xylophone extends Library:
   object core extends Component(zephyrine.core, adversaria.core, typonym.core, wisteria.core,
       contextual.core,
-      panopticon.core, turbulence.core, serpentine.core, gossamer.lexicon):
+      panopticon.core, turbulence.core, gossamer.lexicon):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // The Expr-level `Inlinable` typeclass and its expansion-time instance

--- a/lib/tarantula/doc/basics.md
+++ b/lib/tarantula/doc/basics.md
@@ -78,10 +78,9 @@ do element.click()
 
 An open shadow root is reached with `shadowRoot()`, and searched with the same `element` and `/`.
 
-Note that `XPath` currently expresses only absolute paths of element steps with 1-indexed
-ordinals, plus a trailing attribute — `xp"/html[1]/body[1]/div[2]"`. The predicate forms XPath is
-usually reached for cannot be written yet; they will work here unchanged once Xylophone's XPath
-supports them.
+`XPath` covers the full XPath 1.0 grammar, so the predicate forms browser automation reaches
+for work directly — `xp"//button[text()='Submit']"`, `xp"//*[contains(@class,'active')]"` — as
+does typed construction: `XPath.deep(t"button").where(XPath.textual === t"Submit")`.
 
 ### Using elements
 

--- a/lib/tarantula/src/core/tarantula.Focusable.scala
+++ b/lib/tarantula/src/core/tarantula.Focusable.scala
@@ -58,11 +58,9 @@ object Focusable:
   given tag: [tag <: Tag] => tag is Focusable = Focusable(t"tag name", _.label)
   given domId: Name[DomId] is Focusable = Focusable(t"css selector", v => t"#$v")
 
-  // Xylophone's `XPath` is an absolute path of element steps with 1-indexed ordinals, plus an
-  // optional trailing attribute — `/html[1]/body[1]/div[2]`. That is a strict subset of what the
-  // locator strategy permits: no `//`, no `*`, and no predicate but the ordinal, so the forms
-  // XPath is usually reached for (`//button[text()='Submit']`) cannot yet be written. Wiring the
-  // type in now means those arrive here for free when Xylophone's XPath grows them.
+  // Xylophone's `XPath` covers the full XPath 1.0 grammar, so everything the locator strategy
+  // permits — `//button[text()='Submit']`, `//*[contains(@class,'active')]` — renders through
+  // `encode` unchanged.
   given xpath: XPath is Focusable = Focusable(t"xpath", _.encode)
 
   // Polymorphic for the same reason as `tag`: `ClassList["checkbox"]()` has the refined type

--- a/lib/xylophone/src/core/xylophone.XPath.scala
+++ b/lib/xylophone/src/core/xylophone.XPath.scala
@@ -257,62 +257,42 @@ object XPath:
 
       ${xylophone.internal.xpath[parts, origins]('insertions)}
 
-  // Parses an absolute XPath (`/`, `/root[1]/child[2]`, `/root/@attr`),
-  // reporting the offset of any error. Each step is interpreted by `parseStep`;
-  // an unrecognised (e.g. empty, or `name[x]` with a non-numeric ordinal) step
-  // is a `BadStep`.
+  // Parses any XPath 1.0 expression — location paths, absolute or relative,
+  // and the full expression language — reporting the offset of any error.
   given decodable: (tactic: Tactic[XPath.Error]) => ((XPath is Decodable in Text)^{tactic}) = text =>
-    val string = text.s
-
-    if string.isEmpty || string.charAt(0) != '/'
-    then abort(XPath.Error(XPath.Error.Reason.ExpectedSlash, 0))
-    else
-      var xpath: XPath = XPath()
-      var offset = 1
-
-      while offset < string.length do
-        val slash = string.indexOf('/', offset)
-        val end = if slash < 0 then string.length else slash
-
-        parseStep(string.substring(offset, end).nn.tt) match
-          case Unset => abort(XPath.Error(XPath.Error.Reason.BadStep, offset))
-
-          case step => step.asInstanceOf[Either[Text, (Text, Int)]] match
-            case Left(name)       => xpath = xpath.attribute(name)
-            case Right((name, n)) => xpath = xpath.element(name, n)
-
-        offset = end + 1
-
-      xpath
-
-  // Parse a stored descent segment back into an addressable step. Returns
-  // `Right(name, ordinal)` for an element step, `Left(name)` for an
-  // attribute step, or `Unset` for an unrecognised segment.
-  private def parseStep(segment: Text): Optional[Either[Text, (Text, Int)]] =
-    if segment.length == 0 then Unset
-    else if segment.s.charAt(0) == '@' then Left(segment.s.drop(1).tt)
-    else
-      val s = segment.s
-      val openBracket = s.lastIndexOf('[')
-
-      if openBracket >= 0 && s.endsWith("]") then
-        val name = s.substring(0, openBracket).nn.tt
-        val ordinalText = s.substring(openBracket + 1, s.length - 1).nn
-
-        try Right((name, Integer.parseInt(ordinalText)))
-        catch case _: NumberFormatException => Unset
-      else
-        Right((segment, 1))
+    XPath(XPathReader.parse(text, holes = false))
 
   // XPathError → XPath.Error
   object Error:
+    // Reasons are append-only: `number` values are stable identifiers within
+    // the error 562 envelope and must never be reassigned. `ExpectedSlash`
+    // and `BadStep` were raised by the pre-AST positional parser and are
+    // retained only for numbering.
     enum Reason(val number: Int) extends Clarification:
-      case ExpectedSlash extends Reason(1)
-      case BadStep       extends Reason(2)
+      case ExpectedSlash        extends Reason(1)
+      case BadStep              extends Reason(2)
+      case UnexpectedCharacter  extends Reason(3)
+      case UnterminatedLiteral  extends Reason(4)
+      case UnknownAxis          extends Reason(5)
+      case ExpectedNodeTest     extends Reason(6)
+      case ExpectedExpression   extends Reason(7)
+      case ExpectedCloseParen   extends Reason(8)
+      case ExpectedCloseBracket extends Reason(9)
+      case UnexpectedEnd        extends Reason(10)
+      case UnexpectedToken      extends Reason(11)
 
     given communicable: Reason is Communicable =
-      case Reason.ExpectedSlash => m"an XPath must begin with '/'"
-      case Reason.BadStep       => m"the path step is not a valid XPath step"
+      case Reason.ExpectedSlash        => m"an XPath must begin with '/'"
+      case Reason.BadStep              => m"the path step is not a valid XPath step"
+      case Reason.UnexpectedCharacter  => m"the character is not valid in an XPath"
+      case Reason.UnterminatedLiteral  => m"the string literal is not terminated"
+      case Reason.UnknownAxis          => m"the axis name is not one of the thirteen XPath axes"
+      case Reason.ExpectedNodeTest     => m"a node test was expected"
+      case Reason.ExpectedExpression   => m"an expression was expected"
+      case Reason.ExpectedCloseParen   => m"a closing parenthesis was expected"
+      case Reason.ExpectedCloseBracket => m"a closing square bracket was expected"
+      case Reason.UnexpectedEnd        => m"the XPath ends prematurely"
+      case Reason.UnexpectedToken      => m"the token was not expected at this position"
 
   // `offset` is the character index, within the path text, where the error was
   // detected; consumers (e.g. the `xp"…"` interpolator) use it to position a

--- a/lib/xylophone/src/core/xylophone.XPath.scala
+++ b/lib/xylophone/src/core/xylophone.XPath.scala
@@ -144,7 +144,7 @@ object XPath:
     case Element(name: Text, rank: Int)
     case Attribute(name: Text)
 
-  private def qualify(prefix: Optional[Text], local: Text): Text = prefix match
+  private[xylophone] def qualify(prefix: Optional[Text], local: Text): Text = prefix match
     case prefix: Text => t"$prefix:$local"
     case _            => local
 
@@ -195,6 +195,159 @@ object XPath:
 
   def variable(name: Text): Expression = Expression.Variable(Unset, name)
 
+  object Locus:
+    private[xylophone] def root(document: Xml): Locus = Locus(document, Nil, Unset, Unset)
+
+    // The string-value (§5) of a single node: elements concatenate every
+    // descendant text and CDATA node; the character-carrying kinds are their
+    // own content.
+    private[xylophone] def textOf(node: Node): Text = node match
+      case TextNode(text)                 => text
+      case Cdata(text)                    => text
+      case Comment(text)                  => text
+      case ProcessingInstruction(_, data) => data
+
+      case element: Element =>
+        val builder = StringBuilder()
+        accumulate(element, builder)
+        builder.toString.nn.tt
+
+      case _ =>
+        t""
+
+    private def accumulate(element: Element, builder: StringBuilder): Unit =
+      val children = element.children
+      var i = 0
+
+      while i < children.length do
+        children.readUnchecked(i) match
+          case TextNode(text)   => builder.append(text.s)
+          case Cdata(text)      => builder.append(text.s)
+          case child: Element   => accumulate(child, builder)
+          case _                => ()
+
+        i += 1
+
+  // A located node: the evaluation subject plus the child-index path from the
+  // virtual root (XPath's `/`, the node *above* the root element) down to the
+  // node. Index paths provide parentage, document order and identity in one
+  // stroke — none of which the node tree itself can offer, since nodes carry
+  // no parent pointers and their `equals` deliberately conflates a node with
+  // a singleton `Fragment` of it. `subject` is `Unset` for the virtual root.
+  // An attribute pseudo-node shares its owner element's `path`, holds the
+  // owner as `subject`, and sets `attributeIndex`.
+  case class Locus
+    ( document:       Xml,
+      path:           List[Int],
+      subject:        Optional[Node],
+      attributeIndex: Optional[Int] ):
+
+    private[xylophone] def attributeName: Optional[Text] = attributeIndex match
+      case index: Int => subject match
+        case element: Element =>
+          val keys = element.attributes.keys.drop(index)
+          if keys.hasNext then keys.next() else Unset
+
+        case _ =>
+          Unset
+
+      case _ =>
+        Unset
+
+    def stringValue: Text = attributeIndex match
+      case index: Int => subject match
+        case element: Element =>
+          val values = element.attributes.values.drop(index)
+          if values.hasNext then values.next() else t""
+
+        case _ =>
+          t""
+
+      case _ => subject match
+        case node: Node => Locus.textOf(node)
+
+        case _ => document match
+          case Fragment(nodes*) =>
+            val builder = StringBuilder()
+            nodes.foreach { node => builder.append(Locus.textOf(node).s) }
+            builder.toString.nn.tt
+
+          case node: Node =>
+            Locus.textOf(node)
+
+  // The four XPath 1.0 value types (§1), with the conversion rules of §3.2,
+  // §4.2 and §4.3 as members. A node-set is always in document order without
+  // duplicates.
+  enum Value derives CanEqual:
+    case NodeSet(loci: List[Locus])
+    case Truth(value: Boolean)
+    case Numeric(value: Double)
+    case Textual(value: Text)
+
+    def truth: Boolean = this match
+      case Truth(value)   => value
+      case Numeric(value) => value == value && value != 0.0
+      case Textual(value) => value.s.length > 0
+      case NodeSet(loci)  => loci.stdlib.nonEmpty
+
+    def number: Double = this match
+      case Numeric(value) => value
+      case Truth(value)   => if value then 1.0 else 0.0
+      case Textual(value) => XPath.parseNumber(value)
+      case NodeSet(_)     => XPath.parseNumber(text)
+
+    def text: Text = this match
+      case Textual(value) => value
+      case Truth(value)   => if value then t"true" else t"false"
+      case Numeric(value) => XPath.renderNumber(value)
+
+      case NodeSet(loci) => loci.stdlib.headOption match
+        case Some(locus) => locus.stringValue
+        case None        => t""
+
+  // The `number()` conversion of a string (§4.4): optional whitespace, an
+  // optional minus sign, then the Number production — no exponents, no other
+  // sign forms; anything else is NaN.
+  private[xylophone] def parseNumber(text: Text): Double =
+    val trimmed = text.s.trim.nn
+
+    if trimmed.isEmpty then Double.NaN else
+      var index = if trimmed.charAt(0) == '-' then 1 else 0
+      var digits = false
+      var dot = false
+      var valid = index < trimmed.length
+
+      while index < trimmed.length && valid do
+        val char = trimmed.charAt(index)
+
+        if char >= '0' && char <= '9' then digits = true
+        else if char == '.' && !dot then dot = true
+        else valid = false
+
+        index += 1
+
+      if valid && digits then java.lang.Double.parseDouble(trimmed) else Double.NaN
+
+  object EvaluationError:
+    enum Reason(val number: Int) extends Clarification:
+      case UnknownFunction(name: Text) extends Reason(1)
+      case BadArity(name: Text)        extends Reason(2)
+      case UnboundVariable(name: Text) extends Reason(3)
+      case NotNodeSet                  extends Reason(4)
+      case Unsupported(feature: Text)  extends Reason(5)
+      case Unresolved                  extends Reason(6)
+
+    given communicable: Reason is Communicable =
+      case Reason.UnknownFunction(name) => m"the function $name is not an XPath 1.0 core function"
+      case Reason.BadArity(name)        => m"the function $name was applied to the wrong number of arguments"
+      case Reason.UnboundVariable(name) => m"the variable $$$name has no binding"
+      case Reason.NotNodeSet            => m"a node-set was expected"
+      case Reason.Unsupported(feature)  => m"$feature is not supported"
+      case Reason.Unresolved            => m"the expression contains an unresolved substitution"
+
+  case class EvaluationError(reason: XPath.EvaluationError.Reason)(using Diagnostics)
+  extends fulminate.Error(563, reason.number)(m"the XPath could not be evaluated because $reason")
+
   // Operator precedence levels, loosest-first, following the grammar's
   // production nesting (§3.1-§3.5): or=1, and=2, equality=3, relational=4,
   // additive=5, multiplicative=6, unary=7, union=8; paths and primaries are
@@ -236,7 +389,7 @@ object XPath:
 
   // XPath 1.0 number syntax has no exponent, and the canonical form of an
   // integral value has no decimal point (`string(1.0)` is `1`).
-  private def renderNumber(value: Double): Text =
+  private[xylophone] def renderNumber(value: Double): Text =
     if value != value then t"NaN"
     else if java.lang.Double.isInfinite(value) then (if value > 0 then t"Infinity" else t"-Infinity")
     else if value == Math.floor(value) && Math.abs(value) < 1e15 then value.toLong.toString.tt

--- a/lib/xylophone/src/core/xylophone.XPath.scala
+++ b/lib/xylophone/src/core/xylophone.XPath.scala
@@ -114,6 +114,29 @@ object XPath:
     case Route(origin: Origin, steps: List[Step])
     case Substitution(index: Int)
 
+    // Operator members, not extensions: `soundness.*` exports generic
+    // extensions of the same names (`contains`, `===`, `<`, …) whose context
+    // bounds commit before their givens resolve, so an extension here would
+    // be unreachable under the umbrella import. Members always win.
+    infix def or(right: into[Expression]): Expression = Expression.Or(this, right)
+    infix def and(right: into[Expression]): Expression = Expression.And(this, right)
+    def ===(right: into[Expression]): Expression = Expression.Equal(this, right)
+    def !==(right: into[Expression]): Expression = Expression.Unequal(this, right)
+    def <(right: into[Expression]): Expression = Expression.Less(this, right)
+    def <=(right: into[Expression]): Expression = Expression.LessOrEqual(this, right)
+    def >(right: into[Expression]): Expression = Expression.Greater(this, right)
+    def >=(right: into[Expression]): Expression = Expression.GreaterOrEqual(this, right)
+    def +(right: into[Expression]): Expression = Expression.Add(this, right)
+    def -(right: into[Expression]): Expression = Expression.Subtract(this, right)
+    def *(right: into[Expression]): Expression = Expression.Multiply(this, right)
+    def |(right: into[Expression]): Expression = Expression.Union(this, right)
+
+    infix def contains(right: into[Expression]): Expression =
+      Expression.Call(Unset, t"contains", List(this, right))
+
+    infix def startsWith(right: into[Expression]): Expression =
+      Expression.Call(Unset, t"starts-with", List(this, right))
+
   // The simple positional view of a path: what `Xml`'s position `Locator` can
   // resolve against a `PositionIndex`, and what the Wisteria-derived decoders
   // produce for diagnostics.
@@ -121,8 +144,56 @@ object XPath:
     case Element(name: Text, rank: Int)
     case Attribute(name: Text)
 
-  private def qualify(prefix: Optional[Text], local: Text): Text =
-    prefix.let { prefix => t"$prefix:$local" }.or(local)
+  private def qualify(prefix: Optional[Text], local: Text): Text = prefix match
+    case prefix: Text => t"$prefix:$local"
+    case _            => local
+
+  private val descendantStep: Step = Step(Axis.DescendantOrSelf, NodeTest.Node, Nil)
+
+  // Typed construction. A bare `Text` converts to a `child::name` step or to
+  // a string literal (by target type), so paths and predicates read close to
+  // their XPath forms:
+  //
+  //     XPath.deep(t"div").where(XPath.attribute(t"class").contains(t"button")
+  //         and XPath.textual === t"Submit")
+  //
+  // encodes as `//div[contains(@class,'button') and text()='Submit']`.
+  given stepConversion: Conversion[Text, Step] =
+    name => Step(Axis.Child, NodeTest.Name(Unset, name))
+
+  given literalConversion: Conversion[Text, Expression] = Expression.Literal(_)
+  given integerConversion: Conversion[Int, Expression] = int => Expression.Number(int.toDouble)
+  given decimalConversion: Conversion[Double, Expression] = Expression.Number(_)
+  given pathConversion: Conversion[XPath, Expression] = _.expression
+
+  // Absolute path start: `XPath / t"html" / t"body"` is `/html/body`.
+  def /(step: into[Step]): XPath = XPath(Expression.Route(Origin.Root, List(step)))
+
+  // Descendant-or-self start: `XPath.deep(t"div")` is `//div`.
+  def deep(step: into[Step]): XPath =
+    XPath(Expression.Route(Origin.Root, List(descendantStep, step)))
+
+  // Relative path start: `XPath.relative(t"div")` is `div`.
+  def relative(step: into[Step]): XPath = XPath(Expression.Route(Origin.Here, List(step)))
+
+  // The context node, `.` — usable as a path or, via `pathConversion`, in a
+  // predicate.
+  val here: XPath = XPath(Expression.Route(Origin.Here, List(Step(Axis.Self, NodeTest.Node))))
+
+  // Predicate constructors.
+  def attribute(name: Text): Expression =
+    Expression.Route(Origin.Here, List(Step(Axis.Attribute, NodeTest.Name(Unset, name))))
+
+  val textual: Expression =
+    Expression.Route(Origin.Here, List(Step(Axis.Child, NodeTest.Textual)))
+
+  val position: Expression = Expression.Call(Unset, t"position", Nil)
+  val last: Expression = Expression.Call(Unset, t"last", Nil)
+
+  def function(name: Text)(arguments: into[Expression]*): Expression =
+    Expression.Call(Unset, name, List(arguments*))
+
+  def variable(name: Text): Expression = Expression.Variable(Unset, name)
 
   // Operator precedence levels, loosest-first, following the grammar's
   // production nesting (§3.1-§3.5): or=1, and=2, equality=3, relational=4,
@@ -190,9 +261,9 @@ object XPath:
     case NodeTest.Textual                => t"text()"
     case NodeTest.Comment                => t"comment()"
 
-    case NodeTest.Instruction(target) =>
-      target.let { target => t"processing-instruction('$target')" }
-      . or(t"processing-instruction()")
+    case NodeTest.Instruction(target) => target match
+      case target: Text => t"processing-instruction('$target')"
+      case _            => t"processing-instruction()"
 
   private def renderPredicates(predicates: List[Expression]): Text =
     predicates.map { predicate => t"[${render(predicate, 1)}]" }.join
@@ -312,6 +383,40 @@ derives CanEqual:
 
     case other =>
       XPath(XPath.Expression.Route(XPath.Origin.Filter(other, Nil), List(step)))
+
+  // Appends a `child::` step: `XPath / t"html" / t"body"` is `/html/body`.
+  def /(step: into[XPath.Step]): XPath = append(step)
+
+  // Appends a descendant-or-self step: `XPath.deep(t"div").deep(t"a")` is
+  // `//div//a`.
+  def deep(step: into[XPath.Step]): XPath = append(XPath.descendantStep).append(step)
+
+  // Appends a fully-general step on any axis.
+  def on(axis: XPath.Axis, test: XPath.NodeTest): XPath = append(XPath.Step(axis, test))
+
+  // Adds a predicate to the final step (or, for a stepless filter path, to
+  // the filter expression): `XPath.deep(t"div").where(...)` is `//div[...]`.
+  def where(predicate: into[XPath.Expression]): XPath = expression match
+    case XPath.Expression.Route(origin, steps) =>
+      val stdlibSteps = steps.stdlib
+
+      if stdlibSteps.isEmpty then origin match
+        case XPath.Origin.Filter(filtered, predicates) =>
+          val amended = XPath.Origin.Filter(filtered, List.of(predicates.stdlib :+ predicate))
+          XPath(XPath.Expression.Route(amended, Nil))
+
+        case _ =>
+          XPath(XPath.Expression.Route(XPath.Origin.Filter(expression, List(predicate)), Nil))
+      else
+        val lastStep = stdlibSteps.last
+        val amended = lastStep.copy(predicates = List.of(lastStep.predicates.stdlib :+ predicate))
+        XPath(XPath.Expression.Route(origin, List.of(stdlibSteps.init :+ amended)))
+
+    case other =>
+      XPath(XPath.Expression.Route(XPath.Origin.Filter(other, List(predicate)), Nil))
+
+  // Positional predicate: `(XPath / t"li")(2)` is `/li[2]`.
+  def apply(ordinal: Int): XPath = where(XPath.Expression.Number(ordinal))
 
   def element(name: Text, ordinal: Int = 1): XPath =
     append:

--- a/lib/xylophone/src/core/xylophone.XPath.scala
+++ b/lib/xylophone/src/core/xylophone.XPath.scala
@@ -32,41 +32,223 @@
                                                                                                   */
 package xylophone
 
+import proscenium.compat.*
+
 import anticipation.*
 import contextual.*
 import contingency.*
-import denominative.*
 import distillate.*
 import fulminate.*
 import gossamer.*
+import murmuration.*
 import prepositional.*
-import serpentine.*
 import vacuous.*
 
-object XPath extends Root("/"):
-  type Plane = XPath
+object XPath:
+  // The thirteen XPath 1.0 axes (§2.2). `keyword` is the spelling used in the
+  // unabbreviated `axis::test` syntax.
+  enum Axis(val keyword: Text) derives CanEqual:
+    case Ancestor          extends Axis(t"ancestor")
+    case AncestorOrSelf    extends Axis(t"ancestor-or-self")
+    case Attribute         extends Axis(t"attribute")
+    case Child             extends Axis(t"child")
+    case Descendant        extends Axis(t"descendant")
+    case DescendantOrSelf  extends Axis(t"descendant-or-self")
+    case Following         extends Axis(t"following")
+    case FollowingSibling  extends Axis(t"following-sibling")
+    case Namespace         extends Axis(t"namespace")
+    case Parent            extends Axis(t"parent")
+    case Preceding         extends Axis(t"preceding")
+    case PrecedingSibling  extends Axis(t"preceding-sibling")
+    case Self              extends Axis(t"self")
 
-  given navigable: [text <: Text] => text is Navigable on XPath = identity(_)
-  given admissible: [text <: Text] => text is Admissible on XPath = _ => ()
+  // A node test (§2.3). `Textual` rather than `Text`, which would shadow
+  // gossamer's `Text` throughout this file.
+  enum NodeTest derives CanEqual:
+    case Name(prefix: Optional[Text], local: Text)
+    case Wildcard                                    // *
+    case PrefixWildcard(prefix: Text)                // prefix:*
+    case Node                                        // node()
+    case Textual                                     // text()
+    case Comment                                     // comment()
+    case Instruction(target: Optional[Text])         // processing-instruction('target')
 
-  // XPath path step encodings. Element steps include their 1-indexed ordinal
-  // among siblings sharing the same local name. Attribute steps are prefixed
-  // with `@`, the XPath convention, and may only appear as the final step
-  // of a path.
-  def elementStep(name: Text, ordinal: Int = 1): Text = t"$name[$ordinal]"
-  def attributeStep(name: Text): Text = t"@$name"
+  // One location step. Steps are stored root-first, in source order. The
+  // abbreviations `//`, `.`, `..` and `@` are desugared by the parser
+  // (§2.5): `//` becomes a `descendant-or-self::node()` step, `.` is
+  // `self::node()`, `..` is `parent::node()` and `@name` is
+  // `attribute::name`; the encoder re-sugars them.
+  case class Step(axis: Axis, test: NodeTest, predicates: List[Expression] = Nil)
+  derives CanEqual
 
-  given filesystem: XPath is Filesystem:
-    val name: Text = "XPath"
-    val parent: Text = ".."
-    val self: Text = "."
-    val separator: Text = "/"
+  // Where a path starts: the document root (absolute paths), the context node
+  // (relative paths), or a filter expression (`(//a)[1]/b`).
+  enum Origin derives CanEqual:
+    case Root
+    case Here
+    case Filter(expression: Expression, predicates: List[Expression])
 
-  // The underlying serpentine `Path` already encodes with the leading `/`
-  // separator (Path.encode = root + descent.reverse.join(sep)). Re-using
-  // it directly avoids the double-slash that `t"/${path.path}"` produced.
-  given XPath is Encodable in Text = path =>
-    if path.path.descent.length == 0 then t"/" else path.path.encode
+  // The XPath 1.0 expression language (§3). `Route` is any location path or
+  // path expression; `Substitution` marks an `xp"…"` interpolator insertion
+  // and never appears in a decoded or evaluated expression.
+  enum Expression derives CanEqual:
+    case Or(left: Expression, right: Expression)
+    case And(left: Expression, right: Expression)
+    case Equal(left: Expression, right: Expression)
+    case Unequal(left: Expression, right: Expression)
+    case Less(left: Expression, right: Expression)
+    case LessOrEqual(left: Expression, right: Expression)
+    case Greater(left: Expression, right: Expression)
+    case GreaterOrEqual(left: Expression, right: Expression)
+    case Add(left: Expression, right: Expression)
+    case Subtract(left: Expression, right: Expression)
+    case Multiply(left: Expression, right: Expression)
+    case Divide(left: Expression, right: Expression)
+    case Modulo(left: Expression, right: Expression)
+    case Negate(operand: Expression)
+    case Union(left: Expression, right: Expression)
+    case Literal(text: Text)
+    case Number(value: Double)
+    case Variable(prefix: Optional[Text], name: Text)
+    case Call(prefix: Optional[Text], name: Text, arguments: List[Expression])
+    case Route(origin: Origin, steps: List[Step])
+    case Substitution(index: Int)
+
+  // The simple positional view of a path: what `Xml`'s position `Locator` can
+  // resolve against a `PositionIndex`, and what the Wisteria-derived decoders
+  // produce for diagnostics.
+  enum Location derives CanEqual:
+    case Element(name: Text, rank: Int)
+    case Attribute(name: Text)
+
+  private def qualify(prefix: Optional[Text], local: Text): Text =
+    prefix.let { prefix => t"$prefix:$local" }.or(local)
+
+  // Operator precedence levels, loosest-first, following the grammar's
+  // production nesting (§3.1-§3.5): or=1, and=2, equality=3, relational=4,
+  // additive=5, multiplicative=6, unary=7, union=8; paths and primaries are
+  // atomic.
+  private def render(expression: Expression, minimum: Int): Text =
+    def binary(operator: Text, left: Expression, right: Expression, level: Int): Text =
+      val text = t"${render(left, level)}$operator${render(right, level + 1)}"
+      if level < minimum then t"($text)" else text
+
+    expression match
+      case Expression.Or(left, right)             => binary(t" or ", left, right, 1)
+      case Expression.And(left, right)            => binary(t" and ", left, right, 2)
+      case Expression.Equal(left, right)          => binary(t"=", left, right, 3)
+      case Expression.Unequal(left, right)        => binary(t"!=", left, right, 3)
+      case Expression.Less(left, right)           => binary(t"<", left, right, 4)
+      case Expression.LessOrEqual(left, right)    => binary(t"<=", left, right, 4)
+      case Expression.Greater(left, right)        => binary(t">", left, right, 4)
+      case Expression.GreaterOrEqual(left, right) => binary(t">=", left, right, 4)
+      case Expression.Add(left, right)            => binary(t" + ", left, right, 5)
+      case Expression.Subtract(left, right)       => binary(t" - ", left, right, 5)
+      case Expression.Multiply(left, right)       => binary(t" * ", left, right, 6)
+      case Expression.Divide(left, right)         => binary(t" div ", left, right, 6)
+      case Expression.Modulo(left, right)         => binary(t" mod ", left, right, 6)
+
+      case Expression.Negate(operand) =>
+        val text = t"-${render(operand, 7)}"
+        if minimum > 7 then t"($text)" else text
+
+      case Expression.Union(left, right)          => binary(t"|", left, right, 8)
+      case Expression.Literal(text)               => renderLiteral(text)
+      case Expression.Number(value)               => renderNumber(value)
+      case Expression.Variable(prefix, name)      => t"$$${qualify(prefix, name)}"
+
+      case Expression.Call(prefix, name, arguments) =>
+        t"${qualify(prefix, name)}(${arguments.map(render(_, 1)).join(t",")})"
+
+      case Expression.Route(origin, steps)        => renderRoute(origin, steps)
+      case Expression.Substitution(index)         => t"«$index»"
+
+  // XPath 1.0 number syntax has no exponent, and the canonical form of an
+  // integral value has no decimal point (`string(1.0)` is `1`).
+  private def renderNumber(value: Double): Text =
+    if value != value then t"NaN"
+    else if java.lang.Double.isInfinite(value) then (if value > 0 then t"Infinity" else t"-Infinity")
+    else if value == Math.floor(value) && Math.abs(value) < 1e15 then value.toLong.toString.tt
+    else value.toString.tt
+
+  // XPath 1.0 literals have no escape mechanism: a literal containing one
+  // quote kind is rendered with the other, and a literal containing both is
+  // unrepresentable directly, so it decomposes into a `concat(…)` call over
+  // single-quoted pieces joined by double-quoted apostrophes.
+  private def renderLiteral(text: Text): Text =
+    if text.s.indexOf('\'') < 0 then t"'$text'"
+    else if text.s.indexOf('"') < 0 then t"\"$text\""
+    else
+      val pieces = text.cut(t"'").map { (piece: Text) => t"'$piece'" }
+      t"concat(${pieces.join(t",\"'\",")})"
+
+  private def renderTest(test: NodeTest): Text = test match
+    case NodeTest.Name(prefix, local)    => qualify(prefix, local)
+    case NodeTest.Wildcard               => t"*"
+    case NodeTest.PrefixWildcard(prefix) => t"$prefix:*"
+    case NodeTest.Node                   => t"node()"
+    case NodeTest.Textual                => t"text()"
+    case NodeTest.Comment                => t"comment()"
+
+    case NodeTest.Instruction(target) =>
+      target.let { target => t"processing-instruction('$target')" }
+      . or(t"processing-instruction()")
+
+  private def renderPredicates(predicates: List[Expression]): Text =
+    predicates.map { predicate => t"[${render(predicate, 1)}]" }.join
+
+  // A `descendant-or-self::node()` step with no predicates is the desugaring
+  // of `//`: it renders as an empty segment, so that joining segments with
+  // `/` produces the abbreviated form. As the final step of a path the
+  // abbreviation is unavailable (`a//` is not valid syntax), so it renders in
+  // full.
+  private def renderStep(step: Step, last: Boolean): Text = step match
+    case Step(Axis.DescendantOrSelf, NodeTest.Node, Nil) =>
+      if last then t"descendant-or-self::node()" else t""
+
+    case Step(Axis.Self, NodeTest.Node, Nil)   => t"."
+    case Step(Axis.Parent, NodeTest.Node, Nil) => t".."
+
+    case Step(Axis.Child, test, predicates) =>
+      t"${renderTest(test)}${renderPredicates(predicates)}"
+
+    case Step(Axis.Attribute, test, predicates) =>
+      t"@${renderTest(test)}${renderPredicates(predicates)}"
+
+    case Step(axis, test, predicates) =>
+      t"${axis.keyword}::${renderTest(test)}${renderPredicates(predicates)}"
+
+  private def renderSteps(steps: List[Step]): Text =
+    val length = steps.length
+    steps.zipWithIndex.map { (step, index) => renderStep(step, index == length - 1) }.join(t"/")
+
+  private def renderRoute(origin: Origin, steps: List[Step]): Text = origin match
+    case Origin.Root => steps match
+      case Nil => t"/"
+      case _   => t"/${renderSteps(steps)}"
+
+    case Origin.Here => steps match
+      case Nil => t"."
+      case _   => renderSteps(steps)
+
+    case Origin.Filter(expression, predicates) =>
+      // A filter expression's head must be a `PrimaryExpr`: variable
+      // references, literals, numbers and function calls stand alone;
+      // anything else is parenthesised.
+      val head = expression match
+        case Expression.Variable(_, _) | Expression.Literal(_) | Expression.Call(_, _, _) =>
+          render(expression, 1)
+
+        case Expression.Number(value) if value >= 0 => render(expression, 1)
+        case other                                  => t"(${render(other, 1)})"
+
+      val trail = steps match
+        case Nil => t""
+        case _   => t"/${renderSteps(steps)}"
+
+      t"$head${renderPredicates(predicates)}$trail"
+
+  given XPath is Encodable in Text = xpath => render(xpath.expression, 1)
 
   inline given interpolable: XPath is Interpolable:
     transparent inline def interpolate[parts <: Tuple, origins <: Tuple]
@@ -106,7 +288,7 @@ object XPath extends Root("/"):
   // Parse a stored descent segment back into an addressable step. Returns
   // `Right(name, ordinal)` for an element step, `Left(name)` for an
   // attribute step, or `Unset` for an unrecognised segment.
-  def parseStep(segment: Text): Optional[Either[Text, (Text, Int)]] =
+  private def parseStep(segment: Text): Optional[Either[Text, (Text, Int)]] =
     if segment.length == 0 then Unset
     else if segment.s.charAt(0) == '@' then Left(segment.s.drop(1).tt)
     else
@@ -138,18 +320,79 @@ object XPath extends Root("/"):
   case class Error(reason: XPath.Error.Reason, offset: Int)(using Diagnostics)
   extends fulminate.Error(562, reason.number)(m"the XPath was not valid because $reason")
 
-case class XPath(path: Path on XPath = XPath):
+case class XPath(expression: XPath.Expression = XPath.Expression.Route(XPath.Origin.Root, Nil))
+derives CanEqual:
+
+  // Appends a step to the path. On a non-path expression, the expression
+  // becomes the head of a filter path, per the `FilterExpr '/'
+  // RelativeLocationPath` production.
+  private def append(step: XPath.Step): XPath = expression match
+    case XPath.Expression.Route(origin, steps) =>
+      XPath(XPath.Expression.Route(origin, steps :+ step))
+
+    case other =>
+      XPath(XPath.Expression.Route(XPath.Origin.Filter(other, Nil), List(step)))
+
   def element(name: Text, ordinal: Int = 1): XPath =
-    XPath(path / XPath.elementStep(name, ordinal))
+    append:
+      XPath.Step
+        ( XPath.Axis.Child,
+          XPath.NodeTest.Name(Unset, name),
+          List(XPath.Expression.Number(ordinal)) )
 
   def attribute(name: Text): XPath =
-    XPath(path / XPath.attributeStep(name))
+    append(XPath.Step(XPath.Axis.Attribute, XPath.NodeTest.Name(Unset, name), Nil))
 
-  // Prepend `name[ordinal]` at the root end of the path, leaving the rest
-  // of the descent intact. Used by `Xml`'s Wisteria derivation: each outer
-  // `focus` block runs *after* the inner one, and needs to push its label
-  // to the front of the accumulated XPath (so `/parent[1]/child[1]` lands
+  // Prepend `name[ordinal]` at the root end of the path, leaving the rest of
+  // the steps intact. Used by `Xml`'s Wisteria derivation: each outer `focus`
+  // block runs *after* the inner one, and needs to push its label to the
+  // front of the accumulated XPath (so `/parent[1]/child[1]` lands
   // root-first), not append at the leaf end like `element` does.
   private[xylophone] def prepend(name: Text, ordinal: Int = 1): XPath =
-    val step = XPath.elementStep(name, ordinal)
-    XPath(Path[XPath, XPath.type, Tuple]("/", (path.descent :+ step).to(List)))
+    val step =
+      XPath.Step
+        ( XPath.Axis.Child,
+          XPath.NodeTest.Name(Unset, name),
+          List(XPath.Expression.Number(ordinal)) )
+
+    expression match
+      case XPath.Expression.Route(origin, steps) =>
+        XPath(XPath.Expression.Route(origin, List.of(step :: steps.stdlib)))
+
+      case _ =>
+        this
+
+  // The simple positional view: `Unset` unless this is an absolute path of
+  // `child::name` steps whose only predicate is an integer ordinal (a missing
+  // predicate counts as ordinal 1), optionally ending with a single
+  // `attribute::name` step — the subset that `Xml`'s position `Locator` can
+  // resolve against a `PositionIndex`.
+  private[xylophone] def locations: Optional[List[XPath.Location]] =
+    import XPath.{Axis, Expression, Location, NodeTest, Origin, Step}
+
+    def recur(steps: List[Step], done: List[Location]): Optional[List[Location]] = steps match
+      case Nil =>
+        done.reverse
+
+      case Step(Axis.Child, NodeTest.Name(Unset, local), predicates) :: rest =>
+        predicates match
+          case Nil =>
+            recur(rest, Location.Element(local, 1) :: done)
+
+          case List(Expression.Number(value)) =>
+            if value == Math.floor(value) && value >= 1
+            then recur(rest, Location.Element(local, value.toInt) :: done)
+            else Unset
+
+          case _ =>
+            Unset
+
+      case Step(Axis.Attribute, NodeTest.Name(Unset, local), Nil) :: Nil =>
+        recur(Nil, Location.Attribute(local) :: done)
+
+      case _ =>
+        Unset
+
+    expression match
+      case Expression.Route(Origin.Root, steps) => recur(steps, Nil)
+      case _                                    => Unset

--- a/lib/xylophone/src/core/xylophone.XPathEngine.scala
+++ b/lib/xylophone/src/core/xylophone.XPathEngine.scala
@@ -1,0 +1,682 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xylophone
+
+import proscenium.compat.*
+
+import scala.collection.immutable as sci
+import scala.collection.mutable as scm
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import vacuous.*
+
+private[xylophone] object XPathEngine:
+  import XPath.{Axis, EvaluationError, Expression, Locus, NodeTest, Origin, Step, Value}
+  import EvaluationError.Reason
+
+  private case class Context
+    ( locus: Locus, position: Int, size: Int, variables: Map[Text, Value] )
+
+  def evaluate(xml: Xml, expression: Expression, variables: Map[Text, Value])
+    ( using Tactic[EvaluationError] )
+  :   Value =
+
+    evaluate(expression, Context(Locus.root(xml), 1, 1, variables))
+
+  private def evaluate(expression: Expression, context: Context)(using Tactic[EvaluationError])
+  :   Value =
+
+    expression match
+      case Expression.Or(left, right) =>
+        Value.Truth(evaluate(left, context).truth || evaluate(right, context).truth)
+
+      case Expression.And(left, right) =>
+        Value.Truth(evaluate(left, context).truth && evaluate(right, context).truth)
+
+      case Expression.Equal(left, right) =>
+        Value.Truth(equalTest(evaluate(left, context), evaluate(right, context), true))
+
+      case Expression.Unequal(left, right) =>
+        Value.Truth(equalTest(evaluate(left, context), evaluate(right, context), false))
+
+      case Expression.Less(left, right) =>
+        Value.Truth(relationalTest(evaluate(left, context), evaluate(right, context), _ < _))
+
+      case Expression.LessOrEqual(left, right) =>
+        Value.Truth(relationalTest(evaluate(left, context), evaluate(right, context), _ <= _))
+
+      case Expression.Greater(left, right) =>
+        Value.Truth(relationalTest(evaluate(left, context), evaluate(right, context), _ > _))
+
+      case Expression.GreaterOrEqual(left, right) =>
+        Value.Truth(relationalTest(evaluate(left, context), evaluate(right, context), _ >= _))
+
+      case Expression.Add(left, right) =>
+        Value.Numeric(evaluate(left, context).number + evaluate(right, context).number)
+
+      case Expression.Subtract(left, right) =>
+        Value.Numeric(evaluate(left, context).number - evaluate(right, context).number)
+
+      case Expression.Multiply(left, right) =>
+        Value.Numeric(evaluate(left, context).number * evaluate(right, context).number)
+
+      case Expression.Divide(left, right) =>
+        Value.Numeric(evaluate(left, context).number / evaluate(right, context).number)
+
+      case Expression.Modulo(left, right) =>
+        Value.Numeric(evaluate(left, context).number % evaluate(right, context).number)
+
+      case Expression.Negate(operand) =>
+        Value.Numeric(-evaluate(operand, context).number)
+
+      case Expression.Union(left, right) =>
+        (evaluate(left, context), evaluate(right, context)) match
+          case (Value.NodeSet(left), Value.NodeSet(right)) =>
+            Value.NodeSet(List.of(sortDedup(left.stdlib ++ right.stdlib)))
+
+          case _ =>
+            abort(EvaluationError(Reason.NotNodeSet))
+
+      case Expression.Literal(text)  => Value.Textual(text)
+      case Expression.Number(value)  => Value.Numeric(value)
+
+      case Expression.Variable(prefix, name) =>
+        val key = XPath.qualify(prefix, name)
+
+        context.variables.get(key) match
+          case Some(value) => value
+          case None        => abort(EvaluationError(Reason.UnboundVariable(key)))
+
+      case Expression.Call(prefix, name, arguments) =>
+        prefix match
+          case prefix: Text =>
+            abort(EvaluationError(Reason.UnknownFunction(XPath.qualify(prefix, name))))
+
+          case _ =>
+            call(name, arguments.stdlib.map(evaluate(_, context)), context)
+
+      case Expression.Route(origin, steps) =>
+        Value.NodeSet(List.of(route(origin, steps.stdlib, context)))
+
+      case Expression.Substitution(_) =>
+        abort(EvaluationError(Reason.Unresolved))
+
+  // Comparison semantics (§3.4): node-sets compare existentially over their
+  // members' string-values (or numbers, for relational operators); mixed
+  // plain comparisons promote to boolean, then number, then string.
+  private def equalTest(left: Value, right: Value, equal: Boolean): Boolean = (left, right) match
+    case (Value.NodeSet(left), Value.NodeSet(right)) =>
+      val rights = right.stdlib.map(_.stringValue.s)
+      left.stdlib.exists { locus =>
+        val value = locus.stringValue.s
+        rights.exists { other => (value == other) == equal }
+      }
+
+    case (Value.NodeSet(loci), other) => nodeSetTest(loci.stdlib, other, equal)
+    case (other, Value.NodeSet(loci)) => nodeSetTest(loci.stdlib, other, equal)
+
+    case (left, right) => (left, right) match
+      case (Value.Truth(_), _) | (_, Value.Truth(_))     => (left.truth == right.truth) == equal
+      case (Value.Numeric(_), _) | (_, Value.Numeric(_)) => (left.number == right.number) == equal
+      case _                                             => (left.text.s == right.text.s) == equal
+
+  private def nodeSetTest(loci: sci.List[Locus], other: Value, equal: Boolean): Boolean =
+    other match
+      case Value.Truth(value) => (loci.nonEmpty == value) == equal
+
+      case Value.Numeric(value) =>
+        loci.exists { locus => (XPath.parseNumber(locus.stringValue) == value) == equal }
+
+      case Value.Textual(value) =>
+        loci.exists { locus => (locus.stringValue.s == value.s) == equal }
+
+      case _ =>
+        false
+
+  private def relationalTest(left: Value, right: Value, test: (Double, Double) => Boolean)
+  :   Boolean =
+
+    def numberOf(locus: Locus): Double = XPath.parseNumber(locus.stringValue)
+
+    (left, right) match
+      case (Value.NodeSet(left), Value.NodeSet(right)) =>
+        left.stdlib.exists { a => right.stdlib.exists { b => test(numberOf(a), numberOf(b)) } }
+
+      case (Value.NodeSet(loci), other) =>
+        val number = other.number
+        loci.stdlib.exists { locus => test(numberOf(locus), number) }
+
+      case (other, Value.NodeSet(loci)) =>
+        val number = other.number
+        loci.stdlib.exists { locus => test(number, numberOf(locus)) }
+
+      case (left, right) =>
+        test(left.number, right.number)
+
+  // Document order and identity, both from the index path: lexicographic
+  // comparison, ancestors before descendants, and an element before its
+  // attributes.
+  private def attributeIndexOf(locus: Locus): Int = locus.attributeIndex match
+    case index: Int => index
+    case _          => -1
+
+  private def compareLoci(a: Locus, b: Locus): Int =
+    var pa = a.path.stdlib
+    var pb = b.path.stdlib
+
+    while pa.nonEmpty && pb.nonEmpty do
+      val difference = pa.head - pb.head
+      if difference != 0 then return difference
+      pa = pa.tail
+      pb = pb.tail
+
+    if pa.nonEmpty then 1
+    else if pb.nonEmpty then -1
+    else attributeIndexOf(a) - attributeIndexOf(b)
+
+  private def sortDedup(loci: sci.List[Locus]): sci.List[Locus] =
+    val sorted = loci.sortWith { (a, b) => compareLoci(a, b) < 0 }
+    val buffer = scm.ListBuffer[Locus]()
+
+    sorted.foreach: locus =>
+      if buffer.isEmpty || compareLoci(buffer.last, locus) != 0 then buffer += locus
+
+    buffer.toList
+
+  private def treeNode(node: Node): Boolean = node match
+    case _: Header | _: Doctype => false
+    case _                      => true
+
+  private def appendIndex(path: List[Int], index: Int): List[Int] =
+    List.of(path.stdlib :+ index)
+
+  private def childLoci(locus: Locus): sci.List[Locus] =
+    if attributeIndexOf(locus) >= 0 then sci.Nil else locus.subject match
+      case element: Element =>
+        val children = element.children
+        val buffer = scm.ListBuffer[Locus]()
+        var i = 0
+
+        while i < children.length do
+          val child = children.readUnchecked(i)
+          if treeNode(child) then
+            buffer += Locus(locus.document, appendIndex(locus.path, i), child, Unset)
+          i += 1
+
+        buffer.toList
+
+      case _: Node =>
+        sci.Nil
+
+      case _ => locus.document match
+        case Fragment(nodes*) =>
+          nodes.zipWithIndex.collect:
+            case (node, index) if treeNode(node) =>
+              Locus(locus.document, appendIndex(locus.path, index), node, Unset)
+          . to(sci.List)
+
+        case node: Node =>
+          if treeNode(node)
+          then sci.List(Locus(locus.document, appendIndex(locus.path, 0), node, Unset))
+          else sci.Nil
+
+  private def descendantLoci(locus: Locus): sci.List[Locus] =
+    childLoci(locus).flatMap { child => child :: descendantLoci(child) }
+
+  private def nodeAt(locus: Locus, index: Int): Node = locus.subject match
+    case element: Element => element.children.readUnchecked(index)
+
+    case _ => locus.document match
+      case Fragment(nodes*) => nodes(index)
+      case node: Node       => node
+
+  private def resolve(document: Xml, path: sci.List[Int]): Locus =
+    path.foldLeft(Locus.root(document)): (locus, index) =>
+      Locus(document, appendIndex(locus.path, index), nodeAt(locus, index), Unset)
+
+  private def parentLocus(locus: Locus): sci.List[Locus] =
+    if attributeIndexOf(locus) >= 0
+    then sci.List(Locus(locus.document, locus.path, locus.subject, Unset))
+    else
+      val path = locus.path.stdlib
+      if path.isEmpty then sci.Nil else sci.List(resolve(locus.document, path.init))
+
+  // Nearest-first, as a reverse axis requires for proximity positions.
+  private def ancestorLoci(locus: Locus): sci.List[Locus] = parentLocus(locus).headOption match
+    case Some(parent) => parent :: ancestorLoci(parent)
+    case None         => sci.Nil
+
+  private def siblingLoci(locus: Locus, following: Boolean): sci.List[Locus] =
+    if attributeIndexOf(locus) >= 0 || locus.path.stdlib.isEmpty then sci.Nil else
+      val mine = locus.path.stdlib.last
+
+      parentLocus(locus).headOption match
+        case Some(parent) =>
+          val all = childLoci(parent)
+          if following then all.filter(_.path.stdlib.last > mine)
+          else all.filter(_.path.stdlib.last < mine).reverse
+
+        case None =>
+          sci.Nil
+
+  private def isPrefix(prefix: sci.List[Int], path: sci.List[Int]): Boolean =
+    prefix.length < path.length && path.take(prefix.length) == prefix
+
+  private def followingLoci(locus: Locus): sci.List[Locus] =
+    val root = Locus.root(locus.document)
+
+    descendantLoci(root).filter: candidate =>
+      compareLoci(locus, candidate) < 0
+      && !isPrefix(locus.path.stdlib, candidate.path.stdlib)
+
+  // Nearest-first (reverse document order), as a reverse axis requires.
+  private def precedingLoci(locus: Locus): sci.List[Locus] =
+    val root = Locus.root(locus.document)
+
+    descendantLoci(root).filter: candidate =>
+      compareLoci(candidate, locus) < 0
+      && !isPrefix(candidate.path.stdlib, locus.path.stdlib)
+
+    . reverse
+
+  private def attributeLoci(locus: Locus): sci.List[Locus] =
+    if attributeIndexOf(locus) >= 0 then sci.Nil else locus.subject match
+      case element: Element =>
+        val buffer = scm.ListBuffer[Locus]()
+        var i = 0
+
+        while i < element.attributes.size do
+          buffer += Locus(locus.document, locus.path, element, i)
+          i += 1
+
+        buffer.toList
+
+      case _ =>
+        sci.Nil
+
+  private def axisLoci(axis: Axis, locus: Locus)(using Tactic[EvaluationError])
+  :   sci.List[Locus] =
+
+    axis match
+      case Axis.Child            => childLoci(locus)
+      case Axis.Descendant       => descendantLoci(locus)
+      case Axis.DescendantOrSelf => locus :: descendantLoci(locus)
+      case Axis.Self             => sci.List(locus)
+      case Axis.Parent           => parentLocus(locus)
+      case Axis.Ancestor         => ancestorLoci(locus)
+      case Axis.AncestorOrSelf   => locus :: ancestorLoci(locus)
+      case Axis.FollowingSibling => siblingLoci(locus, true)
+      case Axis.PrecedingSibling => siblingLoci(locus, false)
+      case Axis.Following        => followingLoci(locus)
+      case Axis.Preceding        => precedingLoci(locus)
+      case Axis.Attribute        => attributeLoci(locus)
+
+      case Axis.Namespace =>
+        abort(EvaluationError(Reason.Unsupported(t"the namespace axis")))
+
+  // Node tests, with the principal node type of the axis (§2.3): a name or
+  // wildcard on the attribute axis matches attributes; on every other axis,
+  // elements. Names match the raw label — this model performs no namespace
+  // processing, so `svg:rect` matches the literal label `svg:rect`.
+  private def testLocus(test: NodeTest, axis: Axis, locus: Locus): Boolean =
+    val attributeAxis = axis == Axis.Attribute
+    val isAttribute = attributeIndexOf(locus) >= 0
+
+    test match
+      case NodeTest.Name(prefix, local) =>
+        val qname = XPath.qualify(prefix, local)
+
+        if attributeAxis then locus.attributeName match
+          case name: Text => name.s == qname.s
+          case _          => false
+        else if isAttribute then false
+        else locus.subject match
+          case element: Element => element.label.s == qname.s
+          case _                => false
+
+      case NodeTest.Wildcard =>
+        if attributeAxis then isAttribute
+        else
+          !isAttribute && (locus.subject match
+            case _: Element => true
+            case _          => false)
+
+      case NodeTest.PrefixWildcard(prefix) =>
+        val start = t"$prefix:"
+
+        if attributeAxis then locus.attributeName match
+          case name: Text => name.s.startsWith(start.s)
+          case _          => false
+        else if isAttribute then false
+        else locus.subject match
+          case element: Element => element.label.s.startsWith(start.s)
+          case _                => false
+
+      case NodeTest.Node =>
+        true
+
+      case NodeTest.Textual =>
+        !isAttribute && (locus.subject match
+          case _: TextNode | _: Cdata => true
+          case _                      => false)
+
+      case NodeTest.Comment =>
+        !isAttribute && (locus.subject match
+          case _: Comment => true
+          case _          => false)
+
+      case NodeTest.Instruction(target) =>
+        !isAttribute && (locus.subject match
+          case ProcessingInstruction(target0, _) => target match
+            case target: Text => target0.s == target.s
+            case _            => true
+
+          case _ =>
+            false)
+
+  // Predicates evaluate over the candidate list in axis order, so that
+  // `position()` is the proximity position (§2.4): a numeric result keeps
+  // the candidate at that position; anything else coerces to boolean.
+  private def filterPredicates
+    ( candidates: sci.List[Locus],
+      predicates: sci.List[Expression],
+      variables:  Map[Text, Value] )
+    ( using Tactic[EvaluationError] )
+  :   sci.List[Locus] =
+
+    predicates.foldLeft(candidates): (current, predicate) =>
+      val size = current.length
+
+      current.zipWithIndex.filter: (locus, index) =>
+        evaluate(predicate, Context(locus, index + 1, size, variables)) match
+          case Value.Numeric(value) => value == index + 1
+          case value                => value.truth
+
+      . map(_(0))
+
+  private def evaluateStep
+    ( step: Step, inputs: sci.List[Locus], variables: Map[Text, Value] )
+    ( using Tactic[EvaluationError] )
+  :   sci.List[Locus] =
+
+    val collected = inputs.flatMap: input =>
+      val candidates = axisLoci(step.axis, input).filter(testLocus(step.test, step.axis, _))
+      filterPredicates(candidates, step.predicates.stdlib, variables)
+
+    sortDedup(collected)
+
+  private def route(origin: Origin, steps: sci.List[Step], context: Context)
+    ( using Tactic[EvaluationError] )
+  :   sci.List[Locus] =
+
+    val start: sci.List[Locus] = origin match
+      case Origin.Root => sci.List(Locus.root(context.locus.document))
+      case Origin.Here => sci.List(context.locus)
+
+      case Origin.Filter(expression, predicates) =>
+        evaluate(expression, context) match
+          case Value.NodeSet(loci) =>
+            filterPredicates(sortDedup(loci.stdlib), predicates.stdlib, context.variables)
+
+          case _ =>
+            abort(EvaluationError(Reason.NotNodeSet))
+
+    steps.foldLeft(start) { (loci, step) => evaluateStep(step, loci, context.variables) }
+
+  // The name of a node, as `name()` reports it: an element's label, an
+  // attribute's key, a processing instruction's target; empty otherwise.
+  private def nodeNameOf(locus: Locus): Text = locus.attributeName match
+    case name: Text => name
+
+    case _ => locus.subject match
+      case element: Element                     => element.label
+      case ProcessingInstruction(target, _)     => target
+      case _                                    => t""
+
+  // The rounding used by `round()` and `substring()` (§4.2, §4.4):
+  // floor(x + 0.5), with NaN and the infinities passing through.
+  private def xpathRound(value: Double): Double =
+    if value != value || java.lang.Double.isInfinite(value) then value
+    else Math.floor(value + 0.5)
+
+  // The core function library (§4). Zero-argument forms of `string`,
+  // `number`, `string-length`, `normalize-space`, `name` and friends default
+  // to the context node.
+  private def call(name: Text, arguments: sci.List[Value], context: Context)
+    ( using Tactic[EvaluationError] )
+  :   Value =
+
+    def arity(minimum: Int, maximum: Int): Unit =
+      if arguments.length < minimum || arguments.length > maximum
+      then abort(EvaluationError(Reason.BadArity(name)))
+
+    def nodeSetArgument(value: Value): sci.List[Locus] = value match
+      case Value.NodeSet(loci) => sortDedup(loci.stdlib)
+      case _                   => abort(EvaluationError(Reason.NotNodeSet))
+
+    def defaulted: Value =
+      if arguments.isEmpty then Value.NodeSet(List(context.locus)) else arguments.head
+
+    name.s match
+      case "last" =>
+        arity(0, 0)
+        Value.Numeric(context.size)
+
+      case "position" =>
+        arity(0, 0)
+        Value.Numeric(context.position)
+
+      case "count" =>
+        arity(1, 1)
+        Value.Numeric(nodeSetArgument(arguments.head).length)
+
+      case "id" =>
+        abort(EvaluationError(Reason.Unsupported(t"the id() function")))
+
+      case "local-name" | "name" | "namespace-uri" =>
+        arity(0, 1)
+
+        if name.s == "namespace-uri" then Value.Textual(t"") else
+          val loci =
+            if arguments.isEmpty then sci.List(context.locus)
+            else nodeSetArgument(arguments.head)
+
+          val qualified = loci.headOption match
+            case Some(locus) => nodeNameOf(locus)
+            case None        => t""
+
+          if name.s == "name" then Value.Textual(qualified) else
+            val colon = qualified.s.indexOf(':')
+            if colon < 0 then Value.Textual(qualified)
+            else Value.Textual(qualified.s.substring(colon + 1).nn.tt)
+
+      case "string" =>
+        arity(0, 1)
+        Value.Textual(defaulted.text)
+
+      case "concat" =>
+        if arguments.length < 2 then abort(EvaluationError(Reason.BadArity(name)))
+        val builder = StringBuilder()
+        arguments.foreach { argument => builder.append(argument.text.s) }
+        Value.Textual(builder.toString.nn.tt)
+
+      case "starts-with" =>
+        arity(2, 2)
+        Value.Truth(arguments(0).text.s.startsWith(arguments(1).text.s))
+
+      case "contains" =>
+        arity(2, 2)
+        Value.Truth(arguments(0).text.s.contains(arguments(1).text.s))
+
+      case "substring-before" =>
+        arity(2, 2)
+        val whole = arguments(0).text.s
+        val index = whole.indexOf(arguments(1).text.s)
+        Value.Textual(if index < 0 then t"" else whole.substring(0, index).nn.tt)
+
+      case "substring-after" =>
+        arity(2, 2)
+        val whole = arguments(0).text.s
+        val part = arguments(1).text.s
+        val index = whole.indexOf(part)
+        Value.Textual(if index < 0 then t"" else whole.substring(index + part.length).nn.tt)
+
+      case "substring" =>
+        arity(2, 3)
+        val whole = arguments(0).text.s
+        val start = xpathRound(arguments(1).number)
+
+        val limit =
+          if arguments.length == 3 then start + xpathRound(arguments(2).number)
+          else Double.PositiveInfinity
+
+        val builder = StringBuilder()
+        var position = 1
+
+        while position <= whole.length do
+          if position >= start && position < limit then builder.append(whole.charAt(position - 1))
+          position += 1
+
+        Value.Textual(builder.toString.nn.tt)
+
+      case "string-length" =>
+        arity(0, 1)
+        Value.Numeric(defaulted.text.s.length)
+
+      case "normalize-space" =>
+        arity(0, 1)
+        val whole = defaulted.text.s
+        val builder = StringBuilder()
+        var pending = false
+        var index = 0
+
+        while index < whole.length do
+          val char = whole.charAt(index)
+
+          if char == ' ' || char == '\t' || char == '\r' || char == '\n' then
+            if builder.length > 0 then pending = true
+          else
+            if pending then builder.append(' ')
+            pending = false
+            builder.append(char)
+
+          index += 1
+
+        Value.Textual(builder.toString.nn.tt)
+
+      case "translate" =>
+        arity(3, 3)
+        val whole = arguments(0).text.s
+        val from = arguments(1).text.s
+        val to = arguments(2).text.s
+        val builder = StringBuilder()
+        var index = 0
+
+        while index < whole.length do
+          val char = whole.charAt(index)
+          val mapping = from.indexOf(char)
+
+          if mapping < 0 then builder.append(char)
+          else if mapping < to.length then builder.append(to.charAt(mapping))
+
+          index += 1
+
+        Value.Textual(builder.toString.nn.tt)
+
+      case "boolean" =>
+        arity(1, 1)
+        Value.Truth(arguments.head.truth)
+
+      case "not" =>
+        arity(1, 1)
+        Value.Truth(!arguments.head.truth)
+
+      case "true" =>
+        arity(0, 0)
+        Value.Truth(true)
+
+      case "false" =>
+        arity(0, 0)
+        Value.Truth(false)
+
+      case "lang" =>
+        arity(1, 1)
+        val wanted = arguments.head.text.s.toLowerCase.nn
+
+        val declared = (context.locus :: ancestorLoci(context.locus)).flatMap: locus =>
+          locus.subject match
+            case element: Element if attributeIndexOf(locus) < 0 =>
+              element.attributes.fetch(t"xml:lang") match
+                case value: Text => sci.List(value.s.toLowerCase.nn)
+                case _           => sci.Nil
+
+            case _ =>
+              sci.Nil
+
+        Value.Truth:
+          declared.headOption match
+            case Some(language) =>
+              language == wanted || language.startsWith(wanted + "-")
+
+            case None =>
+              false
+
+      case "number" =>
+        arity(0, 1)
+        Value.Numeric(defaulted.number)
+
+      case "sum" =>
+        arity(1, 1)
+        var total = 0.0
+
+        nodeSetArgument(arguments.head).foreach: locus =>
+          total += XPath.parseNumber(locus.stringValue)
+
+        Value.Numeric(total)
+
+      case "floor" =>
+        arity(1, 1)
+        Value.Numeric(Math.floor(arguments.head.number))
+
+      case "ceiling" =>
+        arity(1, 1)
+        Value.Numeric(Math.ceil(arguments.head.number))
+
+      case "round" =>
+        arity(1, 1)
+        Value.Numeric(xpathRound(arguments.head.number))
+
+      case _ =>
+        abort(EvaluationError(Reason.UnknownFunction(name)))

--- a/lib/xylophone/src/core/xylophone.XPathReader.scala
+++ b/lib/xylophone/src/core/xylophone.XPathReader.scala
@@ -1,0 +1,602 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xylophone
+
+import proscenium.compat.*
+
+import scala.collection.mutable as scm
+
+import anticipation.*
+import contingency.*
+import vacuous.*
+
+// A hand-written lexer and recursive-descent parser for the full XPath 1.0
+// grammar (one method per production of the W3C recommendation), reporting
+// every failure as an `XPath.Error` carrying the character offset at which it
+// was detected, which the `xp"…"` interpolator maps back onto a source-file
+// caret. With `holes` enabled, a NUL (`\u0000`) marker (as inserted between the
+// parts of an interpolated literal) lexes as a numbered hole and parses as an
+// `Expression.Substitution` wherever a primary expression is permitted.
+private[xylophone] object XPathReader:
+  import XPath.{Axis, Expression, NodeTest, Origin, Step}
+  import XPath.Error.Reason
+
+  private enum Token derives CanEqual:
+    case Slash, DoubleSlash, Pipe, Plus, Minus, Equals, Unequals, Less, LessOrEqual, Greater,
+         GreaterOrEqual, Star, OrKeyword, AndKeyword, DivKeyword, ModKeyword,
+         At, OpenParen, CloseParen, OpenBracket, CloseBracket, Comma, Dot, DotDot
+    case NameToken(prefix: Optional[Text], local: Text)
+    case WildcardTest
+    case PrefixWildcardTest(prefix: Text)
+    case NodeTypeToken(name: Text)
+    case AxisToken(axis: Axis)
+    case FunctionToken(prefix: Optional[Text], local: Text)
+    case LiteralToken(text: Text)
+    case NumberToken(value: Double)
+    case VariableToken(prefix: Optional[Text], name: Text)
+    case HoleToken(index: Int)
+
+  private case class Positioned(token: Token, offset: Int)
+
+  // The disambiguation rule of §3.7: `*` is the multiplication operator, and
+  // `and`/`or`/`div`/`mod` are operator names, exactly when the preceding
+  // token could end an operand — i.e. it is not `@`, `::`, `(`, `[`, `,` or
+  // an operator. (`::` never survives as a token here: it is folded into
+  // `AxisToken`, which likewise cannot end an operand.)
+  private def operand(token: Token): Boolean = token match
+    case Token.NameToken(_, _) | Token.WildcardTest | Token.PrefixWildcardTest(_)
+       | Token.LiteralToken(_) | Token.NumberToken(_) | Token.VariableToken(_, _)
+       | Token.CloseParen | Token.CloseBracket | Token.Dot | Token.DotDot
+       | Token.HoleToken(_) =>
+      true
+
+    case _ =>
+      false
+
+  private def nameStart(char: Char): Boolean = Character.isLetter(char) || char == '_'
+
+  private def namePart(char: Char): Boolean =
+    Character.isLetterOrDigit(char) || char == '_' || char == '-' || char == '.'
+
+  private def axisFor(name: String): Optional[Axis] = name match
+    case "ancestor"           => Axis.Ancestor
+    case "ancestor-or-self"   => Axis.AncestorOrSelf
+    case "attribute"          => Axis.Attribute
+    case "child"              => Axis.Child
+    case "descendant"         => Axis.Descendant
+    case "descendant-or-self" => Axis.DescendantOrSelf
+    case "following"          => Axis.Following
+    case "following-sibling"  => Axis.FollowingSibling
+    case "namespace"          => Axis.Namespace
+    case "parent"             => Axis.Parent
+    case "preceding"          => Axis.Preceding
+    case "preceding-sibling"  => Axis.PrecedingSibling
+    case "self"               => Axis.Self
+    case _                    => Unset
+
+  private def tokenize(string: String, holes: Boolean)(using Tactic[XPath.Error])
+  :   scm.ArrayBuffer[Positioned] =
+
+    val tokens = scm.ArrayBuffer[Positioned]()
+    var offset = 0
+    var holeCount = 0
+    val length = string.length
+
+    def push(token: Token, at: Int): Unit = tokens += Positioned(token, at)
+    def afterOperand: Boolean = tokens.nonEmpty && operand(tokens.last.token)
+    def digit(at: Int): Boolean = at < length && string.charAt(at) >= '0' && string.charAt(at) <= '9'
+
+    def scanNumber(start: Int): Unit =
+      var end = start
+      while digit(end) do end += 1
+      if end < length && string.charAt(end) == '.' then
+        end += 1
+        while digit(end) do end += 1
+
+      push(Token.NumberToken(java.lang.Double.parseDouble(string.substring(start, end).nn)), start)
+      offset = end
+
+    def scanLiteral(start: Int): Unit =
+      val quote = string.charAt(start)
+      val close = string.indexOf(quote, start + 1)
+      if close < 0 then abort(XPath.Error(Reason.UnterminatedLiteral, start))
+      push(Token.LiteralToken(string.substring(start + 1, close).nn.tt), start)
+      offset = close + 1
+
+    def scanNcname(start: Int): Int =
+      var end = start + 1
+      while end < length && namePart(string.charAt(end)) do end += 1
+      end
+
+    def skipSpace(at: Int): Int =
+      var index = at
+      while index < length
+            && (string.charAt(index) == ' ' || string.charAt(index) == '\t'
+                || string.charAt(index) == '\r' || string.charAt(index) == '\n')
+      do index += 1
+      index
+
+    def scanName(start: Int): Unit =
+      var end = scanNcname(start)
+      val first = string.substring(start, end).nn
+
+      if afterOperand then
+        first match
+          case "and" => push(Token.AndKeyword, start)
+          case "or"  => push(Token.OrKeyword, start)
+          case "div" => push(Token.DivKeyword, start)
+          case "mod" => push(Token.ModKeyword, start)
+          case _     => abort(XPath.Error(Reason.UnexpectedToken, start))
+
+        offset = end
+      else
+        var prefix: Optional[Text] = Unset
+        var local = first
+
+        if end < length && string.charAt(end) == ':' && end + 1 < length
+           && string.charAt(end + 1) != ':'
+        then
+          if string.charAt(end + 1) == '*' then
+            push(Token.PrefixWildcardTest(first.tt), start)
+            offset = end + 2
+            return
+          else if nameStart(string.charAt(end + 1)) then
+            val localEnd = scanNcname(end + 1)
+            prefix = first.tt
+            local = string.substring(end + 1, localEnd).nn
+            end = localEnd
+          else
+            abort(XPath.Error(Reason.UnexpectedCharacter, end))
+
+        val ahead = skipSpace(end)
+
+        if ahead + 1 < length && string.charAt(ahead) == ':' && string.charAt(ahead + 1) == ':'
+        then
+          if prefix != Unset then abort(XPath.Error(Reason.UnknownAxis, start))
+
+          axisFor(local) match
+            case axis: Axis => push(Token.AxisToken(axis), start)
+            case _          => abort(XPath.Error(Reason.UnknownAxis, start))
+
+          offset = ahead + 2
+        else if ahead < length && string.charAt(ahead) == '(' then
+          if prefix == Unset
+             && (local == "node" || local == "text" || local == "comment"
+                 || local == "processing-instruction")
+          then push(Token.NodeTypeToken(local.tt), start)
+          else push(Token.FunctionToken(prefix, local.tt), start)
+
+          offset = end
+        else
+          push(Token.NameToken(prefix, local.tt), start)
+          offset = end
+
+    while offset < length do
+      val start = offset
+      val char = string.charAt(offset)
+
+      char match
+        case ' ' | '\t' | '\r' | '\n' =>
+          offset += 1
+
+        case '/' =>
+          if offset + 1 < length && string.charAt(offset + 1) == '/' then
+            push(Token.DoubleSlash, start)
+            offset += 2
+          else
+            push(Token.Slash, start)
+            offset += 1
+
+        case '|' => push(Token.Pipe, start); offset += 1
+        case '+' => push(Token.Plus, start); offset += 1
+        case '-' => push(Token.Minus, start); offset += 1
+        case '=' => push(Token.Equals, start); offset += 1
+        case '(' => push(Token.OpenParen, start); offset += 1
+        case ')' => push(Token.CloseParen, start); offset += 1
+        case '[' => push(Token.OpenBracket, start); offset += 1
+        case ']' => push(Token.CloseBracket, start); offset += 1
+        case ',' => push(Token.Comma, start); offset += 1
+        case '@' => push(Token.At, start); offset += 1
+
+        case '!' =>
+          if offset + 1 < length && string.charAt(offset + 1) == '=' then
+            push(Token.Unequals, start)
+            offset += 2
+          else
+            abort(XPath.Error(Reason.UnexpectedCharacter, start))
+
+        case '<' =>
+          if offset + 1 < length && string.charAt(offset + 1) == '=' then
+            push(Token.LessOrEqual, start)
+            offset += 2
+          else
+            push(Token.Less, start)
+            offset += 1
+
+        case '>' =>
+          if offset + 1 < length && string.charAt(offset + 1) == '=' then
+            push(Token.GreaterOrEqual, start)
+            offset += 2
+          else
+            push(Token.Greater, start)
+            offset += 1
+
+        case '*' =>
+          push(if afterOperand then Token.Star else Token.WildcardTest, start)
+          offset += 1
+
+        case '.' =>
+          if digit(offset + 1) then scanNumber(start)
+          else if offset + 1 < length && string.charAt(offset + 1) == '.' then
+            push(Token.DotDot, start)
+            offset += 2
+          else
+            push(Token.Dot, start)
+            offset += 1
+
+        case '\'' | '"' =>
+          scanLiteral(start)
+
+        case '$' =>
+          if offset + 1 < length && nameStart(string.charAt(offset + 1)) then
+            var end = scanNcname(offset + 1)
+            val first = string.substring(offset + 1, end).nn
+
+            if end + 1 < length && string.charAt(end) == ':' && nameStart(string.charAt(end + 1))
+            then
+              val localEnd = scanNcname(end + 1)
+              push
+                ( Token.VariableToken(first.tt, string.substring(end + 1, localEnd).nn.tt),
+                  start )
+              offset = localEnd
+            else
+              push(Token.VariableToken(Unset, first.tt), start)
+              offset = end
+          else
+            abort(XPath.Error(Reason.UnexpectedCharacter, start))
+
+        case '\u0000' if holes =>
+          push(Token.HoleToken(holeCount), start)
+          holeCount += 1
+          offset += 1
+
+        case other =>
+          if other >= '0' && other <= '9' then scanNumber(start)
+          else if nameStart(other) then scanName(start)
+          else abort(XPath.Error(Reason.UnexpectedCharacter, start))
+
+    tokens
+
+  private val descendantStep: Step = Step(Axis.DescendantOrSelf, NodeTest.Node, Nil)
+
+  def parse(text: Text, holes: Boolean)(using Tactic[XPath.Error]): Expression =
+    val tokens = tokenize(text.s, holes)
+    val end = text.s.length
+    var index = 0
+
+    def more: Boolean = index < tokens.length
+    def current: Token = tokens(index).token
+    def here: Int = if more then tokens(index).offset else end
+    def advance(): Unit = index += 1
+
+    def expect(token: Token, reason: Reason): Unit =
+      if more && current == token then advance()
+      else abort(XPath.Error(reason, here))
+
+    def parseAll(): Expression =
+      val result = parseOr()
+      if more then abort(XPath.Error(Reason.UnexpectedToken, here))
+      result
+
+    def parseOr(): Expression =
+      var left = parseAnd()
+
+      while more && current == Token.OrKeyword do
+        advance()
+        left = Expression.Or(left, parseAnd())
+
+      left
+
+    def parseAnd(): Expression =
+      var left = parseEquality()
+
+      while more && current == Token.AndKeyword do
+        advance()
+        left = Expression.And(left, parseEquality())
+
+      left
+
+    def parseEquality(): Expression =
+      var left = parseRelational()
+
+      while more && (current == Token.Equals || current == Token.Unequals) do
+        val equal = current == Token.Equals
+        advance()
+        val right = parseRelational()
+        left = if equal then Expression.Equal(left, right) else Expression.Unequal(left, right)
+
+      left
+
+    def parseRelational(): Expression =
+      var left = parseAdditive()
+
+      while more
+            && (current == Token.Less || current == Token.LessOrEqual
+                || current == Token.Greater || current == Token.GreaterOrEqual)
+      do
+        val operator = current
+        advance()
+        val right = parseAdditive()
+
+        left = operator match
+          case Token.Less           => Expression.Less(left, right)
+          case Token.LessOrEqual    => Expression.LessOrEqual(left, right)
+          case Token.Greater        => Expression.Greater(left, right)
+          case _                    => Expression.GreaterOrEqual(left, right)
+
+      left
+
+    def parseAdditive(): Expression =
+      var left = parseMultiplicative()
+
+      while more && (current == Token.Plus || current == Token.Minus) do
+        val plus = current == Token.Plus
+        advance()
+        val right = parseMultiplicative()
+        left = if plus then Expression.Add(left, right) else Expression.Subtract(left, right)
+
+      left
+
+    def parseMultiplicative(): Expression =
+      var left = parseUnary()
+
+      while more
+            && (current == Token.Star || current == Token.DivKeyword
+                || current == Token.ModKeyword)
+      do
+        val operator = current
+        advance()
+        val right = parseUnary()
+
+        left = operator match
+          case Token.Star       => Expression.Multiply(left, right)
+          case Token.DivKeyword => Expression.Divide(left, right)
+          case _                => Expression.Modulo(left, right)
+
+      left
+
+    def parseUnary(): Expression =
+      if more && current == Token.Minus then
+        advance()
+        Expression.Negate(parseUnary())
+      else
+        parseUnion()
+
+    def parseUnion(): Expression =
+      var left = parsePath()
+
+      while more && current == Token.Pipe do
+        advance()
+        left = Expression.Union(left, parsePath())
+
+      left
+
+    def startsStep(token: Token): Boolean = token match
+      case Token.Dot | Token.DotDot | Token.At | Token.WildcardTest
+         | Token.NameToken(_, _) | Token.PrefixWildcardTest(_) | Token.NodeTypeToken(_)
+         | Token.AxisToken(_) =>
+        true
+
+      case _ =>
+        false
+
+    def parsePath(): Expression =
+      if !more then abort(XPath.Error(Reason.ExpectedExpression, here))
+
+      current match
+        case Token.Slash =>
+          advance()
+
+          if more && startsStep(current)
+          then Expression.Route(Origin.Root, parseRelative())
+          else Expression.Route(Origin.Root, Nil)
+
+        case Token.DoubleSlash =>
+          advance()
+          Expression.Route(Origin.Root, List.of(descendantStep :: parseRelative().stdlib))
+
+        case token if startsStep(token) =>
+          Expression.Route(Origin.Here, parseRelative())
+
+        case _ =>
+          parseFilter()
+
+    def parseRelative(): List[Step] =
+      val steps = scm.ListBuffer[Step]()
+      steps += parseStep()
+
+      while more && (current == Token.Slash || current == Token.DoubleSlash) do
+        if current == Token.DoubleSlash then steps += descendantStep
+        advance()
+        steps += parseStep()
+
+      List.of(steps.toList)
+
+    def parseStep(): Step =
+      if !more then abort(XPath.Error(Reason.ExpectedNodeTest, here))
+
+      current match
+        case Token.Dot =>
+          advance()
+          Step(Axis.Self, NodeTest.Node, Nil)
+
+        case Token.DotDot =>
+          advance()
+          Step(Axis.Parent, NodeTest.Node, Nil)
+
+        case Token.At =>
+          advance()
+          finishStep(Axis.Attribute)
+
+        case Token.AxisToken(axis) =>
+          advance()
+          finishStep(axis)
+
+        case _ =>
+          finishStep(Axis.Child)
+
+    def finishStep(axis: Axis): Step =
+      val test = parseNodeTest()
+      Step(axis, test, parsePredicates())
+
+    def parseNodeTest(): NodeTest =
+      if !more then abort(XPath.Error(Reason.ExpectedNodeTest, here))
+
+      current match
+        case Token.NameToken(prefix, local) =>
+          advance()
+          NodeTest.Name(prefix, local)
+
+        case Token.WildcardTest =>
+          advance()
+          NodeTest.Wildcard
+
+        case Token.PrefixWildcardTest(prefix) =>
+          advance()
+          NodeTest.PrefixWildcard(prefix)
+
+        case Token.NodeTypeToken(name) =>
+          advance()
+          expect(Token.OpenParen, Reason.UnexpectedToken)
+
+          name.s match
+            case "processing-instruction" =>
+              val target: Optional[Text] =
+                if more then current match
+                  case Token.LiteralToken(text) =>
+                    advance()
+                    text
+
+                  case _ =>
+                    Unset
+                else Unset
+
+              expect(Token.CloseParen, Reason.ExpectedCloseParen)
+              NodeTest.Instruction(target)
+
+            case "node" =>
+              expect(Token.CloseParen, Reason.ExpectedCloseParen)
+              NodeTest.Node
+
+            case "text" =>
+              expect(Token.CloseParen, Reason.ExpectedCloseParen)
+              NodeTest.Textual
+
+            case _ =>
+              expect(Token.CloseParen, Reason.ExpectedCloseParen)
+              NodeTest.Comment
+
+        case _ =>
+          abort(XPath.Error(Reason.ExpectedNodeTest, here))
+
+    def parsePredicates(): List[Expression] =
+      val predicates = scm.ListBuffer[Expression]()
+
+      while more && current == Token.OpenBracket do
+        advance()
+        predicates += parseOr()
+        expect(Token.CloseBracket, Reason.ExpectedCloseBracket)
+
+      List.of(predicates.toList)
+
+    def parseFilter(): Expression =
+      val primary = parsePrimary()
+      val predicates = parsePredicates()
+
+      if more && (current == Token.Slash || current == Token.DoubleSlash) then
+        val descend = current == Token.DoubleSlash
+        advance()
+        val rest = parseRelative()
+        val steps = if descend then List.of(descendantStep :: rest.stdlib) else rest
+        Expression.Route(Origin.Filter(primary, predicates), steps)
+      else if predicates.isEmpty then primary
+      else Expression.Route(Origin.Filter(primary, predicates), Nil)
+
+    def parsePrimary(): Expression =
+      if !more then abort(XPath.Error(Reason.ExpectedExpression, here))
+
+      current match
+        case Token.VariableToken(prefix, name) =>
+          advance()
+          Expression.Variable(prefix, name)
+
+        case Token.LiteralToken(text) =>
+          advance()
+          Expression.Literal(text)
+
+        case Token.NumberToken(value) =>
+          advance()
+          Expression.Number(value)
+
+        case Token.HoleToken(index) =>
+          advance()
+          Expression.Substitution(index)
+
+        case Token.OpenParen =>
+          advance()
+          val expression = parseOr()
+          expect(Token.CloseParen, Reason.ExpectedCloseParen)
+          expression
+
+        case Token.FunctionToken(prefix, local) =>
+          advance()
+          expect(Token.OpenParen, Reason.ExpectedExpression)
+
+          if more && current == Token.CloseParen then
+            advance()
+            Expression.Call(prefix, local, Nil)
+          else
+            val arguments = scm.ListBuffer[Expression]()
+            arguments += parseOr()
+
+            while more && current == Token.Comma do
+              advance()
+              arguments += parseOr()
+
+            expect(Token.CloseParen, Reason.ExpectedCloseParen)
+            Expression.Call(prefix, local, List.of(arguments.toList))
+
+        case _ =>
+          abort(XPath.Error(Reason.ExpectedExpression, here))
+
+    parseAll()

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -1916,53 +1916,46 @@ object Xml extends Tag.Container
   // to resolve an `XPath` to a source `Position`; see the descriptor-layout
   // comment on `PositionIndex` below.
   private object Locator:
-    // `XPath.path.descent` is stored leaf-first (Serpentine's `/`
-    // prepends), so the walker iterates it in reverse to descend
-    // root-to-leaf. The XPath convention is `/foo/bar/@attr`, so the
-    // first element step names the *root* element itself (no descent
-    // into children) and subsequent steps descend.
+    // The path arrives as `XPath.Location`s, root-first. The XPath convention
+    // is `/foo/bar/@attr`, so the first element step names the *root* element
+    // itself (no descent into children) and subsequent steps descend.
     private[xylophone] def walk
       ( xml:      Xml,
         data:     Array[Int]^{},
         offset:   Int,
-        segments: Sequence[Text],
-        i:        Int )
+        segments: List[XPath.Location],
+        first:    Boolean )
     :   Optional[Position] =
 
-      if i >= segments.length then
-        Position(data.readUnchecked(offset + 1).z, data.readUnchecked(offset + 2).z, length = data.readUnchecked(offset + 3))
-      else
-        val segment = segments.stdlib(segments.length - 1 - i)
+      segments match
+        case Nil =>
+          Position(data.readUnchecked(offset + 1).z, data.readUnchecked(offset + 2).z, length = data.readUnchecked(offset + 3))
 
-        XPath.parseStep(segment) match
-          case Unset => Unset
+        case XPath.Location.Attribute(attrName) :: _ =>
+          xml match
+            case element: Element => attrPosition(element, data, offset, attrName)
+            case _                => Unset
 
-          case step => step.asInstanceOf[Either[Text, (Text, Int)]] match
-            case Left(attrName) =>
-              xml match
-                case element: Element => attrPosition(element, data, offset, attrName)
-                case _                => Unset
+        case XPath.Location.Element(name, ordinal) :: rest =>
+          xml match
+            case element: Element if first =>
+              // First step names the document's root element.
+              if element.label == name && ordinal == 1 then
+                walk(element, data, offset, rest, false)
+              else
+                Unset
 
-            case Right((name, ordinal)) =>
-              xml match
-                case element: Element if i == 0 =>
-                  // First step names the document's root element.
-                  if element.label == name && ordinal == 1 then
-                    walk(element, data, offset, segments, i + 1)
-                  else
-                    Unset
+            case element: Element =>
+              descend(element, name, ordinal).let: childElementIndex =>
+                val attrCount = data.readUnchecked(offset + 4)
+                val offSlot = offset + 6 + attrCount + childElementIndex
+                val childOff = data.readUnchecked(offSlot)
 
-                case element: Element =>
-                  descend(element, name, ordinal).let: childElementIndex =>
-                    val attrCount = data.readUnchecked(offset + 4)
-                    val offSlot = offset + 6 + attrCount + childElementIndex
-                    val childOff = data.readUnchecked(offSlot)
+                descendAst(element, name, ordinal).let: child =>
+                  walk(child, data, offset + childOff, rest, false)
 
-                    descendAst(element, name, ordinal).let: child =>
-                      walk(child, data, offset + childOff, segments, i + 1)
-
-                case _ =>
-                  Unset
+            case _ =>
+              Unset
 
     private def attrPosition
       ( element:  Element,
@@ -2053,7 +2046,8 @@ object Xml extends Tag.Container
 
       def locate(document: Document[Xml], path: XPath): Optional[Xml.Position] =
         document.metadata.positionIndex.let: index =>
-          Locator.walk(document.root, index.ints, 0, Sequence.from(path.path.descent), 0)
+          path.locations.let: segments =>
+            Locator.walk(document.root, index.ints, 0, segments, true)
 
       // XML has no distinct key positions, so there is nothing to locate by key.
       def locateKey(document: Document[Xml], path: XPath): Optional[Xml.Position] = Unset

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -3939,6 +3939,49 @@ object Xml extends Tag.Container
 
     new XmlParser(Cursor[Text](input), tracking = false, callback).parseXml(headers0)
 
+  // Selects the nodes matching an XPath: `//div[@id='x']` and friends,
+  // evaluated against this tree. The result is a `Fragment` of the matching
+  // tree nodes in document order; a path selecting attributes (`//a/@href`)
+  // yields their values through `selectText` or `evaluate` instead, since
+  // attributes are not tree nodes.
+  extension (xml: Xml)
+    def select(xpath: XPath)(using Tactic[XPath.EvaluationError]): Fragment =
+      XPathEngine.evaluate(xml, xpath.expression, Map()) match
+        case XPath.Value.NodeSet(loci) =>
+          val nodes = loci.stdlib.flatMap: locus =>
+            locus.attributeIndex match
+              case _: Int => scala.collection.immutable.Nil
+
+              case _ => locus.subject match
+                case node: Node => scala.collection.immutable.List(node)
+                case _          => scala.collection.immutable.Nil
+
+          new Fragment(nodes*)
+
+        case _ =>
+          abort(XPath.EvaluationError(XPath.EvaluationError.Reason.NotNodeSet))
+
+    // The string-value of the first matching node (`Unset` when nothing
+    // matches), or of the expression's value for non-node-set results. This is
+    // the way to read an attribute selected by path: `xml.selectText(xp"//a/@href")`.
+    def selectText(xpath: XPath)(using Tactic[XPath.EvaluationError]): Optional[Text] =
+      XPathEngine.evaluate(xml, xpath.expression, Map()) match
+        case XPath.Value.NodeSet(loci) => loci.stdlib.headOption match
+          case Some(locus) => locus.stringValue
+          case None        => Unset
+
+        case value =>
+          value.text
+
+    // Full XPath 1.0 expression evaluation, yielding one of the four value
+    // types: `count(//div)` is a number, `//a` a node-set. Variables referenced
+    // as `$name` resolve from `variables`, keyed by qualified name.
+    def evaluate(xpath: XPath, variables: Map[Text, XPath.Value] = Map())
+      ( using Tactic[XPath.EvaluationError] )
+    :   XPath.Value =
+
+      XPathEngine.evaluate(xml, xpath.expression, variables)
+
   // XmlError → Xml.Error
   case class Error()(using Diagnostics)
   extends fulminate.Error(149, 0)(m"there was an XML error")

--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -349,48 +349,187 @@ object internal:
             case '[type result <: Tuple; result] =>
               '{$result.asInstanceOf[Option[result]]}
 
-  // Reuses `XPath`'s own `Decodable` for validation: the literal is decoded at
-  // macro-expansion time and, if it fails, the `XPath.Error`'s offset is mapped
-  // back to a source position so the error points exactly at the offending
-  // character. Mirrors `jacinta.internal.jsonPointer`.
-  def xpath[parts <: Tuple: Type, origins <: Tuple: Type](insertions: Expr[Seq[Any]])
+  // Parses the literal at macro-expansion time with `XPathReader` (the same
+  // parser the runtime `Decodable` uses, so the compile-time check can never
+  // diverge from runtime behaviour); a failure's offset is mapped back to a
+  // source position so the error points exactly at the offending character.
+  // Substitutions are permitted wherever the grammar allows a primary
+  // expression: each one becomes a NUL-marker hole in the parsed text, and
+  // the parsed AST — with insertions grafted in place of the holes — is
+  // lifted wholesale into the tree, so nothing is re-parsed at runtime.
+  def xpath[parts <: Tuple: Type, origins <: Tuple: Type](insertions0: Expr[Seq[Any]])
   :   Macro[XPath] =
 
     import quotes.reflect.*
+    import XPath.{Axis, Expression, NodeTest, Origin, Step}
 
     def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
       case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].or(halt(m"an interpolator's parts are string-literal types")) :: strings)
       case _               => strings
 
-    def firstOrigin[tuple: Type]: Int = Type.of[tuple] match
-      case '[head *: tail] => TypeRepr.of[head].dealias match
-        case AppliedType(_, ConstantType(IntConstant(start)) :: _) => start
-        case _                                                     => 0
+    def recurOrigins[tuple: Type](acc: List[(Int, Int)]): List[(Int, Int)] =
+      Type.of[tuple] match
+        case '[head *: tail] =>
+          val pair = TypeRepr.of[head].dealias match
+            case AppliedType(_, List(ConstantType(IntConstant(s)), ConstantType(IntConstant(e)))) =>
+              (s, e)
 
-      case _ => 0
+            case _ =>
+              (0, 0)
+
+          recurOrigins[tail](pair :: acc)
+
+        case _ =>
+          acc.reverse
 
     val parts = recur[parts](Nil)
-    if parts.length != 1 then halt(m"an XPath literal cannot have substitutions")
-    val raw: String = parts.head
-    val start: Int = firstOrigin[origins]
+    val partOrigins: List[(Int, Int)] = recurOrigins[origins](Nil)
+    val sourceFile = Position.ofMacroExpansion.sourceFile
+    val macroPos = Position.ofMacroExpansion
 
-    try unsafely(raw.tt.as[XPath]) catch
-      case error: XPath.Error =>
-        val sourceFile = Position.ofMacroExpansion.sourceFile
+    val sourceContent: Optional[String] = sourceFile.content match
+      case Some(s: String) => s
+      case _               => Unset
 
-        val position = sourceFile.content match
-          case Some(content: String) if start > 0 && start < content.length =>
-            val upper = (start + raw.length*6 + 16).min(content.length)
-            val mapping = Interpolation.buildMapping(content.substring(start, upper).nn, raw)
-            val at = (start + mapping(error.offset.min(raw.length))).min(content.length - 1)
-            Position(sourceFile, at, (at + 1).min(content.length))
+    // Per part, the value→source offset mapping (escape sequences in the
+    // source expand to multiple characters); see `interpolator` below.
+    val perPart: IndexedSeq[((String, Int), Int -> Int)] =
+      parts.zip(partOrigins).map: (part, origin) =>
+        val (srcStart, _) = origin
 
-          case _ =>
-            Position.ofMacroExpansion
+        val mapping: Int -> Int = sourceContent.lay[Int -> Int](identity): content =>
+          if srcStart > 0 && srcStart < content.length then
+            val upper = (srcStart + part.length * 6 + 16).min(content.length)
+            Interpolation.buildMapping(content.substring(srcStart, upper).nn, part)
+          else
+            (i: Int) => i
 
-        halt(error.message, position)
+        ((part, srcStart), mapping)
 
-    '{unsafely(${Expr(raw)}.tt.as[XPath])}
+      . toIndexedSeq
+
+    def translate(parserOff: Int): Position =
+      var acc = 0
+      var i = 0
+
+      while i < perPart.length do
+        val ((part, srcStart), mapping) = perPart(i)
+
+        if parserOff <= acc + part.length && srcStart > 0 then
+          val inPart = (parserOff - acc).min(part.length)
+          val at = (srcStart + mapping(inPart)).min((sourceContent.let(_.length).or(Int.MaxValue)) - 1)
+          return Position(sourceFile, at, at + 1)
+
+        acc += part.length + 1
+        i += 1
+
+      macroPos
+
+    val insertions: Seq[Expr[Any]] = insertions0.absolve match
+      case Varargs(exprs) => exprs
+
+    val substitutions: IndexedSeq[Expr[Expression]] =
+      insertions.map: insertion =>
+        insertion.absolve match
+          case '{$text: Text}     => '{Expression.Literal($text)}
+          case '{$string: String} => '{Expression.Literal($string.tt)}
+          case '{$int: Int}       => '{Expression.Number($int.toDouble)}
+          case '{$double: Double} => '{Expression.Number($double)}
+          case '{$xpath: XPath}   => '{$xpath.expression}
+
+          case other =>
+            halt
+              ( m"only Text, Int, Double and XPath values can be substituted into an XPath",
+                other.asTerm.pos )
+
+      . toIndexedSeq
+
+    def liftName(optional: Optional[Text]): Expr[Optional[Text]] = optional match
+      case text: Text => '{${Expr(text.s)}.tt}
+      case _          => '{Unset}
+
+    def liftAxis(axis: Axis): Expr[Axis] = axis match
+      case Axis.Ancestor         => '{Axis.Ancestor}
+      case Axis.AncestorOrSelf   => '{Axis.AncestorOrSelf}
+      case Axis.Attribute        => '{Axis.Attribute}
+      case Axis.Child            => '{Axis.Child}
+      case Axis.Descendant       => '{Axis.Descendant}
+      case Axis.DescendantOrSelf => '{Axis.DescendantOrSelf}
+      case Axis.Following        => '{Axis.Following}
+      case Axis.FollowingSibling => '{Axis.FollowingSibling}
+      case Axis.Namespace        => '{Axis.Namespace}
+      case Axis.Parent           => '{Axis.Parent}
+      case Axis.Preceding        => '{Axis.Preceding}
+      case Axis.PrecedingSibling => '{Axis.PrecedingSibling}
+      case Axis.Self             => '{Axis.Self}
+
+    def liftTest(test: NodeTest): Expr[NodeTest] = test match
+      case NodeTest.Name(prefix, local) =>
+        '{NodeTest.Name(${liftName(prefix)}, ${Expr(local.s)}.tt)}
+
+      case NodeTest.Wildcard               => '{NodeTest.Wildcard}
+      case NodeTest.PrefixWildcard(prefix) => '{NodeTest.PrefixWildcard(${Expr(prefix.s)}.tt)}
+      case NodeTest.Node                   => '{NodeTest.Node}
+      case NodeTest.Textual                => '{NodeTest.Textual}
+      case NodeTest.Comment                => '{NodeTest.Comment}
+      case NodeTest.Instruction(target)    => '{NodeTest.Instruction(${liftName(target)})}
+
+    def liftStep(step: Step): Expr[Step] =
+      '{Step(${liftAxis(step.axis)}, ${liftTest(step.test)}, ${liftExpressions(step.predicates)})}
+
+    def liftSteps(steps: proscenium.List[Step]): Expr[proscenium.List[Step]] =
+      '{proscenium.List(${Varargs(steps.stdlib.map(liftStep))}*)}
+
+    def liftExpressions(expressions: proscenium.List[Expression])
+    :   Expr[proscenium.List[Expression]] =
+
+      '{proscenium.List(${Varargs(expressions.stdlib.map(liftExpression))}*)}
+
+    def liftOrigin(origin: Origin): Expr[Origin] = origin match
+      case Origin.Root => '{Origin.Root}
+      case Origin.Here => '{Origin.Here}
+
+      case Origin.Filter(expression, predicates) =>
+        '{Origin.Filter(${liftExpression(expression)}, ${liftExpressions(predicates)})}
+
+    def liftExpression(expression: Expression): Expr[Expression] = expression match
+      case Expression.Or(l, r)             => '{Expression.Or(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.And(l, r)            => '{Expression.And(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.Equal(l, r)          => '{Expression.Equal(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.Unequal(l, r)        => '{Expression.Unequal(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.Less(l, r)           => '{Expression.Less(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.LessOrEqual(l, r)    => '{Expression.LessOrEqual(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.Greater(l, r)        => '{Expression.Greater(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.GreaterOrEqual(l, r) => '{Expression.GreaterOrEqual(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.Add(l, r)            => '{Expression.Add(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.Subtract(l, r)       => '{Expression.Subtract(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.Multiply(l, r)       => '{Expression.Multiply(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.Divide(l, r)         => '{Expression.Divide(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.Modulo(l, r)         => '{Expression.Modulo(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.Negate(operand)      => '{Expression.Negate(${liftExpression(operand)})}
+      case Expression.Union(l, r)          => '{Expression.Union(${liftExpression(l)}, ${liftExpression(r)})}
+      case Expression.Literal(text)        => '{Expression.Literal(${Expr(text.s)}.tt)}
+      case Expression.Number(value)        => '{Expression.Number(${Expr(value)})}
+
+      case Expression.Variable(prefix, name) =>
+        '{Expression.Variable(${liftName(prefix)}, ${Expr(name.s)}.tt)}
+
+      case Expression.Call(prefix, name, arguments) =>
+        '{Expression.Call(${liftName(prefix)}, ${Expr(name.s)}.tt, ${liftExpressions(arguments)})}
+
+      case Expression.Route(origin, steps) =>
+        '{Expression.Route(${liftOrigin(origin)}, ${liftSteps(steps)})}
+
+      case Expression.Substitution(index) =>
+        substitutions(index)
+
+    val joined: String = parts.mkString("\u0000")
+
+    val expression: Expression =
+      try unsafely(XPathReader.parse(joined.tt, holes = true)) catch
+        case error: XPath.Error => halt(error.message, translate(error.offset))
+
+    '{XPath(${liftExpression(expression)})}
 
   def interpolator[parts <: Tuple: Type, origins <: Tuple: Type]
     ( insertions0: Expr[Seq[Any]] )

--- a/lib/xylophone/src/test/xylophone.XPathTests.scala
+++ b/lib/xylophone/src/test/xylophone.XPathTests.scala
@@ -1,0 +1,243 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xylophone
+
+import soundness.*
+
+import strategies.throwUnsafely
+
+object XPathTests extends Suite(m"Xylophone XPath evaluation tests"):
+  def run(): Unit =
+    given XmlSchema = XmlSchema.Freeform
+    import XPath.Value
+
+    val document: Xml =
+      t"""<app><!-- note --><?render fast?><div class="container active" id="main"><button data-test="submit">Submit</button><button data-test="cancel">Cancel</button><span id="x" class="badge">7</span></div><div class="container"><ul class="list"><li n="1">one</li><li n="2">two</li><li n="3">three</li></ul><![CDATA[raw]]></div><footer xml:lang="en-GB"><p>done</p></footer></app>"""
+      . read[Xml]
+
+    suite(m"Browser-automation locators"):
+      test(m"a text predicate finds a button by its label"):
+        document.selectText(xp"//button[text()='Submit']/@data-test")
+      . assert(_ == t"submit")
+
+      test(m"an attribute predicate finds an element anywhere"):
+        document.selectText(xp"//*[@data-test='cancel']")
+      . assert(_ == t"Cancel")
+
+      test(m"a contains predicate matches a partial attribute value"):
+        document.selectText(xp"//*[contains(@class,'active')]/@id")
+      . assert(_ == t"main")
+
+      test(m"a parent step reaches the enclosing element"):
+        document.select(xp"//span[@id='x']/..") match
+          case Fragment(element: Element) => element.attributes.fetch(t"id")
+          case _                          => Unset
+      . assert(_ == t"main")
+
+      test(m"an attribute-presence predicate selects only carriers"):
+        document.evaluate(xp"count(//*[@data-test])")
+      . assert(_ == Value.Numeric(2))
+
+    suite(m"Axes"):
+      test(m"descendant-or-self finds elements at any depth"):
+        document.evaluate(xp"count(//li)")
+      . assert(_ == Value.Numeric(3))
+
+      test(m"a positional path descends by ordinal"):
+        document.selectText(xp"/app/div[2]/ul/li[2]")
+      . assert(_ == t"two")
+
+      test(m"following-sibling in proximity order"):
+        document.selectText(xp"//li[1]/following-sibling::li[1]")
+      . assert(_ == t"two")
+
+      test(m"preceding-sibling in proximity order"):
+        document.selectText(xp"//li[3]/preceding-sibling::li[1]")
+      . assert(_ == t"two")
+
+      test(m"the nearest ancestor is position one on the ancestor axis"):
+        document.selectText(xp"//li/ancestor::*[1]/@class")
+      . assert(_ == t"list")
+
+      test(m"the attribute axis with a wildcard yields every attribute"):
+        document.evaluate(xp"count(//span/@*)")
+      . assert(_ == Value.Numeric(2))
+
+      test(m"following excludes descendants"):
+        document.evaluate(xp"count(//ul/following::*)")
+      . assert(_ == Value.Numeric(2))
+
+      test(m"a comment node test finds comments"):
+        document.evaluate(xp"count(//comment())")
+      . assert(_ == Value.Numeric(1))
+
+      test(m"a processing-instruction node test matches by target"):
+        document.evaluate(xp"count(//processing-instruction('render'))")
+      . assert(_ == Value.Numeric(1))
+
+      test(m"a text node test selects character data"):
+        document.selectText(xp"//li[1]/text()")
+      . assert(_ == t"one")
+
+    suite(m"Node-set semantics"):
+      test(m"union results arrive in document order"):
+        document.select(xp"//span | //button") match
+          case Fragment(nodes*) =>
+            nodes.map:
+              case element: Element => element.label.s
+              case _                => "?"
+            . mkString(",").tt
+      . assert(_ == t"button,button,span")
+
+      test(m"revisited nodes deduplicate"):
+        document.evaluate(xp"count(//li/../li)")
+      . assert(_ == Value.Numeric(3))
+
+      test(m"a predicate of position()=last() selects the final node"):
+        document.selectText(xp"//li[position()=last()]")
+      . assert(_ == t"three")
+
+      test(m"an arithmetic predicate resolves to a position"):
+        document.selectText(xp"//li[last() - 1]")
+      . assert(_ == t"two")
+
+      test(m"an element's string-value concatenates its descendants"):
+        document.selectText(xp"//footer")
+      . assert(_ == t"done")
+
+      test(m"CDATA contributes to the string-value"):
+        document.evaluate(xp"contains(/app/div[2], 'raw')")
+      . assert(_ == Value.Truth(true))
+
+    suite(m"Coercions and comparisons"):
+      test(m"a number compares against a numeric string"):
+        document.evaluate(xp"1 = '1'")
+      . assert(_ == Value.Truth(true))
+
+      test(m"NaN is unequal to itself"):
+        document.evaluate(xp"number('x') != number('x')")
+      . assert(_ == Value.Truth(true))
+
+      test(m"an integral number renders without a decimal point"):
+        document.evaluate(xp"string(2 div 2)")
+      . assert(_ == Value.Textual(t"1"))
+
+      test(m"a fractional number renders with its decimal part"):
+        document.evaluate(xp"string(0.5)")
+      . assert(_ == Value.Textual(t"0.5"))
+
+      test(m"a node-set compares existentially"):
+        document.evaluate(xp"//li = 'two'")
+      . assert(_ == Value.Truth(true))
+
+      test(m"relational comparison over attribute numbers"):
+        document.evaluate(xp"count(//li[@n > 1])")
+      . assert(_ == Value.Numeric(2))
+
+    suite(m"Function library"):
+      test(m"starts-with tests a prefix"):
+        document.evaluate(xp"starts-with('hello','he')")
+      . assert(_ == Value.Truth(true))
+
+      test(m"substring rounds its bounds"):
+        document.evaluate(xp"substring('12345', 1.5, 2.6)")
+      . assert(_ == Value.Textual(t"234"))
+
+      test(m"substring-before and substring-after split at the match"):
+        document.evaluate(xp"concat(substring-before('a-b','-'), substring-after('a-b','-'))")
+      . assert(_ == Value.Textual(t"ab"))
+
+      test(m"normalize-space collapses interior runs"):
+        document.evaluate(xp"normalize-space('  a   b ')")
+      . assert(_ == Value.Textual(t"a b"))
+
+      test(m"translate maps and deletes characters"):
+        document.evaluate(xp"translate('--abc--','abc-','ABC')")
+      . assert(_ == Value.Textual(t"ABC"))
+
+      test(m"sum totals a node-set numerically"):
+        document.evaluate(xp"sum(//li/@n)")
+      . assert(_ == Value.Numeric(6))
+
+      test(m"round is floor of x plus a half"):
+        document.evaluate(xp"round(2.5) + round(-2.5)")
+      . assert(_ == Value.Numeric(1))
+
+      test(m"string-length defaults to the context node"):
+        document.evaluate(xp"string-length('four')")
+      . assert(_ == Value.Numeric(4))
+
+      test(m"not negates a boolean"):
+        document.evaluate(xp"not(false())")
+      . assert(_ == Value.Truth(true))
+
+      test(m"lang matches a language subtag from an ancestor"):
+        document.selectText(xp"//p[lang('en')]")
+      . assert(_ == t"done")
+
+      test(m"name reports an element's label"):
+        document.evaluate(xp"name(//span)")
+      . assert(_ == Value.Textual(t"span"))
+
+    suite(m"Variables and errors"):
+      test(m"variables resolve from the given bindings"):
+        document.evaluate(XPath(XPath.variable(t"n") + 1), Map(t"n" -> Value.Numeric(2)))
+      . assert(_ == Value.Numeric(3))
+
+      test(m"an unbound variable raises an error"):
+        try
+          document.evaluate(XPath(XPath.variable(t"missing")))
+          t"evaluated"
+        catch case error: XPath.EvaluationError => t"unbound"
+      . assert(_ == t"unbound")
+
+      test(m"an unknown function raises an error"):
+        try
+          document.evaluate(xp"frobnicate()")
+          t"evaluated"
+        catch case error: XPath.EvaluationError => t"unknown"
+      . assert(_ == t"unknown")
+
+      test(m"the namespace axis is unsupported"):
+        try
+          document.select(xp"//namespace::x")
+          t"selected"
+        catch case error: XPath.EvaluationError => t"unsupported"
+      . assert(_ == t"unsupported")
+
+      test(m"the id function is unsupported"):
+        try
+          document.evaluate(xp"id('main')")
+          t"evaluated"
+        catch case error: XPath.EvaluationError => t"unsupported"
+      . assert(_ == t"unsupported")

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -1102,6 +1102,38 @@ object Tests extends Suite(m"Xylophone tests"):
         xp"//button[text()='Submit']".encode
       . assert(_ == t"//button[text()='Submit']")
 
+      test(m"a Text insertion becomes a string literal"):
+        val id = t"target"
+        xp"//div[@id=$id]".encode
+      . assert(_ == t"//div[@id='target']")
+
+      test(m"an Int insertion becomes a number"):
+        val n = 3
+        xp"//li[position()=$n]".encode
+      . assert(_ == t"//li[position()=3]")
+
+      test(m"an XPath insertion splices its expression in parentheses"):
+        val base = xp"/html/body"
+        xp"$base//div".encode
+      . assert(_ == t"(/html/body)//div")
+
+      test(m"an insertion containing both quote kinds renders via concat"):
+        val value = t"it's a \"test\""
+        xp"//a[@title=$value]".encode
+      . assert(_ == t"""//a[@title=concat('it',"'",'s a "test"')]""")
+
+      test(m"an insertion of an unsupported type is rejected"):
+        demilitarize:
+          val flag = true
+          xp"//div[@id=$flag]"
+      . assert(_.nonEmpty)
+
+      test(m"an insertion cannot appear as an axis name"):
+        demilitarize:
+          val axis = t"child"
+          xp"//$axis::div"
+      . assert(_.nonEmpty)
+
       test(m"an unclosed predicate is rejected"):
         demilitarize:
           xp"/root["

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -1282,5 +1282,6 @@ object Tests extends Suite(m"Xylophone tests"):
 
     PositionTests()
     DecoderTests()
+    XPathTests()
     EncoderTests()
     DirectParsingTests()

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -1078,31 +1078,41 @@ object Tests extends Suite(m"Xylophone tests"):
         xp"/root[1]/@id".encode
       . assert(_ == t"/root[1]/@id")
 
-      test(m"a step without an ordinal defaults to [1]"):
+      test(m"a step without an ordinal keeps its abbreviated form"):
         xp"/root/child".encode
-      . assert(_ == t"/root[1]/child[1]")
+      . assert(_ == t"/root/child")
 
       test(m"the root path parses"):
         xp"/".encode
       . assert(_ == t"/")
 
-      test(m"a path not beginning with '/' is rejected at the first character"):
-        demilitarize:
-          xp"root/child"
-        . map(_.focus)
-      . assert(_ == List("r"))
+      test(m"a relative path parses"):
+        xp"root/child".encode
+      . assert(_ == t"root/child")
 
-      test(m"an empty step is rejected at the offending separator"):
-        demilitarize:
-          xp"/root//child"
-        . map(_.focus)
-      . assert(_ == List("/"))
+      test(m"a descendant-or-self step parses"):
+        xp"/root//child".encode
+      . assert(_ == t"/root//child")
 
-      test(m"a non-numeric ordinal is rejected"):
+      test(m"an attribute predicate parses"):
+        xp"//*[@data-test='submit']".encode
+      . assert(_ == t"//*[@data-test='submit']")
+
+      test(m"a text predicate parses"):
+        xp"//button[text()='Submit']".encode
+      . assert(_ == t"//button[text()='Submit']")
+
+      test(m"an unclosed predicate is rejected"):
         demilitarize:
-          xp"/root[x]"
+          xp"/root["
         . map(_.focus.nonEmpty)
       . assert(_ == List(true))
+
+      test(m"an unknown axis is rejected at its first character"):
+        demilitarize:
+          xp"/foo::bar"
+        . map(_.focus)
+      . assert(_ == List("f"))
 
     suite(m"HTTP content-type integration"):
       import charEncoders.utf8Encoder

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -1146,6 +1146,51 @@ object Tests extends Suite(m"Xylophone tests"):
         . map(_.focus)
       . assert(_ == List("f"))
 
+    suite(m"XPath combinators"):
+      test(m"an absolute path builds with /"):
+        (XPath / t"html" / t"body").encode
+      . assert(_ == t"/html/body")
+
+      test(m"deep builds a descendant-or-self step"):
+        XPath.deep(t"div").encode
+      . assert(_ == t"//div")
+
+      test(m"where adds a contains predicate over an attribute"):
+        XPath.deep(t"div").where(XPath.attribute(t"class").contains(t"button")).encode
+      . assert(_ == t"//div[contains(@class,'button')]")
+
+      test(m"predicates compose with and"):
+        XPath.deep(t"div")
+        . where(XPath.attribute(t"class").contains(t"button") and XPath.textual === t"Submit")
+        . encode
+      . assert(_ == t"//div[contains(@class,'button') and text()='Submit']")
+
+      test(m"an ordinal predicate applies to the last step"):
+        (XPath / t"ul" / t"li")(2).encode
+      . assert(_ == t"/ul/li[2]")
+
+      test(m"position and last compose"):
+        (XPath / t"li").where(XPath.position === XPath.last).encode
+      . assert(_ == t"/li[position()=last()]")
+
+      test(m"a parent step re-sugars to double-dot"):
+        XPath.deep(t"span").on(XPath.Axis.Parent, XPath.NodeTest.Node).encode
+      . assert(_ == t"//span/..")
+
+      test(m"an attribute-presence predicate encodes bare"):
+        XPath.deep(t"a").where(XPath.attribute(t"href")).encode
+      . assert(_ == t"//a[@href]")
+
+      test(m"a variable comparison encodes with a dollar"):
+        XPath.relative(t"item").where(XPath.attribute(t"id") === XPath.variable(t"target"))
+        . encode
+      . assert(_ == t"item[@id=$$target]")
+
+      test(m"a combinator path round-trips through the parser"):
+        val path = XPath.deep(t"button").where(XPath.textual === t"Submit")
+        unsafely(path.encode.as[XPath])
+      . assert(_ == XPath.deep(t"button").where(XPath.textual === t"Submit"))
+
     suite(m"HTTP content-type integration"):
       import charEncoders.utf8Encoder
 


### PR DESCRIPTION
Xylophone's `XPath` grows from absolute positional paths to the complete XPath 1.0 language — grammar, typed construction and evaluation — closing the gap that made Tarantula's XPath locator (#1772) close to unusable, as described in #1773. `XPath` is now a real AST with a hand-written parser covering every production of the recommendation; the `xp"…"` interpolator checks the full grammar at compile time (with caret-precise errors) and accepts substitutions; typed combinators build the same AST; and a new evaluation engine executes any expression against an `Xml` tree.

```scala
// The locators browser automation needs, now expressible:
browser.element(xp"//button[text()='Submit']")
browser.element(xp"//*[contains(@class,'active')]")

// Substitutions splice into the AST — no quoting pitfalls:
val id = t"target"
xp"//div[@id=$id]"

// Or construct paths in typed Scala:
XPath.deep(t"button").where(XPath.attribute(t"class").contains(t"primary")
    and XPath.textual === t"Submit")

// And evaluate against a tree:
xml.select(xp"//li[position()=last()]")     // Fragment of matches
xml.selectText(xp"//a/@href")               // string-value of the first match
xml.evaluate(xp"count(//div)")              // full four-type evaluation
```

All 13 axes, node tests, predicates, operators, unions and the core function library are implemented (the `namespace::` axis and `id()` raise typed errors: the XML model has no namespace processing or DTD IDs). One deliberate behaviour change: decoded paths no longer normalise ordinal-free steps, so `xp"/root/child"` round-trips verbatim instead of becoming `/root[1]/child[1]`. Serpentine is no longer a dependency of xylophone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)