### PR TITLE
Make `delineate` outrun FS2 by splitting bytes before decoding them

### DIFF
--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -177,6 +177,72 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
   lazy val jdkKeyBytes: scala.Array[Byte] = scala.Array.tabulate(32)(i => (i*7 + 1).toByte)
   lazy val jdkIvBytes:  scala.Array[Byte] = scala.Array.tabulate(16)(i => (i*13 + 3).toByte)
 
+  // ── Separator-scan variants (see the "Separator scan" suite) ───────────────
+  //
+  // Each mimics the byte duct's real call pattern — scan to the next separator,
+  // step over it, resume — rather than one pass over the corpus, since entering
+  // and leaving the loop once per line is part of what is being measured. All
+  // three return the line count, so a variant that mis-detects shows up as a
+  // different result.
+
+  // What the duct does today: two comparisons and, because `&&` short-circuits,
+  // two branches per byte.
+  def scanPairwise(bytes: scala.Array[Byte]): Int =
+    var position = 0
+    var lines = 0
+
+    while position < bytes.length do
+      var index = position
+
+      while index < bytes.length && { val byte = bytes(index); byte != 10 && byte != 13 }
+      do index += 1
+
+      lines += 1
+      position = index + 1
+
+    lines
+
+  // 10 and 13 share their top five bits, so one mask-and-compare rejects every
+  // byte outside 8-15 with a single branch; only that range takes the exact
+  // test. Sign extension needs no masking away — the mask clears those bits.
+  // Admits tab (9) as a false positive, which is common in real text.
+  def scanMasked(bytes: scala.Array[Byte]): Int =
+    var position = 0
+    var lines = 0
+
+    while position < bytes.length do
+      var index = position
+
+      while index < bytes.length
+          && { val byte = bytes(index)
+               (byte & 0xf8) != 0x08 || (byte != 10 && byte != 13) }
+      do index += 1
+
+      lines += 1
+      position = index + 1
+
+    lines
+
+  // Adding two maps 10 and 13 onto 12 and 15, which share six bits, so the mask
+  // admits only 10-13: one more operation per byte, but no false positive on
+  // tab — only on VT and FF, which are vanishingly rare.
+  def scanBiased(bytes: scala.Array[Byte]): Int =
+    var position = 0
+    var lines = 0
+
+    while position < bytes.length do
+      var index = position
+
+      while index < bytes.length
+          && { val byte = bytes(index) + 2
+               (byte & 0xfc) != 0x0c || (byte != 12 && byte != 15) }
+      do index += 1
+
+      lines += 1
+      position = index + 1
+
+    lines
+
   // ── Shared run helpers (referenced from the staged bodies) ──────────────────
 
   // ZIO's unsafe-run entry point, wrapping each ZIO benchmark's effect.
@@ -1891,6 +1957,25 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
                 turbulence.Benchmarks.smallQuarters.map(q => ZStream.fromChunk(Chunk.fromArray(q.asInstanceOf[scala.Array[Byte]])))
               ZStream.mergeAllUnbounded()(streams*).runCount
         }
+
+    // Separator scan: the byte duct's inner loop in isolation, over the 4 MB
+    // corpus, one call per line. The question is whether replacing two
+    // comparisons (and, with short-circuiting, two branches) per byte with a
+    // mask-and-compare (one branch) pays, and whether biasing by two to narrow
+    // the false-positive range from 8-15 to 10-13 pays for its extra operation.
+    // Note this corpus has no tabs, which the five-bit mask admits and the
+    // six-bit one does not — on tab-heavy text the biased variant would fare
+    // relatively better than it does here.
+    suite(m"Separator scan variants (4 MB)"):
+      bench(m"Two comparisons per byte")(target = 1*Second, operationSize = textSize):
+        '{ turbulence.Benchmarks.scanPairwise(turbulence.Benchmarks.textArray) }
+
+      bench(m"Mask and compare (admits 8-15)")(target = 1*Second, operationSize = textSize):
+        '{ turbulence.Benchmarks.scanMasked(turbulence.Benchmarks.textArray) }
+
+      bench(m"Bias by two, mask and compare (admits 10-13)")
+        ( target = 1*Second, operationSize = textSize ):
+        '{ turbulence.Benchmarks.scanBiased(turbulence.Benchmarks.textArray) }
 
     // Example T: profiles — where the time actually goes in the pipelines the
     // stress suites measure. Each renders as a histogram of the hottest methods

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -368,9 +368,13 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         }
 
     // Line splitting: UTF-8 decode then split the 4 MB corpus into lines,
