### PR TITLE
Compose Pathname suggestions with subcommands and stop duplicating fish completions

### DIFF
--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -199,7 +199,15 @@ extends Cli:
 
         . filter(_.starts(focusText))
 
-      case Shell.Fish | Shell.Powershell =>
+      case Shell.Fish =>
+        // Every output line is a distinct candidate in fish, so `incomplete` cannot be
+        // rendered as a per-candidate duplicate without doubling the menu. Fish already
+        // completes a `/`-terminated candidate without a trailing space, and with several
+        // candidates their longest common prefix stops the insertion short anyway; only a
+        // sole, non-slash, incomplete candidate needs the trailing-space twin, which makes
+        // the LCP the candidate itself so fish inserts it without terminating the word.
+        val sole = items.stdlib.count(!_.hidden) == 1
+
         items.bind:
           case suggestion@Suggestion(core, description, hidden, incomplete, aliases, _, _, _) =>
             if hidden then Nil else
@@ -209,7 +217,21 @@ extends Cli:
                   case description: Text     => t"$text\t$description"
                   case description: Teletype => t"$text\t${description.plain}"
 
-              if !incomplete then List.of(mainLines)
+              if !incomplete || !sole || suggestion.text.ends(t"/") then List.of(mainLines)
               else
                 List.of:
-                  mainLines ++ (suggestion.text :: aliases.stdlib).map { text => t"$text " }
+                  mainLines ++ (suggestion.text :: aliases.stdlib).map: text =>
+                    t"$text "
+
+      case Shell.Powershell =>
+        // PowerShell inserts a `CompletionResult` verbatim, so a trailing-space twin is
+        // just a visible duplicate; `incomplete` has no rendering there.
+        items.bind:
+          case suggestion@Suggestion(core, description, hidden, _, aliases, _, _, _) =>
+            if hidden then Nil else
+              List.of:
+                (suggestion.text :: aliases.stdlib).map: text =>
+                  description.absolve match
+                    case Unset                 => t"$text"
+                    case description: Text     => t"$text\t$description"
+                    case description: Teletype => t"$text\t${description.plain}"

--- a/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
@@ -59,7 +59,9 @@ object Pathname:
         val point = path.s.lastIndexOf('/', path.length - 2) + 1
         val prefix = path.keep(point)
         val core = path.skip(point)
-        Suggestion(core, Unset, incomplete = path != argument(), prefix = prefix)
+        // Only a directory leaves the completion mid-path; a file candidate is complete,
+        // and accepting it should advance to the next argument.
+        Suggestion(core, Unset, incomplete = path.ends(t"/"), prefix = prefix)
 
       // Each branch adds to `prior` rather than replacing it: another extractor evaluated
       // against the same argument (typically a `Subcommand`) must keep its suggestions.

--- a/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
@@ -61,20 +61,26 @@ object Pathname:
         val core = path.skip(point)
         Suggestion(core, Unset, incomplete = path != argument(), prefix = prefix)
 
+      // Each branch adds to `prior` rather than replacing it: another extractor evaluated
+      // against the same argument (typically a `Subcommand`) must keep its suggestions.
       if argument() == t"." then argument.suggest:
         val wd: Path on Local = workingDirectory
-        List.of:
+        val listing = List.of:
           suggest(t"../") ::
             workingDirectory.children.stdlib.toList.filter(_.name.starts(t".")).map: path =>
               val directory = safely(path.entry() == galilei.Directory).or(false)
               suggest(if directory then path.name+t"/" else path.name)
 
+        listing ::: prior
+
       else if argument() == t".." then argument.suggest:
-        List.of:
+        val listing = List.of:
           suggest(t"../") ::
             workingDirectory.children.stdlib.toList.filter(_.name.starts(t"..")).map: path =>
               val directory = safely(path.entry() == galilei.Directory).or(false)
               suggest(if directory then path.name+t"/" else path.name)
+
+        listing ::: prior
 
       else if argument().nil then argument.suggest:
         val children0 = workingDirectory.children.stdlib.toList
