### PR TITLE
Apply layer excludes, and check sigils and select emptiness

### DIFF
--- a/lib/stratiform/src/core/stratiform.Tels.scala
+++ b/lib/stratiform/src/core/stratiform.Tels.scala
@@ -137,11 +137,16 @@ object Tels extends Tels2:
       description: Optional[Text] = Unset,
       encoding:    Optional[Text] = Unset )
 
+  // `excludes` is layer-only: the variant keywords a layer's `exclude`
+  // children remove from the merged SelectDefinition (§20.3). A base-side
+  // SelectDefinition must have none (E216), and composition consumes them,
+  // so a composed schema's excludes are always empty.
   case class SelectDefinition
     ( name:        Text,
       variants:    Array[Variant]^{},
       validators:  Array[Text]^{},
-      description: Optional[Text] = Unset )
+      description: Optional[Text] = Unset,
+      excludes:    Array[Text]^{} = Array.empty )
 
   // A Layer applies incremental refinements per §20.3. `overlay` is the
   // (possibly empty) Struct merged into the document root; the three
@@ -553,6 +558,9 @@ object Tels extends Tels2:
           if records.exists(_.name == newDef.name) || scalars.exists(_.name == newDef.name)
           then abort(Tel.Error(Reason.DuplicateDefinition))
 
+          // A layer-introduced fresh SelectDefinition has no base to
+          // exclude from, so any exclude it carries is E211.
+          if !newDef.excludes.nil then abort(Tel.Error(Reason.ExcludeMissingVariant))
           out += newDef
 
         i += 1
@@ -571,6 +579,16 @@ object Tels extends Tels2:
         if existingIdx < 0 then abort(Tel.Error(Reason.LayerVariantAddition))
         i += 1
 