-    // counting them. Soundness' `delineate` emits boxed `Array[Text]^{}` windows
-    // of lines and counts records per window with no per-line intermediate;
-    // FS2/ZIO allocate a string per line.
+    // counting them. All three allocate one string per line — `delineate` emits
+    // boxed `Array[Text]^{}` windows and counts records per window, but each
+    // record is still a `Text`. (An earlier comment here claimed Soundness had
+    // "no per-line intermediate"; it did, and the row was slower than FS2 for
+    // it.) The interesting differences are how many times each line is copied on
+    // the way into that string, and how the separator is found: FS2 slices
+    // strings its decoder already built, with the intrinsified `String.indexOf`.
     suite(m"Line splitting (4 MB)"):
       bench(m"Soundness  Stream.delineate")
         ( target = 1*Second, operationSize = textSize ):
@@ -1888,10 +1892,23 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               ZStream.mergeAllUnbounded()(streams*).runCount
         }
 
-    // Example T: profiles — where the time actually goes in the two pipelines the
+    // Example T: profiles — where the time actually goes in the pipelines the
     // stress suites measure. Each renders as a histogram of the hottest methods
     // (self time, from JFR execution samples), coloured by package.
     suite(m"Profile: pipeline hotspots"):
+      // Line splitting is two stages — the UTF-8 decode duct and the separator
+      // duct — so this profile attributes between them, and shows what remains
+      // per line once the fast path has removed the second copy.
+      profile(m"Stream.delineate (4 MB of text)")(target = 5*Second):
+        '{
+            var total = 0L
+
+            turbulence.Benchmarks.textData.stream.delineate
+            . sweep(region => range => total += (range: Interval).size)
+
+            total
+        }
+
       profile(m"Conduit hand-off (4 MB in 64 KiB chunks)")(target = 5*Second):
         '{
             val (intake, stream) = Conduit[Data]()

--- a/lib/turbulence/src/core/turbulence.LineSeparation.scala
+++ b/lib/turbulence/src/core/turbulence.LineSeparation.scala
@@ -104,11 +104,17 @@ object LineSeparation:
           private var out1: Text = "".tt
           private var emitted: Int = 0
 
+          // Stage a line that is already built. `step`'s fast path constructs a
+          // line straight from the source window and stages it here, so the
+          // common case never touches `partial`.
+          private update def emit(line: Text): Unit =
+            if emitted == 0 then out0 = line else out1 = line
+            emitted += 1
+
           private update def newline(): Unit =
             val line = partial.toString.tt
             partial.setLength(0)
-            if emitted == 0 then out0 = line else out1 = line
-            emitted += 1
+            emit(line)
 
           // Apply `action` to the current line state, staging completed lines.
           private update def act(action: LineSeparation.Action): Unit = action match
@@ -138,6 +144,34 @@ object LineSeparation:
               emitted = 0
 
             written
+
+          // The index of the next separator at or after `from`, or `stop` if the
+          // window holds none. An ordinary char is rejected by a single
+          // comparison — both '\n' (10) and '\r' (13) are below 14, so only the
+          // rarer control chars need the exact re-check — and runs are skipped
+          // eight at a time, as `Ductile`'s UTF-8 kernel skips ASCII runs. That
+          // kernel combines its eight with a bitwise OR, which cannot serve here:
+          // OR only sets bits, so it cannot spot a low char among high ones. The
+          // minimum can, and compiles to conditional moves rather than branches.
+          private def scan(chars: scala.Array[Char], from: Int, stop: Int): Int =
+            inline def least(left: Int, right: Int): Int = if left < right then left else right
+
+            inline def lowest(at: Int): Int =
+              least
+               ( least(least(chars(at), chars(at + 1)), least(chars(at + 2), chars(at + 3))),
+                 least(least(chars(at + 4), chars(at + 5)), least(chars(at + 6), chars(at + 7))) )
+
+            var index: Int = from
+            var found: Int = -1
+
+            while found < 0 && index < stop do
+              while index + 8 <= stop && lowest(index) > 13 do index += 8
+
+              if index < stop then
+                val char = chars(index)
+                if char == '\n' || char == '\r' then found = index else index += 1
+
+            if found < 0 then stop else found
 
           update def step(source: Region[Text])(range: Interval in source.type)
             ( target: Slate[Array[Text]^{}] )(space: Interval in target.type)
