### PR TITLE
Fix TEL parser's silent truncation after blank-then-deeper lines

### DIFF
--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -3682,7 +3682,29 @@ object Tel extends Tel2:
         while head.blank && !head.eof do fillHead()
 
       val children = parseChildren(parentIndent = -1)
+
+      // Defence in depth: parseChildren(-1) must consume everything up to EOF
+      // or a document separator. If a future change lets every level decline
+      // the current line (as blank-then-deeper once did — issue #1834), report
+      // the unclaimed line rather than silently truncating the document: one
+      // raise, then skip to the end so accrual mode still terminates.
+      if !head.eof && !head.separator then
+        recoverAt(Reason.OverIndentation, head.startLine, 1, head.leadingSpaces.max(1)):
+          while !head.eof && !head.separator do skipRestOfLine()
+
       Tel.Document(directive, pragma, lineEndings, children)
+
+    // Skip the remainder of the head's line (scanning past any refills) and
+    // park the head on the next line. Only used by parseOneDocument's
+    // unclaimed-input recovery, so it stays off every hot path.
+    private update def skipRestOfLine(): (Tactic[Tel.Error]^) ?->{this} Unit =
+      while
+        scanUntil2(LF, CR, Parser.LfRepl, Parser.CrRepl)
+        pos == bufEnd && more
+      do ()
+
+      consumeLineEnding()
+      fillHead()
 
     // ── Document streams (§6.1) ────────────────────────────────────────────────
 
@@ -4267,22 +4289,42 @@ object Tel extends Tel2:
     private update def parseChildren(parentIndent: Int): (Tactic[Tel.Error]^) ?->{this} Array[Tel.Block]^{} =
       val expected = parentIndent + 1
 
-      if head.eof || head.separator || head.indentLevels < expected
-      then EmptyBlocks
-      else
-        val start = blockScratchIx
+      val start = blockScratchIx
 
-        // A line more indented than `expected` is misplaced. Under fail-fast the
-        // first such line raises (unchanged); under a `validate` boundary we record
-        // it and recover (SkipOverIndented / ShallowerIndent) by clamping it to
-        // `expected` so `parseBlock` consumes it as a sibling — guaranteeing the
-        // cursor advances every iteration, so the parser keeps going to EOF and
-        // accrues every defect (e.g. for LSP diagnostics) without ever stalling.
-        while !head.eof && !head.separator && head.indentLevels >= expected do
+      // A line more indented than `expected` is misplaced. Under fail-fast the
+      // first such line raises (unchanged); under a `validate` boundary we record
+      // it and recover (SkipOverIndented / ShallowerIndent) by clamping it to
+      // `expected` so `parseBlock` consumes it as a sibling — guaranteeing the
+      // cursor advances every iteration, so the parser keeps going to EOF and
+      // accrues every defect (e.g. for LSP diagnostics) without ever stalling.
+      var continue = true
+
+      while continue do
+        // §9: blank lines have no structural effect, so a blank run whose next
+        // content line still sits at this level or deeper belongs here, as a
+        // blank-only block. (A deeper line is over-indentation, recovered below
+        // at this level — the level that owns it.) Without the claim, the blank
+        // head's sentinel indent would decline every loop and silently end the
+        // document with the remainder unparsed and unvalidated (issue #1834).
+        if head.blank && !head.eof then
+          val blanks = claimLeadingBlanksFor(expected)
+          if blanks > 0 then
+            pushBlock(Tel.Block(takeComments(0), Unset, takeCompounds(0), blanks))
+
+        if head.eof || head.separator || head.indentLevels < expected then continue = false
+        else
           if head.indentLevels > expected then
             val line   = head.startLine
             val indent = head.leadingSpaces
-            val lastIx = blockScratchIx - 1
+
+            // Blank-only blocks carry no structure to blame, so the reason is
+            // chosen from the nearest preceding block that has any.
+            var lastIx = blockScratchIx - 1
+
+            while lastIx >= start && {
+              val last = scratchBlocks(lastIx)
+              last.comments.nil && last.tabulation.absent && last.compounds.nil
+            } do lastIx -= 1
 
             val reason =
               if lastIx < start then Reason.OverIndentation
@@ -4298,7 +4340,7 @@ object Tel extends Tel2:
 
           parseBlock(expected)  // pushes one block onto scratchBlocks; consumes ≥1 line
 
-        takeBlocks(blockScratchIx - start)
+      takeBlocks(blockScratchIx - start)
 
     // ── parseBlock ───────────────────────────────────────────────────────────
 
@@ -4524,6 +4566,51 @@ object Tel extends Tel2:
               i += 1
 
             0