+      // §20.3: apply the layer's excludes, removing each named variant
+      // from the merged SelectDefinition. An exclude naming no variant of
+      // the base is E211; whether the removals empty a SelectDefinition
+      // that a required SelectRef references (E212) is checked against
+      // the composed schema, where the referencing members are known.
+      layer.excludes.each: keyword =>
+        val idx = variants.indexWhere(_.keyword == keyword)
+        if idx < 0 then abort(Tel.Error(Reason.ExcludeMissingVariant))
+        variants.remove(idx)
+
       val mergedValidators = Array.frozen((base.validators.readable ++ layer.validators.readable).distinct)
 
       SelectDefinition(base.name, Array.from(variants), mergedValidators,
@@ -582,9 +600,26 @@ object Tels extends Tels2:
   // tighten its polarity (§20.3).
   object Validation:
 
-    // Compose `schema`'s layers, then check the composed schema; returns
-    // the composed schema for further use.
+    // Check the base-side constraints, compose `schema`'s layers, then
+    // check the composed schema; returns the composed schema for
+    // further use.
     def validate(schema: Tels): Tels raises Tel.Error =
+      // E207: the schema sigil must be sigil-valid per §6. (An invalid
+      // *pragma* sigil is E105 at parse time; this covers the schema
+      // model itself, however it was constructed.)
+      schema.sigil.let: sigil =>
+        if !sigilValid(sigil) then abort(Tel.Error(Reason.BadSchemaSigil))
+
+      // Base-side select constraints, checked before composition: a
+      // *declared* SelectDefinition must have at least one variant
+      // (E202) and no excludes (E216 — exclude is layer-only). Neither
+      // applies to the composed result: a layer's excludes may
+      // legitimately empty a select (E212 below covers the required
+      // case), and composition consumes them.
+      schema.selects.each: select =>
+        if select.variants.nil then abort(Tel.Error(Reason.EmptySelectVariants))
+        if !select.excludes.nil then abort(Tel.Error(Reason.ExcludeOutsideSelect))
+
       val composed = Layers.compose(schema)
       checkStruct(composed.document, composed)
 
@@ -592,10 +627,8 @@ object Tels extends Tels2:
         checkStruct(Struct(record.members, record.validators), composed)
 
       composed.selects.each: select =>
-        // E202: a SelectDefinition must have at least one variant. E201
-        // also covers duplicates within one SelectDefinition's variants,
-        // and E208 reserves `tel` among variant keywords.
-        if select.variants.nil then abort(Tel.Error(Reason.EmptySelectVariants))
+        // E201 also covers duplicates within one SelectDefinition's
+        // variants, and E208 reserves `tel` among variant keywords.
         val seen = scala.collection.mutable.HashSet.empty[Text]
 
         select.variants.each: variant =>
@@ -603,6 +636,14 @@ object Tels extends Tels2:
           if !seen.add(variant.keyword) then abort(Tel.Error(Reason.DuplicateKeywordInStruct))
 
       composed
+
+    // §6 sigil validity: a single character that is not whitespace, not
+    // a letter or digit, and not a parenthetical symbol. Mirrors the
+    // built-in `sigil` validator.
+    private def sigilValid(sigil: Char): Boolean =
+      !(sigil == ' ' || sigil == '\n' || sigil == '\r' || sigil == '\t')
+        && !sigil.isLetterOrDigit
+        && "()[]{}<>".indexOf(sigil.toInt) < 0
 
     // The Scalar a type resolves to through the composed namespace and
     // the built-ins (§20.5), or Unset for any non-Scalar resolution.
@@ -657,8 +698,19 @@ object Tels extends Tels2:
 
         case select: SelectRef =>
           schema.selects.readable.find(_.name == select.reference) match
-            case scala.Some(definition) => definition.variants.each { variant => claim(variant.keyword) }
-            case scala.None             => ()
+            case scala.Some(definition) =>
+              definition.variants.each { variant => claim(variant.keyword) }
+
+              // E212: a layer's excludes must not empty a
+              // SelectDefinition that an effectively required SelectRef
+              // references — the member could then never be filled.
+              // Checked against the composed schema, where both the
+              // post-exclusion variant lists and the referencing members
+              // are known.
+              if definition.variants.nil && select.required != Polarity.Loose
+              then abort(Tel.Error(Reason.ExcludeEmptiesRequired))
+
+            case scala.None => ()
 
         case _ => ()
 
@@ -720,7 +772,8 @@ object Tels extends Tels2:
         seqEq(a.variants, b.variants, (x, y) => x.keyword == y.keyword &&
           typeEq(x.variantType, y.variantType) && x.description == y.description) &&
         seqEq(a.validators, b.validators, textEq) &&
-        a.description == b.description
+        a.description == b.description &&
+        seqEq(a.excludes, b.excludes, textEq)
 
     private def layerEq(a: Layer, b: Layer): Boolean =
       a.name == b.name && structEq(a.overlay, b.overlay) &&
@@ -839,11 +892,12 @@ object Tels extends Tels2:
       val children   = childCompounds(c)
       val variants   = scala.collection.mutable.ArrayBuffer.empty[Variant]
       val validators = scala.collection.mutable.ArrayBuffer.empty[Text]
+      val excludes   = scala.collection.mutable.ArrayBuffer.empty[Text]
 
       children.each: cc =>
         cc.keyword.s match
           case "validate"    => validators ++= atomTexts(cc).readable
-          case "exclude"     => ()
+          case "exclude"     => scalarAtomText(cc).let { keyword => excludes += keyword }
           case "description" => ()
 
           case "variant" =>
@@ -855,7 +909,8 @@ object Tels extends Tels2:
             abort(Tel.Error(Reason.UnknownKeyword))
 
       SelectDefinition
-        ( seName, Array.from(variants), Array.from(validators), descriptionOf(children) )
+        ( seName, Array.from(variants), Array.from(validators), descriptionOf(children),
+          Array.from(excludes) )
 
     private def parseBody(c: Tel.Compound): Optional[Struct] raises Tel.Error =
       val (members, validators) = parseMembersAndValidators(childCompounds(c))
@@ -1122,6 +1177,7 @@ object Tels extends Tels2:
       val ch = childrenOf(element)
       val variants   = scala.collection.mutable.ArrayBuffer.empty[Variant]
       val validators = scala.collection.mutable.ArrayBuffer.empty[Text]
+      val excludes   = scala.collection.mutable.ArrayBuffer.empty[Text]
       var i = 0
 
       while i < ch.length do
@@ -1129,6 +1185,10 @@ object Tels extends Tels2:
 
         kidx(e) match
           case 1 => variants += variantFromElement(e)
+
+          case 2 => e match
+            case Tel.Element.Value(_, _, t) => excludes += t
+            case _                          => ()
 
           case 3 => e match
             case Tel.Element.Value(_, _, t) => validators += t
@@ -1139,7 +1199,7 @@ object Tels extends Tels2:
         i += 1
 
       SelectDefinition(textAt(ch, 0).or(t""), Array.from(variants), Array.from(validators),
-          textAt(ch, 4))
+          textAt(ch, 4), Array.from(excludes))
 
     // Body meta: Member{field=0, select=1, validate=2}.
     private def bodyFromElement(element: Tel.Element): Struct =

--- a/lib/stratiform/src/test/stratiform.SchemaCorpusTests.scala
+++ b/lib/stratiform/src/test/stratiform.SchemaCorpusTests.scala
@@ -52,12 +52,12 @@ object SchemaCorpusTests extends Suite(m"Stratiform schema corpus tests"):
 
   // Codes this implementation can raise. Corpus cases whose expected codes
   // fall wholly outside this set are pending-implementation and skipped,