@@ -195,16 +229,40 @@ object LineSeparation:
                     produced += deliver(slots, targetOffset + produced)
                   else pending = 13
                 else
-                  // Bulk-append the run of ordinary chars up to the next
-                  // separator (or the window's end).
+                  // The run of ordinary chars up to the next separator (or the
+                  // window's end).
                   val start = sourceOffset + consumed
                   val stop = sourceOffset + sourceLength
-                  var end = start
+                  val end = scan(chars, start, stop)
+                  val length = end - start
 
-                  while end < stop && { val c = chars(end); c != '\n' && c != '\r' } do end += 1
+                  // How many chars of a separator the fast path may take, or 0 if
+                  // it does not apply. It applies when no line is carried from an
+                  // earlier window, this line's separator lies inside the window
+                  // with the char that resolves a two-char sequence present, and
+                  // the policy maps that sequence to a plain line break. The line
+                  // is then built with a single copy straight from the source
+                  // window, leaving `partial` out of the common path — and with it
+                  // the second copy, and the coder that `setLength` never resets,
+                  // so a line with a non-Latin-1 char no longer taxes every line
+                  // after it. Everything else falls through to the state machine
+                  // above, which keeps owning every subtle case.
+                  val separator: Int =
+                    if end >= stop || end + 1 >= stop || partial.length > 0 then 0
+                    else if chars(end) == '\n' then
+                      if chars(end + 1) == '\r' then (if stage.lfcr == Action.Nl then 2 else 0)
+                      else if stage.lf == Action.Nl then 1 else 0
+                    else
+                      if chars(end + 1) == '\n' then (if stage.crlf == Action.Nl then 2 else 0)
+                      else if stage.cr == Action.Nl then 1 else 0
 
-                  partial.append(chars, start, end - start)
-                  consumed += end - start
+                  if separator > 0 then
+                    emit(String(chars, start, length).tt)
+                    consumed += length + separator
+                    produced += deliver(slots, targetOffset + produced)
+                  else
+                    partial.append(chars, start, length)
+                    consumed += length
 
             Duct.Progress(consumed, produced)
 

--- a/lib/turbulence/src/core/turbulence.LineSeparation.scala
+++ b/lib/turbulence/src/core/turbulence.LineSeparation.scala
@@ -397,17 +397,26 @@ object LineSeparation:
         written
 
       // The index of the next separator at or after `from`, or `stop` if the
-      // window holds none. Two signed comparisons per byte, and deliberately no
-      // masking: 10 and 13 are positive and every byte of a multi-byte UTF-8
-      // sequence is negative, so a signed test matches neither, and the loop
-      // stays in the shape the JIT vectorises. (Masking to compare unsigned —
-      // which a minimum-of-eight skip like the char duct's would need, since
-      // signed it would see those negatives as candidates — costs far more than
-      // the wide skip saves: it made this scan 46% of the whole pipeline.)
+      // window holds none. 10 and 13 differ only in their bottom three bits, so
+      // one mask-and-compare rejects every byte outside 8-15 — and, because
+      // `&&` short-circuits, does it in a single branch where two comparisons
+      // take two. Only the 8-15 range pays the exact test. Sign extension needs
+      // no masking away, since the mask clears those bits, and every byte of a
+      // multi-byte UTF-8 sequence is negative and so rejected outright.
+      //
+      // Measured at 53% faster than two comparisons per byte over the 4 MB
+      // corpus (the "Separator scan variants" suite, which keeps all three
+      // honest). Tab (9) falls in the admitted range and pays the exact test
+      // where it occurs, which is far cheaper than a second comparison on every
+      // byte; biasing by two to narrow the range to 10-13 and exclude it
+      // measured slower still, its extra operation costing more than the
+      // false positives it avoids.
       private def scan(bytes: scala.Array[Byte], from: Int, stop: Int): Int =
         var index: Int = from
 
