### PR TITLE
Set simple MathML sub- and superscripts on one terminal line

### DIFF
--- a/lib/archimedes/src/core/archimedes.Cell.scala
+++ b/lib/archimedes/src/core/archimedes.Cell.scala
@@ -117,6 +117,73 @@ object Cell:
     val bottom = denominator.hcenter(width)
     Cell((top.lines :+ repeat(Bar, width)) ::: bottom.lines, width, top.height)
 
+  // Unicode already provides ready-made superscript and subscript glyphs for the
+  // digits, the sign and bracket operators, and much (but not all) of the Latin
+  // alphabet. A script written entirely in characters these tables cover needs no
+  // extra rows: it can be set on the same line as its base, so `x^2` draws as `x²`
+  // instead of stacking `2` diagonally above the `x`. Anything the tables cannot
+  // spell — a fraction, a nested script, a Greek letter, a `q` — falls back to the
+  // diagonal layout below. The lowercase superscript alphabet has no `q`, and the
+  // subscript alphabet is sparser still, so both tables are enumerated explicitly
+  // rather than derived by arithmetic on codepoints.
+
+  private val superscripts: Map[Char, Char] =
+    Map('0' -> '⁰', '1' -> '¹', '2' -> '²', '3' -> '³', '4' -> '⁴',
+        '5' -> '⁵', '6' -> '⁶', '7' -> '⁷', '8' -> '⁸', '9' -> '⁹',
+        '+' -> '⁺', '-' -> '⁻', '−' -> '⁻', '=' -> '⁼',
+        '(' -> '⁽', ')' -> '⁾',
+        'a' -> 'ᵃ', 'b' -> 'ᵇ', 'c' -> 'ᶜ', 'd' -> 'ᵈ', 'e' -> 'ᵉ',
+        'f' -> 'ᶠ', 'g' -> 'ᵍ', 'h' -> 'ʰ', 'i' -> 'ⁱ', 'j' -> 'ʲ',
+        'k' -> 'ᵏ', 'l' -> 'ˡ', 'm' -> 'ᵐ', 'n' -> 'ⁿ', 'o' -> 'ᵒ',
+        'p' -> 'ᵖ', 'r' -> 'ʳ', 's' -> 'ˢ', 't' -> 'ᵗ', 'u' -> 'ᵘ',
+        'v' -> 'ᵛ', 'w' -> 'ʷ', 'x' -> 'ˣ', 'y' -> 'ʸ', 'z' -> 'ᶻ')
+
+  private val subscripts: Map[Char, Char] =
+    Map('0' -> '₀', '1' -> '₁', '2' -> '₂', '3' -> '₃', '4' -> '₄',
+        '5' -> '₅', '6' -> '₆', '7' -> '₇', '8' -> '₈', '9' -> '₉',
+        '+' -> '₊', '-' -> '₋', '−' -> '₋', '=' -> '₌',
+        '(' -> '₍', ')' -> '₎',
+        'a' -> 'ₐ', 'e' -> 'ₑ', 'h' -> 'ₕ', 'i' -> 'ᵢ', 'j' -> 'ⱼ',
+        'k' -> 'ₖ', 'l' -> 'ₗ', 'm' -> 'ₘ', 'n' -> 'ₙ', 'o' -> 'ₒ',
+        'p' -> 'ₚ', 'r' -> 'ᵣ', 's' -> 'ₛ', 't' -> 'ₜ', 'u' -> 'ᵤ',
+        'v' -> 'ᵥ', 'x' -> 'ₓ')
+
+  // The character data a script node stands for, provided it is nothing but
+  // character data: a token element's own text, or the concatenation of a purely
+  // presentational wrapper's children. Note that operators contribute their raw
+  // text, without the spacing `operator` would add — `−x` is set as `⁻ˣ`, not
+  // as ` − x`. Any node with real structure (a fraction, a radical, a table)
+  // yields `Unset`, which is what rules out same-line rendering.
+  private def scriptText(node: Mathml): Optional[Text] = node match
+    case Mrow(contents, _)    => scriptTexts(contents)
+    case Mstyle(contents, _)  => scriptTexts(contents)
+    case Mpadded(contents, _) => scriptTexts(contents)
+    case node                 => node.text
+
+  private def scriptTexts(nodes: List[Mathml]): Optional[Text] =
+    // `Optional` is a union, so a `let` inside a `let` flattens: one absent child
+    // makes the whole concatenation absent.
+    nodes.stdlib.foldLeft(t"": Optional[Text]): (text, node) =>
+      text.let: prefix =>
+        scriptText(node).let(part => t"$prefix$part")
+
+  // The script rewritten in `glyphs`, or `Unset` if any character has no glyph.
+  private def transcribe(text: Text, glyphs: Map[Char, Char]): Optional[Text] =
+    val length = text.s.length
+
+    def recur(index: Int, done: Text): Optional[Text] =
+      if index == length then done else
+        val char = text.s.charAt(index)
+        if glyphs.contains(char) then recur(index + 1, t"$done${glyphs(char)}") else Unset
+
+    if length == 0 then Unset else recur(0, t"")
+
+  // A one-line rendering of `base` with `script` set beside it, when the base
+  // occupies a single line and the script has glyphs for every character.
+  private def sameLine(base: Cell, script: Mathml, glyphs: Map[Char, Char]): Optional[Cell] =
+    if base.height > 1 then Unset else
+      scriptText(script).let(transcribe(_, glyphs)).let(text => line(t"${slice(base, 0)}$text"))
+
   def superscript(base: Cell, script: Cell): Cell =
     val height = base.height + script.height
 
