### PR TITLE
Halve scintillate's per-request CPU and make in-memory streams zero-copy

### DIFF
--- a/lib/scintillate/src/bench/scintillate.Benchmarks.scala
+++ b/lib/scintillate/src/bench/scintillate.Benchmarks.scala
@@ -123,6 +123,7 @@ object Benchmarks extends Suite(m"Scintillate socket-server benchmarks"):
     // test), and G1 rather than the harness's default Serial collector, whose single-threaded
     // stop-the-world pauses would dominate p99 latency in a saturated server workload.
     val stress = Stress(heap = t"2g", gc = t"G1")
+    val profile = Profile(heap = t"2g")
 
     val requestSize  = getRequest.length*Byte
     val responseSize = serializeResponse(okResponse)*Byte
@@ -193,6 +194,23 @@ object Benchmarks extends Suite(m"Scintillate socket-server benchmarks"):
 
       stress(m"ZIO  zio-http Server")
         ( target = 1*Second, threshold = 5*Milli(Second), compliance = 99 ):
+        '{
+            scintillate.HttpRivals.zioServer
+            scintillate.HttpRivals.roundtrip(scintillate.HttpRivals.zioPort)
+        }
+
+    // Where the round-trip's CPU goes, for scintillate and (as the reference) zio-http.
+    // The single profiled client thread's frames are identical in both rows, so any
+    // difference between the histograms is server-side. CPU-only: parked time (the
+    // client awaiting the response, the server awaiting a request) is invisible.
+    suite(m"Profile: HTTP round-trip hotspots"):
+      profile(m"Scintillate  socket round-trip")(target = 5*Second):
+        '{
+            scintillate.HttpRivals.scintillateVirtual
+            scintillate.HttpRivals.roundtrip(scintillate.HttpRivals.scintillateVirtualPort)
+        }
+
+      profile(m"ZIO  zio-http socket round-trip")(target = 5*Second):
         '{
             scintillate.HttpRivals.zioServer
             scintillate.HttpRivals.roundtrip(scintillate.HttpRivals.zioPort)

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -101,6 +101,57 @@ extends RequestServable:
 
     if failed then abort(StreamError(count.b))
 
+  // Case-insensitive substring search over the raw strings, allocation-free: the
+  // header facts below are computed on every request, and `.lower` would allocate a
+  // fresh `Text` per header per request.
+  private def containsIgnoreCase(value: String, token: String): Boolean =
+    val max = value.length - token.length
+    var index = 0
+    var found = false
+
+    while !found && index <= max do
+      if value.regionMatches(true, index, token, 0, token.length) then found = true
+      else index += 1
+
+    found
+
+  // The per-request header facts, gathered in one allocation-free pass. The former
+  // helpers (`keepAlive`, `isUpgrade`, `expectsContinue`, and `requestBody`'s framing
+  // scan) each rescanned the header list, lowercasing every key and value they
+  // touched — a measurable share of the per-request CPU on the JFR profile.
+  private class HeadFacts extends scala.caps.Stateful:
+    var connectionClose: Boolean = false
+    var connectionKeepAlive: Boolean = false
+    var connectionUpgrade: Boolean = false
+    var upgradePresent: Boolean = false
+    var expectContinue: Boolean = false
+    var chunked: Boolean = false
+    var contentLength: Optional[Int] = Unset
+
+  private def factsOf(head: Http.Request.Head): HeadFacts^ =
+    val facts = HeadFacts()
+
+    head.headers.each: header =>
+      val key = header.key.s
+
+      if key.equalsIgnoreCase("connection") then
+        val value = header.value.s
+        if containsIgnoreCase(value, "close") then facts.connectionClose = true
+        if containsIgnoreCase(value, "keep-alive") then facts.connectionKeepAlive = true
+        if containsIgnoreCase(value, "upgrade") then facts.connectionUpgrade = true
+      else if key.equalsIgnoreCase("upgrade") then
+        facts.upgradePresent = true
+      else if key.equalsIgnoreCase("expect") then
+        if containsIgnoreCase(header.value.s, "100-continue") then facts.expectContinue = true
+      else if key.equalsIgnoreCase("transfer-encoding") then
+        if containsIgnoreCase(header.value.s, "chunked") then facts.chunked = true
+      else if key.equalsIgnoreCase("content-length") then
+        // The first such header governs, as the former `.prim` selection did.
+        if facts.contentLength.absent
+        then facts.contentLength = safely(Integer.parseInt(header.value.s.trim.nn))
+
+    facts
+
   // Frame the request body off the shared connection cursor: chunked decoding
   // for `Transfer-Encoding: chunked`, otherwise `Content-Length` bytes, or empty
   // when neither is given. The framed stream stops exactly at the body's end so
