### PR TITLE
Adopt Proscala 3.9.0-RC5-p14 and fix the opaque-List leak sites it reveals

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -71,8 +71,8 @@ object settings:
   // (`SOUNDNESS_SCALA_RELEASE`) is a separate concept, though from `3.9.0-RC4-p1` on the two
   // coincide (earlier releases shipped jars built as e.g. `3.9.0-RC1-propensive`). Override the
   // coordinate with `SOUNDNESS_SCALA_VERSION`.
-  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC5-p11")
-  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC5-p13")
+  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC5-p14")
+  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC5-p14")
   // Empty by default → download `scalaRelease`. Set to a local `release` directory to use its
   // `release/lib` jars directly (fork-developer mode).
   val scalaHome = sys.env.getOrElse("SOUNDNESS_SCALA_HOME", "")

--- a/lib/anthology/src/linker/anthology.Bundler.scala
+++ b/lib/anthology/src/linker/anthology.Bundler.scala
@@ -112,6 +112,6 @@ object Bundler:
           case _ =>
             Nil.stdlib
 
-      entries.distinctBy(_.ref)
+      entries.stdlib.distinctBy(_.ref)
 
     jarfile

--- a/lib/burdock/src/core/burdock.Repackager.scala
+++ b/lib/burdock/src/core/burdock.Repackager.scala
@@ -260,7 +260,7 @@ object Repackager:
         val entries: List[Zip.Entry] =
           List.of((bootstrap :: keptEntries.stdlib ++ inlined.stdlib).distinctBy(_.ref.show))
 
-        Zipfile.write(outputJar)(manifestEntry :: entries)
+        Zipfile.write(outputJar)((manifestEntry :: entries).stdlib)
 
         // The output also carries the manifest entry, hence `entries.length + 1`.
         Summary

--- a/lib/dendrology/src/tree/dendrology.TreeDiagram.scala
+++ b/lib/dendrology/src/tree/dendrology.TreeDiagram.scala
@@ -56,7 +56,7 @@ object TreeDiagram:
 
       input.stdlib.zipWithIndex.to(Chain).flatMap: (item, index) =>
         val tiles: List[TreeTile] =
-          List.of(((if index == last then Last else Branch) :: level).reverse)
+          ((if index == last then Last else Branch) :: level).reverse
 
         ((tiles, item) #::
           recur((if index == last then Space else Extender) :: level, getChildren(item)))

--- a/lib/digression/src/ansi/digression_ansi.scala
+++ b/lib/digression/src/ansi/digression_ansi.scala
@@ -221,7 +221,7 @@ package teletypeables:
     val tableLines = List.from(dataOnly.render.stdlib)
 
     val allLines = init :: (tableLines: List[Teletype])
-    val root = (allLines: Iterable[Teletype]).join(e"\n")
+    val root = (allLines.stdlib: Iterable[Teletype]).join(e"\n")
 
     stack.cause.lay(root): cause => e"$root\n${palette.message}(caused by:)\n$cause"
 

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -145,7 +145,7 @@ extends Cli:
       val allFlags = (flag.name :: flag.aliases)
 
       if longOnly then