-  // mirroring the E1xx suite's `< 200` gate. E207 (bad sigil), E211/E212
-  // (exclude checks), E312/E313 (codec rejection needs a configured
-  // binding, which the corpus convention cannot supply) are excluded.
+  // mirroring the E1xx suite's `< 200` gate. E312/E313 are excluded: codec
+  // rejection needs a configured binding, which the corpus convention
+  // cannot supply.
   val implemented: scala.collection.immutable.Set[Int] =
     scala.collection.immutable.Set
-      ( 201, 202, 203, 204, 205, 206, 208, 209, 210, 213, 214, 215, 216, 217,
+      ( 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217,
         218, 219, 220, 221,
         301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 314 )
 

--- a/lib/stratiform/src/test/stratiform.SchemaValidityTests.scala
+++ b/lib/stratiform/src/test/stratiform.SchemaValidityTests.scala
@@ -1,0 +1,211 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import soundness.*
+
+import proscenium.compat.*
+
+import strategies.throwUnsafely
+import errorDiagnostics.stackTracesDiagnostics
+import charEncoders.utf8Encoder
+
+// The schema-validity checks of §20.1 beyond keys and encodings: E207
+// (sigil validity), E202/E216 base-side select constraints, and the
+// layer `exclude` operation (§20.3) with E211 (no such variant) and
+// E212 (emptying a SelectDefinition referenced by a required SelectRef).
+object SchemaValidityTests extends Suite(m"Stratiform schema validity tests"):
+
+  private def schemaOf(text: Text): Tels = Tels.Reconstructor.fromTel(text.read[Tel])
+
+  // The schema-validity code raised by composing and checking `schema`, or 0.
+  private def codeOf(schema: Tels): Int =
+    try
+      Tels.Validation.validate(schema)
+      0
+    catch case error: Tel.Error => error.reason.number
+
+  private def schemaCode(text: Text): Int = codeOf(schemaOf(text))
+
+  // A base schema with a three-variant Select, referenced by `pet`.
+  private def menagerie(required: Boolean, layerBody: Text): Text =
+    val polarity = if required then t"" else t" optional"
+    Text(s"""|tel 1.0
+             |
+             |name menagerie
+             |
+             |record Cat
+             |  field name Identifier
+             |
+             |record Dog
+             |  field name Identifier
+             |
+             |record Fox
+             |  field name Identifier
+             |
+             |select Pet
+             |  variant cat Cat
+             |  variant dog Dog
+             |  variant fox Fox
+             |
+             |document
+             |  select Pet$polarity repeatable
+             |${layerBody.s}""".stripMargin)
+
+  def run(): Unit =
+    suite(m"Sigil validity (E207)"):
+      test(m"a parenthetical sigil raises E207"):
+        codeOf(schemaOf(t"tel 1.0\nname t\ndocument\n  field a String\n").copy(sigil = '('))
+      . assert(_ == 207)
+
+      test(m"a letter sigil raises E207"):
+        codeOf(schemaOf(t"tel 1.0\nname t\ndocument\n  field a String\n").copy(sigil = 'x'))
+      . assert(_ == 207)
+
+      test(m"a symbolic sigil is accepted"):
+        codeOf(schemaOf(t"tel 1.0\nname t\ndocument\n  field a String\n").copy(sigil = '%'))
+      . assert(_ == 0)
+
+    suite(m"Base-side select constraints"):
+      test(m"E202: a base SelectDefinition with no variants"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |select Empty
+                       |  validate something
+                       |document
+                       |  field a String
+                       |""".stripMargin))
+      . assert(_ == 202)
+
+      test(m"E216: exclude in a base SelectDefinition body"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |record Cat
+                       |  field name Identifier
+                       |select Pet
+                       |  variant cat Cat
+                       |  exclude cat
+                       |document
+                       |  select Pet optional
+                       |""".stripMargin))
+      . assert(_ == 216)
+
+    suite(m"Layer excludes (§20.3, E211/E212)"):
+      test(m"an excluded variant is removed from the composed select"):
+        val composed = Tels.Validation.validate:
+          schemaOf(menagerie(required = false, Text("""|layer no-foxes
+                                                   |  select Pet
+                                                   |    exclude fox
+                                                   |""".stripMargin)))
+        composed.selects.readable.find(_.name == t"Pet").get.variants.readable.map(_.keyword.s).toList
+      . assert(_ == List("cat", "dog"))
+
+      test(m"a document using an excluded variant fails with E306"):
+        val composed = Tels.Validation.validate:
+          schemaOf(menagerie(required = false, Text("""|layer no-foxes
+                                                   |  select Pet
+                                                   |    exclude fox
+                                                   |""".stripMargin)))
+        capture[Tel.Error](Tel.Type.assign(t"tel 1.0\n\nfox robin\n".read[Tel], composed))
+        . reason.number
+      . assert(_ == 306)
+
+      test(m"E211: exclude names a variant absent from the base"):
+        schemaCode(menagerie(required = false, Text("""|layer no-wolves
+                                                   |  select Pet
+                                                   |    exclude wolf
+                                                   |""".stripMargin)))
+      . assert(_ == 211)
+
+      test(m"E211: exclude in a layer-introduced fresh select"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |record Cat
+                       |  field name Identifier
+                       |document
+                       |  field a String
+                       |layer fresh
+                       |  select Pet
+                       |    variant cat Cat
+                       |    exclude cat
+                       |""".stripMargin))
+      . assert(_ == 211)
+
+      test(m"E212: excludes emptying a required select"):
+        schemaCode(menagerie(required = true, Text("""|layer none
+                                                  |  select Pet
+                                                  |    exclude cat
+                                                  |    exclude dog
+                                                  |    exclude fox
+                                                  |""".stripMargin)))
+      . assert(_ == 212)
+
+      test(m"emptying an optional select is permitted"):
+        schemaCode(menagerie(required = false, Text("""|layer none
+                                                   |  select Pet
+                                                   |    exclude cat
+                                                   |    exclude dog
+                                                   |    exclude fox
+                                                   |""".stripMargin)))
+      . assert(_ == 0)
+
+      test(m"E212: a required SelectRef inside a record also counts"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |record Cat
+                       |  field name Identifier
+                       |record Owner
+                       |  field name Identifier
+                       |  select Pet
+                       |select Pet
+                       |  variant cat Cat
+                       |document
+                       |  field owner Owner optional repeatable
+                       |layer none
+                       |  select Pet
+                       |    exclude cat
+                       |""".stripMargin))
+      . assert(_ == 212)
+
+      test(m"excludes survive a BinTEL round-trip of the schema document"):
+        // The SelectChild `exclude` variant (§20.5) must be carried by the
+        // semantic reconstruction, or a layer loses its excludes when a
+        // schema travels as BinTEL.
+        val doc = menagerie(required = false, Text("""|layer no-foxes
+                                                  |  select Pet
+                                                  |    exclude fox
+                                                  |""".stripMargin)).read[Tel]
+        val body = doc.bintel(Tels.Axiom.tels)
+        val element = Bintel.decode(body, Tels.Axiom.tels)
+        val composed = Tels.Validation.validate(Tels.SemanticReconstructor.fromElement(element))
+        composed.selects.readable.find(_.name == t"Pet").get.variants.readable.map(_.keyword.s).toList
+      . assert(_ == List("cat", "dog"))

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -2873,6 +2873,7 @@ object Tests extends Suite(m"Stratiform Tests"):
     VerifyTests()
     AccrualTests()
     SchemaCorpusTests()
