### PR TITLE
Add `venture`/`guard` for dependency-aware error accumulation

### DIFF
--- a/doc/philosophy/error-handling.md
+++ b/doc/philosophy/error-handling.md
@@ -85,6 +85,32 @@ Under an accruing strategy the recorded errors are collected; under a throwing o
 first still throws. The operation states which of the two it means, and the strategy
 decides what becomes of it.
 
+## Ventures and guards
+
+A fallback value flows onwards, and downstream code cannot tell it from a real one — a
+consistency check fed a placeholder raises spurious *cascade* errors. `venture` and
+`guard` make the dependency structure explicit instead:
+
+```scala
+def decodePerson(json: Json): Person raises Json.Error =
+  val name: Venture[Text] = venture(json.name.as[Text])
+  val role: Venture[Role] = venture(json.role.as[Role])
+
+  venture(checkConsistency(name(), role()))
+
+  guard:
+    Person(name(), role())
+```
+
+A `venture` evaluates immediately — its errors accrue like any others — but remembers
+whether anything went wrong. Forcing a failed venture with `name()` skips the enclosing
+venture or `guard` block rather than producing a value, so the consistency check above
+never runs on garbage; and because `role` was evaluated eagerly at its declaration, its
+errors were collected even if `name` failed first. `guard` runs its block only when no
+error has been recorded so far. Under a fail-fast strategy both constructs disappear:
+an error escapes at the venture itself, and `guard` is the identity — the same body
+serves every strategy, which is the point.
+
 ## Making the response total
 
 `safely` and `unsafely` are the two escape hatches, and they are deliberately conspicuous.
@@ -110,8 +136,9 @@ implicit search rather than about the error. Importing `explainMissingContext` t
 into a diagnosis naming the strategy imports that would satisfy it.
 
 **There is a vocabulary to learn.** `raise`, `abort`, `safely`, `unsafely`, `recover`,
-`mitigate`, `accrue`, `capture`, `attempt` — nine words where `try`/`catch` has two. Each
-earns its place, but the learning curve is real and front-loaded.
+`mitigate`, `accrue`, `capture`, `attempt`, `venture`, `guard` — eleven words where
+`try`/`catch` has two. Each earns its place, but the learning curve is real and
+front-loaded.
 
 See [expressive errors](expressive-errors.md) for what an error value carries, and
 [honest signatures](honest-signatures.md) for the wider principle that a signature states

--- a/lib/caesura/src/core/caesura.Dsv.scala
+++ b/lib/caesura/src/core/caesura.Dsv.scala
@@ -368,22 +368,59 @@ object Dsv extends Dsv2:
         // the fresh (`^`) result honestly admits the capture — no seal.
         DsvProductDecoder[derivation](
           (row: Dsv) =>
-            var count = 0
+            val foci = infer[Foci[CellRef]]
 
-            build[derivation]:
-              [field] => context =>
-                // Positional mode (`columns` Unset): read the field's span starting at `count`.
-                // Header mode: locate the field by column name; an absent column hands the field
-                // an empty `Dsv` so `Optional` fields decode to `Unset` rather than misreading by
-                // position.
-                val row2 = row.columns.lay(Dsv(row.data.drop(count))): columns =>
-                  columns(label).lay(Dsv(Array.of[Text]())): i =>
-                    Dsv(row.data.drop(i))
+            // Positional mode (`columns` Unset): read the field's span starting at `count`.
+            // Header mode: locate the field by column name; an absent column hands the field
+            // an empty `Dsv` so `Optional` fields decode to `Unset` rather than misreading by
+            // position.
+            def fieldRow(label: Text, count: Int): Dsv =
+              row.columns.lay(Dsv(row.data.drop(count))): columns =>
+                columns(label).lay(Dsv(Array.of[Text]())): i =>
+                  Dsv(row.data.drop(i))
 
-                count += spans.readUnchecked(index)
+            if !foci.active then
+              // Fail-fast path: the first recorded error escapes through the tactic, so decode
+              // and construct in a single traversal with no venture slots and no focus
+              // bookkeeping.
+              var count = 0
 
-                focus(CellRef(Prim, label)):
-                  contextual.decoded(row2))
+              build[derivation]:
+                [field] => context =>
+                  val row2 = fieldRow(label, count)
+                  count += spans.readUnchecked(index)
+                  contextual.decoded(row2)
+
+            else
+              // Accruing path (as in jacinta's `decodeObject`): decode EVERY field into a
+              // venture slot first, marking a slot failed if its decode registered any focus,
+              // and construct only when all slots are clean — user constructor code never sees
+              // a garbage fallback value. On failure the returned value is never used (the
+              // caller's scope is tainted), and siblings keep accruing in the meantime.
+              var count = 0
+
+              val slots: Array[Venture[Any]]^{} =
+                contexts[derivation]()[Venture[Any]]:
+                  [field] => context =>
+                    val row2 = fieldRow(label, count)
+                    count += spans.readUnchecked(index)
+
+                    focus(CellRef(Prim, label)):
+                      val before = foci.length
+                      val value: field = contextual.decoded(row2)
+                      if foci.length > before then Venture.failed else Venture(value)
+
+              var failed = false
+              var slot = 0
+
+              while slot < slots.length do
+                if !slots.readUnchecked(slot).ready then failed = true
+                slot += 1
+
+              if failed then null.asInstanceOf[derivation]
+              else
+                build[derivation]:
+                  [field] => context => slots.readUnchecked(index).asInstanceOf[Venture[field]].vouch)
 
   object EncodableDerivation extends ProductDerivable[Encodable in Dsv]:
     inline def conjunction[derivation <: Product: ProductReflection]

--- a/lib/caesura/src/core/caesura.Dsv.scala
+++ b/lib/caesura/src/core/caesura.Dsv.scala
@@ -353,6 +353,41 @@ object Dsv extends Dsv2:
       type Form = Dsv
       def decoded(row: Dsv): derivation = lambda(row)
 
+    // Scans the venture slots and constructs positionally through the threaded `Mirror` — a
+    // plain method: the argument buffer must not be allocated inside an inline expansion,
+    // where its fresh root capability leaks into the expansion site's capture sets (see
+    // `Dsv.flatten`). Returns an unused null when any slot failed: the caller's accruing
+    // scope is tainted, so the result is discarded.
+    private final class ArrayProduct(values: Array[Any]^{}) extends Product:
+      def canEqual(that: Any): Boolean = true
+      def productArity: Int = values.length
+      def productElement(index: Int): Any = values.readUnchecked(index)
+
+    private def gate[derivation <: Product]
+      ( reflection: ProductReflection[derivation],
+        slots:      Array[Venture[Any]]^{},
+        active:     Boolean )
+    :   derivation =
+
+      var failed = false
+      var slot = 0
+
+      if active then
+        while slot < slots.length do
+          if !slots.readUnchecked(slot).ready then failed = true
+          slot += 1
+
+      if failed then null.asInstanceOf[derivation]
+      else
+        val arguments = Array[Any](slots.length)
+        slot = 0
+
+        while slot < slots.length do
+          arguments(slot) = slots.readUnchecked(slot).vouch
+          slot += 1
+
+        reflection.fromProduct(ArrayProduct(Array.freeze(arguments)))
+
     inline def conjunction[derivation <: Product: ProductReflection]
     :   (derivation is Decodable in Dsv)^ =
 
@@ -379,48 +414,34 @@ object Dsv extends Dsv2:
                 columns(label).lay(Dsv(Array.of[Text]())): i =>
                   Dsv(row.data.drop(i))
 
-            if !foci.active then
-              // Fail-fast path: the first recorded error escapes through the tactic, so decode
-              // and construct in a single traversal with no venture slots and no focus
-              // bookkeeping.
-              var count = 0
+            // A SINGLE field traversal serving both modes, branching on `foci.active` per
+            // field. One traversal is load-bearing: every wisteria traversal re-summons each
+            // field's decoder (`summonInline`), recursively deriving nested types, so
+            // traversals multiply EXPONENTIALLY with nesting depth at compile time.
+            //
+            // Accruing mode: each slot is marked failed if its decode registered any focus,
+            // and the record is constructed only when every slot is clean — user constructor
+            // code never sees a garbage fallback value. On failure the returned value is never
+            // used (the caller's scope is tainted), and siblings keep accruing in the
+            // meantime. Fail-fast mode: the first recorded error escapes through the tactic,
+            // so no focus bookkeeping and no failure scan are needed.
+            val active = foci.active
+            var count = 0
 
-              build[derivation]:
+            val slots: Array[Venture[Any]]^{} =
+              contexts[derivation]()[Venture[Any]]:
                 [field] => context =>
                   val row2 = fieldRow(label, count)
                   count += spans.readUnchecked(index)
-                  contextual.decoded(row2)
 
-            else
-              // Accruing path (as in jacinta's `decodeObject`): decode EVERY field into a
-              // venture slot first, marking a slot failed if its decode registered any focus,
-              // and construct only when all slots are clean — user constructor code never sees
-              // a garbage fallback value. On failure the returned value is never used (the
-              // caller's scope is tainted), and siblings keep accruing in the meantime.
-              var count = 0
-
-              val slots: Array[Venture[Any]]^{} =
-                contexts[derivation]()[Venture[Any]]:
-                  [field] => context =>
-                    val row2 = fieldRow(label, count)
-                    count += spans.readUnchecked(index)
-
+                  if !active then Venture(contextual.decoded(row2))
+                  else
                     focus(CellRef(Prim, label)):
                       val before = foci.length
                       val value: field = contextual.decoded(row2)
                       if foci.length > before then Venture.failed else Venture(value)
 
-              var failed = false
-              var slot = 0
-
-              while slot < slots.length do
-                if !slots.readUnchecked(slot).ready then failed = true
-                slot += 1
-
-              if failed then null.asInstanceOf[derivation]
-              else
-                build[derivation]:
-                  [field] => context => slots.readUnchecked(index).asInstanceOf[Venture[field]].vouch)
+            gate[derivation](infer[ProductReflection[derivation]], slots, active))
 
   object EncodableDerivation extends ProductDerivable[Encodable in Dsv]:
     inline def conjunction[derivation <: Product: ProductReflection]

--- a/lib/caesura/src/test/caesura.AccrualTests.scala
+++ b/lib/caesura/src/test/caesura.AccrualTests.scala
@@ -42,6 +42,15 @@ import dsvFormats.csvWithHeaderFormat
 
 case class ARecord(name: Text, age: Int, height: Int) derives CanEqual
 
+object CProbe:
+  @scala.caps.unsafe.untrackedCaptures
+  var constructions: Int = 0
+
+// The body statement observes construction: decoding must never construct from garbage
+// fallback values, so a decode with any failed cell must leave the counter untouched.
+case class CChecked(name: Text, age: Int) derives CanEqual:
+  CProbe.constructions += 1
+
 object AccrualTests extends Suite(m"Caesura multi-error accrual tests"):
 
   case class Issues(items: List[(Text, Dsv.Error)] = Nil)(using Diagnostics)
@@ -89,6 +98,19 @@ object AccrualTests extends Suite(m"Caesura multi-error accrual tests"):
             case Dsv.Error.Reason.Unparseable(_, _) => true
             case _                                 => false
       . assert(identity)
+
+    suite(m"Gated construction"):
+      test(m"Constructor does not run when any cell failed"):
+        CProbe.constructions = 0
+        val issues = validateDsv(row(t"name,age\nZoe,young"))(_.as[CChecked])
+        (issues.items.length, CProbe.constructions)
+      . assert(_ == (1, 0))
+
+      test(m"Constructor runs exactly once when all cells are clean"):
+        CProbe.constructions = 0
+        validateDsv(row(t"name,age\nZoe,5"))(_.as[CChecked])
+        CProbe.constructions
+      . assert(_ == 1)
 
     suite(m"Multiple missing cells"):
       test(m"Two missing cells accrue two errors"):

--- a/lib/contingency/doc/basics.md
+++ b/lib/contingency/doc/basics.md
@@ -122,21 +122,21 @@ but multiple `raises` clauses are cumbersome: not only does the method need to
 declare each error type, any method which invokes it must also handle _all_ of
 these errors.
 
-Instead, we can _tend_ them into an `EventError`:
+Instead, we can _mitigate_ them into an `EventError`:
 
 ```amok
 syntax  scala
 ##
 def eventData(event: Text): Bytes raises EventError =
-  tend:
+  mitigate:
     case ParseError()  => EventError()
     case AccessError() => EventError()
     case AsciiError()  => EventError()
-  .within:
+  .protect:
     convert(Json.parse(event).as[Event].message)
 ```
 
-This has the effect that any exception matching one of the `tend` cases will
+This has the effect that any exception matching one of the `mitigate` cases will
 be transformed into the right-hand side of the case—in this case, a new
 `EventError`.
 
@@ -154,11 +154,11 @@ from one type to the other, like so:
 syntax  scala
 ##
 def processEvent(event: Text): Unit raises EventError =
-  tend:
+  mitigate:
     case ParseError(line) => EventError(m"invalid JSON at line $line")
     case AccessError(key) => EventError(m"key $key was missing")
     case AsciiError()     => EventError(m"the message contained invalid ASCII")
-  .within:
+  .protect:
     send(convert(Json.parse(event).as[Event].message))
 ```
 
@@ -170,21 +170,21 @@ in the return type ensures that handler.
 
 Sometimes, however, in the event of certain errors, we want to _return_ a
 value—some sort of "fallback" value—instead of continuing along an
-error-recovery path. For this, we can use `mend` instead of `tend`, and the
+error-recovery path. For this, we can use `recover` instead of `mitigate`, and the
 right-hand side of each case will represent the return value:
 ```amok
 syntax  scala
 ##
 def processEvent(event: Text): Unit raises EventError = send:
-  mend:
+  recover:
     case ParseError(_)  => Bytes(0, 1)
     case AccessError(_) => Bytes(0, 2)
     case AsciiError(_)  => Bytes(0, 3)
