### PR TITLE
Verify and tune stream backpressure, and enable HTTP/2 receive-side flow control

### DIFF
--- a/doc/modules/streams.md
+++ b/doc/modules/streams.md
@@ -201,6 +201,37 @@ supervise(Confluence(first, second, third))
 materialized once and shared immutably between them. A full subscriber queue parks the pump, so
 the slowest subscriber gates the source — the correct behaviour for replication.
 
+### Tuning backpressure
+
+Every stage that allocates a buffer consults the `Buffering` policy in scope, so one given
+tunes a whole pipeline. Its members are:
+
+ - `capacity(substrate)` — the staging block size: 4096 bytes, 2048 characters or 256 records
+   by default. Staging blocks want to stay cache-resident.
+ - `transfer(substrate)` — the size of a block crossing an asynchronous boundary, sixteen
+   staging blocks by default. Every such block costs a synchronized hand-off, so boundary
+   blocks want to be much larger than staging blocks.
+ - `depth` — the number of transfer blocks of headroom a `Conduit` holds between its writer and
+   reader, 16 by default. A conduit's in-flight data is bounded by `(depth + 1)` transfer
+   blocks; hand-off throughput collapses at very shallow depths (a depth of 2 reaches less than
+   a tenth of the default's throughput in the benchmark sweep) and plateaus around the default
+   for a producer and consumer in lockstep, but bursty pipelines still gain from a depth
+   covering their burst size in transfer blocks.
+ - `recycle` — whether drained transfer blocks return to the writer for reuse (on by default);
+   a shared, size-capped pool amortizes block allocation across conduit instances.
+
+Backpressure applies wherever data crosses between threads: a `Conduit` writer parks on a full
+ring, `Divergence`'s pump parks on the slowest subscriber's ring (closing a subscriber's stream
+releases it), `Confluence`'s pumps park uniformly on the shared queue, and HTTP/2 applies
+credit-based flow control in both directions — the advertised receive window (1 MiB by default,
+tunable per connection) bounds how far a peer can run ahead of a consumer that has stopped
+reading, with the window replenished only as the body is actually drained.
+
+One structure deliberately opts out: `Relay` is the many-producer record bus, and its contract
+is that producers never block. HTTP/2's outbound frame multiplexer depends on that — a blocking
+`put` there would risk distributed deadlock between streams — so a relay's discipline is its
+single consumer, not a bound.
+
 ### Compression
 
 A byte stream compresses and decompresses with a named scheme, as a stage in a pipeline or over

--- a/lib/cataclysm/src/core/cataclysm.Css.scala
+++ b/lib/cataclysm/src/core/cataclysm.Css.scala
@@ -83,7 +83,7 @@ object Css:
     case At(name: Text, prelude: Text, body: Optional[List[Node]])
 
   given streamable: (Monitor, Probate, Formatting) => Css is Streamable by Text over Credit = css =>
-    val producer = Producer[Text](4096)
+    val producer = Producer[Text]()
 
     async:
       write(css)(producer.put(_))

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -288,7 +288,7 @@ object Html extends Tag.Container
   =>  ((Document[Html] is Streamable by Text over Credit)^{monitor, caps.any}) = document =>
     val formatting = summon[Formatting]
     val dom = document.metadata
-    val producer = Producer[Text](4096)
+    val producer = Producer[Text]()
     val block = formatting.indented
 
     async:

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -304,7 +304,7 @@ object Protobuf extends Protobuf2:
   // fiber. The bytes themselves are already assembled (Protobuf length-prefixes nested messages, so
   // their lengths must be known up front); this hands them out in bounded chunks.
   def emit(value: Protobuf)(using Monitor, Probate): Iterator[Data] =
-    val producer = Producer[Data](4096)
+    val producer = Producer[Data]()
 
     async:
       producer.put(value.payload)

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -400,7 +400,7 @@ object Tests extends Suite(m"Scintillate tests"):
             caps.unsafe.unsafeAssumePure:
               Http.Response(Http.Ok):
                 Http.Body.Flowing: () =>
-                  val producer = Producer[Data](4096)
+                  val producer = Producer[Data]()
 
                   async:
                     var i = 0

--- a/lib/telekinesis/src/http2/telekinesis.Http2.scala
+++ b/lib/telekinesis/src/http2/telekinesis.Http2.scala
@@ -495,11 +495,26 @@ object Http2:
     // precedes the first SETTINGS frame in prior-knowledge h2c.
     private[telekinesis] val connectionPreface: Bytes = t"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".in[Bytes]
 
-    // Our advertised SETTINGS: disable server push; a generous stream window.
-    private[telekinesis] val initialSettings: List[Setting] =
+    // The HTTP/2 default flow-control window (RFC 7540 §6.9.2): the initial
+    // send budget for the connection, and for a stream until SETTINGS say
+    // otherwise.
+    private[telekinesis] val defaultWindow: Int = 65535
+
+    // Our advertised receive budget, per stream and (via an initial
+    // connection-level WINDOW_UPDATE) per connection: the peer may have at most
+    // this many unconsumed bytes in flight, which is what bounds the inbound
+    // body relays — they are unbounded structures bounded by protocol credit.
+    // Replenishment is consumption-driven and batched: a WINDOW_UPDATE goes out
+    // once half the budget is pending, so a stalled consumer stalls the peer's
+    // sender rather than accumulating its output.
+    private[telekinesis] val receiveWindow: Int = 1024*1024
+
+    // Our advertised SETTINGS: disable server push; our receive-side stream
+    // window.
+    private[telekinesis] def initialSettings(window: Int): List[Setting] =
       List
         ( Setting(SettingId.EnablePush.id, 0),
-          Setting(SettingId.InitialWindowSize.id, 0x7fffffff) )
+          Setting(SettingId.InitialWindowSize.id, window) )
 
     // Dispatch one decoded frame. Lives on the companion — taking the connection as a
     // plain parameter — so the reader daemon's body stays free of `this` captures.
@@ -535,11 +550,10 @@ object Http2:
 
         case Frame.Data(id, payload, endStream) =>
           conn.streams.get(id).foreach: stream =>
+            // No replenishment here: the peer's window refills only as the
+            // application drains the body (see `Stream.Body`), so an unread
+            // body backpressures the peer at the advertised window.
             stream.acceptData(payload)
-            // Replenish the peer's flow-control window for what we consumed.
-            if payload.length > 0 then
-              conn.send(Frame.WindowUpdate(0, payload.length))
-              conn.send(Frame.WindowUpdate(id, payload.length))
 
             if endStream then
               stream.end()
@@ -567,7 +581,7 @@ object Http2:
   // `Spool[Frame]` to the socket, serialising all writes (so no lock is needed); a
   // reader daemon parses inbound frames and dispatches them by stream id. Must be
   // created within a `supervise`-provided `Monitor`.
-  class Connection(duplex: Duplex)(using Monitor, Probate):
+  class Connection(duplex: Duplex, window: Int = Connection.receiveWindow)(using Monitor, Probate):
     import Http2.Connection.*
 
     private val streams: scc.TrieMap[Int, Http2.Stream] = scc.TrieMap()
@@ -575,7 +589,35 @@ object Http2:
     private val outbound: Relay[Frame] = Relay()
     private val started: Promise[Unit] = Promise()
 
+    // Consumed-but-unreplenished inbound bytes at connection level, and the
+    // batching threshold: one WINDOW_UPDATE per half-window consumed, not one
+    // per DATA frame.
+    private val connPending: juca.AtomicInteger = juca.AtomicInteger(0)
+    private val threshold: Int = (window/2).max(1)
+
     private def send(frame: Frame): Unit = outbound.put(frame)
+
+    // Consumption-driven replenishment: the body's accounted stream reports
+    // each drained record's bytes, which accumulate per stream and per
+    // connection until the threshold releases them as WINDOW_UPDATEs.
+    private[telekinesis] def consumed(stream: Http2.Stream, count: Int): Unit =
+      stream.unreplenished.addAndGet(count)
+      connPending.addAndGet(count)
+      replenish(stream.unreplenished, stream.id)
+      replenish(connPending, 0)
+
+    // CAS-drain: emit one WINDOW_UPDATE for everything pending once the
+    // threshold is crossed; concurrent consumers of different streams race
+    // safely on the connection counter.
+    private def replenish(pending: juca.AtomicInteger, id: Int): Unit =
+      var continue = true
+
+      while continue do
+        val value = pending.get
+        if value < threshold then continue = false
+        else if pending.compareAndSet(value, 0) then
+          send(Frame.WindowUpdate(id, value))
+          continue = false
 
     // Tear the connection down after an unrecoverable reader/writer failure: unblock a
     // pending handshake, end every open stream so awaiters of its headers/body/trailers
@@ -634,14 +676,24 @@ object Http2:
     // Plain using-parameters, de-sugared from `raises`: a context-function result may
     // not hide `this`.
     def start()(using Tactic[Async.Error]): Unit =
