### PR TITLE
Honour the peer's flow-control windows and frame size in the HTTP/2 client

### DIFF
--- a/lib/telekinesis/src/http2/telekinesis.Http2.scala
+++ b/lib/telekinesis/src/http2/telekinesis.Http2.scala
@@ -500,6 +500,10 @@ object Http2:
     // otherwise.
     private[telekinesis] val defaultWindow: Int = 65535
 
+    // The HTTP/2 default maximum frame size (RFC 7540 §6.5.2): the largest
+    // DATA payload we may send until the peer's SETTINGS raise it.
+    private[telekinesis] val defaultMaxFrame: Int = 16384
+
     // Our advertised receive budget, per stream and (via an initial
     // connection-level WINDOW_UPDATE) per connection: the peer may have at most
     // this many unconsumed bytes in flight, which is what bounds the inbound
@@ -523,8 +527,16 @@ object Http2:
       ( using Tactic[Http2.Error] )
     :   Boolean =
       frame match
-        case Frame.Settings(_, ack) =>
+        case Frame.Settings(settings, ack) =>
           if !ack then
+            // Adopt the peer's advertised initial per-stream send window and
+            // maximum frame size, which bound our request-body DATA frames.
+            settings.stdlib.find(_.id == SettingId.InitialWindowSize.id).foreach: setting =>
+              conn.peerInitialWindow.set(setting.value.toInt)
+
+            settings.stdlib.find(_.id == SettingId.MaxFrameSize.id).foreach: setting =>
+              conn.peerMaxFrame.set(setting.value.toInt)
+
             conn.send(Frame.Settings(Nil, ack = true))
             conn.started.offer(())
 
@@ -566,9 +578,19 @@ object Http2:
             stream.end()
             conn.streams.remove(id)
 
+          conn.streamWindows.remove(id)
           true
 
-        case Frame.WindowUpdate(_, _) | Frame.Continuation(_, _, _) | Frame.Ignored(_, _) =>
+        // An inbound WINDOW_UPDATE grants send credit: on stream 0 it tops up
+        // the connection window, otherwise the named stream's window (RFC 7540
+        // §6.9) — releasing a request-body upload parked at exhaustion.
+        case Frame.WindowUpdate(id, increment) =>
+          if id == 0 then conn.connWindow.release(increment)
+          else conn.streamWindows.get(id).foreach(_.release(increment))
+
+          true
+
+        case Frame.Continuation(_, _, _) | Frame.Ignored(_, _) =>
           true
 
   // One outbound request stream's receive side: a promise for its response header
@@ -594,6 +616,18 @@ object Http2:
     // per DATA frame.
     private val connPending: juca.AtomicInteger = juca.AtomicInteger(0)
     private val threshold: Int = (window/2).max(1)
+
+    // Send-side flow control (RFC 7540 §6.9), as the server role: the
+    // connection window, per-stream windows created lazily at the peer's
+    // advertised initial size, and the peer's advertised limits from SETTINGS.
+    private[telekinesis] val connWindow: FlowWindow = FlowWindow(defaultWindow)
+    private[telekinesis] val streamWindows: scc.TrieMap[Int, FlowWindow] = scc.TrieMap()
+
+    private[telekinesis] val peerInitialWindow: juca.AtomicInteger =
+      juca.AtomicInteger(defaultWindow)
+
+    private[telekinesis] val peerMaxFrame: juca.AtomicInteger =
+      juca.AtomicInteger(defaultMaxFrame)
 
     private def send(frame: Frame): Unit = outbound.put(frame)
 
@@ -700,7 +734,14 @@ object Http2:
 
       send(Frame.Headers(id, encoder.encode(headerBlock), endStream = noBody, endHeaders = true))
 
-      body.let: payload => send(Frame.Data(id, payload, endStream = true))
+      // The body drains under the peer's flow-control windows and frame-size
+      // limit, so a large upload parks this (requesting) fiber at window
+      // exhaustion until the peer's WINDOW_UPDATEs grant more.
+      body.let: payload =>
+        val streamWindow = streamWindows.getOrElseUpdate(id, FlowWindow(peerInitialWindow.get))
+
+        sendFlowControlled
+          (id, payload, endStream = true, connWindow, streamWindow, peerMaxFrame.get, send)
 
       stream
 
@@ -824,6 +865,40 @@ object Http2:
       if !trailers.ready then trailers.offer(Nil)
       body.stop()
 
