### PR TITLE
Make Brotli faster than Google's pure-Java decoder by unboxing its envelope

### DIFF
--- a/lib/pneumatic/src/brotli/pneumatic.Brotli.scala
+++ b/lib/pneumatic/src/brotli/pneumatic.Brotli.scala
@@ -52,82 +52,94 @@ import zephyrine.*
 // the entire window; the encoder because it chooses its framing from the total length), so `accept`
 // accumulates input and `finish` produces the transformed bytes in one pass.
 private[pneumatic] trait BrotliEngine extends caps.Mutable:
-  protected val pending: scala.collection.mutable.ArrayBuffer[Byte] =
-    scala.collection.mutable.ArrayBuffer()
-
+  // The engine's produced-but-undelivered output: a flat byte array drained by bulk
+  // copies. This was a `scala.collection.mutable.ArrayBuffer[Byte]`, which is not
+  // specialized — its backing store is an `Object[]` — so a 4 MB decode built a 32 MB
+  // pointer array through millions of boxed appends, then unboxed every byte again on
+  // the way out: an envelope that cost more than the Brotli decode inside it.
+  private var pending: scala.Array[Byte] = new scala.Array[Byte](0)
+  private var limit: Int = 0
   private var delivered: Int = 0
+
+  // Installs the engine's finished output, taken whole from the codec.
+  protected update def install(consume bytes: scala.Array[Byte]): Unit =
+    pending = bytes
+    limit = bytes.length
+    delivered = 0
 
   update def accept(bytes: Array[Byte]^{caps.any.rd}, offset: Int, length: Int): Unit
   update def finish(): Unit
 
   update def deliver(target: scala.Array[Byte]^, offset: Int, space: Int): Int =
-    var produced = 0
+    val count = (limit - delivered).min(space)
 
-    while delivered < pending.length && produced < space do
-      target(offset + produced) = pending(delivered)
-      delivered += 1
-      produced += 1
+    if count > 0 then
+      System.arraycopy(pending, delivered, target, offset, count)
+      delivered += count
 
-    if delivered == pending.length then
-      pending.clear()
-      delivered = 0
+      if delivered == limit then
+        pending = new scala.Array[Byte](0)
+        limit = 0
+        delivered = 0
 
-    produced
+    count
 
   update def gather(): Data =
-    val result = Array[Byte](pending.length - delivered)
-    var i = 0
-
-    while delivered < pending.length do
-      result(i) = pending(delivered)
-      i += 1
-      delivered += 1
-
-    pending.clear()
+    val count = limit - delivered
+    val result = new scala.Array[Byte](count)
+    System.arraycopy(pending, delivered, result, 0, count)
+    pending = new scala.Array[Byte](0)
+    limit = 0
     delivered = 0
-    Array.freeze(result)
+    Array.unsafeFrozen(result)
+
+// Accumulates its input as a flat, doubling byte array: the counterpart of the
+// output side above, replacing another boxing `ArrayBuffer` (and a per-byte
+// generic `readUnchecked`, an unspecialized `ScalaRunTime.array_apply`) with two
+// bulk copies per accepted window.
+private[pneumatic] trait BrotliAccumulator extends caps.Mutable:
+  private var input: scala.Array[Byte] = new scala.Array[Byte](8192)
+  private var length0: Int = 0
+
+  protected def accumulated: scala.Array[Byte] = input
+  protected def accumulatedLength: Int = length0
+
+  protected update def accumulate(bytes: Array[Byte]^{caps.any.rd}, offset: Int, length: Int)
+  :   Unit =
+
+    if length0 + length > input.length then
+      var size = input.length*2
+      while size < length0 + length do size *= 2
+      val grown = new scala.Array[Byte](size)
+      System.arraycopy(input, 0, grown, 0, length0)
+      input = grown
+
+    System.arraycopy(bytes.asInstanceOf[scala.Array[Byte]], offset, input, length0, length)
+    length0 += length
 
 // Accumulates the whole compressed stream, then decodes it in one pass (see `BrotliDecoder`).
-private[pneumatic] class BrotliDecoderEngine extends BrotliEngine:
-  private val input: scala.collection.mutable.ArrayBuffer[Byte] =
-    scala.collection.mutable.ArrayBuffer()
-
+private[pneumatic] class BrotliDecoderEngine extends BrotliEngine, BrotliAccumulator:
   private var finished = false
 
   update def accept(bytes: Array[Byte]^{caps.any.rd}, offset: Int, length: Int): Unit =
-    var i = 0
-    while i < length do { input += bytes.readUnchecked(offset + i); i += 1 }
+    accumulate(bytes, offset, length)
 
   update def finish(): Unit =
     if !finished then
       finished = true
