### PR TITLE
Stop rebuilding the response head and re-looking-up charsets on every request

### DIFF
--- a/lib/hieroglyph/src/core/hieroglyph.CharEncoder.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.CharEncoder.scala
@@ -59,7 +59,10 @@ extends Encodable, Findable:
   type Self = Text
   type Form = Data
 
-  def encoded(text: Text): Data = Array.unsafeFrozen(text.s.getBytes(encoding.name.s).nn)
+  // The `Charset` itself, not its name: `getBytes(String)` looks the charset up
+  // by name on every call, which showed as 4.7% of an HTTP pipeline's profile.
+  // `encoding.charset` resolves once, being a `lazy val`.
+  def encoded(text: Text): Data = Array.unsafeFrozen(text.s.getBytes(encoding.charset).nn)
 
   // Chunk boundaries are not character boundaries: a surrogate pair may be
   // split across two chunks, so encoding each chunk independently (as this

--- a/lib/scintillate/src/bench/scintillate.Benchmarks.scala
+++ b/lib/scintillate/src/bench/scintillate.Benchmarks.scala
@@ -217,6 +217,14 @@ object Benchmarks extends Suite(m"Scintillate socket-server benchmarks"):
     // difference between the histograms is server-side. CPU-only: parked time (the
     // client awaiting the response, the server awaiting a request) is invisible.
     suite(m"Profile: HTTP round-trip hotspots"):
+      // The connection loop with no sockets under it: where the socket rows
+      // below spend most of their samples parked in `kqueue`/`poll` — which is
+      // honest for a round-trip, but drowns everything else — this one puts
+      // every sample inside the HTTP stack itself. The right instrument for
+      // asking where a request's CPU and allocation actually go.
+      profile(m"1000 pipelined GETs through serveConnection")(target = 5*Second):
+        '{ scintillate.Benchmarks.drivePipeline() }
+
       profile(m"Scintillate  socket round-trip")(target = 5*Second):
         '{
             scintillate.HttpRivals.scintillateVirtual

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -56,6 +56,7 @@ import turbulence.*
 import urticose.*
 import vacuous.*
 import zephyrine.*
+import java.lang as jl
 import java.net as jn
 import scala.util.NotGiven
 
@@ -841,20 +842,28 @@ object Http:
             val key = header.key.lower
             key != t"transfer-encoding" && key != t"content-length"
 
-      val head: Text = Text.build:
-        append(t"HTTP/1.1 ")
-        append(response.status.code.toString.tt)
-        append(t" ")
-        append(response.status.description)
-        append(t"\r\n")
+      // Built into a pre-sized buffer rather than through `Text.build`, whose
+      // builder starts at the default sixteen characters and reallocates its way
+      // up to the few hundred a head occupies: `AbstractStringBuilder.newCapacity`
+      // was 13% of this pipeline's profile, more than any other frame. The status
+      // code is appended as an `Int`, which also saves rendering it to a `Text`
+      // first.
+      val head: Text =
+        val builder = jl.StringBuilder(256)
+        builder.append("HTTP/1.1 ")
+        builder.append(response.status.code)
+        builder.append(' ')
+        builder.append(response.status.description.s)
+        builder.append("\r\n")
 
         headers.each: header =>
-          append(header.key)
-          append(t": ")
-          append(header.value)
-          append(t"\r\n")
+          builder.append(header.key.s)
+          builder.append(": ")
+          builder.append(header.value.s)
+          builder.append("\r\n")
 
-        append(t"\r\n")
+        builder.append("\r\n")
+        builder.toString.tt
 
       // Materialize successive blocks off a pull endpoint as a chunk iterator.
       def pulls(endpoint: (Stream[Data] over Credit)^): Iterator[Data]^{endpoint} =


### PR DESCRIPTION
Profiling the HTTP pipeline with sockets removed — so that samples land in the HTTP stack rather than 84% in `kqueue`/`poll` — put two avoidable costs at the top.

**`AbstractStringBuilder.newCapacity`, 13.4%**, the largest frame in the profile: `Text.build` starts its builder at the default sixteen characters, and a response head runs to a few hundred, so every response reallocated and copied its way up. The head now builds into a buffer sized for it, and the status code appends as an `Int` rather than being rendered to a `Text` first. A sized `Text.build` overload would be the general fix, but it collides with the existing one during context-function overload resolution, so this stays local pending a considered API.

**`Charset.lookup`, 4.7%**: `CharEncoder.encoded` passed the charset *by name*, so `getBytes(String)` resolved it on every call, though `Encoding` already caches the `Charset` in a `lazy val`. This one is not confined to HTTP — every `CharEncoder.encoded` call in the codebase paid it.

| Row (in-memory, no sockets) | Before | After |
|---|---|---|
| 1000 pipelined GETs through `serveConnection` | 2093 op/s | **2552 op/s** (+21.9%) |
| Serialize a fixed response | 2.27 M op/s | **2.43 M op/s** (+7.2%) |
| *Parse a request head (untouched here)* | 4.145 M op/s | 4.152 M op/s |

Together with the header-scanning change that merged in #1801, the pipeline has gone from 1727 to 2552 op/s across the two PRs — **+47.8%**.

The socket-free profile row that found both is added alongside, since the socket round-trip rows cannot see this layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)