### PR TITLE
Raise E206 on layer field-type conflicts and check E209/E217 in validation

### DIFF
--- a/lib/stratiform/res/test/stratiform/corpus/neg/e206-layer-field-type-mismatch.check
+++ b/lib/stratiform/res/test/stratiform/corpus/neg/e206-layer-field-type-mismatch.check
@@ -22,7 +22,7 @@ Document {
                     keyword: "name",
                     atoms: [
                         Inline {
-                            text: "e207-test",
+                            text: "e206-test",
                             preceding_spaces: 1,
                         },
                     ],
@@ -53,7 +53,7 @@ Document {
                                             preceding_spaces: 1,
                                         },
                                         Inline {
-                                            text: "string",
+                                            text: "String",
                                             preceding_spaces: 1,
                                         },
                                     ],
@@ -109,7 +109,7 @@ Document {
                                                             preceding_spaces: 1,
                                                         },
                                                         Inline {
-                                                            text: "identifier",
+                                                            text: "Identifier",
                                                             preceding_spaces: 1,
                                                         },
                                                     ],
@@ -132,5 +132,4 @@ Document {
     ],
 }
 errors:
-  E310 [0,6): Scalar value failed validation: `type` failed validation: TypeName must start with an uppercase ASCII letter
-  E310 [0,10): Scalar value failed validation: `type` failed validation: TypeName must start with an uppercase ASCII letter
+  E206 [0,0): Layer Field merge requires both base and layer types to be Struct: layer `extension` field `foo` in overlay: type mismatch

--- a/lib/stratiform/res/test/stratiform/corpus/neg/e206-layer-field-type-mismatch.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/neg/e206-layer-field-type-mismatch.tel
@@ -1,11 +1,11 @@
 tel 1.0 https://tel-lang.org/schema/tels
 
-name e207-test
+name e206-test
 
 document
-  field foo string
+  field foo String
 
 layer
   name extension
   overlay
-    field foo identifier
+    field foo Identifier

--- a/lib/stratiform/src/core/stratiform.Tels.scala
+++ b/lib/stratiform/src/core/stratiform.Tels.scala
@@ -417,6 +417,18 @@ object Tels extends Tels2:
               case Some(idx) =>
                 members(idx) match
                   case existing: Field =>