-  .within:
+  .protect:
     convert(Json.parse(event).as[Event].message)
 ```
 
-Here, we _mend_ the subexpression
+Here, we _recover_ the subexpression
 `convert(Json.parse(event).as[Event].message)` and produce a two-byte message
 (such as `Bytes(0, 1)`, which could be a representation of the failure). Either
 this, or the successful evaluation of the subexpression will be passed to the
@@ -318,6 +318,54 @@ cannot affect the end result, because that value is guaranteed to be discarded.
 But this guarantee does not apply to side-effects, including additional errors
 which may be raised as a consequence of the ersatz value. Ideally, ersatz values should be innocuous and independent.
 
+### Ventures and guards
+
+The trouble with ersatz values is that they flow onwards: a consistency check
+or a validating constructor downstream has no way to know it received a
+placeholder, and may raise spurious _cascade_ errors about a value nobody ever
+supplied. `venture` and `guard` remove that hazard by making the dependency
+structure explicit.
+
+`venture(…)` evaluates its block _immediately_, under the ambient tactic — so
+every error it raises accrues exactly as it would outside — but yields a
+`Venture[Value]`: the computed value if the block recorded no errors, or the
+`Failed` marker if it did. Crucially, an `abort` inside a venture is
+_delimited_: it registers its error and abandons only the venture, not the
+whole aggregation scope. Sibling ventures therefore contribute their full
+error sets independently:
+
+```scala
+def decodePerson(json: Json): Person raises Json.Error =
+  val name: Venture[Text] = venture(json.name.as[Text])
+  val role: Venture[Role] = venture(json.role.as[Role])
+
+  venture(checkConsistency(name(), role()))
+
+  guard:
+    Person(name(), role())
+```
+
+Forcing a venture with `name()` requires a _skip-scope_ in context — an
+enclosing `venture` or `guard` block, witnessed by a contextual `Guard`
+capability. Forcing a `Failed` venture escapes to that scope without
+registering anything further (its errors are already in the accrual): above,
+if `name` failed, the consistency check is skipped entirely — but since `role`
+was evaluated eagerly at its declaration, its errors were still collected.
+Forcing outside any skip-scope is a compile error: there would be nowhere
+well-defined to skip to.
+
+`guard` runs its block only if the ambient tactic is _clean_ — no errors
+recorded so far in the aggregation scope. If the tactic is tainted, the block
+is skipped by certifying the tactic, surrendering the scope to its accumulated
+errors. Under a fail-fast tactic (where any error already escaped), `guard` is
+the identity and `venture` is transparent eager evaluation, so code written
+this way costs nothing when accrual is not in play.
+
+An earlier design consideration — allowing a bare `name()` anywhere, escaping
+to the enclosing aggregation boundary — was rejected: it would silently
+abandon the rest of the method, losing later, independent errors. The
+skip-scope requirement keeps the escape target statically precise.
+
 ### Performance
 
 One advantage of using Scala's `boundary` and `break` infrastructure instead of
@@ -328,7 +376,7 @@ any other immutable datatype.
 ### Strategies
 
 Each error must be handled by a `Tactic`, which will typically be constrained
-to a limited scope—often the `within` block of a `mend` or `tend`, or a
+to a limited scope—often the `protect` block of a `recover` or `mitigate`, or a
 `safely` or `unsafely` block. They are _tactics_ in the sense that they apply
 within a limited scope.
 

--- a/lib/contingency/src/core/contingency.Accrual.scala
+++ b/lib/contingency/src/core/contingency.Accrual.scala
@@ -62,7 +62,15 @@ object Accrual:
       record(error)
       throw accumulated
 
-    def certify(): Unit = ()
+    // If anything has accrued, surrender the block to its accumulated error (the throw unwinds
+    // to `accrueBody`'s `catch`, which reports the accrual to the outer tactic). Formerly a
+    // no-op, which broke the uniform `certify` contract for accruing scopes.
+    def certify(): Unit =
+      if changed then
+        import scala.unsafeExceptions.canThrowAny
+        throw accumulated
+
+    override def tainted: Boolean = changed
 
     def accumulated: accrual = ref.get().nn
     def changed: Boolean = ref.get().nn != initial

--- a/lib/contingency/src/core/contingency.Guard.scala
+++ b/lib/contingency/src/core/contingency.Guard.scala
@@ -32,11 +32,15 @@
                                                                                                   */
 package contingency
 
-import fulminate.Hazard
+import scala.caps
 
 import scala.language.experimental.pureFunctions
 
-// Holds an unevaluated `Tactic[error] ?=> result` body; `apply()` re-evaluates it under whichever
-// `Tactic[error]` is in scope at the call, allowing late binding to different error handlers.
-final class Deferred[result, error <: Hazard](body: Tactic[error]^ ?=> result):
-  def apply()(using Tactic[error]^): result = body
+// The witness of an enclosing skip-scope: a lexical region — a `venture(…)` or `guard{…}` block —
+// which can be abandoned when a failed `Venture` is forced within it. `escape` performs that
+// abandonment: for a `venture`, it fails the venture itself (recording nothing further — the
+// forced venture's errors are already in the accrual); for a `guard`, it certifies the ambient
+// tactic, surrendering the whole aggregation scope to its accumulated errors. A capability, so
+// that forcing is only possible where a skip-scope statically encloses it.
+trait Guard extends caps.ExclusiveCapability:
+  def escape(): Nothing

--- a/lib/contingency/src/core/contingency.TrackTactic.scala
+++ b/lib/contingency/src/core/contingency.TrackTactic.scala
@@ -46,6 +46,7 @@ extends Tactic[error]:
   def record(error: Diagnostics ?=> error): Unit = foci.register(error)
   def finish(): Unit = ()
   def certify(): Unit = if foci.tainted then boundary.break(None)
+  override def tainted: Boolean = foci.tainted
 
   def abort(error: Diagnostics ?=> error): Nothing =
     foci.register(error)

--- a/lib/contingency/src/core/contingency.Venture.scala
+++ b/lib/contingency/src/core/contingency.Venture.scala
@@ -34,33 +34,27 @@ package contingency
 
 import scala.language.experimental.pureFunctions
 
-import fulminate.*
+// The outcome of a `venture(…)`: either the computed value itself, or the `Failed` sentinel
+// marking that one or more errors were recorded while it was computed. A sentinel union (like
+// vacuous's `Optional`) rather than an enum, so a successful venture allocates nothing — but
+// OPAQUE, unlike `Optional`: a transparent union would let the `apply()` extension unify with any
+// type at all, polluting extension resolution repo-wide. The errors themselves are NOT held
+// here — they were already recorded into the ambient tactic's accrual at the venture's declaration
+// site; `Failed` is only the "this value is unusable" marker, which is why forcing a failed
+// venture escapes without reporting anything further.
+object Venture:
+  case object Failed
 
-// A `Tactic` is an `Emit` that can additionally `abort`: a value-replacing abnormal exit. `raises
-// error` (`Tactic[error] ?=>`) is therefore the stronger obligation than `emits error`; code with a
-// `Tactic` can satisfy either, but a fire-and-forget context offering only an `Emit` cannot supply
-// the `abort` half. See [[Emit]].
-trait Tactic[-error <: Hazard] extends Emit[error]:
-  private inline def tactic: this.type = this
-  def abort(error: Diagnostics ?=> error): Nothing
+  opaque type Type[value] = Failed.type | value
 
-  // The flush point of an aggregation scope: if `tainted`, `certify` does not return — it
-  // surrenders the scope to its accumulated errors; otherwise it is a no-op. On a fail-fast
-  // tactic it is always a no-op, since a recorded error would already have escaped.
-  def certify(): Unit
+  inline def apply[value](value: value): Type[value] = value
+  inline def failed[value]: Type[value] = Failed
 
-  // Whether any error has been recorded in this tactic's aggregation scope. Truthfully `false`
-  // on every fail-fast tactic (`record` never returns there), and forwarded through `contramap`
-  // so that taint is visible across `mitigate`d library boundaries.
-  def tainted: Boolean = false
+  extension [value](venture: Type[value])
+    inline def ready: Boolean = venture.asInstanceOf[AnyRef] ne Failed
 
-  override def contramap[error2 <: Hazard](lambda: error2 => error)
-  :   Tactic[error2]^ =
-
-    scala.caps.unsafe.unsafeAssumeSeparate:
-      new Tactic[error2]:
-        def diagnostics: Diagnostics = tactic.diagnostics
-        def record(error: Diagnostics ?=> error2): Unit = tactic.record(lambda(error))
-        def abort(error: Diagnostics ?=> error2): Nothing = tactic.abort(lambda(error))
-        def certify(): Unit = tactic.certify()
-        override def tainted: Boolean = tactic.tainted
+    // Forcing requires a `Guard`: the witness of an enclosing skip-scope (a `venture` or `guard`
+    // block) to which a failed venture can escape. With no skip-scope in context, forcing does
+    // not compile — there would be nowhere well-defined to skip to.
+    inline def apply()(using guard: Guard^): value =
+      if venture.ready then venture.asInstanceOf[value] else guard.escape()

--- a/lib/contingency/src/core/contingency.Venture.scala
+++ b/lib/contingency/src/core/contingency.Venture.scala
@@ -34,6 +34,8 @@ package contingency
 
 import scala.language.experimental.pureFunctions
 
+import fulminate.*
+
 // The outcome of a `venture(…)`: either the computed value itself, or the `Failed` sentinel
 // marking that one or more errors were recorded while it was computed. A sentinel union (like
 // vacuous's `Optional`) rather than an enum, so a successful venture allocates nothing — but
@@ -45,7 +47,7 @@ import scala.language.experimental.pureFunctions
 object Venture:
   case object Failed
 
-  opaque type Type[value] = Failed.type | value
+  opaque type Type[+value] = Failed.type | value
 
   inline def apply[value](value: value): Type[value] = value
   inline def failed[value]: Type[value] = Failed
@@ -58,3 +60,10 @@ object Venture:
     // not compile — there would be nowhere well-defined to skip to.
     inline def apply()(using guard: Guard^): value =
       if venture.ready then venture.asInstanceOf[value] else guard.escape()
+
+    // Escape-free forcing for a venture the caller has already established is ready — for code
+    // (e.g. a decoder's construction pass) that checks a whole batch of ventures before using
+    // any. Panics on a failed venture: reaching one here is a logic error, not an error state.
+    inline def vouch: value =
+      if venture.ready then venture.asInstanceOf[value]
+      else panic(m"a failed venture was vouched for")

--- a/lib/contingency/src/core/contingency.Venture.scala
+++ b/lib/contingency/src/core/contingency.Venture.scala
@@ -49,8 +49,11 @@ object Venture:
 
   opaque type Type[+value] = Failed.type | value
 
-  inline def apply[value](value: value): Type[value] = value
-  inline def failed[value]: Type[value] = Failed
+  // Not `inline`: an inline body is re-elaborated at each expansion site, where the opaque
+  // `Type`'s RHS is invisible, so `Failed.type <: Type[value]` no longer holds (the
+  // branded-opaque inline-widening trap). Both are trivial and JIT-inlined anyway.
+  def apply[value](value: value): Type[value] = value
+  def failed[value]: Type[value] = Failed
 
   extension [value](venture: Type[value])
     inline def ready: Boolean = venture.asInstanceOf[AnyRef] ne Failed

--- a/lib/contingency/src/core/contingency.VentureTactic.scala
+++ b/lib/contingency/src/core/contingency.VentureTactic.scala
@@ -34,33 +34,46 @@ package contingency
 
 import scala.language.experimental.pureFunctions
 
+import java.util.concurrent.atomic as juca
+
 import fulminate.*
 
-// A `Tactic` is an `Emit` that can additionally `abort`: a value-replacing abnormal exit. `raises
-// error` (`Tactic[error] ?=>`) is therefore the stronger obligation than `emits error`; code with a
-// `Tactic` can satisfy either, but a fire-and-forget context offering only an `Emit` cannot supply
-// the `abort` half. See [[Emit]].
-trait Tactic[-error <: Hazard] extends Emit[error]:
-  private inline def tactic: this.type = this
-  def abort(error: Diagnostics ?=> error): Nothing
+// The tactic interposed by `venture(…)` between its block and the ambient tactic. `record`
+// forwards to the ambient tactic — errors accrue exactly as they would outside the venture, and
+// under a fail-fast ambient tactic the forwarded `record` escapes immediately, preserving
+// fail-fast semantics verbatim. `abort`, however, is DELIMITED: it records the error to the
+// ambient accrual but abandons only the venture, yielding `Venture.Failed` — so a leaf may abort
+// honestly without destroying the enclosing aggregation scope. The tactic is also the venture's
+// own `Guard`: forcing a failed venture within the block escapes here, failing this venture
+// without recording anything further.
+class VentureTactic[error <: Hazard, value]
+  ( outer: Tactic[error]^, label: boundary.Label[Venture[value]] )
+  ( using diagnostics0: Diagnostics )
+extends Tactic[error], Guard:
+  private given boundary.Label[Venture[value]] = label
 
-  // The flush point of an aggregation scope: if `tainted`, `certify` does not return — it
-  // surrenders the scope to its accumulated errors; otherwise it is a no-op. On a fail-fast
-  // tactic it is always a no-op, since a recorded error would already have escaped.
-  def certify(): Unit
+  // An atomic box rather than a `var`, like `AccrueTactic`'s accumulator: a `var` would classify
+  // the tactic as `Stateful`, imposing update-method discipline on the whole `Tactic` interface.
+  private val count: juca.AtomicInteger = juca.AtomicInteger(0)
 
-  // Whether any error has been recorded in this tactic's aggregation scope. Truthfully `false`
-  // on every fail-fast tactic (`record` never returns there), and forwarded through `contramap`
-  // so that taint is visible across `mitigate`d library boundaries.
-  def tainted: Boolean = false
+  def diagnostics: Diagnostics = diagnostics0
 
-  override def contramap[error2 <: Hazard](lambda: error2 => error)
-  :   Tactic[error2]^ =
+  // Whether errors were recorded during THIS venture's evaluation — the condition under which the
+  // completed block's value is discarded as `Failed`. Distinct from `tainted`, which also reflects
+  // the ambient scope: an earlier venture's failure must not fail this one.
+  def failed: Boolean = count.get() > 0
 
-    scala.caps.unsafe.unsafeAssumeSeparate:
-      new Tactic[error2]:
-        def diagnostics: Diagnostics = tactic.diagnostics
-        def record(error: Diagnostics ?=> error2): Unit = tactic.record(lambda(error))
-        def abort(error: Diagnostics ?=> error2): Nothing = tactic.abort(lambda(error))
-        def certify(): Unit = tactic.certify()
-        override def tainted: Boolean = tactic.tainted
+  override def tainted: Boolean = failed || outer.tainted
+
+  def record(error: Diagnostics ?=> error): Unit =
+    count.incrementAndGet()
+    outer.record(error)
+
+  def abort(error: Diagnostics ?=> error): Nothing =
+    count.incrementAndGet()
+    outer.record(error)
+    boundary.break(Venture.failed)
+
+  def certify(): Unit = if failed then boundary.break(Venture.failed)
+
+  def escape(): Nothing = boundary.break(Venture.failed)

--- a/lib/contingency/src/core/contingency_core.scala
+++ b/lib/contingency/src/core/contingency_core.scala
@@ -190,6 +190,13 @@ infix type mitigates [error <: Hazard, error2 <: Hazard] =
 
 infix type tracks [result, focus] = Foci[focus] ?=> result
 
+type Venture[value] = Venture.Type[value]
+
+// The single capability a `venture` block receives: its delimiting tactic, which is also its own
+// skip-scope witness (`Guard`). A named alias rather than an inline intersection because the
+// parser cannot parse a parenthesized capturing intersection in context-function position.
+type Venturer[error <: Hazard] = Tactic[error] & Guard
+
 
 inline def focus[focus, result](using foci: Foci[focus])
   ( transform: (Optional[focus] aka "prior") ?=> focus )
