### PR TITLE
Rework Exoskeleton's help output into an aligned, man-page-style layout

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1866,7 +1866,7 @@ object exoskeleton extends Library:
   object args extends Component(escapade.core, profanity.core, ambience.core, quantitative.units):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
-  object core extends Component(args, galilei.jvm, digression.ansi):
+  object core extends Component(args, escritoire.core, galilei.jvm, digression.ansi):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -85,7 +85,7 @@ trait Cli extends Console, caps.ExclusiveCapability:
   def workingDirectory: WorkingDirectory
   def proceed: Boolean
   def login: Login
-  def register(flag: Flag, discoverable: Discoverable): Unit = ()
+  def register(flag: Flag, discoverable: Discoverable, operand: Optional[Text]): Unit = ()
   def present(flag: Flag): Unit = ()
   def explain(update: (Optional[Text] aka "prior") ?=> Optional[Text]): Unit = ()
 

--- a/lib/exoskeleton/src/args/exoskeleton.CommandGroup.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.CommandGroup.scala
@@ -35,37 +35,9 @@ package exoskeleton
 import scala.language.experimental.pureFunctions
 
 import anticipation.*
-import distillate.*
-import gossamer.*
-import prepositional.*
+import escapade.*
 import vacuous.*
 
-object Interpretable:
-  given unit: Unit is Interpretable:
-    override def operand: Boolean = false
-    def interpret(arguments: List[Argument]): Unit = ()
-
-  given decoder: [operand: Decodable in Text] => operand is Interpretable = arguments =>
-    arguments.stdlib.headOption.absolve match
-      case Some(value) => value().as[operand]
-
-trait Interpretable extends Typeclass:
-  def operand: Boolean = true
-
-  // The display name for this operand type in `help` output, e.g. the `file` of `--log <file>`.
-  // `Unset` means the type suggests no particular name, and a generic `value` is shown instead.
-  def placeholder: Optional[Text] = Unset
-
-  // The name to display for the operand, or `Unset` if the type takes no operand at all.
-  def operandName: Optional[Text] = if operand then placeholder.or(t"value") else Unset
-
-  def interpret(arguments: List[Argument]): Optional[Self]
-
-  def map[self2](lambda: Self => self2): (self2 is Interpretable)^{this, lambda} =
-    new Interpretable:
-      type Self = self2
-      override def operand: Boolean = Interpretable.this.operand
-      override def placeholder: Optional[Text] = Interpretable.this.placeholder
-
-      def interpret(arguments: List[Argument]): Optional[Self] =
-        Interpretable.this.interpret(arguments).let(lambda(_))
+// A named grouping of related subcommands, under which they are listed together (with the
+// group's description, if given) in `help` output.
+case class CommandGroup(name: Text, description: Optional[Text | Teletype] = Unset)

--- a/lib/exoskeleton/src/args/exoskeleton.Commandline.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Commandline.scala
@@ -53,7 +53,7 @@ case class Commandline
     ( using cli: Cli, discoverable: (? <: operand) is Discoverable )
   :   Optional[operand] =
 
-    cli.register(flag, discoverable)
+    cli.register(flag, discoverable, operand.operandName)
 
     parameters.seek { (key, _) => flag.matches(key) }.let: (_, operands) =>
       cli.present(flag)

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -76,7 +76,7 @@ extends Topical:
     ( using cli: Cli )
   :   Unit =
 
-    cli.register(this, discoverable)
+    cli.register(this, discoverable, interpretable.operandName)
 
 
   def matches(key: Argument): Boolean =
@@ -94,7 +94,7 @@ extends Topical:
             suggestions:   (? <: Topic) is Discoverable = Discoverable.noSuggestions )
   :   Optional[Topic] =
 
-    cli.register(this, suggestions)
+    cli.register(this, suggestions, interpretable.operandName)
     cli.parameter(this)
 
 

--- a/lib/exoskeleton/src/args/exoskeleton.Subcommand.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Subcommand.scala
@@ -40,8 +40,11 @@ import rudiments.*
 import vacuous.*
 
 case class Subcommand