+
+    // Claim a run of blank lines that precedes further content belonging to the
+    // child level `expected` (§9: blank lines have no structural effect). The
+    // caller guarantees the head is parked on a blank, non-EOF line. Unlike
+    // consumeTrailingBlanksFor, a *deeper* following line also commits the
+    // claim: parseChildren then recovers the over-indentation at this level,
+    // which is the level that owns it. EOF and separators decline, leaving the
+    // run to consumeTrailingBlanksFor's EOF/documentEndsWithLf accounting.
+    private update def claimLeadingBlanksFor(expected: Int): (Tactic[Tel.Error]^) ?->{this} Int =
+      inHold:
+        val mk = beginMark()
+
+        val firstBlankSnapshot = (head.leadingSpaces, head.indentLevels, head.blank,
+                                  head.eof, head.startLine)
+
+        val savedBoundary = prevLineWasBoundary
+        val savedLineNo = lineNo
+        var count = 0
+
+        while !head.eof && head.blank do
+          count += 1
+          fillHead()
+
+        val keep = !head.eof && !head.separator && head.indentLevels >= expected
+
+        if keep then count
+        else
+          // Rewind to the first blank.
+          syncTo()
+          cursor.cue(mk)
+          syncFrom()
+          head.leadingSpaces = firstBlankSnapshot._1
+          head.indentLevels  = firstBlankSnapshot._2
+          head.blank         = firstBlankSnapshot._3
+          head.eof           = firstBlankSnapshot._4
+          head.startLine     = firstBlankSnapshot._5
+          prevLineWasBoundary = savedBoundary
+          lineNo = savedLineNo
+          var i = 0
+
+          while i < firstBlankSnapshot._1 && more && peek == SP do
+            advance()
+            i += 1
+
+          0
 
     // ── Predicates over the parked head ──────────────────────────────────────
 
@@ -5511,13 +5598,12 @@ object Tel extends Tel2:
     // Step to the next compound entry at exactly `indent`, transparently
     // consuming blank lines, comment lines and tabulation headers on the way
     // (with the same side effects and checks as `parseBlock`). Returns null
-    // when the entry region ends: EOF, a document separator, a shallower
-    // line, or — matching the AST path, which leaves such a tail unconsumed —
-    // blank lines followed by a deeper line. A deeper line reached without an
-    // intervening blank fails fast with the `Reason` the AST path would
-    // record. On a compound line, consumes the keyword (leaving the parser
-    // mid-line, right after it) and records the entry state for the
-    // per-entry consumers.
+    // when the entry region ends: EOF, a document separator, or a shallower
+    // line. A deeper line — with or without intervening blank lines, which
+    // are structurally transparent (§9) — fails fast with the `Reason` the
+    // AST path would record. On a compound line, consumes the keyword
+    // (leaving the parser mid-line, right after it) and records the entry
+    // state for the per-entry consumers.
     private[stratiform] update def directKeyword(indent: Int)(using Tactic[Tel.Error]): Text | Null =
       if directKeywordAdvance(indent, textual = true) then directEntryKeyword else null
 
@@ -5535,14 +5621,12 @@ object Tel extends Tel2:
         if head.eof || head.separator then done = true
         else if head.blank then
           // A blank line ends the current block: any active tabulation stops
-          // applying to what follows.
+          // applying to what follows. Structurally the blanks are transparent
+          // (§9): the next iteration classifies whatever follows them exactly
+          // as if they weren't there — matching the AST path's parseChildren,
+          // which claims such a run as a blank-only block.
           directTabulation = Unset
           while !head.eof && head.blank do fillHead()
-
-          // Blanks followed by a deeper line: the AST path leaves the blanks
-          // unclaimed and every `parseChildren` level exits, silently ending
-          // the document — mirrored by ending the entry region at every level.
-          if !head.eof && !head.separator && head.indentLevels > indent then done = true
         else if head.indentLevels < indent then
           done = true
         else if head.indentLevels > indent then

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -157,6 +157,19 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
         accrual + (prior.let(_.pointer.encode).or(t"/"), error)
     . protect(text.read[Tel])
 