@@ -243,10 +250,44 @@ extension [value](optional: Optional[value])
     catch case error: Exception => Unset
 
 
-def defer[result, error <: Hazard](body: Tactic[error]^ ?=> result)
-:   Deferred[result, error]^{body} =
+// Eagerly evaluates `block` under a `VentureTactic` interposed before the ambient tactic: every
+// error recorded in the block accrues into the ambient scope exactly as it would outside (with
+// declaration-site foci), but an `abort` — or a completed block that recorded anything — yields
+// `Venture.Failed` in place of a value, abandoning only the venture. Sibling ventures therefore
+// contribute their full error sets independently, and downstream code that forces the result is
+// skipped rather than fed a garbage fallback. Under a fail-fast ambient tactic, the forwarded
+// `record` escapes immediately: `venture` degrades to transparent eager evaluation.
+// The block receives ONE capability serving two interfaces — the venture's tactic, which is also
+// its `Guard` (both escape to the same boundary) — in a single context-function layer (see
+// `safely` above for why a second layer cannot be reconciled under capture checking; an
+// intersection rather than two parameters because the same capability cannot be passed twice
+// under separation checking).
+def venture[error <: Hazard](using tactic: Tactic[error]^, diagnostics: Diagnostics)[value]
+  ( block: Venturer[error] ?=> value )
+:   Venture[value] =
 
-  Deferred(body)
+  boundary: label ?=>
+    val inner = VentureTactic[error, value](tactic, label)
+    val value = block(using inner)
+
+    if inner.failed then Venture.failed else Venture(value)
+
+
+// Runs `block` only if the ambient tactic is clean: if any error has been recorded in the
+// enclosing aggregation scope, the block is skipped by certifying the tactic, which surrenders
+// the scope to its accumulated errors. Within the block, forcing a failed `Venture` escapes the
+// same way. Under a fail-fast tactic, `tainted` is truthfully always false (an error would
+// already have escaped), so `guard` is the identity.
+def guard[error <: Hazard](using tactic: Tactic[error]^, diagnostics: Diagnostics)[result]
+  ( block: Guard^ ?=> result )
+:   result =
+
+  def surrender(): Nothing =
+    tactic.certify()
+    panic(m"a tainted tactic failed to certify")
+
+  if tactic.tainted then surrender()
+  else block(using new Guard { def escape(): Nothing = surrender() })
 
 
 transparent inline def recover(inline handler: PartialFunction[Exception, Any]): Recovery[?] =

--- a/lib/contingency/src/core/contingency_core.scala
+++ b/lib/contingency/src/core/contingency_core.scala
@@ -190,7 +190,7 @@ infix type mitigates [error <: Hazard, error2 <: Hazard] =
 
 infix type tracks [result, focus] = Foci[focus] ?=> result
 
-type Venture[value] = Venture.Type[value]
+type Venture[+value] = Venture.Type[value]
 
 // The single capability a `venture` block receives: its delimiting tactic, which is also its own
 // skip-scope witness (`Guard`). A named alias rather than an inline intersection because the

--- a/lib/contingency/src/core/soundness_contingency_core.scala
+++ b/lib/contingency/src/core/soundness_contingency_core.scala
@@ -35,11 +35,12 @@ package soundness
 export
   contingency
   . { abort, abortive, accrual, Accrual, accrue, amalgamate, AmalgamateTactic, Attempt, attempt,
-      AttemptTactic, capture, certify, dare, defer, Deferred, EitherTactic, Emit, Errors,
-      ExpectationError, Fatal, Foci, focus, HaltTactic, handle, Handler, lest, Mitigable, mitigate,
+      AttemptTactic, capture, certify, dare, EitherTactic, Emit, Errors, ExpectationError, Fatal,
+      Foci, focus, guard, Guard, HaltTactic, handle, Handler, lest, Mitigable, mitigate,
       Mitigation, mitigates, OptionalTactic, Pointer, raise, raises, recover, Recovery, safely,
       survive, Tactic, throwErrors, ThrowTactic, track, TrackFoci, Tracking, tracks, TrackTactic,
-      Unchecked, unsafely, Validate, validate, Validation }
+      Unchecked, unsafely, Validate, validate, Validation, venture, Venture, Venturer,
+      VentureTactic }
 
 package strategies:
   export

--- a/lib/contingency/src/test/contingency.CompositionTests.scala
+++ b/lib/contingency/src/test/contingency.CompositionTests.scala
@@ -1,0 +1,365 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package contingency
+
+import soundness.*
+
+import proscenium.compat.*
+import contingency.strategies.throwUnsafely
+
+import errorDiagnostics.stackTracesDiagnostics
+
+case class CErrorA(value: Int)(using Diagnostics) extends Error(m"composition error a: $value")
+case class CErrorB(value: Int)(using Diagnostics) extends Error(m"composition error b: $value")
+
+case class Tally(values: List[Int])(using Diagnostics)
+extends Error(m"tally of ${values.length} errors")
+
+case class Located(items: List[(Text, Int)])(using Diagnostics)
+extends Error(m"${items.length} located errors")
+
+object CompositionTests extends Suite(m"Contingency composition"):
+
+  def failA(n: Int): Int raises CErrorA = raise(CErrorA(n)) yet -1
+  def abortA(n: Int): Int raises CErrorA = abort(CErrorA(n))
+
+  // Direct `Validate` construction: a `raises … tracks …` function VALUE cannot be typed under
+  // capture checking, so the body must beta-reduce away into `protect`'s inline position. See
+  // rep/DECISIONS.md and jacinta.ValidationTests.
+  private inline def collect(inline body: Unit raises CErrorA tracks Pointer): Tally =
+    Validate[Tally, [r] =>> r raises CErrorA, Pointer]
+      ( Tally(Nil), { case CErrorA(n) => Tally(accrual.values :+ n) } )
+    . protect(body)
+
+  private inline def collectB(inline body: Unit raises CErrorB tracks Pointer): Tally =
+    Validate[Tally, [r] =>> r raises CErrorB, Pointer]
+      ( Tally(Nil), { case CErrorB(n) => Tally(accrual.values :+ n) } )
+    . protect(body)
+
+  private inline def collectLocated(inline body: Unit raises CErrorA tracks Pointer): Located =
+    Validate[Located, [r] =>> r raises CErrorA, Pointer]
+      ( Located(Nil),
+        { case CErrorA(n) => Located(accrual.items :+ (prior.let(_.text).or(t"?"), n)) } )
+    . protect(body)
+
+  def run(): Unit =
+    suite(m"Eager evaluation and independence"):
+      test(m"Two failing sibling ventures both collected, never forced"):
+        collect:
+          val a: Venture[Int] = venture(failA(1))
+          val b: Venture[Int] = venture(failA(2))
+          ()
+        . values
+      . assert(_ == List(1, 2))
+
+      test(m"A clean venture evaluates once; forcing twice reuses the value"):
+        var count = 0
+        var total = 0
+
+        collect:
+          val a = venture { count += 1; 5 }
+          guard:
+            total = a() + a()
+          ()
+
+        (count, total)
+      . assert(_ == (1, 10))
+
+      test(m"abort inside a venture is delimited; siblings still contribute"):
+        collect:
+          val a = venture(abortA(1))
+          val b = venture(failA(2))
+          ()
+        . values
+      . assert(_ == List(1, 2))
+
+    suite(m"Dependency skipping without cascades"):
+      test(m"A step depending on a failed venture is skipped, with no cascade error"):
+        var ran = false
+
+        collect:
+          val a = venture(failA(1))
+          val b = venture(7)
+
+          venture:
+            val sum = a() + b()
+            ran = true
+            if sum > 0 then raise(CErrorA(99))
+
+          ()
+        . values -> ran
+      . assert(_ == List(1) -> false)
+
+      test(m"A dependent step with clean inputs runs and contributes its own errors"):
+        collect:
+          val a = venture(3)
+          val b = venture(4)
+
+          venture:
+            if a() + b() > 0 then raise(CErrorA(99))
+
+          val c = venture(failA(3))
+          ()
+        . values
+      . assert(_ == List(99, 3))
+
+      test(m"Forcing a Venture without a skip-scope in context does not compile"):
+        demilitarize:
+          def force(v: Venture[Int]): Int = v()
+      . assert(_.nonEmpty)
+
+      test(m"A nested venture's skip is delimited; later siblings still contribute"):
+        collect:
+          val a = venture(failA(1))
+          val b = venture { a() + 1 }
+          val c = venture(failA(4))
+          ()
+        . values
+      . assert(_ == List(1, 4))
+
+    suite(m"guard"):
+      test(m"guard runs when the tactic is clean and yields the block's value"):
+        recover:
+          case Tally(values) => values.sum
+        . protect:
+            track[Pointer](Tally(Nil)):
+              case CErrorA(n) => Tally(accrual.values :+ n)
+            . protect:
+                val a = venture(3)
+                guard(a() * 2)
+      . assert(_ == 6)
+
+      test(m"guard is skipped when tainted; the full accrual is reported"):
+        var probe = false
+
+        val outcome = recover:
+          case Tally(values) => values
+        . protect:
+            track[Pointer](Tally(Nil)):
+              case CErrorA(n) => Tally(accrual.values :+ n)
+            . protect:
+                val a = venture(failA(1))
+                val b = venture(failA(2))
+
+                guard:
+                  probe = true
+                  List(a(), b())
+
+        outcome -> probe
+      . assert(_ == List(1, 2) -> false)
+
+      test(m"A raise inside an outer guard makes an inner guard certify out"):
+        var inner = false
+        var after = false
+
+        val outcome = recover:
+          case Tally(values) => values
+        . protect:
+            track[Pointer](Tally(Nil)):
+              case CErrorA(n) => Tally(accrual.values :+ n)
+            . protect:
+                guard:
+                  raise(CErrorA(5))
+                  guard { inner = true; List.empty[Int] }
+                  after = true
+                  List.empty[Int]
+
+        (outcome, inner, after)
+      . assert(_ == (List(5), false, false))
+
+      test(m"guard is the identity under safely"):
+        safely[CErrorA](guard(5))
+      . assert(_ == 5)
+
+      test(m"guard is the identity under unsafely"):
+        unsafely[CErrorA](guard(9))
+      . assert(_ == 9)
+
+      test(m"guard is the identity under attempt"):
+        attempt[CErrorA](guard(5))
+      . assert(_ == Attempt.Success(5))
+
+      test(m"Under safely, a failing venture escapes eagerly, before any guard"):
+        safely[CErrorA]:
+          val a = venture(failA(1))
+          guard(9)
+      . assert(_ == Unset)
+
+    suite(m"Nested aggregation scopes"):
+      test(m"validate inside validate: inner aggregation is fully delimited"):
+        var innerValues: List[Int] = List(-1)
+
+        collect:
+          val inner = collect:
+            failA(1)
+            failA(2)
+            ()
+
+          innerValues = inner.values
+          ()
+        . values -> innerValues
+      . assert(_ == List() -> List(1, 2))
+
+      test(m"ventures and guard under accrue"):
+        var probe = false
+
+        val outcome = capture[Tally]:
+          accrue(Tally(Nil)) { (tally, error) => error match
+            case CErrorA(n) => Tally(tally.values :+ n)
+            case _          => tally
+          } { case CErrorA(_) => () }
+          . protect:
+              val a = venture(failA(1))
+              val b = venture(failA(2))
+              guard { probe = true; () }
+              ()
+
+        outcome.values -> probe
+      . assert(_ == List(1, 2) -> false)
+
+      test(m"track aborts the outer tactic with the fold, with ventures"):
+        recover:
+          case Tally(values) => values
+        . protect:
+            track[Pointer](Tally(Nil)):
+              case CErrorA(n) => Tally(accrual.values :+ n)
+            . protect:
+                venture(failA(1))
+                venture(failA(2))
+                List.empty[Int]
+      . assert(_ == List(1, 2))
+
+    suite(m"Composition across raises boundaries"):
+      test(m"Both inner-library failures surface through mitigate, transformed"):
+        def innerLibrary(): Unit raises CErrorA =
+          venture(failA(1))
+          venture(failA(2))
+          ()
+
+        collectB:
+          mitigate:
+            case CErrorA(n) => CErrorB(n + 100)
+          . protect(innerLibrary())
+          ()
+        . values
+      . assert(_ == List(101, 102))
+
+      test(m"Taint crosses a mitigation boundary: inner guard is skipped"):
+        var probe = false
+
+        def innerLibrary(): Unit raises CErrorA =
+          guard { probe = true; () }
+          ()
+
+        collectB:
+          raise(CErrorB(1))
+
+          mitigate:
+            case CErrorA(n) => CErrorB(n + 100)
+          . protect(innerLibrary())
+          ()
+        . values -> probe
+      . assert(_ == List(1) -> false)
+
+    suite(m"Decoding shapes"):
+      test(m"Choice point: a failed discriminator reports one error and no branch runs"):
+        var branchA = false
+        var branchB = false
+
+        collect:
+          val tag = venture(failA(10))
+
+          venture:
+            tag() match
+              case 1 => branchA = true
+              case _ => branchB = true
+
+          ()
+        . values -> (branchA, branchB)
+      . assert(_ == List(10) -> (false, false))
+
+      test(m"Choice point: clean discriminator, failing branch contributes its errors"):
+        var branchA = false
+        var branchB = false
+
+        collect:
+          val tag = venture(1)
+
+          venture:
+            if tag() == 1 then
+              branchA = true
+              failA(7)
+              ()
+            else branchB = true
+
+          ()
+        . values -> (branchA, branchB)
+      . assert(_ == List(7) -> (true, false))
+
+      test(m"Collection decode: failures carry element pointers; assembly is skipped"):
+        var assembled = false
+
+        val outcome = collectLocated:
+          val items = List(0, 1, 2, 3, 4).map: index =>
+            focus(prior.or(Pointer.Self)(index.toString.tt)):
+              venture(if index % 2 == 0 then index else failA(index))
+
+          guard:
+            val values = items.map(_())
+            assembled = true
+
+          ()
+
+        outcome.items -> assembled
+      . assert(_ == List(t"1" -> 1, t"3" -> 3) -> false)
+
+      test(m"focus supplements venture-recorded errors"):
+        collectLocated:
+          focus(prior.or(Pointer.Self)(t"field")):
+            venture(failA(9))
+          ()
+        . items
+      . assert(_ == List(t"field" -> 9))
+
+    suite(m"Existing semantics unchanged"):
+      test(m"raise-with-ersatz still folds every error under validate"):
+        collect:
+          failA(1)
+          failA(2)
+          ()
+        . values
+      . assert(_ == List(1, 2))
+
+      test(m"safely still returns Unset on the first raise"):
+        safely(failA(2))
+      . assert(_ == Unset)

--- a/lib/contingency/src/test/contingency_test.scala
+++ b/lib/contingency/src/test/contingency_test.scala
@@ -377,39 +377,6 @@ object Tests extends Suite(m"Contingency"):
         . to(List)
       . assert(_ == List(2, 4))
 