-  ( name: Text, description: Optional[Text | Teletype] = Unset, hidden: Boolean = false ):
+  ( name:        Text,
+    description: Optional[Text | Teletype]  = Unset,
+    hidden:      Boolean                    = false,
+    group:       Optional[CommandGroup]     = Unset ):
 
   def unapply(argument: Argument)(using Cli): Boolean =
-    argument.suggest(Suggestion(name, description, hidden) :: prior)
+    argument.suggest(Suggestion(name, description, hidden, group = group) :: prior)
     argument() == name

--- a/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
@@ -49,10 +49,11 @@ object Suggestion:
       aliases:     List[Text]                = Nil,
       prefix:      Text                      = t"",
       suffix:      Text                      = t"",
-      expanded:    Boolean                   = false )
+      expanded:    Boolean                   = false,
+      group:       Optional[CommandGroup]    = Unset )
   :   Suggestion =
 
-    new Suggestion(core, description, hidden, incomplete, aliases, prefix, suffix, expanded)
+    new Suggestion(core, description, hidden, incomplete, aliases, prefix, suffix, expanded, group)
 
 
 case class Suggestion
@@ -63,6 +64,7 @@ case class Suggestion
     aliases:     List[Text],
     prefix:      Text,
     suffix:      Text,
-    expanded:    Boolean ):
+    expanded:    Boolean,
+    group:       Optional[CommandGroup] ):
 
   def text: Text = prefix+core+suffix

--- a/lib/exoskeleton/src/args/soundness_exoskeleton_args.scala
+++ b/lib/exoskeleton/src/args/soundness_exoskeleton_args.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   exoskeleton
-  . { Argument, arguments, Cli, Commandline, Discoverable, Flag, Interpretable, Interpreter, Login,
-      Shell, Subcommand, Suggestible, Suggestion, Switch }
+  . { Argument, arguments, Cli, CommandGroup, Commandline, Discoverable, Flag, Interpretable,
+      Interpreter, Login, Shell, Subcommand, Suggestible, Suggestion, Switch }
 
 package interpreters:
   export exoskeleton.interpreters.{posixInterpreter, posixClusteringInterpreter, simpleInterpreter}

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -67,7 +67,15 @@ extends Cli:
   private lazy val parameters: interpreter.Topic = interpreter.interpret(arguments)
 
   val flags: scm.HashMap[Flag, Discoverable] = scm.HashMap()
+  val operandNames: scm.HashMap[Flag, Text] = scm.HashMap()
+  val globalFlags: scm.HashSet[Flag] = scm.HashSet()
   val seenFlags: scm.HashSet[Flag] = scm.HashSet()
+
+  // Whether any suggestions have been offered yet for the focused argument. Flags registered
+  // before this point were checked before subcommand dispatch, so they are "global": they apply
+  // regardless of (and may influence) which subcommand is chosen.
+  @scala.caps.unsafe.untrackedCaptures
+  private var dispatchSuggested: Boolean = false
 
   @scala.caps.unsafe.untrackedCaptures
   var explanation: Optional[Text] = Unset
@@ -93,7 +101,7 @@ extends Cli:
       case Argument.Format.CharFlag(ordinal) => false
       case Argument.Format.FlagSuffix        => focusPosition.let(_.z > Sec).or(true)
 
-  override def register(flag: Flag, discoverable: Discoverable): Unit =
+  override def register(flag: Flag, discoverable: Discoverable, operand: Optional[Text]): Unit =
     val operands = interpreter.find(parameters, flag)
 
     interpreter.focus(parameters).let: argument =>
@@ -105,7 +113,10 @@ extends Cli:
         val allSuggestions = discoverable.discover(tab).to(List)
         if allSuggestions != Nil then cursorSuggestions = allSuggestions
 
-    if !flag.secret then flags(flag) = discoverable
+    if !flag.secret then
+      flags(flag) = discoverable
+      operand.let(operandNames(flag) = _)
+      if !dispatchSuggested then globalFlags += flag
 
   override def present(flag: Flag): Unit = if !flag.repeatable then seenFlags += flag
 
@@ -119,6 +130,7 @@ extends Cli:
       suffix:   Text ) =
 
     if focused(argument) then
