### PR TITLE
Render operation sizes at the call site and trim wrapped-line spaces

### DIFF
--- a/lib/sedentary/src/core/sedentary.OperationSize.scala
+++ b/lib/sedentary/src/core/sedentary.OperationSize.scala
@@ -42,7 +42,13 @@ object OperationSize:
   // both the per-operation size text and (later, given a measured mean time)
   // the throughput rate text, so `Bench.apply` itself doesn't need to be
   // generic over the unit or carry a `Decimalizer` of its own.
-  given conversion: [size <: Measure] => Decimalizer
+  //
+  // `inline`, so the body re-elaborates at the summoning site: `express` is itself inline,
+  // and expanding it here — where `size` is abstract and the caller's `Prefixes` and
+  // `Designation` givens are invisible — collects no units and selects no prefix,
+  // rendering `4194304*Byte` as `4.2×10⁶ ` (unitless, trailing separator space) instead
+  // of `4.2 MB`.
+  inline given conversion: [size <: Measure] => Decimalizer
   =>  Conversion[Quantity[size], OperationSize] = quantity =>
 
     OperationSize

--- a/lib/tessellate/src/core/tessellate.Flow.scala
+++ b/lib/tessellate/src/core/tessellate.Flow.scala
@@ -141,6 +141,16 @@ object Flow:
       if fromCluster == toCluster then textual(t"")
       else content.segment(charStart(fromCluster).z thru charStart(toCluster).u)
 
+    // A line as emitted: trailing spaces are dropped, as at a soft break. The walk skips
+    // space clusters without a width check (correctly — a break there would absorb them),
+    // so a segment ending in spaces can exceed `width`; emitted at a hard break or at the
+    // end of the content, it would overflow the line's cell budget, which `Alignment.pad`
+    // cannot recover (padding never truncates).
+    def line(fromCluster: Int, toCluster: Int): textual =
+      var end = toCluster
+      while end > fromCluster && plain.charAt(charStart(end - 1)) == ' ' do end -= 1
+      segment(fromCluster, end)
+
     def hardBreak(cluster: Int): Boolean =
       val char = plain.charAt(charStart(cluster))
       char == '\n' || char == '\r'
@@ -180,9 +190,9 @@ object Flow:
     // recent space cluster on the current line. Lines accumulate in reverse in `acc`.
     def recur(cluster: Int, lineStart: Int, lastSpace: Int, acc: List[textual]): List[textual] =
       if cluster >= clusters then
-        if lineStart == cluster then acc else segment(lineStart, cluster) :: acc
+        if lineStart == cluster then acc else line(lineStart, cluster) :: acc
       else if hardBreak(cluster) then
-        recur(cluster + 1, cluster + 1, cluster + 1, segment(lineStart, cluster) :: acc)
+        recur(cluster + 1, cluster + 1, cluster + 1, line(lineStart, cluster) :: acc)
       else if plain.charAt(charStart(cluster)) == ' ' then
         recur(cluster + 1, lineStart, cluster, acc)
       else
@@ -196,7 +206,7 @@ object Flow:
           if breakAt > lineStart then
             recur(breakAt, breakAt, breakAt, (segment(lineStart, breakAt) + hyphenText) :: acc)
           else if lastSpace > lineStart then
-            recur(lastSpace + 1, lastSpace + 1, lastSpace + 1, segment(lineStart, lastSpace) :: acc)
+            recur(lastSpace + 1, lastSpace + 1, lastSpace + 1, line(lineStart, lastSpace) :: acc)
           else
             recur(cluster + 1, lineStart, lastSpace, acc)
         else


### PR DESCRIPTION
Benchmark reports showed operation sizes as unscaled, unitless numbers like `4.2×10⁶` with a stray trailing space, and in width-constrained tables that trailing space pushed every column to its right out of alignment. Operation sizes now render with their proper units and prefixes (`4.2 MB`), throughput rates likewise (`320 MB·s¯¹`), and wrapped lines no longer carry trailing spaces that overflow their column's width budget.

## Operation sizes render with their units

A benchmark declared with an `operationSize` showed its `Size` and `Rate` columns unscaled and unitless — `4.2×10⁶ ` rather than `4.2 MB` — with a trailing space where the unit should have been. The conversion from `Quantity` to `OperationSize` expanded the inline `Quantity.express` inside `sedentary` itself, where the measure is an abstract type (so no units were collected) and the benchmark's own `Prefixes` and `Designation` givens are out of scope (so no prefix was selected, leaving an orphaned separator space). The conversion is now an `inline given`, so its body re-elaborates at each benchmark's summoning site, where the units are concrete:

```scala
val size = input.length*Byte
bench(m"...")(target = 1*Second, operationSize = size)
```

now reports `4.2 MB` and `320 MB·s¯¹` in place of `4.2×10⁶ ` and `3.2×10⁸ s¯¹`.

## Wrapped lines no longer overflow their width budget

`Flow.wrap` in `tessellate` emitted lines that kept their trailing spaces. The wrapping walk skips space clusters without a width check — correctly, since a break there would absorb them — but a segment emitted at a hard break or at the end of the content could then be wider than the requested width, and alignment padding never truncates. In a width-constrained table, where the column solver shrinks a column to its minimum content width, such a cell overflowed its column by one cell and misaligned everything to its right. Wrapped lines now drop trailing spaces wherever they are emitted: at soft breaks (including runs of consecutive spaces), at hard breaks, and at the end of the content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