+    SchemaValidityTests()
     KeyTests()
     TelpTests()
     CodecTests()


### PR DESCRIPTION
The last three unimplemented TEL schema-validity checks land, along with the layer `exclude` operation they depend on: a layer can now actually remove variants from a merged SelectDefinition, an exclude naming no base variant is rejected (E211), excludes that would empty a select referenced by a required member are rejected (E212), and a schema sigil that is not sigil-valid is rejected (E207).

**Layer excludes now work.** A layer's `exclude` children remove the named variants from the merged SelectDefinition during composition, so a composed schema no longer silently retains excluded variants — a document using an excluded variant keyword now fails with E306:

```tel
select Pet
  variant cat Cat
  variant dog Dog
  variant fox Fox

document
  select Pet optional repeatable

layer no-foxes
  select Pet
    exclude fox
```

An `exclude` naming a variant absent from the base — including any exclude on a layer-introduced fresh select, which has no base to exclude from — raises **E211**. Excludes are carried on `Tels.SelectDefinition.excludes` (layer-only; composition consumes them) and survive BinTEL round-trips of schema documents.

**E212.** Excludes may legitimately empty an *optional* select, but emptying a SelectDefinition referenced by an effectively required SelectRef — a member that could then never be filled — raises **E212**. This is checked against the composed schema, where the referencing members are known; the Rust reference documents this check as deferred, so Stratiform goes one step further here. Accordingly, E202 (empty variants) and E216 (base-side exclude) become base-side, pre-composition checks in `Tels.Validation`.

**E207.** A `Schema.sigil` that is not sigil-valid per §6 — whitespace, a letter or digit, or a parenthetical symbol — is rejected at schema validation, mirroring the built-in `sigil` validator. (An invalid *pragma* sigil remains E105 at parse time; E207 covers the schema model itself, however it was constructed.)

Closes #1814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)