@@ -82,10 +88,12 @@ object Pathname:
         val children =
           if !showAll then children0.filter(!_.name.starts(t".")) else children0
 
-        List.of:
+        val listing = List.of:
          children.map: path =>
           val directory = safely(path.entry() == galilei.Directory).or(false)
           suggest(if directory then path.name+t"/" else path.name)
+
+        listing ::: prior
 
       else
         val absolute = argument().starts(t"/")
@@ -105,12 +113,14 @@ object Pathname:
           val children2 =
             if !showAll then children.filter(!_.name.starts(t".")) else children
 
-          children2.map: path =>
+          val listing = children2.map: path =>
             val directory = safely(path.entry() == galilei.Directory).or(false)
             val slash = if directory then t"/" else t""
 
             suggest:
               if absolute then path.encode+slash else workingDirectory.toward(path).encode+slash
+
+          listing ::: prior
 
     scala.caps.unsafe.unsafeAssumeSeparate:
       safely(workingDirectory.resolve(argument())).option

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -68,6 +68,8 @@ object Tests extends Suite(m"Exoskeleton Tests"):
             val Ubuntu = Subcommand("ubuntu", e"Ubuntu")
             val Gentoo = Subcommand("gentoo", e"Gentoo Linux")
             val Tree = Subcommand("tree", e"path-segment completion", hidden = true)
+            val Files = Subcommand("files", e"path completion", hidden = true)
+            val Verify = Subcommand("verify", e"verify a file")
 
             class Hue(name: Text)
             class Segment(name: Text)
@@ -114,6 +116,15 @@ object Tests extends Suite(m"Exoskeleton Tests"):
 
                   Flag[Segment]("at", description = t"path segment")()
                   execute(Exit.Ok)
+
+                case Files() :: rest =>
+                  import systems.javaSystem
+                  given WorkingDirectory = summon[Cli].workingDirectory
+
+                  rest match
+                    case Verify() :: Pathname(file) :: _ => execute(Exit.Ok)
+                    case Pathname(file) :: Nil           => execute(Exit.Ok)
+                    case _                               => execute(Exit.Fail(1))
 
                 case _ =>
                   execute(Exit.Fail(1))
@@ -410,6 +421,90 @@ object Tests extends Suite(m"Exoskeleton Tests"):
             test(m"fish focus=0 exits cleanly"):
               sh"$tool '{completions}' fish 0 0 /dev/null -- abcd".exec[Exit]()
             .assert(_ == Exit.Ok)