-        while index < stop && { val byte = bytes(index); byte != 10 && byte != 13 }
+        while index < stop
+            && { val byte = bytes(index)
+                 (byte & 0xf8) != 0x08 || (byte != 10 && byte != 13) }
         do index += 1
 
         index

--- a/lib/turbulence/src/core/turbulence.LineSeparation.scala
+++ b/lib/turbulence/src/core/turbulence.LineSeparation.scala
@@ -396,33 +396,21 @@ object LineSeparation:
 
         written
 
-      // As the char duct's `scan`, over bytes. The comparison is on the
-      // unsigned value: every byte of a multi-byte UTF-8 sequence has its high
-      // bit set, so unsigned it exceeds 13 and is skipped with the ordinary
-      // bytes, where signed it would be negative and fall to the re-check —
-      // which would forfeit the wide skip on exactly the non-ASCII text that
-      // needs it most.
+      // The index of the next separator at or after `from`, or `stop` if the
+      // window holds none. Two signed comparisons per byte, and deliberately no
+      // masking: 10 and 13 are positive and every byte of a multi-byte UTF-8
+      // sequence is negative, so a signed test matches neither, and the loop
+      // stays in the shape the JIT vectorises. (Masking to compare unsigned —
+      // which a minimum-of-eight skip like the char duct's would need, since
+      // signed it would see those negatives as candidates — costs far more than
+      // the wide skip saves: it made this scan 46% of the whole pipeline.)
       private def scan(bytes: scala.Array[Byte], from: Int, stop: Int): Int =
-        inline def least(left: Int, right: Int): Int = if left < right then left else right
-
-        inline def lowest(at: Int): Int =
-          least
-           ( least(least(bytes(at) & 0xff, bytes(at + 1) & 0xff),
-                   least(bytes(at + 2) & 0xff, bytes(at + 3) & 0xff)),
-             least(least(bytes(at + 4) & 0xff, bytes(at + 5) & 0xff),
-                   least(bytes(at + 6) & 0xff, bytes(at + 7) & 0xff)) )
-
         var index: Int = from
-        var found: Int = -1
 
-        while found < 0 && index < stop do
-          while index + 8 <= stop && lowest(index) > 13 do index += 8
+        while index < stop && { val byte = bytes(index); byte != 10 && byte != 13 }
+        do index += 1
 
-          if index < stop then
-            val byte = bytes(index)
-            if byte == 10 || byte == 13 then found = index else index += 1
-
-        if found < 0 then stop else found
+        index
 
       update def step(source: Region[Data])(range: Interval in source.type)
         ( target: Slate[Array[Text]^{}] )(space: Interval in target.type)

--- a/lib/turbulence/src/core/turbulence.LineSeparation.scala
+++ b/lib/turbulence/src/core/turbulence.LineSeparation.scala
@@ -35,7 +35,9 @@ package turbulence
 import proscenium.compat.*
 import rudiments.reverse
 
+import java.io as ji
 import java.lang as jl
+import java.nio.charset as jnc
 
 import anticipation.*
 import contingency.*
@@ -305,6 +307,241 @@ object LineSeparation:
               count += 1
 
             count
