### PR TITLE
Support scalar encodings in the staged BinTEL parser

### DIFF
--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -573,6 +573,20 @@ object Bintel:
     if parser.offset != data.length then abort(Bintel.Error(Bintel.Error.Reason.TrailingBytes))
     result
 
+  // Codec-aware direct parsing: leaves whose type declares a §21.7
+  // encoding (the `Tel.Encoded` marker) read codec bytes through the
+  // binding, with B13/B14 and, under `checkCanonical`, B15 — matching
+  // the AST decoder's rules exactly.
+  def parse[value](data: Data, codecs: Tel.Codec.Bindings, checkCanonical: Boolean = false)
+    ( using parsable: (value is Bintel.Parsable)^ )
+    ( using tactic: Tactic[Bintel.Error] )
+  :   value =
+
+    val parser = BintelParser(data, Tel.Codec.Resolver(codecs), checkCanonical)
+    val result = parsable.parse(BintelReader(parser, tactic))
+    if parser.offset != data.length then abort(Bintel.Error(Bintel.Error.Reason.TrailingBytes))
+    result
+
   // Decode BinTEL body bytes to a typed value, deriving the schema from the value's type
   // — the inverse of `value.bintel`.
   def read[value: Tel.Decodable](data: Data)
@@ -582,6 +596,17 @@ object Bintel:
 
     val schema = Tels.tels[value](Text("root"))
     present(decode(data, schema), schema).as[value]
+
+  // As above, decoding scalars whose derived schema declares a §21.7
+  // encoding through the codec binding.
+  def read[value: Tel.Decodable]
+    ( data: Data, codecs: Tel.Codec.Bindings, checkCanonical: Boolean = false )
+    ( using value is TelSchematic over Tels.Type )
+    ( using Tactic[Bintel.Error], Tactic[Tel.Error] )
+  :   value =
+
+    val schema = Tels.tels[value](Text("root"))
+    present(decode(data, schema, codecs, checkCanonical), schema).as[value]
 
   private def resolveType(t: Tels.Type, schema: Tels): Tels.Type = t match
     case Tels.Reference(name) =>

--- a/lib/stratiform/src/binary/stratiform.BintelParser.scala
+++ b/lib/stratiform/src/binary/stratiform.BintelParser.scala
@@ -34,6 +34,7 @@ package stratiform
 
 import anticipation.*
 import contingency.*
+import vacuous.*
 
 // Reads BinTEL body bytes for direct parsing (`Bintel.Parsable`): the
 // document structure is fully count-driven and self-delimiting, so the
@@ -45,7 +46,11 @@ import contingency.*
 // The class is public — generated parsers, spliced into user modules, bind
 // it once per read and step through its direct rim — but only stratiform's
 // read path can construct one.
-final class BintelParser private[stratiform] (input: Data):
+final class BintelParser private[stratiform]
+  ( input: Data,
+    codecs: Optional[Tel.Codec.Resolver] = Unset,
+    checkCanonical: Boolean = false ):
+
   @scala.caps.unsafe.untrackedCaptures
   private[stratiform] val data: scala.Array[Byte] = input.asInstanceOf[scala.Array[Byte]]
 
@@ -92,13 +97,39 @@ final class BintelParser private[stratiform] (input: Data):
     offset += length
     result
 
-  // One scalar payload's raw bytes, without UTF-8 decoding: the leaf a
-  // codec-aware staged parser would use for encoded scalars (§21.7).
-  // The staged layer derives its plans from Scala types, which declare
-  // no encodings, so nothing generates calls to this yet; full staged
-  // codec support is deferred until derived schemas can. Framing is
-  // codec-independent, so `directSkipScalar` already skips encoded
-  // scalars correctly.
+  // One scalar payload through the §21.7 codec named `encoding`: the raw
+  // bytes are read via `directScalarBytes` and decoded by the bound codec
+  // — B13 when no binding is configured or the name does not resolve, B14
+  // when the codec rejects the bytes, and B15 under the OPTIONAL
+  // re-encode canonicality check. Generated parsers call this at leaves
+  // whose type declares an encoding via the `Tel.Encoded` marker.
+  def directEncodedScalar(encoding: String)(using Tactic[Bintel.Error]): String =
+    val bytes = directScalarBytes()
+
+    val codec = codecs.let(_(Text(encoding)))
+    . or(abort(Bintel.Error(Bintel.Error.Reason.CodecUnresolved)))
+
+    val frozen = bytes.asInstanceOf[Data]
+
+    codec.decode(frozen) match
+      case Tel.Codec.Decoded.Failure(_) =>
+        abort(Bintel.Error(Bintel.Error.Reason.CodecDecodeFailed))
+
+      case Tel.Codec.Decoded.Value(text) =>
+        if checkCanonical then codec.encode(text) match
+          case Tel.Codec.Encoded.Bytes(re) =>
+            if !java.util.Arrays.equals(re.asInstanceOf[scala.Array[Byte]], bytes)
+            then abort(Bintel.Error(Bintel.Error.Reason.CodecNoncanonical))
+
+          case Tel.Codec.Encoded.Invalid(_) =>
+            abort(Bintel.Error(Bintel.Error.Reason.CodecNoncanonical))
+
+        text.s
+
+  // One scalar payload's raw bytes, without UTF-8 decoding: the leaf
+  // `directEncodedScalar` reads before applying its codec. Framing is
+  // codec-independent, so `directSkipScalar` skips encoded scalars
+  // correctly too.
   def directScalarBytes()(using Tactic[Bintel.Error]): scala.Array[Byte] =
     val length = directCount()
 