-      send(Frame.Settings(initialSettings, ack = false))
+      send(Frame.Settings(initialSettings(window), ack = false))
+
+      // The connection window has no SETTINGS entry: raise it from the RFC
+      // default to our receive budget. It can only be raised, so a budget below
+      // the default leaves the connection at the default and the stream window
+      // is what gates.
+      if window > defaultWindow then send(Frame.WindowUpdate(0, window - defaultWindow))
       started.await()
 
     // Open a new client stream, send its header block (and optional body), and return
     // the stream handle whose promises/spool the reader will populate.
     def request(headerBlock: List[HpackEntry], body: Optional[Bytes]): Http2.Stream =
       val id = nextId.getAndAdd(2)
-      val stream = Http2.Stream(id)
+
+      // The consumption callback reaches only JMM-safe state (atomic counters
+      // and the thread-safe outbound relay), so it is laundered pure at this
+      // rim rather than tracked into the stream.
+      val stream = Http2.Stream(id, scala.caps.unsafe.unsafeAssumePure(consumed))
       streams(id) = stream
       val encoder = Hpack()
       val noBody = body.absent
@@ -679,11 +731,78 @@ object Http2:
       writer.cancel()
       duplex.close()
 
+  object Stream:
+    // The inbound body buffer: an unbounded relay whose effective buffering is
+    // bounded by protocol credit — the peer may have at most the advertised
+    // receive window in flight beyond what the consumer has drained. Draining
+    // through `stream` accounts each record's bytes via `onConsume` at the
+    // point data actually leaves the buffer for the application, and the
+    // connection turns the accumulation into deferred, batched WINDOW_UPDATEs.
+    class Body(onConsume: Int -> Unit):
+      private val relay: Relay[Bytes] = Relay()
+
+      private[telekinesis] def put(data: Bytes): Unit = relay.put(data)
+      private[telekinesis] def stop(): Unit = relay.stop()
+
+      def stream
+        ( using addressable: (Array[Bytes]^{}) is Addressable, buffering: Buffering )
+      :   (zephyrine.Stream[Array[Bytes]^{}] over Credit)^ =
+
+        accounted(relay.stream)
+
+      // A pass-through wrapper counting the bytes of each record the consumer
+      // skips past — the single point where records leave the relay's window.
+      private def accounted
+        ( consume underlying0: (zephyrine.Stream[Array[Bytes]^{}] over Credit)^ )
+        ( using addressable: (Array[Bytes]^{}) is Addressable )
+      :   (zephyrine.Stream[Array[Bytes]^{}] over Credit)^ =
+
+        new zephyrine.Stream[Array[Bytes]^{}](using addressable):
+          type Transport = Credit
+
+          // The adopted stream is held through a neutral carrier: an exclusive
+          // field would be read-only, so the accessor re-asserts the ownership
+          // this wrapper took at construction.
+          private val held: AnyRef = underlying0.asInstanceOf[AnyRef]
+
+          private def underlying: (zephyrine.Stream[Array[Bytes]^{}] over Credit)^ =
+            held.asInstanceOf[(zephyrine.Stream[Array[Bytes]^{}] over Credit)^]
+
+          update def refill(demand: Credit): Optional[Int] = underlying.refill(demand)
+
+          protected def storage0: AnyRef =
+            val current = underlying
+            current.storage(using Unsafe).asInstanceOf[AnyRef]
+
+          def start: Int = underlying.start
+          def limit: Int = underlying.limit
+
+          update def skip(count: Int): Unit =
+            val window = storage0.asInstanceOf[scala.Array[AnyRef]]
+            val offset = underlying.start
+            var index = 0
+            var bytes = 0
+
+            while index < count do
+              bytes += window(offset + index).asInstanceOf[Bytes].length
+              index += 1
+
+            underlying.skip(count)
+            if bytes > 0 then onConsume(bytes)
+
+          override update def close(): Unit = underlying.close()
+
   // Http2.Stream -> Http2.Stream
-  class Stream(val id: Int):
+  class Stream(val id: Int, onConsume: (Http2.Stream, Int) -> Unit = (_, _) => ()):
     val headers: Promise[List[HpackEntry]] = Promise()
     val trailers: Promise[List[HpackEntry]] = Promise()
-    val body: Relay[Bytes] = Relay()
+
+    // Consumed-but-unreplenished inbound bytes, drained by the connection's
+    // batched replenishment.
+    private[telekinesis] val unreplenished: juca.AtomicInteger = juca.AtomicInteger(0)
+
+    val body: Stream.Body = Stream.Body(count => onConsume(this, count))
+
     // Untracked: written only by the connection's single reader daemon.
     @caps.unsafe.untrackedCaptures
     private var headersSeen: Boolean = false
@@ -707,15 +826,11 @@ object Http2:
 
   // Http2ServerConnection → Http2.ServerConnection
   object ServerConnection:
-    // The HTTP/2 default flow-control window (RFC 7540 §6.9.2): the initial send
-    // budget for the connection, and for a stream until the peer's SETTINGS say
-    // otherwise.
-    private val defaultWindow: Int = 65535
-
-    // Our advertised SETTINGS: a generous stream window. (`EnablePush` is a
-    // client-only setting, so the server sends only the window.)
-    private val serverSettings: List[Setting] =
-      List(Setting(SettingId.InitialWindowSize.id, 0x7fffffff))
+    // Our advertised SETTINGS: our receive-side stream window (see
+    // `Connection.receiveWindow`). `EnablePush` is a client-only setting, so
+    // the server sends only the window.
+    private def serverSettings(window: Int): List[Setting] =
+      List(Setting(SettingId.InitialWindowSize.id, window))
 
     // Dispatch one decoded frame, in the server role: the peer is a client, so a
     // HEADERS frame for an unknown (client-initiated, odd) stream id CREATES the
@@ -760,7 +875,10 @@ object Http2:
                 conn.streams.remove(id)
 
             case None =>
-              val stream = Http2.Stream(id)
+              // The consumption callback reaches only JMM-safe state (atomic
+              // counters and the thread-safe outbound relay), so it is
+              // laundered pure at this rim rather than tracked into the stream.
+              val stream = Http2.Stream(id, scala.caps.unsafe.unsafeAssumePure(conn.consumed))
               conn.streams(id) = stream
               stream.acceptHeaders(decoder.decode(block))
               if endStream then stream.end() else ()
@@ -770,11 +888,10 @@ object Http2:
 
         case Frame.Data(id, payload, endStream) =>
           conn.streams.get(id).foreach: stream =>
+            // No replenishment here: the peer's window refills only as the
+            // handler drains the request body (see `Stream.Body`), so an
+            // unread body backpressures the peer at the advertised window.
             stream.acceptData(payload)
-            // Replenish the peer's flow-control window for what we consumed.
-            if payload.length > 0 then
-              conn.send(Frame.WindowUpdate(0, payload.length))
-              conn.send(Frame.WindowUpdate(id, payload.length))
 
             if endStream then
               stream.end()
@@ -811,8 +928,10 @@ object Http2:
   // each header block is encoded with a fresh (always-literal) HPACK encoder, so
   // no encoder state is shared. Must be created within a `supervise`-provided
   // `Monitor`.
-  class ServerConnection(duplex: Duplex^)(using Monitor, Probate):
+  class ServerConnection(duplex: Duplex^, window: Int = Connection.receiveWindow)
+    ( using Monitor, Probate ):
     import Http2.ServerConnection.*
+    import Http2.Connection.defaultWindow
 
     // A socket-backed `Duplex` captures its I/O capabilities, so it crosses into
     // the reader/writer daemons (and reaches `close`) as a neutral `AnyRef` rim.
@@ -833,7 +952,29 @@ object Http2:
     // and runs its handler. Stopped when the connection ends.
     private[telekinesis] val accepted: Relay[Http2.Stream] = Relay()
 
+    // Receive-side replenishment state, as `Connection`'s: consumed bytes
+    // accumulate per stream and per connection, released as batched
+    // WINDOW_UPDATEs at the half-window threshold.
+    private val connPending: juca.AtomicInteger = juca.AtomicInteger(0)
+    private val threshold: Int = (window/2).max(1)
+
     private[telekinesis] def send(frame: Frame): Unit = outbound.put(frame)
+
+    private[telekinesis] def consumed(stream: Http2.Stream, count: Int): Unit =
+      stream.unreplenished.addAndGet(count)
+      connPending.addAndGet(count)
+      replenish(stream.unreplenished, stream.id)
+      replenish(connPending, 0)
+
+    private def replenish(pending: juca.AtomicInteger, id: Int): Unit =
+      var continue = true
+
+      while continue do
+        val value = pending.get
+        if value < threshold then continue = false
+        else if pending.compareAndSet(value, 0) then
+          send(Frame.WindowUpdate(id, value))
+          continue = false
 
     // Tear the connection down after an unrecoverable reader/writer failure or a
     // bad preface: unblock a pending handshake, end every open stream, and stop
@@ -893,7 +1034,11 @@ object Http2:
     // await the client's (which the dispatch acks). Plain using-parameters,
     // de-sugared from `raises`: a context-function result may not hide `this`.
     def start()(using Tactic[Async.Error]): Unit =
-      send(Frame.Settings(serverSettings, ack = false))
+      send(Frame.Settings(serverSettings(window), ack = false))
+
+      // Raise the connection window from the RFC default to our receive
+      // budget, as `Connection.start` does.
+      if window > defaultWindow then send(Frame.WindowUpdate(0, window - defaultWindow))
       started.await()
 
     // Run `handler` for each client-initiated stream as it arrives, on the