+  // Send `payload` as DATA frames on `streamId`, honouring the peer's
+  // flow-control windows (RFC 7540 §6.9) and its maximum frame size (§6.5.2):
+  // each chunk is bounded by the connection window, the stream window and
+  // SETTINGS_MAX_FRAME_SIZE, and the calling fiber parks when a window is
+  // exhausted until an inbound WINDOW_UPDATE tops it up. An empty payload
+  // carries no data and is sent immediately (its only role is `endStream`);
+  // otherwise `endStream` rides the final chunk. Shared by both roles: the
+  // server's response bodies and the client's request bodies drain identically.
+  private def sendFlowControlled
+    ( streamId:     Int,
+      payload:      Bytes,
+      endStream:    Boolean,
+      connWindow:   FlowWindow,
+      streamWindow: FlowWindow,
+      maxFrame:     Int,
+      emit:         Frame => Unit )
+  :   Unit =
+
+    if payload.length == 0 then emit(Frame.Data(streamId, payload, endStream)) else
+      var offset = 0
+
+      while offset < payload.length do
+        val remaining = (payload.length - offset).min(maxFrame.max(1))
+        // Acquire connection credit first, then stream credit up to that, and
+        // return any connection surplus the stream could not match.
+        val connChunk = connWindow.acquire(remaining)
+        val streamChunk = streamWindow.acquire(connChunk)
+        if streamChunk < connChunk then connWindow.release(connChunk - streamChunk)
+
+        val chunk: Bytes = payload.slice(offset, offset + streamChunk)
+        val last: Boolean = endStream && offset + streamChunk == payload.length
+        emit(Frame.Data(streamId, chunk, last))
+        offset += streamChunk
+
   // Http2ServerConnection → Http2.ServerConnection
   object ServerConnection:
     // Our advertised SETTINGS: our receive-side stream window (see
@@ -850,6 +925,9 @@ object Http2:
             // retroactively adjusted — a deliberate simplification).
             settings.stdlib.find(_.id == SettingId.InitialWindowSize.id).foreach: setting =>
               conn.peerInitialWindow.set(setting.value.toInt)
+
+            settings.stdlib.find(_.id == SettingId.MaxFrameSize.id).foreach: setting =>
+              conn.peerMaxFrame.set(setting.value.toInt)
 
             conn.send(Frame.Settings(Nil, ack = true))
             conn.started.offer(())
@@ -947,6 +1025,9 @@ object Http2:
     private[telekinesis] val connWindow: FlowWindow = FlowWindow(defaultWindow)
     private[telekinesis] val streamWindows: scc.TrieMap[Int, FlowWindow] = scc.TrieMap()
     private[telekinesis] val peerInitialWindow: juca.AtomicInteger = juca.AtomicInteger(defaultWindow)
+
+    private[telekinesis] val peerMaxFrame: juca.AtomicInteger =
+      juca.AtomicInteger(Connection.defaultMaxFrame)
 
     // Streams opened by the client, in arrival order; the serve loop takes each
     // and runs its handler. Stopped when the connection ends.
@@ -1055,28 +1136,12 @@ object Http2:
       send(Frame.Headers(streamId, encoder.encode(entries), endStream, endHeaders = true))
 
     // Send `payload` as DATA on `streamId`, honouring the peer's flow-control
-    // windows (RFC 7540 §6.9): the payload drains in chunks bounded by the
-    // connection and stream send windows, blocking the calling (per-stream) fiber
-    // when a window is exhausted until an inbound WINDOW_UPDATE tops it up. An
-    // empty payload carries no data and is sent immediately (its only role is
-    // `endStream`). `endStream` rides the final chunk.
+    // windows and frame-size limit; see `sendFlowControlled`. Blocks the
+    // calling (per-stream) fiber at window exhaustion.
     def sendData(streamId: Int, payload: Bytes, endStream: Boolean): Unit =
-      if payload.length == 0 then send(Frame.Data(streamId, payload, endStream)) else
-        val streamWindow = streamWindows.getOrElseUpdate(streamId, FlowWindow(peerInitialWindow.get))
-        var offset = 0
-
-        while offset < payload.length do
-          val remaining = payload.length - offset
-          // Acquire connection credit first, then stream credit up to that, and
-          // return any connection surplus the stream could not match.
-          val connChunk = connWindow.acquire(remaining)
-          val streamChunk = streamWindow.acquire(connChunk)
-          if streamChunk < connChunk then connWindow.release(connChunk - streamChunk)
-
-          val chunk: Bytes = payload.slice(offset, offset + streamChunk)
-          val last: Boolean = endStream && offset + streamChunk == payload.length
-          send(Frame.Data(streamId, chunk, last))
-          offset += streamChunk
+      val streamWindow = streamWindows.getOrElseUpdate(streamId, FlowWindow(peerInitialWindow.get))
+      sendFlowControlled
+        (streamId, payload, endStream, connWindow, streamWindow, peerMaxFrame.get, send)
 
     // Send a trailing HEADERS block (always end-stream) on `streamId` — the
     // response trailers, e.g. gRPC's `grpc-status`. A response with trailers must

--- a/lib/telekinesis/src/test/telekinesis.Http2Tests.scala
+++ b/lib/telekinesis/src/test/telekinesis.Http2Tests.scala
@@ -531,6 +531,103 @@ object Http2Tests extends Suite(m"Telekinesis HTTP/2 Tests"):
 
       . assert(_ == (4, 20000, 20))
 