+      dispatchSuggested = true
       cursorSuggestions = update(using cursorSuggestions.aka["prior"]).map: suggestion =>
         if suggestion.expanded then suggestion
         else suggestion.copy(core = prefix+suggestion.core+suffix, expanded = true)
@@ -163,7 +175,7 @@ extends Cli:
         lazy val aliasesWidth = items.map(_.aliases.join(t" ").length).max + 1
 
         val itemLines: List[Command] = items.bind:
-          case Suggestion(core0, description, hidden, incomplete, aliases, prefix, suffix, _) =>
+          case Suggestion(core0, description, hidden, incomplete, aliases, prefix, suffix, _, _) =>
             val hiddenParam = if hidden then sh"-n" else sh""
             val shortFlag = focusText.starts(t"-") && !focusText.starts(t"--")
             val aliasText = if shortFlag then core0 else aliases.join(t" ").fit(aliasesWidth)
@@ -209,7 +221,7 @@ extends Cli:
         val sole = items.stdlib.count(!_.hidden) == 1
 
         items.bind:
-          case suggestion@Suggestion(core, description, hidden, incomplete, aliases, _, _, _) =>
+          case suggestion@Suggestion(core, description, hidden, incomplete, aliases, _, _, _, _) =>
             if hidden then Nil else
               val mainLines = (suggestion.text :: aliases.stdlib).map: text =>
                 description.absolve match
@@ -227,7 +239,7 @@ extends Cli:
         // PowerShell inserts a `CompletionResult` verbatim, so a trailing-space twin is
         // just a visible duplicate; `incomplete` has no rendering there.
         items.bind:
-          case suggestion@Suggestion(core, description, hidden, _, aliases, _, _, _) =>
+          case suggestion@Suggestion(core, description, hidden, _, aliases, _, _, _, _) =>
             if hidden then Nil else
               List.of:
                 (suggestion.text :: aliases.stdlib).map: text =>

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -71,7 +71,8 @@ def helpTree
   ( using interpreter: Interpreter )
 :   Help =
 
-  def probe(prefix: List[Text]): (List[Suggestion], List[Flag]) =
+  def probe(prefix: List[Text])
+  :   (List[Suggestion], List[Flag], Set[Flag], scala.collection.Map[Flag, Text]) =
     val focus = prefix.length
     val textArguments = prefix :+ t""
     val synthesized = Cli.arguments(textArguments.stdlib, focus, Unset, Prim)
@@ -91,35 +92,57 @@ def helpTree
           login )
 
     block(using completion)
-    (completion.cursorSuggestions, completion.flags.keySet.to(List))
+
+    ( completion.cursorSuggestions,
+      completion.flags.keySet.to(List),
+      completion.globalFlags.foldLeft(Set[Flag]())(_ + _),
+      completion.operandNames )
 
   def build
     ( prefix:      List[Text],
       command:     Text,
       description: Optional[Text | Teletype],
-      seen:        Set[List[Text]] )
+      group:       Optional[CommandGroup],
+      seen:        Set[List[Text]],
+      inherited:   Set[Flag] )
   :   Help =
 
-    if seen.has(prefix) then Help(command, description, Nil, Nil) else
-      val (suggestions, flags) = probe(prefix)
+    if seen.has(prefix) then Help(command, description, Nil, Nil, group) else
+      val (suggestions, flags, globals, operands) = probe(prefix)
 
-      val parameters = flags.map: flag =>
+      // Flags already attributed to an ancestor re-register at every deeper prefix, since each
+      // probe re-runs the whole program; they belong to the ancestor, so drop them here.
+      val ownFlags = flags.filter(!inherited.has(_))
+
+      val parameters = ownFlags.map: flag =>
         Help.Param
           ( Flag.serialize(flag.name),
             flag.aliases.map(Flag.serialize(_)),
             flag.description,
-            flag.repeatable )
+            flag.repeatable,
+            globals.has(flag),
+            operands.get(flag).optional )
+
+      val known = flags.stdlib.foldLeft(inherited)(_ + _)
 
       val children =
         List.of(suggestions.stdlib.distinctBy(_.core)).bind: suggestion =>
           val childPrefix = prefix :+ suggestion.core
 
           if suggestion.hidden || suggestion.incomplete then Nil