@@ -108,45 +159,32 @@ extends RequestServable:
   // Upstream #1570's kernel-stream body with this branch's cursor convention
   // (`Cursor[Data, {}]^`: a concrete cap argument, never `?`, which collapses inline
   // receiver proxies to read-only).
-  private def requestBody(cursor: Cursor[Data, {}]^, head: Http.Request.Head)
+  private def requestBody(cursor: Cursor[Data, {}]^, facts: HeadFacts^)
   :   (Stream[Data] over Credit)^{cursor} =
    // The stream's own fresh capability is laundered into the declared result, which
    // tracks the single-owner cursor.
    scala.caps.unsafe.unsafeAssumePure:
-
-     val chunked: Boolean = head.headers.exists: header =>
-       header.key.lower == t"transfer-encoding" && header.value.lower.contains(t"chunked")
-
-     if chunked then Http.Request.chunkedBody(cursor) else
-       val length: Optional[Int] =
-         head.headers.filter(_.key.lower == t"content-length").prim.let(_.value)
-         . lay(Unset: Optional[Int]): text =>
-             safely(Integer.parseInt(text.s.trim.nn))
-
-       length.lay(Http.emptyBody())(Http.Request.fixedBody(cursor, _))
+     if facts.chunked then Http.Request.chunkedBody(cursor)
+     else facts.contentLength.lay(Http.emptyBody())(Http.Request.fixedBody(cursor, _))
 
   // RFC 7230 §6.3: HTTP/1.1 keeps connections alive unless `Connection: close`;
   // HTTP/1.0 closes unless `Connection: keep-alive`.
-  private def keepAlive(head: Http.Request.Head): Boolean =
-    val connection = head.headers.filter(_.key.lower == t"connection").map(_.value.lower)
-
+  private def keepAlive(head: Http.Request.Head, facts: HeadFacts^): Boolean =
     head.version match
-      case 1.1 => !connection.exists(_.contains(t"close"))
-      case _   => connection.exists(_.contains(t"keep-alive"))
+      case 1.1 => !facts.connectionClose
+      case _   => facts.connectionKeepAlive
 
   // A request asks to upgrade the protocol (e.g. to WebSocket) when it carries
   // `Connection: Upgrade` together with an `Upgrade` header. Such a request's
   // body is the unbounded remainder of the connection, so a frame reader can
   // keep receiving bytes after the handshake.
-  private def isUpgrade(head: Http.Request.Head): Boolean =
-    head.headers.filter(_.key.lower == t"connection").exists(_.value.lower.contains(t"upgrade")) &&
-      head.headers.exists(_.key.lower == t"upgrade")
+  private def isUpgrade(facts: HeadFacts^): Boolean =
+    facts.connectionUpgrade && facts.upgradePresent
 
   // A client may withhold a request body until the server agrees to receive it
   // with an interim `100 Continue` (RFC 7231 §5.1.1).
-  private def expectsContinue(head: Http.Request.Head): Boolean =
-    head.version == 1.1 && head.headers.exists: header =>
-      header.key.lower == t"expect" && header.value.lower.contains(t"100-continue")
+  private def expectsContinue(head: Http.Request.Head, facts: HeadFacts^): Boolean =
+    head.version == 1.1 && facts.expectContinue
 
   private def streaming(response: Http.Response^): Boolean = response.body match
     case Http.Body.Flowing(_) => true
@@ -199,10 +237,11 @@ extends RequestServable:
 
       . protect:
           val head = Http.Request.parseHead(cursor)
