### PR TITLE
Name charsets by constant, not by string

### DIFF
--- a/lib/anticipation/src/text/anticipation.internal.scala
+++ b/lib/anticipation/src/text/anticipation.internal.scala
@@ -39,6 +39,7 @@ import scala.quoted.*
 import scala.reflect.*
 import scala.util.*
 
+import java.nio.charset.StandardCharsets
 import symbolism.*
 
 object internal:
@@ -51,7 +52,8 @@ object internal:
 
     def apply(string: String): Text = make(string)
     def apply(chars: Array[Char]^{}): Text = make(String(chars.asInstanceOf[scala.Array[Char]]))
-    def apply(bytes: Array[Byte]^{}): Text = make(String(bytes.asInstanceOf[scala.Array[Byte]], "ASCII"))
+    def apply(bytes: Array[Byte]^{}): Text =
+      make(String(bytes.asInstanceOf[scala.Array[Byte]], StandardCharsets.US_ASCII))
 
     extension (text: Text) inline def s: String = text.asInstanceOf[String]
 

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -36,6 +36,7 @@ import scala.collection.immutable.Vector
 
 import scala.caps
 
+import java.nio.charset.StandardCharsets
 import fulminate.*
 import proscenium.compat.*
 
@@ -407,7 +408,7 @@ object Cbor extends Cbor2, Dynamic:
 
         else if cbor.isTextString then
           val text = cbor.asInstanceOf[String]
-          val bytes = Array.unsafeFrozen(text.getBytes("UTF-8").nn)
+          val bytes = Array.unsafeFrozen(text.getBytes(StandardCharsets.UTF_8).nn)
           head(out, 3, bytes.length.toLong)
           out.put(bytes)
 

--- a/lib/gossamer/src/core/gossamer.internal.scala
+++ b/lib/gossamer/src/core/gossamer.internal.scala
@@ -40,6 +40,7 @@ import scala.collection.immutable.Seq
 import scala.collection.immutable.{List, Nil, ::}
 import scala.quoted.*
 
+import java.nio.charset.StandardCharsets
 import anticipation.*
 import denominative.*
 import fulminate.*
@@ -168,7 +169,7 @@ object internal:
 
       given showable: Ascii is Showable =
         // Read-only use of the underlying JVM array: the `String` constructor copies.
-        ascii => String(ascii.asInstanceOf[scala.Array[Byte]], "ASCII").nn.tt
+        ascii => String(ascii.asInstanceOf[scala.Array[Byte]], StandardCharsets.US_ASCII).nn.tt
 
       given concatenable: Ascii is Concatenable:
         type Operand = Ascii
@@ -190,7 +191,8 @@ object internal:
         def single(operand: Byte): Ascii = scala.IArray(operand)
         def fromChar(char: Char): Byte = char.toByte
         def length(ascii: Ascii): Int = ascii.size
-        def text(ascii: Ascii): Text = String(ascii.asInstanceOf[scala.Array[Byte]], "ASCII").nn.tt
+        def text(ascii: Ascii): Text =
+          String(ascii.asInstanceOf[scala.Array[Byte]], StandardCharsets.US_ASCII).nn.tt
         def access(ascii: Ascii, index: Ordinal): Byte =
           import scala.IArray.apply
           ascii(index.n0)

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -42,6 +42,7 @@ import scala.language.experimental.into
 import scala.language.experimental.pureFunctions
 
 import java.lang as jl
+import java.nio.charset.StandardCharsets
 import java.net.{URLEncoder, URLDecoder}
 import java.util.regex as jur
 
@@ -100,7 +101,7 @@ extension (module: Text.type)
     block(using builder.aka["builder"])
     builder()
 
-  def ascii(bytes: Data): Text = new String(Array.unsafeJvm(bytes), "ASCII").tt
+  def ascii(bytes: Data): Text = new String(Array.unsafeJvm(bytes), StandardCharsets.US_ASCII).tt
 
   def fill(length: Int)(lambda: Int => Char): Text =
     val buffer = Array.scribe[Char](length): scribe =>
@@ -119,9 +120,9 @@ extension (context: StringContext)
   def t = SimpleTExtractor(context.parts.head.tt)
 
 extension (bytes: Data)
-  def utf8: Text = String(Array.unsafeJvm(bytes), "UTF-8").tt
-  def utf16: Text = String(Array.unsafeJvm(bytes), "UTF-16").tt
-  def ascii: Text = String(Array.unsafeJvm(bytes), "ASCII").tt
+  def utf8: Text = String(Array.unsafeJvm(bytes), StandardCharsets.UTF_8).tt
+  def utf16: Text = String(Array.unsafeJvm(bytes), StandardCharsets.UTF_16).tt
+  def ascii: Text = String(Array.unsafeJvm(bytes), StandardCharsets.US_ASCII).tt
 
   // Printable Unicode Encoding
   def pue: Text =