-    suite(m"defer / Deferred"):
-      test(m"defer holds the unapplied body; apply() runs it under the in-scope tactic"):
-        def failing(n: Int): String raises ErrorA = raise(ErrorA(n)) yet "fallback"
-
-        recover:
-          case ErrorA(n) => s"recovered:$n"
-        . protect:
-            val held = contingency.defer(failing(7))
-            held()
-      . assert(_ == "recovered:7")
-
-      test(m"defer re-evaluates the body on each apply() with the current tactic"):
-        var counter = 0
-        def increment(): Int raises ErrorA =
-          counter += 1
-          counter
-
-        recover:
-          case ErrorA(_) => -1
-        . protect:
-            val held = contingency.defer(increment())
-            held()
-            held()
-            held()
-      . assert(_ == 3)
-
-      test(m"defer of a plain value is identity-with-wrapping"):
-        recover:
-          case ErrorA(n) => n
-        . protect:
-            contingency.defer(17)()
-      . assert(_ == 17)
-
     suite(m"Foci / Pointer / track / validate / focus"):
       test(m"Pointer.Self has empty text"):
         Pointer.Self.text
@@ -661,3 +628,5 @@ object Tests extends Suite(m"Contingency"):
           ErrorA(99)
         err.message.text
       . assert(_ == t"error a: 99")
+
+    CompositionTests()

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -35,6 +35,10 @@ package facsimile
 
 import scala.caps
 
+// By name: `contingency.*` would otherwise shadow this package's own `Guard` (the PDF
+// standard-security handler) with contingency's skip-scope capability of the same name.
+import facsimile.Guard
+
 import anticipation.*
 import aviation.*
 import contingency.*

--- a/lib/facsimile/src/core/facsimile.PdfWriter.scala
+++ b/lib/facsimile/src/core/facsimile.PdfWriter.scala
@@ -34,6 +34,10 @@ package facsimile
 
 import proscenium.compat.*
 
+// By name: `contingency.*` would otherwise shadow this package's own `Guard` (the PDF
+// standard-security handler) with contingency's skip-scope capability of the same name.
+import facsimile.Guard
+
 import anticipation.*
 import contingency.*
 import gossamer.*

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -306,7 +306,9 @@ trait Json2 extends Json3:
 
     private inline def decodeObject[derivation <: Product]
       ( json: Json )
-      ( using ProductReflection[derivation], Foci[Json.Focus], Tactic[Json.Error] )
+      ( using reflection: ProductReflection[derivation],
+              foci:       Foci[Json.Focus],
+              tactic:     Tactic[Json.Error] )
     :   derivation =
 
       val root = json.root
@@ -328,24 +330,60 @@ trait Json2 extends Json3:
       // back the same way they are written.
       val renames: Map[Text, Text] = relabelling[derivation, Json]
 
-      build[derivation]: [field] =>
-        context =>
-          val key: Text = renames(label).or(label)
+      if !foci.active then
+        // Fail-fast path: no accrual is possible (the first recorded error escapes through the
+        // tactic), so decode and construct in the single traversal, with no venture slots and no
+        // focus bookkeeping.
+        build[derivation]: [field] =>
+          context =>
+            val key: Text = renames(label).or(label)
 
-          focus({
-            val base = prior.let(_.pointer).or(JsonPointer())
-
-            val newPointer =
-              JsonPointer
-                ( base.url,
-                  Path[JsonPointer, JsonPointer.type, Tuple]
-                    ( base.path.root, (base.path.descent :+ key).to(List) ) )
-
-            Json.Focus(newPointer)
-          }):
             values.get(key.s) match
               case Some(value) => context.decoded(new Json(value))
               case None        => default.or(context.decoded(new Json(Json.Ast(Unset))))
+
+      else
+        // Accruing path: decode EVERY field first, marking each slot failed if its decode
+        // registered any focus (the field decoders capture the resolution-scoped tactic, so a
+        // venture tactic cannot be interposed here; the foci delta detects the same thing). Only
+        // if every slot is clean is the product constructed — user code in constructors never
+        // sees a garbage fallback value. On any failure, the returned value is never used: this
+        // decode's own caller sees its focus delta (or, at top level, the tracking scope is
+        // tainted), so the result is discarded, and siblings keep accruing in the meantime.
+        val slots: Array[Venture[Any]] =
+          contexts[derivation]()[Venture[Any]]: [field] =>
+            context =>
+              val key: Text = renames(label).or(label)
+
+              focus({
+                val base = prior.let(_.pointer).or(JsonPointer())
+
+                val newPointer =
+                  JsonPointer
+                    ( base.url,
+                      Path[JsonPointer, JsonPointer.type, Tuple]
+                        ( base.path.root, (base.path.descent :+ key).to(List) ) )
+
+                Json.Focus(newPointer)
+              }):
+                val before = foci.length
+
+                val value: field =
+                  values.get(key.s) match
+                    case Some(value) => context.decoded(new Json(value))
+                    case None        => default.or(context.decoded(new Json(Json.Ast(Unset))))
+
+                if foci.length > before then Venture.failed else Venture(value)
+
+        var failed = false
+        var slot = 0
+
+        while slot < slots.length do
+          if !slots(slot).ready then failed = true
+          slot += 1
+
+        if failed then null.asInstanceOf[derivation]
+        else build[derivation]: [field] => context => slots(index).asInstanceOf[Venture[field]].vouch
 
     inline def disjunction[derivation: SumReflection]: derivation is Json.Decodable =
       // A sum encodes as a discriminated object. Its precise per-variant schema is
@@ -370,19 +408,27 @@ trait Json2 extends Json3:
               val variantNames: Map[Text, Text] = Map.from:
                 variantRelabelling[derivation, Json].stdlib.map: (variant, wire) => wire -> variant
 
-              val wire: Text = discriminable.discriminate(json).or:
-                focus(prior.or(Json.Focus(JsonPointer())))(abort(Json.Error(Reason.Absent)))
+              discriminable.discriminate(json).lay:
+                focus(prior.or(Json.Focus(JsonPointer()))):
+                  // Under an accruing scope, a missing discriminator records ONE error and skips
+                  // the variant decode without killing the whole scope: the returned value is
+                  // never used (the caller sees the focus delta, or the tracking scope is
+                  // tainted), so siblings keep accruing. Fail-fast scopes abort as before.
+                  if infer[Foci[Json.Focus]].active
+                  then raise(Json.Error(Reason.Absent)) yet null.asInstanceOf[derivation]
+                  else abort(Json.Error(Reason.Absent))
 
-              val discriminant: Text = variantNames(wire).or(wire)
+              . apply: wire =>
+                  val discriminant: Text = variantNames(wire).or(wire)
 
-              // The variant decodes the whole value for the internal-field
-              // shape (its tag is simply skipped as an unknown key — no need
-              // to rebuild the object without it), and the extracted payload
-              // for every other shape.
-              val payload = if fieldShaped then json else discriminable.variant(json)
+                  // The variant decodes the whole value for the internal-field
+                  // shape (its tag is simply skipped as an unknown key — no need
+                  // to rebuild the object without it), and the extracted payload
+                  // for every other shape.
+                  val payload = if fieldShaped then json else discriminable.variant(json)
 
-              delegate(discriminant): [variant <: derivation] =>
-                context => context.decoded(payload)
+                  delegate(discriminant): [variant <: derivation] =>
+                    context => context.decoded(payload)
 
   object ParsableDerivation extends Derivable[Json.Field]:
     inline def conjunction[derivation <: Product: ProductReflection]

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -379,11 +379,11 @@ trait Json2 extends Json3:
         var slot = 0
 
         while slot < slots.length do
-          if !slots(slot).ready then failed = true
+          if !slots.readUnchecked(slot).ready then failed = true
           slot += 1
 
         if failed then null.asInstanceOf[derivation]
-        else build[derivation]: [field] => context => slots(index).asInstanceOf[Venture[field]].vouch
+        else build[derivation]: [field] => context => slots.readUnchecked(index).asInstanceOf[Venture[field]].vouch
 
     inline def disjunction[derivation: SumReflection]: derivation is Json.Decodable =
       // A sum encodes as a discriminated object. Its precise per-variant schema is

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -304,6 +304,62 @@ trait Json2 extends Json3:
                     infer[Foci[Json.Focus]],
                     infer[Tactic[Json.Error]] )
 