-        List.of(allFlags.collect { case text: Text => text }).match
+        allFlags.collect { case text: Text => text }.match
           case main :: aliases =>
             List
               ( Suggestion

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -490,7 +490,7 @@ object SourceCode:
 
     try
       val settings = ("-classpath" :: cp.s :: scalac.commandLineArguments.map(_.s)).map(_.nn)
-      val driver = interactive.InteractiveDriver(settings)
+      val driver = interactive.InteractiveDriver(settings.stdlib)
       // The driver resolves the URI as a path, so it must use the `file` scheme, though no
       // file exists there: the source text is supplied directly.
       val uri = java.nio.file.Path.of("/harlequin-highlighting.scala").nn.toUri.nn

--- a/lib/jacinta/src/core/jacinta.internal.scala
+++ b/lib/jacinta/src/core/jacinta.internal.scala
@@ -1299,7 +1299,7 @@ object internal:
         Apply(applied, slots.stdlib.map { slot => Ref(slot) })
 
       Block
-        ( '{ $reader.openObject() }.asTerm :: slotDefs ::: seenDefs ::: loop ::: absents,
+        ( ('{ $reader.openObject() }.asTerm :: slotDefs ::: seenDefs ::: loop ::: absents).stdlib,
           construct )
       . asExprOf[value]
 

--- a/lib/mosquito/src/core/mosquito.internal.scala
+++ b/lib/mosquito/src/core/mosquito.internal.scala
@@ -146,7 +146,7 @@ object internal:
           val bottom = t"⎝ ${items.last.pad(width, Rtl)} ⎠"
           val middle = items.tail.init.map: item => t"⎜ ${item.pad(width, Rtl)} ⎟"
 
-          (top :: middle ::: bottom :: Nil).join(t"\n")
+          (top :: List.of(middle) ::: bottom :: Nil).join(t"\n")
 
   extension [left](left: Vector[left, 3])
     def cross[right](right: Vector[right, 3])

--- a/lib/phoenicia/src/core/phoenicia.Truetype.scala
+++ b/lib/phoenicia/src/core/phoenicia.Truetype.scala
@@ -123,7 +123,7 @@ case class Truetype(data: Data) extends Sfnt:
         (t"loca", Array.freeze(newLoca)) ::
         (t"head", Array.freeze(newHead)) :: (carried: List[(Text, Data)])
 
-    Truetype(Sfnt.assemble(data.slice(0, 4), List.of(entries)))
+    Truetype(Sfnt.assemble(data.slice(0, 4), entries))
 
   def subset(text: Text): Truetype raises Font.Error = subset(Set.from(text.chars.readable))
 

--- a/lib/punctuation/src/ansi/punctuation.Renderer.scala
+++ b/lib/punctuation/src/ansi/punctuation.Renderer.scala
@@ -240,7 +240,7 @@ object Renderer:
             (mk + Space + head) :: tail.map(indent(_, hang))
 
       if tight then rendered.flat
-      else interleaveBlanks(rendered.map(List.of(_)))
+      else interleaveBlanks(rendered)
 
 
   // -- helpers --------------------------------------------------------------

--- a/lib/punctuation/src/core/punctuation.Markdown.scala
+++ b/lib/punctuation/src/core/punctuation.Markdown.scala
@@ -164,7 +164,7 @@ object Markdown:
 
         nodes match
           case Nil =>
-            if block then List.of(((TextNode("\n"): Html of Flow) :: done).reverse)
+            if block then ((TextNode("\n"): Html of Flow) :: done).reverse
             else done.reverse
 
           case Layout.Paragraph(_, contents*) :: tail if tight =>

--- a/lib/quantitative/src/core/quantitative.Prefixes.scala
+++ b/lib/quantitative/src/core/quantitative.Prefixes.scala
@@ -45,7 +45,7 @@ class Prefixes(val prefixes: List[MetricPrefix], val minimum: Double) extends Pl
   def select(value: Double): MetricPrefix =
     if value == 0.0 then NoPrefix else
       val abs = math.abs(value)
-      val candidates = (NoPrefix :: prefixes).sortBy(-_.exponent)
+      val candidates = (NoPrefix :: prefixes).stdlib.sortBy(-_.exponent)
 
       val chosen = candidates.find: prefix =>
         abs/math.pow(prefix.base.toDouble, prefix.exponent.toDouble) >= minimum

--- a/lib/urticose/src/core/urticose.Hostname.scala
+++ b/lib/urticose/src/core/urticose.Hostname.scala
@@ -42,6 +42,7 @@ import fulminate.*
 import gossamer.*
 import hypotenuse.*
 import prepositional.*
+import proscenium.compat.sum
 import rudiments.*
 import spectacular.*
 import symbolism.*


### PR DESCRIPTION
Bumps the compiler to Proscala **3.9.0-RC5-p14** and fixes the thirteen call sites that the new compiler correctly rejects.

## The compiler release

-p14 brings two relevant changes:

- **givenprefix**: implicit-search candidates now get explicit package-object prefixes (the `typedImplicit` analogue of upstream #21527, closing the soundness#1809 opacity leak in the other polarity). Extension methods and conversions found by implicit search no longer leak the underlying type of a top-level opaque type in their results.
- **depset**: a backport of scala/scala3#26720 removing quadratic capture-set dependent growth. Derivation-heavy modules compile roughly an order of magnitude faster (exegesis.core: ~12 minutes → under a minute).

## The leak-site fixes

Thirteen sites only ever compiled because proscenium's `opaque type List` leaked as `sci.List` through implicit-search-resolved extensions (the `::` cons given, murmuration's `map`, …), silently resolving stdlib members, subtyping, and API argument types against the underlying type. Each fix is minimal and semantics-preserving, in three patterns:

- **Use the real opaque-List extension** — `urticose.Hostname`: `import proscenium.compat.sum` (the extension existed; the import was missing — the compiler's own suggestion).
- **One explicit `.stdlib` at the narrowest point** where the underlying list is genuinely wanted — `quantitative.Prefixes` (`sortBy`/`find`/`last` chain), `digression_ansi` (`List` is not an `Iterable`), `jacinta.internal` (quotes' `Block` takes `sci.List`), `harlequin.SourceCode` (`InteractiveDriver` takes `sci.List`), `anthology.Bundler` (`distinctBy`), `burdock.Repackager` (`Zipfile.write(Iterable)`).
- **Drop `List.of(...)` wrappers made redundant** by honestly-opaque sub-expressions — `dendrology.TreeDiagram`, `exoskeleton.Completion`, `phoenicia.Truetype`, `punctuation.Markdown`, `punctuation.Renderer`, plus `mosquito.internal` (an underlying list now needs its explicit `List.of` to join an opaque cons chain).

The two commits are deliberately one PR: the fixes require the sealed compiler (under earlier compilers the leaked stdlib members win the very resolutions the fixes rely on), and the compiler bump requires the fixes.

## Verification

Against a local build of the exact released trunk content: `soundness.all.compile` fully green (13,216 targets, clean build), and all twelve affected modules compile individually; exegesis 42/42, dendrology 19/19, quantitative 104/104 test suites pass.

Developed with LLM assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)