+
+  // Whether a `0x0A` or `0x0D` byte in this encoding can only be a line
+  // terminator. UTF-8 is self-synchronising — every byte of a multi-byte
+  // sequence has its high bit set — and the single-byte encodings are
+  // ASCII-transparent by construction, so in all of these a terminator can be
+  // found without decoding first. UTF-16 emphatically is not: `0x0A` occurs
+  // inside its code units, and splitting its bytes would cut characters in half.
+  def asciiTransparent(charset: jnc.Charset): Boolean =
+    charset == jnc.StandardCharsets.UTF_8 || charset == jnc.StandardCharsets.US_ASCII
+      || charset == jnc.StandardCharsets.ISO_8859_1
+
+  // The byte-level twin of `lines`, for an ASCII-transparent encoding: it finds
+  // terminators in the raw bytes and decodes each completed line in one step
+  // with `String(bytes, …, charset)`, the JDK's fused decode-and-construct. That
+  // removes the separate decoding stage and its intermediate `char[]` — the JFR
+  // profile of the 4 MB corpus attributed 53% of line splitting to decoding,
+  // against 44% to the splitting itself — and, because only whole lines are ever
+  // decoded, a multi-byte character split across two windows needs no handling
+  // at all: its bytes simply accumulate like any others.
+  //
+  // Deliberately not a `given`: it is applied by name from `delineate`, which
+  // has checked the encoding, rather than found by `via`'s implicit search,
+  // which has not. `lines` above remains the reference implementation, and the
+  // test harness runs every policy and every fragmentation through both.
+  def byteLines(consume policy: LineSeparation^, charset: jnc.Charset)(using Buffering)
+  :   (Duct[Data, Array[Text]^{}] { type Transport = Credit; type Upstream = Credit })^ =
+
+    new Duct[Data, Array[Text]^{}]:
+      type Transport = Credit
+      type Upstream = Credit
+
+      // The incomplete current line's bytes, carried across steps: the
+      // counterpart of the char duct's `StringBuilder`, and free of its coder
+      // trap, since bytes carry no encoding state to inflate.
+      private val partial: ji.ByteArrayOutputStream = ji.ByteArrayOutputStream(64)
+
+      // A separator's first byte at a window boundary (10 or 13; 0 = none).
+      private var pending: Int = 0
+
+      private var drained: Boolean = false
+      private var tail: List[Text] = Nil
+
+      def regulation: Credit is Regulation = summon[Credit is Regulation]
+
+      // One byte completes at most one line, so line-credit is a sound
+      // byte-credit; surplus consumption is carried in `partial`.
+      def translate(demand: Credit): Credit = demand
+
+      override def quantum: Int = 2
+
+      private var out0: Text = "".tt
+      private var out1: Text = "".tt
+      private var emitted: Int = 0
+
+      private update def emit(line: Text): Unit =
+        if emitted == 0 then out0 = line else out1 = line
+        emitted += 1
+
+      private update def newline(): Unit =
+        val line = partial.toString(charset).nn.tt
+        partial.reset()
+        emit(line)
+
+      private update def act(action: LineSeparation.Action): Unit = action match
+        case Action.Nl   => newline()
+        case Action.NlCr => newline(); partial.write(13)
+        case Action.NlLf => newline(); partial.write(10)
+        case Action.CrNl => partial.write(13); newline()
+        case Action.NlNl => newline(); newline()
+        case Action.Cr   => partial.write(13)
+        case Action.Lf   => partial.write(10)
+        case Action.LfNl => partial.write(10); newline()
+        case Action.Skip => ()
+
+      private update def deliver(slots: scala.Array[AnyRef]^, at: Int): Int =
+        var written: Int = 0
+
+        if emitted > 0 then
+          slots(at) = out0.asInstanceOf[AnyRef]
+          written = 1
+
+          if emitted == 2 then
+            slots(at + 1) = out1.asInstanceOf[AnyRef]
+            written = 2
+
+          emitted = 0
+
+        written
+
+      // As the char duct's `scan`, over bytes. The comparison is on the
+      // unsigned value: every byte of a multi-byte UTF-8 sequence has its high
+      // bit set, so unsigned it exceeds 13 and is skipped with the ordinary
+      // bytes, where signed it would be negative and fall to the re-check —
+      // which would forfeit the wide skip on exactly the non-ASCII text that
+      // needs it most.
+      private def scan(bytes: scala.Array[Byte], from: Int, stop: Int): Int =
+        inline def least(left: Int, right: Int): Int = if left < right then left else right
+
+        inline def lowest(at: Int): Int =
+          least
+           ( least(least(bytes(at) & 0xff, bytes(at + 1) & 0xff),
+                   least(bytes(at + 2) & 0xff, bytes(at + 3) & 0xff)),
+             least(least(bytes(at + 4) & 0xff, bytes(at + 5) & 0xff),
+                   least(bytes(at + 6) & 0xff, bytes(at + 7) & 0xff)) )
+
+        var index: Int = from
+        var found: Int = -1
+
+        while found < 0 && index < stop do
+          while index + 8 <= stop && lowest(index) > 13 do index += 8
+
+          if index < stop then
+            val byte = bytes(index)
+            if byte == 10 || byte == 13 then found = index else index += 1
+
+        if found < 0 then stop else found
+
+      update def step(source: Region[Data])(range: Interval in source.type)
+        ( target: Slate[Array[Text]^{}] )(space: Interval in target.type)
+      :   Duct.Progress =
+
+        val sourceInterval: Interval = range
+        val sourceOffset = sourceInterval.start.n0
+        val sourceLength = sourceInterval.size
+        val targetInterval: Interval = space
+        val targetOffset = targetInterval.start.n0
+        val targetSpace = targetInterval.size
+        val bytes = unsafely(source.raw.asInstanceOf[scala.Array[Byte]])
+
+        val slots: scala.Array[AnyRef]^ =
+          unsafely(target.raw.asInstanceOf[scala.Array[AnyRef]]).asInstanceOf[scala.Array[AnyRef]^]
+
+        var consumed: Int = 0
+        var produced: Int = 0
+
+        while consumed < sourceLength && produced + 2 <= targetSpace do
+          if pending != 0 then
+            val first = pending
+            pending = 0
+            val byte = bytes(sourceOffset + consumed)
+
+            if first == 10 then
+              if byte == 13 then { consumed += 1; act(policy.lfcr) } else act(policy.lf)
+            else
+              if byte == 10 then { consumed += 1; act(policy.crlf) } else act(policy.cr)
+
+            produced += deliver(slots, targetOffset + produced)
+          else
+            val byte = bytes(sourceOffset + consumed)
+
+            if byte == 10 then
+              consumed += 1
+
+              if consumed < sourceLength then
+                if bytes(sourceOffset + consumed) == 13
+                then { consumed += 1; act(policy.lfcr) }
+                else act(policy.lf)
+
+                produced += deliver(slots, targetOffset + produced)
+              else pending = 10
+            else if byte == 13 then
+              consumed += 1
+
+              if consumed < sourceLength then
+                if bytes(sourceOffset + consumed) == 10
+                then { consumed += 1; act(policy.crlf) }
+                else act(policy.cr)
+
+                produced += deliver(slots, targetOffset + produced)
+              else pending = 13
+            else
+              val start = sourceOffset + consumed
+              val stop = sourceOffset + sourceLength
+              val end = scan(bytes, start, stop)
+              val length = end - start
+
+              // The fast path, as in the char duct: no line carried, the
+              // separator inside the window with its resolving byte present,
+              // and a policy that maps the sequence to a plain line break — so
+              // the line's bytes go straight to the decoder in one call.
+              val separator: Int =
+                if end >= stop || end + 1 >= stop || partial.size > 0 then 0
+                else if bytes(end) == 10 then
+                  if bytes(end + 1) == 13 then (if policy.lfcr == Action.Nl then 2 else 0)
+                  else if policy.lf == Action.Nl then 1 else 0
+                else
+                  if bytes(end + 1) == 10 then (if policy.crlf == Action.Nl then 2 else 0)
+                  else if policy.cr == Action.Nl then 1 else 0
+
+              if separator > 0 then
+                emit(String(bytes, start, length, charset).tt)
+                consumed += length + separator
+                produced += deliver(slots, targetOffset + produced)
+              else
+                partial.write(bytes, start, length)
+                consumed += length
+
+        Duct.Progress(consumed, produced)
+
+      override update def flush(target: Slate[Array[Text]^{}])(space: Interval in target.type)
+      :   Int =
+
+        val targetInterval: Interval = space
+        val targetOffset = targetInterval.start.n0
+        val targetSpace = targetInterval.size
+
+        if !drained then
+          drained = true
+          var lines: List[Text] = Nil
+
+          if pending == 10 then act(policy.lf) else if pending == 13 then act(policy.cr)
+          pending = 0
+
+          if emitted > 0 then
+            lines ::= out0
+            if emitted == 2 then lines ::= out1
+            emitted = 0
+
+          if partial.size > 0 then
+            lines ::= partial.toString(charset).nn.tt
+            partial.reset()
+
+          tail = lines.reverse
+
+        var count: Int = 0
+
+        val slots: scala.Array[AnyRef]^ =
+          unsafely(target.raw.asInstanceOf[scala.Array[AnyRef]]).asInstanceOf[scala.Array[AnyRef]^]
+
+        while count < targetSpace && tail.nonEmpty do
+          slots(targetOffset + count) = tail.head.asInstanceOf[AnyRef]
+          tail = tail.tail
+          count += 1
+
+        count
 
   enum NewlineSeq:
     case Cr, Lf, CrLf, LfCr

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -139,14 +139,22 @@ extension (data: Data)
     decoder.decoded(data).delineate
 
 extension (consume stream: (Stream[Data] over Credit)^)