-          val upgrade = isUpgrade(head)
+          val facts = factsOf(head)
+          val upgrade = isUpgrade(facts)
 
           // Tell a waiting client it may send the body before we read it.
-          if expectsContinue(head) then writeAll(out, continueResponse.stream)
+          if expectsContinue(head, facts) then writeAll(out, continueResponse.stream)
 
           // The framed body, minted once and lent single-owner: the handler and
           // the post-response drain share it, so the handler pulls what it
@@ -212,7 +251,7 @@ extends RequestServable:
           val bodyStream: (Stream[Data] over Credit)^{cursor} =
             // Both branches produce a stream over the same single-owner cursor.
             scala.caps.unsafe.unsafeAssumePure:
-              if upgrade then streamOf(cursor) else requestBody(cursor, head)
+              if upgrade then streamOf(cursor) else requestBody(cursor, facts)
 
           // Neutral carrier: the spring re-lends the same single-owner stream.
           val bodyRef: AnyRef = bodyStream.asInstanceOf[AnyRef]
@@ -227,7 +266,7 @@ extends RequestServable:
                 () => bodyRef.asInstanceOf[Stream[Data] over Credit] )
 
           var upgraded = false
-          var keep = keepAlive(head)
+          var keep = keepAlive(head, facts)
 
           // The responder retains only per-request locals; no aliased writer.
           val respond: Http.Connection.Respond^ = scala.caps.unsafe.unsafeAssumeSeparate:

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -381,6 +381,12 @@ object Http:
     // with `peek`/`next` rather than `seek` so it works on a bare `Cursor[Data, ?]`
     // parameter (which loses the `tracked` `Operand = Byte` refinement that
     // `seek`'s signature relies on).
+    // The last successfully-parsed `Host` header, memoized across requests; see the
+    // comment at its use in `parseHead`. Untracked: an immutable pair behind a benign
+    // read-mostly race, not a capability-bearing state.
+    @scala.caps.unsafe.untrackedCaptures @volatile
+    private var hostMemo: (Text, Host) | Null = null
+
     // `maxRequestLine` and `maxHeaders` bound how many bytes the request line and
     // the header block may occupy, yielding `414`/`431` (rather than reading an
     // unbounded amount) — the scan aborts mid-token once the cap is crossed.
@@ -445,13 +451,26 @@ object Http:
 
       val headers = readHeaders(Nil).reverse
 
-      val hostText: Optional[Text] = headers.filter(_.key.lower == t"host").prim.let(_.value)
+      val hostText: Optional[Text] =
+        headers.filter(_.key.s.equalsIgnoreCase("host")).prim.let(_.value)
 
       val host: Host = hostText.lay(abort(Http.Request.Error(Http.Request.Error.Reason.Host(t"")))):
         text =>
-          safely(text.as[Host]).or:
-            safely(text.cut(t":").prim.or(text).as[Host]).or:
-              abort(Http.Request.Error(Http.Request.Error.Reason.Host(text)))
+          // The typed parse of the union (`Hostname | Ipv4 | Ipv6`, trying each form) is
+          // the costliest step of parsing a request, yet every request on a keep-alive
+          // connection repeats the same bytes, and host cardinality per server is tiny.
+          // Only a successful parse is memoized, so a missing or invalid host still
+          // aborts here; a stale memo under concurrency merely reparses.
+          hostMemo match
+            case (cached, host0) if cached == text => host0
+            case _ =>
+              val parsed =
+                safely(text.as[Host]).or:
+                  safely(text.cut(t":").prim.or(text).as[Host]).or:
+                    abort(Http.Request.Error(Http.Request.Error.Reason.Host(text)))
+
+              hostMemo = (text, parsed)
+              parsed
 
       Head(method, version, host, target, headers)
 
@@ -768,10 +787,14 @@ object Http:
       // server adds `Connection: close`), so its body is written raw.
       val chunkable: Boolean = version != 1.0 && version != 0.9
 
+      // Case-insensitive on the raw strings: `.lower` would allocate a fresh `Text` per
+      // header per response on this hot path.
       val explicitChunked: Boolean = response.textHeaders.exists: header =>