+      // The reverse direction: the server advertises a small window and the
+      // client's request-body upload must stall at exactly that window until
+      // WINDOW_UPDATEs grant more — previously the client ignored flow control
+      // entirely and sent the whole body as one frame. A hand-rolled
+      // frame-level peer observes the wire directly, so receipt is counted
+      // without consuming anything.
+      test(m"a client upload stalls at the peer's advertised window"):
+        supervise:
+          val (clientSide, serverSide) = pair()
+          val received = java.util.concurrent.atomic.AtomicLong(0)
+          val streamId = java.util.concurrent.atomic.AtomicInteger(0)
+
+          daemon:
+            safely:
+              serverSide.send(zephyrine.Stream(Frame.Settings(
+                  List(Setting(SettingId.InitialWindowSize.id, 4096)), ack = false).serialize))
+
+              val source = serverSide.source
+              var skipped = 0
+
+              while skipped < 24 do source.refill(zephyrine.Credit(4096)) match
+                case count: Int =>
+                  if count > 0 then
+                    val take = count.min(24 - skipped)
+                    source.skip(take)
+                    skipped += take
+
+                case _ =>
+                  skipped = 24
+
+              val reader = FrameReader(source)
+              var continue = true
+
+              while continue do (reader.next(): @unchecked) match
+                case Unset    => continue = false
+                case f: Frame => f match
+                  case Frame.Settings(_, false) =>
+                    serverSide.send(zephyrine.Stream(Frame.Settings(Nil, ack = true).serialize))
+
+                  case Frame.Headers(id, _, _, _) => streamId.set(id)
+                  case Frame.Data(_, payload, _)  => received.addAndGet(payload.length)
+                  case _                          => ()
+
+          val client = Http2.Connection(clientSide)
+          client.start()
+
+          val payload: Data = Array.tabulate(20000)(i => (i%256).toByte)
+
+          val request = Http.Request(Http.Post, 2.0, unsafely(t"unix".as[Host]), t"/upload",
+              Nil, () => Stream(payload))
+
+          val fetched = scala.caps.unsafe.unsafeAssumeSeparate:
+            async:
+              val (_, response) = client.fetch(request, t"http", t"unix")
+              response.status.code
+
+          // Wait for the first DATA to land, then poll until the wire goes
+          // quiet: a too-early sample can only under-read, and a correct
+          // client freezes at exactly the advertised window.
+          var warm = 0
+
+          while received.get() == 0 && warm < 500 do
+            Thread.sleep(10)
+            warm += 1
+
+          var frozen = -1L
+          var stable = 0
+          var attempts = 0
+
+          while stable < 5 && attempts < 500 do
+            val current = received.get()
+            if current == frozen then stable += 1 else { frozen = current; stable = 0 }
+            Thread.sleep(10)
+            attempts += 1
+
+          // Grant more credit: the parked upload must resume and complete.
+          serverSide.send(zephyrine.Stream(Frame.WindowUpdate(0, 65535).serialize))
+          serverSide.send(zephyrine.Stream(Frame.WindowUpdate(streamId.get, 65535).serialize))
+
+          var drained = 0
+
+          while received.get() < 20000 && drained < 500 do
+            Thread.sleep(10)
+            drained += 1
+
+          val hpack = Hpack()
+          val respHeaders = hpack.encode(List(HpackEntry(t":status", t"200")))
+
+          serverSide.send:
+            zephyrine.Stream(Frame.Headers(streamId.get, respHeaders, true, true).serialize)
+
+          val status = scala.caps.unsafe.unsafeAssumeSeparate(fetched.await())
+          client.close()
+          (frozen, received.get(), status)
+
+      . assert(_ == ((4096L, 20000L, 200)))
+
       test(m"a session lends one connection to several multiplexed requests"):
         supervise:
           val (clientSide, serverSide) = pair()


### PR DESCRIPTION
The HTTP/2 client sent each request body as a single DATA frame, ignoring the peer's advertised windows and `SETTINGS_MAX_FRAME_SIZE` entirely — a protocol violation for any body over 16 KiB (the default frame-size limit) or the peer's stream window (65,535 bytes by default), invisible in-repo only because our own server didn't enforce what it advertised. Uploads and gRPC client-streaming beyond those sizes would fail against compliant servers.

### Release notes

- The client now drains request bodies under the peer's connection window, stream window and maximum frame size, parking the requesting fiber at window exhaustion until the peer grants credit — so a large upload is paced by the receiver, exactly like a server response body.
- The client adopts the peer's `InitialWindowSize` and `MaxFrameSize` from SETTINGS, releases send credit on `WINDOW_UPDATE`, and drops a stream's window on reset.
- The DATA-draining loop is now shared by both roles, which also fixes the server side's missing `SETTINGS_MAX_FRAME_SIZE` cap: response DATA frames no longer exceed the peer's advertised frame size.
- A frame-level test pins the behaviour: against a peer advertising a 4 KiB window, a 20 kB upload freezes at exactly 4,096 bytes on the wire and completes once credit is granted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