-  // Split a byte stream into its lines: character decoding under the ambient
-  // `CharDecoder`, then line splitting as above.
+  // Split a byte stream into its lines. Where the encoding is ASCII-transparent
+  // — UTF-8 and the single-byte encodings, in which a `0x0A` byte can only be a
+  // terminator — the separators are found in the raw bytes and each line is
+  // decoded whole, in one fused JDK call, with no separate decoding stage and no
+  // intermediate `char[]`. Any other encoding (UTF-16 above all, whose code
+  // units contain `0x0A` bytes) decodes first and splits the characters.
   @targetName("delineateData")
   def delineate
     ( using decoder: CharDecoder, lineSeparation: LineSeparation, buffering: Buffering )
   :   (Stream[Array[Text]^{}] over Credit)^ =
 
-    stream.via(decoder).asInstanceOf[(Stream[Text] over Credit)^].delineate
+    val charset = decoder.encoding.charset
+
+    if LineSeparation.asciiTransparent(charset)
+    then stream.viaDuct(LineSeparation.byteLines(lineSeparation, charset))
+    else stream.via(decoder).asInstanceOf[(Stream[Text] over Credit)^].delineate
 
 extension (consume stream: (Stream[Data] over Credit)^)
   // View a pull endpoint as a `java.io.InputStream` for handing to JDK APIs:

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -519,11 +519,42 @@ object Tests extends Suite(m"Turbulence tests"):
         else if chunk == 0 then input.stream.delineate.records.to(List)
         else input.s.grouped(chunk).map(_.tt).stream.delineate.records.to(List)
 