--- a/lib/stratiform/src/binaryStaged/stratiform.bintelInternal.scala
+++ b/lib/stratiform/src/binaryStaged/stratiform.bintelInternal.scala
@@ -256,7 +256,7 @@ object bintelInternal:
   private enum Elem:
     case Scalar(kind: Int)
     case Nested(instance: BintelInlinable, tpe: Any)
-    case SeamText(decoder: Any)
+    case SeamText(decoder: Any, encoding: Option[String])
 
   private enum Plan:
     case Leaf(kind: Int)
@@ -264,7 +264,7 @@ object bintelInternal:
     case OptionalLeaf(kind: Int)
     case OptionalNested(instance: BintelInlinable, innerType: Any)
     case Gather(element: Elem, elementType: Any)
-    case SeamText(decoder: Any)
+    case SeamText(decoder: Any, encoding: Option[String])
 
   private def resolve[field: Type](cache: Cache)(using Quotes): Option[BintelInlinable] =
     import quotes.reflect.*
@@ -287,6 +287,26 @@ object bintelInternal:
 
     case other =>
       other
+
+  // The §21.7 encoding a field type declares via the `Tel.Encoded`
+  // marker, read from the literal name type of the resolved instance at
+  // expansion time — so the generated leaf pays nothing at runtime to
+  // discover it. `None` for undeclared types (the UTF-8 text form).
+  private def staticEncoding[fieldType: Type](using Quotes): Option[String] =
+    import quotes.reflect.*
+
+    Implicits.search(TypeRepr.of[fieldType is Tel.Encoded[?]]) match
+      case success: ImplicitSearchSuccess =>
+        val encodedSymbol = TypeRepr.of[Tel.Encoded[?]].typeSymbol
+
+        success.tree.tpe.baseType(encodedSymbol) match
+          case AppliedType(_, List(name)) => name.dealias match
+            case ConstantType(StringConstant(text)) => Some(text)
+            case _                                  => None
+
+          case _ => None
+
+      case _ => None
 
   // A custom scalar leaf: its `Decodable in Text`, resolved at expansion
   // time with a reflection-level search and an erasing cast across the
@@ -395,7 +415,8 @@ object bintelInternal:
                       case _ =>
                         textDecoder[element] match
                           case Some(decoder) =>
-                            Plan.Gather(Elem.SeamText(decoder), elementType)
+                            Plan.Gather
+                              (Elem.SeamText(decoder, staticEncoding[element]), elementType)
 
                           case None =>
                             reject("a collection of an unsupported element")
@@ -413,7 +434,7 @@ object bintelInternal:
 
               case _ =>
                 textDecoder[field] match
-                  case Some(decoder) => Plan.SeamText(decoder)
+                  case Some(decoder) => Plan.SeamText(decoder, staticEncoding[field])
 
                   case None =>
                     if cache.active.contains(tpe.show) then reject("recursive")
@@ -603,10 +624,17 @@ object bintelInternal:
         case KText    => '{ t"" }
         case KString  => Expr("")
 
-      def seamRead(decoder: Any): Expr[Any] =
+      def seamRead(decoder: Any, encoding: Option[String]): Expr[Any] =
         val found = decoder.asInstanceOf[Expr[Any]]
-        '{ $found.asInstanceOf[Any is Decodable in Text]
-             . decoded(Text($parser.directScalar()(using $btactic))) }
+
+        // An encoded leaf (§21.7) reads codec bytes; the decoded semantic
+        // text then flows through the same `Decodable in Text` as the
+        // UTF-8 form, so value semantics are identical either way.
+        val atom: Expr[String] = encoding match
+          case Some(name) => '{ $parser.directEncodedScalar(${Expr(name)})(using $btactic) }
+          case None       => '{ $parser.directScalar()(using $btactic) }
+
+        '{ $found.asInstanceOf[Any is Decodable in Text].decoded(Text($atom)) }
 
       // Per-field gathering state for repeatable fields.
       val builders: scala.collection.immutable.Map[Int, Symbol] =