+    // The per-field decode and focus construction, shared by the fail-fast and accruing
+    // traversals of `decodeObject` — plain methods, NOT part of the inline expansion: inlining
+    // the field body twice per derivation (once per traversal) blew up compilation of large
+    // schema modules (apoplexy's OpenAPI) and can exceed the JVM class-size limit.
+    private def decodeField[field]
+      ( context:  (Json.Decodable { type Self = field })^,
+        values:   Map[String, Json.Ast],
+        key:      Text,
+        fallback: Optional[field] )
+    :   field =
+
+      values.get(key.s) match
+        case Some(value) => context.decoded(new Json(value))
+        case None        => fallback.or(context.decoded(new Json(Json.Ast(Unset))))
+
+    // Scans the venture slots and constructs positionally through the threaded `Mirror` — a
+    // plain method: the argument buffer must not be allocated inside an inline expansion,
+    // where its fresh root capability leaks into the expansion site's capture sets. Returns
+    // an unused null when any slot failed: the caller's accruing scope is tainted, so the
+    // result is discarded.
+    private def gate[derivation <: Product]
+      ( reflection: ProductReflection[derivation],
+        slots:      Array[Venture[Any]]^{},
+        active:     Boolean )
+    :   derivation =
+
+      var failed = false
+      var slot = 0
+
+      if active then
+        while slot < slots.length do
+          if !slots.readUnchecked(slot).ready then failed = true
+          slot += 1
+
+      if failed then null.asInstanceOf[derivation]
+      else
+        val arguments = Array[Any](slots.length)
+        slot = 0
+
+        while slot < slots.length do
+          arguments(slot) = slots.readUnchecked(slot).vouch
+          slot += 1
+
+        Json.Parsable.assemble[derivation](reflection, Array.freeze(arguments))
+
+    private def fieldFocus(prior: Optional[Json.Focus], key: Text): Json.Focus =
+      val base = prior.let(_.pointer).or(JsonPointer())
+
+      val pointer =
+        JsonPointer
+          ( base.url,
+            Path[JsonPointer, JsonPointer.type, Tuple]
+              ( base.path.root, (base.path.descent :+ key).to(List) ) )
+
+      Json.Focus(pointer)
+
     private inline def decodeObject[derivation <: Product]
       ( json: Json )
       ( using reflection: ProductReflection[derivation],
@@ -330,60 +386,36 @@ trait Json2 extends Json3:
       // back the same way they are written.
       val renames: Map[Text, Text] = relabelling[derivation, Json]
 
-      if !foci.active then
-        // Fail-fast path: no accrual is possible (the first recorded error escapes through the
-        // tactic), so decode and construct in the single traversal, with no venture slots and no
-        // focus bookkeeping.
-        build[derivation]: [field] =>
+      // A SINGLE field traversal serving both modes, branching on `foci.active` per field.
+      // One traversal is load-bearing: every wisteria traversal re-summons each field's decoder
+      // (`summonInline`), recursively deriving nested types, so traversals multiply
+      // EXPONENTIALLY with nesting depth at compile time — a second one sent apoplexy's OpenAPI
+      // derivation into the compiler's heap limit.
+      //
+      // Accruing mode: each slot is marked failed if its decode registered any focus (the field
+      // decoders capture the resolution-scoped tactic, so a venture tactic cannot be interposed
+      // here; the foci delta detects the same thing), and the product is constructed only when
+      // every slot is clean — user code in constructors never sees a garbage fallback value. On
+      // any failure, the returned value is never used: this decode's own caller sees its focus
+      // delta (or, at top level, the tracking scope is tainted), so the result is discarded,
+      // and siblings keep accruing in the meantime. Fail-fast mode: the first recorded error
+      // escapes through the tactic, so no focus bookkeeping and no failure scan are needed.
+      val active = foci.active
+
+      val slots: Array[Venture[Any]]^{} =
+        contexts[derivation]()[Venture[Any]]: [field] =>
           context =>
             val key: Text = renames(label).or(label)
 
-            values.get(key.s) match
-              case Some(value) => context.decoded(new Json(value))
-              case None        => default.or(context.decoded(new Json(Json.Ast(Unset))))
-
-      else
-        // Accruing path: decode EVERY field first, marking each slot failed if its decode
-        // registered any focus (the field decoders capture the resolution-scoped tactic, so a
-        // venture tactic cannot be interposed here; the foci delta detects the same thing). Only
-        // if every slot is clean is the product constructed — user code in constructors never
-        // sees a garbage fallback value. On any failure, the returned value is never used: this
-        // decode's own caller sees its focus delta (or, at top level, the tracking scope is
-        // tainted), so the result is discarded, and siblings keep accruing in the meantime.
-        val slots: Array[Venture[Any]] =
-          contexts[derivation]()[Venture[Any]]: [field] =>
-            context =>
-              val key: Text = renames(label).or(label)
-
-              focus({
-                val base = prior.let(_.pointer).or(JsonPointer())
-
-                val newPointer =
-                  JsonPointer
-                    ( base.url,
-                      Path[JsonPointer, JsonPointer.type, Tuple]
-                        ( base.path.root, (base.path.descent :+ key).to(List) ) )
-
-                Json.Focus(newPointer)
-              }):
+            if !active
+            then Venture(decodeField[field](context, values, key, default[Optional[field]]))
+            else
+              focus(fieldFocus(prior, key)):
                 val before = foci.length
-
-                val value: field =
-                  values.get(key.s) match
-                    case Some(value) => context.decoded(new Json(value))
-                    case None        => default.or(context.decoded(new Json(Json.Ast(Unset))))
-
+                val value: field = decodeField[field](context, values, key, default[Optional[field]])
                 if foci.length > before then Venture.failed else Venture(value)
 
-        var failed = false
-        var slot = 0
-
-        while slot < slots.length do
-          if !slots.readUnchecked(slot).ready then failed = true
-          slot += 1
-
-        if failed then null.asInstanceOf[derivation]
-        else build[derivation]: [field] => context => slots.readUnchecked(index).asInstanceOf[Venture[field]].vouch
+      gate[derivation](reflection, slots, active)
 
     inline def disjunction[derivation: SumReflection]: derivation is Json.Decodable =
       // A sum encodes as a discriminated object. Its precise per-variant schema is

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -1026,20 +1026,31 @@ object Json extends Json2, Dynamic:
             found = reader.keyIndex(table)
 
           index = 0
+          var failed = false
 
           while index < count do
             if values(index).asInstanceOf[AnyRef] eq AbsentSlot then
               val fallback = entries.readUnchecked(index)(2).asInstanceOf[Optional[Any]]
 
-              values(index) =
-                if fallback.present then fallback
-                else if focused
-                then focus(descend(prior, keys.readUnchecked(index).tt))(entries.readUnchecked(index)(1).absent())
-                else entries.readUnchecked(index)(1).absent()
+              if fallback.present then values(index) = fallback
+              else if focused then
+                // Unlike the mid-loop parse (where a token-level mismatch must stay fail-fast —
+                // the stream cannot be resynchronized), absent keys are only discovered here,
+                // after the object is fully consumed, so EVERY missing field can accrue: the
+                // venture delimits `absent()`'s abort (the `Tactic` is a call-time parameter,
+                // not resolution-captured), records it at this field's focus, and continues.
+                focus(descend(prior, keys.readUnchecked(index).tt)):
+                  given Diagnostics = tactic.diagnostics
+                  val ventured = venture(entries.readUnchecked(index)(1).absent())
+                  if ventured.ready then values(index) = ventured.vouch else failed = true
+              else values(index) = entries.readUnchecked(index)(1).absent()
 
             index += 1
 
-          make(Array.freeze(values))
+          // Construction is gated on a full set of clean slots, so user constructor code never
+          // sees a garbage value; on failure the returned value is never used (the caller's
+          // tracking scope is tainted by the errors recorded above).
+          if failed then null.asInstanceOf[derivation] else make(Array.freeze(values))
 
   // The direct-parsing counterpart of `Json.Decodable`: consumes JSON tokens
   // from a `Json.Reader` instead of walking a materialized `Json`, so

--- a/lib/jacinta/src/test/jacinta.ValidationTests.scala
+++ b/lib/jacinta/src/test/jacinta.ValidationTests.scala
@@ -44,6 +44,20 @@ case class VPerson(name: Text, age: Int, email: Text) derives CanEqual
 case class VAddress(street: Text, city: Text, zip: Text) derives CanEqual
 case class VContact(person: VPerson, address: VAddress) derives CanEqual
 
+object VProbe:
+  var constructions: Int = 0
+
+// The body statement observes construction: decoding must never construct from garbage
+// fallback values, so a decode with any failed field must leave the counter untouched.
+case class VChecked(name: Text, age: Int) derives CanEqual:
+  VProbe.constructions += 1
+
+enum VShape derives CanEqual:
+  case VCircle(radius: Int)
+  case VSquare(side: Int)
+
+case class VMix(shape: VShape, name: Text) derives CanEqual
+
 case class Issues(items: List[(Text, Json.Error)] = Nil)(using Diagnostics)
 extends Error(m"${items.length} validation issues"):
   def +(focus: Text, error: Json.Error): Issues = Issues(items :+ (focus, error))
@@ -156,6 +170,87 @@ object ValidationTests extends Suite(m"Jacinta validation tests"):
                         "address": {"street": 2, "city": 3, "zip": 4}}""".read[Json]
         validateJson(json)(_.as[VContact]).items.length
       . assert(_ == 6)
+
+    suite(m"Gated construction"):
+      test(m"Constructor does not run when any field failed"):
+        VProbe.constructions = 0
+        val json = t"""{"name": "Zoe"}""".read[Json]
+        val issues = validateJson(json)(_.as[VChecked])
+        (issues.items.length, VProbe.constructions)
+      . assert(_ == (1, 0))
+
+      test(m"Constructor runs exactly once when all fields are clean"):
+        VProbe.constructions = 0
+        val json = t"""{"name": "Zoe", "age": 5}""".read[Json]
+        validateJson(json)(_.as[VChecked])
+        VProbe.constructions
+      . assert(_ == 1)
+
+      test(m"A nested record with failures does not construct its parent"):
+        VProbe.constructions = 0
+        val json = t"""{"person": {"name": "D"}, "address": {"street": "X"}}""".read[Json]
+        validateJson(json)(_.as[VContact]).items.length
+      . assert(_ == 4)
+
+    suite(m"Sum discriminators under accrual"):
+      import discriminables.jsonByKindDiscriminable
+
+      test(m"A clean sum field decodes; no issues"):
+        val json = t"""{"shape": {"kind": "VCircle", "radius": 3}, "name": "ok"}""".read[Json]
+        validateJson(json)(_.as[VMix]).items.length
+      . assert(_ == 0)
+
+      test(m"A missing discriminator accrues one error without killing the scope"):
+        val json = t"""{"shape": {"radius": 3}, "name": 42}""".read[Json]
+        validateJson(json)(_.as[VMix]).items.length
+      . assert(_ == 2)
+
+      test(m"The missing-discriminator error and its sibling report their pointers"):
+        val json = t"""{"shape": {"radius": 3}, "name": 42}""".read[Json]
+        validateJson(json)(_.as[VMix]).items.map(_(0).s).pipe(xs => Set.from(xs.stdlib))
+      . assert(_ == Set("#/shape", "#/name"))
+
+    suite(m"Ventures and guards over Json decoding"):
+      import dynamicJsonAccess.enabled
+      test(m"Failed sibling reads both accrue; dependent steps are skipped"):
+        var consistencyRan = false
+        var constructed = false
+
+        val json = t"""{"name": 42, "age": "x"}""".read[Json]
+
+        val issues = validateJson(json): json =>
+          val name = venture(json.name.as[Text])
+          val age = venture(json.age.as[Int])
+
+          venture:
+            val consistent = name().length < age()
+            consistencyRan = true
+
+          guard:
+            constructed = true
+
+        (issues.items.length, consistencyRan, constructed)
+      . assert(_ == (2, false, false))
+
+      test(m"Clean reads run the consistency check and the guarded construction"):
+        var consistencyRan = false
+        var constructed = false
+
+        val json = t"""{"name": "Ada", "age": 36}""".read[Json]
+
+        validateJson(json): json =>
+          val name = venture(json.name.as[Text])
+          val age = venture(json.age.as[Int])
+
+          venture:
+            val consistent = name().length < age()
+            consistencyRan = true
+
+          guard:
+            constructed = true
+
+        (consistencyRan, constructed)
+      . assert(_ == (true, true))
 
     suite(m"Position-aware focus (tracked Json)"):
       case class Tagged(items: List[(Text, Optional[Int], Optional[Int])] = Nil)

--- a/lib/jacinta/src/test/jacinta.ValidationTests.scala
+++ b/lib/jacinta/src/test/jacinta.ValidationTests.scala
@@ -210,6 +210,39 @@ object ValidationTests extends Suite(m"Jacinta validation tests"):
         validateJson(json)(_.as[VMix]).items.map(_(0).s).pipe(xs => Set.from(xs.stdlib))
       . assert(_ == Set("#/shape", "#/name"))
 
+    suite(m"Streaming-parse accrual"):
+      // The direct-parse path: `Tactic[ParseError]` comes from the ambient `throwUnsafely`
+      // (token-level errors stay fail-fast; a malformed stream cannot be resynchronized), while
+      // `Json.Error`s — absent required fields, discovered after the object is consumed — accrue.
+      inline def validateRead[result](text: Text)
+        (inline decode: Text => result raises Json.Error tracks Json.Focus)
+      :   Issues =
+        Validate[Issues, [r] =>> r raises Json.Error, Json.Focus]
+          ( Issues(),
+            { case error: Json.Error => accrual + (prior.let(_.pointer.encode).or(t"#"), error) } )
+        . protect(decode(text))
+
+      test(m"Two missing fields accrue on the direct-parse path"):
+        validateRead(t"""{"name": "Bob"}""")(_.read[VPerson in Json]).items.length
+      . assert(_ == 2)
+
+      test(m"Pointers identify both missing fields on the direct-parse path"):
+        validateRead(t"""{"name": "Bob"}""")(_.read[VPerson in Json])
+        . items.map(_(0).s).pipe(xs => Set.from(xs.stdlib))
+      . assert(_ == Set("#/age", "#/email"))
+
+      test(m"Direct-parse construction is skipped when a field is missing"):
+        VProbe.constructions = 0
+        val issues = validateRead(t"""{"name": "Zoe"}""")(_.read[VChecked in Json])
+        (issues.items.length, VProbe.constructions)
+      . assert(_ == (1, 0))
+
+      test(m"Direct-parse construction runs once when clean"):
+        VProbe.constructions = 0
+        validateRead(t"""{"name": "Zoe", "age": 5}""")(_.read[VChecked in Json])
+        VProbe.constructions
+      . assert(_ == 1)
+
     suite(m"Ventures and guards over Json decoding"):
       import dynamicJsonAccess.enabled
       test(m"Failed sibling reads both accrue; dependent steps are skipped"):

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -966,6 +966,7 @@ object Tel extends Tel2:
                       else entries.readUnchecked(found)(1).parse(reader, indent)
 
           index = 0
+          var failedSlots = false
 
           while index < count do
             val parsing = unwrap(entries.readUnchecked(index)(1))
@@ -989,15 +990,25 @@ object Tel extends Tel2:
             else if values(index).asInstanceOf[AnyRef] eq AbsentSlot then
               val fallback = entries.readUnchecked(index)(2).asInstanceOf[Optional[Any]]
 
-              values(index) =
-                if fallback.present then fallback
-                else if focused
-                then focus(descend(prior, Text(keys.readUnchecked(index))))(entries.readUnchecked(index)(1).absent())
-                else entries.readUnchecked(index)(1).absent()
+              if fallback.present then values(index) = fallback
+              else if focused then
+                // Absent keys are only discovered here, after the entry region is fully
+                // consumed, so EVERY missing field can accrue: the venture delimits
+                // `absent()`'s abort (the `Tactic` is a call-time parameter, not
+                // resolution-captured), records it at this field's focus, and continues.
+                focus(descend(prior, Text(keys.readUnchecked(index)))):
+                  given Diagnostics = tactic.diagnostics
+                  val ventured = venture(entries.readUnchecked(index)(1).absent())
+                  if ventured.ready then values(index) = ventured.vouch else failedSlots = true
+              else values(index) = entries.readUnchecked(index)(1).absent()
 
             index += 1
 
-          make(values.asInstanceOf[Array[Any]^{}])
+          // Construction is gated on a full set of clean slots, so user constructor code never
+          // sees a garbage value; on failure the returned value is never used (the caller's
+          // tracking scope is tainted by the errors recorded above).
+          if failedSlots then null.asInstanceOf[derivation]
+          else make(values.asInstanceOf[Array[Any]^{}])
 
   // The direct-parsing counterpart of `Tel.Decodable`: consumes compound
   // entries from a `TelReader` instead of walking a materialized `Tel`, so

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -243,6 +243,36 @@ trait Tel2 extends Tel3:
     // a plain method, NOT part of the inline expansion: inlining this body twice per derivation
     // (once per traversal) pushed classes with many derived decoders over the JVM class-size
     // limit.
+    // Scans the venture slots and constructs positionally through the threaded `Mirror` — a
+    // plain method: the argument buffer must not be allocated inside an inline expansion,
+    // where its fresh root capability leaks into the expansion site's capture sets. Returns
+    // an unused null when any slot failed: the caller's accruing scope is tainted, so the
+    // result is discarded.
+    private def gate[derivation <: Product]
+      ( reflection: ProductReflection[derivation],
+        slots:      Array[Venture[Any]]^{},
+        active:     Boolean )
+    :   derivation =
+
+      var failed = false
+      var slot = 0
+
+      if active then
+        while slot < slots.length do
+          if !slots.readUnchecked(slot).ready then failed = true
+          slot += 1
+
+      if failed then null.asInstanceOf[derivation]
+      else
+        val arguments = Array[Any](slots.length)
+        slot = 0
+
+        while slot < slots.length do
+          arguments(slot) = slots.readUnchecked(slot).vouch
+          slot += 1
+
+        Tel.Parsable.assemble[derivation](reflection, Array.freeze(arguments))
+
     private def decodeField[field]
       ( ctx:        (Tel.Decodable { type Self = field })^,
         telVal:     Tel,
@@ -351,11 +381,21 @@ trait Tel2 extends Tel3:
 
               val foci = infer[Foci[Tel.Focus]]
 
-              if !foci.active then
-                // Fail-fast path: the first recorded error escapes through the tactic, so
-                // decode and construct in a single traversal, with no venture slots and no
-                // focus bookkeeping.
-                build[derivation]: [field] =>
+              // A SINGLE field traversal serving both modes, branching on `foci.active` per
+              // field. One traversal is load-bearing: every wisteria traversal re-summons each
+              // field's decoder (`summonInline`), recursively deriving nested types, so
+              // traversals multiply EXPONENTIALLY with nesting depth at compile time.
+              //
+              // Accruing mode: each slot is marked failed if its decode registered any focus,
+              // and the product is constructed only when every slot is clean — user constructor
+              // code never sees a garbage fallback value. On failure the returned value is
+              // never used (the caller's scope is tainted), and siblings keep accruing in the
+              // meantime. Fail-fast mode: the first recorded error escapes through the tactic,
+              // so no focus bookkeeping and no failure scan are needed.
+              val active = foci.active
+
+              val slots: Array[Venture[Any]]^{} =
+                contexts[derivation]()[Venture[Any]]: [field] =>
                   ctx =>
                     val keyword: Text = renames(label).or(Tel.camelToKebab(label.s))
 
@@ -363,23 +403,11 @@ trait Tel2 extends Tel3:
                       if assigned.length == 0 then scala.collection.immutable.Nil
                       else assigned(index).stdlib
 
-                    decodeField[field](ctx, telVal, keyword, positional, default[Optional[field]])
-
-              else
-                // Accruing path (as in jacinta's `decodeObject`): decode EVERY field into a
-                // venture slot first, marking a slot failed if its decode registered any focus,
-                // and construct only when all slots are clean — user constructor code never
-                // sees a garbage fallback value. On failure the returned value is never used
-                // (the caller's scope is tainted), and siblings keep accruing in the meantime.
-                val slots: Array[Venture[Any]]^{} =
-                  contexts[derivation]()[Venture[Any]]: [field] =>
-                    ctx =>
-                      val keyword: Text = renames(label).or(Tel.camelToKebab(label.s))
-
-                      val positional: scala.collection.immutable.List[Tel.Atom] =
-                        if assigned.length == 0 then scala.collection.immutable.Nil
-                        else assigned(index).stdlib
-
+                    if !active then
+                      Venture:
+                        decodeField[field]
+                          (ctx, telVal, keyword, positional, default[Optional[field]])
+                    else
                       // Tag every error registered while decoding this field with its
                       // keyword path, so that under a `validate[Tel.Focus]` boundary the
                       // primitives' `raise … yet sentinel` accrue per-field rather than the
@@ -396,17 +424,7 @@ trait Tel2 extends Tel3:
 
                         if foci.length > before then Venture.failed else Venture(value)
 
-                var failed = false
-                var slot = 0
-
-                while slot < slots.length do
-                  if !slots.readUnchecked(slot).ready then failed = true
-                  slot += 1
-
-                if failed then null.asInstanceOf[derivation]
-                else
-                  build[derivation]: [field] =>
-                    ctx => slots.readUnchecked(index).asInstanceOf[Venture[field]].vouch
+              gate[derivation](infer[ProductReflection[derivation]], slots, active)
 
     inline def disjunction[derivation: SumReflection]: derivation is Tel.Decodable =
       // A sum is a document whose single child compound is the chosen variant, keyed by

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -239,6 +239,72 @@ trait Tel2 extends Tel3:
         Tel.Field(Tel.Parsable.fromDecodable(infer[derivation is Tel.Decodable]))
 
   object DecodableDerivation extends Derivable[Tel.Decodable]:
+    // The per-field decode, shared by the fail-fast and accruing traversals of `conjunction` —
+    // a plain method, NOT part of the inline expansion: inlining this body twice per derivation
+    // (once per traversal) pushed classes with many derived decoders over the JVM class-size
+    // limit.
+    private def decodeField[field]
+      ( ctx:        (Tel.Decodable { type Self = field })^,
+        telVal:     Tel,
+        keyword:    Text,
+        positional: scala.collection.immutable.List[Tel.Atom],
+        fallback:   Optional[field] )
+      ( using tactic: Tactic[Tel.Error] )
+    :   field =
+
+      given fulminate.Diagnostics = tactic.diagnostics
+
+      // A `List`/`Set` field (`ctx.repeatable`) is encoded as repeated
+      // keyword compounds, so gather them all into a Document for the
+      // collection decoder — positionally-assigned atoms first, since
+      // atoms precede children (§18.3 step 4). Every other field —
+      // scalar, nested product, `Optional`, `Map` (a single `entries`
+      // compound) — reads one match.
+      if ctx.repeatable then
+        val compounds =
+          if positional.isEmpty
+          then telVal.childCompounds.filter(_.keyword == keyword)
+          else
+            val buffer = scala.collection.mutable.ArrayBuffer.empty[Tel.Compound]
+
+            // A flag's atom is its keyword, meaning presence: it
+            // becomes a bare compound, not an atom-bearing one.
+            positional.foreach: atom =>
+              buffer +=
+                ( if ctx.nature == Tel.Nature.Flag
+                  then Tel.Compound(keyword, Array.empty, Unset, Array.empty)
+                  else Tel.Compound(keyword, Array.of(atom), Unset, Array.empty) )
+
+            telVal.childCompounds.each: compound =>
+              if compound.keyword == keyword then buffer += compound
+
+            Array.from(buffer)
+
+        ctx.decoded:
+          Tel.make
+            ( Tel.Document
+              ( Unset, Unset, Tel.LineEndings.Lf,
+               Array.of(Tel.Block(Array.empty, Unset, compounds, 0)) ) )
+      else
+        val match0 = telVal.field(keyword)
+
+        if positional.isEmpty then
+          match0.lay(fallback.or(ctx.absent()))(ctx.decoded(_))
+        else
+          // §20.2 step 5c: an inline atom plus a same-keyword
+          // child fills a non-repeatable member twice (E308).
+          // The atom wins — atoms precede children.
+          if match0.present
+          then raise(Tel.Error(Tel.Error.Reason.NonRepeatableTooMany))
+
+          ctx.decoded:
+            Tel.make:
+              // A flag's atom is its keyword, meaning presence:
+              // it becomes a bare compound.
+              if ctx.nature == Tel.Nature.Flag
+              then Tel.Compound(keyword, Array.empty, Unset, Array.empty)
+              else Tel.Compound(keyword, Array.of(positional.head), Unset, Array.empty)
+
     inline def conjunction[derivation <: Product: ProductReflection]
     :   derivation is Tel.Decodable =
 
@@ -283,72 +349,64 @@ trait Tel2 extends Tel3:
               val assigned: Array[List[Tel.Atom]]^{} =
                 if atoms.length == 0 then Array.empty else Positional.assign(atoms, profiles)
 
-              build[derivation]: [field] =>
-                ctx =>
-                  val keyword: Text = renames(label).or(Tel.camelToKebab(label.s))
+              val foci = infer[Foci[Tel.Focus]]
 
-                  val positional: scala.collection.immutable.List[Tel.Atom] =
-                    if assigned.length == 0 then scala.collection.immutable.Nil
-                    else assigned(index).stdlib
+              if !foci.active then
+                // Fail-fast path: the first recorded error escapes through the tactic, so
+                // decode and construct in a single traversal, with no venture slots and no
+                // focus bookkeeping.
+                build[derivation]: [field] =>
+                  ctx =>
+                    val keyword: Text = renames(label).or(Tel.camelToKebab(label.s))
 
-                  // Tag every error registered while decoding this field with its
-                  // keyword path, so that under a `validate[Tel.Focus]` boundary the
-                  // primitives' `raise … yet sentinel` accrue per-field rather than the
-                  // first malformed field aborting the whole record.
-                  focus({
-                    val base = prior.let(_.pointer).or(TelPath.Root)
-                    Tel.Focus(base.prepend(keyword))
-                  }):
-                    // A `List`/`Set` field (`ctx.repeatable`) is encoded as repeated
-                    // keyword compounds, so gather them all into a Document for the
-                    // collection decoder — positionally-assigned atoms first, since
-                    // atoms precede children (§18.3 step 4). Every other field —
-                    // scalar, nested product, `Optional`, `Map` (a single `entries`
-                    // compound) — reads one match.
-                    if ctx.repeatable then
-                      val compounds =
-                        if positional.isEmpty
-                        then telVal.childCompounds.filter(_.keyword == keyword)
-                        else
-                          val buffer = scala.collection.mutable.ArrayBuffer.empty[Tel.Compound]
+                    val positional: scala.collection.immutable.List[Tel.Atom] =
+                      if assigned.length == 0 then scala.collection.immutable.Nil
+                      else assigned(index).stdlib
 
-                          // A flag's atom is its keyword, meaning presence: it
-                          // becomes a bare compound, not an atom-bearing one.
-                          positional.foreach: atom =>
-                            buffer +=
-                              ( if ctx.nature == Tel.Nature.Flag
-                                then Tel.Compound(keyword, Array.empty, Unset, Array.empty)
-                                else Tel.Compound(keyword, Array.of(atom), Unset, Array.empty) )
+                    decodeField[field](ctx, telVal, keyword, positional, default[Optional[field]])
 
-                          telVal.childCompounds.each: compound =>
-                            if compound.keyword == keyword then buffer += compound
+              else
+                // Accruing path (as in jacinta's `decodeObject`): decode EVERY field into a
+                // venture slot first, marking a slot failed if its decode registered any focus,
+                // and construct only when all slots are clean — user constructor code never
+                // sees a garbage fallback value. On failure the returned value is never used
+                // (the caller's scope is tainted), and siblings keep accruing in the meantime.
+                val slots: Array[Venture[Any]]^{} =
+                  contexts[derivation]()[Venture[Any]]: [field] =>
+                    ctx =>
+                      val keyword: Text = renames(label).or(Tel.camelToKebab(label.s))
 
-                          Array.from(buffer)
+                      val positional: scala.collection.immutable.List[Tel.Atom] =
+                        if assigned.length == 0 then scala.collection.immutable.Nil
+                        else assigned(index).stdlib
 
-                      ctx.decoded:
-                        Tel.make
-                          ( Tel.Document
-                            ( Unset, Unset, Tel.LineEndings.Lf,
-                             Array.of(Tel.Block(Array.empty, Unset, compounds, 0)) ) )
-                    else
-                      val match0 = telVal.field(keyword)
+                      // Tag every error registered while decoding this field with its
+                      // keyword path, so that under a `validate[Tel.Focus]` boundary the
+                      // primitives' `raise … yet sentinel` accrue per-field rather than the
+                      // first malformed field aborting the whole record.
+                      focus({
+                        val base = prior.let(_.pointer).or(TelPath.Root)
+                        Tel.Focus(base.prepend(keyword))
+                      }):
+                        val before = foci.length
 
-                      if positional.isEmpty then
-                        match0.lay(default.or(ctx.absent()))(ctx.decoded(_))
-                      else
-                        // §20.2 step 5c: an inline atom plus a same-keyword
-                        // child fills a non-repeatable member twice (E308).
-                        // The atom wins — atoms precede children.
-                        if match0.present
-                        then raise(Tel.Error(Tel.Error.Reason.NonRepeatableTooMany))
+                        val value: field =
+                          decodeField[field]
+                            (ctx, telVal, keyword, positional, default[Optional[field]])
 
-                        ctx.decoded:
-                          Tel.make:
-                            // A flag's atom is its keyword, meaning presence:
-                            // it becomes a bare compound.
-                            if ctx.nature == Tel.Nature.Flag
-                            then Tel.Compound(keyword, Array.empty, Unset, Array.empty)
-                            else Tel.Compound(keyword, Array.of(positional.head), Unset, Array.empty)
+                        if foci.length > before then Venture.failed else Venture(value)
+
+                var failed = false
+                var slot = 0
+
+                while slot < slots.length do
+                  if !slots.readUnchecked(slot).ready then failed = true
+                  slot += 1
+
+                if failed then null.asInstanceOf[derivation]
+                else
+                  build[derivation]: [field] =>
+                    ctx => slots.readUnchecked(index).asInstanceOf[Venture[field]].vouch
 
     inline def disjunction[derivation: SumReflection]: derivation is Tel.Decodable =
       // A sum is a document whose single child compound is the chosen variant, keyed by
@@ -374,14 +432,22 @@ trait Tel2 extends Tel3:
                 val compounds = telVal.childCompounds
 
                 // A sum position with no child compound carries no variant to
-                // dispatch on: a decode-layer absence, not a crash.
-                if compounds.nil then abort(Tel.Error(Tel.Error.Reason.Absent))
+                // dispatch on: a decode-layer absence, not a crash. Under an
+                // accruing scope, record ONE error and skip the variant decode
+                // without killing the whole scope: the returned value is never
+                // used (the caller sees the focus delta, or the tracking scope
+                // is tainted), so siblings keep accruing. Fail-fast scopes
+                // abort as before.
+                if compounds.nil then
+                  if infer[Foci[Tel.Focus]].active
+                  then raise(Tel.Error(Tel.Error.Reason.Absent)) yet null.asInstanceOf[derivation]
+                  else abort(Tel.Error(Tel.Error.Reason.Absent))
+                else
+                  val variant: Tel = Tel.make(compounds.head)
+                  val variantKeyword: Text = labels(variant.keyword).or(variant.keyword)
 
-                val variant: Tel = Tel.make(compounds.head)
-                val variantKeyword: Text = labels(variant.keyword).or(variant.keyword)
-
-                delegate(variantKeyword): [variant <: derivation] =>
-                  ctx => ctx.decoded(variant)
+                  delegate(variantKeyword): [variant <: derivation] =>
+                    ctx => ctx.decoded(variant)
 
   object EncodableDerivation extends Derivable[Tel.Encodable]:
     inline def conjunction[derivation <: Product: ProductReflection]

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -44,6 +44,15 @@ case class APerson(name: Text, age: Int, email: Text) derives CanEqual
 case class AContact(person: APerson, company: Text) derives CanEqual
 case class APair(width: Int, height: Int) derives CanEqual
 
+object TProbe:
+  @scala.caps.unsafe.untrackedCaptures
+  var constructions: Int = 0
+
+// The body statement observes construction: decoding must never construct from garbage
+// fallback values, so a decode with any failed field must leave the counter untouched.
+case class TChecked(name: Text, age: Int) derives CanEqual:
+  TProbe.constructions += 1
+
 object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
 
   case class Issues(items: List[(Text, Tel.Error)] = Nil)(using Diagnostics)
@@ -244,6 +253,21 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
       test(m"Single wrong-type field: one error"):
         val tel = t"width five\nheight 10\n".read[Tel]
         validateTel(tel)(_.as[APair]).items.length
+      . assert(_ == 1)
+
+    suite(m"Gated construction"):
+      test(m"Constructor does not run when any field failed"):
+        TProbe.constructions = 0
+        val tel = t"name Zoe\nage young\n".read[Tel]
+        val issues = validateTel(tel)(_.as[TChecked])
+        (issues.items.length, TProbe.constructions)
+      . assert(_ == (1, 0))
+
+      test(m"Constructor runs exactly once when all fields are clean"):
+        TProbe.constructions = 0
+        val tel = t"name Zoe\nage 5\n".read[Tel]
+        validateTel(tel)(_.as[TChecked])
+        TProbe.constructions
       . assert(_ == 1)
 
     suite(m"Multiple missing fields"):

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -430,6 +430,36 @@ object Xml extends Tag.Container
               raise(Xml.Error())
               buildWith[derivation](Element(t"", Attributes.empty, Array.empty))
 
+    // Scans the venture slots and constructs positionally through the threaded `Mirror` — a
+    // plain method: the argument buffer must not be allocated inside an inline expansion,
+    // where its fresh root capability leaks into the expansion site's capture sets. Returns
+    // an unused null when any slot failed: the caller's accruing scope is tainted, so the
+    // result is discarded.
+    private def gate[derivation <: Product]
+      ( reflection: ProductReflection[derivation],
+        slots:      Array[Venture[Any]]^{},
+        active:     Boolean )
+    :   derivation =
+
+      var failed = false
+      var slot = 0
+
+      if active then
+        while slot < slots.length do
+          if !slots.readUnchecked(slot).ready then failed = true
+          slot += 1
+
+      if failed then null.asInstanceOf[derivation]
+      else
+        val arguments = Array[Any](slots.length)
+        slot = 0
+
+        while slot < slots.length do
+          arguments(slot) = slots.readUnchecked(slot).vouch
+          slot += 1
+
+        Xml.Parsable.assemble[derivation](reflection, Array.freeze(arguments))
+
     private inline def buildWith[derivation <: Product: ProductReflection]
       ( element: Element )
       ( using foci: Foci[Xml.Focus], tactic: Tactic[Xml.Error] )
@@ -458,61 +488,69 @@ object Xml extends Tag.Container
 
         i += 1
 
-      if !foci.active then
-        // Fail-fast path: the first recorded error escapes through the tactic, so decode and
-        // construct in a single traversal with no venture slots and no focus bookkeeping.
-        build[derivation]: [field] =>
+      // A SINGLE field traversal serving both modes, branching on `foci.active` per field. One
+      // traversal is load-bearing: every wisteria traversal re-summons each field's decoder
+      // (`summonInline`), recursively deriving nested types, so traversals multiply
+      // EXPONENTIALLY with nesting depth at compile time.
+      //
+      // Accruing mode: each slot is marked failed if its decode registered any focus, and the
+      // product is constructed only when every slot is clean — user constructor code never
+      // sees a garbage fallback value. On failure the returned value is never used (the
+      // caller's scope is tainted), and siblings keep accruing in the meantime. Fail-fast mode:
+      // the first recorded error escapes through the tactic, so no focus bookkeeping and no
+      // failure scan are needed.
+      val active = foci.active
+
+      val slots: Array[Venture[Any]]^{} =
+        contexts[derivation]()[Venture[Any]]: [field] =>
           context =>
             val fieldLabel: Text = wisteria.label[Text]
             val wireName: Text = renames(fieldLabel).or(fieldLabel)
 
-            if attributeFields.defines(fieldLabel) then
-              // `@attribute` field: decode from the matching attribute as a
-              // `TextNode`; a missing attribute falls back to the declared
-              // default, else the `Absent` sentinel (raise + continue).
-              element.attributes(wireName).lay(default.or(context.decoded(Absent))): text =>
-                context.decoded(TextNode(text))
+            def decodeNow(): field =
+              if attributeFields.defines(fieldLabel) then
+                // `@attribute` field: decode from the matching attribute as a
+                // `TextNode`; a missing attribute falls back to the declared
+                // default, else the `Absent` sentinel (raise + continue).
+                element.attributes(wireName).lay(default.or(context.decoded(Absent))): text =>
+                  context.decoded(TextNode(text))
+              else
+                // The `AnyRef` cast (rather than `asMatchable`) sidesteps the
+                // capture-refined singleton type the checker would otherwise
+                // require of the scrutinee.
+                context.asInstanceOf[AnyRef] match
+                  case marked: Repeatable if marked.repeatable =>
+                    // A repeatable (collection) field gathers *all* same-label
+                    // children, in document order, into a synthetic `Fragment`
+                    // for the collection decoder — stratiform's synthetic-
+                    // document idea. Zero matches decode the empty fragment
+                    // (an empty collection): the declared default is never
+                    // consulted, exactly as on the direct path.
+                    val gathered: scm.ArrayBuffer[Node] = scm.ArrayBuffer()
+                    var child = 0
+
+                    while child < element.children.length do
+                      element.children.readUnchecked(child) match
+                        case node: Element => if node.label == wireName then gathered += node
+                        case _             => ()
+
+                      child += 1
+
+                    context.decoded(Fragment(gathered.toSeq*))
+
+                  case _ =>
+                    children.get(wireName.s) match
+                      case Some(child) => context.decoded(child)
+                      // Missing field: fall back to the case-class declared
+                      // default (Wisteria's `default`); if absent, hand the
+                      // `Absent` sentinel to the field's decoder. Primitives
+                      // detect it and `raise + continue`; nested conjunctions
+                      // detect it and may further short-circuit via a
+                      // user-supplied `Default[Nested]`.
+                      case None => default.or(context.decoded(Absent))
+
+            if !active then Venture(decodeNow())
             else
-              // The `AnyRef` cast (rather than `asMatchable`) sidesteps the
-              // capture-refined singleton type the checker would otherwise
-              // require of the scrutinee.
-              context.asInstanceOf[AnyRef] match
-                case marked: Repeatable if marked.repeatable =>
-                  // A repeatable (collection) field gathers *all* same-label
-                  // children, in document order, into a synthetic `Fragment`
-                  // for the collection decoder — stratiform's synthetic-
-                  // document idea. Zero matches decode the empty fragment
-                  // (an empty collection): the declared default is never
-                  // consulted, exactly as on the direct path.
-                  val gathered: scm.ArrayBuffer[Node] = scm.ArrayBuffer()
-                  var child = 0
-
-                  while child < element.children.length do
-                    element.children.readUnchecked(child) match
-                      case node: Element => if node.label == wireName then gathered += node
-                      case _             => ()
-
-                    child += 1
-
-                  context.decoded(Fragment(gathered.toSeq*))
-
-                case _ =>
-                  children.get(wireName.s) match
-                    case Some(child) => context.decoded(child)
-                    case None        => default.or(context.decoded(Absent))
-
-      else
-        // Accruing path (as in jacinta's `decodeObject`): decode EVERY field into a venture
-        // slot first, marking a slot failed if its decode registered any focus, and construct
-        // only when all slots are clean — user constructor code never sees a garbage fallback
-        // value. On failure the returned value is never used (the caller's scope is tainted),
-        // and siblings keep accruing in the meantime.
-        val slots: Array[Venture[Any]] =
-          contexts[derivation]()[Venture[Any]]: [field] =>
-            context =>
-              val fieldLabel: Text = wisteria.label[Text]
-              val wireName: Text = renames(fieldLabel).or(fieldLabel)
-
               focus({
                 // Each outer `focus` runs *after* the inner one, so we
                 // extend `prior` at the root side (`/outer/inner`), not the
@@ -521,62 +559,10 @@ object Xml extends Tag.Container
                 Xml.Focus(base.prepend(wireName, 1))
               }):
                 val before = foci.length
-
-                val value: field =
-                  if attributeFields.defines(fieldLabel) then
-                    // `@attribute` field: decode from the matching attribute as a
-                    // `TextNode`; a missing attribute falls back to the declared
-                    // default, else the `Absent` sentinel (raise + continue).
-                    element.attributes(wireName).lay(default.or(context.decoded(Absent))): text =>
-                      context.decoded(TextNode(text))
-                  else
-                    // The `AnyRef` cast (rather than `asMatchable`) sidesteps the
-                    // capture-refined singleton type the checker would otherwise
-                    // require of the scrutinee.
-                    context.asInstanceOf[AnyRef] match
-                      case marked: Repeatable if marked.repeatable =>
-                        // A repeatable (collection) field gathers *all* same-label
-                        // children, in document order, into a synthetic `Fragment`
-                        // for the collection decoder — stratiform's synthetic-
-                        // document idea. Zero matches decode the empty fragment
-                        // (an empty collection): the declared default is never
-                        // consulted, exactly as on the direct path.
-                        val gathered: scm.ArrayBuffer[Node] = scm.ArrayBuffer()
-                        var child = 0
-
-                        while child < element.children.length do
-                          element.children.readUnchecked(child) match
-                            case node: Element =>
-                              if node.label == wireName then gathered += node
-
-                            case _ => ()
-
-                          child += 1
-
-                        context.decoded(Fragment(gathered.toSeq*))
-
-                      case _ =>
-                        children.get(wireName.s) match
-                          case Some(child) => context.decoded(child)
-                          // Missing field: fall back to the case-class declared
-                          // default (Wisteria's `default`); if absent, hand the
-                          // `Absent` sentinel to the field's decoder. Primitives
-                          // detect it and `raise + continue`; nested conjunctions
-                          // detect it and may further short-circuit via a
-                          // user-supplied `Default[Nested]`.
-                          case None => default.or(context.decoded(Absent))
-
+                val value: field = decodeNow()
                 if foci.length > before then Venture.failed else Venture(value)
 
-        var failed = false
-        var slot = 0
-
-        while slot < slots.length do
-          if !slots.readUnchecked(slot).ready then failed = true
-          slot += 1
-
-        if failed then null.asInstanceOf[derivation]
-        else build[derivation]: [field] => context => slots.readUnchecked(index).asInstanceOf[Venture[field]].vouch
+      gate[derivation](infer[ProductReflection[derivation]], slots, active)
 
     // Sealed-trait disjunction picks a variant by element label. We screen
     // the discriminator against `variantLabels` *before* `delegate`-ing so

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -432,7 +432,7 @@ object Xml extends Tag.Container
 
     private inline def buildWith[derivation <: Product: ProductReflection]
       ( element: Element )
-      ( using Foci[Xml.Focus], Tactic[Xml.Error] )
+      ( using foci: Foci[Xml.Focus], tactic: Tactic[Xml.Error] )
     :   derivation =
 
       // Fields marked `@attribute` are read from the element's attributes
@@ -458,17 +458,14 @@ object Xml extends Tag.Container
 
         i += 1
 
-      build[derivation]: [field] =>
-        context =>
-          val fieldLabel: Text = wisteria.label[Text]
-          val wireName: Text = renames(fieldLabel).or(fieldLabel)
-          focus({
-            // Each outer `focus` runs *after* the inner one, so we
-            // extend `prior` at the root side (`/outer/inner`), not the
-            // leaf side that `XPath#element` would use.
-            val base = prior.let(_.path).or(XPath())
-            Xml.Focus(base.prepend(wireName, 1))
-          }):
+      if !foci.active then
+        // Fail-fast path: the first recorded error escapes through the tactic, so decode and
+        // construct in a single traversal with no venture slots and no focus bookkeeping.
+        build[derivation]: [field] =>
+          context =>
+            val fieldLabel: Text = wisteria.label[Text]
+            val wireName: Text = renames(fieldLabel).or(fieldLabel)
+
             if attributeFields.defines(fieldLabel) then
               // `@attribute` field: decode from the matching attribute as a
               // `TextNode`; a missing attribute falls back to the declared
@@ -502,13 +499,84 @@ object Xml extends Tag.Container
                 case _ =>
                   children.get(wireName.s) match
                     case Some(child) => context.decoded(child)
-                    // Missing field: fall back to the case-class declared
-                    // default (Wisteria's `default`); if absent, hand the
-                    // `Absent` sentinel to the field's decoder. Primitives
-                    // detect it and `raise + continue`; nested conjunctions
-                    // detect it and may further short-circuit via a
-                    // user-supplied `Default[Nested]`.
                     case None        => default.or(context.decoded(Absent))
+
+      else
+        // Accruing path (as in jacinta's `decodeObject`): decode EVERY field into a venture
+        // slot first, marking a slot failed if its decode registered any focus, and construct
+        // only when all slots are clean — user constructor code never sees a garbage fallback
+        // value. On failure the returned value is never used (the caller's scope is tainted),
+        // and siblings keep accruing in the meantime.
+        val slots: Array[Venture[Any]] =
+          contexts[derivation]()[Venture[Any]]: [field] =>
+            context =>
+              val fieldLabel: Text = wisteria.label[Text]
+              val wireName: Text = renames(fieldLabel).or(fieldLabel)
+
+              focus({
+                // Each outer `focus` runs *after* the inner one, so we
+                // extend `prior` at the root side (`/outer/inner`), not the
+                // leaf side that `XPath#element` would use.
+                val base = prior.let(_.path).or(XPath())
+                Xml.Focus(base.prepend(wireName, 1))
+              }):
+                val before = foci.length
+
+                val value: field =
+                  if attributeFields.defines(fieldLabel) then
+                    // `@attribute` field: decode from the matching attribute as a
+                    // `TextNode`; a missing attribute falls back to the declared
+                    // default, else the `Absent` sentinel (raise + continue).
+                    element.attributes(wireName).lay(default.or(context.decoded(Absent))): text =>
+                      context.decoded(TextNode(text))
+                  else
+                    // The `AnyRef` cast (rather than `asMatchable`) sidesteps the
+                    // capture-refined singleton type the checker would otherwise
+                    // require of the scrutinee.
+                    context.asInstanceOf[AnyRef] match
+                      case marked: Repeatable if marked.repeatable =>
+                        // A repeatable (collection) field gathers *all* same-label
+                        // children, in document order, into a synthetic `Fragment`
+                        // for the collection decoder — stratiform's synthetic-
+                        // document idea. Zero matches decode the empty fragment
+                        // (an empty collection): the declared default is never
+                        // consulted, exactly as on the direct path.
+                        val gathered: scm.ArrayBuffer[Node] = scm.ArrayBuffer()
+                        var child = 0
+
+                        while child < element.children.length do
+                          element.children.readUnchecked(child) match
+                            case node: Element =>
+                              if node.label == wireName then gathered += node
+
+                            case _ => ()
+
+                          child += 1
+
+                        context.decoded(Fragment(gathered.toSeq*))
+
+                      case _ =>
+                        children.get(wireName.s) match
+                          case Some(child) => context.decoded(child)
+                          // Missing field: fall back to the case-class declared
+                          // default (Wisteria's `default`); if absent, hand the
+                          // `Absent` sentinel to the field's decoder. Primitives
+                          // detect it and `raise + continue`; nested conjunctions
+                          // detect it and may further short-circuit via a
+                          // user-supplied `Default[Nested]`.
+                          case None => default.or(context.decoded(Absent))
+
+                if foci.length > before then Venture.failed else Venture(value)
+
+        var failed = false
+        var slot = 0
+
+        while slot < slots.length do
+          if !slots.readUnchecked(slot).ready then failed = true
+          slot += 1
+
+        if failed then null.asInstanceOf[derivation]
+        else build[derivation]: [field] => context => slots.readUnchecked(index).asInstanceOf[Venture[field]].vouch
 
     // Sealed-trait disjunction picks a variant by element label. We screen
     // the discriminator against `variantLabels` *before* `delegate`-ing so
@@ -551,7 +619,13 @@ object Xml extends Tag.Container
                       raise(Xml.Error()) yet derivationDefault()
 
                     case _ =>
-                      abort(Xml.Error())
+                      // Under an accruing scope, record ONE error and skip the variant decode
+                      // without killing the whole scope: the returned value is never used (the
+                      // caller sees the focus delta, or the tracking scope is tainted), so
+                      // siblings keep accruing. Fail-fast scopes abort as before.
+                      if infer[Foci[Xml.Focus]].active
+                      then raise(Xml.Error()) yet null.asInstanceOf[derivation]
+                      else abort(Xml.Error())
 
   // A sum discriminated by an attribute on the value's element —
   // `<payment type="Card">…</payment>`. This is the shape a sum nested

--- a/lib/xylophone/src/test/xylophone.DecoderTests.scala
+++ b/lib/xylophone/src/test/xylophone.DecoderTests.scala
@@ -51,6 +51,16 @@ case class XmlIssues(items: List[(Text, Xml.Error)] = Nil)(using Diagnostics)
 extends Error(m"${items.length} XML decoding issues"):
   def +(focus: Text, error: Xml.Error): XmlIssues = XmlIssues(items :+ (focus, error))
 
+object XProbe:
+  var constructions: Int = 0
+
+// The body statement observes construction: decoding must never construct from garbage
+// fallback values, so a decode with any failed field must leave the counter untouched.
+case class XChecked(name: Text, age: Int) derives CanEqual:
+  XProbe.constructions += 1
+
+case class XMix(shape: DShape, name: Text) derives CanEqual
+
 // Wrapped in an object so the `given Default[DPerson]` is in lexical scope
 // *at the conjunction call site* — the `summonFrom` inside the inlined
 // `Xml.DecodableDerivation.conjunction` body resolves against the call
@@ -118,6 +128,24 @@ object DecoderTests extends Suite(m"Xylophone case-class decoder tests"):
               <company>Acme</company>
             </root>""".as[DContact]
       . assert(_ == DContact(DPerson(t"Carol", 40, t"c@x"), t"Acme"))