+  // Negative-corpus fixtures whose accrued diagnostics legitimately differ
+  // from the reference parser's report, each with the reason recorded here.
+  // Keep this list small: every entry weakens the no-silent-truncation
+  // guarantee below for that fixture.
+  private val strictExemptions: List[Text] = List
+    ( t"e106-less-than-margin",       // reference double-reports one defect at one span
+      t"e107-odd-indentation",        // reference double-reports one defect at one span
+      t"e112-child-of-comment",       // we report the specific E112; reference generalizes to E111
+      t"e113-source-after-literal",   // we report the specific E113; reference generalizes to E111
+      t"e114-duplicate-literal",      // we report E114+E115; reference generalizes to one E111
+      t"e119-non-space-after-marker", // we report per heading; reference reports per marker
+      t"e122-pragma-with-remark" )    // reference cascades an extra E105 from its recovery
+
   // A document schema with two required scalar fields and no defaults: a document
   // omitting both yields two `RequiredMemberAbsent` violations.
   private val twoRequiredSchema: Tels = Tels(
@@ -406,6 +419,55 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
            ( Tel.Error.Reason.BadVersion,
              Tel.Error.Reason.OverIndentation,
              Tel.Error.Reason.TrailingSpaces )
+
+      // Issue #1834: a blank line followed by a deeper line used to unwind the
+      // whole parse, silently dropping the rest of the document — the AST and
+      // every subsequent diagnostic.
+      test(m"A blank line before a deeper child is not itself an error (§9)"):
+        validateRead(t"parent\n\n  child\n").items.length
+      . assert(_ == 0)
+
+      test(m"A blank line before a deeper comment block is valid (§11.1)"):
+        validateRead(t"parent\n\n  # note\n  child\n").items.length
+      . assert(_ == 0)
+
+      test(m"A defect after a blank-then-deeper line still accrues (#1834)"):
+        validateRead(t"tel 1.0\n\nparent\n\n  child\n   bogus\n").items.stdlib.map(_(1).reason).to(List)
+      . assert(_ == List(Tel.Error.Reason.OddIndentation))
+
+      test(m"The post-blank odd-indent defect is located on its own line"):
+        validateRead(t"tel 1.0\n\nparent\n\n  child\n   bogus\n").items.stdlib.map(_(1).span.startLine).to(List)
+      . assert(_ == List(5.z))
+
+      test(m"Blank-then-over-indented recovers and later defects accrue"):
+        validateRead(t"parent\n\n    deep\ntail \n").items.map(_(1).reason).to[Set]
+      . assert(_ == Set(Tel.Error.Reason.OverIndentation, Tel.Error.Reason.TrailingSpaces))
+
+      test(m"Blank-then-deeper after a tabulation header blames the tabulation"):
+        validateRead(t"# a  # b\n\n    deep\n").items.map(_(1).reason).to[Set]
+      . assert(_.has(Tel.Error.Reason.RowWrongIndent))
+
+    suite(m"Corpus diagnostics are complete (no silent truncation)"):
+      // The corpus membership checks in stratiform_test pass if any ONE
+      // expected code is raised, so a parser that reports the first defect and
+      // silently stops (as blank-then-deeper once made it — issue #1834) still
+      // passes them. These compare the accrued multiset of codes against the
+      // reference parser's full report from the `.check` file, and require the
+      // whole positive corpus to accrue nothing.
+      CorpusLoader.negative.each: testcase =>
+        val expected = CheckFormat.parse(testcase.check).errors.map(_.code)
+
+        if expected.stdlib.nonEmpty && expected.stdlib.forall(_ < 200)
+        && !strictExemptions.stdlib.contains(testcase.stem)
+        then
+          test(m"accrues exactly the reference diagnostics on ${testcase.stem}"):
+            validateRead(testcase.source.utf8).items.stdlib.map(_(1).reason.number).sorted
+          . assert(_ == expected.stdlib.sorted)
+
+      CorpusLoader.positive.each: testcase =>
+        test(m"accrues no diagnostics on ${testcase.stem}"):
+          validateRead(testcase.source.utf8).items.length
+        . assert(_ == 0)
 
     suite(m"Located schema-validation errors (LSP diagnostics)"):
       test(m"Unknown-keyword errors carry their keyword pointer"):

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -133,6 +133,38 @@ object Tests extends Suite(m"Stratiform Tests"):
           TelCheckTree.of(reparsed)
         . assert(_ == TelCheckTree.of(testcase.source.read[Tel]))
 
+    suite(m"Blank-then-deeper layout (§9, issue #1834)"):
+      // Blank lines have no structural effect: a blank run before a deeper
+      // line neither errors nor (formerly) silently ends the document. The
+      // blanks are preserved as a blank-only block, so these documents must
+      // round-trip byte-for-byte.
+      test(m"a blank line before a first child round-trips byte-for-byte"):
+        t"parent\n\n  child\n".read[Tel].show
+      . assert(_ == t"parent\n\n  child\n")
+
+      test(m"a blank line before a deeper comment round-trips byte-for-byte"):
+        t"parent\n\n  # note\n  child\n".read[Tel].show
+      . assert(_ == t"parent\n\n  # note\n  child\n")
+
+      test(m"a blank line before a grandchild round-trips byte-for-byte"):
+        t"parent\n  a\n\n    b\n".read[Tel].show
+      . assert(_ == t"parent\n  a\n\n    b\n")
+
+      test(m"two blank lines before a first child round-trip byte-for-byte"):
+        t"parent\n\n\n  child\n".read[Tel].show
+      . assert(_ == t"parent\n\n\n  child\n")
+
+      test(m"a blank line before an over-indented line fails fast with E111"):
+        capture[Tel.Error](t"parent\n\n    too-deep\n".read[Tel]).reason.number
+      . assert(_ == 111)
+
+      test(m"the streaming parser agrees on a blank-then-deeper document"):
+        val source = t"parent\n\n  child value\n"
+        val bytes: Data = summon[CharEncoder].encoded(source)
+        TelCheckTree.of(Tel.make(Tel.Parser.parse(Cursor[Data](bytes))))
+        == TelCheckTree.of(source.read[Tel])
+      . assert(identity)
+
     suite(m"Streaming parser — positive corpus"):
       CorpusLoader.positive.each: testcase =>
         test(m"streaming parses ${testcase.stem}"):
@@ -192,6 +224,20 @@ object Tests extends Suite(m"Stratiform Tests"):
               Tel.Parser.parse(chunkedCursor(testcase.source, n))))
             tree == baseline
         . assert(identity)