+                    // §20.3: a restated field's type must be structurally
+                    // equal to the base's (a polarity-only refinement) or
+                    // both must be Structs, which merge recursively;
+                    // anything else is E206.
+                    val mergedType = (existing.fieldType, f.fieldType) match
+                      case (baseType: Struct, layerType: Struct) =>
+                        mergeStruct(baseType, layerType)
+
+                      case (baseType, layerType) =>
+                        if Reconstructor.typeEq(baseType, layerType) then baseType
+                        else abort(Tel.Error(Reason.LayerFieldTypeMismatch))
+
                     members(idx) =
                       Field
                         ( required   = mergePolarity(existing.required, f.required,
@@ -424,7 +436,7 @@ object Tels extends Tels2:
                          repeatable = mergePolarity(existing.repeatable, f.repeatable,
                                         PolarityAxis.Repeatable),
                          keyword     = f.keyword,
-                         fieldType   = existing.fieldType,
+                         fieldType   = mergedType,
                          default     = existing.default,
                          // §20.3: a layer's non-null description overrides
                          // the base's; otherwise the base's is inherited.
@@ -655,12 +667,15 @@ object Tels extends Tels2:
           case scala.Some(definition) => Scalar(definition.validators, definition.encoding)
 
           case scala.None =>
-            if name == Builtin.String || name == Builtin.Identifier
-              || name == Builtin.TypeName || name == Builtin.Sigil
-            then Scalar(Array.empty)
-            else Unset
+            if builtinScalar(name) then Scalar(Array.empty) else Unset
 
       case _ => Unset
+
+    // The built-in scalar TypeNames of §20.5. (`Flag` is not among them:
+    // it parses to the Flag type directly, never to a Reference.)
+    private def builtinScalar(name: Text): Boolean =
+      name == Builtin.String || name == Builtin.Identifier
+        || name == Builtin.TypeName || name == Builtin.Sigil
 
     private def checkStruct(struct: Struct, schema: Tels): Unit raises Tel.Error =
       val keywords = scala.collection.mutable.HashSet.empty[Text]
@@ -679,7 +694,21 @@ object Tels extends Tels2:
           // Merge-produced nested Structs are checked regardless of `key`.
           field.fieldType match
             case nested: Struct => checkStruct(nested, schema)
-            case _              => ()
+
+            // E209/E217: a Field's Reference must resolve, through the
+            // composed namespace or the §20.5 built-ins, to a record or
+            // scalar; a SelectDefinition can only be the target of a
+            // SelectRef.
+            case Reference(name) =>
+              if !schema.records.readable.exists(_.name == name)
+                && !schema.scalars.readable.exists(_.name == name)
+                && !builtinScalar(name)
+              then
+                if schema.selects.readable.exists(_.name == name)
+                then abort(Tel.Error(Reason.ReferenceKindMismatch))
+                else abort(Tel.Error(Reason.UnresolvedReference))
+
+            case _ => ()
 
           val required   = field.required != Polarity.Loose
           val repeatable = field.repeatable == Polarity.Loose
@@ -710,7 +739,15 @@ object Tels extends Tels2:
               if definition.variants.nil && select.required != Polarity.Loose
               then abort(Tel.Error(Reason.ExcludeEmptiesRequired))
 
-            case scala.None => ()
+            // E209/E217: a SelectRef must resolve to a SelectDefinition;
+            // a record, scalar or built-in name is a kind mismatch, and
+            // anything else is unresolved.
+            case scala.None =>
+              if schema.records.readable.exists(_.name == select.reference)
+                || schema.scalars.readable.exists(_.name == select.reference)
+                || builtinScalar(select.reference)
+              then abort(Tel.Error(Reason.ReferenceKindMismatch))
+              else abort(Tel.Error(Reason.UnresolvedReference))
 
         case _ => ()
 
@@ -749,7 +786,7 @@ object Tels extends Tels2:
       case (a: Exclude, b: Exclude) => a.keyword == b.keyword
       case _                        => false
 
-    private def typeEq(a: Type, b: Type): Boolean = (a, b) match
+    private[Tels] def typeEq(a: Type, b: Type): Boolean = (a, b) match
       case (a: Struct, b: Struct)         => structEq(a, b)
 
       case (a: Scalar, b: Scalar) =>

--- a/lib/stratiform/src/test/stratiform.SchemaValidityTests.scala
+++ b/lib/stratiform/src/test/stratiform.SchemaValidityTests.scala
@@ -40,9 +40,10 @@ import errorDiagnostics.stackTracesDiagnostics
 import charEncoders.utf8Encoder
 
 // The schema-validity checks of §20.1 beyond keys and encodings: E207
-// (sigil validity), E202/E216 base-side select constraints, and the
-// layer `exclude` operation (§20.3) with E211 (no such variant) and
-// E212 (emptying a SelectDefinition referenced by a required SelectRef).
+// (sigil validity), E202/E216 base-side select constraints, E206 layer
+// field-type merges, E209/E217 reference resolution, and the layer
+// `exclude` operation (§20.3) with E211 (no such variant) and E212
+// (emptying a SelectDefinition referenced by a required SelectRef).
 object SchemaValidityTests extends Suite(m"Stratiform schema validity tests"):
 
   private def schemaOf(text: Text): Tels = Tels.Reconstructor.fromTel(text.read[Tel])
@@ -118,6 +119,94 @@ object SchemaValidityTests extends Suite(m"Stratiform schema validity tests"):
                        |  select Pet optional
                        |""".stripMargin))
       . assert(_ == 216)
+
+    suite(m"Layer field-type merges (§20.3, E206)"):
+      test(m"E206: a layer restates a field with a different type"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |document
+                       |  field foo String
+                       |layer extension
+                       |  overlay
+                       |    field foo Identifier
+                       |""".stripMargin))
+      . assert(_ == 206)
+
+      test(m"restating a field with the same type is permitted"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |document
+                       |  field foo String optional
+                       |layer extension
+                       |  overlay
+                       |    field foo String
+                       |""".stripMargin))
+      . assert(_ == 0)
+
+      test(m"restating a field referencing the same record is permitted"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |record Cat
+                       |  field name Identifier
+                       |document
+                       |  field pet Cat optional
+                       |layer extension
+                       |  overlay
+                       |    field pet Cat
+                       |""".stripMargin))
+      . assert(_ == 0)
+
+      test(m"E206: a record-body field restated with a different type"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |record Cat
+                       |  field name Identifier
+                       |document
+                       |  field pet Cat optional
+                       |layer extension
+                       |  record Cat
+                       |    field name String
+                       |""".stripMargin))
+      . assert(_ == 206)
+
+    suite(m"Reference resolution (E209/E217)"):
+      test(m"E209: a field references an undefined TypeName"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |document
+                       |  field foo Missing
+                       |""".stripMargin))
+      . assert(_ == 209)
+
+      test(m"E217: a field references a SelectDefinition"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |record Cat
+                       |  field name Identifier
+                       |select Pet
+                       |  variant cat Cat
+                       |document
+                       |  field foo Pet optional
+                       |""".stripMargin))
+      . assert(_ == 217)
+
+      test(m"E209: a SelectRef references an undefined name"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |document
+                       |  select Missing optional
+                       |""".stripMargin))
+      . assert(_ == 209)
+
+      test(m"E217: a SelectRef references a record"):
+        schemaCode(Text("""|tel 1.0
+                       |name t
+                       |record Cat
+                       |  field name Identifier
+                       |document
+                       |  select Cat optional
+                       |""".stripMargin))
+      . assert(_ == 217)
 
     suite(m"Layer excludes (§20.3, E211/E212)"):
       test(m"an excluded variant is removed from the composed select"):


### PR DESCRIPTION
Stratiform's layer composition silently discarded a layer field's conflicting type: `mergeStruct` always kept the base's `fieldType` when a layer restated an existing keyword, so the E206 (`LayerFieldTypeMismatch`) check required by §20.1 never fired. Separately, `Validation.validate` performed no reference-resolution checks at all — a dangling `Reference` (E209) or a kind-mismatched one (E217) was only discovered lazily when a document was assigned against the schema. This fixes both, refreshes the modernised `e206-layer-field-type-mismatch` corpus fixture from the reference implementation, and adds direct tests for all three codes. Fixes #1839.

### Release notes

- A layer `field` that restates an existing keyword with a conflicting type now raises **E206**, per §20.3 of the TEL specification: the base and layer types must be structurally equal (a polarity-only refinement, merged as before) or both be `Struct`s, in which case their members and validators are now merged recursively rather than the layer's being dropped.

  ```
  document
    field foo String

  layer extension
    overlay
      field foo Identifier   # now E206; previously merged silently as String
  ```

- `Tels.Validation.validate` now checks reference resolution across the composed schema: a `field` whose type names no record, scalar or §20.5 built-in raises **E209** (`UnresolvedReference`), and one naming a `select` raises **E217** (`ReferenceKindMismatch`). Likewise a `select` member referencing an undefined name raises E209, and one referencing a record or scalar raises E217. Previously these were only caught when validating a document against the schema, and only for the parts a document exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)