-          else List(build(childPrefix, suggestion.core, suggestion.description, seen + prefix))
+          else
+            List
+              ( build
+                  ( childPrefix,
+                    suggestion.core,
+                    suggestion.description,
+                    suggestion.group,
+                    seen + prefix,
+                    known ) )
 
-      Help(command, description, parameters, children.sort(_.command))
+      Help(command, description, parameters, children.sort(_.command), group)
 
-  build(Nil, command, Unset, Set())
+  build(Nil, command, Unset, Unset, Set(), Set())
 
 package executives:
   given completions: (backstop: Backstop) => Executive:

--- a/lib/exoskeleton/src/core/exoskeleton.Help.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Help.scala
@@ -36,8 +36,10 @@ import scala.language.experimental.pureFunctions
 
 import anticipation.*
 import escapade.*
+import escritoire.*
 import gossamer.*
 import hieroglyph.*, textMetrics.uniformMetric
+import polysyllabic.*
 import symbolism.*
 import rudiments.*
 import vacuous.*
@@ -47,39 +49,201 @@ object Help:
     ( name:        Text,
       aliases:     List[Text],
       description: Optional[Text | Teletype],
-      repeatable:  Boolean )
+      repeatable:  Boolean,
+      global:      Boolean        = false,
+      operand:     Optional[Text] = Unset )
+
+  // A line of the rendered body: an indented label with an optional description, laid out so
+  // that every description starts in the same column; a bold subheading, which does not
+  // participate in that alignment; or a blank spacer between blocks.
+  private enum Row:
+    case Item(depth: Int, label: Text, bold: Boolean, description: Optional[Text | Teletype])
+    case Label(depth: Int, text: Text)
+    case Blank
+
+  private def label(param: Param): Text =
+    val names: Text = ((param.name :: param.aliases): List[Text]).join(t", ")
+
+    val core: Text = param.operand.absolve match
+      case Unset         => names
+      case operand: Text => t"$names <$operand>"
+
+    if param.repeatable then t"$core..." else core
+
+  private def paramItems(params: scala.List[Param], depth: Int): scala.List[Row] =
+    params.map: param => Row.Item(depth, label(param), false, param.description)
+
+  private def commandRows(children: scala.List[Help], depth: Int): scala.List[Row] =
+    children.flatMap: sub =>
+      val block =
+        Row.Item(depth, sub.command, true, sub.description) ::
+          paramItems(sub.parameters.stdlib, depth + 1) :::
+          commandRows(sub.subcommands.stdlib, depth + 1)
+
+      if sub.parameters.stdlib.isEmpty && sub.subcommands.stdlib.isEmpty then block
+      else (Row.Blank :: block) :+ Row.Blank
+
+  // Collapse runs of consecutive spacers and strip them from either end of a section.
+  private def compact(rows: scala.List[Row]): scala.List[Row] =
+    val trimmed = rows.dropWhile(_ == Row.Blank).reverse.dropWhile(_ == Row.Blank).reverse
+
+    trimmed.foldRight(scala.List[Row]()): (row, done) =>
+      if row == Row.Blank && !done.isEmpty && done.head == Row.Blank then done else row :: done
 
   // Render the tree to a `Teletype`, then borrow escapade's `Teletype is Printable` so that a
-  // `Help` value can be passed straight to `Out.println` and print nicely on the terminal.
-  given printable: Help is Printable = summon[Teletype is Printable].contramap(_.teletype)
+  // `Help` value can be passed straight to `Out.println` and print nicely on the terminal,
+  // wrapped to its width. `Hyphenation.fallback` satisfies the condition without any import,
+  // wrapping only at spaces; import a language's patterns (e.g. `hyphenations.english`) for
+  // hyphenated wrapping.
+  given printable: (hyphenation: Hyphenation) => Help is Printable =
+    (help, termcap) => summon[Teletype is Printable].print(help.teletype(termcap.width), termcap)
 
 case class Help
   ( command:     Text,
     description: Optional[Text | Teletype],
     parameters:  List[Help.Param],
-    subcommands: List[Help] ):
+    subcommands: List[Help],
+    group:       Optional[CommandGroup] = Unset ):
 
