### PR TITLE
Supply TastyInfo when reifying a diagnostic TASTy payload

### DIFF
--- a/lib/delicious/src/scala/delicious.Reifier.scala
+++ b/lib/delicious/src/scala/delicious.Reifier.scala
@@ -151,6 +151,23 @@ class Reifier(classpath: LocalClasspath):
             ( ju.Base64.getDecoder.nn.decode(tasty.s).nn.asInstanceOf[scala.Array[Byte]],
               false )
 
+        // `TreeUnpickler`'s constructor reads `compilationUnitInfo.tastyInfo.get.attributes`
+        // UNCONDITIONALLY, so the `TastyInfo` must be present or every payload dies on `None.get` —
+        // inside `unpickle` below, where the `catch` turns it into a silent `Unset`. The one-argument
+        // `CompilationUnitInfo` supplies `None`, so `DottyUnpickler`'s own header/attributes step is
+        // reproduced here too. Its VALUES are inert for a diagnostic payload — the pickler writes no
+        // attributes section, so this is `Attributes.empty` and every flag is false, exactly what
+        // `DottyUnpickler` would compute — but the `Some` wrapper is load-bearing.
+        val attributes =
+          unpickler.unpickle(DottyUnpickler.AttributesSectionUnpickler()).map(_.attributes)
+          . getOrElse(dtd.core.tasty.Attributes.empty)
+
+        val header = unpickler.header
+
+        val version =
+          dotty.tools.tasty.TastyVersion
+            (header.majorVersion, header.minorVersion, header.experimentalVersion)
+
         // The file exists only to give the compilation unit an associated name: its
         // contents are never read (the unpickler above already has the bytes), but the
         // decode is repeated inline because only a fluid Java result adapts to the pure
@@ -159,7 +176,8 @@ class Reifier(classpath: LocalClasspath):
           CompilationUnitInfo
             ( VirtualFile
                 ( "<delicious>",
-                  ju.Base64.getDecoder.nn.decode(tasty.s).nn.asInstanceOf[scala.Array[Byte]] ) )
+                  ju.Base64.getDecoder.nn.decode(tasty.s).nn.asInstanceOf[scala.Array[Byte]] ),
+              Some(dtd.core.TastyInfo(version, attributes)) )
           . nn
         val positions = unpickler.unpickle(DottyUnpickler.PositionsSectionUnpickler())
         val comments = unpickler.unpickle(DottyUnpickler.CommentsSectionUnpickler())


### PR DESCRIPTION
Reifying a type from a semantic-diagnostic TASTy payload silently produced nothing, because the compilation unit handed to the unpickler carried no TASTy info; delicious now supplies it, so payloads reify as intended.

`Reifier` built its `CompilationUnitInfo` with the one-argument constructor, which supplies `None` for the TASTy info. `TreeUnpickler`'s constructor reads `compilationUnitInfo.tastyInfo.get.attributes` unconditionally, so every payload died on `None.get` — and because that happens inside `unpickle`, the surrounding `catch` turned the failure into a silent `Unset` rather than an error. The symptom was a reifier that never produced a type and never said why.

This reproduces `DottyUnpickler`'s own header/attributes step and passes `Some(TastyInfo(version, attributes))`:

```scala
val attributes =
  unpickler.unpickle(DottyUnpickler.AttributesSectionUnpickler()).map(_.attributes)
  . getOrElse(dtd.core.tasty.Attributes.empty)

val header = unpickler.header

val version =
  dotty.tools.tasty.TastyVersion
    (header.majorVersion, header.minorVersion, header.experimentalVersion)
```

The values are inert for a diagnostic payload — the pickler writes no attributes section, so this is `Attributes.empty` with every flag false, exactly what `DottyUnpickler` would compute. It is the `Some` wrapper that is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)