+
+      // Diagnostics must be chunking-invariant too: the fail-fast first error
+      // is the same whatever the chunk boundaries.
+      CorpusLoader.negative.each: testcase =>
+        val codes = CorpusLoader.expectedCodes(testcase)
+        if codes.stdlib.nonEmpty && codes.stdlib.forall(_ < 200) then
+          test(m"all chunk sizes raise the same error on ${testcase.stem}"):
+            val baseline =
+              capture[Tel.Error](Tel.Parser.parse(Cursor[Data](testcase.source))).reason.number
+            val sizes = List(1, 7, 64, 1024, testcase.source.readable.length.max(1))
+            sizes.stdlib.forall: n =>
+              capture[Tel.Error](Tel.Parser.parse(chunkedCursor(testcase.source, n)))
+              . reason.number == baseline
+          . assert(identity)
 
     suite(m"Document streams (§6.1)"):
       // Each `.check` fixture holds a `=== document N ===` sequence; the parsed
@@ -410,6 +456,11 @@ object Tests extends Suite(m"Stratiform Tests"):
 
       test(m"Nested records parse directly"):
         val doc = t"title Acme\nboss\n  name Bob\n  age 40\n"
+        (doc.read[Tests.Company in Tel], parity[Tests.Company](doc))
+      . assert(_ == (Tests.Company(t"Acme", Tests.Person(t"Bob", 40)), true))
+
+      test(m"A blank line before a nested record's children parses directly (#1834)"):
+        val doc = t"title Acme\nboss\n\n  name Bob\n  age 40\n"
         (doc.read[Tests.Company in Tel], parity[Tests.Company](doc))
       . assert(_ == (Tests.Company(t"Acme", Tests.Person(t"Bob", 40)), true))
 


### PR DESCRIPTION
Fixes #1834. Stratiform's TEL parser silently stopped parsing — dropping both the AST tail and every subsequent diagnostic — at the first blank line followed by a more-indented line, reporting success on documents with arbitrarily many defects. The parser now treats blank runs as structurally transparent (§9), attaching the following lines where the spec places them; the streaming/direct path matches; and a new post-condition in `parseOneDocument` turns any future "unclaimed input" bug into a diagnostic instead of silent data loss. The test suite is tightened so this class of bug cannot pass again: negative-corpus diagnostics are now compared exactly (multiset of codes) against the reference report, the whole positive corpus must accrue zero diagnostics, and negative cases are chunk-boundary-fuzzed. The reference implementation's contrary E111 behaviour is reported upstream as propensive/tel#24.

### Release notes

- A blank line followed by a deeper-indented line no longer silently ends a TEL document: `parent` / *blank* / `  child` now parses `child` as an ordinary child of `parent` (per §9/§13), blank-then-deeper comments (§11.1) are valid, and genuine defects anywhere after such a point are reported, e.g.:
  ```scala
  t"tel 1.0\n\nparent\n\n  child\n   bogus\n".read[Tel]  // now raises E107 (odd indentation) on line 6
  ```
- Documents with this shape round-trip byte-for-byte; blank runs are preserved in the AST as blank-only blocks.
- `TelReader`'s direct parsing path now reaches child regions preceded by blank lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
