### PR TITLE
Distinguish operand-value suggestions from subcommands

### DIFF
--- a/lib/exoskeleton/src/args/exoskeleton.Argument.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Argument.scala
@@ -113,5 +113,7 @@ case class Argument
       options.stdlib.map: option => (operand.suggest(option).text, option)
       . to(Map)
 
-    suggest(options.map(operand.suggest(_)))
+    // Marked as operand values, not subcommands: they are candidates *for* this argument, so the
+    // help tree must not descend into them (see `Suggestion.operand`).
+    suggest(options.map(operand.suggest(_).copy(operand = true)))
     mapping(this())

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -109,6 +109,9 @@ extends Topical:
       case List(value) => mapping(value())
       case _           => Unset
 
-    given suggestions: Topic is Discoverable = _ => options.map(suggestible.suggest(_))
+    // Marked as operand values, not subcommands: they are candidates for this flag's operand, so
+    // the help tree must not descend into them (see `Suggestion.operand`).
+    given suggestions: Topic is Discoverable =
+      _ => options.map(suggestible.suggest(_).copy(operand = true))
 
     this()

--- a/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
@@ -50,10 +50,12 @@ object Suggestion:
       prefix:      Text                      = t"",
       suffix:      Text                      = t"",
       expanded:    Boolean                   = false,
-      group:       Optional[CommandGroup]    = Unset )
+      group:       Optional[CommandGroup]    = Unset,
+      operand:     Boolean                   = false )
   :   Suggestion =
 
-    new Suggestion(core, description, hidden, incomplete, aliases, prefix, suffix, expanded, group)
+    new Suggestion
+      (core, description, hidden, incomplete, aliases, prefix, suffix, expanded, group, operand)
 
 
 case class Suggestion
@@ -65,6 +67,12 @@ case class Suggestion
     prefix:      Text,
     suffix:      Text,
     expanded:    Boolean,
-    group:       Optional[CommandGroup] ):
+    group:       Optional[CommandGroup],
+    // A candidate *value* for an operand — a filename, or one of a `select`'s options — rather
+    // than a subcommand. Both are offered identically at the cursor, but only a subcommand is
+    // part of the command's interface, and the help tree is built by probing these same
+    // suggestions: without this distinction, `--help` enumerates the working directory (or
+    // whatever else the machine happens to hold) as though it were syntax.
+    operand:     Boolean = false ):
 
   def text: Text = prefix+core+suffix

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -176,7 +176,7 @@ extends Cli:
         lazy val aliasesWidth = items.map(_.aliases.join(t" ").length).maximize(identity).or(0) + 1
 
         val itemLines: List[Command] = items.bind:
-          case Suggestion(core0, description, hidden, incomplete, aliases, prefix, suffix, _, _) =>
+          case Suggestion(core0, description, hidden, incomplete, aliases, prefix, suffix, _, _, _) =>
             val hiddenParam = if hidden then sh"-n" else sh""
             val shortFlag = focusText.starts(t"-") && !focusText.starts(t"--")
             val aliasText = if shortFlag then core0 else aliases.join(t" ").fit(aliasesWidth)
@@ -222,7 +222,7 @@ extends Cli:
         val sole = items.stdlib.count(!_.hidden) == 1
 
         items.bind:
-          case suggestion@Suggestion(core, description, hidden, incomplete, aliases, _, _, _, _) =>
+          case suggestion@Suggestion(core, description, hidden, incomplete, aliases, _, _, _, _, _) =>
             if hidden then Nil else
               val mainLines = (suggestion.text :: aliases.stdlib).map: text =>
                 description.absolve match
@@ -241,7 +241,7 @@ extends Cli:
         // PowerShell inserts a `CompletionResult` verbatim, so a trailing-space twin is
         // just a visible duplicate; `incomplete` has no rendering there.
         items.bind:
-          case suggestion@Suggestion(core, description, hidden, _, aliases, _, _, _, _) =>
+          case suggestion@Suggestion(core, description, hidden, _, aliases, _, _, _, _, _) =>
             if hidden then Nil else
 
                 (suggestion.text :: aliases.stdlib).map: text =>

--- a/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
@@ -75,8 +75,10 @@ object Pathname:
         val prefix = path.keep(point)
         val core = path.skip(point)
         // Only a directory leaves the completion mid-path; a file candidate is complete,
-        // and accepting it should advance to the next argument.
-        Suggestion(core, Unset, incomplete = path.ends(t"/"), prefix = prefix)
+        // and accepting it should advance to the next argument. Every candidate is an operand
+        // value rather than a subcommand, so the help tree does not enumerate the working
+        // directory as though it were syntax (see `Suggestion.operand`).
+        Suggestion(core, Unset, incomplete = path.ends(t"/"), prefix = prefix, operand = true)
 
       // Each branch adds to `prior` rather than replacing it: another extractor evaluated
       // against the same argument (typically a `Subcommand`) must keep its suggestions.

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -173,7 +173,10 @@ def helpTree
         suggestions.stdlib.distinctBy(_.core).to(List).bind: suggestion =>
           val childPrefix = prefix :+ suggestion.core
 
-          if suggestion.hidden || suggestion.incomplete then Nil
+          // An operand *value* (a filename, a `select` option) is offered at the cursor exactly
+          // as a subcommand is, but it is not part of the command's interface: descending into
+          // it would document whatever the machine currently holds as though it were syntax.
+          if suggestion.hidden || suggestion.incomplete || suggestion.operand then Nil
           else
             List
               ( build


### PR DESCRIPTION
## Problem

`helpTree` builds the generated help by re-running the application in completion mode and descending into each cursor suggestion as if it were a child command. But a suggestion offered at the cursor is not necessarily a subcommand: `Pathname` offers filenames, and `Argument.select` / `Flag.select` offer an operand's admissible values. Both are indistinguishable from a `Subcommand` suggestion at that point, so both became children of the help tree.

The visible result is that `--help` documents whatever the machine happens to hold as though it were syntax. For a CLI with a file operand, every entry in the working directory is listed under that subcommand — so the "help" differs depending on where you run it from:

```
  validate     parse and validate a TEL file, reporting its errors
    --llm      report problems by position only, without quoting source lines
    Cargo.lock
    Cargo.toml
    PSI-48.tel
    logo.svg
    readme.md
    tels.tel
```

## Fix

`Suggestion` gains an `operand: Boolean = false` field marking a candidate *value* rather than a subcommand. It is set by `Pathname` and by both `select` methods, and `helpTree` skips such suggestions when descending, alongside the existing `hidden` and `incomplete` cases.

Completion output is unchanged: the suggestions are still offered at the cursor exactly as before, and `Completion.serialize` does not consult the new field. Only the generated help stops treating values as commands:

```
  validate     parse and validate a TEL file, reporting its errors
    --llm      report problems by position only, without quoting source lines
```

There was no way to achieve this from the application side. `hidden` removes a suggestion from bash and fish completion entirely; `incomplete` means "this word is unfinished" and suppresses the trailing space after an accepted value; and a help probe is indistinguishable from a genuine empty-prefix completion, so the application cannot suppress the suggestions by context either.

## Notes

- The three positional `Suggestion(...)` patterns in `Completion.serialize` gain the extra `_`.
- A natural follow-up, not attempted here: positional operands have no representation in `Help`, so the usage line cannot yet name them (`validate <file>`). Flags already carry an operand name via `Help.Param`.

Verified against `exoskeleton.test.run` (116 passed) and by driving a real Ethereal launcher through the zsh completion protocol before and after: schema-name, layer-name and filename completions are byte-identical, while the help tree loses only the value entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)