@@ -159,6 +226,24 @@ object Cell:
         Writing(t"$left$scripts")
 
     Cell(lines, base.width + right, superscript.height + base.baseline)
+
+  // Each of the three script schemata prefers the same-line Unicode form, and falls
+  // back to stacking when the script is not spellable in script glyphs.
+
+  private def superscripted(base: Mathml, script: Mathml): Cell =
+    val cell = of(base)
+    sameLine(cell, script, superscripts).or(superscript(cell, of(script)))
+
+  private def subscripted(base: Mathml, script: Mathml): Cell =
+    val cell = of(base)
+    sameLine(cell, script, subscripts).or(subscript(cell, of(script)))
+
+  // Both scripts must go on the line, or neither: an inline subscript beneath a
+  // stacked superscript would set the two in different columns.
+  private def subsupscripted(base: Mathml, sub: Mathml, sup: Mathml): Cell =
+    val cell = of(base)
+    val inlined = sameLine(cell, sub, subscripts).let(sameLine(_, sup, superscripts))
+    inlined.or(subsup(cell, of(sub), of(sup)))
 
   def overscript(base: Cell, over: Cell): Cell =
     val width = max(base.width, over.width)
@@ -359,9 +444,9 @@ object Cell:
     case Mfrac(numer, denom, _)    => fraction(of(numer), of(denom))
     case Msqrt(contents, _)        => radical(row(contents))
     case Mroot(base, index, _)     => root(of(base), of(index))
-    case Msup(base, script, _)     => superscript(of(base), of(script))
-    case Msub(base, script, _)     => subscript(of(base), of(script))
-    case Msubsup(base, sb, sp, _)  => subsup(of(base), of(sb), of(sp))
+    case Msup(base, script, _)     => superscripted(base, script)
+    case Msub(base, script, _)     => subscripted(base, script)
+    case Msubsup(base, sb, sp, _)  => subsupscripted(base, sb, sp)
     case Mover(base, over, _)      => overscript(of(base), of(over))
     case Munder(base, under, _)    => underscript(of(base), of(under))
     case Munderover(base, u, o, _) => underover(of(base), of(u), of(o))

--- a/lib/archimedes/src/test/archimedes_test.scala
+++ b/lib/archimedes/src/test/archimedes_test.scala
@@ -348,17 +348,41 @@ object Tests extends Suite(m"Archimedes tests"):
             && result.contains(t"<mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr>")
 
     suite(m"Rendering to the terminal"):
-      test(m"a superscript stacks the exponent above the base"):
+      test(m"a simple superscript is set inline with Unicode glyphs"):
         Msup(Mi(t"x"), Mn(t"2")).draw
-      .assert(_ == t" 2\nx ")
+      .assert(_ == t"x²")
 
-      test(m"a subscript stacks the index below the base"):
+      test(m"a simple subscript is set inline with Unicode glyphs"):
         Msub(Mi(t"x"), Mn(t"i")).draw
-      .assert(_ == t"x \n i")
+      .assert(_ == t"xᵢ")
 
-      test(m"a subsup places both scripts around the base"):
+      test(m"an inline subsup sets the subscript before the superscript"):
         Msubsup(Mi(t"x"), Mn(t"i"), Mn(t"2")).draw