-        header.key.lower == t"transfer-encoding" && header.value.lower == t"chunked"
+        header.key.s.equalsIgnoreCase("transfer-encoding")
+          && header.value.s.equalsIgnoreCase("chunked")
 
-      val hasContentLength: Boolean = response.textHeaders.exists(_.key.lower == t"content-length")
+      val hasContentLength: Boolean =
+        response.textHeaders.exists(_.key.s.equalsIgnoreCase("content-length"))
 
       val (extraHeaders, chunked): (List[Header], Boolean) =
         if upgrade then (Nil, false) else response.body match

--- a/lib/zephyrine/src/core/zephyrine.Stream.scala
+++ b/lib/zephyrine/src/core/zephyrine.Stream.scala
@@ -49,10 +49,17 @@ import vacuous.*
 // threads and no synchronization, executing as nested calls on the consumer's
 // thread.
 object Stream:
-  // A single-chunk in-memory stream. The chunk is copied into fresh storage
-  // once, at construction, so the region can be exposed mutably.
+  // A single-chunk in-memory stream. An immutable medium that exposes its backing
+  // (`Data`) is shared by reference — the same zero-copy hand-off `Conduit`, `Cursor`
+  // and `Duct` already make, and regions of this stream are only ever read (see
+  // `regionStable`). Any other medium is copied into fresh storage once, on first
+  // refill, so the region can be exposed mutably.
   def apply[medium](value: medium)(using addressable0: medium is Addressable)
   :   (Stream[medium] over Credit)^ =
+
+    // Cast-erased optional carrier, as `Cursor` holds it.
+    val backing0: Optional[AnyRef] =
+      addressable0.backing(value).asInstanceOf[Optional[AnyRef]]
 
     new Stream[medium]:
       type Transport = Credit
@@ -61,10 +68,11 @@ object Stream:
       // Untracked, cast-erased: reached only through this endpoint.
       @caps.unsafe.untrackedCaptures
       private val storage: addressable0.Storage =
-        addressable0.allocate(size.max(1)).asInstanceOf[addressable0.Storage]
+        backing0.or(addressable0.allocate(size.max(1)).asInstanceOf[AnyRef])
+        . asInstanceOf[addressable0.Storage]
       private var start0: Int = 0
       private var limit0: Int = 0
-      private var loaded: Boolean = false
+      private var loaded: Boolean = backing0.present
 
       // The single buffer is filled once and only ever read thereafter, so its
       // region ranges stay valid indefinitely — safe to share by reference.


### PR DESCRIPTION
Profiling the HTTP round-trip attributed scintillate's serial cost to a header-processing cluster: four separate header scans per request, each lowercasing every key and value it touched, and an eager typed parse of the `Host` header (a `Hostname | Ipv4 | Ipv6` union, trying each form) on every request. And the saturated fan-in rows attributed `Confluence`'s 2× allocation deficit against ZIO not to the merge but to `Stream.apply`'s defensive copy of every in-memory value.

## Single-pass header facts

`serveRequest` now gathers its header facts in one allocation-free pass with case-insensitive comparisons on the raw strings; `parseHead` memoizes the last successful `Host` parse (every request on a keep-alive connection repeats the same bytes; only successes are cached, so missing or invalid hosts still abort eagerly); and `Response.serialize`'s framing scans drop their `.lower` allocations. Serial throughput rises ~14% (21.0k → 23.9k req/s at N=1).

## Zero-copy single-chunk streams

`Stream.apply` was the last copying straggler: `Conduit`, `Cursor` and `Duct` already share an immutable medium's backing through `Addressable.backing`. A frozen `Data`'s array is now shared by reference (regions of such a stream are only ever read), so `.stream` over in-memory data allocates nothing. Measured on the saturated fan-in rows: allocation falls from 0.27 MB to 4.9 kB per 256 KiB merge (ZIO: 0.14 MB), serial throughput rises 42% (40.5k → 57.5k op/s) and peak 13% (282k → 318k, vs ZIO's ~151–180k).

A JFR `Profile` suite for the HTTP round-trip (scintillate and zio-http side by side — the client frames are identical, so differences are server-side) is added to the scintillate benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)