### PR TITLE
Compile on the Scala 3.10 stream, with per-stream sources for compiler-internal APIs

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -72,6 +72,12 @@ object settings:
   // coincide (earlier releases shipped jars built as e.g. `3.9.0-RC1-propensive`). Override the
   // coordinate with `SOUNDNESS_SCALA_VERSION`.
   val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC5-p14")
+
+  // The compiler *stream* — the major Scala version, without the patch level — which is what
+  // decides the shape of the compiler-internal APIs a handful of modules wrap. Everything else
+  // in Soundness is written once and compiles on every stream; where an API genuinely differs
+  // (see the `Shim` component trait), this selects the sources that bridge it.
+  val scalaStream = if scalaVersion.startsWith("3.10") then "3.10" else "3.9"
   val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC5-p14")
   // Empty by default → download `scalaRelease`. Set to a local `release` directory to use its
   // `release/lib` jars directly (fork-developer mode).
@@ -540,6 +546,30 @@ extends BaseScalaModule, SonatypeCentralPublishModule, PlatformCross:
       :+ s"-Xplugin:${consequentToolchain.plugin().path}"
       :+ "-P:consequent:umbrella=soundness"
       :+ s"-Xplugin:${beneficence.plugin.assembly().path}"
+// A component whose sources are chosen by compiler stream. Soundness is written once and
+// compiles on every stream the fork carries, with one exception: the few modules that reach into
+// *compiler-internal* APIs, which upstream is free to reshape between major versions — 3.10 gave
+// `InteractiveDriver`'s second parameter a type with no default, and made a `TastyInfo` parameter
+// a lazy loader, so neither call form is valid on both streams. A `Shim` isolates that: the
+// library keeps one `src/scala-<stream>` directory per stream, each defining the same names, and
+// only the directory for the stream being compiled is ever built. Dependants name the shim like
+// any other component and never see the difference; the shim's own methods are `inline`, so
+// nothing survives into the caller's bytecode but the version-appropriate call.
+//
+// Deliberately ONE component with stream-selected sources rather than a pair of components: every
+// declared component must be packaged in exactly one bundle (see `groupCheck`), so a second,
+// never-built component would either fail that check or, if bundled, be compiled on the stream it
+// cannot compile on. This way the published artifact name is stable across streams too.
+// The sources of a *shim* component: `lib/<library>/src/scala-3.9` or `.../scala-3.10`, chosen by
+// the stream being compiled. A component overriding `sources` with this is the whole mechanism —
+// `object compiler extends Component(): override def sources = Task.Sources(shimSources(moduleDir))`
+// — and is deliberately ONE component with stream-selected sources rather than a pair of
+// components: every declared component must be packaged in exactly one bundle (see `groupCheck`),
+// so a second, never-built component would either fail that check or be compiled on the stream it
+// cannot compile on. The published artifact name stays stable across streams this way too.
+def shimSources(moduleDir: os.Path): os.Path =
+  moduleDir / os.up / s"scala-${settings.scalaStream}"
+
 // Like `Component`, but not published to Maven Central. For demos, examples, and
 // other modules that are built and tested but never released.
 trait Internal(dependencies: JavaModule*) extends BaseScalaModule:
@@ -805,6 +835,7 @@ object soundness extends Toolchain:
     harlequin.md, harlequin.ansi, austronesian.core, anthology.linker, anthology.link, anthology.nir,
     anthology.lira,
     anthology.`scala`, exegesis.core, hellenism.jvm, delicious.core, delicious.`scala`,
+    delicious.compiler, harlequin.compiler,
     delicious.ansi, anthology.kotlin, anthology.oci, anthology.xeq, hyperbole.stacks,
     vivisection.core):
     def summary = "Developer tools: compilers, build tooling, source analysis and version control"
@@ -1586,7 +1617,15 @@ object delicious extends Library:
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
 
-  object `scala` extends Component(core, stenography.core, anthology.core):
+  // Wraps `CompilationUnitInfo`'s TastyInfo parameter, which differs between streams; see `Shim`.
+  object compiler extends Component():
+    override def sources = Task.Sources(shimSources(moduleDir))
+    override def scalaJs = false // wraps the Scala compiler (dotty)
+    def mvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
+    override def scalacOptions = Task:
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
+
+  object `scala` extends Component(core, compiler, stenography.core, anthology.core):
     override def scalaJs = false // wraps the Scala compiler (dotty)
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
@@ -2140,7 +2179,15 @@ object hallucination extends Library:
       settings.sep(super.scalacOptions())
 
 object harlequin extends Library:
-  object core extends Component(anthology.scala, stenography.core, hellenism.jvm,
+  // Wraps `InteractiveDriver`, whose constructor differs between streams; see `Shim`.
+  object compiler extends Component():
+    override def sources = Task.Sources(shimSources(moduleDir))
+    override def scalaJs = false // wraps the Scala compiler (dotty)
+    def mvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
+    override def scalacOptions = Task:
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
+
+  object core extends Component(compiler, anthology.scala, stenography.core, hellenism.jvm,
       prophesy.core):
     override def scalaJs = false // syntax highlighting via `anthology.scala` (the compiler)
     override def scalacOptions = Task:

--- a/build.mill
+++ b/build.mill
@@ -244,8 +244,18 @@ object toolchain extends Module:
       (sl, "scala3-compiler_3", "scala3-compiler.jar", v, Seq(
         (sl, "scala3-interfaces", v),
         (sl, "tasty-core_3", v),
-        (sl, "scala3-library_3", v),
-        ("org.scala-lang.modules", "scala-asm", "9.9.0-scala-1"),
+        (sl, "scala3-library_3", v))
+        // The compiler's ASM flavour is per-stream, matching the fork's published POMs:
+        // up to 3.9 the backend uses the shaded scala-asm; from 3.10 upstream imports
+        // org.objectweb.asm directly, so the coordinate depends on the org.ow2.asm jars
+        // (asm-util and asm-commons pull in asm, asm-tree and asm-analysis). Without the
+        // right flavour the compiler itself fails at runtime, e.g. with
+        // `ClassNotFoundException: org.objectweb.asm.tree.ClassNode`.
+        ++ (if v.startsWith("3.10") then Seq(
+              ("org.ow2.asm", "asm-util", "9.10.1"),
+              ("org.ow2.asm", "asm-commons", "9.10.1"))
+            else Seq(("org.scala-lang.modules", "scala-asm", "9.9.0-scala-1")))
+        ++ Seq(
         ("org.scala-sbt", "compiler-interface", "1.12.0"),
         ("org.scala-sbt", "util-interface", "1.11.5"))),
       (sl, "scala3-repl_3", "scala3-repl.jar", v, Seq(
@@ -351,11 +361,19 @@ trait Toolchain extends ScalaModule:
     // The fork-built jars come from the repository view because Zinc locates the standard
     // library within this classpath BY FILENAME (`scala-library-<version>*.jar`), and the
     // distribution's own filenames are unversioned. The compiler's own third-party runtime
-    // dependencies (scala-asm for bytecode, the sbt compiler/util interfaces for the bridge) are
-    // not shipped in the release, so they are resolved from the ordinary repositories.
+    // dependencies (ASM for bytecode, the sbt compiler/util interfaces for the bridge) are
+    // not shipped in the release, so they are resolved from the ordinary repositories. The
+    // ASM flavour is per-stream: up to 3.9 the backend uses the shaded scala-asm; from 3.10
+    // upstream imports org.objectweb.asm directly (asm-util and asm-commons pull in asm,
+    // asm-tree and asm-analysis), and without it the compiler dies in GenBCode with
+    // `NoClassDefFoundError: org/objectweb/asm/tree/ClassNode`.
     val versioned = os.walk(toolchain.repo().path).filter(_.ext == "jar").map(PathRef(_))
-    val thirdParty = defaultResolver().classpath(Seq(
-      mvn"org.scala-lang.modules:scala-asm:9.9.0-scala-1",
+    val asm =
+      if settings.scalaVersion.startsWith("3.10") then Seq(
+        mvn"org.ow2.asm:asm-util:9.10.1",
+        mvn"org.ow2.asm:asm-commons:9.10.1")
+      else Seq(mvn"org.scala-lang.modules:scala-asm:9.9.0-scala-1")
+    val thirdParty = defaultResolver().classpath(asm ++ Seq(
       mvn"org.scala-sbt:compiler-interface:1.12.0",
       mvn"org.scala-sbt:util-interface:1.11.5"))
 

--- a/lib/caesura/src/core/caesura.Dsv.scala
+++ b/lib/caesura/src/core/caesura.Dsv.scala
@@ -172,11 +172,11 @@ object Dsv extends Dsv2:
 
   given text: (format: Dsv.Format) => (tactic: Tactic[Dsv.Error])
   =>  Text is Decodable in Dsv =
-    caps.unsafe.unsafeAssumePure: dsv => decodeCell(dsv, t"Text", t""): cell => cell
+    caps.unsafe.unsafeAssumePure: dsv => decodeCell(dsv, t"Text", t"")(cell => cell)
 
   given string: (format: Dsv.Format) => (tactic: Tactic[Dsv.Error])
   =>  String is Decodable in Dsv =
-    caps.unsafe.unsafeAssumePure: dsv => decodeCell(dsv, t"String", ""): cell => cell.s
+    caps.unsafe.unsafeAssumePure: dsv => decodeCell(dsv, t"String", "")(cell => cell.s)
 
   inline given decodableDerivation: [value <: Product: ProductReflection]
   =>  value is Decodable in Dsv =

--- a/lib/delicious/src/scala-3.10/delicious.Shim.scala
+++ b/lib/delicious/src/scala-3.10/delicious.Shim.scala
@@ -1,0 +1,46 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package delicious
+
+import dotty.tools.dotc as dtd
+import dotty.tools.dotc.core.CompilationUnitInfo
+import dotty.tools.io.VirtualFile
+
+// The 3.10 spelling of the compiler-internal APIs delicious wraps. The 3.9 directory defines the
+// same names against that stream's shapes; nothing else in delicious knows which is in play.
+object Shim:
+  // 3.10 takes a lazy loader, `() => Option[TastyInfo]`, in place of the eager `Option`.
+  inline def compilationUnitInfo
+     (file: VirtualFile, tastyInfo: dtd.core.TastyInfo)
+  :   CompilationUnitInfo =
+    CompilationUnitInfo(file, () => Some(tastyInfo))

--- a/lib/delicious/src/scala-3.9/delicious.Shim.scala
+++ b/lib/delicious/src/scala-3.9/delicious.Shim.scala
@@ -1,0 +1,46 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package delicious
+
+import dotty.tools.dotc as dtd
+import dotty.tools.dotc.core.CompilationUnitInfo
+import dotty.tools.io.VirtualFile
+
+// The 3.9 spelling of the compiler-internal APIs delicious wraps. The 3.10 directory defines the
+// same names against that stream's shapes; nothing else in delicious knows which is in play.
+object Shim:
+  // 3.9 takes the `TastyInfo` by value.
+  inline def compilationUnitInfo
+     (file: VirtualFile, tastyInfo: dtd.core.TastyInfo)
+  :   CompilationUnitInfo =
+    CompilationUnitInfo(file, Some(tastyInfo))

--- a/lib/delicious/src/scala/delicious.Reifier.scala
+++ b/lib/delicious/src/scala/delicious.Reifier.scala
@@ -173,13 +173,11 @@ class Reifier(classpath: LocalClasspath):
         // decode is repeated inline because only a fluid Java result adapts to the pure
         // formal, as above.
         val info =
-          CompilationUnitInfo
+          Shim.compilationUnitInfo
             ( VirtualFile
                 ( "<delicious>",
                   ju.Base64.getDecoder.nn.decode(tasty.s).nn.asInstanceOf[scala.Array[Byte]] ),
-              // Scala 3.10 makes this parameter a lazy loader (`tastyInfoLoader:
-              // () => Option[TastyInfo]`); the `Some` wrapper remains load-bearing.
-              () => Some(dtd.core.TastyInfo(version, attributes)) )
+              dtd.core.TastyInfo(version, attributes) )
           . nn
         val positions = unpickler.unpickle(DottyUnpickler.PositionsSectionUnpickler())
         val comments = unpickler.unpickle(DottyUnpickler.CommentsSectionUnpickler())

--- a/lib/delicious/src/scala/delicious.Reifier.scala
+++ b/lib/delicious/src/scala/delicious.Reifier.scala
@@ -177,7 +177,9 @@ class Reifier(classpath: LocalClasspath):
             ( VirtualFile
                 ( "<delicious>",
                   ju.Base64.getDecoder.nn.decode(tasty.s).nn.asInstanceOf[scala.Array[Byte]] ),
-              Some(dtd.core.TastyInfo(version, attributes)) )
+              // Scala 3.10 makes this parameter a lazy loader (`tastyInfoLoader:
+              // () => Option[TastyInfo]`); the `Some` wrapper remains load-bearing.
+              () => Some(dtd.core.TastyInfo(version, attributes)) )
           . nn
         val positions = unpickler.unpickle(DottyUnpickler.PositionsSectionUnpickler())
         val comments = unpickler.unpickle(DottyUnpickler.CommentsSectionUnpickler())

--- a/lib/digression/src/core/digression.Smap.scala
+++ b/lib/digression/src/core/digression.Smap.scala
@@ -68,7 +68,7 @@ object Smap:
 
     // The source position an output line maps to, when the file table knows the entry's file.
     def origin(line: Int): Optional[(File, Int)] =
-      apply(line).let: (fileId, input) => files.at(fileId).let: file => (file, input)
+      apply(line).let: (fileId, input) => files.at(fileId).let(file => (file, input))
 
   // Where a line of inlined code was written: the file's recorded name, its full path, the
   // 1-based line number, and — when the SMAP's writer emitted a `<default>Class` stratum, as the

--- a/lib/galilei/src/jvm/galilei.Device.scala
+++ b/lib/galilei/src/jvm/galilei.Device.scala
@@ -69,7 +69,10 @@ object Device:
             Io.Error(path, Io.Error.Operation.Create, Io.Error.Reason.Unsupported)
 
         . protect:
-            sh"mknod $path ${kind.flag} $major $minor"() match
+            // `exec[Exit]()` rather than `()`: the inline `apply()` binds an erased proxy for
+            // `Exec is Intelligible` with a compiler-generated skolem cast, which Scala 3.10 no
+            // longer accepts as pure (scala/scala3#24990, re-opened by scala/scala3#26813).
+            sh"mknod $path ${kind.flag} $major $minor".exec[Exit]() match
               case Exit.Ok => ()
 
               case _ =>

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -490,10 +490,7 @@ object SourceCode:
 
     try
       val settings = ("-classpath" :: cp.s :: scalac.commandLineArguments.map(_.s)).map(_.nn)
-      // Scala 3.10 adds a `logicalRootPackage` constructor parameter (no default);
-      // `CachedLogicalPackage.none` restores the previous behaviour.
-      val driver =
-        interactive.InteractiveDriver(settings.stdlib, interactive.CachedLogicalPackage.none)
+      val driver = Shim.interactiveDriver(settings.stdlib)
       // The driver resolves the URI as a path, so it must use the `file` scheme, though no
       // file exists there: the source text is supplied directly.
       val uri = java.nio.file.Path.of("/harlequin-highlighting.scala").nn.toUri.nn

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -490,7 +490,10 @@ object SourceCode:
 
     try
       val settings = ("-classpath" :: cp.s :: scalac.commandLineArguments.map(_.s)).map(_.nn)
-      val driver = interactive.InteractiveDriver(settings.stdlib)
+      // Scala 3.10 adds a `logicalRootPackage` constructor parameter (no default);
+      // `CachedLogicalPackage.none` restores the previous behaviour.
+      val driver =
+        interactive.InteractiveDriver(settings.stdlib, interactive.CachedLogicalPackage.none)
       // The driver resolves the URI as a path, so it must use the `file` scheme, though no
       // file exists there: the source text is supplied directly.
       val uri = java.nio.file.Path.of("/harlequin-highlighting.scala").nn.toUri.nn

--- a/lib/harlequin/src/scala-3.10/harlequin.Shim.scala
+++ b/lib/harlequin/src/scala-3.10/harlequin.Shim.scala
@@ -1,0 +1,43 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package harlequin
+
+import dotty.tools.dotc.interactive
+
+// The 3.10 spelling of the compiler-internal APIs harlequin wraps. The 3.9 directory defines the
+// same names against that stream's shapes; nothing else in harlequin knows which is in play.
+object Shim:
+  // 3.10 replaced the `Option[LogicalPackage]` parameter with a `CachedLogicalPackage`, and gave
+  // it no default; `none` is the empty case, matching 3.9's behaviour.
+  inline def interactiveDriver(settings: scala.collection.immutable.List[String]): interactive.InteractiveDriver =
+    interactive.InteractiveDriver(settings, interactive.CachedLogicalPackage.none)

--- a/lib/harlequin/src/scala-3.9/harlequin.Shim.scala
+++ b/lib/harlequin/src/scala-3.9/harlequin.Shim.scala
@@ -1,0 +1,42 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package harlequin
+
+import dotty.tools.dotc.interactive
+
+// The 3.9 spelling of the compiler-internal APIs harlequin wraps. The 3.10 directory defines the
+// same names against that stream's shapes; nothing else in harlequin knows which is in play.
+object Shim:
+  // 3.9's second parameter is `Option[LogicalPackage] = None`, so it is simply omitted.
+  inline def interactiveDriver(settings: scala.collection.immutable.List[String]): interactive.InteractiveDriver =
+    interactive.InteractiveDriver(settings)

--- a/lib/ultimatum/src/core/ultimatum.Frame.scala
+++ b/lib/ultimatum/src/core/ultimatum.Frame.scala
@@ -41,7 +41,7 @@ import vacuous.*
 object Frame:
   // Combine two optional maxima as a minimum, treating `Unset` as +infinity.
   private def lesser(a: Optional[Int], b: Optional[Int]): Optional[Int] =
-    a.lay(b): av => b.lay(av): bv => av.min(bv)
+    a.lay(b): av => b.lay(av)(bv => av.min(bv))
 
   // Min/max along the split axis: the minimum is the larger of the split's own
   // minimum and the SUM of its children's minima (a container can be no smaller


### PR DESCRIPTION
Makes Soundness compile on the Proscala **3.10** stream, and introduces a standard way to write the few sources that genuinely cannot be shared between compiler streams.

With this branch, `./mill soundness.all.compile` is **13902/13902** against `3.10.0-dev-p14` from a clean build — the first time the 3.10 stream has compiled Soundness — with `wisteria.test` (56/56) and `jacinta.test` (724/724) passing. The one remaining gap is `exegesis.test`, filed separately as #1829.

## Per-stream sources for compiler-internal APIs

Soundness is written once and compiles on every stream, with one exception: modules that reach into *compiler-internal* APIs, which upstream is free to reshape between major versions. 3.10 gave `InteractiveDriver`'s second constructor parameter a type with no default (3.9: `Option[LogicalPackage] = None`), and made `CompilationUnitInfo`'s `TastyInfo` parameter a lazy loader — so for `harlequin` and `delicious` neither call form is valid on both streams.

A library that needs to bridge such an API now keeps one source directory per stream — `src/scala-3.9` and `src/scala-3.10` — each defining the same names. No interface is declared anywhere: only one directory is ever compiled, so the callers are checked against whichever is in play. A component whose `sources` are `shimSources(moduleDir)` gets the directory matching `settings.scalaStream`, itself derived from the compiler version mill was told to use, and the shim methods are `inline`, so only the version-appropriate call survives into the caller. Each bridge is two lines:

```scala
// src/scala-3.9
inline def interactiveDriver(settings: List[String]): interactive.InteractiveDriver =
  interactive.InteractiveDriver(settings)

// src/scala-3.10
inline def interactiveDriver(settings: List[String]): interactive.InteractiveDriver =
  interactive.InteractiveDriver(settings, interactive.CachedLogicalPackage.none)
```

Deliberately **one** component with stream-selected sources rather than a pair of shim components: `groupCheck` requires every declared component to be packaged in exactly one bundle, so a second, never-built component would either fail that check or be compiled on the stream it cannot compile on. The published artifact name also stays stable across streams this way.

## The rest of the changes

- **Per-stream ASM in `build.mill`** (two places — the synthesized local-repo POM and `scalaCompilerClasspath`): from 3.10 upstream's JVM backend imports `org.objectweb.asm` directly rather than the shaded `scala-asm`, so the compiler needs the `org.ow2.asm` 9.10.1 jars on its own runtime classpath. Without it every module dies in `GenBCode` with `NoClassDefFoundError: org/objectweb/asm/tree/ClassNode`.
- **`relaxedLambdaSyntax` parenthesisations** (`digression.Smap`, `caesura.Dsv` ×2, `ultimatum.Frame`): the feature is now in preview, and two single-line lambdas on one line are rejected — the second is parenthesised.
- **`galilei.Device`**: after upstream reverted #26579 (their #26813, for binary compatibility), the inliner's erased-proxy cast is no longer pure, so an `erased` parameter's right-hand side fails the purity check; the call site takes the non-erased `exec[Exit]()` path instead.

## Verification

- `soundness.all.compile` 13902/13902 on **3.10.0-dev-p14**, clean build; wisteria and jacinta suites green.
- `harlequin.core` and `delicious.scala` compile from these same sources on **both** 3.9.0-RC5-p14 and 3.10.0-dev-p14 — the shim mechanism exercised in both directions.
- A full clean `soundness.all.compile` on **3.9** is running as I open this, to confirm the branch does not regress the stream main is published against; I will report the result here.

The compiler side is already released: 3.10.0-dev-p14 carries three fork patches for defects the upstream fast-forward introduced (`prunecomplete`, `anonspec`, `picklesource`), all documented in the proscala repo and upstream candidates.

Developed with LLM assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