--- a/lib/telekinesis/src/test/telekinesis.Http2Tests.scala
+++ b/lib/telekinesis/src/test/telekinesis.Http2Tests.scala
@@ -473,6 +473,64 @@ object Http2Tests extends Suite(m"Telekinesis HTTP/2 Tests"):
 
       . assert(_ == (200000, true))
 
+      // Receive-side flow control: the client advertises a small window and
+      // does not read the body, so the server's send side must stall at window
+      // exhaustion — after four full 1000-byte chunks (the fifth takes only the
+      // 96-byte remainder and parks). Draining the body replenishes the window
+      // in batched WINDOW_UPDATEs and the transfer completes.
+      test(m"a peer stalls at a small advertised window until the body drains"):
+        supervise:
+          val (clientSide, serverSide) = pair()
+          val server = Http2.ServerConnection(serverSide)
+          val serverRef: AnyRef = server.asInstanceOf[AnyRef]
+          val sent = java.util.concurrent.atomic.AtomicInteger(0)
+
+          daemon:
+            safely:
+              val server0 = serverRef.asInstanceOf[Http2.ServerConnection]
+
+              server0.accepted.stream.records.each: stream =>
+                unsafely:
+                  stream.headers.await()
+                  server0.sendHeaders(stream.id, List(HpackEntry(t":status", t"200")), false)
+                  var index = 0
+
+                  while index < 20 do
+                    val chunk: Data = Array.tabulate(1000)(i => ((index*1000 + i)%256).toByte)
+                    server0.sendData(stream.id, chunk, endStream = index == 19)
+                    sent.incrementAndGet()
+                    index += 1
+
+          val client = Http2.Connection(clientSide, window = 4096)
+          val serverStarted = scala.caps.unsafe.unsafeAssumeSeparate(async(server.start()))
+          client.start()
+          scala.caps.unsafe.unsafeAssumeSeparate:
+            serverStarted.await()
+
+          val request = Http.Request(Http.Get, 2.0, unsafely(t"unix".as[Host]), t"/slow", Nil,
+              () => Http.emptyBody())
+
+          val (_, response) = client.fetch(request, t"http", t"unix")
+
+          // Bounded poll until the sender goes quiet: a too-early sample can
+          // only under-read, and a correct implementation freezes at four.
+          var frozen = -1
+          var stable = 0
+          var attempts = 0
+
+          while stable < 5 && attempts < 500 do
+            val current = sent.get()
+            if current == frozen then stable += 1 else { frozen = current; stable = 0 }
+            Thread.sleep(10)
+            attempts += 1
+
+          val received = response.body.stream.memoize
+          client.close()
+          server.close()
+          (frozen, received.length, sent.get())
+
+      . assert(_ == (4, 20000, 20))
+
       test(m"a session lends one connection to several multiplexed requests"):
         supervise:
           val (clientSide, serverSide) = pair()

--- a/lib/telekinesis/src/test/telekinesis.Http2Tests.scala
+++ b/lib/telekinesis/src/test/telekinesis.Http2Tests.scala
@@ -417,6 +417,22 @@ object Http2Tests extends Suite(m"Telekinesis HTTP/2 Tests"):
 
       . assert(_ == (4, 6, 3))
 
+      test(m"one release wakes every waiter parked on an empty window"):
+        supervise:
+          val window = FlowWindow(0)
+          val first: Promise[Int] = Promise()
+          val second: Promise[Int] = Promise()
+          async(first.offer(window.acquire(2)))
+          async(second.offer(window.acquire(2)))
+
+          // `release` signals all waiters, and each requests no more than half the
+          // grant, so both must complete whichever order they park and wake; a
+          // single-signal implementation would leave one parked forever.
+          window.release(4)
+          (first.await(), second.await())
+
+      . assert(_ == (2, 2))
+
       test(m"a response larger than the connection window streams intact"):
         supervise:
           val (clientSide, serverSide) = pair()

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -188,6 +188,28 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
     def capacity(substrate: Substrate): Int = n
     def depth: Int = 4
 
+  // A fixed-capacity, fixed-depth `Buffering`, for the ring-depth sweep. The
+  // standard 4096-byte capacity keeps the transfer block at its standard 64 KiB,
+  // so only the ring depth varies between rows.
+  def buffering(n: Int, depth0: Int): Buffering = new Buffering:
+    def capacity(substrate: Substrate): Int = n
+    def depth: Int = depth0
+
+  // Deterministic, data-independent CPU work proportional to `count`: the
+  // slow-consumer rows charge every rival's consumer the same per-block drag, so
+  // the producer runs ahead and what differs between rows is the hand-off's
+  // buffering policy. Callers fold the result into theirs (`& 1L`), keeping the
+  // loop alive under JIT.
+  def burn(count: Int): Long =
+    var acc: Long = 0L
+    var index: Int = 0
+
+    while index < count*4 do
+      acc = acc*31 + index
+      index += 1
+
+    acc
+
   // Int rather than Long: ZIO's `take`/`drop` are `Int`-counted, and both values
   // fit; Soundness's and FS2's `Long`-counted versions widen automatically.
   val dropBytes: Int = 65536
@@ -955,6 +977,209 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
                   ZIO.foreachPar(streams)(_.runCount).map(_.sum)
         }
 