+
+          suite(m"Pathname completions"):
+            import interfaces.paths.pathOnLinux
+
+            val tool = summon[Enclave.Tool].path
+
+            // A directory of known content, used as the working directory of each completion
+            // invocation below so `Pathname`'s listings are deterministic.
+            val fixture: Path on Linux = unsafely:
+              val dir: Path on Linux = temporaryDirectory[Path on Linux]/t"exoskeleton-${Uuid()}"
+              dir.create[Directory]()
+              (dir/t"one.txt").create[File]()
+              (dir/t"two.txt").create[File]()
+              (dir/t"src").create[Directory]()
+              dir
+
+            given WorkingDirectory = () => fixture.encode
+
+            // Issue #1783: the fish/powershell branch renders `Suggestion.incomplete` as a
+            // second candidate line with a trailing space, so every path entry shows twice
+            // in the menu, and selecting the twin inserts a stray trailing space.
+            test(m"fish lists a file candidate exactly once"):
+              sh"$tool '{completions}' fish 3 0 /dev/null -- abcd files verify ''".exec[Text]()
+            .aspire(_.cut(t"\n").stdlib.count(_.starts(t"one.txt")) == 1)
+
+            test(m"fish lists a directory candidate exactly once"):
+              sh"$tool '{completions}' fish 3 0 /dev/null -- abcd files verify ''".exec[Text]()
+            .aspire(_.cut(t"\n").stdlib.count(_.starts(t"src/")) == 1)
+
+            test(m"powershell lists a file candidate exactly once"):
+              val line = t"abcd files verify "
+              sh"$tool '{completions}' powershell ${line.length} 0 '' -- $line".exec[Text]()
+            .aspire(_.cut(t"\n").stdlib.count(_.starts(t"one.txt")) == 1)
+
+            // Issue #1783, `incomplete` too broad: `Pathname` marks every candidate that
+            // differs from the argument as incomplete, so even plain files get zsh's
+            // suffix-suppressing `compadd` twin; only directories should.
+            test(m"zsh emits no suffix-suppressing twin for a plain file"):
+              sh"$tool '{completions}' zsh 4 0 /dev/null -- abcd files verify ''".exec[Text]()
+            .aspire(_.cut(t"\n").stdlib.count(_.contains(t"one.txt")) == 1)
+
+            test(m"zsh still emits the suffix-suppressing twin for a directory"):
+              sh"$tool '{completions}' zsh 4 0 /dev/null -- abcd files verify ''".exec[Text]()
+            .assert(_.cut(t"\n").stdlib.count(_.contains(t"src/")) == 2)
+
+            // Issue #1782: `Pathname` discards the `prior` suggestions, so a subcommand and
+            // a path matched against the same argument should offer the union, but the
+            // extractor evaluated last erases the other's suggestions.
+            test(m"subcommands and paths at one position combine on fish"):
+              sh"$tool '{completions}' fish 2 0 /dev/null -- abcd files ''".exec[Text]()
+            .aspire { out => out.contains(t"verify") && out.contains(t"one.txt") }
+
+            test(m"subcommands and paths at one position combine on bash"):
+              sh"$tool '{completions}' bash 2 0 /dev/null -- abcd files ''".exec[Text]()
+            .aspire { out => out.contains(t"verify") && out.contains(t"one.txt") }
+
+            test(m"subcommands and paths at one position combine on zsh"):
+              sh"$tool '{completions}' zsh 3 0 /dev/null -- abcd files ''".exec[Text]()
+            .aspire { out => out.contains(t"verify") && out.contains(t"one.txt") }
+
+            // Issue #1782, worst case: a partial word matching no file must still offer the
+            // subcommand it matches, not an empty list.
+            test(m"a partial word matching no file still offers the subcommand"):
+              sh"$tool '{completions}' fish 2 3 /dev/null -- abcd files ver".exec[Text]()
+            .aspire(_.contains(t"verify"))
+
+            // Issue #1086 guard, end-to-end: a unique directory candidate must complete
+            // progressively — inserted without a trailing space, not advancing to the next
+            // argument.
+            test(m"fish inserts a unique directory without advancing"):
+              scala.caps.unsafe.unsafeAssumeSeparate:
+                Fish.tmux():
+                  Tmux.enter(t"cd ${fixture.encode}")
+                  Tmux.enter('\r')
+                  Tmux.progress(t"files verify sr")
+            .assert(_ == t"files verify src/^")
+
+            test(m"fish menu shows each path entry once"):
+              scala.caps.unsafe.unsafeAssumeSeparate:
+                Fish.tmux(width = 120):
+                  Tmux.enter(t"cd ${fixture.encode}")
+                  Tmux.enter('\r')
+                  Tmux.completions(t"files verify ")
+            .aspire { out => out.cut(t"one.txt").stdlib.length == 2 && out.cut(t"src/").stdlib.length == 2 }
 
       object HelpApp:
         import interpreters.posixInterpreter

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -73,6 +73,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
 
             class Hue(name: Text)
             class Segment(name: Text)
+            class Node(name: Text)
 
             cli:
               arguments match
@@ -114,7 +115,13 @@ object Tests extends Suite(m"Exoskeleton Tests"):
                     case argument :: Nil => Segment(argument())
                     case _               => Segment(t"")
 
+                  given Node is Discoverable = _ => List(Suggestion(t"key.", incomplete = true))
+                  given Node is Interpretable =
+                    case argument :: Nil => Node(argument())
+                    case _               => Node(t"")
+
                   Flag[Segment]("at", description = t"path segment")()
