### PR TITLE
Implement the Agent Client Protocol client in Espionage

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -848,7 +848,8 @@ object soundness extends Toolchain:
     caduceus.resend,
     orthodoxy.core,
     jacinta.http,
-    stratiform.http, stratiform.optics, obligatory.core, obligatory.json, synesthesia.core, apoplexy.core,
+    stratiform.http, stratiform.optics, obligatory.core, obligatory.json, synesthesia.content,
+    synesthesia.core, apoplexy.core,
     cataclysm.html, querencia.core, telekinesis.http2, embarcadero.containerd, obligatory.grpc,
     xenophile.core, xenophile.js, xenophile.wasm, xenophile.typescript, xenophile.webidl,
     xenophile.wit, xenophile.cffi, xenophile.scalanative, xenophile.kotlin, telekinesis.core,
@@ -2945,7 +2946,12 @@ object symbolism extends Library:
       settings.sep(super.scalacOptions())
 
 object synesthesia extends Library:
-  object core extends Component(obligatory.json, scintillate.server, revolution.core):
+  // The MCP/ACP-shared content-block vocabulary, deliberately free of `core`'s HTTP-server
+  // closure so that a client which spawns agent subprocesses can depend on it.
+  object content extends Component(jacinta.core):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium")
+  object core extends Component(content, obligatory.json, scintillate.server, revolution.core):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
       settings.maxInlines(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"), "48")

--- a/build.mill
+++ b/build.mill
@@ -834,8 +834,8 @@ object soundness extends Toolchain:
     anthology.java,
     harlequin.md, harlequin.ansi, austronesian.core, anthology.linker, anthology.link, anthology.nir,
     anthology.lira,
-    anthology.`scala`, exegesis.core, hellenism.jvm, delicious.core, delicious.`scala`,
-    delicious.compiler, harlequin.compiler,
+    anthology.`scala`, exegesis.core, espionage.core, hellenism.jvm, delicious.core,
+    delicious.`scala`, delicious.compiler, harlequin.compiler,
     delicious.ansi, anthology.kotlin, anthology.oci, anthology.xeq, hyperbole.stacks,
     vivisection.core):
     def summary = "Developer tools: compilers, build tooling, source analysis and version control"
@@ -1804,6 +1804,22 @@ object tessellate extends Library:
   object test extends Tests(core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions())
+
+object espionage extends Library:
+  object core extends Component(obligatory.json, guillotine.core, synesthesia.content):
+    override def scalaJs = false // transitively JVM-only through `obligatory.json`
+    override def scalacOptions = Task:
+      settings.maxInlines(settings.sep(super.scalacOptions() ++ Seq("-Yno-predef",
+        "-Yimports:java.lang,proscenium")), "48")
+
+  object demo extends Internal(core, ethereal.core, exoskeleton.completions):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium")
+    override def mainClass: Task.Simple[Option[String]] = Some("espionage.DemoAcpClient")
+
+  object test extends Tests(core):
+    override def scalacOptions = Task:
+      settings.maxInlines(settings.sep(super.scalacOptions()), "48")
 
 object ethereal extends Library:
   object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, coaxial.jvm, quantitative.units, telekinesis.jvm, urticose.url, gastronomy.core, zeppelin.core):
@@ -2947,7 +2963,7 @@ object symbolism extends Library:
 
 object synesthesia extends Library:
   // The MCP/ACP-shared content-block vocabulary, deliberately free of `core`'s HTTP-server