+    // Example N2: ring-depth sweep for the cross-thread hand-off — the tuning
+    // data behind `Buffering.depth`'s conservative default of 16 (its comment
+    // records hand-off throughput still improving at 64). Depth multiplies the
+    // worst-case in-flight blocks of every copy-path conduit, so the win must
+    // justify the memory; each row is Example L's pipeline with only the ring
+    // depth varied.
+    suite(m"Conduit depth sweep (4 MB in 64 KiB chunks)"):
+      bench(m"depth 2")(target = 1*Second, operationSize = size):
+        '{
+            given Buffering = turbulence.Benchmarks.buffering(4096, 2)
+            val (intake, stream) = Conduit[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(intake.put)
+              intake.finish())
+            var total = 0L
+            stream.sweep(region => range => total += (range: Interval).size)
+            producer.join()
+            total
+        }
+
+      bench(m"depth 4")(target = 1*Second, operationSize = size):
+        '{
+            given Buffering = turbulence.Benchmarks.buffering(4096, 4)
+            val (intake, stream) = Conduit[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(intake.put)
+              intake.finish())
+            var total = 0L
+            stream.sweep(region => range => total += (range: Interval).size)
+            producer.join()
+            total
+        }
+
+      bench(m"depth 16 (standard)")(target = 1*Second, operationSize = size):
+        '{
+            given Buffering = turbulence.Benchmarks.buffering(4096, 16)
+            val (intake, stream) = Conduit[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(intake.put)
+              intake.finish())
+            var total = 0L
+            stream.sweep(region => range => total += (range: Interval).size)
+            producer.join()
+            total
+        }
+
+      bench(m"depth 64")(target = 1*Second, operationSize = size):
+        '{
+            given Buffering = turbulence.Benchmarks.buffering(4096, 64)
+            val (intake, stream) = Conduit[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(intake.put)
+              intake.finish())
+            var total = 0L
+            stream.sweep(region => range => total += (range: Interval).size)
+            producer.join()
+            total
+        }
+
+      bench(m"depth 256")(target = 1*Second, operationSize = size):
+        '{
+            given Buffering = turbulence.Benchmarks.buffering(4096, 256)
+            val (intake, stream) = Conduit[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(intake.put)
+              intake.finish())
+            var total = 0L
+            stream.sweep(region => range => total += (range: Interval).size)
+            producer.join()
+            total
+        }
+
+    // Example N3: the price and payoff of backpressure. Every row funnels the
+    // same 4 MB through a cross-thread hand-off to a consumer slowed by a fixed
+    // amount of per-block CPU work (`burn` — data-independent, so every rival's
+    // consumer drags identically). Throughput is consumer-gated for every row;
+    // the differentiating columns are allocation and peak heap, where the
+    // unbounded models buffer the producer's entire lead and the bounded ones
+    // hold it to the ring.
+    suite(m"Backpressure vs unbounded model: slow consumer (4 MB)"):
+      bench(m"Soundness  Conduit depth 16")(target = 1*Second, operationSize = size):
+        '{
+            val (intake, stream) = Conduit[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(intake.put)
+              intake.finish())
+            var total = 0L
+            stream.sweep: region =>
+              range =>
+                val count = (range: Interval).size
+                total += count + (turbulence.Benchmarks.burn(count) & 1L)
+            producer.join()
+            total
+        }
+
+      bench(m"Unbounded  LinkedBlockingQueue")(target = 1*Second, operationSize = size):
+        '{
+            val queue = new java.util.concurrent.LinkedBlockingQueue[AnyRef]()
+            val end = new Object
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(chunk => queue.put(chunk.asInstanceOf[AnyRef]))
+              queue.put(end))
+            var total = 0L
+            var running = true
+            while running do
+              val item = queue.take()
+              if item eq end then running = false else
+                val count = item.asInstanceOf[Data].length
+                total += count + (turbulence.Benchmarks.burn(count) & 1L)
+            producer.join()
+            total
+        }
+
+      bench(m"Unbounded  Relay[Data]")(target = 1*Second, operationSize = size):
+        '{
+            val relay = Relay[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(relay.put)
+              relay.stop())
+            var total = 0L
+            relay.stream.records.each: chunk =>
+              total += chunk.length + (turbulence.Benchmarks.burn(chunk.length) & 1L)
+            producer.join()
+            total
+        }
+
+      bench(m"FS2  Channel.unbounded")(target = 1*Second, operationSize = size):
+        '{
+            import cats.effect.unsafe.implicits.global
+            import cats.effect.IO, cats.syntax.all.*
+            val program = fs2.concurrent.Channel.unbounded[IO, fs2.Chunk[Byte]].flatMap: channel =>
+              val produce =
+                turbulence.Benchmarks.inputChunkList.foldLeft(IO.unit): (io, chunk) =>
+                  io *> channel.send(fs2.Chunk.array(chunk.asInstanceOf[scala.Array[Byte]])).void
+                *> channel.close.void
+              produce.start *> channel.stream.compile.fold(0L): (acc, chunk) =>
+                acc + chunk.size + (turbulence.Benchmarks.burn(chunk.size) & 1L)
+            program.unsafeRunSync()
+        }
+
+      bench(m"ZIO  Queue.unbounded")(target = 1*Second, operationSize = size):
+        '{
+            turbulence.Benchmarks.runZio:
+              import zio.*, zio.stream.*
+              val source =
+                ZStream.fromIterable
+                  (turbulence.Benchmarks.inputChunkList.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
+              for
+                queue <- Queue.unbounded[Take[Nothing, Chunk[Byte]]]
+                _     <- source.runIntoQueue(queue).fork
+                total <- ZStream.fromQueue(queue).flattenTake.runFold(0L): (acc, c) =>
+                           acc + c.size + (turbulence.Benchmarks.burn(c.size) & 1L)
+              yield total
+        }
+
+    // Example N4: fan-out with one dragging subscriber. Every library gates the
+    // source on its slowest subscriber (the correct replication semantics), so
+    // these rows quantify what that gating costs each of them when one of three
+    // consumers carries the Example N3 per-block drag.
+    suite(m"Divergence with one slow subscriber (4 MB in, 12 MB consumed)"):
+      bench(m"Soundness  Divergence")(target = 1*Second, operationSize = size):
+        '{
+            supervise:
+              val ticket = new java.util.concurrent.atomic.AtomicInteger(0)
+              val subscribers = Divergence(turbulence.Benchmarks.input.stream, 3)
+              val tasks = subscribers.map: subscriber =>
+                async:
+                  val slow = ticket.getAndIncrement() == 0
+                  var total = 0L
+                  subscriber.sweep: region =>
+                    range =>
+                      val count = (range: Interval).size
+                      total += count
+                      if slow then total += turbulence.Benchmarks.burn(count) & 1L
+                  total
+              tasks.map(_.await()).sum
+        }
+
+      bench(m"FS2  broadcastThrough")(target = 1*Second, operationSize = size):
+        '{
+            import cats.effect.unsafe.implicits.global
+            import cats.effect.IO, cats.syntax.all.*
+            val counter: fs2.Pipe[IO, Byte, Long] = _.chunks.foldMap(chunk => chunk.size.toLong)
+            val slow: fs2.Pipe[IO, Byte, Long] = _.chunks.foldMap: chunk =>
+              chunk.size.toLong + (turbulence.Benchmarks.burn(chunk.size) & 1L)
+            fs2.Stream.chunk(fs2.Chunk.array(turbulence.Benchmarks.inputArray)).covary[IO]
+            . broadcastThrough(slow, counter, counter).compile.foldMonoid.unsafeRunSync()
+        }
+
+      bench(m"ZIO  broadcast")(target = 1*Second, operationSize = size):
+        '{
+            turbulence.Benchmarks.runZio:
+              import zio.*, zio.stream.*
+              ZIO.scoped:
+                ZStream.fromChunk(Chunk.fromArray(turbulence.Benchmarks.inputArray)).broadcast(3, 16).flatMap: streams =>
+                  ZIO.foreachPar(streams.zipWithIndex): (stream, index) =>
+                    if index == 0 then
+                      stream.chunks.runFold(0L): (acc, chunk) =>
+                        acc + chunk.size + (turbulence.Benchmarks.burn(chunk.size) & 1L)
+                    else stream.runCount
+                  . map(_.sum)
+        }
+
     // Example O: stress rows — the memory profile of the cross-thread hand-off
     // pipeline from Example L, run as 16 concurrent pipelines for a fixed
     // wall-clock window. The throughput rows above measure speed; these measure
@@ -1047,6 +1272,144 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
                 _     <- source.runIntoQueue(queue).fork
                 total <- ZStream.fromQueue(queue).flattenTake.runFold(0L)((acc, c) => acc + c.size)
               yield total
+        }
+
+    // Example P2: what the absence of backpressure costs. The Example N3
+    // pipeline — a producer racing ahead of a CPU-slowed consumer — in a pinned
+    // 128 MB heap, doubling the pipeline count towards 64. A bounded hand-off
+    // holds each pipeline's in-flight data to its ring, so the sweep should keep
+    // climbing; the unbounded models buffer each producer's entire 4 MB lead, so
+    // their sweeps are expected to die early on OutOfMemoryError or GC thrash —
+    // the largest N each row reaches is the finding.
+    suite(m"Stress: unbounded-model blowup (slow consumer, 128 MB heap, N ≤ 64)"):
+      import threading.platformThreading
+
+      constrained(m"Soundness  Conduit depth 16")(target = 1*Second, sweep = 64):
+        '{
+            val (intake, stream) = Conduit[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(intake.put)
+              intake.finish())
+            var total = 0L
+            stream.sweep: region =>
+              range =>
+                val count = (range: Interval).size
+                total += count + (turbulence.Benchmarks.burn(count) & 1L)
+            producer.join()
+            total
+        }
+
+      constrained(m"Unbounded  LinkedBlockingQueue")(target = 1*Second, sweep = 64):
+        '{
+            val queue = new java.util.concurrent.LinkedBlockingQueue[AnyRef]()
+            val end = new Object
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(chunk => queue.put(chunk.asInstanceOf[AnyRef]))
+              queue.put(end))
+            var total = 0L
+            var running = true
+            while running do
+              val item = queue.take()
+              if item eq end then running = false else
+                val count = item.asInstanceOf[Data].length
+                total += count + (turbulence.Benchmarks.burn(count) & 1L)
+            producer.join()
+            total
+        }
+
+      constrained(m"Unbounded  Relay[Data]")(target = 1*Second, sweep = 64):
+        '{
+            val relay = Relay[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(relay.put)
+              relay.stop())
+            var total = 0L
+            relay.stream.records.each: chunk =>
+              total += chunk.length + (turbulence.Benchmarks.burn(chunk.length) & 1L)
+            producer.join()
+            total
+        }
+
+      constrained(m"FS2  Channel.unbounded")(target = 1*Second, sweep = 64):
+        '{
+            import cats.effect.unsafe.implicits.global
+            import cats.effect.IO, cats.syntax.all.*
+            val program = fs2.concurrent.Channel.unbounded[IO, fs2.Chunk[Byte]].flatMap: channel =>
+              val produce =
+                turbulence.Benchmarks.inputChunkList.foldLeft(IO.unit): (io, chunk) =>
+                  io *> channel.send(fs2.Chunk.array(chunk.asInstanceOf[scala.Array[Byte]])).void
+                *> channel.close.void
+              produce.start *> channel.stream.compile.fold(0L): (acc, chunk) =>
+                acc + chunk.size + (turbulence.Benchmarks.burn(chunk.size) & 1L)
+            program.unsafeRunSync()
+        }
+
+      constrained(m"ZIO  Queue.unbounded")(target = 1*Second, sweep = 64):
+        '{
+            turbulence.Benchmarks.runZio:
+              import zio.*, zio.stream.*
+              val source =
+                ZStream.fromIterable
+                  (turbulence.Benchmarks.inputChunkList.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
+              for
+                queue <- Queue.unbounded[Take[Nothing, Chunk[Byte]]]
+                _     <- source.runIntoQueue(queue).fork
+                total <- ZStream.fromQueue(queue).flattenTake.runFold(0L): (acc, c) =>
+                           acc + c.size + (turbulence.Benchmarks.burn(c.size) & 1L)
+              yield total
+        }
+
+    // Example P3: the same slow-consumer pipeline at a fixed N=16 in the roomy
+    // default heap — the headline retained/peakHeap comparison. The bounded
+    // conduit's live set stays flat at the ring bound; the unbounded models'
+    // grows with the producer's lead, and the retained column shows it.
+    suite(m"Stress: retained memory under slow consumption (4 MB, N=16)"):
+      import threading.platformThreading
+
+      stress(m"Soundness  Conduit depth 16")(target = 2*Second, concurrency = 16):
+        '{
+            val (intake, stream) = Conduit[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(intake.put)
+              intake.finish())
+            var total = 0L
+            stream.sweep: region =>
+              range =>
+                val count = (range: Interval).size
+                total += count + (turbulence.Benchmarks.burn(count) & 1L)
+            producer.join()
+            total
+        }
+
+      stress(m"Unbounded  LinkedBlockingQueue")(target = 2*Second, concurrency = 16):
+        '{
+            val queue = new java.util.concurrent.LinkedBlockingQueue[AnyRef]()
+            val end = new Object
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(chunk => queue.put(chunk.asInstanceOf[AnyRef]))
+              queue.put(end))
+            var total = 0L
+            var running = true
+            while running do
+              val item = queue.take()
+              if item eq end then running = false else
+                val count = item.asInstanceOf[Data].length
+                total += count + (turbulence.Benchmarks.burn(count) & 1L)
+            producer.join()
+            total
+        }
+
+      stress(m"Unbounded  Relay[Data]")(target = 2*Second, concurrency = 16):
+        '{
+            val relay = Relay[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.each(relay.put)
+              relay.stop())
+            var total = 0L
+            relay.stream.records.each: chunk =>
+              total += chunk.length + (turbulence.Benchmarks.burn(chunk.length) & 1L)
+            producer.join()
+            total
         }
 
     // Example Q: gzip-decompression memory — the pipeline from Example 1b run as

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -210,6 +210,15 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
 
     acc
 