+      // The same input through the byte-level duct (`Stream[Data].delineate`
+      // under a UTF-8 decoder, which is ASCII-transparent, so the separators are
+      // found in the bytes and each line is decoded whole). Fragmenting by BYTES
+      // rather than characters is the point: it cuts multi-byte characters in
+      // half at a window boundary, which the byte duct must carry through.
+      def splitBytes(input: Text, chunk: Int)(using LineSeparation): List[Text] =
+        // A `Data` is a frozen byte array, so each freshly-copied range is frozen
+        // by the cast. The chunking is an explicit loop rather than `grouped` +
+        // `map`: mapping a cast over an iterator of fresh arrays is not
+        // capture-polymorphic enough to typecheck.
+        val bytes = input.s.getBytes("UTF-8").nn
+        val pieces = scala.collection.mutable.ListBuffer[Data]()
+        var index = 0
+
+        if chunk == 0 then pieces += bytes.asInstanceOf[Data] else
+          while index < bytes.length do
+            val size = chunk.min(bytes.length - index)
+            pieces += java.util.Arrays.copyOfRange(bytes, index, index + size).nn.asInstanceOf[Data]
+            index += size
+
+        pieces.iterator.stream.delineate.records.to(List)
+
       def check(policy: Text, cases: List[(Text, List[Text])])(using LineSeparation): Unit =
         for fragment <- List(-1, 0, 1, 3) do
           cases.stdlib.zipWithIndex.each: (row, index) =>
             test(m"$policy, case $index, chunk size $fragment"):
               splitLines(row(0), fragment)
+            . assert(_ == row(1))
+
+        // Differential: the char duct above is the reference implementation, and
+        // the byte duct must agree with it on every policy, every case and every
+        // fragmentation.
+        for fragment <- List(0, 1, 3) do
+          cases.stdlib.zipWithIndex.each: (row, index) =>
+            test(m"$policy, case $index, byte chunk size $fragment"):
+              splitBytes(row(0), fragment)
             . assert(_ == row(1))
 
       suite(m"adaptive linefeeds"):