+
+    suite(m"Gated construction"):
+      test(m"Constructor does not run when any field failed"):
+        XProbe.constructions = 0
+        val issues = validateXml(x"<root><name>Zoe</name></root>")(_.as[XChecked])
+        (issues.items.length, XProbe.constructions)
+      . assert(_ == (1, 0))
+
+      test(m"Constructor runs exactly once when all fields are clean"):
+        XProbe.constructions = 0
+        validateXml(x"<root><name>Zoe</name><age>5</age></root>")(_.as[XChecked])
+        XProbe.constructions
+      . assert(_ == 1)
+
+      test(m"A failing sum field and a missing sibling both accrue"):
+        validateXml(x"<root><shape><foo>bar</foo></shape></root>")(_.as[XMix])
+        . items.map(_(0).s).to[Set]
+      . assert(_ == Set("/shape[1]", "/name[1]"))
 
     suite(m"Sum type by element label"):
       test(m"Decode the Circle variant"):

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -178,40 +178,40 @@ trait Yaml2:
 
     private inline def buildWith[derivation <: Product: ProductReflection]
       ( arr: Array[Any]^{} | Null )
-      ( using Foci[Yaml.Focus], Tactic[Yaml.Error] )
+      ( using foci: Foci[Yaml.Focus], tactic: Tactic[Yaml.Error] )
     :   derivation =
 
       // `@name[Yaml]` / bare `@name` renames: field name -> mapping key, read
       // back the same way they are written.
       val renames: Map[Text, Text] = relabelling[derivation, Yaml]
 