-  def teletype: Teletype = lines(0).join(e"\n")
+  def teletype(width: Int = Int.MaxValue)(using Hyphenation): Teletype =
+    val globalParams: scala.List[Help.Param] = parameters.stdlib.filter(_.global)
+    val localParams: scala.List[Help.Param] = parameters.stdlib.filter(!_.global)
+    val ungrouped: scala.List[Help] = subcommands.stdlib.filter(_.group == Unset)
+    val groupList: scala.List[CommandGroup] = subcommands.stdlib.flatMap(_.group.option).distinct
 
-  private def label(param: Help.Param): Text =
-    ((param.name :: param.aliases): List[Text]).join(t", ")
+    // Wrap prose into `available` columns using escritoire's borderless paragraph layout, which
+    // breaks at spaces and admissible hyphenation points. Below 20 columns, overrun instead.
+    def wrap(teletype: Teletype, available: Int): scala.List[Teletype] =
+      columnar.Paragraph.fit(Array.of(teletype), available.max(20), TextAlignment.Left)
+      . stdlib.toList
 
-  private def lines(depth: Int): List[Teletype] =
-    val indent: Text = t"  "*depth
+    // Each section is a heading (one or more unaligned lines) plus its rows, which all
+    // participate in the global description-column alignment.
+    val groupSections: scala.List[(scala.List[Teletype], scala.List[Help.Row])] =
+      groupList.map: group =>
+        val members = subcommands.stdlib.filter(_.group == group)
 
-    val title: Teletype = description.absolve match
-      case Unset              => e"$indent$Bold($command)"
-      case text: Text         => e"$indent$Bold($command)  $text"
-      case teletype: Teletype => e"$indent$Bold($command)  $teletype"
+        // A flag borne identically by every member of the group is factored out of the
+        // individual subcommands and listed once, as common to the whole group.
+        val common: scala.List[Help.Param] =
+          if members.length < 2 then scala.List()
+          else members.head.parameters.stdlib.filter: param =>
+            members.forall(_.parameters.stdlib.contains(param))
 
-    val width: Int = parameters.stdlib.map(label(_).length).maxOption.getOrElse(0)
+        val factored: scala.List[Help] = members.map: member =>
+          member.copy(parameters = member.parameters.filter(!common.contains(_)))
 
-    val paramLines: List[Teletype] = parameters.map: param =>
-      param.description.absolve match
-        case Unset              => e"$indent    ${label(param)}"
-        case text: Text         => e"$indent    ${label(param).fit(width)}  $text"
-        case teletype: Teletype => e"$indent    ${label(param).fit(width)}  $teletype"
+        val commonRows: scala.List[Help.Row] =
+          if common.isEmpty then scala.List()
+          else
+            Help.Row.Blank :: Help.Row.Label(1, t"Common options:") :: Help.paramItems(common, 2)
 
-    val subLines: List[Teletype] = subcommands.bind(_.lines(depth + 1))
+        val title: Text = t"${group.name}:"
 