@@ -696,11 +724,11 @@ object bintelInternal:
 
                 focusedOver[fieldType]('{ $raw.asInstanceOf[fieldType] }).asTerm
 
-          case Plan.SeamText(decoder) =>
+          case Plan.SeamText(decoder, encoding) =>
             fieldTypes(index).asType match
               case '[fieldType] =>
                 focusedOver[fieldType]
-                  ('{ ${seamRead(decoder)}.asInstanceOf[fieldType] }).asTerm
+                  ('{ ${seamRead(decoder, encoding)}.asInstanceOf[fieldType] }).asTerm
 
           case Plan.Gather(element, elementType0) =>
             val elementType = elementType0.asInstanceOf[TypeRepr]
@@ -718,8 +746,8 @@ object bintelInternal:
                     instance0.asInstanceOf[BintelInlinable { type Self = element }]
                     . parse(reader)
 
-                  case Elem.SeamText(decoder) =>
-                    '{ ${seamRead(decoder)}.asInstanceOf[element] }
+                  case Elem.SeamText(decoder, encoding) =>
+                    '{ ${seamRead(decoder, encoding)}.asInstanceOf[element] }
 
                 '{ $builder += ${ focusedOver[element](occurrence) } }.asTerm
 
@@ -800,7 +828,7 @@ object bintelInternal:
                 instance.asInstanceOf[BintelInlinable { type Self = fieldType }]
                 . absent(tactic)
 
-              case Plan.SeamText(_) =>
+              case Plan.SeamText(_, _) =>
                 '{ abort(Tel.Error(Tel.Error.Reason.Absent))(using $tactic) }
 
               case Plan.Gather(_, _) =>

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -1800,6 +1800,23 @@ object Tel extends Tel2:
     def encode(text: Text): Tel.Codec.Encoded
     def decode(bytes: Data): Tel.Codec.Decoded
 
+  // Declares that a Scala type's TEL scalar form carries the named §21.7
+  // encoding. The name is a *literal type*, so the staged BinTEL parser
+  // reads it at macro-expansion time, and the schema derivation reifies
+  // the same declaration into the derived `Tels.Scalar`'s `encoding` —
+  // one declaration, coherent across both layers:
+  //
+  //     given Money is Tel.Encoded["decimal-varint"] = Tel.Encoded()
+  //
+  // The declaring type also needs a `Decodable in Text` (and, to encode,
+  // an `Encodable in Text`): the codec maps the scalar's semantic *text*
+  // to bytes, exactly as at validation time.
+  object Encoded:
+    def apply[self, name <: Label](): self is Encoded[name] =
+      new Encoded[name] { type Self = self }
+
+  open class Encoded[name <: Label] extends prepositional.Typeclass
+
   object Element:
     case class Node
       ( keywordIndex: Optional[Int],

--- a/lib/stratiform/src/core/stratiform.Tels2.scala
+++ b/lib/stratiform/src/core/stratiform.Tels2.scala
@@ -142,6 +142,15 @@ object Tels2:
 // field, and `Map` to repeatable `entries` of `key`/`value`. Mixed into `object
 // Tels` so the givens sit in the `Transport` companion's implicit scope.
 trait Tels2:
+  // A type declaring a §21.7 encoding via the `Tel.Encoded` marker is a
+  // scalar whose derived schema carries that encoding, so the AST and
+  // staged BinTEL paths agree on its wire form by construction.
+  given encoded: [value, name <: Label]
+  =>  (marker: value is Tel.Encoded[name])
+  =>  (name0: ValueOf[name])
+  =>  value is TelSchematic over Tels.Type =
+    () => Tels.Scalar(Array.empty, Text(name0.value))
+
   given text: Text is TelSchematic over Tels.Type = () => Tels.Scalar(Array.empty)
   given string: String is TelSchematic over Tels.Type = () => Tels.Scalar(Array.empty)
   given int: Int is TelSchematic over Tels.Type = () => Tels.Scalar(Array.empty)

--- a/lib/stratiform/src/test/stratiform.CodecTests.scala
+++ b/lib/stratiform/src/test/stratiform.CodecTests.scala
@@ -285,3 +285,67 @@ object CodecTests extends Suite(m"Stratiform codec tests"):
         val reconstructed = Tels.SemanticReconstructor.fromElement(element)
         reconstructed.scalars.readable.find(_.name == t"Amount").map(_.encoding).getOrElse(Unset)
       . assert(_ == t"decimal-varint")
+
+    suite(m"Staged parser (Bintel.Parsable) encoded scalars"):
+      given (Payment is Bintel.Parsable) = BintelInlinable.parsable[Payment]
+
+      def paymentBytes: Data =
+        val schema = Tels.tels[Payment](t"payment")
+        val element = Tel.Type.assign(t"tel 1.0\n\namount 300\n".read[Tel], schema)
+        Bintel.encode(element, schema, bindings)
+
+      test(m"the derived schema carries the declared encoding"):
+        Tels.tels[Payment](t"payment").document.members.readable.head.absolve match
+          case f: Tels.Field => f.fieldType.absolve match
+            case s: Tels.Scalar => s.encoding
+      . assert(_ == t"decimal-varint")
+
+      test(m"an encoded scalar is written as codec bytes under the derived schema"):
+        paymentBytes.readable.toSeq
+      . assert(_ == bytesOf(0x01, 0x00, 0x02, 0xAC, 0x02).readable.toSeq)
+
+      test(m"the generated parser decodes an encoded scalar through the codec"):
+        Bintel.parse[Payment](paymentBytes, bindings).amount.value
+      . assert(_ == 300L)
+
+      test(m"parsing without a binding raises B13"):
+        capture[Bintel.Error](Bintel.parse[Payment](paymentBytes)).reason
+      . assert(_ == Bintel.Error.Reason.CodecUnresolved)
+
+      test(m"B14: bytes the codec rejects fail the generated parser"):
+        val body = bytesOf(0x01, 0x00, 0x01, 0x80)
+        capture[Bintel.Error](Bintel.parse[Payment](body, bindings)).reason
+      . assert(_ == Bintel.Error.Reason.CodecDecodeFailed)
+
+      test(m"non-canonical bytes parse leniently without the B15 check"):
+        val body = bytesOf(0x01, 0x00, 0x03, 0xAC, 0x82, 0x00)
+        Bintel.parse[Payment](body, bindings).amount.value
+      . assert(_ == 300L)
+
+      test(m"B15: the canonicality check rejects overlong bytes"):
+        val body = bytesOf(0x01, 0x00, 0x03, 0xAC, 0x82, 0x00)
+        capture[Bintel.Error](Bintel.parse[Payment](body, bindings, checkCanonical = true))
+        . reason
+      . assert(_ == Bintel.Error.Reason.CodecNoncanonical)
+
+      test(m"an unencoded sibling field still parses as UTF-8 text"):
+        val schema = Tels.tels[Invoice](t"invoice")
+        val element = Tel.Type.assign(t"tel 1.0\n\namount 300\nmemo lunch\n".read[Tel], schema)
+        val body = Bintel.encode(element, schema, bindings)
+        given (Invoice is Bintel.Parsable) = BintelInlinable.parsable[Invoice]
+        val invoice = Bintel.parse[Invoice](body, bindings)
+        (invoice.amount.value, invoice.memo)
+      . assert(_ == (300L, t"lunch"))
+
+// Fixtures for the staged encoded-scalar tests: a scalar type whose BinTEL
+// form is the `decimal-varint` codec's bytes, declared once via the
+// `Tel.Encoded` marker — the schema derivation and the staged parser both
+// read the same declaration.
+class Money(val value: Long)
+
+object Money:
+  given decodable: Money is Decodable in Text = text => Money(text.s.toLong)
+  given encoded: Money is Tel.Encoded["decimal-varint"] = Tel.Encoded()
+
+case class Payment(amount: Money)
+case class Invoice(amount: Money, memo: Text)


### PR DESCRIPTION
The staged BinTEL parser catches up with scalar encodings: a Scala type declares its §21.7 codec once, via the new `Tel.Encoded` marker, and both BinTEL layers — the AST path through the derived schema, and the compile-time-generated parser — read that single declaration, so a type's wire form cannot silently diverge between them.

**Declaring an encoding.** A scalar type names its codec with a literal type:

```scala
class Money(val value: Long)

object Money:
  given decodable: Money is Decodable in Text = text => Money(text.s.toLong)
  given encoded: Money is Tel.Encoded["decimal-varint"] = Tel.Encoded()
```

The schema derivation reifies the marker into the derived `Tels.Scalar`'s `encoding`, so `Tels.tels[Payment]` produces a schema under which the AST encoder and decoder write and read `Money` fields as codec bytes. The staged generator reads the literal name at macro-expansion time, so the generated parser reaches its codec through a static name — no runtime schema inspection at the leaf.

**Parsing with a binding.** `Bintel.parse` and `Bintel.read` gain codec-aware overloads:

```scala
given (Payment is Bintel.Parsable) = BintelInlinable.parsable[Payment]

Bintel.parse[Payment](bytes, bindings)
Bintel.parse[Payment](bytes, bindings, checkCanonical = true)
```

`BintelParser` carries the resolve-once codec resolver and the canonicality flag, and its new `directEncodedScalar` leaf applies the bound codec with exactly the AST decoder's rules — B13 when no binding resolves the name, B14 when the codec rejects the bytes, and B15 under the optional re-encode canonicality check — before the decoded semantic text flows through the type's ordinary `Decodable in Text`.

Closes #1815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)