+  // A fresh copy of a corpus chunk. The slow-consumer rows hand off
+  // producer-allocated data, as a socket or file read would: passing the shared
+  // corpus by reference would let an unbounded hand-off buffer an arbitrary lead
+  // for the cost of its queue nodes alone, hiding exactly the retention the rows
+  // exist to measure.
+  def freshChunk(chunk: Data): Data =
+    java.util.Arrays.copyOf(chunk.asInstanceOf[scala.Array[Byte]], chunk.length).nn
+    . asInstanceOf[Data]
+
   // Int rather than Long: ZIO's `take`/`drop` are `Int`-counted, and both values
   // fit; Soundness's and FS2's `Long`-counted versions widen automatically.
   val dropBytes: Int = 65536
@@ -1061,7 +1070,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         '{
             val (intake, stream) = Conduit[Data]()
             val producer = Thread.ofVirtual.start(() =>
-              turbulence.Benchmarks.inputChunks.each(intake.put)
+              turbulence.Benchmarks.inputChunks.each: chunk =>
+                intake.put(turbulence.Benchmarks.freshChunk(chunk))
               intake.finish())
             var total = 0L
             stream.sweep: region =>
@@ -1077,7 +1087,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             val queue = new java.util.concurrent.LinkedBlockingQueue[AnyRef]()
             val end = new Object
             val producer = Thread.ofVirtual.start(() =>
-              turbulence.Benchmarks.inputChunks.each(chunk => queue.put(chunk.asInstanceOf[AnyRef]))
+              turbulence.Benchmarks.inputChunks.each: chunk =>
+                queue.put(turbulence.Benchmarks.freshChunk(chunk).asInstanceOf[AnyRef])
               queue.put(end))
             var total = 0L
             var running = true
@@ -1094,7 +1105,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         '{
             val relay = Relay[Data]()
             val producer = Thread.ofVirtual.start(() =>
-              turbulence.Benchmarks.inputChunks.each(relay.put)
+              turbulence.Benchmarks.inputChunks.each: chunk =>
+                relay.put(turbulence.Benchmarks.freshChunk(chunk))
               relay.stop())
             var total = 0L
             relay.stream.records.each: chunk =>
@@ -1110,7 +1122,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             val program = fs2.concurrent.Channel.unbounded[IO, fs2.Chunk[Byte]].flatMap: channel =>
               val produce =
                 turbulence.Benchmarks.inputChunkList.foldLeft(IO.unit): (io, chunk) =>
-                  io *> channel.send(fs2.Chunk.array(chunk.asInstanceOf[scala.Array[Byte]])).void
+                  io *> channel.send(fs2.Chunk.array(
+                    turbulence.Benchmarks.freshChunk(chunk).asInstanceOf[scala.Array[Byte]])).void
                 *> channel.close.void
               produce.start *> channel.stream.compile.fold(0L): (acc, chunk) =>
                 acc + chunk.size + (turbulence.Benchmarks.burn(chunk.size) & 1L)
@@ -1123,7 +1136,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               import zio.*, zio.stream.*
               val source =
                 ZStream.fromIterable
-                  (turbulence.Benchmarks.inputChunkList.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
+                  (turbulence.Benchmarks.inputChunkList.map: c =>
+                    Chunk.fromArray(turbulence.Benchmarks.freshChunk(c).asInstanceOf[scala.Array[Byte]]))
               for
                 queue <- Queue.unbounded[Take[Nothing, Chunk[Byte]]]
                 _     <- source.runIntoQueue(queue).fork
@@ -1288,7 +1302,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         '{
             val (intake, stream) = Conduit[Data]()
             val producer = Thread.ofVirtual.start(() =>
-              turbulence.Benchmarks.inputChunks.each(intake.put)
+              turbulence.Benchmarks.inputChunks.each: chunk =>
+                intake.put(turbulence.Benchmarks.freshChunk(chunk))
               intake.finish())
             var total = 0L
             stream.sweep: region =>
@@ -1304,7 +1319,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             val queue = new java.util.concurrent.LinkedBlockingQueue[AnyRef]()
             val end = new Object
             val producer = Thread.ofVirtual.start(() =>
-              turbulence.Benchmarks.inputChunks.each(chunk => queue.put(chunk.asInstanceOf[AnyRef]))
+              turbulence.Benchmarks.inputChunks.each: chunk =>
+                queue.put(turbulence.Benchmarks.freshChunk(chunk).asInstanceOf[AnyRef])
               queue.put(end))
             var total = 0L
             var running = true
@@ -1321,7 +1337,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         '{
             val relay = Relay[Data]()
             val producer = Thread.ofVirtual.start(() =>
-              turbulence.Benchmarks.inputChunks.each(relay.put)
+              turbulence.Benchmarks.inputChunks.each: chunk =>
+                relay.put(turbulence.Benchmarks.freshChunk(chunk))
               relay.stop())
             var total = 0L
             relay.stream.records.each: chunk =>
@@ -1337,7 +1354,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             val program = fs2.concurrent.Channel.unbounded[IO, fs2.Chunk[Byte]].flatMap: channel =>
               val produce =
                 turbulence.Benchmarks.inputChunkList.foldLeft(IO.unit): (io, chunk) =>
-                  io *> channel.send(fs2.Chunk.array(chunk.asInstanceOf[scala.Array[Byte]])).void
+                  io *> channel.send(fs2.Chunk.array(
+                    turbulence.Benchmarks.freshChunk(chunk).asInstanceOf[scala.Array[Byte]])).void
                 *> channel.close.void
               produce.start *> channel.stream.compile.fold(0L): (acc, chunk) =>
                 acc + chunk.size + (turbulence.Benchmarks.burn(chunk.size) & 1L)
@@ -1350,7 +1368,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               import zio.*, zio.stream.*
               val source =
                 ZStream.fromIterable
-                  (turbulence.Benchmarks.inputChunkList.map(c => Chunk.fromArray(c.asInstanceOf[scala.Array[Byte]])))
+                  (turbulence.Benchmarks.inputChunkList.map: c =>
+                    Chunk.fromArray(turbulence.Benchmarks.freshChunk(c).asInstanceOf[scala.Array[Byte]]))
               for
                 queue <- Queue.unbounded[Take[Nothing, Chunk[Byte]]]
                 _     <- source.runIntoQueue(queue).fork
@@ -1370,7 +1389,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         '{
             val (intake, stream) = Conduit[Data]()
             val producer = Thread.ofVirtual.start(() =>
-              turbulence.Benchmarks.inputChunks.each(intake.put)
+              turbulence.Benchmarks.inputChunks.each: chunk =>
+                intake.put(turbulence.Benchmarks.freshChunk(chunk))
               intake.finish())
             var total = 0L
             stream.sweep: region =>
@@ -1386,7 +1406,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             val queue = new java.util.concurrent.LinkedBlockingQueue[AnyRef]()
             val end = new Object
             val producer = Thread.ofVirtual.start(() =>
-              turbulence.Benchmarks.inputChunks.each(chunk => queue.put(chunk.asInstanceOf[AnyRef]))
+              turbulence.Benchmarks.inputChunks.each: chunk =>
+                queue.put(turbulence.Benchmarks.freshChunk(chunk).asInstanceOf[AnyRef])
               queue.put(end))
             var total = 0L
             var running = true
@@ -1403,7 +1424,8 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         '{
             val relay = Relay[Data]()
             val producer = Thread.ofVirtual.start(() =>
-              turbulence.Benchmarks.inputChunks.each(relay.put)
+              turbulence.Benchmarks.inputChunks.each: chunk =>
+                relay.put(turbulence.Benchmarks.freshChunk(chunk))
               relay.stop())
             var total = 0L
             relay.stream.records.each: chunk =>

--- a/lib/turbulence/src/core/turbulence.Confluence.scala
+++ b/lib/turbulence/src/core/turbulence.Confluence.scala
@@ -123,6 +123,9 @@ object Confluence:
 
               source.skip(count)
 
+              // A full queue parks this pump here. There is no reader-side
+              // close to release an abandoned merge: the pumps are children of
+              // the enclosing scope, and cancelling it interrupts the put.
               queue.put
                 (Block(storage.asInstanceOf[AnyRef], if stable then start else 0, count))
 

--- a/lib/turbulence/src/core/turbulence.Divergence.scala
+++ b/lib/turbulence/src/core/turbulence.Divergence.scala
@@ -189,6 +189,12 @@ object Divergence:
 
                   case _ =>
                     panic(m"unexpected value in manifold hand-off")
+
+          // A departing subscriber closes its own ring: buffered blocks are
+          // discarded, a pump parked on this ring is released, and later offers
+          // are dropped — so an abandoned slow subscriber cannot wedge the
+          // fan-out for every other subscriber.
+          override update def close(): Unit = queue.close()
         )
 
       // The cast target elides the elements' `^`: the cast is erased either way, and a