-    List.of(title :: paramLines.stdlib ::: subLines.stdlib)
+        val explanation: scala.List[Teletype] = group.description.absolve match
+          case Unset              => scala.List()
+          case text: Text         => wrap(e"$text", width - 2)
+          case teletype: Teletype => wrap(teletype, width - 2)
+
+        val indented: scala.List[Teletype] = explanation.map: line => e"  $line"
+
+        val heading: scala.List[Teletype] =
+          if indented.isEmpty then scala.List(e"$Bold($title)")
+          else e"$Bold($title)" :: indented ::: scala.List(e"")
+
+        (heading, Help.compact(Help.commandRows(factored, 1) ::: commonRows))
+
+    // A tool without subcommands never reaches dispatch, so all of its flags count as "global";
+    // presenting them as anything other than plain options would be noise.
+    val leaf: Boolean = subcommands.stdlib.isEmpty
+
+    val standard: scala.List[(scala.List[Teletype], scala.List[Help.Row])] =
+      if leaf then
+        scala.List
+          ( (scala.List(e"$Bold(Options:)"),
+             Help.compact(Help.paramItems(parameters.stdlib, 1))) )
+      else
+        scala.List
+          ( (scala.List(e"$Bold(Global options:)"),
+             Help.compact(Help.paramItems(globalParams, 1))),
+            (scala.List(e"$Bold(Options:)"),
+             Help.compact(Help.paramItems(localParams, 1))),
+            (scala.List(e"$Bold(Commands:)"),
+             Help.compact(Help.commandRows(ungrouped, 1))) )
+
+    val sections: scala.List[(scala.List[Teletype], scala.List[Help.Row])] =
+      standard.filter(!_._2.isEmpty) ::: groupSections
+
+    // The column at which every description starts: two spaces after the widest label.
+    val column: Int =
+      sections.flatMap(_._2).map:
+        case Help.Row.Item(depth, label, _, _) => depth*2 + label.length
+        case _                                 => 0
+
+      . maxOption.getOrElse(0) + 2
+
+    def render(row: Help.Row): scala.List[Teletype] = row match
+      case Help.Row.Blank => scala.List(e"")
+
+      case Help.Row.Label(depth, text) =>
+        val indent: Text = t"  "*depth
+        scala.List(e"$indent$Bold($text)")
+
+      case Help.Row.Item(depth, label, bold, description) =>
+        val indent: Text = t"  "*depth
+
+        val explanation: Optional[Teletype] = description.absolve match
+          case Unset              => Unset
+          case text: Text         => e"$text"
+          case teletype: Teletype => teletype
+
+        explanation.absolve match
+          case Unset =>
+            scala.List(if bold then e"$indent$Bold($label)" else e"$indent$label")
+
+          case explanation: Teletype =>
+            val fitted: Text = label.fit(column - 2 - indent.length)
+            val padded: Teletype = if bold then e"$indent$Bold($fitted)" else e"$indent$fitted"
+            val margin: Text = t" "*column
+            val lines = wrap(explanation, width - column)
+
+            if lines.isEmpty then scala.List(padded)
+            else e"$padded  ${lines.head}" :: lines.tail.map: line => e"$margin$line"
+
+    // Global flags precede the subcommand on the command line; flags belonging to this command
+    // or to any subcommand follow it. Each part appears only if such flags actually exist, and
+    // when only a single flag is possible, it is named outright rather than called `options`.
+    def summarize(params: scala.List[Help.Param], plural: Text): Text =
+      if params.isEmpty then t""
+      else if params.length == 1 then
+        val param = params.head
+
+        val core: Text = param.operand.absolve match
+          case Unset         => param.name
+          case operand: Text => t"${param.name} <$operand>"
+
+        if param.repeatable then t" [$core]..." else t" [$core]"
+      else
+        t" [$plural]"
+
+    val usage: Teletype =
+      if leaf then e"$Bold(Usage:) $command${summarize(parameters.stdlib, t"options")}"
+      else
+        def descendants(node: Help): scala.List[Help.Param] =
+          node.parameters.stdlib ::: node.subcommands.stdlib.flatMap(descendants)
+
+        val globals: Text = summarize(globalParams, t"global options")
+        val posterior = (localParams ::: subcommands.stdlib.flatMap(descendants)).distinct
+        val locals: Text = summarize(posterior, t"options")
+
+        e"$Bold(Usage:) $command$globals <command>$locals"
+
+    val header: scala.List[Teletype] = description.absolve match
+      case Unset              => scala.List(usage)
+      case text: Text         => usage :: e"" :: wrap(e"$text", width)
+      case teletype: Teletype => usage :: e"" :: wrap(teletype, width)
+
+    val body: scala.List[Teletype] =
+      header ::: sections.flatMap: (heading, rows) => e"" :: (heading ::: rows.flatMap(render))
+
+    List.of(body).join(e"\n")

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -524,31 +524,58 @@ object Tests extends Suite(m"Exoskeleton Tests"):
         import interpreters.posixInterpreter
         import stdios.muteStdio
 
+        val admin = CommandGroup(t"Admin commands", t"Commands for user administration.")
+
+        class Delay(text: Text)
+
+        given Delay is Interpretable:
+          override def placeholder: Optional[Text] = t"seconds"
+
+          def interpret(arguments: List[Argument]): Optional[Delay] = arguments match
+            case argument :: _ => Delay(argument())
+            case _             => Unset
+
         val Alpha = Subcommand(t"alpha", e"a command to run")
         val Beta = Subcommand(t"beta", e"another command to run")
         val Gamma = Subcommand(t"gamma", e"a hidden command", hidden = true)
         val Distribution = Subcommand(t"distribution", e"a different command to run")
         val Ubuntu = Subcommand(t"ubuntu", e"Ubuntu")
         val RedHat = Subcommand(t"red hat", e"Red Hat Linux")