+                  Flag[Node]("node", description = t"node prefix")()
                   execute(Exit.Ok)
 
                 case Files() :: rest =>
@@ -402,13 +409,20 @@ object Tests extends Suite(m"Exoskeleton Tests"):
               sh"$tool '{completions}' fish 2 1 /dev/null -- abcd distribution g".exec[Text]()
             .check(_.contains(t"gentoo"))
 
-            // Regression check for #1086 part (2): `Suggestion.incomplete` on fish branch.
-            // With the bug, output contained `src/` once; with the fix, it appears twice
-            // (the second with a trailing space) to force fish's LCP no-trailing-space
-            // behaviour for progressive completion.
-            test(m"fish incomplete suggestion emits LCP duplicate"):
+            // #1086 rendered `Suggestion.incomplete` on fish as a trailing-space twin of
+            // every candidate, forcing fish's LCP no-trailing-space behaviour; #1783 showed
+            // the twin doubles the visible menu. Fish already inserts a `/`-terminated
+            // candidate without a trailing space, so a slash-terminated candidate must
+            // appear exactly once...
+            test(m"fish slash-terminated incomplete suggestion is not duplicated"):
               sh"$tool '{completions}' fish 3 0 /dev/null -- abcd tree --at ".exec[Text]()
-            .check(_.cut(t"\n").stdlib.count(_.starts(t"src/")) >= 2)
+            .assert(_.cut(t"\n").stdlib.count(_.starts(t"src/")) == 1)
+
+            // ...and the twin survives only where fish needs it: a sole incomplete
+            // candidate with no slash of its own.
+            test(m"fish sole non-slash incomplete suggestion keeps its LCP twin"):
+              sh"$tool '{completions}' fish 3 0 /dev/null -- abcd tree --node ".exec[Text]()
+            .check(_.cut(t"\n").stdlib.count(_.starts(t"key.")) == 2)
 
             // Regression check for #1109: with focus0 = 0 and position0 = 0 the
             // completions executive previously hit a `.get` on an empty Option in
@@ -444,23 +458,23 @@ object Tests extends Suite(m"Exoskeleton Tests"):
             // in the menu, and selecting the twin inserts a stray trailing space.
             test(m"fish lists a file candidate exactly once"):
               sh"$tool '{completions}' fish 3 0 /dev/null -- abcd files verify ''".exec[Text]()
-            .aspire(_.cut(t"\n").stdlib.count(_.starts(t"one.txt")) == 1)
+            .assert(_.cut(t"\n").stdlib.count(_.starts(t"one.txt")) == 1)
 
             test(m"fish lists a directory candidate exactly once"):
               sh"$tool '{completions}' fish 3 0 /dev/null -- abcd files verify ''".exec[Text]()
-            .aspire(_.cut(t"\n").stdlib.count(_.starts(t"src/")) == 1)
+            .assert(_.cut(t"\n").stdlib.count(_.starts(t"src/")) == 1)
 
             test(m"powershell lists a file candidate exactly once"):
               val line = t"abcd files verify "
               sh"$tool '{completions}' powershell ${line.length} 0 '' -- $line".exec[Text]()
-            .aspire(_.cut(t"\n").stdlib.count(_.starts(t"one.txt")) == 1)
+            .assert(_.cut(t"\n").stdlib.count(_.starts(t"one.txt")) == 1)
 
             // Issue #1783, `incomplete` too broad: `Pathname` marks every candidate that
             // differs from the argument as incomplete, so even plain files get zsh's
             // suffix-suppressing `compadd` twin; only directories should.
             test(m"zsh emits no suffix-suppressing twin for a plain file"):
               sh"$tool '{completions}' zsh 4 0 /dev/null -- abcd files verify ''".exec[Text]()
