### PR TITLE
Cut two hot loops: HTTP header scanning and Markdown escaping

### DIFF
--- a/lib/punctuation/src/bench/punctuation.Benchmarks.scala
+++ b/lib/punctuation/src/bench/punctuation.Benchmarks.scala
@@ -41,7 +41,9 @@ import fulminate.*
 import gossamer.*
 import hellenism.*, classloaders.threadContextClassloader
 import hieroglyph.*, charDecoders.utf8Decoder, textSanitizers.strictSanitizer
+import prepositional.*
 import probably.*
+import spectacular.show
 import proscenium.*
 import proscenium.compat.*
 import quantitative.*
@@ -79,6 +81,13 @@ object Benchmarks extends Suite(m"Punctuation benchmarks"):
 
   def parseNative(text: Text): Int = Parser.parse(text).children.length
 
+  // Parsed once, outside the timed region, so the serialization rows measure
+  // `.show` alone rather than a parse-and-show round trip.
+  lazy val mediumDoc:    Markdown of Layout = Parser.parse(medium)
+  lazy val stressMixDoc: Markdown of Layout = Parser.parse(stressMix)
+
+  def serializeNative(doc: Markdown of Layout): Int = doc.show.s.length
+
   // ─── benchmarks ───────────────────────────────────────────────────────────
 
   def run(): Unit =
@@ -88,6 +97,19 @@ object Benchmarks extends Suite(m"Punctuation benchmarks"):
     val mediumSize:         Quantity[Bytes[1]] = medium.s.getBytes("UTF-8").nn.length*Byte
     val stressMixSize:      Quantity[Bytes[1]] = stressMix.s.getBytes("UTF-8").nn.length*Byte
     val emphasisStressSize: Quantity[Bytes[1]] = emphasisStress.s.getBytes("UTF-8").nn.length*Byte
+
+    // Serialization had no coverage at all, though `escapeTextual` runs once per
+    // character of every textual span — the counterpart of the parse side's
+    // batched `isSpecial` scan, and the place a character-class test on this
+    // side actually costs something.
+    suite(m"Markdown serialization throughput"):
+      bench(m"serialize medium (~19 KB, real README)")
+        ( target = 1*Second, operationSize = mediumSize ):
+        '{ punctuation.Benchmarks.serializeNative(punctuation.Benchmarks.mediumDoc) }
+
+      bench(m"serialize stress-mix (~38 KB, every feature)")
+        ( target = 1*Second, operationSize = stressMixSize ):
+        '{ punctuation.Benchmarks.serializeNative(punctuation.Benchmarks.stressMixDoc) }
 
     suite(m"Markdown parsing throughput"):
       bench(m"parse small (~2 KB, mixed prose)")

--- a/lib/punctuation/src/core/punctuation.Serializer.scala
+++ b/lib/punctuation/src/core/punctuation.Serializer.scala
@@ -92,6 +92,7 @@ private[punctuation] object Serializer:
   // inline construct when the output is re-parsed. We escape conservatively:
   // every occurrence, not only "active" ones. CommonMark is happy to accept
   // backslash escapes ahead of any ASCII punctuation character.
+  //
   private inline def inlineSpecial(char: Char): Boolean = char match
     case '\\' | '`' | '*' | '_' | '[' | ']' | '<' | '>' | '&' => true
     case _                                                    => false
@@ -106,16 +107,25 @@ private[punctuation] object Serializer:
 
   private def escapeTextual(text: Text): Text =
     val s = text.s
-    val buf = StringBuilder()
-    var i = 0
+    var first = 0
 
-    while i < s.length do
-      val c = s.charAt(i)
-      if inlineSpecial(c) then buf.add('\\')
-      buf.add(c)
-      i += 1
+    // Most textual spans contain nothing to escape, and the builder below copies
+    // every character whether or not any of them needed it. Scan first, and
+    // return the original unchanged when nothing does; only a span that really
+    // contains a special character pays for a copy.
+    while first < s.length && !inlineSpecial(s.charAt(first)) do first += 1
 
-    buf.text
+    if first == s.length then text else
+      val buf = StringBuilder()
+      var i = 0
+
+      while i < s.length do
+        val c = s.charAt(i)
+        if inlineSpecial(c) then buf.add('\\')
+        buf.add(c)
+        i += 1
+
+      buf.text
 
   private def escapeLinkLabel(text: Text): Text =
     val s = text.s

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -402,10 +402,32 @@ object Http:
 
       def upTo(stop: Char, limit: Int, reason: Reason): Text = cursor.hold:
         val start = cursor.mark
+        val target: Byte = stop.toByte
+        var found = false
 