+        val UserAdd = Subcommand(t"useradd", e"add a user account", group = admin)
+        val UserDel = Subcommand(t"userdel", e"remove a user account", group = admin)
 
-        def app(using Cli): Execution = arguments match
-          case Alpha() :: _ => execute(Exit.Ok)
-          case Beta() :: _  => execute(Exit.Ok)
-          case Gamma() :: _ => execute(Exit.Ok)
+        def app(using Cli): Execution =
+          Flag(t"verbose", description = t"verbose output")()
 
-          case Distribution() :: rest => rest match
-            case Ubuntu() :: _ =>
-              Flag(t"one", description = t"the first one")()
-              Flag(t"two", description = t"the second one")()
+          arguments match
+            case Alpha() :: _ => execute(Exit.Ok)
+            case Beta() :: _  => execute(Exit.Ok)
+            case Gamma() :: _ => execute(Exit.Ok)
+
+            case Distribution() :: rest => rest match
+              case Ubuntu() :: _ =>
+                Flag(t"one", description = t"the first one")()
+                Flag(t"two", description = t"the second one")()
+                execute(Exit.Ok)
+
+              case RedHat() :: _ =>
+                Flag(t"only", description = t"there is only one")()
+                execute(Exit.Ok)
+
+              case _ => execute(Exit.Ok)
+
+            case UserAdd() :: _ =>
+              Flag(t"home", description = t"specify the home directory")()
+              Flag(t"groups", repeatable = true, description = t"add the user to a group")()
+              Flag(t"force", description = t"do not ask for confirmation")()
               execute(Exit.Ok)
 
-            case RedHat() :: _ =>
-              Flag(t"only", description = t"there is only one")()
+            case UserDel() :: _ =>
+              Flag(t"force", description = t"do not ask for confirmation")()
+              Flag[Delay](t"wait", description = t"delay the deletion")()
               execute(Exit.Ok)
 
-            case _ => execute(Exit.Ok)
-
-          case _ => execute(Exit.Fail(1))
+            case _ => execute(Exit.Fail(1))
 
         lazy val tree: Help =
           helpTree
@@ -561,7 +588,25 @@ object Tests extends Suite(m"Exoskeleton Tests"):
 
       test(m"Help root lists visible subcommands"):
         HelpApp.tree.subcommands.map(_.command)
-      .assert(_ == List(t"alpha", t"beta", t"distribution"))
+      .assert(_ == List(t"alpha", t"beta", t"distribution", t"useradd", t"userdel"))
+
+      test(m"Flags checked before subcommand dispatch are global root parameters"):
+        HelpApp.tree.parameters
+      .assert(_ == List(Help.Param(t"--verbose", Nil, t"verbose output", false, true, t"value")))
+
+      test(m"Operand placeholders are derived from the operand type"):
+        HelpApp.tree.subcommands
+         .filter(_.command == t"userdel").bind(_.parameters)
+         .filter(_.name == t"--wait").map(_.operand)
+      .assert(_ == List(t"seconds"))
+
+      test(m"Global flags are not repeated in subcommand nodes"):
+        HelpApp.tree.subcommands.bind(_.parameters).map(_.name).has(t"--verbose")
+      .assert(_ == false)
+
+      test(m"Subcommands carry their command group"):
+        HelpApp.tree.subcommands.filter(_.command == t"useradd").map(_.group)
+      .assert(_ == List(HelpApp.admin))
 
       test(m"Help excludes hidden subcommands"):
         HelpApp.tree.subcommands.map(_.command).has(t"gamma")
@@ -581,3 +626,49 @@ object Tests extends Suite(m"Exoskeleton Tests"):
       test(m"Help renders as Printable text mentioning a subcommand"):
         summon[Help is Printable].print(HelpApp.tree, stdios.muteStdio.termcap)
       .assert(_.contains(t"alpha"))