@@ -606,6 +637,28 @@ object Tests extends Suite(m"Turbulence tests"):
           val input = long + t"\ny"
           input.s.grouped(7).map(_.tt).stream.delineate.records.to(List)
         . assert(_ == List(Text(String(scala.Array.fill(10000)('x'))), t"y"))
+
+        // Characters of two, three and four bytes, fragmented at every byte
+        // boundary: each window boundary lands mid-character, so the byte duct
+        // is forced to accumulate a partial character and decode it only once
+        // the whole line is present. (The char-level harness cannot cover this:
+        // fragmenting *characters* would split the surrogate pair of `🚀`.)
+        val multiByte = t"café\n— dash\n数据\r\n🚀 rocket"
+        val multiByteLines = List(t"café", t"— dash", t"数据", t"🚀 rocket")
+
+        for chunk <- List(1, 2, 3, 5, 7) do
+          test(m"multi-byte characters split across windows, byte chunk size $chunk"):
+            splitBytes(multiByte, chunk)
+          . assert(_ == multiByteLines)
+
+        // Lines far longer than any window, of three-byte characters, fragmented
+        // three bytes at a time. Compared as a boolean: the values themselves run
+        // to twelve kilobytes, which the report cannot usefully render.
+        for size <- List(10, 100, 700, 1000, 4000) do
+          test(m"a long line of multi-byte characters is decoded whole, $size chars"):
+            val long = Text(String(scala.Array.fill(size)('数')))
+            splitBytes(long + t"\n" + long, 3) == List(long, long)
+          . assert(_ == true)
 
         test(m"lines of an empty byte stream is empty"):
           Iterator.empty[Data].stream.delineate.records.to(List)


### PR DESCRIPTION
Line splitting was roughly 1.5–2× behind `fs2.text.lines`, despite the benchmark suite's own comment claiming Soundness had "no per-line intermediate". The comment was false, and each fix below was chosen by profiling rather than guesswork.

**One copy per line, not two.** Every line was copied into a `StringBuilder` and again by `toString`; and since `setLength(0)` never resets a builder's coder, one non-Latin-1 character — the corpus has several per line — inflated it to UTF-16 permanently, so every later line paid a `StringUTF16.compress` scan that could only fail. Lines whose separator lies inside the current window are now built straight from it with a single copy. *(185 op/s.)*

**Splitting bytes, not characters.** With the copy gone, the profile put 53% of the time in UTF-8 decoding — the stream was decoded into an intermediate `char[]` by one duct and split by another. UTF-8 is self-synchronising, so separators can be found in raw bytes: `Stream[Data].delineate` now decodes each completed line whole via `String(bytes, …, charset)`, the JDK's fused decode-and-construct. The decode stage and its buffer disappear, and characters split across windows need no handling at all, since only whole lines are decoded. UTF-16 keeps the old path — its code units contain `0x0A` bytes.

**The scan.** That first landed as a *regression* (174 op/s): the byte scan had `& 0xff` masking so a minimum-of-eight skip would treat high-bit bytes as ordinary, which defeated the vectorisation the char duct's identical skip gets free — 46% of the pipeline in the scan alone. Removing it reached 240 op/s. Then, since 10 and 13 differ only in their bottom three bits, one mask-and-compare (`(b & 0xf8) == 0x08`) rejects everything outside 8–15 in a single branch where two comparisons take two: 53% faster in isolation, and 28% faster than biasing by two first to exclude tab. *(253 op/s.)*

| | Throughput |
|---|---|
| **Soundness `delineate`** | **253 op/s** |
| FS2 `text.lines` | 205 op/s |
| ZIO `ZPipeline.splitLines` | 163 op/s |

What remains is ~71% JDK decode-and-construct and under 0.5% duct machinery.

The char duct stays the reference implementation, and the harness runs every policy and case through **both**, fragmenting the byte path by *bytes* so windows land mid-character — which the char harness cannot do, as fragmenting characters would split a surrogate pair. Added: two-, three- and four-byte characters split at every byte boundary, and 12 kB lines decoded whole. The three scan variants remain a benchmark suite so a later "simplification" back to the obvious form has to answer for itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)