-      .assert(_ == t" 2\nx \n i")
+      .assert(_ == t"xᵢ²")
+
+      test(m"a multi-token superscript inlines if every glyph exists"):
+        Msup(Mi(t"e"), Mrow(Mo(t"−"), Mi(t"x"))).draw
+      .assert(_ == t"e⁻ˣ")
+
+      test(m"a superscript with no glyph stacks above the base"):
+        Msup(Mi(t"x"), Mi(t"ρ")).draw
+      .assert(_ == t" ρ\nx ")
+
+      test(m"a subscript with no glyph stacks below the base"):
+        Msub(Mi(t"x"), Mi(t"q")).draw
+      .assert(_ == t"x \n q")
+
+      test(m"a structured superscript stacks above the base"):
+        Msup(Mi(t"x"), Mfrac(Mn(t"1"), Mn(t"2"))).draw
+      .assert(_ == t"  1 \n ───\n  2 \nx   ")
+
+      test(m"a superscript on a tall base stacks above it"):
+        Msup(Mfenced(Mfrac(Mn(t"1"), Mn(t"2"))), Mn(t"2")).draw
+      .assert(_ == t"     2\n⎛ 1 ⎞ \n⎜───⎟ \n⎝ 2 ⎠ ")
+
+      test(m"a subsup inlines only when both scripts have glyphs"):
+        Msubsup(Mi(t"x"), Mn(t"i"), Mi(t"ρ")).draw
+      .assert(_ == t" ρ\nx \n i")
 
       test(m"a fraction stacks over a rule"):
         Mfrac(Mn(t"1"), Mn(t"2")).draw
@@ -405,8 +429,8 @@ object Tests extends Suite(m"Archimedes tests"):
       .assert(_ == t"▁▁▁   \n╲   1 \n╱  ───\n▔▔▔ n ")
 
       test(m"a big sigma only takes even heights, rounding up"):
-        Mrow(Mo(t"∑"), Msup(Mi(t"x"), Mn(t"2"))).draw
-      .assert(_ == t"▁▁▁  \n╲   2\n╱  x \n▔▔▔  ")
+        Mrow(Mo(t"∑"), Msup(Mi(t"x"), Mi(t"ρ"))).draw
+      .assert(_ == t"▁▁▁  \n╲   ρ\n╱  x \n▔▔▔  ")
 
       test(m"a big pi adapts to any height"):
         Mrow(Mo(t"∏"), Mfrac(Mn(t"1"), Mi(t"n"))).draw


### PR DESCRIPTION
Archimedes drew every MathML `<msup>`, `<msub>` and `<msubsup>` by stacking the script diagonally above or below its base, spending an extra row of terminal height even on something as simple as `x²`. Where Unicode already provides script glyphs for every character of the script, and the base occupies a single line, the script is now set on the same line as its base; anything the glyph tables cannot spell — a Greek index, a fraction, a nested script — still stacks as before, as does any script on a tall base, where the vertical offset is what distinguishes a superscript from a subscript.

Terminal rendering of simple scripts is now one line high:

```scala
Msup(Mi(t"x"), Mn(t"2")).draw                  // x²   (was " 2" over "x ")
Msub(Mi(t"x"), Mn(t"i")).draw                  // xᵢ
Msubsup(Mi(t"x"), Mn(t"i"), Mn(t"2")).draw     // xᵢ²
Msup(Mi(t"e"), Mrow(Mo(t"−"), Mi(t"x"))).draw  // e⁻ˣ
```

A script qualifies only if *every* one of its characters has a glyph: the digits, `+ - − = ( )`, the lowercase alphabet except `q` for superscripts, and `a e h i j k l m n o p r s t u v x` for subscripts. Otherwise the previous layout is used unchanged:

```scala
Msup(Mi(t"x"), Mi(t"ρ")).draw                            // ρ stacked above x
Msup(Mi(t"x"), Mfrac(Mn(t"1"), Mn(t"2"))).draw           // ½ stacked above x
Msup(Mfenced(Mfrac(Mn(t"1"), Mn(t"2"))), Mn(t"2")).draw  // 2 above the bracket
```

`<msubsup>` goes inline only when both scripts qualify, so the two are never set in different columns. MathML serialisation to XML and HTML is unaffected — this changes only `.draw`/`.cell` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
