### PR TITLE
Run Confluence's fan-in pumps on virtual threads in the stress rows

### DIFF
--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -1426,14 +1426,22 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
 
     // Example X: saturated fan-in. Each operation is itself concurrent (four sources
     // merging), so at high N this measures each library's scheduler multiplexing many
-    // small concurrent merges — thread hand-offs against fiber wakeups. If this
-    // pipeline's serial latency proves to exceed a couple of milliseconds, its SLO
-    // (alone) should rise to 20 ms.
+    // small concurrent merges — and almost all of the operation's cost is the *setup*
+    // of that concurrency, since the stable sources share their windows by reference.
+    // The suite-level `platformThreading` pins only the harness workers; the Soundness
+    // bodies re-import `virtualThreading` so that `Confluence`'s internal pumps (one
+    // strand per source, forked per operation) are virtual threads — the counterpart
+    // of the rivals' per-merge fiber spawns, and the configuration a
+    // massively-concurrent application would use. On platform threads the row measures
+    // OS thread creation, ~two orders of magnitude dearer than a fiber spawn, not
+    // merging. If this pipeline's serial latency proves to exceed a couple of
+    // milliseconds, its SLO (alone) should rise to 20 ms.
     suite(m"Stress: saturated fan-in sweep (256 KiB over 4 streams, N ≤ 128)"):
       import threading.platformThreading
 
       saturated(m"Soundness  Confluence")(target = 1*Second, sweep = 128):
         '{
+            import threading.virtualThreading
             supervise:
               val merged = Confluence(turbulence.Benchmarks.smallQuarters.map(q => q.stream)*)
               var total = 0L
@@ -1466,6 +1474,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
       saturated(m"Soundness  Confluence")
         ( target = 1*Second, threshold = 10*Milli(Second), compliance = 99 ):
         '{
+            import threading.virtualThreading
             supervise:
               val merged = Confluence(turbulence.Benchmarks.smallQuarters.map(q => q.stream)*)
               var total = 0L


### PR DESCRIPTION
The saturated fan-in stress rows made Soundness's `Confluence` look dramatically worse than ZIO's `mergeAllUnbounded` — but the row was measuring the wrong thing. The suite-level `platformThreading` import is meant to pin the harness workers; because givens resolve at the quote site, it also governed the `supervise` inside the Soundness bodies, so `Confluence` forked four platform OS threads per operation. An OS thread spawn is ~two orders of magnitude dearer than the per-merge fiber spawns the rivals pay for the same setup, and on a 256 KiB zero-copy merge that fixed cost was the entire measurement.

With the internal pumps on virtual threads — the counterpart of the rivals' fiber spawns, and the configuration a massively-concurrent application would use; the harness workers stay platform-pinned — the comparison inverts:

| | Serial (N=1) | Peak |
|---|---|---|
| Soundness `Confluence` | 40.5k op/s (p50 20 µs) | ~282k op/s |
| ZIO `mergeAllUnbounded` | 4.0k op/s (p50 196 µs) | ~181k op/s |
| FS2 `parJoinUnbounded` | 1.8k op/s | ~flat |

The suite comment now explains the two threading dials so the distinction survives future edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)