### PR TITLE
Document why the hand-off unparks on every item

### DIFF
--- a/lib/zephyrine/src/core/zephyrine.Handoff.scala
+++ b/lib/zephyrine/src/core/zephyrine.Handoff.scala
@@ -88,6 +88,18 @@ final class Handoff(depth: Int) extends caps.SharedCapability:
       if position - head.get < capacity then
         slots.lazySet((position & mask).toInt, item)
         tail.set(position + 1)
+
+        // Deliberately unparked on EVERY item, not only on the empty→non-empty
+        // transition. The narrower wake is sound — a parked consumer must have
+        // observed emptiness at its guarded re-check, so only the offer ending
+        // the emptiness can have anyone to wake — and it removes the dominant
+        // profile frame (the virtual thread's park-permit exchange,
+        // `getAndSetBoolean`, 33% of the pipeline). It was measured, and it is
+        // 33% SLOWER: re-granting the permit per item keeps the counterpart's
+        // next `park` returning immediately, extending the spin budget across
+        // the thread boundary, where the sparing wake lets it truly sleep and
+        // repays the saved exchanges in wakeup latency at every ring drain.
+        // The profile cost is the cheaper side of the trade.
         val waiting = consumer
         if waiting != null then LockSupport.unpark(waiting)
         return


### PR DESCRIPTION
The Conduit hand-off profile shows a third of its time in `getAndSetBoolean` — the JDK virtual thread's park permit, atomically exchanged on every `LockSupport.park`/`unpark`. This PR adds twelve lines of comment, and no code change, because the obvious optimisation was implemented, measured twice (the second time as a same-session A/B), and found to be **33% slower** despite removing the frame from the profile entirely.

The elision is provably sound: a parked consumer must have observed emptiness at its guarded re-check, so only the offer ending the emptiness can have anyone to wake — one integer comparison elides every other unpark. But the per-item unpark is load-bearing: re-granting the permit each item keeps the counterpart's next `park` returning immediately, extending the spin budget across the thread boundary, where the sparing wake lets it truly sleep and repays the saved exchanges in wakeup latency at every ring drain (48,782 → 32,665 op/s).

The comment records this at the site so the dominant-looking profile frame is never again "optimised" without the history. It also answers a design question worth keeping: separation-style protocol reasoning can prove wakeup elisions *correct*, but no static analysis can delete a happens-before edge at a genuine thread boundary — and here, correct was not faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)