-  // closure so that a client which spawns agent subprocesses can depend on it.
+  // closure so that `espionage.core` (which spawns agent subprocesses) can depend on it.
   object content extends Component(jacinta.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium")
@@ -3393,7 +3409,7 @@ val allLibraries: Seq[Library] = Seq(
   charisma, chiaroscuro, coaxial, concordance, contextual, contingency, corpuscular,
   cosmopolite,
   degustation, delicious, dendrology, denominative, digression, dissonance, distillate, diuretic,
-  embarcadero, enigmatic, escapade, escritoire, ethereal, eucalyptus, exegesis,
+  embarcadero, enigmatic, escapade, escritoire, espionage, ethereal, eucalyptus, exegesis,
   exoskeleton, facsimile,
   frontier, fulminate, galilei, gastronomy, geodesy, gesticulate, gigantism,
   gnossienne, gossamer, graffiti, guillotine, hallucination, harlequin, hellenism, hieroglyph,

--- a/doc/modules/acp.md
+++ b/doc/modules/acp.md
@@ -1,0 +1,71 @@
+## ACP
+
+### About
+
+The [Agent Client Protocol](https://agentclientprotocol.com/) is how an editor — or any program —
+drives a coding agent: Claude Code, Gemini CLI, and a growing set of others speak it over the
+agent's standard input and output. Espionage implements the client half of the protocol, version
+1, for programmatic use: spawn an agent, open a session, send a prompt, and watch its work stream
+back — messages, thoughts, tool calls, plans — while answering the requests it makes of you:
+permission to act, file access, terminals.
+
+### On ACP
+
+The protocol is JSON-RPC both ways at once. The client calls the agent — `initialize`,
+`session/new`, `session/prompt` — and the agent calls back, mid-turn: a `session/update`
+notification for every chunk of progress, and requests that block its work until the client
+answers. A prompt is therefore not a function call but a *turn*: one long-lived request whose
+response arrives only after everything the agent did inside it.
+
+Espionage models the turn directly. `prompt` blocks until the agent reports why the turn ended,
+while the updates stream concurrently to handlers registered before connecting; the capabilities
+the client advertises are derived from those registrations, so the declaration can never disagree
+with the implementation. Everything comes from the `soundness` package:
+
+```scala
+import soundness.*
+```
+
+### Connecting
+
+`Acp.connect` spawns the agent, exchanges `initialize`, and lends a connection for the duration
+of a block. The first block registers handlers; the second holds the live connection:
+
+```scala
+Acp.connect(Acp.Agent(sh"claude-code-acp")):
+  Acp.updated:
+    Acp.update match
+      case Acp.AgentMessageChunk(Acp.TextContent(text, _)) => Out.print(text)
+      case other                                           => ()
+
+  Acp.permission:
+    Acp.options.filter(_.kind == Acp.PermissionOptionKind.AllowOnce).prim
+    . lay(Acp.Cancelled): option => Acp.Selected(option.optionId)
+
+. apply:
+    val session = connection.newSession(workingDirectory[Text])
+    val stopReason = connection.prompt(session.sessionId, t"Fix the failing test")
+```
+
+An unregistered capability is never advertised: a client that registers no `readFile` handler
+reports no filesystem support, and a conformant agent will not ask.
+
+### Filesystem and terminals
+
+The agent works with *your* view of the world if you offer one: `Acp.readFile` and
+`Acp.writeFile` serve the agent's file requests (including unsaved editor state, if you have
+any), and `Acp.terminals` supplies the five terminal operations as one bundle, since the protocol
+advertises them as a single capability.
+
+### Cancellation
+
+`connection.cancel(sessionId)` notifies the agent, and the turn completes with the `Cancelled`
+stop reason. Permission requests pending at that moment — or arriving before the next turn — are
+answered `Cancelled` automatically, as the protocol requires; opening a new turn resets the
+session.
+
+### Content
+
+ACP adopts MCP's content vocabulary — `TextContent`, `ImageContent`, `AudioContent`,
+`ResourceLink`, `EmbeddedResource` — and Espionage shares those types with
+[synesthesia](mcp.md), so content crosses between the two protocols without translation.

--- a/lib/espionage/src/core/espionage.Acp.scala
+++ b/lib/espionage/src/core/espionage.Acp.scala
@@ -1,0 +1,1420 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package espionage
+
+import java.io as ji
+import java.util.concurrent as juc
+
+import scala.caps
+
+import ambience.*
+import anticipation.*
+import contingency.*
+import denominative.*
+import distillate.*
+import eucalyptus.*
+import fulminate.*
+import gossamer.*
+import guillotine.*
+import hieroglyph.*
+import jacinta.*
+import obligatory.*
+import parasite.*
+import prepositional.*
+import rudiments.*
+import turbulence.*
+import vacuous.*
+import zephyrine.*
+import Acp.*
+
+// The client half of the Agent Client Protocol (https://agentclientprotocol.com/), version 1: the
+// role an editor plays, here for programmatic use. A program spawns an agent as a subprocess (or
+// speaks to one behind a stream pair), negotiates capabilities, opens sessions, sends prompts,
+// and receives the agent's streamed updates and callback requests — permissions, filesystem
+// access, terminals — through handlers it registers before connecting.
+object Acp:
+  // The protocol version this library implements: a single integer, incremented by the
+  // specification only for breaking changes.
+  val version: Int = 1
+
+  // The content-block vocabulary is MCP's, which ACP adopts verbatim; it lives in synesthesia's
+  // `content` component — free of that library's HTTP stack — and is re-exported here so the ACP
+  // vocabulary is complete under `Acp`.
+  export synesthesia.Content.*
+
+  object Envelope:
+    // Pure and throwing, like the other derivation anchors; see `InitializeResult.decodable`.
+    given encodable: Envelope is Json.Encodable =
+      caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
+
+    given decodable: Envelope is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+  // Any JSON-RPC message, read only for the two members that decide how it is handled: the method
+  // it names — which a response does not — and the id it correlates on, which a notification does
+  // not. Both are optional, so every message decodes.
+  case class Envelope(method: Optional[Text] = Unset, id: Optional[Json] = Unset)
+
+  // Initialization
+
+  case class FsCapabilities
+    ( readTextFile:  Optional[Boolean] = Unset,
+      writeTextFile: Optional[Boolean] = Unset )
+
+  case class ClientCapabilities
+    ( fs:       Optional[FsCapabilities] = Unset,
+      terminal: Optional[Boolean]        = Unset )
+
+  case class PromptCapabilities
+    ( image:           Optional[Boolean] = Unset,
+      audio:           Optional[Boolean] = Unset,
+      embeddedContext: Optional[Boolean] = Unset )
+
+  case class McpCapabilities(http: Optional[Boolean] = Unset, sse: Optional[Boolean] = Unset)
+
+  case class AgentCapabilities
+    ( loadSession:        Optional[Boolean]            = Unset,
+      promptCapabilities: Optional[PromptCapabilities] = Unset,
+      mcpCapabilities:    Optional[McpCapabilities]    = Unset )
+
+  case class AuthMethod(id: Text, name: Text, description: Optional[Text] = Unset)
+
+  object InitializeResult:
+    // Pure and throwing: each internal summon mints its own throwing tactic; a decode failure
+    // surfaces as `Json.Error` handled at the transport. Threading a caller's tactic through the
+    // capture-polymorphic derivation is rejected by separation checking. The other decoder
+    // anchors below follow the same shape.
+    given decodable: InitializeResult is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+  case class InitializeResult
+    ( protocolVersion:   Int,
+      agentCapabilities: Optional[AgentCapabilities] = Unset,
+      authMethods:       List[AuthMethod]            = Nil,
+      _meta:             Optional[Json]              = Unset )
+
+  // Sessions
+
+  case class EnvVariable(name: Text, value: Text)
+
+  // How the agent should reach a Model Context Protocol server the client wants connected to a
+  // session: the stdio transport's launch specification.
+  case class McpServer
+    ( name:    Text,
+      command: Text,
+      args:    List[Text]        = Nil,
+      env:     List[EnvVariable] = Nil )
+
+  case class SessionMode(id: Text, name: Text, description: Optional[Text] = Unset)
+
+  case class SessionModeState(currentModeId: Text, availableModes: List[SessionMode] = Nil)
+
+  object NewSessionResult:
+    given decodable: NewSessionResult is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+  case class NewSessionResult
+    ( sessionId: Text,
+      modes:     Optional[SessionModeState] = Unset,
+      _meta:     Optional[Json]             = Unset )
+
+  // Prompt turns
+
+  object StopReason:
+    given encodable: StopReason is Json.Encodable = Json.Encodable(() => Morphology.Str):
+      case StopReason.EndTurn         => t"end_turn".in[Json]
+      case StopReason.MaxTokens       => t"max_tokens".in[Json]
+      case StopReason.MaxTurnRequests => t"max_turn_requests".in[Json]
+      case StopReason.Refusal         => t"refusal".in[Json]
+      case StopReason.Cancelled       => t"cancelled".in[Json]
+
+    given decodable: StopReason is Json.Decodable =
+      // Pure and throwing, like the derivation anchors: the decode cannot thread a
+      // caller's tactic under separation checking.
+      import strategies.throwUnsafely
+
+      caps.unsafe.unsafeAssumePure:
+        Json.Decodable(Morphology.Str): json =>
+          json.as[Text] match
+            case t"end_turn"          => StopReason.EndTurn
+            case t"max_tokens"        => StopReason.MaxTokens
+            case t"max_turn_requests" => StopReason.MaxTurnRequests
+            case t"refusal"           => StopReason.Refusal
+            case t"cancelled"         => StopReason.Cancelled
+            case _                    => abort(Json.Error(Json.Error.Reason.OutOfRange))
+
+  // Why a prompt turn ended: the result of `session/prompt`.
+  enum StopReason:
+    case EndTurn, MaxTokens, MaxTurnRequests, Refusal, Cancelled
+
+  object PromptResult:
+    given decodable: PromptResult is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+  case class PromptResult(stopReason: StopReason, _meta: Optional[Json] = Unset)
+
+  // Tool calls
+
+  object ToolKind:
+    given encodable: ToolKind is Json.Encodable = Json.Encodable(() => Morphology.Str):
+      case ToolKind.Read    => t"read".in[Json]
+      case ToolKind.Edit    => t"edit".in[Json]
+      case ToolKind.Delete  => t"delete".in[Json]
+      case ToolKind.Move    => t"move".in[Json]
+      case ToolKind.Search  => t"search".in[Json]
+      case ToolKind.Execute => t"execute".in[Json]
+      case ToolKind.Think   => t"think".in[Json]
+      case ToolKind.Fetch   => t"fetch".in[Json]
+      case ToolKind.Other   => t"other".in[Json]
+
+    given decodable: ToolKind is Json.Decodable =
+      // Pure and throwing, like the derivation anchors: the decode cannot thread a
+      // caller's tactic under separation checking.
+      import strategies.throwUnsafely
+
+      caps.unsafe.unsafeAssumePure:
+        Json.Decodable(Morphology.Str): json =>
+          json.as[Text] match
+            case t"read"    => ToolKind.Read
+            case t"edit"    => ToolKind.Edit
+            case t"delete"  => ToolKind.Delete
+            case t"move"    => ToolKind.Move
+            case t"search"  => ToolKind.Search
+            case t"execute" => ToolKind.Execute
+            case t"think"   => ToolKind.Think
+            case t"fetch"   => ToolKind.Fetch
+            case _          => ToolKind.Other
+
+  enum ToolKind:
+    case Read, Edit, Delete, Move, Search, Execute, Think, Fetch, Other
+
+  object ToolCallStatus:
+    given encodable: ToolCallStatus is Json.Encodable = Json.Encodable(() => Morphology.Str):
+      case ToolCallStatus.Pending    => t"pending".in[Json]
+      case ToolCallStatus.InProgress => t"in_progress".in[Json]
+      case ToolCallStatus.Completed  => t"completed".in[Json]
+      case ToolCallStatus.Failed     => t"failed".in[Json]
+      case ToolCallStatus.Cancelled  => t"cancelled".in[Json]
+
+    given decodable: ToolCallStatus is Json.Decodable =
+      // Pure and throwing, like the derivation anchors: the decode cannot thread a
+      // caller's tactic under separation checking.
+      import strategies.throwUnsafely
+
+      caps.unsafe.unsafeAssumePure:
+        Json.Decodable(Morphology.Str): json =>
+          json.as[Text] match
+            case t"pending"     => ToolCallStatus.Pending
+            case t"in_progress" => ToolCallStatus.InProgress
+            case t"completed"   => ToolCallStatus.Completed
+            case t"failed"      => ToolCallStatus.Failed
+            case t"cancelled"   => ToolCallStatus.Cancelled
+            case _              => abort(Json.Error(Json.Error.Reason.OutOfRange))
+
+  enum ToolCallStatus:
+    case Pending, InProgress, Completed, Failed, Cancelled
+
+  case class ToolCallLocation(path: Text, line: Optional[Int] = Unset)
+
+  object ToolCallContent:
+    import dynamicJsonAccess.enabled
+
+    private val typeTag = Json.discriminatedUnion[ToolCallContent](t"type")
+
+    given encodable: ToolCallContent is Json.Encodable = Json.Encodable(() => Morphology.Any):
+      case content: ToolContent  => typeTag.rewrite(t"content",  content.in[Json])
+      case content: ToolDiff     => typeTag.rewrite(t"diff",     content.in[Json])
+      case content: ToolTerminal => typeTag.rewrite(t"terminal", content.in[Json])
+
+    given decodable: ToolCallContent is Json.Decodable =
+      // Pure and throwing, like the derivation anchors: the decode cannot thread a
+      // caller's tactic under separation checking.
+      import strategies.throwUnsafely
+
+      caps.unsafe.unsafeAssumePure:
+        Json.Decodable(Morphology.Any): json =>
+          json.`type`.as[Text] match
+            case "content"  => json.as[ToolContent]
+            case "diff"     => json.as[ToolDiff]
+            case "terminal" => json.as[ToolTerminal]
+            case _          => abort(Json.Error(Json.Error.Reason.OutOfRange))
+
+  // What a tool call produced, as the agent reports it: ordinary content, a structured file
+  // diff, or a reference to a terminal the agent runs a command in.
+  sealed trait ToolCallContent
+
+  object ToolContent:
+    given decodable: ToolContent is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+    given encodable: ToolContent is Json.Encodable =
+      caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
+
+  case class ToolContent(content: ContentBlock) extends ToolCallContent
+
+  object ToolDiff:
+    given decodable: ToolDiff is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+    given encodable: ToolDiff is Json.Encodable =
+      caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
+
+  case class ToolDiff(path: Text, oldText: Optional[Text] = Unset, newText: Text)
+  extends ToolCallContent
+
+  object ToolTerminal:
+    given decodable: ToolTerminal is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+    given encodable: ToolTerminal is Json.Encodable =
+      caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
+
+  case class ToolTerminal(terminalId: Text) extends ToolCallContent
+
+  object ToolCall:
+    given decodable: ToolCall is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+  // A tool call as first reported (the `tool_call` update): only the id and title are required.
+  case class ToolCall
+    ( toolCallId: Text,
+      title:      Text,
+      kind:       Optional[ToolKind]       = Unset,
+      status:     Optional[ToolCallStatus] = Unset,
+      content:    List[ToolCallContent]    = Nil,
+      locations:  List[ToolCallLocation]   = Nil,
+      rawInput:   Optional[Json]           = Unset,
+      rawOutput:  Optional[Json]           = Unset )
+  extends SessionUpdate
+
+  object ToolCallUpdate:
+    given decodable: ToolCallUpdate is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+  // A later report about an existing tool call (the `tool_call_update` update): every member but
+  // the id is optional, and a present member replaces what was previously reported. The same
+  // shape carries the tool call a permission request concerns.
+  case class ToolCallUpdate
+    ( toolCallId: Text,
+      title:      Optional[Text]                   = Unset,
+      kind:       Optional[ToolKind]               = Unset,
+      status:     Optional[ToolCallStatus]         = Unset,
+      content:    Optional[List[ToolCallContent]]  = Unset,
+      locations:  Optional[List[ToolCallLocation]] = Unset,
+      rawInput:   Optional[Json]                   = Unset,
+      rawOutput:  Optional[Json]                   = Unset )
+  extends SessionUpdate
+
+  // Plans
+
+  object PlanPriority:
+    given encodable: PlanPriority is Json.Encodable = Json.Encodable(() => Morphology.Str):
+      case PlanPriority.High   => t"high".in[Json]
+      case PlanPriority.Medium => t"medium".in[Json]
+      case PlanPriority.Low    => t"low".in[Json]
+
+    given decodable: PlanPriority is Json.Decodable =
+      // Pure and throwing, like the derivation anchors: the decode cannot thread a
+      // caller's tactic under separation checking.
+      import strategies.throwUnsafely
+
+      caps.unsafe.unsafeAssumePure:
+        Json.Decodable(Morphology.Str): json =>
+          json.as[Text] match
+            case t"high"   => PlanPriority.High
+            case t"medium" => PlanPriority.Medium
+            case t"low"    => PlanPriority.Low
+            case _         => abort(Json.Error(Json.Error.Reason.OutOfRange))
+
+  enum PlanPriority:
+    case High, Medium, Low
+
+  object PlanStatus:
+    given encodable: PlanStatus is Json.Encodable = Json.Encodable(() => Morphology.Str):
+      case PlanStatus.Pending    => t"pending".in[Json]
+      case PlanStatus.InProgress => t"in_progress".in[Json]
+      case PlanStatus.Completed  => t"completed".in[Json]
+
+    given decodable: PlanStatus is Json.Decodable =
+      // Pure and throwing, like the derivation anchors: the decode cannot thread a
+      // caller's tactic under separation checking.
+      import strategies.throwUnsafely
+
+      caps.unsafe.unsafeAssumePure:
+        Json.Decodable(Morphology.Str): json =>
+          json.as[Text] match
+            case t"pending"     => PlanStatus.Pending
+            case t"in_progress" => PlanStatus.InProgress
+            case t"completed"   => PlanStatus.Completed
+            case _              => abort(Json.Error(Json.Error.Reason.OutOfRange))
+
+  enum PlanStatus:
+    case Pending, InProgress, Completed
+
+  case class PlanEntry(content: Text, priority: PlanPriority, status: PlanStatus)
+
+  case class AvailableCommand(name: Text, description: Text, input: Optional[Json] = Unset)
+
+  // Session updates
+
+  object SessionUpdate:
+    import dynamicJsonAccess.enabled
+
+    private val typeTag = Json.discriminatedUnion[SessionUpdate](t"sessionUpdate")
+
+    given encodable: SessionUpdate is Json.Encodable = Json.Encodable(() => Morphology.Any):
+      case update: UserMessageChunk  => typeTag.rewrite(t"user_message_chunk", update.in[Json])
+      case update: AgentMessageChunk => typeTag.rewrite(t"agent_message_chunk", update.in[Json])
+      case update: AgentThoughtChunk => typeTag.rewrite(t"agent_thought_chunk", update.in[Json])
+      case update: ToolCall          => typeTag.rewrite(t"tool_call", update.in[Json])
+      case update: ToolCallUpdate    => typeTag.rewrite(t"tool_call_update", update.in[Json])
+      case update: Plan              => typeTag.rewrite(t"plan", update.in[Json])
+
+      case update: AvailableCommandsUpdate =>
+        typeTag.rewrite(t"available_commands_update", update.in[Json])
+
+      case update: CurrentModeUpdate => typeTag.rewrite(t"current_mode_update", update.in[Json])
+
+    given decodable: SessionUpdate is Json.Decodable =
+      // Pure and throwing, like the derivation anchors: the decode cannot thread a
+      // caller's tactic under separation checking.
+      import strategies.throwUnsafely
+
+      caps.unsafe.unsafeAssumePure:
+        Json.Decodable(Morphology.Any): json =>
+          json.sessionUpdate.as[Text] match
+            case "user_message_chunk"        => json.as[UserMessageChunk]
+            case "agent_message_chunk"       => json.as[AgentMessageChunk]
+            case "agent_thought_chunk"       => json.as[AgentThoughtChunk]
+            case "tool_call"                 => json.as[ToolCall]
+            case "tool_call_update"          => json.as[ToolCallUpdate]
+            case "plan"                      => json.as[Plan]
+            case "available_commands_update" => json.as[AvailableCommandsUpdate]
+            case "current_mode_update"       => json.as[CurrentModeUpdate]
+            case _                           => abort(Json.Error(Json.Error.Reason.OutOfRange))
+
+  // One `session/update` notification: everything an agent reports about a turn as it runs,
+  // discriminated on the wire by its `sessionUpdate` member.
+  sealed trait SessionUpdate
+
+  object UserMessageChunk:
+    given decodable: UserMessageChunk is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+    given encodable: UserMessageChunk is Json.Encodable =
+      caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
+
+  case class UserMessageChunk(content: ContentBlock) extends SessionUpdate
+
+  object AgentMessageChunk:
+    given decodable: AgentMessageChunk is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+    given encodable: AgentMessageChunk is Json.Encodable =
+      caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
+
+  case class AgentMessageChunk(content: ContentBlock) extends SessionUpdate
+
+  object AgentThoughtChunk:
+    given decodable: AgentThoughtChunk is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+    given encodable: AgentThoughtChunk is Json.Encodable =
+      caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
+
+  case class AgentThoughtChunk(content: ContentBlock) extends SessionUpdate
+
+  object Plan:
+    given decodable: Plan is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+    given encodable: Plan is Json.Encodable =
+      caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
+
+  case class Plan(entries: List[PlanEntry] = Nil) extends SessionUpdate
+
+  object AvailableCommandsUpdate:
+    given decodable: AvailableCommandsUpdate is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+    given encodable: AvailableCommandsUpdate is Json.Encodable =
+      caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
+
+  case class AvailableCommandsUpdate(availableCommands: List[AvailableCommand] = Nil)
+  extends SessionUpdate
+
+  object CurrentModeUpdate:
+    given decodable: CurrentModeUpdate is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+    given encodable: CurrentModeUpdate is Json.Encodable =
+      caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
+
+  case class CurrentModeUpdate(currentModeId: Text) extends SessionUpdate
+
+  // Permissions
+
+  object PermissionOptionKind:
+    given encodable: PermissionOptionKind is Json.Encodable = Json.Encodable(() => Morphology.Str):
+      case PermissionOptionKind.AllowOnce    => t"allow_once".in[Json]
+      case PermissionOptionKind.AllowAlways  => t"allow_always".in[Json]
+      case PermissionOptionKind.RejectOnce   => t"reject_once".in[Json]
+      case PermissionOptionKind.RejectAlways => t"reject_always".in[Json]
+
+    given decodable: PermissionOptionKind is Json.Decodable =
+      // Pure and throwing, like the derivation anchors: the decode cannot thread a
+      // caller's tactic under separation checking.
+      import strategies.throwUnsafely
+
+      caps.unsafe.unsafeAssumePure:
+        Json.Decodable(Morphology.Str): json =>
+          json.as[Text] match
+            case t"allow_once"    => PermissionOptionKind.AllowOnce
+            case t"allow_always"  => PermissionOptionKind.AllowAlways
+            case t"reject_once"   => PermissionOptionKind.RejectOnce
+            case t"reject_always" => PermissionOptionKind.RejectAlways
+            case _                => abort(Json.Error(Json.Error.Reason.OutOfRange))
+
+  enum PermissionOptionKind:
+    case AllowOnce, AllowAlways, RejectOnce, RejectAlways
+
+  object PermissionOption:
+    given decodable: PermissionOption is Json.Decodable =
+      import strategies.throwUnsafely
+      caps.unsafe.unsafeAssumePure(Json.DecodableDerivation.derived)
+
+    given encodable: PermissionOption is Json.Encodable =
+      caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
+
+  case class PermissionOption(optionId: Text, name: Text, kind: PermissionOptionKind)
+
+  object RequestPermissionOutcome:
+    import dynamicJsonAccess.enabled
+
+    private val typeTag = Json.discriminatedUnion[RequestPermissionOutcome](t"outcome")
+
+    given encodable: RequestPermissionOutcome is Json.Encodable =
+      Json.Encodable(() => Morphology.Any):
+        case Selected(optionId) =>
+          typeTag.rewrite(t"selected", Map(t"optionId" -> optionId.in[Json]).in[Json])
+
+        case Cancelled =>
+          typeTag.rewrite(t"cancelled", Map[Text, Json]().in[Json])
+
+    given decodable: RequestPermissionOutcome is Json.Decodable =
+      // Pure and throwing, like the derivation anchors: the decode cannot thread a
+      // caller's tactic under separation checking.
+      import strategies.throwUnsafely
+
+      caps.unsafe.unsafeAssumePure:
+        Json.Decodable(Morphology.Any): json =>
+          json.outcome.as[Text] match
+            case "selected"  => Selected(json.optionId.as[Text])
+            case "cancelled" => Cancelled
+            case _           => abort(Json.Error(Json.Error.Reason.OutOfRange))
+
+  // The user's answer to a permission request: one of the offered options, or `Cancelled` — which
+  // is also the mandatory answer to every request still pending when its turn is cancelled.
+  sealed trait RequestPermissionOutcome
+  case class Selected(optionId: Text) extends RequestPermissionOutcome
+  case object Cancelled extends RequestPermissionOutcome
+
+  case class RequestPermissionResult(outcome: RequestPermissionOutcome)
+
+  // Filesystem and terminal results
+
+  case class ReadTextFileResult(content: Text)
+  case class CreateTerminalResult(terminalId: Text)
+
+  case class TerminalExitStatus(exitCode: Optional[Int] = Unset, signal: Optional[Text] = Unset)
+
+  case class TerminalOutputResult
+    ( output:     Text,
+      truncated:  Boolean,
+      exitStatus: Optional[TerminalExitStatus] = Unset )
+
+  // The bundle of terminal operations a client offers an agent, registered whole: the protocol
+  // advertises terminal support as a single capability, so the five methods are all-or-nothing.
+  trait Terminals:
+    def create
+      ( sessionId:       Text,
+        command:         Text,
+        args:            List[Text],
+        env:             List[EnvVariable],
+        cwd:             Optional[Text],
+        outputByteLimit: Optional[Long] )
+    :   Text
+
+    def output(sessionId: Text, terminalId: Text): TerminalOutputResult
+    def waitForExit(sessionId: Text, terminalId: Text): TerminalExitStatus
+    def kill(sessionId: Text, terminalId: Text): Unit
+    def release(sessionId: Text, terminalId: Text): Unit
+
+  // Handler context shapes. Every handler is lent the session id it concerns, its tagged
+  // payloads, and an error emitter; each shape is a single context-parameter clause, and results
+  // are pure, so nothing lent to a handler can leave it — by return value, closure or task.
+
+  type Turned1[payload, result] =
+    (sessionId: Text aka "sessionId", payload: payload, emit: Emit[Acp.Error]^) ?=> result
+
+  type Turned2[payload1, payload2, result] =
+    ( sessionId: Text aka "sessionId",
+      payload1:  payload1,
+      payload2:  payload2,
+      emit:      Emit[Acp.Error]^ )
+    ?=> result
+
+  type Turned3[payload1, payload2, payload3, result] =
+    ( sessionId: Text aka "sessionId",
+      payload1:  payload1,
+      payload2:  payload2,
+      payload3:  payload3,
+      emit:      Emit[Acp.Error]^ )
+    ?=> result
+
+  // The handler signature of each feature, named for its registration combinator.
+
+  type UpdateHandler = Turned1[SessionUpdate aka "update", Unit]
+
+  type PermissionHandler =
+    Turned2[ToolCallUpdate aka "toolCall", List[PermissionOption] aka "options",
+        RequestPermissionOutcome]
+
+  type ReadFileHandler =
+    Turned3[Text aka "path", Optional[Int] aka "line", Optional[Int] aka "limit", Text]
+
+  type WriteFileHandler = Turned2[Text aka "path", Text aka "content", Unit]
+
+  // Contextual accessors, reading a handler's context by its tag; `connection` reads the live
+  // connection `connect` lends to its block.
+
+  transparent inline def connection(using connection: Acp.Connection): connection.type =
+    connection
+
+  inline def sessionId(using sessionId: Text aka "sessionId"): Text = sessionId()
+  inline def update(using update: SessionUpdate aka "update"): SessionUpdate = update()
+
+  inline def toolCall(using toolCall: ToolCallUpdate aka "toolCall"): ToolCallUpdate =
+    toolCall()
+
+  inline def options(using options: List[PermissionOption] aka "options")
+  :   List[PermissionOption] =
+
+    options()
+
+  inline def path(using path: Text aka "path"): Text = path()
+  inline def line(using line: Optional[Int] aka "line"): Optional[Int] = line()
+  inline def limit(using limit: Optional[Int] aka "limit"): Optional[Int] = limit()
+  inline def content(using content: Text aka "content"): Text = content()
+
+  // Registration combinators, each writing a boxed handler into the lent registry. Inline, so the
+  // registry capability flows from the use site rather than a fresh root minted at the method
+  // boundary.
+
+  transparent inline def updated(handler: UpdateHandler)(using registry: Acp.Registry^): Unit =
+    registry.updated0 = Acp.Registry.Slot[UpdateHandler](handler)
+
+  transparent inline def permission(handler: PermissionHandler)(using registry: Acp.Registry^)
+  :   Unit =
+
+    registry.permission0 = Acp.Registry.Slot[PermissionHandler](handler)
+
+  transparent inline def readFile(handler: ReadFileHandler)(using registry: Acp.Registry^)
+  :   Unit =
+
+    registry.readFile0 = Acp.Registry.Slot[ReadFileHandler](handler)
+
+  transparent inline def writeFile(handler: WriteFileHandler)(using registry: Acp.Registry^)
+  :   Unit =
+
+    registry.writeFile0 = Acp.Registry.Slot[WriteFileHandler](handler)
+
+  transparent inline def terminals(handler: Terminals)(using registry: Acp.Registry^): Unit =
+    registry.terminal0 = Acp.Registry.Slot[Terminals](handler)
+
+  // An escape hatch: adjusts the derived capabilities, applied last, at initialization.
+  transparent inline def capabilities(adjust: ClientCapabilities => ClientCapabilities)
+    ( using registry: Acp.Registry^ )
+  :   Unit =
+
+    registry.adjust0 = adjust
+
+  // Connects to an ACP agent for the duration of a lambda. The first block registers the
+  // client's handlers on the lent registry; once it returns, the registry is consumed and
+  // frozen, the client's capabilities are derived from what was registered, and the exchange
+  // opens: a writer task drains outgoing messages onto the agent's input, a reader task routes
+  // what comes back, and `initialize` is exchanged — aborting with `Incompatible` if the agent
+  // answers with a protocol version other than this library's. The second block then holds a
+  // live, initialized connection; when it returns, the exchange is torn down and a subprocess
+  // agent is killed, so nothing can outlive the agent it speaks to. Everything stateful —
+  // registry, service, dispatchers, connection — is local to this call: nothing
+  // capability-carrying is ever stored in an application-lifetime object. `observer`, if given,
+  // sees every message in both directions as it crosses the transport.
+  //
+  // `capture` lets the connection block capture the monitor, which a block that spawns a task —
+  // to prompt and cancel concurrently, say — needs; exegesis's `Lsp.proxy` takes the same shape.
+  def connect[result, capture^](agent: Agent, observer: Observer = Observer.Silent)
+    ( register: (registry: Acp.Registry^) ?=> Unit )
+    ( lambda: (connection: Acp.Connection) ?->{capture} result )
+    ( using Monitor^{capture}, Probate, Diagnostics, WorkingDirectory, Tactic[Acp.Error] )
+  :   result =
+
+    import strategies.throwUnsafely
+
+    val registry: Acp.Registry^ = Acp.Registry()
+    register(using registry)
+
+    val state: State = State()
+    val service: Service^ = Service(registry, state)
+
+    def open(sink: (Intake[Data] over Credit)^, read: (Text => Unit) => Unit): result =
+      Exchange.exchange(service, state, observer, sink, read): connection =>
+        connection.initialize(service.capabilities)
+        lambda(using connection)
+
+    agent match
+      case Agent.Streams(input, output) =>
+        val streamable = summon[ji.InputStream is Streamable by Data over Credit]
+        val sink = summon[ji.OutputStream is Sink by Data over Credit].intake(output)
+
+        try open(sink, Transport.pump(streamable.stream(input), observer)(_)) finally sink.finish()
+
+      case Agent.Process(command) =>
+        // Launched with a silent logger and a throwing tactic: a failure to launch has no
+        // caller's `Tactic` to be raised through here, and an exec log has no channel to reach —
+        // an ACP agent owns standard output.
+        import logging.silentLogging
+
+        val job = command.fork[Exit]()
+
+        // The child is killed rather than waited for: an agent that never notices its input
+        // closing — or that outlives an exchange that ended early — would otherwise outlive the
+        // session it was lent to.
+        try open(job.intake, Transport.pump(job.stdout(), observer)(_)) finally job.abort()
+
+  // The method a message names, or `Unset` if it names none — which marks it a response.
+  private[espionage] def method(json: Json): Optional[Text] = envelope(json).method
+
+  // The id a message correlates on, for a message of any kind.
+  private[espionage] def identifier(json: Json): Optional[Json] = envelope(json).id
+
+  private[espionage] def envelope(json: Json): Envelope =
+    import strategies.throwUnsafely
+    try json.as[Envelope] catch case _: Exception => Envelope()
+
+  private[espionage] def requestId(json: Json): Optional[Json] =
+    // Throwing rather than `safely`: the request decodable cannot thread the boundary tactic
+    // under separation checking, and an unreadable id is simply absent.
+    import strategies.throwUnsafely
+    try json.as[JsonRpc.Request].id catch case _: Exception => Unset
+
+  // An observer of the raw traffic crossing the transport, for a client that exposes a log of
+  // the messages it exchanges. Each message is reported as the text that was read from — or
+  // framed onto — the wire, before parsing, so a malformed message is observed too.
+  object Observer:
+    // The default: a client that does not expose its traffic pays nothing for the hook.
+    object Silent extends Observer:
+      def received(message: Text): Unit = ()
+      def sent(message: Text): Unit = ()
+
+    given silent: Observer = Silent
+
+  trait Observer:
+    def received(message: Text): Unit
+    def sent(message: Text): Unit
+
+  object Agent:
+    // An agent launched as a subprocess: how a client normally starts one.
+    def apply(command: guillotine.Command): Agent = Agent.Process(command)
+
+    // An agent already running behind a pair of streams. Widened to `Agent`, which is what
+    // `connect` is indexed by.
+    def streams(input: ji.InputStream, output: ji.OutputStream): Agent =
+      Agent.Streams(input, output)
+
+  // An ACP agent this process can speak to: the far end of the exchange `connect` opens.
+  //
+  // A plain value, holding no capability: the channel is minted when the connection opens and
+  // disposed of when it ends, and a stream or an intake — single-owner, and dead once the agent
+  // is gone — has no business being carried in a description of where to find an agent.
+  enum Agent:
+    // Standard input and output of a subprocess carry the protocol.
+    case Process(command: guillotine.Command)
+
+    // An agent already running behind a pair of byte streams: one in this process, one behind a
+    // socket, or a fixture in a test.
+    case Streams(input: ji.InputStream, output: ji.OutputStream)
+
+  // AcpError → Acp.Error
+  object Error:
+    // Each reason carries its JSON-RPC wire code (`code`), alongside the sequential `number`
+    // used for the SN-148 diagnostic. A fault raised in a handler is converted into an error
+    // response whose `error.code` is the reason's wire code.
+    enum Reason(val number: Int, val code: Int) extends Clarification:
+      case Parse          extends Reason(1, -32700)
+      case InvalidRequest extends Reason(2, -32600)
+      case MethodNotFound extends Reason(3, -32601)
+      case InvalidParams  extends Reason(4, -32602)
+      case Internal       extends Reason(5, -32603)
+      case AuthRequired   extends Reason(6, -32000)
+      case Incompatible   extends Reason(7, 0)
+
+    // The inverse of `code`: recovers the reason from an error response's wire code, for a
+    // client reading a fault an agent sent it. A code outside the standard set is `Unset` here,
+    // and reported as `Internal` by the caller. (`Incompatible` is local — a protocol-version
+    // mismatch discovered at initialization — and its zero is not a wire code.)
+    def reason(code: Int): Optional[Reason] =
+      var found: Optional[Reason] = Unset
+      var index: Int = 0
+
+      while index < Reason.values.length do
+        val reason = Reason.values(index)
+        if reason.code == code && reason.code != 0 then found = reason
+        index += 1
+
+      found
+
+    given communicable: Reason is Communicable =
+      case Reason.Parse          => m"the message could not be parsed as JSON"
+      case Reason.InvalidRequest => m"the message was not a valid JSON-RPC request"
+      case Reason.MethodNotFound => m"the method name was not recognised"
+      case Reason.InvalidParams  => m"the parameters were not valid for the requested method"
+      case Reason.Internal       => m"an internal error occurred"
+      case Reason.AuthRequired   => m"the agent requires authentication"
+
+      case Reason.Incompatible =>
+        m"the agent does not support the protocol version this client implements"
+
+  case class Error(reason: Acp.Error.Reason, details: Optional[Text] = Unset)(using Diagnostics)
+  extends fulminate.Error(148, reason.number)(m"the ACP operation failed because $reason"):
+    // The message sent to the agent in the error response: the given details, or the reason's
+    // standard description.
+    def response: Text = details.or(reason.communicate.text)
+
+  // AcpRegistry → Acp.Registry
+  object Registry:
+    // A context-function value adapts to any non-context-function expected type by being
+    // applied, so a handler cannot inhabit an `Optional[...]` union directly: the box holds it
+    // intact.
+    case class Slot[handler](value: handler)
+
+  // The target of the registration combinators, lent to the block given to `Acp.connect` for its
+  // duration, then consumed by the service it configures: registration after the exchange begins
+  // is impossible by construction. An exclusive capability, so it cannot escape the block; its
+  // slots are public untracked vars — the combinators are inline, assigning from their expansion
+  // sites. The slots are an erased rim (`AnyRef | Null`): a union mentioning a context-function
+  // type freshens its capture sets at every adaptation, so the typed boundary is the combinator
+  // (whose parameter is the pure handler type — a handler closing over the registry is rejected
+  // there) and the service's invocation helpers, which restore the type by cast.
+  class Registry private[espionage] () extends caps.ExclusiveCapability:
+
+    @scala.caps.unsafe.untrackedCaptures
+    var updated0: AnyRef | Null = null
+
+    @scala.caps.unsafe.untrackedCaptures
+    var permission0: AnyRef | Null = null
+
+    @scala.caps.unsafe.untrackedCaptures
+    var readFile0: AnyRef | Null = null
+
+    @scala.caps.unsafe.untrackedCaptures
+    var writeFile0: AnyRef | Null = null
+
+    @scala.caps.unsafe.untrackedCaptures
+    var terminal0: AnyRef | Null = null
+
+    @scala.caps.unsafe.untrackedCaptures
+    var adjust0: Optional[ClientCapabilities => ClientCapabilities] = Unset
+
+    // The capabilities the client advertises at initialization, derived from what was
+    // registered, so the declaration can never disagree with the implementation; `adjust0`, if
+    // registered, is applied last.
+    private[espionage] def capabilities: ClientCapabilities =
+      def flag(slot: AnyRef | Null): Optional[Boolean] = if slot == null then Unset else true
+
+      val fs: Optional[FsCapabilities] =
+        if readFile0 == null && writeFile0 == null then Unset
+        else FsCapabilities(flag(readFile0), flag(writeFile0))
+
+      val derived = ClientCapabilities(fs, flag(terminal0))
+      adjust0.lay(derived)(_(derived))
+
+  // AcpConnection → Acp.Connection
+  // The client's half of an ACP exchange: the handle a program holds on a running agent. It is a
+  // capability, lent by `Acp.connect` for the duration of a lambda and disposed of afterwards,
+  // so it cannot outlive the agent it speaks to.
+  //
+  // Outbound messages are put on the inherited `JsonRpc` channel, which the exchange's writer
+  // drains onto the transport; inbound messages are read by the exchange's reader and routed. A
+  // request blocks the caller until its response arrives, but never blocks the reader, so
+  // several requests may be in flight at once — a prompt turn stays open while its updates
+  // stream — and may be answered out of order.
+  class Connection private[espionage] (state: State)(using Monitor, Diagnostics)
+  extends JsonRpc, caps.ExclusiveCapability:
+    type Origin = AcpAgent
+
+    import strategies.throwUnsafely
+
+    // One proxy module per sub-interface, both sharing this instance's outgoing channel. The
+    // connection is confined by its own type and each proxy is a member of it, so sealing the
+    // reference the generated modules hold is sound; the macro cannot take a capability-typed
+    // splice.
+    private val channel: JsonRpc = caps.unsafe.unsafeAssumePure(this)
+
+    val lifecycle: AcpAgentLifecycle =
+      caps.unsafe.unsafeAssumePure(channel.proxy[AcpAgentLifecycle])
+
+    val sessions: AcpAgentSession = caps.unsafe.unsafeAssumePure(channel.proxy[AcpAgentSession])
+
+    // What the agent reported at initialization: pure data, recorded by `initialize`.
+    @scala.caps.unsafe.untrackedCaptures
+    private var initialized0: Optional[InitializeResult] = Unset
+
+    // A fault the agent reports as an error response arrives as a `JsonRpc.Error` carrying the
+    // wire code, which is exactly the vocabulary of `Acp.Error.Reason`; a code outside the
+    // standard set is reported as `Internal`, with the agent's own message as the detail.
+    private def ask[result](block: => result)(using Tactic[Acp.Error]): result =
+      try block catch case error: JsonRpc.Error =>
+        abort
+         ( Acp.Error
+            ( error.code.let(Acp.Error.reason(_)).or(Acp.Error.Reason.Internal),
+              error.detail ) )
+
+    // The raw seam: sends a message exactly as given, without minting an id or awaiting an
+    // answer, for the methods this library does not model.
+    def send(message: Json): Unit = put(message)
+
+    // Negotiates the protocol version and capabilities. The client sends the latest version it
+    // supports; an agent that cannot speak it answers with its own latest, which this client —
+    // implementing exactly one — must then reject.
+    def initialize(capabilities: ClientCapabilities = ClientCapabilities())
+      ( using Tactic[Acp.Error] )
+    :   InitializeResult =
+
+      val result = ask(lifecycle.initialize(Acp.version, capabilities))
+      if result.protocolVersion != Acp.version then abort(Acp.Error(Error.Reason.Incompatible))
+      initialized0 = result
+      result
+
+    def authenticate(methodId: Text)(using Tactic[Acp.Error]): Unit =
+      ask(lifecycle.authenticate(methodId)) yet ()
+
+    def newSession(cwd: Text, mcpServers: List[McpServer] = Nil)(using Tactic[Acp.Error])
+    :   NewSessionResult =
+
+      ask(sessions.`session/new`(cwd, mcpServers))
+
+    // Resumes an existing session: the agent replays the whole conversation through
+    // `session/update` notifications — routed to the registered update handler — before this
+    // returns.
+    def loadSession(sessionId: Text, cwd: Text, mcpServers: List[McpServer] = Nil)
+      ( using Tactic[Acp.Error] )
+    :   Unit =
+
+      ask(sessions.`session/load`(sessionId, cwd, mcpServers)) yet ()
+
+    // One prompt turn: blocks until the agent reports why the turn ended, while its updates
+    // stream concurrently to the registered update handler. Opening a new turn resets the
+    // session's cancellation, so a client may prompt again after cancelling.
+    def prompt(sessionId: Text, content: List[ContentBlock])(using Tactic[Acp.Error])
+    :   StopReason =
+
+      state.begin(sessionId)
+      ask(sessions.`session/prompt`(sessionId, content)).stopReason
+
+    // The plain-text form of `prompt`.
+    def prompt(sessionId: Text, text: Text)(using Tactic[Acp.Error]): StopReason =
+      prompt(sessionId, List(TextContent(text)))
+
+    // Cancels the session's current turn. A notification, not a request: the turn's outcome is
+    // the in-flight `session/prompt` response, which the agent must complete with the
+    // `Cancelled` stop reason. Permission requests pending when this is called — and any that
+    // arrive before the next turn opens — are answered `Cancelled`, as the protocol requires.
+    def cancel(sessionId: Text): Unit =
+      state.cancel(sessionId)
+      sessions.`session/cancel`(sessionId)
+
+    def setMode(sessionId: Text, modeId: Text)(using Tactic[Acp.Error]): Unit =
+      ask(sessions.`session/set_mode`(sessionId, modeId)) yet ()
+
+    // What the agent reported at initialization, for a caller that has initialized.
+    def agentCapabilities: Optional[AgentCapabilities] = initialized0.let(_.agentCapabilities)
+    def authMethods: List[AuthMethod] = initialized0.lay(Nil)(_.authMethods)
+
+  // AcpState → Acp.State
+  // The per-connection state shared between the connection (which cancels turns and opens new
+  // ones) and the service (which must answer permission requests for a cancelled turn with the
+  // `Cancelled` outcome). Pure, concurrent data: it is written by the caller's thread and read by
+  // the reader's dispatch tasks.
+  private[espionage] class State:
+    private val flags: juc.ConcurrentHashMap[Text, java.lang.Boolean] = juc.ConcurrentHashMap()
+
+    private[espionage] def cancel(sessionId: Text): Unit =
+      flags.put(sessionId, java.lang.Boolean.TRUE)
+
+    // Opening a turn clears the session's cancellation, so a client may prompt again after
+    // cancelling.
+    private[espionage] def begin(sessionId: Text): Unit = flags.remove(sessionId)
+
+    private[espionage] def cancelled(sessionId: Text): Boolean = flags.get(sessionId) != null
+
+  // AcpService → Acp.Service
+  // One live ACP client service: the bridge between the macro-generated JSON-RPC dispatchers and
+  // the registered handlers. It is created per `Acp.connect` invocation and lives only in its
+  // frame; it is an exclusive capability, so it cannot be stored in an application-lifetime
+  // object.
+  private[espionage] object Service:
+    // The fault recorded by the current dispatch's emitter, if any; collected (and cleared) after
+    // each dispatch and turned into an error response. Unlike `LspSession`, whose single-threaded
+    // dispatch loop lets one slot serve every dispatch, agent requests here are dispatched on
+    // spawned tasks — a permission handler may block on user input while updates keep streaming —
+    // so concurrent dispatches must not cross their faults: the slot is per-thread, and `conclude`
+    // runs on the thread that dispatched. The cell is a separate pure-data object rather than the
+    // service itself, so the emitter lent to a handler captures only the cell.
+    private[espionage] class Cell:
+      private val fault0: ThreadLocal[Acp.Error | Null] = ThreadLocal()
+
+      private[espionage] def record(error: Acp.Error): Unit = fault0.set(error)
+
+      private[espionage] def collect(): Optional[Acp.Error] = fault0.get() match
+        case null             => Unset
+        case error: Acp.Error => fault0.set(null) yet error
+
+    // Building the service consumes the registry: nothing can register once the exchange begins.
+    private[espionage] def apply(consume registry: Registry^, state: State): Service^ =
+      new Service(registry, state)
+
+  private[espionage] class Service private (handlers: Registry^, state: State)
+  extends AcpClient, caps.ExclusiveCapability:
+    // Confined to this class rather than the file: `Acp.Error`'s constructor needs a
+    // `Diagnostics`, and an ambient one would compete with the connection's own.
+    import errorDiagnostics.stackTracesDiagnostics
+
+    private val fault0: Service.Cell = Service.Cell()
+
+    // The capabilities to advertise at initialization, derived from what was registered.
+    private[espionage] val capabilities: ClientCapabilities = handlers.capabilities
+
+    private[espionage] def fault(): Optional[Acp.Error] = fault0.collect()
+
+    // The fault-aware conclusion of one dispatch: a fault recorded by the handler pre-empts its
+    // result — for a request it becomes the error response, echoing the request's id; for a
+    // notification, which may not be answered, it is discarded (this direction has no channel to
+    // report it on).
+    private[espionage] def conclude(json: Json, response: Optional[Json]): Optional[Json] =
+      fault().lay(response): fault =>
+        Acp.requestId(json).let(JsonRpc.failure(fault.reason.code, fault.response, _))
+
+    private def emitter(): Emit[Acp.Error] =
+      val cell = fault0
+
+      Emit[Acp.Error]: fault => cell.record(fault)
+
+    // Records a `MethodNotFound` fault for a request whose capability was never advertised. A
+    // conformant agent checks the capability before calling, but a misbehaving one must receive an
+    // answer rather than hang awaiting one.
+    private def unregistered[result](default: result): result =
+      fault0.record(Acp.Error(Acp.Error.Reason.MethodNotFound))
+      default
+
+    // Invocation helpers: one per handler shape. Each looks up the handler (`null` means
+    // unregistered), and applies it with its tagged payloads. The registry's slots are an erased
+    // rim, so each helper restores the handler's type with a single, annotated cast; the
+    // annotation also stops the context-function value being applied at the definition.
+
+    private def turned1[payload, result](default: result)(handler: AnyRef | Null)
+      ( sessionId: Text, payload: payload )
+    :   result =
+
+      if handler == null then default else
+        val invoke: Turned1[payload, result] =
+          handler.asInstanceOf[Acp.Registry.Slot[Turned1[payload, result]]].value
+
+        invoke(using sessionId.aka["sessionId"], payload, emitter())
+
+    private def turned2[payload1, payload2, result](default: result)(handler: AnyRef | Null)
+      ( sessionId: Text, payload1: payload1, payload2: payload2 )
+    :   result =
+
+      if handler == null then default else
+        val invoke: Turned2[payload1, payload2, result] =
+          handler.asInstanceOf[Acp.Registry.Slot[Turned2[payload1, payload2, result]]].value
+
+        invoke(using sessionId.aka["sessionId"], payload1, payload2, emitter())
+
+    private def turned3[payload1, payload2, payload3, result](default: result)
+      ( handler: AnyRef | Null )
+      ( sessionId: Text, payload1: payload1, payload2: payload2, payload3: payload3 )
+    :   result =
+
+      if handler == null then default else
+        val invoke: Turned3[payload1, payload2, payload3, result] =
+          handler.asInstanceOf[Acp.Registry.Slot[Turned3[payload1, payload2, payload3, result]]]
+          . value
+
+        invoke(using sessionId.aka["sessionId"], payload1, payload2, payload3, emitter())
+
+    // The terminal bundle, restored from its slot; `null` if terminals were never registered.
+    private def terminals: Terminals | Null =
+      if handlers.terminal0 == null then null
+      else handlers.terminal0.asInstanceOf[Acp.Registry.Slot[Terminals]].value
+
+    // Session
+
+    def `session/update`(sessionId: Text, update: SessionUpdate): Unit =
+      turned1[SessionUpdate aka "update", Unit](())(handlers.updated0)
+       ( sessionId, update.aka["update"] )
+
+    // The protocol requires a permission request pending when its turn is cancelled to be
+    // answered `Cancelled`. A request arriving after cancellation is answered without troubling
+    // the handler; one already blocking in the handler when the cancellation arrives is answered
+    // `Cancelled` when the handler returns, its selection discarded. (The response is sent when
+    // the handler completes, not at the instant of cancellation: an answer that cannot take
+    // effect arriving late is harmless, and it spares the dispatch a race against its own
+    // handler.)
+    def `session/request_permission`
+      ( sessionId: Text, toolCall: ToolCallUpdate, options: List[PermissionOption] )
+    :   RequestPermissionResult =
+
+      if state.cancelled(sessionId) then RequestPermissionResult(Cancelled) else
+        val outcome: RequestPermissionOutcome =
+          turned2
+           [ ToolCallUpdate aka "toolCall",
+             List[PermissionOption] aka "options",
+             RequestPermissionOutcome ]
+           ( Cancelled )
+           ( handlers.permission0 )
+           ( sessionId, toolCall.aka["toolCall"], options.aka["options"] )
+
+        RequestPermissionResult(if state.cancelled(sessionId) then Cancelled else outcome)
+
+    // Filesystem
+
+    def `fs/read_text_file`
+      ( sessionId: Text, path: Text, line: Optional[Int], limit: Optional[Int] )
+    :   ReadTextFileResult =
+
+      if handlers.readFile0 == null then unregistered(ReadTextFileResult(t"")) else
+        val content: Text =
+          turned3[Text aka "path", Optional[Int] aka "line", Optional[Int] aka "limit", Text]
+           ( t"" )
+           ( handlers.readFile0 )
+           ( sessionId, path.aka["path"], line.aka["line"], limit.aka["limit"] )
+
+        ReadTextFileResult(content)
+
+    def `fs/write_text_file`(sessionId: Text, path: Text, content: Text): Json =
+      if handlers.writeFile0 == null then unregistered(()) else
+        turned2[Text aka "path", Text aka "content", Unit]
+         ( () )
+         ( handlers.writeFile0 )
+         ( sessionId, path.aka["path"], content.aka["content"] )
+
+      Json.ast(Json.Ast(Json.JsonNull))
+
+    // Terminals
+
+    def `terminal/create`
+      ( sessionId:       Text,
+        command:         Text,
+        args:            Optional[List[Text]],
+        env:             Optional[List[EnvVariable]],
+        cwd:             Optional[Text],
+        outputByteLimit: Optional[Long] )
+    :   CreateTerminalResult =
+
+      terminals match
+        case null => unregistered(CreateTerminalResult(t""))
+
+        case terminals: Terminals =>
+          CreateTerminalResult
+           ( terminals.create
+              ( sessionId, command, args.or(Nil), env.or(Nil), cwd, outputByteLimit ) )
+
+    def `terminal/output`(sessionId: Text, terminalId: Text): TerminalOutputResult =
+      terminals match
+        case null                 => unregistered(TerminalOutputResult(t"", false))
+        case terminals: Terminals => terminals.output(sessionId, terminalId)
+
+    def `terminal/wait_for_exit`(sessionId: Text, terminalId: Text): TerminalExitStatus =
+      terminals match
+        case null                 => unregistered(TerminalExitStatus())
+        case terminals: Terminals => terminals.waitForExit(sessionId, terminalId)
+
+    def `terminal/kill`(sessionId: Text, terminalId: Text): Json =
+      terminals match
+        case null                 => unregistered(())
+        case terminals: Terminals => terminals.kill(sessionId, terminalId)
+
+      Json.ast(Json.Ast(Json.JsonNull))
+
+    def `terminal/release`(sessionId: Text, terminalId: Text): Json =
+      terminals match
+        case null                 => unregistered(())
+        case terminals: Terminals => terminals.release(sessionId, terminalId)
+
+      Json.ast(Json.Ast(Json.JsonNull))
+
+  // AcpTransport → Acp.Transport
+  // The Agent Client Protocol's stdio framing: newline-delimited JSON, one UTF-8 message per line,
+  // with no embedded newlines — deliberately simpler than LSP's `Content-Length` headers. Splitting
+  // happens on the raw `Lf` byte before any text decoding, so multi-byte UTF-8 content passes
+  // through unharmed. The framing is symmetrical, so it lives here and each end of an exchange
+  // supplies its own channel.
+  private[espionage] object Transport:
+    // A message with its terminator. Encoded compactly at the write site: an indented encoding
+    // would embed the newlines the framing forbids.
+    def frame(body: Text): Data =
+      import charEncoders.utf8Encoder
+      t"$body\n".in[Data]
+
+    // Reads framed messages from a channel until it is exhausted, handing each to `receive`. A
+    // blank line — including the remnant of a `\r\n` terminator — carries no message and is
+    // skipped rather than reported. The observer sees the message as it arrived — before parsing,
+    // so a malformed message is observed too, and without the framing, so both directions read
+    // alike in a log.
+    def pump(consume source: (Stream[Data] over Credit)^, observer: Acp.Observer^)
+      ( receive: Text => Unit )
+    :   Unit =
+
+      import strategies.throwUnsafely
+
+      source.toProgression.stdlib.iterator.frames[Linefeed].each: frame =>
+        val message: Text = frame.utf8
+
+        if message.length > 0 && message != t"\r" then
+          observer.received(message)
+          receive(message)
+
+  // AcpExchange → Acp.Exchange
+  // Establishes an exchange with an ACP agent: opens the channel to it, starts a writer draining
+  // the connection's outgoing messages onto it and a reader routing what comes back, lends the
+  // connection, and tears everything down afterwards.
+  //
+  // The reader is its own task, which is what lets a caller block on a response: a request awaits
+  // its promise while the reader goes on reading, so a prompt turn stays open while its updates
+  // stream, and several requests may be in flight at once, answered out of order.
+  private[espionage] object Exchange:
+    // A free function, not a method: the reader is supplied as a partly-applied `pump`, whose
+    // closure captures the observer, and a method of the exchange would have that same observer in
+    // its own prefix — an overlap separation checking rejects.
+    // `capture` flows through from `Acp.connect`: the lent block may capture the monitor (to
+    // spawn tasks of its own), so the lambda — and the monitor it overlaps with — must both be
+    // typed to admit it.
+    private[espionage] def exchange[result, capture^]
+      ( service:  Service^,
+        state:    State,
+        observer: Acp.Observer,
+        sink:     (Intake[Data] over Credit)^,
+        read:     (Text => Unit) => Unit )
+      ( lambda: Acp.Connection ->{capture} result )
+      ( using Monitor^{capture}, Probate, Diagnostics )
+    :   result =
+
+      import strategies.throwUnsafely
+      import Json.jsonEncodableInText
+
+      // Sealed: the connection captures this exchange's monitor and diagnostics, and an honest
+      // `Acp.Connection^` would hide them from the writer and reader that serve it. It is a local
+      // of this method, lent to `lambda` and dead once `lambda` returns.
+      val connection: Acp.Connection = caps.unsafe.unsafeAssumePure(Acp.Connection(state))
+
+      // The service is confined by its own type and the dispatch closures are locals of this
+      // method, so sealing the reference the generated dispatchers hold is sound; the macro cannot
+      // take a capability-typed splice. One dispatcher per served interface, so each generated
+      // class stays within the JVM constant-pool limit.
+      val serving: AcpClient = caps.unsafe.unsafeAssumePure(service)
+
+      val sessionDispatch: Json => Optional[Json] =
+        caps.unsafe.unsafeAssumeSeparate(JsonRpc.serve[AcpClientSession](serving))
+
+      val fsDispatch: Json => Optional[Json] =
+        caps.unsafe.unsafeAssumeSeparate(JsonRpc.serve[AcpClientFs](serving))
+
+      val terminalDispatch: Json => Optional[Json] =
+        caps.unsafe.unsafeAssumeSeparate(JsonRpc.serve[AcpClientTerminal](serving))
+
+      val sessionMethods: List[Text] = JsonRpc.methods[AcpClientSession]
+      val fsMethods: List[Text] = JsonRpc.methods[AcpClientFs]
+      val terminalMethods: List[Text] = JsonRpc.methods[AcpClientTerminal]
+
+      // A single writer, so writes never interleave. The encoding is compact — the framing
+      // forbids embedded newlines. The observer sees the encoded body, not the terminator.
+      val writer: Task[Unit] = async:
+        connection.outgoing.stdlib.iterator.each: json =>
+          val body: Text = json.encode
+          observer.sent(body)
+          sink.put(Transport.frame(body))
+          sink.flush()
+
+      // Runs one dispatch and sends its conclusion. Faults become error responses; a message the
+      // dispatcher cannot decode is answered rather than dropped, so the agent never hangs
+      // awaiting an answer.
+      def serve(dispatch: Json => Optional[Json])(json: Json): Unit =
+        val id: Optional[Json] = Acp.requestId(json)
+
+        val response: Optional[Json] =
+          try dispatch(json) catch
+            case error: Json.Error => JsonRpc.failure(-32602, t"Invalid params", id)
+            case error: Exception  => JsonRpc.failure(-32603, t"Internal error", id)
+
+        service.conclude(json, response).let(connection.put)
+
+      // The channel is read by a partly-applied `pump`, rather than by handing the stream over:
+      // the stream is single-owner, so it is minted and consumed within the reader task, which
+      // also keeps this thread off the channel's first refill — a blocking read that would
+      // otherwise happen before the writer that unblocks it has started.
+      //
+      // Routing differs by message kind. A response is handed to any dispatcher for correlation. A
+      // notification — `session/update`, whose chunk ordering is semantically significant — is
+      // dispatched synchronously on the reader task. A request (`session/request_permission`,
+      // `fs/*`, `terminal/*`) is dispatched on a spawned task: a permission handler may block on a
+      // decision for minutes, and running it here would stall both update streaming and response
+      // correlation. (This is the deliberate divergence from LSP's single-loop server, whose
+      // reverse direction is notifications-only for exactly that reason.)
+      val reader: Task[Unit] = async:
+        read: message =>
+          safely(message.as[Json]).let: json =>
+            Acp.method(json).lay(sessionDispatch(json) yet ()): method =>
+              if sessionMethods.has(method) then
+                if method == t"session/update" then serve(sessionDispatch)(json)
+                else async(serve(sessionDispatch)(json)) yet ()
+              else if fsMethods.has(method) then
+                async(serve(fsDispatch)(json)) yet ()
+              else if terminalMethods.has(method) then
+                async(serve(terminalDispatch)(json)) yet ()
+              else
+                // A method this client does not model: a request is answered, so the agent never
+                // hangs, and a notification is ignored, as the protocol allows.
+                Acp.identifier(json).let: id =>
+                  connection.put(JsonRpc.failure(-32601, t"Method not found", id))
+
+      try lambda(connection) finally
+        reader.cancel()
+        writer.cancel()
+
+// The client→agent request/notification surface, split so that each interface can be compiled
+// into its own JSON-RPC proxy class. The method names are the wire methods; return type `Unit`
+// marks a notification.
+
+trait AcpAgentLifecycle:
+  @rpc
+  def initialize(protocolVersion: Int, clientCapabilities: Acp.ClientCapabilities)
+  :   Acp.InitializeResult
+
+  @rpc
+  def authenticate(methodId: Text): Json
+
+trait AcpAgentSession:
+  @rpc
+  def `session/new`(cwd: Text, mcpServers: List[Acp.McpServer]): Acp.NewSessionResult
+
+  @rpc
+  def `session/load`(sessionId: Text, cwd: Text, mcpServers: List[Acp.McpServer]): Json
+
+  @rpc
+  def `session/prompt`(sessionId: Text, prompt: List[Acp.ContentBlock]): Acp.PromptResult
+
+  @rpc
+  def `session/cancel`(sessionId: Text): Unit
+
+  @rpc
+  def `session/set_mode`(sessionId: Text, modeId: Text): Json
+
+// The whole agent surface: what `Acp.Connection`'s generated proxies call.
+trait AcpAgent extends AcpAgentLifecycle, AcpAgentSession
+
+// The agent→client surface this client serves, split (as above) into one generated dispatcher
+// class per interface. `session/update` is the protocol's only notification in this direction;
+// everything else is a request the agent blocks on.
+
+trait AcpClientSession:
+  @rpc
+  def `session/update`(sessionId: Text, update: Acp.SessionUpdate): Unit
+
+  @rpc
+  def `session/request_permission`
+    ( sessionId: Text,
+      toolCall:  Acp.ToolCallUpdate,
+      options:   List[Acp.PermissionOption] )
+  :   Acp.RequestPermissionResult
+
+trait AcpClientFs:
+  @rpc
+  def `fs/read_text_file`
+    ( sessionId: Text, path: Text, line: Optional[Int], limit: Optional[Int] )
+  :   Acp.ReadTextFileResult
+
+  @rpc
+  def `fs/write_text_file`(sessionId: Text, path: Text, content: Text): Json
+
+trait AcpClientTerminal:
+  @rpc
+  def `terminal/create`
+    ( sessionId:       Text,
+      command:         Text,
+      args:            Optional[List[Text]],
+      env:             Optional[List[Acp.EnvVariable]],
+      cwd:             Optional[Text],
+      outputByteLimit: Optional[Long] )
+  :   Acp.CreateTerminalResult
+
+  @rpc
+  def `terminal/output`(sessionId: Text, terminalId: Text): Acp.TerminalOutputResult
+
+  @rpc
+  def `terminal/wait_for_exit`(sessionId: Text, terminalId: Text): Acp.TerminalExitStatus
+
+  @rpc
+  def `terminal/kill`(sessionId: Text, terminalId: Text): Json
+
+  @rpc
+  def `terminal/release`(sessionId: Text, terminalId: Text): Json
+
+// The whole client surface: what `Service` implements and the exchange's reader dispatches.
+trait AcpClient extends AcpClientSession, AcpClientFs, AcpClientTerminal

--- a/lib/espionage/src/core/soundness_espionage_core.scala
+++ b/lib/espionage/src/core/soundness_espionage_core.scala
@@ -1,0 +1,36 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export espionage.{Acp, AcpAgent, AcpAgentLifecycle, AcpAgentSession, AcpClient,
+    AcpClientSession, AcpClientFs, AcpClientTerminal}

--- a/lib/espionage/src/demo/espionage_demo.scala
+++ b/lib/espionage/src/demo/espionage_demo.scala
@@ -1,0 +1,73 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package espionage
+
+import soundness.*
+
+import backstops.stackTraceBackstop
+import executives.completions
+import interpreters.posixInterpreter
+import probates.awaitProbate
+import errorDiagnostics.stackTracesDiagnostics
+import strategies.throwUnsafely
+import threading.virtualThreading
+import workingDirectories.defaultWorkingDirectory
+
+// A minimal ACP client: spawns `claude-code-acp` (which must be on the path), opens a session in
+// the current working directory, sends the command-line arguments as one prompt, and prints the
+// agent's streamed answer, granting every permission it asks for. Run with
+// `mill espionage.demo.run -- Say hello`.
+object DemoAcpClient:
+  import Acp.*
+
+  def main(args: Array[Text]): Unit = cli:
+    execute:
+      supervise:
+        Acp.connect(Acp.Agent(sh"claude-code-acp")):
+          updated:
+            update match
+              case AgentMessageChunk(TextContent(text, _)) => Out.print(text)
+              case other                                   => ()
+
+          permission:
+            options.filter(_.kind == PermissionOptionKind.AllowOnce).prim
+            . lay(Cancelled): option => Selected(option.optionId)
+
+        . apply:
+            val session = connection.newSession(summon[WorkingDirectory].directory())
+            val text = arguments.map(_()).join(t" ")
+            val stop = connection.prompt(session.sessionId, text)
+            Out.println(t"")
+            Out.println(t"The turn ended: $stop")
+
+      Exit.Ok

--- a/lib/espionage/src/test/espionage_test.scala
+++ b/lib/espionage/src/test/espionage_test.scala
@@ -1,0 +1,555 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package espionage
+
+import java.io as ji
+
+import scala.caps
+import scala.collection.mutable as scm
+
+import soundness.*
+
+import Json.jsonEncodableInText
+import errorDiagnostics.stackTracesDiagnostics
+import probates.awaitProbate
+import strategies.throwUnsafely
+import threading.virtualThreading
+import workingDirectories.defaultWorkingDirectory
+
+// Kept as a top-level object (its own class) rather than nested in `Tests` so the ACP codecs the
+// dispatchers inline do not add to the `Tests` class, which would otherwise exceed the JVM
+// per-class size limit. The service and dispatchers are built once and sealed pure: a live
+// capability may not inhabit an object field, but this fixture drives dispatch synchronously and
+// retains nothing beyond the tests.
+object TestClient:
+  import Acp.*
+
+  // What the handlers saw, for the assertions.
+  val updates: scm.ArrayBuffer[Text] = scm.ArrayBuffer()
+
+  val state: Acp.State = Acp.State()
+
+  private val fixture: AnyRef =
+    val registry: Acp.Registry^ = Acp.Registry()
+    given registry0: (Acp.Registry^{registry}) = registry
+
+    updated:
+      update match
+        case AgentMessageChunk(TextContent(text, _)) =>
+          updates.synchronized(updates.append(t"${sessionId}:${text}"))
+
+        case other =>
+          updates.synchronized(updates.append(t"${sessionId}:other"))
+
+    permission:
+      options.filter(_.kind == PermissionOptionKind.AllowOnce).prim
+      . lay(Cancelled): option => Selected(option.optionId)
+
+    readFile:
+      t"contents of ${path}"
+
+    Acp.Service(registry, state).asInstanceOf[AnyRef]
+
+  private def service: Acp.Service = fixture.asInstanceOf[Acp.Service]
+
+  private val dispatch0: AnyRef =
+    val serving: AcpClient = fixture.asInstanceOf[Acp.Service]
+    val session: Json => Optional[Json] =
+      caps.unsafe.unsafeAssumeSeparate(JsonRpc.serve[AcpClientSession](serving))
+
+    val fs: Json => Optional[Json] =
+      caps.unsafe.unsafeAssumeSeparate(JsonRpc.serve[AcpClientFs](serving))
+
+    val terminal: Json => Optional[Json] =
+      caps.unsafe.unsafeAssumeSeparate(JsonRpc.serve[AcpClientTerminal](serving))
+    val sessionMethods = JsonRpc.methods[AcpClientSession]
+    val fsMethods = JsonRpc.methods[AcpClientFs]
+
+    val route: Json => Optional[Json] = json =>
+      Acp.method(json).lay(session(json)): method =>
+        if sessionMethods.has(method) then session(json)
+        else if fsMethods.has(method) then fs(json)
+        else terminal(json)
+
+    caps.unsafe.unsafeAssumeSeparate(route).asInstanceOf[AnyRef]
+
+  def dispatch(json: Json): Optional[Json] =
+    dispatch0.asInstanceOf[Json => Optional[Json]](json)
+
+  // Dispatch plus the service's fault-aware conclusion, as the exchange performs it.
+  def roundtrip(json: Json): Optional[Json] = service.conclude(json, dispatch(json))
+
+  def capabilities: Acp.ClientCapabilities = service.capabilities
+
+// A scripted in-process agent joined to a real `Acp.connect` exchange by a pair of pipes: an
+// exchange that crosses the framing and the codecs in both directions, exactly as it would
+// between a client and an agent it launched. The script answers `initialize` and `session/new`,
+// then for each `session/prompt` streams updates, requests a permission, and finally reports the
+// turn's stop reason — unless the turn is cancelled first, in which case the permission request
+// is made only after `session/cancel` arrives, exercising the mandatory `cancelled` answer.
+object AgentFixture:
+  import Acp.*
+  import dynamicJsonAccess.enabled
+
+  // What the fake agent observed, for the assertions.
+  val received: scm.ArrayBuffer[Text] = scm.ArrayBuffer()
+
+  private def record(note: Text): Unit = received.synchronized(received.append(note))
+
+  private def result(id: Json, result: Json): Json =
+    Map(t"jsonrpc" -> t"2.0".in[Json], t"id" -> id, t"result" -> result).in[Json]
+
+  private def request(id: Text, method: Text, params: Json): Json =
+    Map
+     ( t"jsonrpc" -> t"2.0".in[Json],
+       t"id"      -> id.in[Json],
+       t"method"  -> method.in[Json],
+       t"params"  -> params )
+    . in[Json]
+
+  private def notification(method: Text, params: Json): Json =
+    Map(t"jsonrpc" -> t"2.0".in[Json], t"method" -> method.in[Json], t"params" -> params).in[Json]
+
+  private def update(sessionId: Text, update: SessionUpdate): Json =
+    notification
+     ( t"session/update",
+       Map(t"sessionId" -> sessionId.in[Json], t"update" -> update.in[Json]).in[Json] )
+
+  private def permission(id: Text, sessionId: Text): Json =
+    // Literal JSON rather than encoded records: the inline encodable for the opaque `List`
+    // cannot be summoned here, and a fixture's wire text reads best as wire text anyway.
+    val options: Json =
+      t"""[{"optionId":"allow","name":"Allow","kind":"allow_once"},
+          {"optionId":"deny","name":"Deny","kind":"reject_once"}]"""
+      . as[Json]
+
+    request
+     ( id,
+       t"session/request_permission",
+       Map
+        ( t"sessionId" -> sessionId.in[Json],
+          t"toolCall"  -> t"""{"toolCallId":"call1"}""".as[Json],
+          t"options"   -> options )
+       . in[Json] )
+
+  // Runs the scripted agent over the given streams until its input is exhausted.
+  def serve(input: ji.InputStream, output: ji.OutputStream): Unit =
+    val print: ji.PrintStream = ji.PrintStream(output, true)
+
+    def send(json: Json): Unit = print.synchronized:
+      print.print(json.encode.s + "\n")
+      print.flush()
+
+    // The prompt request currently awaiting its answer: the turn stays open until the
+    // permission sequence completes, and its response must echo this request's id.
+    var promptRequest: Optional[Json] = Unset
+
+    val streamable = summon[ji.InputStream is Streamable by Data over Credit]
+
+    streamable.stream(input).toProgression.stdlib.iterator.frames[Linefeed].each: frame =>
+      val message: Text = frame.utf8
+
+      if message.length > 0 then
+        val json: Json = message.as[Json]
+        val method: Text = try json.method.as[Text] catch case _: Exception => t""
+
+        method match
+          case t"initialize" =>
+            record(t"initialize")
+
+            send:
+              result
+               ( json.id,
+                 Map
+                  ( t"protocolVersion"   -> Acp.version.in[Json],
+                    t"agentCapabilities" -> Map(t"loadSession" -> false.in[Json]).in[Json] )
+                 . in[Json] )
+
+          case t"session/new" =>
+            record(t"session/new:${json.params.cwd.as[Text]}")
+            send(result(json.id, Map(t"sessionId" -> t"sess1".in[Json]).in[Json]))
+
+          case t"session/prompt" =>
+            val sessionId: Text = json.params.sessionId.as[Text]
+            val text: Text =
+              try json.params.prompt.as[List[ContentBlock]] match
+                case TextContent(text, _) :: _ => text
+                case _                         => t""
+              catch case _: Exception => t""
+
+            record(t"session/prompt:$sessionId:$text")
+
+            promptRequest = json
+
+            if text == t"cancel me" then
+              // Hold the turn open: the permission request is sent only once the client's
+              // cancellation arrives.
+              ()
+            else
+              send(update(sessionId, AgentMessageChunk(TextContent(t"Hello, "))))
+              send(update(sessionId, AgentMessageChunk(TextContent(t"world!"))))
+              send(update(sessionId, ToolCall(t"call1", t"Reading a file")))
+              send(permission(t"perm1", sessionId))
+
+          case t"session/cancel" =>
+            val sessionId: Text = json.params.sessionId.as[Text]
+            record(t"session/cancel:$sessionId")
+            send(permission(t"perm2", sessionId))
+
+          case t"" =>
+            // A response: a permission answer, correlated by id.
+            val id: Text = try json.id.as[Text] catch case _: Exception => t""
+            val outcome: Text =
+              try json.result.outcome.outcome.as[Text] catch case _: Exception => t"?"
+
+            record(t"answer:$id:$outcome")
+
+            def conclude(stopReason: Text): Unit =
+              promptRequest.let: prompt =>
+                send:
+                  result
+                   ( Acp.requestId(prompt).or(json.id),
+                     Map(t"stopReason" -> stopReason.in[Json]).in[Json] )
+
+              promptRequest = Unset
+
+            if id == t"perm1" then conclude(t"end_turn")
+            else if id == t"perm2" then conclude(t"cancelled")
+
+          case other =>
+            record(t"unexpected:$other")
+
+// The `session/prompt` ids the fixture correlates on: the fake agent answers `perm1`'s prompt by
+// re-reading the request that carried it, so the two prompts are distinguished by their text.
+object Tests extends Suite(m"Espionage Tests"):
+  def run(): Unit =
+    import Acp.*
+
+    suite(m"String enum codecs"):
+      test(m"StopReason encodes as its wire string"):
+        StopReason.MaxTurnRequests.in[Json].encode
+      . assert(_ == t"\"max_turn_requests\"")
+
+      test(m"StopReason decodes from its wire string"):
+        t"\"refusal\"".as[Json].as[StopReason]
+      . assert(_ == StopReason.Refusal)
+
+      test(m"ToolKind decodes an unknown kind as Other"):
+        t"\"_custom\"".as[Json].as[ToolKind]
+      . assert(_ == ToolKind.Other)
+
+      test(m"PermissionOptionKind round-trips"):
+        val kinds = List
+         ( PermissionOptionKind.AllowOnce, PermissionOptionKind.AllowAlways,
+           PermissionOptionKind.RejectOnce, PermissionOptionKind.RejectAlways )
+
+        kinds.map: kind =>
+          kind.in[Json].encode.as[Json].as[PermissionOptionKind]
+      . assert:
+          _ == List
+                ( PermissionOptionKind.AllowOnce, PermissionOptionKind.AllowAlways,
+                  PermissionOptionKind.RejectOnce, PermissionOptionKind.RejectAlways )
+
+    suite(m"Session update codecs"):
+      test(m"agent_message_chunk decodes"):
+        val json = t"""{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}}"""
+        json.as[Json].as[SessionUpdate]
+      . assert(_ == AgentMessageChunk(TextContent(t"hi")))
+
+      test(m"user_message_chunk decodes"):
+        val json = t"""{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"hi"}}"""
+        json.as[Json].as[SessionUpdate]
+      . assert(_ == UserMessageChunk(TextContent(t"hi")))
+
+      test(m"agent_thought_chunk decodes"):
+        val json = t"""{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"hm"}}"""
+        json.as[Json].as[SessionUpdate]
+      . assert(_ == AgentThoughtChunk(TextContent(t"hm")))
+
+      test(m"tool_call decodes with kind, status and a diff"):
+        val json =
+          t"""{"sessionUpdate":"tool_call","toolCallId":"c1","title":"Edit","kind":"edit",
+              "status":"in_progress","content":[{"type":"diff","path":"/a.txt","newText":"x"}]}"""
+
+        json.as[Json].as[SessionUpdate]
+      . assert:
+          _ == ToolCall
+                ( t"c1",
+                  t"Edit",
+                  ToolKind.Edit,
+                  ToolCallStatus.InProgress,
+                  List(ToolDiff(t"/a.txt", Unset, t"x")) )
+
+      test(m"tool_call_update decodes with only an id and status"):
+        val json = t"""{"sessionUpdate":"tool_call_update","toolCallId":"c1","status":"completed"}"""
+        json.as[Json].as[SessionUpdate]
+      . assert(_ == ToolCallUpdate(t"c1", status = ToolCallStatus.Completed))
+
+      test(m"plan decodes"):
+        val json =
+          t"""{"sessionUpdate":"plan","entries":[{"content":"step","priority":"high","status":"pending"}]}"""
+
+        json.as[Json].as[SessionUpdate]
+      . assert(_ == Plan(List(PlanEntry(t"step", PlanPriority.High, PlanStatus.Pending))))
+
+      test(m"available_commands_update decodes"):
+        val json =
+          t"""{"sessionUpdate":"available_commands_update","availableCommands":[{"name":"web","description":"Search"}]}"""
+
+        json.as[Json].as[SessionUpdate]
+      . assert(_ == AvailableCommandsUpdate(List(AvailableCommand(t"web", t"Search"))))
+
+      test(m"current_mode_update decodes"):
+        val json = t"""{"sessionUpdate":"current_mode_update","currentModeId":"yolo"}"""
+        json.as[Json].as[SessionUpdate]
+      . assert(_ == CurrentModeUpdate(t"yolo"))
+
+    suite(m"Permission outcome codecs"):
+      test(m"a selection encodes with its discriminator"):
+        import dynamicJsonAccess.enabled
+        val json = Selected(t"allow").asInstanceOf[RequestPermissionOutcome].in[Json]
+        (json.outcome.as[Text], json.optionId.as[Text])
+      . assert(_ == (t"selected", t"allow"))
+
+      test(m"a cancellation encodes with its discriminator"):
+        import dynamicJsonAccess.enabled
+        Cancelled.asInstanceOf[RequestPermissionOutcome].in[Json].outcome.as[Text]
+      . assert(_ == t"cancelled")
+
+    suite(m"Capability derivation"):
+      test(m"no registrations advertise no capabilities"):
+        val registry: Acp.Registry^ = Acp.Registry()
+        registry.capabilities
+      . assert(_ == ClientCapabilities())
+
+      test(m"a read handler advertises only readTextFile"):
+        val registry: Acp.Registry^ = Acp.Registry()
+        given registry0: (Acp.Registry^{registry}) = registry
+        readFile(t"")
+        registry.capabilities
+      . assert(_ == ClientCapabilities(fs = FsCapabilities(readTextFile = true)))
+
+      test(m"a terminal bundle advertises the terminal capability"):
+        val registry: Acp.Registry^ = Acp.Registry()
+        given registry0: (Acp.Registry^{registry}) = registry
+
+        terminals:
+          new Terminals:
+            def create
+              ( sessionId:       Text,
+                command:         Text,
+                args:            List[Text],
+                env:             List[EnvVariable],
+                cwd:             Optional[Text],
+                outputByteLimit: Optional[Long] )
+            :   Text =
+              t"term1"
+
+            def output(sessionId: Text, terminalId: Text): TerminalOutputResult =
+              TerminalOutputResult(t"", false)
+
+            def waitForExit(sessionId: Text, terminalId: Text): TerminalExitStatus =
+              TerminalExitStatus(0)
+
+            def kill(sessionId: Text, terminalId: Text): Unit = ()
+            def release(sessionId: Text, terminalId: Text): Unit = ()
+
+        registry.capabilities
+      . assert(_ == ClientCapabilities(terminal = true))
+
+      test(m"the adjust hook is applied last"):
+        val registry: Acp.Registry^ = Acp.Registry()
+        given registry0: (Acp.Registry^{registry}) = registry
+        capabilities(_.copy(terminal = true))
+        registry.capabilities
+      . assert(_ == ClientCapabilities(terminal = true))
+
+      test(m"the fixture derives fs.readTextFile and nothing else"):
+        TestClient.capabilities
+      . assert(_ == ClientCapabilities(fs = FsCapabilities(readTextFile = true)))
+
+    suite(m"Dispatch"):
+      test(m"session/update reaches the registered handler"):
+        TestClient.updates.synchronized(TestClient.updates.clear())
+
+        val message =
+          t"""{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1",
+              "update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}}}}"""
+
+        TestClient.roundtrip(message.as[Json])
+        TestClient.updates.synchronized(TestClient.updates.to(List))
+      . assert(_ == List(t"s1:hi"))
+
+      test(m"session/request_permission answers the handler's selection"):
+        val message =
+          t"""{"jsonrpc":"2.0","id":9,"method":"session/request_permission","params":{
+              "sessionId":"s1","toolCall":{"toolCallId":"c1"},
+              "options":[{"optionId":"go","name":"Go","kind":"allow_once"}]}}"""
+
+        import dynamicJsonAccess.enabled
+        TestClient.roundtrip(message.as[Json]).let(_.result.outcome.optionId.as[Text])
+      . assert(_ == t"go")
+
+      test(m"session/request_permission rejects when no option is allowable"):
+        val message =
+          t"""{"jsonrpc":"2.0","id":10,"method":"session/request_permission","params":{
+              "sessionId":"s1","toolCall":{"toolCallId":"c1"},
+              "options":[{"optionId":"no","name":"No","kind":"reject_once"}]}}"""
+
+        import dynamicJsonAccess.enabled
+        TestClient.roundtrip(message.as[Json]).let(_.result.outcome.outcome.as[Text])
+      . assert(_ == t"cancelled")
+
+      test(m"a cancelled session answers permission requests with cancelled"):
+        TestClient.state.cancel(t"s2")
+
+        val message =
+          t"""{"jsonrpc":"2.0","id":11,"method":"session/request_permission","params":{
+              "sessionId":"s2","toolCall":{"toolCallId":"c1"},
+              "options":[{"optionId":"go","name":"Go","kind":"allow_once"}]}}"""
+
+        import dynamicJsonAccess.enabled
+        TestClient.roundtrip(message.as[Json]).let(_.result.outcome.outcome.as[Text])
+      . assert(_ == t"cancelled")
+
+      test(m"fs/read_text_file answers the handler's content"):
+        val message =
+          t"""{"jsonrpc":"2.0","id":12,"method":"fs/read_text_file","params":{
+              "sessionId":"s1","path":"/tmp/a.txt"}}"""
+
+        TestClient.roundtrip(message.as[Json])
+        . let(_.as[JsonRpc.Response].result.as[ReadTextFileResult])
+      . assert(_ == ReadTextFileResult(t"contents of /tmp/a.txt"))
+
+      test(m"an unregistered capability is answered with an error"):
+        val message =
+          t"""{"jsonrpc":"2.0","id":13,"method":"fs/write_text_file","params":{
+              "sessionId":"s1","path":"/tmp/a.txt","content":"x"}}"""
+
+        import dynamicJsonAccess.enabled
+        TestClient.roundtrip(message.as[Json]).let(_.error.code.as[Int])
+      . assert(_ == -32601)
+
+    suite(m"Agent exchange"):
+      test(m"a full prompt turn crosses the exchange"):
+        AgentFixture.received.synchronized(AgentFixture.received.clear())
+        TestClient.updates.synchronized(TestClient.updates.clear())
+
+        val toAgent: ji.PipedOutputStream = ji.PipedOutputStream()
+        val agentIn: ji.PipedInputStream = ji.PipedInputStream(toAgent, 65536)
+        val toClient: ji.PipedOutputStream = ji.PipedOutputStream()
+        val clientIn: ji.PipedInputStream = ji.PipedInputStream(toClient, 65536)
+
+        val log: scm.ArrayBuffer[Text] = scm.ArrayBuffer()
+
+        supervise:
+          async(AgentFixture.serve(agentIn, toClient))
+
+          Acp.connect(Acp.Agent.streams(clientIn, toAgent)):
+            updated:
+              update match
+                case AgentMessageChunk(TextContent(text, _)) =>
+                  log.synchronized(log.append(t"chunk:$text"))
+
+                case update: ToolCall =>
+                  log.synchronized(log.append(t"tool:${update.title}"))
+
+                case other =>
+                  log.synchronized(log.append(t"other"))
+
+            permission:
+              options.filter(_.kind == PermissionOptionKind.AllowOnce).prim
+              . lay(Cancelled): option => Selected(option.optionId)
+
+          . apply:
+              val session = connection.newSession(t"/workspace")
+              log.synchronized(log.append(t"session:${session.sessionId}"))
+              val stop = connection.prompt(session.sessionId, t"hello agent")
+              log.synchronized(log.append(t"stop:$stop"))
+
+        log.synchronized(log.to(List))
+      . assert:
+          _ == List
+                ( t"session:sess1",
+                  t"chunk:Hello, ",
+                  t"chunk:world!",
+                  t"tool:Reading a file",
+                  t"stop:EndTurn" )
+
+      test(m"the agent saw the turn as scripted"):
+        AgentFixture.received.synchronized(AgentFixture.received.to(List))
+      . assert:
+          _ == List
+                ( t"initialize",
+                  t"session/new:/workspace",
+                  t"session/prompt:sess1:hello agent",
+                  t"answer:perm1:selected" )
+
+      test(m"a cancelled turn ends with the cancelled stop reason"):
+        AgentFixture.received.synchronized(AgentFixture.received.clear())
+
+        val toAgent: ji.PipedOutputStream = ji.PipedOutputStream()
+        val agentIn: ji.PipedInputStream = ji.PipedInputStream(toAgent, 65536)
+        val toClient: ji.PipedOutputStream = ji.PipedOutputStream()
+        val clientIn: ji.PipedInputStream = ji.PipedInputStream(toClient, 65536)
+
+        val stopped: Promise[StopReason] = Promise()
+        var stop: Optional[StopReason] = Unset
+
+        supervise:
+          async(AgentFixture.serve(agentIn, toClient))
+
+          Acp.connect(Acp.Agent.streams(clientIn, toAgent)):
+            permission:
+              options.filter(_.kind == PermissionOptionKind.AllowOnce).prim
+              . lay(Cancelled): option => Selected(option.optionId)
+
+          . apply:
+              val session = connection.newSession(t"/workspace")
+
+              async(stopped.offer(connection.prompt(session.sessionId, t"cancel me")))
+
+              // Cancel once the agent has the prompt: the fixture answers the prompt only after
+              // its post-cancellation permission request is answered `cancelled`.
+              while AgentFixture.received.synchronized(AgentFixture.received.length) < 3
+              do Thread.sleep(10)
+
+              connection.cancel(session.sessionId)
+              stop = stopped.await()
+
+        stop
+      . assert(_ == StopReason.Cancelled)
+
+      test(m"the cancelled turn's permission request was answered cancelled"):
+        AgentFixture.received.synchronized(AgentFixture.received.to(List))
+      . assert(_.has(t"answer:perm2:cancelled"))

--- a/lib/obligatory/src/core/obligatory.Linefeed.scala
+++ b/lib/obligatory/src/core/obligatory.Linefeed.scala
@@ -60,4 +60,37 @@ object Linefeed:
 
       framed.asInstanceOf[Iterator[Text]^{input, this}]
 
+  // Byte-level counterpart of `framable`, for protocols framed as newline-delimited JSON over a
+  // binary stream (such as the Agent Client Protocol). Splitting happens on the raw `Lf` byte
+  // before any text decoding, so multi-byte UTF-8 content passes through unharmed; a final
+  // unterminated fragment is yielded as-is. The explicit `new` and the relabelling cast follow
+  // `CarriageReturn.framable`.
+  //
+  // The terminator is consumed with `advance()`, never `next()`: this framer reads *live*
+  // streams (a subprocess's output), and `next()` refills eagerly, so a frame ending flush with
+  // its chunk would block awaiting bytes beyond the terminator instead of being delivered. The
+  // deferred refill is paid at the head of the following frame — the one place a block is
+  // correct. (See the boundary-safety note on `Cursor.advance`.)
+  given framableData: (Data is Framable by Linefeed) = new Framable:
+    type Self = Data
+    type Operand = Linefeed
+
+    def frames(input: Iterator[Data]^): Iterator[Data]^{input, this} =
+      val cursor = Cursor(input)
+
+      val framed =
+        Framable.frames[Data]:
+          cursor.hold:
+            val start = cursor.mark
+
+            // As in `ContentLength`: the inline `grab` expansion re-infers a fresh `any.rd` on
+            // the frozen chunk; the cast reasserts the frozen form, which `grab` already
+            // guarantees.
+            if !cursor.finished && cursor.seek(Lf.toByte.asInstanceOf[cursor.addressable.Operand])
+            then cursor.grab(start, cursor.mark).asInstanceOf[Data].also(cursor.advance())
+            else if cursor.mark == start then Unset
+            else cursor.grab(start, cursor.mark).asInstanceOf[Data]
+
+      framed.asInstanceOf[Iterator[Data]^{input, this}]
+
 sealed trait Linefeed

--- a/lib/obligatory/src/test/obligatory_test.scala
+++ b/lib/obligatory/src/test/obligatory_test.scala
@@ -73,6 +73,30 @@ object Tests extends Suite(m"Obligatory Tests"):
         Chain(t"""one\r\ntwo\r\nthree\r\n""").iterator.frames[CrLf].to(List)
       . assert(_ == List("one", "two", "three"))
 
+      test(m"Unframe bytes by linefeed lines"):
+        Chain(t"one\ntwo\nth".in[Data], t"ree".in[Data])
+        . iterator
+        . frames[Linefeed]
+        . map(_.utf8)
+        . to(List)
+      . assert(_ == List("one", "two", "three"))
+
+      test(m"Unframe bytes by linefeed lines, without terminal fragment"):
+        Chain(t"one\ntwo\nthree\n".in[Data]).iterator.frames[Linefeed].map(_.utf8).to(List)
+      . assert(_ == List("one", "two", "three"))
+
+      test(m"Unframe bytes by linefeed lines, retaining empty lines"):
+        Chain(t"one\n\ntwo\n".in[Data]).iterator.frames[Linefeed].map(_.utf8).to(List)
+      . assert(_ == List("one", "", "two"))
+
+      test(m"Unframe bytes by linefeed splits multi-byte UTF-8 content correctly"):
+        Chain(t"""{"text":"café"}\n{"text":"naïve"}\n""".in[Data])
+        . iterator
+        . frames[Linefeed]
+        . map(_.utf8)
+        . to(List)
+      . assert(_ == List(t"""{"text":"café"}""", t"""{"text":"naïve"}"""))
+
       test(m"Length-prefixed chunks"):
         Chain(Data(0, 0, 0, 3, 50, 100, -100, 0, 0, 0, 1, -128, 0, 0, 0, 5, 5, 4, 3, 2, 1))
         . iterator

--- a/lib/synesthesia/src/content/soundness_synesthesia_content.scala
+++ b/lib/synesthesia/src/content/soundness_synesthesia_content.scala
@@ -1,0 +1,37 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+// Aliased: `Content` in the umbrella belongs to gesticulate's media-typed payload. The members
+// are also reachable through `Mcp` and `Acp`, which re-export them.
+export synesthesia.{Content as McpContent}

--- a/lib/synesthesia/src/content/synesthesia.Content.scala
+++ b/lib/synesthesia/src/content/synesthesia.Content.scala
@@ -1,0 +1,206 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package synesthesia
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import jacinta.*
+import vacuous.*
+
+// The content-block vocabulary shared by the Model Context Protocol and the Agent Client
+// Protocol, which adopts MCP's JSON representations for content verbatim. It lives in its own
+// component so that an ACP client (which spawns agents as subprocesses) can reuse these types
+// without acquiring `synesthesia.core`'s HTTP server stack. `object Mcp` re-exports every member,
+// so MCP code continues to read `Mcp.TextContent` and so on.
+object Content:
+  // Anchor givens for the records the hand-written sum codecs dispatch to via `.json`/`.as`.
+  // Deriving each once here lets every consumer reference it instead of re-inline-expanding the
+  // whole derivation. See the corresponding anchors in `object Mcp`.
+  object Icon:
+    given (Tactic[Json.Error]) => Icon is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given Icon is Json.Encodable = Json.EncodableDerivation.derived
+
+  object Annotations:
+    given (Tactic[Json.Error]) => Annotations is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given Annotations is Json.Encodable = Json.EncodableDerivation.derived
+
+  object TextContent:
+    given (Tactic[Json.Error]) => TextContent is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given TextContent is Json.Encodable = Json.EncodableDerivation.derived
+
+  object ImageContent:
+    given (Tactic[Json.Error]) => ImageContent is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given ImageContent is Json.Encodable = Json.EncodableDerivation.derived
+
+  object AudioContent:
+    given (Tactic[Json.Error]) => AudioContent is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given AudioContent is Json.Encodable = Json.EncodableDerivation.derived
+
+  object ResourceLink:
+    given (Tactic[Json.Error]) => ResourceLink is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given ResourceLink is Json.Encodable = Json.EncodableDerivation.derived
+
+  object EmbeddedResource:
+    given (Tactic[Json.Error]) => EmbeddedResource is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given EmbeddedResource is Json.Encodable = Json.EncodableDerivation.derived
+
+  object TextResourceContents:
+    given (Tactic[Json.Error]) => TextResourceContents is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given TextResourceContents is Json.Encodable = Json.EncodableDerivation.derived
+
+  object BlobResourceContents:
+    given (Tactic[Json.Error]) => BlobResourceContents is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given BlobResourceContents is Json.Encodable = Json.EncodableDerivation.derived
+
+  case class Icon
+    ( src:      Text,
+      mimeType: Optional[Text]       = Unset,
+      sizes:    Optional[List[Text]] = Unset,
+      theme:    Optional[Text]       = Unset )
+
+  object Contents:
+    given encodable: Contents is Json.Encodable = Json.Encodable(() => Morphology.Any):
+      _.contents match
+        case text: TextResourceContents => text.in[Json]
+        case blob: BlobResourceContents => blob.in[Json]
+
+    given decodable: Tactic[Json.Error] => Contents is Json.Decodable =
+      Json.Decodable(Morphology.Any): json =>
+        Contents(safely(json.as[TextResourceContents]).or(json.as[BlobResourceContents]))
+
+  case class Contents(contents: TextResourceContents | BlobResourceContents)
+
+  case class ResourceContents
+    ( uri: Text, mimeType: Optional[Text] = Unset, _meta: Optional[Json] = Unset )
+
+  case class TextResourceContents
+    ( uri: Text, mimeType: Optional[Text] = Unset, text: Text, _meta: Optional[Json] = Unset )
+
+  case class BlobResourceContents
+    ( uri: Text, mimeType: Optional[Text] = Unset, blob: Text, _meta: Optional[Json] = Unset )
+
+  case class Annotations
+    ( audience:     Optional[List[Role]] = Unset,
+      priority:     Optional[Double]     = Unset,
+      lastModified: Optional[Text]       = Unset )
+
+  object Role:
+    given encodable: Role is Json.Encodable = Json.Encodable(() => Morphology.Str):
+      case Role.User      => t"user".in[Json]
+      case Role.Assistant => t"assistant".in[Json]
+
+    given decodable: Tactic[Json.Error] => Role is Json.Decodable =
+      Json.Decodable(Morphology.Str): json =>
+        json.as[Text] match
+          case t"user"      => Role.User
+          case t"assistant" => Role.Assistant
+          case _            => abort(Json.Error(Json.Error.Reason.OutOfRange))
+
+  enum Role:
+    case User, Assistant
+
+  object ContentBlock:
+    import dynamicJsonAccess.enabled
+
+    private val typeTag = Json.discriminatedUnion[ContentBlock](t"type")
+
+    given encodable: ContentBlock is Json.Encodable = Json.Encodable(() => Morphology.Any):
+      case content: TextContent      => typeTag.rewrite(t"text",          content.in[Json])
+      case content: ImageContent     => typeTag.rewrite(t"image",         content.in[Json])
+      case content: AudioContent     => typeTag.rewrite(t"audio",         content.in[Json])
+      case content: ResourceLink     => typeTag.rewrite(t"resource_link", content.in[Json])
+      case content: EmbeddedResource => typeTag.rewrite(t"resource", content.in[Json])
+
+    given decodable: Tactic[Json.Error] => ContentBlock is Json.Decodable =
+      Json.Decodable(Morphology.Any): json =>
+        json.`type`.as[Text] match
+          case "text"          => json.as[TextContent]
+          case "image"         => json.as[ImageContent]
+          case "audio"         => json.as[AudioContent]
+          case "resource_link" => json.as[ResourceLink]
+          case "resource"      => json.as[EmbeddedResource]
+          case _               => abort(Json.Error(Json.Error.Reason.OutOfRange))
+
+  sealed trait ContentBlock
+
+  case class TextContent(text: Text, annotations: Optional[Annotations] = Unset)
+  extends ContentBlock
+
+  // `uri` is defined by ACP (which otherwise adopts MCP's image content shape) and not by MCP;
+  // as an `Optional` member it vanishes from the MCP wire when unset.
+  case class ImageContent
+    ( data:        Text,
+      mimeType:    Text,
+      uri:         Optional[Text]        = Unset,
+      annotations: Optional[Annotations] = Unset )
+  extends ContentBlock
+
+  case class AudioContent(data: Text, mimeType: Text, annotations: Optional[Annotations] = Unset)
+  extends ContentBlock
+
+  case class ResourceLink
+    ( name:        Text,
+      uri:         Text,
+      title:       Optional[Text]        = Unset,
+      description: Optional[Text]        = Unset,
+      icons:       Optional[List[Icon]]  = Unset,
+      mimeType:    Optional[Text]        = Unset,
+      annotations: Optional[Annotations] = Unset,
+      size:        Optional[Long]        = Unset,
+      _meta:       Optional[Json]        = Unset )
+  extends ContentBlock
+
+  case class EmbeddedResource
+    ( resource:    Contents,
+      annotations: Optional[Annotations] = Unset,
+      _meta:       Optional[Json]        = Unset )
+  extends ContentBlock

--- a/lib/synesthesia/src/core/synesthesia.Mcp.scala
+++ b/lib/synesthesia/src/core/synesthesia.Mcp.scala
@@ -63,24 +63,18 @@ object Mcp:
 
   type Cursor = Text
 
+  // The content-block vocabulary (`ContentBlock` and its members, resource contents, `Icon`,
+  // `Annotations`, `Role`) lives in the `content` component's `object Content`, shared with the
+  // Agent Client Protocol; the export preserves the `Mcp.TextContent` spelling for MCP code.
+  export Content.*
+
   // Anchor givens for the MCP records derived in many places: those shared across protocol types
-  // (Icon, Annotations) and the variants the hand-written sum codecs dispatch to via `.json`/`.as`
-  // (TextContent, …). Deriving each once here lets every consumer reference it instead of
-  // re-inline-expanding the whole derivation — cutting a clean `synesthesia.core` compile by ~25%.
-  // Only genuinely multiply-shared records are anchored: anchoring rarely-shared types regresses,
-  // since each anchor still costs one derivation and enlarges the implicit-search space everywhere.
-  object Icon:
-    given (Tactic[Json.Error]) => Icon is Json.Decodable =
-      Json.DecodableDerivation.derived
-
-    given Icon is Json.Encodable = Json.EncodableDerivation.derived
-
-  object Annotations:
-    given (Tactic[Json.Error]) => Annotations is Json.Decodable =
-      Json.DecodableDerivation.derived
-
-    given Annotations is Json.Encodable = Json.EncodableDerivation.derived
-
+  // and the variants the hand-written sum codecs dispatch to via `.json`/`.as`. Deriving each
+  // once here lets every consumer reference it instead of re-inline-expanding the whole
+  // derivation — together with the content-block anchors (which moved to `object Content` with
+  // their types) they cut a clean `synesthesia.core` compile by ~25%. Only genuinely
+  // multiply-shared records are anchored: anchoring rarely-shared types regresses, since each
+  // anchor still costs one derivation and enlarges the implicit-search space everywhere.
   object Implementation:
     given (Tactic[Json.Error]) => Implementation is Json.Decodable =
       Json.DecodableDerivation.derived
@@ -92,49 +86,6 @@ object Mcp:
       Json.DecodableDerivation.derived
 
     given BaseMetadata is Json.Encodable = Json.EncodableDerivation.derived
-
-  object TextContent:
-    given (Tactic[Json.Error]) => TextContent is Json.Decodable =
-      Json.DecodableDerivation.derived
-
-    given TextContent is Json.Encodable = Json.EncodableDerivation.derived
-
-  object ImageContent:
-    given (Tactic[Json.Error]) => ImageContent is Json.Decodable =
-      Json.DecodableDerivation.derived
-
-    given ImageContent is Json.Encodable = Json.EncodableDerivation.derived
-
-  object AudioContent:
-    given (Tactic[Json.Error]) => AudioContent is Json.Decodable =
-      Json.DecodableDerivation.derived
-
-    given AudioContent is Json.Encodable = Json.EncodableDerivation.derived
-
-  object ResourceLink:
-    given (Tactic[Json.Error]) => ResourceLink is Json.Decodable =
-      Json.DecodableDerivation.derived
-
-    given ResourceLink is Json.Encodable = Json.EncodableDerivation.derived
-
-  object EmbeddedResource:
-    given (Tactic[Json.Error]) => EmbeddedResource is Json.Decodable =
-      Json.DecodableDerivation.derived
-
-    given EmbeddedResource is Json.Encodable = Json.EncodableDerivation.derived
-
-  object TextResourceContents:
-    given (Tactic[Json.Error]) => TextResourceContents is Json.Decodable =
-      Json.DecodableDerivation.derived
-
-    given TextResourceContents is Json.Encodable = Json.EncodableDerivation.derived
-
-  object BlobResourceContents:
-    given (Tactic[Json.Error]) => BlobResourceContents is Json.Decodable =
-      Json.DecodableDerivation.derived
-
-    given BlobResourceContents is Json.Encodable = Json.EncodableDerivation.derived
-
 
   def send[interface <: Mcp.Server](id: Text, server: interface, mcpInterface: Interface)
     ( dispatch: Json => Optional[Json] )
@@ -238,12 +189,6 @@ object Mcp:
   case class TaskMetadata(ttl: Optional[Int] = Unset)
   case class RelatedTaskMetadata(taskId: Text)
 
-  case class Icon
-    ( src:      Text,
-      mimeType: Optional[Text]       = Unset,
-      sizes:    Optional[List[Text]] = Unset,
-      theme:    Optional[Text]       = Unset )
-
   case class BaseMetadata(name: Text, title: Optional[Text] = Unset)
 
   case class Implementation
@@ -311,17 +256,6 @@ object Mcp:
       elicitation:  Optional[Elicitation]     = Unset,
       tasks:        Optional[Tasks]           = Unset )
 
-  object Contents:
-    given encodable: Contents is Json.Encodable = Json.Encodable(() => Morphology.Any):
-      _.contents match
-        case text: TextResourceContents => text.in[Json]
-        case blob: BlobResourceContents => blob.in[Json]
-
-    given decodable: Tactic[Json.Error] => Contents is Json.Decodable =
-      Json.Decodable(Morphology.Any): json =>
-        Contents(safely(json.as[TextResourceContents]).or(json.as[BlobResourceContents]))
-
-  case class Contents(contents: TextResourceContents | BlobResourceContents)
   case class Context(arguments: Optional[Map[Text, Text]] = Unset)
   case class ListResources(nextCursor: Optional[Cursor] = Unset, resources: List[Resource] = Nil)
 
@@ -351,41 +285,12 @@ object Mcp:
       annotations: Annotations          = Annotations(),
       _meta:       Optional[Json]       = Unset )
 