+
+      test(m"Help wraps descriptions at the terminal width, aligned to the description column"):
+        val narrow: Termcap = new Termcap:
+          def ansi: Boolean = false
+          def color: ColorDepth = ColorDepth.NoColor
+          override def width: Int = 45
+
+        summon[Help is Printable].print(HelpApp.tree, narrow).cut(t"\n")
+      .assert: lines =>
+        lines.has(t"    --force <value>      do not ask for")
+          && lines.has(t"                         confirmation")
+
+      test(m"Help renders in aligned man-page style"):
+        summon[Help is Printable].print(HelpApp.tree, stdios.muteStdio.termcap)
+      .assert:
+        _.cut(t"\n") == List
+              (t"Usage: mytool [--verbose <value>] <command> [options]",
+               t"",
+               t"Global options:",
+               t"  --verbose <value>      verbose output",
+               t"",
+               t"Commands:",
+               t"  alpha                  a command to run",
+               t"  beta                   another command to run",
+               t"",
+               t"  distribution           a different command to run",
+               t"",
+               t"    red hat              Red Hat Linux",
+               t"      --only <value>     there is only one",
+               t"",
+               t"    ubuntu               Ubuntu",
+               t"      --one <value>      the first one",
+               t"      --two <value>      the second one",
+               t"",
+               t"Admin commands:",
+               t"  Commands for user administration.",
+               t"",
+               t"  useradd                add a user account",
+               t"    --groups <value>...  add the user to a group",
+               t"    --home <value>       specify the home directory",
+               t"",
+               t"  userdel                remove a user account",
+               t"    --wait <seconds>     delay the deletion",
+               t"",
+               t"  Common options:",
+               t"    --force <value>      do not ask for confirmation")


### PR DESCRIPTION
Restructures `Help` rendering around an adaptive `Usage:` line and labelled sections, with every description aligned to a single global column across the whole command tree.

## What changed

- **Global flags by registration order.** A flag checked before any subcommand suggestion is offered at the dispatch position applies regardless of the chosen subcommand, so it renders in its own `Global options:` section and precedes `<command>` in the usage line. Flags attributed to an ancestor no longer duplicate into every subtree node.
- **`CommandGroup`.** A new optional `group` on `Subcommand` renders grouped commands together under their own subheading and description. A flag borne identically by every member of a group is factored out of the individual commands into a shared `Common options:` list.
- **Adaptive usage line.** Each of the global, `<command>` and trailing options parts appears only when such flags or subcommands actually exist (recursively, for the trailing part), and a part with exactly one possible flag names it outright — `[--verbose <value>]` — instead of saying `[options]`.
- **Typeclass-derived operand names.** `Interpretable` gains a `placeholder` member, so a flag's operand is displayed with a name determined by its type (`--wait <seconds>`), falling back to `<value>`; `Unit`-interpreted switches show none. The name is captured at runtime through a third parameter on `Cli.register`. Repeatable flags are marked with `...`.
- **Terminal-width wrapping.** Descriptions wrap to `Termcap.width` via escritoire's borderless paragraph layout (hyphenation-aware through polysyllabic, caller-selectable via the ambient `Hyphenation`), with continuation lines indented to the description column. `exoskeleton.core` gains a dependency on `escritoire.core`.

## Example

```
Usage: mytool [--verbose <value>] <command> [options]

Global options:
  --verbose <value>      verbose output

Commands:
  alpha                  a command to run
  beta                   another command to run

  distribution           a different command to run

    red hat              Red Hat Linux
      --only <value>     there is only one

    ubuntu               Ubuntu
      --one <value>      the first one
      --two <value>      the second one

Admin commands:
  Commands for user administration.

  useradd                add a user account
    --groups <value>...  add the user to a group
    --home <value>       specify the home directory

  userdel                remove a user account
    --wait <seconds>     delay the deletion

  Common options:
    --force <value>      do not ask for confirmation
```

## Tests

Four structural tests (global detection, ancestor deduplication, group propagation, operand placeholders), a golden test pinning the exact layout above, and a wrapping test rendering at width 45. The full `exoskeleton.test` suite passes (87 tests), and `ethereal` compiles unchanged against the extended `Cli.register`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)