--- a/lib/turbulence/src/core/turbulence.Relay.scala
+++ b/lib/turbulence/src/core/turbulence.Relay.scala
@@ -50,6 +50,12 @@ import zephyrine.*
 // instead of paying one hand-off per element. (`Conduit` is the byte/char
 // counterpart: strictly SPSC and block-structured. A relay is for
 // many-producer, record-granularity traffic: events, notifications, messages.)
+//
+// Unbounded BY CONTRACT, not oversight: producers must never block, because a
+// relay is the bus that fans many writers into one drain — HTTP/2's outbound
+// frame multiplexer relies on it, where a blocking `put` would risk
+// distributed deadlock between streams. Anything needing a bounded hand-off is
+// a `Conduit`; a relay's discipline is its single consumer.
 object Relay:
   private object Termination extends scala.caps.Pure
 

--- a/lib/turbulence/src/core/turbulence.Sink.scala
+++ b/lib/turbulence/src/core/turbulence.Sink.scala
@@ -169,13 +169,13 @@ object Sink:
   // transitional `Writable` bridges below.
   def buffered[target, medium]
     ( target: target, write: (target, Chain[medium]) => Unit )
-    ( using addressable0: medium is Addressable )
+    ( using addressable0: medium is Addressable, buffering: Buffering )
   :   (Intake[medium] over Credit)^{write, caps.any} =
 
     new Intake[medium]:
       type Transport = Credit
 
-      private val block: Int = 2048
+      private val block: Int = buffering.capacity(addressable0.substrate)
       // Untracked, cast-erased: reached only through this endpoint.
       @caps.unsafe.untrackedCaptures
       private val storage: addressable0.Storage =
@@ -183,6 +183,9 @@ object Sink:
       private var mark0: Int = 0
       private var chunks: List[medium] = Nil
 
+      // Honestly unbounded: this intake accumulates every chunk until `finish`
+      // hands them to `write`, so it truly accepts everything — a bound here
+      // would be a fiction, not backpressure.
       def demand: Credit = Credit(Long.MaxValue)
       protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
       def mark: Int = mark0

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -35,6 +35,7 @@ package turbulence
 import scala.caps
 
 import java.io as ji
+import java.util.concurrent.atomic.AtomicLong
 
 import soundness.*
 import proscenium.compat.*
@@ -45,6 +46,7 @@ import strategies.throwUnsafely
 import probates.panicProbate
 import errorDiagnostics.emptyDiagnostics
 
+import scala.collection.immutable as sci
 import scala.collection.mutable as scm
 
 object Tests extends Suite(m"Turbulence tests"):
@@ -478,6 +480,18 @@ object Tests extends Suite(m"Turbulence tests"):
           unsafely(scala.caps.unsafe.unsafeAssumeSeparate(reader.await()))
       . assert(_ == Set.from(for index <- 1 to 4; value <- 1 to 25 yield t"${index*100 + value}"))
 
+      // The relay's contract is that producers never block: it is the many-producer
+      // record bus (HTTP/2's outbound frame mux relies on this to avoid distributed
+      // deadlock), so its buffering is unbounded by design. A bounded relay would
+      // wedge this test, which writes far more than any plausible bound with no
+      // reader attached.
+      test(m"relay puts never block, even with no reader"):
+        val relay = Relay[Text]()
+        for _ <- 1 to 100000 do relay.put(t"x")
+        relay.stop()
+        relay.stream.records.to(List).length
+      . assert(_ == 100000)
+
       test(m"per-producer order is preserved through the relay"):
         supervise:
           val relay = Relay[Text]()
@@ -760,6 +774,89 @@ object Tests extends Suite(m"Turbulence tests"):
             true
       . assert(identity)
 
+      // With no reader, the four pumps may pull at most the shared queue's capacity
+      // plus one in-flight block each before parking, and no source may run ahead of
+      // that bound: the payload is fifty times larger, so an ungated merge fails by
+      // an order of magnitude. Draining afterwards proves the parked pumps recover.
+      test(m"a slow reader parks every confluence pump uniformly"):
+        supervise:
+          given Buffering = probeBuffering(16, 2)
+          val counters = sci.IndexedSeq.fill(4)(AtomicLong(0))
+          val builder = scala.collection.immutable.List.newBuilder[AnyRef]
+          var index = 0
+
+          while index < 4 do
+            builder += Meter(chunkStream(256), counters(index)).asInstanceOf[AnyRef]
+            index += 1
+
+          val merged = Confluence(builder.result().map(_.asInstanceOf[Stream[Data] over Credit])*)
+          awaitStability(counters)
+
+          // Queue capacity is `depth.max(sources.length)` transfer blocks: four, plus
+          // one snapshotted block in flight per parked pump.
+          val bounded = counters.map(_.get()).forall(_ <= 80L)
+          val gather = Gather2()
+          merged.pump(gather)
+
+          ( bounded,
+            counters.map(_.get()).forall(_ == 4096L),
+            scala.caps.unsafe.unsafeAssumeSeparate(gather.data).readable.length )
+      . assert(_ == ((true, true, 16384)))
+
+      test(m"cancelling the confluence scope releases parked pumps"):
+        supervise:
+          val counters = sci.IndexedSeq.fill(4)(AtomicLong(0))
+
+          val outer = async:
+            given Buffering = probeBuffering(16, 2)
+            val builder = scala.collection.immutable.List.newBuilder[AnyRef]
+            var index = 0
+
+            while index < 4 do
+              builder += Meter(chunkStream(256), counters(index)).asInstanceOf[AnyRef]
+              index += 1
+
+            val merged =
+              Confluence(builder.result().map(_.asInstanceOf[Stream[Data] over Credit])*)
+
+            // Never read: the pumps fill the queue and park, and only cancellation
+            // of this scope may release them. The sleep is interrupted by `cancel`.
+            Thread.sleep(3600000)
+
+          awaitStability(counters)
+          outer.cancel()
+          true
+      . assert(identity)
+
+      // One subscriber is never refilled, so its full ring parks the pump: the
+      // metered source must stop within the ring-plus-in-flight bound even while the
+      // other subscriber drains freely. Draining the stalled subscriber then releases
+      // the pump and both must receive the complete payload.
+      test(m"the slowest subscriber gates the divergence pump"):
+        supervise:
+          given Buffering = probeBuffering(16, 2)
+          val counter = AtomicLong(0)
+          val subscribers = Divergence(Meter(chunkStream(256), counter), 2)
+          val eager = subscribers(0)
+          val stalled = subscribers(1)
+          val gatherA = Gather2()
+
+          val taskA = caps.unsafe.unsafeAssumePure:
+            async:
+              scala.caps.unsafe.unsafeAssumeSeparate(eager.pump(gatherA))
+              scala.caps.unsafe.unsafeAssumeSeparate(gatherA.data).readable.length
+
+          awaitStability(sci.IndexedSeq(counter))
+          val gated = counter.get()
+          val gatherB = Gather2()
+          scala.caps.unsafe.unsafeAssumeSeparate(stalled.pump(gatherB))
+
+          ( gated <= 64L,
+            taskA.await(),
+            scala.caps.unsafe.unsafeAssumeSeparate(gatherB.data).readable.length,
+            counter.get() )
+      . assert(_ == ((true, 4096, 4096, 4096L)))
+
       // `OutputStream.write` permits the caller to reuse its array afterwards, and the chunk
       // is read only when the stream is consumed, so aliasing the caller's array would let a
       // later write rewrite bytes already handed over.
@@ -807,3 +904,63 @@ class Gather2() extends Intake[Data]:
     if mark1 > 0 then
       addressable.cloneStorage(storage, 0, mark1)(target)
       mark1 = 0