-      build[derivation]: [field] =>
-        context =>
-          val key: Text = renames(label).or(label)
-          val target = key.s
-          var found: Yaml.Ast | Null = null
+      def fieldAst(target: String): Yaml.Ast | Null =
+        var found: Yaml.Ast | Null = null
 
-          if arr != null then
-            val n = arr.length
-            var i = 0
+        if arr != null then
+          val n = arr.length
+          var i = 0
 
-            while i < n && found == null do
-              val entryKey = arr.readUnchecked(i).asInstanceOf[Yaml.Ast]
+          while i < n && found == null do
+            val entryKey = arr.readUnchecked(i).asInstanceOf[Yaml.Ast]
 
-              entryKey.asMatchable match
-                case s: String if s == target => found = arr.readUnchecked(i + 1).asInstanceOf[Yaml.Ast]
-                case _                        => ()
-              i += 2
-          // Each outer `focus` runs *after* the inner one
-          // (contingency's try/finally order), so we extend
-          // `prior` at the root side via `prepend` so a nested
-          // case-class error lands at `/outer/inner` rather than
-          // `/inner/outer`. See `feedback-xml-decoder-split-design`
-          // lesson 4.
-          focus({
-            val base = prior.let(_.pointer).or(YamlPath())
-            Yaml.Focus(base.prepend(key))
-          }):
+            entryKey.asMatchable match
+              case s: String if s == target =>
+                found = arr.readUnchecked(i + 1).asInstanceOf[Yaml.Ast]
+
+              case _ => ()
+            i += 2
+
+        found
+
+      if !foci.active then
+        // Fail-fast path: the first recorded error escapes through the tactic, so decode and
+        // construct in a single traversal with no venture slots and no focus bookkeeping.
+        build[derivation]: [field] =>
+          context =>
+            val key: Text = renames(label).or(label)
+            val found = fieldAst(key.s)
+
             if found != null then context.decoded(new Yaml(found))
             // Missing field: try the case-class declared default
             // (Wisteria's `default`); if absent, hand the