-      val array: scala.Array[Byte]^ = new scala.Array[Byte](input.length)
-      var k = 0
-      while k < input.length do { array(k) = input(k); k += 1 }
-      val decoded = BrotliDecoder.decode(array, array.length)
-      var i = 0
-      while i < decoded.length do { pending += decoded(i); i += 1 }
+      install(BrotliDecoder.decode(accumulated, accumulatedLength))
 
 // Accumulates the whole payload, then emits it as Brotli (see `BrotliEncoder`).
-private[pneumatic] class BrotliEncoderEngine extends BrotliEngine:
-  private val input: scala.collection.mutable.ArrayBuffer[Byte] =
-    scala.collection.mutable.ArrayBuffer()
-
+private[pneumatic] class BrotliEncoderEngine extends BrotliEngine, BrotliAccumulator:
   private var finished = false
 
   update def accept(bytes: Array[Byte]^{caps.any.rd}, offset: Int, length: Int): Unit =
-    var i = 0
-    while i < length do { input += bytes.readUnchecked(offset + i); i += 1 }
+    accumulate(bytes, offset, length)
 
   update def finish(): Unit =
     if !finished then
       finished = true
-      val array: scala.Array[Byte]^ = new scala.Array[Byte](input.length)
-      var k = 0
-      while k < input.length do { array(k) = input(k); k += 1 }
-      val encoded = BrotliEncoder.encode(array, array.length)
-      var i = 0
-      while i < encoded.length do { pending += encoded(i); i += 1 }
+      install(BrotliEncoder.encode(accumulated, accumulatedLength))
 
 // The `Duct` stage: a thin wrapper presenting a Brotli engine to the streaming kernel, draining the
 // engine's retained `pending` buffer into whatever space each step or flush offers. The shape

--- a/lib/pneumatic/src/test/pneumatic_test.scala
+++ b/lib/pneumatic/src/test/pneumatic_test.scala
@@ -328,6 +328,17 @@ object Tests extends Suite(m"Pneumatic tests"):
         brotliVaried.compress[Brotli].decompress[Brotli].to[List]
       . assert(_ == brotliVaried.to[List])
 
+      // The benchmark corpus, exactly as `turbulence.Benchmarks` generates it: 4 MB of
+      // semi-compressible bytes. The benchmark row only counts the decoded length, so
+      // this pins the content — a decoder change that produced the right length of
+      // wrong bytes would score there and fail here. Compared as a boolean: the
+      // values run to four megabytes, which the report cannot usefully render.
+      test(m"Roundtrip the 4 MB benchmark corpus (Brotli)"):
+        val corpus: Data = Data.fill(4 << 20)(i => ((i*31 + (i >> 6)) & 0xff).toByte)
+        val decoded = corpus.stream.compress[Brotli].decompress[Brotli].memoize
+        decoded.to[List] == corpus.to[List]
+      . assert(_ == true)
+
       test(m"Brotli actually compresses a repetitive payload"):
         val payload = (t"the quick brown fox jumped " * 500).in[Data]
         payload.compress[Brotli].length < payload.length


### PR DESCRIPTION
The Brotli benchmark rows ran behind the `org.brotli.dec` baseline, raising the question of whether the Java version was native. It isn't — the jar contains no native code — and neither was our decoder the problem: it's a faithful port with Google's own techniques (flat packed-`int[]` Huffman tables, a 64-bit bit accumulator, allocation-free command loop).

The cost was the streaming envelope around it: both input and output staged through `scala.collection.mutable.ArrayBuffer[Byte]`, which is **not specialized** — its backing store is an `Object[]`. One 4 MB decode built a 32 MB pointer array through four million boxed appends, then unboxed every byte again on the way out, with the compressed input paying the same plus a non-inlined generic array read. Six-ish full passes over the data around a decoder that needed none of them. Gzip never had this layer; Brotli was the module's outlier.

Both sides now stage in flat byte arrays moved by `System.arraycopy`. The separation checker required the codec's output to be installed through a `consume` parameter — which documents the ownership hand-off better than the per-byte copy it replaces.

| 4 MB corpus | Before | After | Baseline |
|---|---|---|---|
| Decompress | 80 op/s | **910 op/s** | Google pure-Java: 124 |
| Compress | 73 op/s | **149 op/s** | our Gzip (native zlib): 105 |

Honest caveat on the 7.3× decompression margin: this corpus, compressed by our own greedy encoder, decodes copy-dominated, which favours our one-shot flat-array decoder over Google's streaming ring buffer; literal-heavy streams will show a smaller edge. The compression figure needs no caveat: our pure-Scala Brotli now outruns native zlib Gzip on this corpus.

The bench row only counts decoded length, so a new test round-trips the exact 4 MB benchmark corpus byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)