--- a/lib/hallucination/src/png/hallucination.PngCodec.scala
+++ b/lib/hallucination/src/png/hallucination.PngCodec.scala
@@ -33,6 +33,7 @@
 package hallucination
 
 import java.io as ji
+import java.nio.charset.StandardCharsets
 import proscenium.compat.*
 
 import scala.collection.mutable as scm
@@ -354,7 +355,7 @@ private[hallucination] object PngCodec:
     // stream has), and `OutputStream.write` only reads the array it is given.
     def chunk(chunkType: String, body: Data): Unit =
       writeInt(output, body.length)
-      val typeBytes = chunkType.getBytes("UTF-8").nn
+      val typeBytes = chunkType.getBytes(StandardCharsets.UTF_8).nn
       output.write(typeBytes)
       output.write(Array.unsafeJvm(body))
       writeInt(output, corpuscular.Crc32.checksum(Array.unsafeFrozen(typeBytes), body))

--- a/lib/mandible/src/core/mandible.Classfile.scala
+++ b/lib/mandible/src/core/mandible.Classfile.scala
@@ -36,6 +36,7 @@ import java.lang.classfile as jlc
 import java.lang.classfile.attribute as jlca
 import java.lang.classfile.instruction as jlci
 
+import java.nio.charset.StandardCharsets
 import anticipation.*
 import contingency.*
 import fulminate.*
@@ -82,7 +83,7 @@ class Classfile(data: scala.IArray[Byte]):
   val sourceDebugExtension: Optional[Text] =
     model.attributes.nn.to[List].stdlib.collect:
       case attribute: jlca.SourceDebugExtensionAttribute =>
-        String(attribute.contents.nn, "UTF-8").tt
+        String(attribute.contents.nn, StandardCharsets.UTF_8).tt
 
     . headOption.getOrElse(Unset)
 

--- a/lib/phoenicia/src/core/phoenicia.Sfnt.scala
+++ b/lib/phoenicia/src/core/phoenicia.Sfnt.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package phoenicia
 
+import java.nio.charset.StandardCharsets
 import proscenium.compat.*
 
 import anticipation.*
@@ -168,7 +169,7 @@ object Sfnt:
     sorted.indices.each: index =>
       val (tag, table) = sorted(index)
       val directory = 12 + index*16
-      val tagBytes = tag.s.getBytes("US-ASCII").nn
+      val tagBytes = tag.s.getBytes(StandardCharsets.US_ASCII).nn
 
       (0 until 4).each: position => buffer(directory + position) = tagBytes(position)
 
@@ -215,7 +216,7 @@ trait Sfnt:
   lazy val tables: Map[Sfnt.Table.Tag, TableOffset] =
     (0 until numTables).flatMap: n =>
       val start = 12 + n*16
-      val tableTag = String(Array.unsafeJvm(data), start, 4, "ASCII").tt
+      val tableTag = String(Array.unsafeJvm(data), start, 4, StandardCharsets.US_ASCII).tt
       val checksum = B32(data, start + 4)
       val offset = B32(data, start + 8).s32.int
       val length = B32(data, start + 12).s32.int
@@ -379,7 +380,7 @@ trait Sfnt:
 
           case _ =>
             try String(bytes, start, length, "x-MacRoman").tt
-            catch case _: Exception => String(bytes, start, length, "ISO-8859-1").tt
+            catch case _: Exception => String(bytes, start, length, StandardCharsets.ISO_8859_1).tt
 
     lazy val records: Array[Record]^{} =
       Array.from:

--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -33,6 +33,7 @@
 package stratiform
 
 import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
 import proscenium.compat.*
 
 import scala.language.unsafeNulls
@@ -338,7 +339,7 @@ object Bintel:
         cursor.offset += len.toInt
 
         val text =
-          try Text(new String(bytes, "UTF-8"))
+          try Text(new String(bytes, StandardCharsets.UTF_8))
           catch case _: Exception => abort(Bintel.Error(Bintel.Error.Reason.BadUtf8))
 
         Tel.Element.Value(kidx.toInt, s, text)
@@ -546,7 +547,7 @@ object Bintel:
 
   private def encodeValue(out: ByteArrayOutputStream, value: Tel.Element.Value): Unit =
     writeVarint(out, value.keywordIndex.toLong)
-    val bytes = value.text.s.getBytes("UTF-8")
+    val bytes = value.text.s.getBytes(StandardCharsets.UTF_8)
     writeVarint(out, bytes.length.toLong)
     out.write(bytes)
 

--- a/lib/telekinesis/src/http2/telekinesis.Hpack.scala
+++ b/lib/telekinesis/src/http2/telekinesis.Hpack.scala
@@ -35,6 +35,7 @@ package telekinesis
 import scala.collection.mutable as scm
 import proscenium.compat.*
 