-            .aspire(_.cut(t"\n").stdlib.count(_.contains(t"one.txt")) == 1)
+            .assert(_.cut(t"\n").stdlib.count(_.contains(t"one.txt")) == 1)
 
             test(m"zsh still emits the suffix-suppressing twin for a directory"):
               sh"$tool '{completions}' zsh 4 0 /dev/null -- abcd files verify ''".exec[Text]()
@@ -471,21 +485,21 @@ object Tests extends Suite(m"Exoskeleton Tests"):
             // extractor evaluated last erases the other's suggestions.
             test(m"subcommands and paths at one position combine on fish"):
               sh"$tool '{completions}' fish 2 0 /dev/null -- abcd files ''".exec[Text]()
-            .aspire { out => out.contains(t"verify") && out.contains(t"one.txt") }
+            .assert { out => out.contains(t"verify") && out.contains(t"one.txt") }
 
             test(m"subcommands and paths at one position combine on bash"):
               sh"$tool '{completions}' bash 2 0 /dev/null -- abcd files ''".exec[Text]()
-            .aspire { out => out.contains(t"verify") && out.contains(t"one.txt") }
+            .assert { out => out.contains(t"verify") && out.contains(t"one.txt") }
 
             test(m"subcommands and paths at one position combine on zsh"):
               sh"$tool '{completions}' zsh 3 0 /dev/null -- abcd files ''".exec[Text]()
-            .aspire { out => out.contains(t"verify") && out.contains(t"one.txt") }
+            .assert { out => out.contains(t"verify") && out.contains(t"one.txt") }
 
             // Issue #1782, worst case: a partial word matching no file must still offer the
             // subcommand it matches, not an empty list.
             test(m"a partial word matching no file still offers the subcommand"):
               sh"$tool '{completions}' fish 2 3 /dev/null -- abcd files ver".exec[Text]()
-            .aspire(_.contains(t"verify"))
+            .assert(_.contains(t"verify"))
 
             // Issue #1086 guard, end-to-end: a unique directory candidate must complete
             // progressively — inserted without a trailing space, not advancing to the next
@@ -504,7 +518,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
                   Tmux.enter(t"cd ${fixture.encode}")
                   Tmux.enter('\r')
                   Tmux.completions(t"files verify ")
-            .aspire { out => out.cut(t"one.txt").stdlib.length == 2 && out.cut(t"src/").stdlib.length == 2 }
+            .assert { out => out.cut(t"one.txt").stdlib.length == 2 && out.cut(t"src/").stdlib.length == 2 }
 
       object HelpApp:
         import interpreters.posixInterpreter


### PR DESCRIPTION
Tab completion now composes correctly when subcommands and `Pathname` arguments are matched against the same position, and path candidates are no longer shown twice in fish and PowerShell. Fixes #1782 and #1783.

`Pathname` now carries the `prior` suggestions forward instead of replacing them, so a CLI that offers both subcommands and a bare file argument at the same position — the shape that surfaced these issues — completes to the union of the two, in whichever order the extractors are evaluated:

```scala
positional match
  case Verify() :: Pathname(file) :: Nil => ...
  case Pathname(file) :: Nil             => ...
```

Completing the first word now offers `verify` *and* the directory listing, and a partial word matching no file (`myapp ver<TAB>`) still offers the subcommand instead of an empty list.

`Suggestion.incomplete` — "accepting this candidate should not advance to the next argument" — is now rendered per shell rather than by copying zsh's duplicate-`compadd` idiom verbatim. Fish no longer receives a trailing-space twin of every candidate (which doubled the visible menu and inserted a stray space when selected): fish already inserts `/`-terminated candidates without a trailing space, so the twin survives only for a sole, non-slash, incomplete candidate, where it is needed to stop fish terminating the word. PowerShell, which inserts completion results verbatim, never receives the twin. Zsh keeps its `-S ''` pair, which it merges correctly. `Pathname` also marks only directories as incomplete, so plain files complete with a terminating space on every shell.

The behaviour is pinned by a new test suite completing against a fixture directory through the raw completion protocol on all four shells, plus end-to-end tmux tests confirming that a unique directory candidate still completes progressively in fish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)