-        while !cursor.finished && !(cursor.peek == stop) do
+        // Scan the cursor's buffered region directly rather than stepping it one
+        // datum at a time. Each `peek`/`next` pair goes through
+        // `addressable.storageAddress`, which erases to an `invokeinterface`
+        // returning `Object` plus an unbox — "a major hot-path tax" in
+        // `zephyrine.Cursor`'s own words — and a request head pays it per
+        // character of every method, target, name and value. The local index is
+        // pushed back to the cursor before any refill, the protocol the
+        // ypsiloid, xylophone and honeycomb parsers follow, and which this file
+        // already uses for chunked bodies. The size limit is checked once per
+        // buffer rather than once per character, which is equivalent: the limit
+        // is an offset bound, and no single buffer can cross it unnoticed.
+        while !found && cursor.more do
           if cursor.position.n0 > limit then abort(Http.Request.Error(reason))
-          cursor.next()
+
+          val bytes = cursor.unsafeBuffer(using Unsafe).asInstanceOf[scala.Array[Byte]]
+          val from = cursor.unsafePos(using Unsafe)
+          val end = cursor.unsafeWriteEnd(using Unsafe)
+          var index = from
+
+          while index < end && bytes(index) != target do index += 1
+
+          cursor.unsafeAdvanceBy(index - from)(using Unsafe)
+          found = index < end
 
         Ascii(cursor.grab(start, cursor.mark)).show
 
@@ -442,7 +464,9 @@ object Http:
           val key: Text = upTo(':', headerLimit, Reason.HeadersTooLarge)
           cursor.next()
 
-          while cursor.peek == ' ' || cursor.peek == '\t' do cursor.next()
+          // One `peek` per iteration, not two: each goes through the cursor's
+          // `storageAddress` indirection.
+          while { val char = cursor.peek; char == ' ' || char == '\t' } do cursor.next()
 
           val value: Text = upTo('\r', headerLimit, Reason.HeadersTooLarge)
           cursor.next()


### PR DESCRIPTION
Two independent optimisations, each measured before and after, plus a third that was attempted, measured and reverted.

## HTTP header scanning (+21%)

`Http.upTo` stepped the cursor one datum at a time to find each token's terminator. Every `peek`/`next` pair goes through `addressable.storageAddress`, which erases to an `invokeinterface` returning `Object` plus an unbox — what `zephyrine.Cursor` calls "a major hot-path tax" for scan loops — and a request head paid it per character of every method, target, name and value. It now scans the cursor's buffered region directly and pushes the index back with `unsafeAdvanceBy` before any refill: the protocol the ypsiloid, xylophone and honeycomb parsers already follow, and which this same file already used for chunked bodies. The size limit moves from per character to per buffer, which is equivalent — it bounds an offset, and no single buffer can cross it unnoticed. The optional-whitespace skip also stops evaluating `peek` twice per iteration.

| Row (in-memory, no sockets) | Before | After |
|---|---|---|
| 1000 pipelined GETs through `serveConnection` | 1727 op/s | **2093 op/s** (+21.2%) |
| Parse a request head | 3.99 M op/s | 4.15 M op/s (+3.9%) |
| *Serialize a fixed response (untouched)* | 2.23 M op/s | 2.27 M op/s (+1.7%) |

The untouched row gives the noise floor. The isolated parse row gains less than the pipeline because it parses from a *preset* cursor, whose accessors skip the refill checks a stream-backed cursor pays — and the stream-backed one is what a server actually drives.

## Markdown escaping (+20% / +16%)

`escapeTextual` copied every character of every textual span through a builder, whether or not any needed escaping — and in ordinary prose none do. It now scans first and returns the original `Text` untouched unless a special character is present. Serialization had no benchmark coverage at all, so two rows are added with it.

| New row | Before | After |
|---|---|---|
| serialize medium (19 KB README) | 6695 op/s | **8057 op/s** (+20.3%) |
| serialize stress-mix (38 KB) | 3027 op/s | **3514 op/s** (+16.1%) |

Recorded in the commit for whoever optimises here next: converting `inlineSpecial` from its sparse `match` to a frozen lookup table (as `InlineParser.isSpecial` uses on the parse side) was measured both before and after this change and made no difference either time. The character test was never the cost; the copy was.

## Not included: stratiform

The atom-run scan in `Tel.parseCompoundLineRest` tests four constants per byte over every compound line, and the file already contains SWAR scanners (`scanUntil3`, `scanUntil4`) with no callers. Wiring them up cost 11% on the 61 KB corpus and 5–6% on several others, so it is not in this PR. TEL atom runs are a handful of bytes — too short to amortise a word-at-a-time setup, so the scan does one word check, hits, and falls through to the scalar tail having done strictly more work. That is very likely why those scanners were written and never connected: they suit scanning to end-of-line, where `scanUntil1`/`scanUntil2` are in fact used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)