-  case class ResourceContents
-    ( uri: Text, mimeType: Optional[Text] = Unset, _meta: Optional[Json] = Unset )
-
-  case class TextResourceContents
-    ( uri: Text, mimeType: Optional[Text] = Unset, text: Text, _meta: Optional[Json] = Unset )
-
-  case class BlobResourceContents
-    ( uri: Text, mimeType: Optional[Text] = Unset, blob: Text, _meta: Optional[Json] = Unset )
-
   case class ListPrompts(nextCursor: Optional[Cursor] = Unset, prompts: List[Prompt] = Nil)
-
-  case class Annotations
-    ( audience:     Optional[List[Role]] = Unset,
-      priority:     Optional[Double]     = Unset,
-      lastModified: Optional[Text]       = Unset )
 
   case class Complete(completion: Completion)
 
   case class Completion
     ( values: List[Text] = Nil, total: Optional[Int] = Unset, hasMore: Optional[Boolean] = Unset )
-
-  object Role:
-    given encodable: Role is Json.Encodable = Json.Encodable(() => Morphology.Str):
-      case Role.User      => t"user".in[Json]
-      case Role.Assistant => t"assistant".in[Json]
-
-    given decodable: Tactic[Json.Error] => Role is Json.Decodable =
-      Json.Decodable(Morphology.Str): json =>
-        json.as[Text] match
-          case t"user"      => Role.User
-          case t"assistant" => Role.Assistant
-          case _            => abort(Json.Error(Json.Error.Reason.OutOfRange))
-
-  enum Role:
-    case User, Assistant
 
   object TaskSupport:
     given encodable: TaskSupport is Json.Encodable = Json.Encodable(() => Morphology.Str):
