### PR TITLE
Expand a leading tilde in exoskeleton's Pathname

### DIFF
--- a/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
@@ -54,6 +54,23 @@ import filesystemBackends.virtualMachineFilesystem
 
 object Pathname:
   def unapply(argument: Argument)(using WorkingDirectory, Cli, System): Option[Path on Local] =
+    // The property is read straight off the `System` capability rather than through
+    // `Directories.homeText`, which panics when it is unset. An unknown home leaves `~` alone,
+    // to resolve (and fail) like any other name.
+    val home: Optional[Text] = summon[System](t"user.home").let: text =>
+      if text.length > 1 && text.ends(t"/") then text.skip(1, Bidi.Rtl) else text
+
+    // A shell expands `~` before exec, but a quoted argument and every partial word handed to
+    // the completion script arrive with the tilde intact, so it is expanded here too.
+    def expand(text: Text): Text = home.lay(text): home =>
+      if text == t"~" then home else if text.starts(t"~/") then home+text.skip(1) else text
+
+    // The inverse, so a completion under a tilde stays short and keeps its tilde.
+    def abbreviate(text: Text): Text = home.lay(text): home =>
+      if text == home then t"~"
+      else if text.starts(home+t"/") then t"~"+text.skip(home.length)
+      else text
+
     safely:
       def suggest(path: Text): Suggestion =
         val point = path.s.lastIndexOf('/', path.length - 2) + 1
@@ -98,11 +115,14 @@ object Pathname:
         listing ::: prior
 
       else
+        val tilde = home.present && (argument() == t"~" || argument().starts(t"~/"))
         val absolute = argument().starts(t"/")
-        val directory = argument().ends(t"/")
+        // A bare `~` names the home directory itself, so it lists that directory's children,
+        // exactly as `~/` does; without this it would list the home directory's siblings.
+        val directory = argument().ends(t"/") || argument() == t"~"
         // Resolution runs under its own optional tactic; no aliased writer.
         val prototype = scala.caps.unsafe.unsafeAssumeSeparate:
-          workingDirectory.resolve(argument())
+          workingDirectory.resolve(expand(argument()))
         val showAll = argument.tab.or(Prim) > Prim || prototype.name.starts(t".")
         val base: Optional[Path on Local] = if directory then prototype else prototype.parent
         val children0 = base.let(base => List.of(base.children.stdlib.toList)).or(List[Path on Local]())
@@ -120,9 +140,11 @@ object Pathname:
             val slash = if directory then t"/" else t""
 
             suggest:
-              if absolute then path.encode+slash else workingDirectory.toward(path).encode+slash
+              if tilde then abbreviate(path.encode)+slash
+              else if absolute then path.encode+slash
+              else workingDirectory.toward(path).encode+slash
 
           listing ::: prior
 
     scala.caps.unsafe.unsafeAssumeSeparate:
-      safely(workingDirectory.resolve(argument())).option
+      safely(workingDirectory.resolve(expand(argument()))).option

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -77,6 +77,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
             val Tree = Subcommand("tree", e"path-segment completion", hidden = true)
             val Files = Subcommand("files", e"path completion", hidden = true)
             val Verify = Subcommand("verify", e"verify a file")
+            val Home = Subcommand("home", e"check a path against the home directory", hidden = true)
 
             class Hue(name: Text)
             class Segment(name: Text)
@@ -136,6 +137,11 @@ object Tests extends Suite(m"Exoskeleton Tests"):
                   given WorkingDirectory = summon[Cli].workingDirectory
 
                   rest match
+                    // Issue #1807: a leading `~` must name the home directory, so the exit
+                    // status reports where the argument actually resolved to.
+                    case Home() :: Pathname(file) :: _ =>
+                      execute(if file.encode == Directories.homeText then Exit.Ok else Exit.Fail(2))
+
                     case Verify() :: Pathname(file) :: _ => execute(Exit.Ok)
                     case Pathname(file) :: Nil           => execute(Exit.Ok)
                     case _                               => execute(Exit.Fail(1))
@@ -497,6 +503,23 @@ object Tests extends Suite(m"Exoskeleton Tests"):
             test(m"subcommands and paths at one position combine on bash"):
               sh"$tool '{completions}' bash 2 0 /dev/null -- abcd files ''".exec[Text]()
             .assert { out => out.contains(t"verify") && out.contains(t"one.txt") }
+
+            // Issue #1807: a leading `~` was resolved as an ordinary relative name, so it
+            // named a nonexistent `~` entry in the working directory instead of the home
+            // directory, and offered no completions beneath it.
+            test(m"a bare tilde resolves to the home directory"):
+              sh"$tool files home '~'".exec[Exit]()
+            .assert(_ == Exit.Ok)
+
+            test(m"a tilde with a trailing slash resolves to the home directory"):
+              sh"$tool files home '~/'".exec[Exit]()
+            .assert(_ == Exit.Ok)
+
+            test(m"tilde completions list the home directory and keep the tilde"):
+              sh"$tool '{completions}' fish 3 0 /dev/null -- abcd files verify '~/'".exec[Text]()
+            .assert: output =>
+                val lines = output.cut(t"\n").stdlib.filter(!_.nil)
+                lines.nonEmpty && lines.forall(_.starts(t"~/"))
 
             test(m"subcommands and paths at one position combine on zsh"):
               sh"$tool '{completions}' zsh 3 0 /dev/null -- abcd files ''".exec[Text]()


### PR DESCRIPTION
Command-line arguments beginning with `~` are now understood by `Pathname` as references to the user's home directory, both when the argument is matched and when completions are generated for it, so a quoted `'~/notes'` and a half-typed `~/no<TAB>` both behave as the user expects instead of naming a nonexistent `~` entry in the working directory.

### Tilde expansion in `Pathname`

A shell normally expands `~` before your application ever runs, so `Pathname` never had to. But two cases reach the program with the tilde intact: an argument the user quoted, and — more often — the partial word a shell hands to the completion script. Previously `Pathname` resolved these as ordinary relative names, against a `~` directory that does not exist, so the extracted path was wrong and no completions were offered.

`~` on its own, and any argument starting `~/`, now resolve against the `user.home` system property:

```scala
case Pathname(file) :: _ => // `~/notes` is now $HOME/notes
```

Completions keep the tilde rather than expanding it into the command line, so typing `~/Doc` and pressing Tab offers `~/Documents/`.

A `~user/…` form is still taken literally; resolving another user's home directory would require a passwd lookup that Soundness does not currently provide.

Closes #1807.