+
+// Passes refills through unchanged, counting the bytes the consumer skips past
+// into an external counter, so backpressure tests can observe how far a pump has
+// pulled a source without touching the live endpoint.
+class Meter(consume underlying0: (Stream[Data] over Credit)^, counter: AtomicLong)
+extends Stream[Data]:
+  type Transport = Credit
+
+  // The adopted stream is held through a neutral carrier: Stream is deliberately not
+  // Unscoped, so an exclusive field would be read-only; the accessor re-asserts the
+  // ownership this wrapper took at construction.
+  private val held: AnyRef = underlying0.asInstanceOf[AnyRef]
+
+  private def underlying: (Stream[Data] over Credit)^ =
+    held.asInstanceOf[(Stream[Data] over Credit)^]
+
+  update def refill(demand: Credit): Optional[Int] = underlying.refill(demand)
+
+  protected def storage0: AnyRef =
+    val current = underlying
+    unsafely(current.storage).asInstanceOf[AnyRef]
+
+  def start: Int = underlying.start
+  def limit: Int = underlying.limit
+
+  update def skip(count: Int): Unit =
+    counter.addAndGet(count.toLong)
+    underlying.skip(count)
+
+  override update def close(): Unit = underlying.close()
+
+// A tiny buffering policy for the backpressure tests: staging, transfer and
+// hand-off blocks all collapse to `block` and recycling is off, so blocking
+// states are reached with a few tens of bytes and the block arithmetic in
+// assertions is exact.
+def probeBuffering(block: Int, depth0: Int): Buffering = new Buffering:
+  def capacity(substrate: Substrate): Int = block
+  def depth: Int = depth0
+  override def transfer(substrate: Substrate): Int = block
+  override def recycle: Boolean = false
+
+// A transient (non-region-stable) source of `chunks` sixteen-byte blocks: fan-in
+// and fan-out snapshot such sources block-by-block, which is the bounded path
+// the gating tests exercise.
+def chunkStream(chunks: Int): (Stream[Data] over Credit)^ =
+  Iterator.fill(chunks)(Data.fill(16)(_.toByte)).stream
+
+// Poll (bounded) until two consecutive samples of every counter agree, i.e. the
+// pumps have gone quiet. A too-early return can only under-read a counter, so a
+// correct implementation can never fail its bound by sampling here.
+def awaitStability(counters: sci.IndexedSeq[AtomicLong]): Unit =
+  var previous: sci.IndexedSeq[Long] = counters.map(_.get())
+  var stable: Boolean = false
+  var attempts: Int = 0
+
+  while !stable && attempts < 500 do
+    Thread.sleep(10)
+    val current = counters.map(_.get())
+    if current == previous then stable = true else previous = current
+    attempts += 1

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -857,6 +857,37 @@ object Tests extends Suite(m"Turbulence tests"):
             counter.get() )
       . assert(_ == ((true, 4096, 4096, 4096L)))
 
+      // Closing a subscriber's stream closes its ring: the pump, parked on the
+      // abandoned subscriber, is released, its later offers to that ring are
+      // discarded, and the surviving subscriber still receives the full payload.
+      test(m"closing a divergence subscriber releases the pump"):
+        supervise:
+          given Buffering = probeBuffering(16, 2)
+          val counter = AtomicLong(0)
+          val subscribers = Divergence(Meter(chunkStream(256), counter), 2)
+          val eager = subscribers(0)
+          val abandoned = subscribers(1)
+          awaitStability(sci.IndexedSeq(counter))
+          scala.caps.unsafe.unsafeAssumeSeparate(abandoned.close())
+          val gather = Gather2()
+          scala.caps.unsafe.unsafeAssumeSeparate(eager.pump(gather))
+
+          ( scala.caps.unsafe.unsafeAssumeSeparate(gather.data).readable.length,
+            counter.get() )
+      . assert(_ == ((4096, 4096L)))
+
+      test(m"sink.buffered stages by the buffering block size"):
+        given Buffering = probeBuffering(7, 2)
+        var sizes: sci.List[Int] = sci.Nil
+
+        val intake = Sink.buffered[Unit, Data]
+          ((), (_, chunks) => sizes = chunks.stdlib.to(sci.List).map(_.length))
+
+        intake.put(Data.fill(8)(_.toByte))
+        intake.finish()
+        sizes
+      . assert(_ == sci.List(7, 1))
+
       // `OutputStream.write` permits the caller to reuse its array afterwards, and the chunk
       // is read only when the stream is consumed, so aliasing the caller's array would let a
       // later write rewrite bytes already handed over.

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -1679,7 +1679,7 @@ object Xml extends Tag.Container
     ( using formatting: Formatting, monitor: Monitor, probate: Probate )
   :   Iterator[Text] =
 
-    val producer = Producer[Text](4096)
+    val producer = Producer[Text]()
 
     async:
       writeDocument(producer, formatting, document)

--- a/lib/zephyrine/src/core/zephyrine.Producer.scala
+++ b/lib/zephyrine/src/core/zephyrine.Producer.scala
@@ -38,6 +38,7 @@ import java.util.concurrent as juc
 
 import anticipation.Data
 import denominative.*
+import vacuous.*
 
 // A sink into which a value of one medium is written in pieces. The same producing code can be
 // driven two ways without duplicating it: `Producer.collect` runs it synchronously and returns the
@@ -52,11 +53,16 @@ object Producer:
   type Bytes = Producer[Data] { type Operand = Byte }
 
   // Streaming: chunks are queued (with backpressure) and drained through `iterator`. The producing
-  // code must run on a separate fiber, since `put` blocks once the queue is full.
-  def apply[medium](block: Int = 4096, depth: Int = 2)(using addr: medium is Addressable)
+  // code must run on a separate fiber, since `put` blocks once the queue is full. The staging
+  // block defaults to the buffering policy's capacity for the medium; `depth` keeps its own
+  // shallow default rather than adopting `Buffering.depth`, since this queue holds materialized
+  // chunks rather than recycled transfer blocks, so a conduit-deep queue would multiply retention
+  // for no measured benefit.
+  def apply[medium](block: Optional[Int] = Unset, depth: Int = 2)
+    ( using addr: medium is Addressable, buffering: Buffering )
   :   (Channel[medium] { type Operand = addr.Operand })^ =
 
-    Channel(block, depth)(using addr)
+    Channel(block.or(buffering.capacity(addr.substrate)), depth)(using addr)
 
   // Synchronous: run `body`, accumulating directly into a builder, and return the whole value. No
   // concurrency, no chunk buffer, and none of the streaming path's single-thread deadlock risk.

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package zephyrine
 
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, AtomicReference}
+
 import soundness.*
 
 import proscenium.compat.*
@@ -1112,6 +1114,252 @@ object Tests extends Suite(m"Zephyrine tests"):
           (lent, rest)
         . assert(_ == (List[Byte](0, 1, 2, 3, 4), List[Byte](5, 6)))
 