@@ -537,7 +442,16 @@ object Mcp:
   case class SamplingMessage
     ( role: Role, content: List[SamplingMessageContentBlock], _meta: Optional[Json] = Unset )
 
-  object SamplingMessageContentBlock:
+  // Previously a sealed marker trait, but three of its members now live in `object Content`
+  // (shared with ACP), and a class cannot extend a trait defined in a component it precedes; a
+  // union type expresses the same closed set. Its codecs cannot live in a companion (an alias
+  // has none, and implicit scope dealiases past it), so they anchor in `object ToolUseContent`:
+  // the implicit scope of a union includes the companions of its members, and `ToolUseContent`
+  // is the first member owned by this component.
+  type SamplingMessageContentBlock =
+    TextContent | ImageContent | AudioContent | ToolUseContent | ToolResultContent
+
+  object ToolUseContent:
     import dynamicJsonAccess.enabled
 
     private val typeTag = Json.discriminatedUnion[SamplingMessageContentBlock](t"type")
@@ -559,8 +473,6 @@ object Mcp:
           case "tool_result" => json.as[ToolResultContent]
           case _             => abort(Json.Error(Json.Error.Reason.OutOfRange))
 
-  sealed trait SamplingMessageContentBlock
-
   case class ModelPreferences
     ( hints:                Optional[List[ModelHint]] = Unset,
       costPriority:         Optional[Double]          = Unset,
@@ -569,66 +481,13 @@ object Mcp:
 
   case class ModelHint(name: Optional[Text] = Unset)
 
-  object ContentBlock:
-    import dynamicJsonAccess.enabled
-
-    private val typeTag = Json.discriminatedUnion[ContentBlock](t"type")
-
-    given encodable: ContentBlock is Json.Encodable = Json.Encodable(() => Morphology.Any):
-      case content: TextContent      => typeTag.rewrite(t"text",          content.in[Json])
-      case content: ImageContent     => typeTag.rewrite(t"image",         content.in[Json])
-      case content: AudioContent     => typeTag.rewrite(t"audio",         content.in[Json])
-      case content: ResourceLink     => typeTag.rewrite(t"resource_link", content.in[Json])
-      case content: EmbeddedResource => typeTag.rewrite(t"resource", content.in[Json])
-
-    given decodable: Tactic[Json.Error] => ContentBlock is Json.Decodable =
-      Json.Decodable(Morphology.Any): json =>
-        json.`type`.as[Text] match
-          case "text"          => json.as[TextContent]
-          case "image"         => json.as[ImageContent]
-          case "audio"         => json.as[AudioContent]
-          case "resource_link" => json.as[ResourceLink]
-          case "resource"      => json.as[EmbeddedResource]
-          case _               => abort(Json.Error(Json.Error.Reason.OutOfRange))
-
-  sealed trait ContentBlock
-
-  case class TextContent(text: Text, annotations: Optional[Annotations] = Unset)
-  extends ContentBlock, SamplingMessageContentBlock
-
-  case class ImageContent(data: Text, mimeType: Text, annotations: Optional[Annotations] = Unset)
-  extends ContentBlock, SamplingMessageContentBlock
-
-  case class AudioContent(data: Text, mimeType: Text, annotations: Optional[Annotations] = Unset)
-  extends ContentBlock, SamplingMessageContentBlock
-
-  case class ResourceLink
-    ( name:        Text,
-      uri:         Text,
-      title:       Optional[Text]       = Unset,
-      description: Optional[Text]       = Unset,
-      icons:       Optional[List[Icon]] = Unset,
-      mimeType:    Optional[Text]       = Unset,
-      annotations: Annotations          = Annotations(),
-      size:        Optional[Long]       = Unset,
-      _meta:       Optional[Json]       = Unset )
-  extends ContentBlock
-
-  case class EmbeddedResource
-    ( resource:    Contents,
-      annotations: Optional[Annotations] = Unset,
-      _meta:       Optional[Json]        = Unset )
-  extends ContentBlock
-
   case class ToolUseContent(id: Text, name: Text, input: Json)
-  extends SamplingMessageContentBlock
 
   case class ToolResultContent
     ( toolUseId:         Text,
       content:           List[ContentBlock] = Nil,
       structuredContent: Optional[Json]     = Unset,
       isError:           Optional[Boolean]  = Unset )
-  extends SamplingMessageContentBlock
 
   case class CreateMessage
     ( role:       Role,


### PR DESCRIPTION
Soundness can now drive a coding agent. Espionage is a new library implementing the client half of the [Agent Client Protocol](https://agentclientprotocol.com/), the protocol editors use to talk to agents like Claude Code and Gemini CLI: it spawns an agent, opens a session, sends prompts, and streams back the agent's messages, thoughts, plans and tool calls while answering the permission, filesystem and terminal requests the agent makes along the way. It is built in the same style as Exegesis, Soundness's Language Server Protocol library, on the same JSON-RPC foundations, and it shares the content-block vocabulary with Synesthesia's Model Context Protocol support so that content crosses between the two protocols without translation.

## Espionage: an ACP client

`Acp.connect` spawns the agent, negotiates the protocol, and lends a connection for the duration of a block. The first block registers handlers; the second holds the live connection:

```scala
Acp.connect(Acp.Agent(sh"claude-code-acp")):
  updated:
    update match
      case AgentMessageChunk(TextContent(text, _)) => Out.print(text)
      case other                                   => ()

  permission:
    options.filter(_.kind == PermissionOptionKind.AllowOnce).prim
    . lay(Cancelled): option => Selected(option.optionId)

. apply:
    val session = connection.newSession(workingDirectory)
    val stopReason = connection.prompt(session.sessionId, t"Fix the failing test")
```

A prompt is a *turn*, not a call: one long-lived request whose progress arrives as separate notifications. `prompt` blocks until the agent reports why the turn ended, while the updates stream concurrently to the registered handler.

The capabilities the client advertises are **derived from what was registered**, never declared, so they cannot disagree with the implementation — a client that registers no `readFile` handler reports no filesystem support, and a conformant agent will not ask. Register `readFile`/`writeFile` to serve the agent's file requests, and `terminals` to supply the five terminal operations as one bundle, since the protocol advertises them as a single capability.

`connection.cancel(sessionId)` ends the current turn with the `Cancelled` stop reason; permission requests outstanding at that moment, or arriving before the next turn, are answered `cancelled` automatically as the specification requires.

## Shared content types

The content-block vocabulary MCP and ACP have in common — `TextContent`, `ImageContent`, `AudioContent`, `ResourceLink`, `EmbeddedResource` and the resource-contents types — now lives in a new `synesthesia.content` component that depends only on `jacinta.core`, so an ACP client need not acquire an HTTP server stack to use it. MCP code is unaffected: `Mcp.TextContent` and friends still resolve, through a re-export.

Two visible consequences. `Mcp.SamplingMessageContentBlock` is now a union type rather than a sealed trait, so a `match` over it is unchanged but an `isInstanceOf` check against the trait no longer applies; and `Mcp.ImageContent` gains an optional `uri` member, defined by ACP, which is absent from the MCP wire when unset.

## Byte-level newline framing

`obligatory.Linefeed` gains a `Data is Framable by Linefeed` instance, for protocols framed as newline-delimited JSON over a binary stream. Splitting happens on the raw byte before any text decoding, so multi-byte UTF-8 content passes through unharmed.