+import java.nio.charset.StandardCharsets
 import anticipation.*
 import contingency.*
 import gossamer.*
@@ -83,7 +84,7 @@ object Hpack:
       buf.add(rest.toByte)
 
   private def writeString(buf: ByteBuf^, text: Text): Unit =
-    val raw: Data = Array.unsafeFrozen(text.s.getBytes("US-ASCII").nn)
+    val raw: Data = Array.unsafeFrozen(text.s.getBytes(StandardCharsets.US_ASCII).nn)
     val huffed: Data = Huffman.encode(raw)
 
     // Use whichever encoding is shorter (RFC permits either); flag Huffman in bit 7.

--- a/lib/telekinesis/src/wasi/telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/telekinesis_wasi.scala
@@ -33,6 +33,7 @@
 package telekinesis
 
 import scala.annotation.nowarn
+import java.nio.charset.StandardCharsets
 import proscenium.compat.*
 
 import anticipation.*
@@ -89,7 +90,7 @@ package httpBackends:
         case List(host, path) => (host, t"/$path")
         case _                => (afterScheme, t"/")
 
-      def bytes(text: Text): Data = Array.unsafeFrozen(text.s.getBytes("UTF-8").nn)
+      def bytes(text: Text): Data = Array.unsafeFrozen(text.s.getBytes(StandardCharsets.UTF_8).nn)
 
       // Request headers travel in a `fields` resource, whose ownership passes into the
       // `outgoing-request`, whose ownership in turn passes into `handle` — so neither is
@@ -212,7 +213,7 @@ object WasiHttpServer:
     ( inline handler: Http.Request => Http.Response )
   :   Unit =
 
-    def bytes(text: Text): Data = Array.unsafeFrozen(text.s.getBytes("UTF-8").nn)
+    def bytes(text: Text): Data = Array.unsafeFrozen(text.s.getBytes(StandardCharsets.UTF_8).nn)
 
     val requestHandle = new Wasm.Handle(request).asInstanceOf[Wasm.Handle of "incoming-request"]
     val incoming: Foreign of "incoming-request" from Wit = requestHandle

--- a/lib/turbulence/src/wasi/turbulence_wasi.scala
+++ b/lib/turbulence/src/wasi/turbulence_wasi.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package turbulence
 
+import java.nio.charset.StandardCharsets
 import proscenium.compat.*
 
 import java.io as ji
@@ -108,7 +109,7 @@ package stdios:
           catch case error: Wasm.Error => -1
           finally handle.dispose()
 
-    def bytes(text: Text): Data = Array.unsafeFrozen(text.s.getBytes("UTF-8").nn)
+    def bytes(text: Text): Data = Array.unsafeFrozen(text.s.getBytes(StandardCharsets.UTF_8).nn)
 
     new Stdio:
       val termcap: Termcap = termcap0

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -33,6 +33,7 @@
 package ypsiloid
 
 import scala.collection.immutable.Vector
+import java.nio.charset.StandardCharsets
 import proscenium.compat.*
 
 import scala.caps
@@ -2044,7 +2045,7 @@ object Yaml extends Yaml2, Dynamic:
     private var blockParentIndent: Int = -1
 
     update def resetText(input: Text): Unit =
-      val data: Data = Array.unsafeFrozen(input.s.getBytes("UTF-8").nn)
+      val data: Data = Array.unsafeFrozen(input.s.getBytes(StandardCharsets.UTF_8).nn)
       val cursor0 = makeCursor(data)
       cursor1 = cursor0.asInstanceOf[AnyRef]
       resetParserState()


### PR DESCRIPTION
`getBytes(String)` and `new String(bytes, String)` resolve the charset by name on every call. When the HTTP profile caught `CharEncoder` doing this per encode, the lookup was 4.7% of the pipeline (fixed in #1802); this PR converts the same call shape everywhere else it appears on a runtime path.

Converted: `Data.utf8`/`utf16`/`ascii` and `Text.ascii` in gossamer, and the `Ascii` conversions in gossamer and anticipation — which sit under most text-to-bytes handling in the codebase — plus HPACK header encoding, the WASI byte shims, and the CBOR, YAML, BinTEL, SFNT, PNG and classfile codecs. Several of these files already used `StandardCharsets` elsewhere, so this is as much consistency as speed. Left alone: macro-time and build-tooling sites (jacinta and stratiform macros, the atomizers, burdock, degustation, anthology, reliquary), where the lookup happens once per compilation or artifact.

Measured honestly: on the YAML and CBOR parse benchmarks the change is **performance-neutral** — all deltas within the ±4% band that the untouched rival rows define — because one lookup per document parse is noise. The change is strictly-not-worse per call, and its measurable win was the per-encode HTTP case already landed; this completes the sweep so no future hot path rediscovers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)