+        // The ring holds `Integer.highestOneBit(depth.max(2)*2 - 1)` blocks — two, at
+        // depth 2 — so publishing exactly that many staging blocks single-threadedly
+        // fills it without ever blocking, and demand must then be exactly zero: the
+        // state in which the next hand-off would park the writer.
+        test(m"demand reaches zero exactly when a hand-off would park"):
+          given Buffering = probeBuffering(16, 2)
+
+          Conduit[Data]() match
+           case (intake, stream) =>
+            for _ <- 1 to 2 do
+              intake.reserve(16)
+              intake.commit(16)
+
+            intake.demand.count
+        . assert(_ == 0L)
+
+        test(m"demand recovers block-by-block as the reader drains"):
+          given Buffering = probeBuffering(16, 2)
+
+          Conduit[Data]() match
+           case (intake, stream) =>
+            for _ <- 1 to 2 do
+              intake.reserve(16)
+              intake.commit(16)
+
+            def drain(): Long =
+              stream.refill(Credit(16)) match
+                case count: Int => stream.skip(count)
+                case _          => ()
+
+              intake.demand.count
+
+            (drain(), drain())
+        . assert(_ == ((16L, 32L)))
+
+        // Each block-sized `put` is one ring hand-off: the third parks the writer, so
+        // its progress counter freezes at two, and each block the reader drains lets
+        // exactly one more hand-off through before the writer parks again.
+        test(m"a writer parks on a full conduit and resumes when drained"):
+          given Buffering = probeBuffering(16, 2)
+
+          Conduit[Data]() match
+           case (intake, stream) =>
+            val chunk: Data = Data.fill(16)(_.toByte)
+            val written = AtomicInteger(0)
+
+            val writer = scala.caps.unsafe.unsafeAssumeSeparate:
+              onThread: () =>
+                for _ <- 1 to 8 do
+                  intake.put(chunk)
+                  written.incrementAndGet()
+
+                intake.finish()
+
+            awaitProgress(2, written)
+            val parked = awaitParked(writer)
+            val frozen = written.get()
+
+            stream.refill(Credit(16)) match
+              case count: Int => stream.skip(count)
+              case _          => ()
+
+            // The unpark is asynchronous, so wait for the released hand-off to land
+            // before observing the writer parked again on the next full ring.
+            awaitProgress(3, written)
+            val reparked = awaitParked(writer)
+            val advanced = written.get()
+
+            def drain(total: Int): Int = stream.refill(Credit(16)) match
+              case count: Int =>
+                stream.skip(count)
+                drain(total + count)
+
+              case _ => total
+
+            val rest = drain(0)
+            writer.join(10000)
+            (parked, frozen, reparked, advanced, 16 + rest)
+        . assert(_ == ((true, 2, true, 3, 128)))
+
+        // Committed-but-unconsumed data can occupy at most the ring (two blocks), the
+        // writer's staging block and one sub-block chunk mid-copy: sampling after
+        // every drained window must never observe more, however the threads
+        // interleave. An unbounded hand-off would exceed this by orders of magnitude.
+        test(m"in-flight conduit data never exceeds the configured bound"):
+          given Buffering = probeBuffering(16, 2)
+
+          Conduit[Data]() match
+           case (intake, stream) =>
+            val chunk: Data = Data.fill(8)(_.toByte)
+            val produced = AtomicLong(0)
+
+            val writer = scala.caps.unsafe.unsafeAssumeSeparate:
+              onThread: () =>
+                for _ <- 1 to 2048 do
+                  intake.put(chunk)
+                  produced.addAndGet(8)
+
+                intake.finish()
+
+            var consumed: Long = 0
+            var worst: Long = 0
+
+            def loop(): Unit = stream.refill(Credit(64)) match
+              case count: Int =>
+                stream.skip(count)
+                consumed += count
+                worst = worst.max(produced.get() - consumed)
+                loop()
+
+              case _ => ()
+
+            loop()
+            writer.join(10000)
+            (consumed, worst <= 64L)
+        . assert(_ == ((16384L, true)))
+
+        // With the ring full, the intake's demand is zero: the pump's refill is
+        // granted nothing, it falls into the `reserve(1)` branch, and the writer
+        // parks handing off the next block. Draining the reader side releases it and
+        // the transfer completes.
+        test(m"a pump into a full conduit parks and completes after draining"):
+          given Buffering = probeBuffering(16, 2)
+
+          Conduit[Data]() match
+           case (intake, stream) =>
+            for _ <- 1 to 2 do
+              intake.reserve(16)
+              intake.commit(16)
+
+            val payload: Data = Data.fill(64)(_.toByte)
+
+            val writer = scala.caps.unsafe.unsafeAssumeSeparate:
+              onThread(() => payload.stream.pump(intake))
+
+            val parked = awaitParked(writer)
+
+            def drain(total: Int): Int = stream.refill(Credit(1000)) match
+              case count: Int =>
+                stream.skip(count)
+                drain(total + count)
+
+              case _ => total
+
+            val total = drain(0)
+            writer.join(10000)
+            (parked, total)
+        . assert(_ == ((true, 96)))
+
+        test(m"a two-stage duct chain compounds demand translation"):
+          val recorder = Recorder(small.stream)
+          val gather = Gather()
+          gather.credit = 20
+
+          scala.caps.unsafe.unsafeAssumeSeparate:
+            recorder.viaDuct(Doubler()).viaDuct(Doubler()).pump(gather)
+
+          recorder.demands.last
+        . assert(_ == 5L)
+
+        test(m"a terminal sweep demands the transfer credit from its source"):
+          val recorder = Recorder(small.stream)
+
+          scala.caps.unsafe.unsafeAssumeSeparate:
+            recorder.sweep: region =>
+              range => ()
+
+          recorder.demands.last
+        . assert(_ == summon[Buffering].transfer(Substrate.Bytes).toLong)
+
+      suite(m"Handoff backpressure tests"):
+        test(m"offer parks only when the ring is full"):
+          val handoff = Handoff(2)
+          handoff.offer("a")
+          handoff.offer("b")
+          val producer = onThread(() => handoff.offer("c"))
+          val parked = awaitParked(producer)
+          handoff.take()
+          producer.join(10000)
+          (parked, producer.isAlive)
+        . assert(_ == ((true, false)))
+
+        test(m"take parks on an empty ring until an offer"):
+          val handoff = Handoff(2)
+          val received = AtomicReference[AnyRef | Null](null)
+          val consumer = onThread(() => received.set(handoff.take()))
+          val parked = awaitParked(consumer)
+          handoff.offer("x")
+          consumer.join(10000)
+          (parked, received.get())
+        . assert(_ == ((true, "x")))
+
+        test(m"interrupting a parked producer raises InterruptedException"):
+          val handoff = Handoff(2)
+          handoff.offer("a")
+          handoff.offer("b")
+          val caught = AtomicReference[Throwable | Null](null)
+
+          val producer = onThread: () =>
+            try handoff.offer("c") catch case error: InterruptedException => caught.set(error)
+
+          val parked = awaitParked(producer)
+          producer.interrupt()
+          producer.join(10000)
+          (parked, caught.get() != null)
+        . assert(_ == ((true, true)))
+
+        test(m"interrupting a parked consumer raises InterruptedException"):
+          val handoff = Handoff(2)
+          val caught = AtomicReference[Throwable | Null](null)
+
+          val consumer = onThread: () =>
+            try handoff.take() catch case error: InterruptedException => caught.set(error)
+
+          val parked = awaitParked(consumer)
+          consumer.interrupt()
+          consumer.join(10000)
+          (parked, caught.get() != null)
+        . assert(_ == ((true, true)))
+
+        test(m"close releases a parked producer and discards later offers"):
+          val handoff = Handoff(2)
+          handoff.offer("a")
+          handoff.offer("b")
+          val producer = onThread(() => handoff.offer("c"))
+          val parked = awaitParked(producer)
+          handoff.close()
+          producer.join(10000)
+          handoff.offer("d")
+          (parked, producer.isAlive, handoff.size)
+        . assert(_ == ((true, false, 0)))
+
+        test(m"free tracks occupancy across offers and takes"):
+          val handoff = Handoff(4)
+          val initial = handoff.free
+          handoff.offer("a")
+          val one = handoff.free
+          handoff.offer("b")
+          val two = handoff.free
+          handoff.take()
+          val three = handoff.free
+          handoff.take()
+          val four = handoff.free
+          (initial, one, two, three, four)
+        . assert(_ == ((4, 3, 2, 3, 4)))
+
 
   // A reference-typed record for the boxed-medium (record stream) tests.
   case class Row(id: Int)
@@ -1246,3 +1494,38 @@ object Tests extends Suite(m"Zephyrine tests"):
     def start: Int = underlying.start
     def limit: Int = underlying.limit
     update def skip(count: Int): Unit = underlying.skip(count)
+
+  // A tiny buffering policy for the backpressure tests: staging, transfer and
+  // hand-off blocks all collapse to `block` and recycling is off, so blocking
+  // states are reached with a few tens of bytes and the block arithmetic in
+  // assertions is exact.
+  def probeBuffering(block: Int, depth0: Int): Buffering = new Buffering:
+    def capacity(substrate: Substrate): Int = block
+    def depth: Int = depth0
+    override def transfer(substrate: Substrate): Int = block
+    override def recycle: Boolean = false
+
+  // A platform thread running `action`: the park-observation tests inspect the
+  // thread's state, which a virtual thread does not report as `WAITING`.
+  def onThread(action: () => Unit): Thread = Thread.ofPlatform().nn.start(() => action()).nn
+
+  // Poll (bounded) until `counter` reaches `expected`; a counter frozen short of it
+  // fails the caller's assertion. Only ever used to await progress the test has made
+  // inevitable: the bound is the test's patience, not synchronization.
+  def awaitProgress(expected: Int, counter: AtomicInteger): Unit =
+    var attempts: Int = 0
+
+    while counter.get() < expected && attempts < 5000 do
+      attempts += 1
+      Thread.sleep(1)
+
+  // Poll (bounded) until `thread` is parked. Only ever used to await a state the
+  // test has made inevitable: the bound is the test's patience, not synchronization.
+  def awaitParked(thread: Thread): Boolean =
+    var attempts: Int = 0
+
+    while thread.getState != Thread.State.WAITING && attempts < 5000 do
+      attempts += 1
+      Thread.sleep(1)
+
+    thread.getState == Thread.State.WAITING


### PR DESCRIPTION
This PR turns the streaming layer's backpressure story from prose into verified behaviour: new tests pin the kernel's park/resume, bounded in-flight-data and demand-translation mechanics, fan-in/fan-out gating and cancellation release; new benchmarks measure backpressure against deliberately unbounded hand-off models (raw `LinkedBlockingQueue`, `Relay`, FS2/ZIO unbounded) and sweep the `Conduit` ring depth; the tuning surface is unified under `Buffering` (`Sink.buffered` and `Producer` no longer hardcode staging sizes); closing a `Divergence` subscriber now releases a pump parked on its ring (previously an abandoned slow subscriber wedged the fan-out permanently); and HTTP/2 gains real receive-side flow control — a finite advertised window (1 MiB default, tunable per connection) replenished only as the application drains the body, so a stalled consumer stalls the peer's sender.

### Release notes

- **Backpressure test coverage**: `Handoff` ring park/unpark/interrupt/close semantics, `Conduit` writer parking and in-flight bounds, pump stall/recovery, multi-stage demand translation, `Confluence` uniform pump gating, `Divergence` slowest-subscriber gating, `Relay`'s producers-never-block contract.
- **`Buffering` is now the single tuning surface**: `Sink.buffered` and `Producer` take their staging block sizes from the policy in scope instead of private constants (`Producer(block = …)` still overrides per call).
- **`Divergence` subscribers can leave**: `close()` on a subscriber's stream closes its ring, releasing the pump; other subscribers are unaffected.
- **HTTP/2 receive-side flow control**: both roles advertise a finite window and defer `WINDOW_UPDATE` to consumption, batched at half-window granularity. Tune per connection:
  ```scala
  Http2.Connection(duplex, window = 65536)
  ```
- **New benchmarks**: `Conduit` depth sweep, slow-consumer backpressure-vs-unbounded suites (throughput, constrained-heap sweep, retained memory), fan-out with one dragging subscriber.
- **Docs**: a "Tuning backpressure" section in the streams topic doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