@@ -221,6 +221,46 @@ trait Yaml2:
             // conjunctions detect wrong-shape and may further
             // short-circuit via a user-supplied `Default[Nested]`.
             else default.or(context.decoded(new Yaml(Yaml.Ast(Unset))))
+
+      else
+        // Accruing path (as in jacinta's `decodeObject`): decode EVERY field into a venture
+        // slot first, marking a slot failed if its decode registered any focus, and construct
+        // only when all slots are clean — user constructor code never sees a garbage fallback
+        // value. On failure the returned value is never used (the caller's scope is tainted),
+        // and siblings keep accruing in the meantime.
+        val slots: Array[Venture[Any]] =
+          contexts[derivation]()[Venture[Any]]: [field] =>
+            context =>
+              val key: Text = renames(label).or(label)
+              val found = fieldAst(key.s)
+
+              // Each outer `focus` runs *after* the inner one
+              // (contingency's try/finally order), so we extend
+              // `prior` at the root side via `prepend` so a nested
+              // case-class error lands at `/outer/inner` rather than
+              // `/inner/outer`. See `feedback-xml-decoder-split-design`
+              // lesson 4.
+              focus({
+                val base = prior.let(_.pointer).or(YamlPath())
+                Yaml.Focus(base.prepend(key))
+              }):
+                val before = foci.length
+
+                val value: field =
+                  if found != null then context.decoded(new Yaml(found))
+                  else default.or(context.decoded(new Yaml(Yaml.Ast(Unset))))
+
+                if foci.length > before then Venture.failed else Venture(value)
+
+        var failed = false
+        var slot = 0
+
+        while slot < slots.length do
+          if !slots.readUnchecked(slot).ready then failed = true
+          slot += 1
+
+        if failed then null.asInstanceOf[derivation]
+        else build[derivation]: [field] => context => slots.readUnchecked(index).asInstanceOf[Venture[field]].vouch
 
     // Sealed-trait disjunction picks a variant by mapping discriminator
     // (`type:` key). We screen the discriminator against
@@ -259,7 +299,13 @@ trait Yaml2:
                       raise(Yaml.Error(Reason.Absent)) yet derivationDefault()
 
                     case _ =>
-                      abort(Yaml.Error(Reason.Absent))
+                      // Under an accruing scope, record ONE error and skip the variant decode
+                      // without killing the whole scope: the returned value is never used (the
+                      // caller sees the focus delta, or the tracking scope is tainted), so
+                      // siblings keep accruing. Fail-fast scopes abort as before.
+                      if infer[Foci[Yaml.Focus]].active
+                      then raise(Yaml.Error(Reason.Absent)) yet null.asInstanceOf[derivation]
+                      else abort(Yaml.Error(Reason.Absent))
 
   object EncodableDerivation extends Derivable[Encodable in Yaml]:
     inline def conjunction[derivation <: Product: ProductReflection]

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -122,6 +122,40 @@ trait Yaml2:
     case given Reflection[`value`]            => EncodableDerivation.derived
 
   object DecodableDerivation extends Derivable[Decodable in Yaml]:
+    // Scans the venture slots and constructs positionally through the threaded `Mirror` — a
+    // plain method: the argument buffer must not be allocated inside an inline expansion,
+    // where its fresh root capability leaks into the expansion site's capture sets. Returns
+    // an unused null when any slot failed: the caller's accruing scope is tainted, so the
+    // result is discarded.
+    private final class ArrayProduct(values: Array[Any]^{}) extends Product:
+      def canEqual(that: Any): Boolean = true
+      def productArity: Int = values.length
+      def productElement(index: Int): Any = values.readUnchecked(index)
+
+    private def gate[derivation <: Product]
+      ( reflection: ProductReflection[derivation],
+        slots:      Array[Venture[Any]]^{},
+        active:     Boolean )
+    :   derivation =
+
+      var failed = false
+      var slot = 0
+
+      if active then
+        while slot < slots.length do
+          if !slots.readUnchecked(slot).ready then failed = true
+          slot += 1
+
+      if failed then null.asInstanceOf[derivation]
+      else
+        val arguments = Array[Any](slots.length)
+        slot = 0
+
+        while slot < slots.length do
+          arguments(slot) = slots.readUnchecked(slot).vouch
+          slot += 1
+
+        reflection.fromProduct(ArrayProduct(Array.freeze(arguments)))
     inline def conjunction[derivation <: Product: ProductReflection]
     :   derivation is Decodable in Yaml =
 
@@ -204,15 +238,25 @@ trait Yaml2:
 
         found
 
-      if !foci.active then
-        // Fail-fast path: the first recorded error escapes through the tactic, so decode and
-        // construct in a single traversal with no venture slots and no focus bookkeeping.
-        build[derivation]: [field] =>
+      // A SINGLE field traversal serving both modes, branching on `foci.active` per field. One
+      // traversal is load-bearing: every wisteria traversal re-summons each field's decoder
+      // (`summonInline`), recursively deriving nested types, so traversals multiply
+      // EXPONENTIALLY with nesting depth at compile time.
+      //
+      // Accruing mode: each slot is marked failed if its decode registered any focus, and the
+      // product is constructed only when every slot is clean — user constructor code never
+      // sees a garbage fallback value. On failure the returned value is never used (the
+      // caller's scope is tainted), and siblings keep accruing in the meantime. Fail-fast mode:
+      // the first recorded error escapes through the tactic, so no focus bookkeeping and no
+      // failure scan are needed.
+      val active = foci.active
+
+      val slots: Array[Venture[Any]]^{} =
+        contexts[derivation]()[Venture[Any]]: [field] =>
           context =>
             val key: Text = renames(label).or(label)
             val found = fieldAst(key.s)
 
-            if found != null then context.decoded(new Yaml(found))
             // Missing field: try the case-class declared default
             // (Wisteria's `default`); if absent, hand the
             // `Yaml.Ast(Unset)` sentinel to the field's decoder.
@@ -220,20 +264,12 @@ trait Yaml2:
             // continue` with a zero/empty sentinel; nested
             // conjunctions detect wrong-shape and may further
             // short-circuit via a user-supplied `Default[Nested]`.
-            else default.or(context.decoded(new Yaml(Yaml.Ast(Unset))))
+            def decodeNow(): field =
+              if found != null then context.decoded(new Yaml(found))
+              else default.or(context.decoded(new Yaml(Yaml.Ast(Unset))))
 
-      else
-        // Accruing path (as in jacinta's `decodeObject`): decode EVERY field into a venture
-        // slot first, marking a slot failed if its decode registered any focus, and construct
-        // only when all slots are clean — user constructor code never sees a garbage fallback
-        // value. On failure the returned value is never used (the caller's scope is tainted),
-        // and siblings keep accruing in the meantime.
-        val slots: Array[Venture[Any]] =
-          contexts[derivation]()[Venture[Any]]: [field] =>
-            context =>
-              val key: Text = renames(label).or(label)
-              val found = fieldAst(key.s)
-
+            if !active then Venture(decodeNow())
+            else
               // Each outer `focus` runs *after* the inner one
               // (contingency's try/finally order), so we extend
               // `prior` at the root side via `prepend` so a nested
@@ -245,22 +281,10 @@ trait Yaml2:
                 Yaml.Focus(base.prepend(key))
               }):
                 val before = foci.length
-
-                val value: field =
-                  if found != null then context.decoded(new Yaml(found))
-                  else default.or(context.decoded(new Yaml(Yaml.Ast(Unset))))
-
+                val value: field = decodeNow()
                 if foci.length > before then Venture.failed else Venture(value)
 
-        var failed = false
-        var slot = 0
-
-        while slot < slots.length do
-          if !slots.readUnchecked(slot).ready then failed = true
-          slot += 1
-
-        if failed then null.asInstanceOf[derivation]
-        else build[derivation]: [field] => context => slots.readUnchecked(index).asInstanceOf[Venture[field]].vouch
+      gate[derivation](infer[ProductReflection[derivation]], slots, active)
 
     // Sealed-trait disjunction picks a variant by mapping discriminator
     // (`type:` key). We screen the discriminator against

--- a/lib/ypsiloid/src/test/ypsiloid.DefaultTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.DefaultTests.scala
@@ -51,6 +51,16 @@ case class Issues2(items: List[(Text, Yaml.Error)] = Nil)(using Diagnostics)
 extends Error(m"${items.length} validation issues"):
   def +(focus: Text, error: Yaml.Error): Issues2 = Issues2(items :+ (focus, error))
 
+object YProbe:
+  var constructions: Int = 0
+
+// The body statement observes construction: decoding must never construct from garbage
+// fallback values, so a decode with any failed field must leave the counter untouched.
+case class YChecked(name: Text, age: Int) derives CanEqual:
+  YProbe.constructions += 1
+
+case class YMix(shape: DShape, name: Text) derives CanEqual
+
 object DefaultPersonScope:
   given Default[DPerson] = () => DPerson(t"", 0, t"")
 
@@ -117,3 +127,23 @@ object DefaultTests extends Suite(m"Ypsiloid Default-driven sentinel tests"):
         val yaml = t"foo: bar\n".read[Yaml]
         validateYaml(yaml)(_.as[DShape]).items.length
       . assert(_ == 1)
+
+    suite(m"Gated construction"):
+      test(m"Constructor does not run when any field failed"):
+        YProbe.constructions = 0
+        val yaml = t"name: Zoe\n".read[Yaml]
+        val issues = validateYaml(yaml)(_.as[YChecked])
+        (issues.items.length, YProbe.constructions)
+      . assert(_ == (1, 0))
+
+      test(m"Constructor runs exactly once when all fields are clean"):
+        YProbe.constructions = 0
+        val yaml = t"name: Zoe\nage: 5\n".read[Yaml]
+        validateYaml(yaml)(_.as[YChecked])
+        YProbe.constructions
+      . assert(_ == 1)
+
+      test(m"A failing sum field and a missing sibling both accrue"):
+        val yaml = t"shape:\n  foo: bar\n".read[Yaml]
+        validateYaml(yaml)(_.as[YMix]).items.map(_(0).s).to[Set]
+      . assert(_ == Set("#/shape", "#/name"))


### PR DESCRIPTION
Contingency gains `venture` and `guard`, completing the validation-mode error-handling design: execution continues past errors to collect comprehensive feedback, but computations that functionally depend on a failed value are skipped rather than fed a garbage fallback. All five decoder derivations (JSON, YAML, XML, CSV, TEL) now gate record construction on a full set of cleanly-decoded fields, missing sum discriminators accrue instead of aborting the whole validation scope, and jacinta's direct-parse path reports every missing field rather than just the first. The unused late-binding `defer`/`Deferred` is removed.

## Release notes

A `venture` evaluates its block immediately, under whatever error-handling strategy is ambient, but remembers whether anything went wrong. Forcing a failed venture — `name()` below — skips the enclosing `venture` or `guard` block instead of producing a value, and `guard` runs its block only if no error has been recorded so far:

```scala
def decodePerson(json: Json): Person raises Json.Error =
  val name: Venture[Text] = venture(json.name.as[Text])
  val role: Venture[Role] = venture(json.role.as[Role])

  venture(checkConsistency(name(), role()))   // skipped if either input failed

  guard:
    Person(name(), role())                    // runs only on a clean tactic
```

Because ventures evaluate eagerly, a failure in `name` never prevents `role`'s errors from being collected; and because dependent steps are skipped, no spurious cascade errors are reported. Under a fail-fast strategy (`throwUnsafely`, `safely`, `attempt`, …) both constructs vanish: an error escapes at the venture itself and `guard` is the identity — the same body serves every strategy. `Tactic` gains a `tainted` query, forwarded through `mitigate`, so taint is visible across library boundaries between different error types; and `Venture` is a zero-allocation opaque sentinel union.

Derived decoders in jacinta, ypsiloid, xylophone, caesura and stratiform now decode every field before constructing a record, and construct only when all fields are clean — user constructor code never runs on placeholder values. A missing sum discriminator records one error at its own pointer and lets sibling fields keep accruing. `text.read[T in Json]` now reports *all* missing required fields, matching `json.as[T]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)