### PR TITLE
Render the discovered exit statuses in generated help

### DIFF
--- a/lib/exoskeleton/src/core/exoskeleton.Help.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Help.scala
@@ -196,8 +196,20 @@ case class Help
             (scala.List(e"$Bold(Commands:)"),
              Help.compact(Help.commandRows(ungrouped, 1))) )
 
+    // Every status reachable anywhere in the tree, deduplicated by code and ordered by it. A
+    // status is recorded against the node whose dispatch branch can return it, but an exit code
+    // means the same thing wherever it comes from, so the reader wants the whole table in one
+    // place rather than scattered through the command listing.
+    def reachableStatuses(help: Help): scala.List[Status] =
+      help.statuses.stdlib.toList ::: help.subcommands.stdlib.toList.flatMap(reachableStatuses)
+
+    val statusRows: scala.List[Help.Row] =
+      reachableStatuses(this).distinctBy(_.code).sortBy(_.code).map: status =>
+        Help.Row.Item(1, t"${status.code}", false, status.description)
+
     val sections: scala.List[(scala.List[Teletype], scala.List[Help.Row])] =
       standard.filter(!_._2.isEmpty) ::: groupSections
+      ::: scala.List((scala.List(e"$Bold(Exit statuses:)"), statusRows)).filter(!_._2.isEmpty)
 
     // The column at which every description starts: two spaces after the widest label.
     val column: Int =

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -733,7 +733,11 @@ object Tests extends Suite(m"Exoskeleton Tests"):
                t"    --wait <seconds>     delay the deletion",
                t"",
                t"  Common options:",
-               t"    --force <value>      do not ask for confirmation")
+               t"    --force <value>      do not ask for confirmation",
+               t"",
+               t"Exit statuses:",
+               t"  1                      the server could not be reached",
+               t"  2                      the configuration file was invalid")
 
       suite(m"Manpage tests"):
         val manual = Manual


### PR DESCRIPTION
## Problem

`Status` exists so that an application's exit codes document themselves. Its own doc comment says as much:

> Returning one from an `execute` block both sets the process's exit code and makes the status discoverable: each `Status.exit` demands a `Registry` for its own singleton type, so the block's `execute` accumulates the union of every status it can return, and documents them without the application having to list them twice.

The discovery machinery all works: `execute` calls `cli.record(statuses)` even in completion mode (where the block itself never runs), `helpTree`'s probe reads them back, and they reach `Help.statuses`. But `Help.teletype` never renders that field, so the documentation half of the feature was inert — an application could declare a careful taxonomy of exit codes and `--help` would say nothing about any of them.

## Fix

Statuses reachable anywhere in the tree are rendered in an `Exit statuses:` section, deduplicated by code and ordered by it:

```
Exit statuses:
  1                      the server could not be reached
  2                      the configuration file was invalid
```

A status is recorded against the node whose dispatch branch can return it, so the alternative would be to print each node's statuses beside that subcommand. Collecting them into one table reads better: an exit code means the same thing wherever it is returned, and a reader consulting `--help` for "what does 2 mean?" wants one place to look. The rows join the existing description-column alignment, so they line up with the options and commands above them.

The section is omitted entirely when no statuses were discovered, so an application that returns only `Exit.Ok`/`Exit.Fail` is unaffected.

## Notes

- `exoskeleton_test.scala`'s full-render assertion gains the new section; `HelpApp` already declares `CannotConnect` (1) and `BadConfig` (2), which is why they now appear.
- Verified with `exoskeleton.test.run` (116 passed) and against a real Ethereal launcher whose subcommands declare six distinct statuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)