### PR TITLE
Adopt dysasymptotic nomenclature for collection-cost gating

### DIFF
--- a/doc/api-reduction-candidates.md
+++ b/doc/api-reduction-candidates.md
@@ -342,7 +342,6 @@ ultimatum's is the likelier one to rename.
 | `Hebrew*` | aviation | 2 | `HebrewCalendar`, `HebrewMonth` |
 | `Indian*` | aviation | 2 | `IndianCalendar`, `IndianMonth` |
 | `Islamic*` | aviation | 2 | `IslamicCalendar`, `IslamicMonth` |
-| `Linear*` | denominative | 2 | `LinearAccessComplexity`, `LinearSizeComplexity` |
 | `Mac*` | galilei, urticose | 2 | `MacAddress`, `MacOs` |
 | `Map*` | proscenium | 2 | `MapHasAsJava`, `MapHasAsScala` |
 | `Metric*` | quantitative | 2 | `MetricPrefix`, `MetricUnit` |
@@ -395,7 +394,7 @@ ultimatum's is the likelier one to rename.
 `SyntaxMatcher`, `TeletypeFormattable`, `TemperatureScale`, `TemporaryDirectory`, `TerminalBoard`,
 `TestPalette`, `ThemeColor`, `ThrowTactic`, `TlsAcceptance`, `TopMenu`, `TransferEncoding`,
 `TraversalOrder`, `TrieMap`, `TripleDes`, `TypescriptDialect`, `UdpResponse`,
-`UnboundedSizeComplexity`, `UncheckedError`, `UniformDistribution`, `UnitsNames`, `UnusedFeature`,
+`UncheckedError`, `UniformDistribution`, `UnitsNames`, `UnusedFeature`,
 `UrlPalette`, `UsedSets`, `UsesBlob`, `ValueToken`, `VentureTactic`, `VersionResponse`,
 `VersoPanel`, `VerticalAlignment`, `VirtualSupervisor`, `WarningFlag`, `WebserverErrorPage`,
 `WeekDate`, `WeekdayOrdinal`, `WideCharacterWidth`, `WireType`, `WritingBuilder`, `WsSessional`,

--- a/lib/anthology/src/apk/anthology.Apk.scala
+++ b/lib/anthology/src/apk/anthology.Apk.scala
@@ -47,7 +47,7 @@ import vacuous.*
 import gastronomy.providers.javaStdlibProvider
 import denominative.*
 import symbolism.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // A complete, installable Android application package—dexed code, a binary manifest, aligned
 // and signed—bound to the Android runtime: the application node reached from `Classfile`

--- a/lib/anthology/src/apk/anthology.Axml.scala
+++ b/lib/anthology/src/apk/anthology.Axml.scala
@@ -39,7 +39,7 @@ import gossamer.*
 import rudiments.*
 import vacuous.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // Android binary XML ("AXML"): the compact, chunked encoding Android's framework parses a
 // manifest from — a string pool, an optional resource-map chunk, then a flat stream of

--- a/lib/anthology/src/apk/anthology_apk.scala
+++ b/lib/anthology/src/apk/anthology_apk.scala
@@ -48,7 +48,7 @@ import serpentine.*
 import turbulence.*
 import zeppelin.*
 import rudiments.`:+`
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object apkOptions:
   private def apk(edit: Apk.Configuration => Apk.Configuration): Toolchain.Setting =

--- a/lib/apoplexy/src/core/apoplexy.internal.scala
+++ b/lib/apoplexy/src/core/apoplexy.internal.scala
@@ -55,7 +55,7 @@ import xylophone.*
 
 import charEncoders.utf8Encoder
 import strategies.throwUnsafely
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Apoplexy:
   // --- compile-time spec access -------------------------------------------

--- a/lib/archimedes/src/core/archimedes.Cell.scala
+++ b/lib/archimedes/src/core/archimedes.Cell.scala
@@ -45,7 +45,7 @@ import vacuous.*
 import symbolism.*
 
 import Mathml.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // A `Cell` is a rectangular block of monospaced character cells with a `baseline`
 // — the row index (from the top) of the mathematical axis that composition aligns

--- a/lib/archimedes/src/core/archimedes.Ergo.scala
+++ b/lib/archimedes/src/core/archimedes.Ergo.scala
@@ -51,7 +51,7 @@ import vacuous.*
 
 import Mathml.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // A parser for "ergo": a one-line shorthand for Presentation MathML that emits
 // `archimedes` nodes. The whole expression is delimited by a bracket pair; the

--- a/lib/aviation/src/core/aviation.Regime.scala
+++ b/lib/aviation/src/core/aviation.Regime.scala
@@ -38,7 +38,7 @@ import contingency.*
 import fulminate.*
 import rudiments.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // A `Regime` is the calendar in force as it changed through history: an ordered sequence of
 // segments, each handing over to the next at a Julian day number. Because the Julian day number is

--- a/lib/aviation/src/core/aviation.Rrule.scala
+++ b/lib/aviation/src/core/aviation.Rrule.scala
@@ -44,7 +44,7 @@ import spectacular.*
 import vacuous.*
 import denominative.*
 import symbolism.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // One `BYDAY` entry: a weekday, optionally with an ordinal — `3MO` (3rd Monday), `-1FR` (last
 // Friday), or a bare `TU` (every Tuesday in the period). The ordinal is meaningful only under

--- a/lib/aviation/src/core/aviation.timestampInternal.scala
+++ b/lib/aviation/src/core/aviation.timestampInternal.scala
@@ -50,7 +50,7 @@ import rudiments.*
 import spectacular.*
 import symbolism.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // A `Timestamp` is a zoneless point on the millisecond-since-JDN-epoch grid, packed into one
 // `Long` as `jdn*MillisPerDay + msOfDay`. Its precision is a phantom `Form` type member (set with

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -39,7 +39,7 @@ import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import abstractables.instantAbstractable
 import chronometries.unix
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Aviation Tests"):
   def run(): Unit =

--- a/lib/bitumen/src/core/bitumen.Tar.scala
+++ b/lib/bitumen/src/core/bitumen.Tar.scala
@@ -54,7 +54,7 @@ import hypotenuse.*
 import scala.caps
 import aperture.*
 import pneumatic.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tar:
   // TarRef → Tar.Ref

--- a/lib/bitumen/src/test/bitumen_test.scala
+++ b/lib/bitumen/src/test/bitumen_test.scala
@@ -42,7 +42,7 @@ import galilei.javaPath
 
 import charEncoders.asciiEncoder
 import strategies.throwUnsafely
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Bitumen Tests"):
   def run(): Unit =

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -38,7 +38,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class BadPerson(name: Int, age: Text) derives CanEqual
 

--- a/lib/burdock/src/core/burdock.Repackager.scala
+++ b/lib/burdock/src/core/burdock.Repackager.scala
@@ -56,7 +56,7 @@ import errorDiagnostics.emptyDiagnostics
 import parasite.probates.cancelProbate
 import parasite.threading.virtualThreading
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // The repackager. Reads the dependency hashes embedded by the compile-time macro
 // and partitions them: a hash that resolves to a public URL is externalized (a

--- a/lib/cacophony/src/test/cacophony_test.scala
+++ b/lib/cacophony/src/test/cacophony_test.scala
@@ -36,7 +36,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Cacophony Tests"):
 

--- a/lib/caesura/src/test/caesura.AccrualTests.scala
+++ b/lib/caesura/src/test/caesura.AccrualTests.scala
@@ -37,7 +37,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import dsvFormats.csvWithHeaderFormat
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class ARecord(name: Text, age: Int, height: Int) derives CanEqual
 

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -41,7 +41,7 @@ import errorDiagnostics.stackTracesDiagnostics
 
 import cataclysm.Css.Syntax
 import Css.Node.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Cataclysm Tests"):
   // ── CSS-structure helpers ───────────────────────────────────────────────

--- a/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
@@ -46,7 +46,7 @@ import symbolism.*
 import spectacular.*
 import vacuous.*
 import wisteria.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Contrastable:
   inline given derived: [entity] => entity is Contrastable = summonFrom:

--- a/lib/concordance/src/core/rudiments.Appendable.scala
+++ b/lib/concordance/src/core/rudiments.Appendable.scala
@@ -41,7 +41,7 @@ import prepositional.*
 // collection are gated on the acknowledgement of that linear cost, like `Countable`.
 object Appendable:
   // Appending to a `List` copies all of it: O(n), so the instance demands the marker.
-  given list: [element, list <: List[element]] => (complexity: LinearSizeComplexity)
+  given list: [element, list <: List[element]] => (complexity: Dysasymptotic.LinearSize)
   =>  list is Appendable by element =
     (list, element) => List.of(list.stdlib :+ element).asInstanceOf[list]
 
@@ -57,7 +57,7 @@ object Appendable:
     (set, element) => Set.of(set.stdlib + element).asInstanceOf[set]
 
   // The frozen array is rebuilt in full: O(n), so the instance demands the marker.
-  given frozenArray: [element: scala.reflect.ClassTag] => (complexity: LinearSizeComplexity)
+  given frozenArray: [element: scala.reflect.ClassTag] => (complexity: Dysasymptotic.LinearSize)
   =>  (Array[element]^{}) is Appendable by element =
     (array, element) => Array.frozen(array.readable :+ element)
 

--- a/lib/concordance/src/core/rudiments.Deindex.scala
+++ b/lib/concordance/src/core/rudiments.Deindex.scala
@@ -142,6 +142,15 @@ extension [element](sequence: List[element])
   // expanded body's type at each call site, where capture checking stamps a fresh `^` capture
   // variable on the union — which is spurious (and an error) when `element` is a pure type such as
   // `Text`. A plain method keeps the declared `Optional[element]` result and stays capture-clean.
-  // Only `prim` gets this ungated `List` special case (O(1)); `sec`/`ter` go through the
-  // `Dysasymptotic.LinearAccess`-gated `Applicable` route like every other positional access on `List`.
+  // `prim`/`sec`/`ter` get these ungated `List` special cases because their walk is bounded (at
+  // most three cells), so they are not dysasymptotic; positional access at an arbitrary ordinal
+  // goes through the `Dysasymptotic.LinearAccess`-gated `Applicable` route.
   def prim: Optional[element] = if sequence.stdlib.isEmpty then Unset else sequence.stdlib.head
+
+  def sec: Optional[element] =
+    val rest = sequence.stdlib.drop(1)
+    if rest.isEmpty then Unset else rest.head
+
+  def ter: Optional[element] =
+    val rest = sequence.stdlib.drop(2)
+    if rest.isEmpty then Unset else rest.head

--- a/lib/concordance/src/core/rudiments.Deindex.scala
+++ b/lib/concordance/src/core/rudiments.Deindex.scala
@@ -143,5 +143,5 @@ extension [element](sequence: List[element])
   // variable on the union — which is spurious (and an error) when `element` is a pure type such as
   // `Text`. A plain method keeps the declared `Optional[element]` result and stays capture-clean.
   // Only `prim` gets this ungated `List` special case (O(1)); `sec`/`ter` go through the
-  // `LinearAccessComplexity`-gated `Applicable` route like every other positional access on `List`.
+  // `Dysasymptotic.LinearAccess`-gated `Applicable` route like every other positional access on `List`.
   def prim: Optional[element] = if sequence.stdlib.isEmpty then Unset else sequence.stdlib.head

--- a/lib/concordance/src/core/rudiments.Prependable.scala
+++ b/lib/concordance/src/core/rudiments.Prependable.scala
@@ -47,7 +47,7 @@ object Prependable:
   given chain: [element] => Chain[element] is Prependable by element =
     (chain, element) => Chain.of(element #:: chain.stdlib)
 
-  given frozenArray: [element: scala.reflect.ClassTag] => (complexity: LinearSizeComplexity)
+  given frozenArray: [element: scala.reflect.ClassTag] => (complexity: Dysasymptotic.LinearSize)
   =>  (Array[element]^{}) is Prependable by element =
     (array, element) => Array.frozen(array.readable.prepended(element))
 

--- a/lib/contingency/src/test/contingency.CompositionTests.scala
+++ b/lib/contingency/src/test/contingency.CompositionTests.scala
@@ -36,7 +36,7 @@ import soundness.*
 import contingency.strategies.throwUnsafely
 
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class CErrorA(value: Int)(using Diagnostics) extends Error(m"composition error a: $value")
 case class CErrorB(value: Int)(using Diagnostics) extends Error(m"composition error b: $value")

--- a/lib/contingency/src/test/contingency_test.scala
+++ b/lib/contingency/src/test/contingency_test.scala
@@ -36,7 +36,7 @@ import soundness.*
 import contingency.strategies.throwUnsafely
 
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class VarargsError(arguments: Text*)(using Diagnostics) extends Error(m"varargs error")
 case class VarargsError2(argument: Text, arguments: Text*)(using Diagnostics) extends Error(m"varargs error 2")

--- a/lib/denominative/src/core/denominative.Applicable.scala
+++ b/lib/denominative/src/core/denominative.Applicable.scala
@@ -75,8 +75,8 @@ object Applicable:
 
     def access(sequence: Sequence[element], index: Ordinal): Result = sequence.stdlib(index.n0)
 
-  // Opaque `List`: positional access is O(n), so the instance is gated behind `LinearAccessComplexity`.
-  given list: [element] => (complexity: LinearAccessComplexity) => List[element] is Applicable:
+  // Opaque `List`: positional access is O(n), so the instance is gated behind `Dysasymptotic.LinearAccess`.
+  given list: [element] => (complexity: Dysasymptotic.LinearAccess) => List[element] is Applicable:
     type Self = List[element]
     type Operand = Ordinal
     type Result = element

--- a/lib/denominative/src/core/denominative.Countable.scala
+++ b/lib/denominative/src/core/denominative.Countable.scala
@@ -62,9 +62,9 @@ object Countable:
     def size(self: Option[element]): Int = if self == None then 0 else 1
     override def nil(self: Option[element]): Boolean = self.isEmpty
 
-  // `List#size` is O(n), so the `Countable` instance is gated behind `LinearSizeComplexity`; the O(1)
+  // `List#size` is O(n), so the `Countable` instance is gated behind `Dysasymptotic.LinearSize`; the O(1)
   // `nil`/`occupied` come from the ungated `Vacuiscible.list` instead.
-  given list: [element] => (complexity: LinearSizeComplexity) => List[element] is Countable:
+  given list: [element] => (complexity: Dysasymptotic.LinearSize) => List[element] is Countable:
     def size(self: List[element]): Int = self.stdlib.length
     override def nil(self: List[element]): Boolean = self.stdlib.isEmpty
 
@@ -90,9 +90,9 @@ object Countable:
     override def nil(self: HashMap[key, element]): Boolean = self.isEmpty
 
   // `Chain#length` forces the whole stream (and diverges on infinite ones), so the
-  // `Countable` instance is gated behind `UnboundedSizeComplexity`; the O(1) `nil` comes from the
+  // `Countable` instance is gated behind `Dysasymptotic.UnboundedSize`; the O(1) `nil` comes from the
   // ungated `Vacuiscible.lazyList` instead.
-  given lazyList: [element] => (complexity: UnboundedSizeComplexity) => Chain[element] is Countable:
+  given lazyList: [element] => (complexity: Dysasymptotic.UnboundedSize) => Chain[element] is Countable:
     def size(self: Chain[element]): Int = self.stdlib.length
     override def nil(self: Chain[element]): Boolean = self.stdlib.isEmpty
 

--- a/lib/denominative/src/core/denominative.Definable.scala
+++ b/lib/denominative/src/core/denominative.Definable.scala
@@ -76,7 +76,7 @@ object Definable:
 
   // Positional update on a linked list rebuilds its prefix, so — as with `Applicable.list` —
   // the instance is gated behind the linear-access acknowledgement rather than withheld.
-  given list: [element] => (complexity: LinearAccessComplexity) => List[element] is Definable:
+  given list: [element] => (complexity: Dysasymptotic.LinearAccess) => List[element] is Definable:
     type Self = List[element]
     type Operand = Ordinal
     type Result = element

--- a/lib/denominative/src/core/denominative.Definable.scala
+++ b/lib/denominative/src/core/denominative.Definable.scala
@@ -55,8 +55,12 @@ object Definable:
       else sequence
 
   // The rebuilt array is fresh, so freezing it is discharged by construction; the `ClassTag`
-  // is captured at the instance (as `Segmentable.iarray` does), not per call.
-  given frozenArray: [element: scala.reflect.ClassTag] => (Array[element]^{}) is Definable:
+  // is captured at the instance (as `Segmentable.iarray` does), not per call. A one-element
+  // update copies the whole array — dysasymptotic, like the frozen array's `Appendable`,
+  // `Prependable` and `Truncable` instances — so it is gated on the same acknowledgement.
+  given frozenArray: [element: scala.reflect.ClassTag]
+        => (complexity: Dysasymptotic.LinearSize)
+        => (Array[element]^{}) is Definable:
     type Self = Array[element]^{}
     type Operand = Ordinal
     type Result = element

--- a/lib/denominative/src/core/denominative.Terminable.scala
+++ b/lib/denominative/src/core/denominative.Terminable.scala
@@ -56,13 +56,13 @@ object Terminable:
   given indexedSeq: [element] => IndexedSeq[element] is Terminable by element = _.last
 
   // Walking to the end of a strict linked structure is O(n).
-  given list: [element, list <: List[element]] => (complexity: LinearSizeComplexity)
+  given list: [element, list <: List[element]] => (complexity: Dysasymptotic.LinearSize)
   =>  list is Terminable by element =
     _.stdlib.last
 
   // Forcing a lazy structure to its end diverges on an infinite one: unbounded, not merely
   // linear — the same gate `Chain.size` demands.
-  given lazyList: [element, chain <: Chain[element]] => (complexity: UnboundedSizeComplexity)
+  given lazyList: [element, chain <: Chain[element]] => (complexity: Dysasymptotic.UnboundedSize)
   =>  chain is Terminable by element =
     _.stdlib.last
 
@@ -84,17 +84,17 @@ object Truncable:
     _.init
 
   // Dropping the last element copies the whole spine.
-  given list: [element, list <: List[element]] => (complexity: LinearSizeComplexity)
+  given list: [element, list <: List[element]] => (complexity: Dysasymptotic.LinearSize)
   =>  list is Truncable to List[element] =
     value => List.of(value.stdlib.init)
 
   // The rebuilt array is fresh, so freezing it is discharged by construction.
   given frozenArray: [element: scala.reflect.ClassTag, array <: (Array[element]^{})]
-  =>  (complexity: LinearSizeComplexity)
+  =>  (complexity: Dysasymptotic.LinearSize)
   =>  array is Truncable to (Array[element]^{}) =
     value => Array.frozen(value.readable.init)
 
-  given lazyList: [element, chain <: Chain[element]] => (complexity: UnboundedSizeComplexity)
+  given lazyList: [element, chain <: Chain[element]] => (complexity: Dysasymptotic.UnboundedSize)
   =>  chain is Truncable to Chain[element] =
     value => Chain.of(value.stdlib.init)
 

--- a/lib/denominative/src/core/denominative.Vacuiscible.scala
+++ b/lib/denominative/src/core/denominative.Vacuiscible.scala
@@ -35,8 +35,8 @@ package denominative
 import prepositional.*
 
 // Emptiness alone, split from `Countable`: `nil` is O(1) for every collection, including those
-// (like `List`) whose `size` is O(n) and gated behind `LinearSizeComplexity`, and those (like
-// `Chain`) whose `size` may diverge and is gated behind `UnboundedSizeComplexity`. Types whose
+// (like `List`) whose `size` is O(n) and gated behind `Dysasymptotic.LinearSize`, and those (like
+// `Chain`) whose `size` may diverge and is gated behind `Dysasymptotic.UnboundedSize`. Types whose
 // size is cheap implement `Countable`, which extends this trait; `nil`-only consumers should demand
 // only `Vacuiscible`.
 object Vacuiscible:
@@ -46,13 +46,13 @@ object Vacuiscible:
   given countable: [self] => (countable: self is Countable) => self is Vacuiscible = countable
 
   // `List`'s emptiness is O(1), so it gets an ungated instance here rather than relying on
-  // the `LinearSizeComplexity`-gated `Countable.list` through the `countable` bridge; being more
+  // the `Dysasymptotic.LinearSize`-gated `Countable.list` through the `countable` bridge; being more
   // specific, it wins whenever both are in scope.
   given list: [element] => List[element] is Vacuiscible:
     def nil(self: List[element]): Boolean = self.stdlib.isEmpty
 
   // `Chain`'s emptiness is O(1) — it forces only the first node — so, like `List`, it gets an
-  // ungated instance here rather than reaching the `UnboundedSizeComplexity`-gated `Countable.lazyList`.
+  // ungated instance here rather than reaching the `Dysasymptotic.UnboundedSize`-gated `Countable.lazyList`.
   given lazyList: [element] => Chain[element] is Vacuiscible:
     def nil(self: Chain[element]): Boolean = self.stdlib.isEmpty
 

--- a/lib/denominative/src/core/denominative.dysasymptotics.scala
+++ b/lib/denominative/src/core/denominative.dysasymptotics.scala
@@ -32,26 +32,48 @@
                                                                                                   */
 package denominative
 
-// Gates for operations whose asymptotic cost is worse than their name implies. Each is a plain marker
-// type — *not* a capability — required in a `using` position by the instance that provides the
-// expensive operation. A downstream file opts into a whole class of such operations by importing the
-// matching enabler from the `asymptotics` package, e.g. `import asymptotics.linearSizeComplexity`,
-// which leaves every acknowledgement greppable. Because they carry no authority, they need none of
-// the `erased`/scope-function machinery a capability would; a harmless runtime residue is fine.
+// Gates for dysasymptotic operations. Each is a plain marker type — *not* a capability —
+// required in a `using` position by the instance that provides the expensive operation. A
+// downstream file opts into a whole class of such operations by importing the matching enabler
+// from the `dysasymptotics` package, e.g. `import dysasymptotics.linearSize`, which leaves every
+// acknowledgement greppable. Because they carry no authority, they need none of the
+// `erased`/scope-function machinery a capability would; a harmless runtime residue is fine.
+//
+// An operation's *semantic scope* is the portion of the data involved that the operation's
+// specification identifies as its subject: the data whose values must be observed, compared,
+// transformed, replaced, or produced in order to yield the specified result. Data that is merely
+// incorporated into the result unchanged, or traversed only to reach the subject, lies outside
+// the semantic scope.
+//
+// An operation on a particular data structure is *dysasymptotic* when its computational cost
+// grows more than logarithmically with some measure of the data outside its semantic scope —
+// typically the size of the containing structure, or the distance of the subject from the
+// structure's point of access — while the scope itself remains bounded with respect to that
+// measure. Dysasymptoticity is a property of the operation on that *representation*, not of the
+// operation in the abstract — `size` is free on `Sequence` but dysasymptotic on `List` — which
+// is why the gates sit on typeclass instances rather than on methods. Cost that merely tracks
+// the semantic scope is never gated, however large the scope grows: `fold` over an infinite
+// `Chain` diverges semantically, not dysasymptotically, whereas `Chain.size` (bounded scope,
+// unbounded cost) is dysasymptotic. (A few whole-scope operations on `List`, such as `iterate`
+// and `retrace`, are gated only because they route through `Countable`, whose `size` is
+// dysasymptotic there — a granularity artefact, not policy.)
+object Dysasymptotic:
+  // Computing the length of a strict linked structure — `List.size`, and the size-derived
+  // ordinal operations `gamut`/`limit`/`ult`/`pen`/`ant` — or rebuilding a structure wholesale
+  // for a bounded-scope change — `:+` on a `List`, and `:+`/`+:`/`lead`/`define` on a frozen
+  // array: O(n) in the data outside the scope.
+  sealed trait LinearSize
 
-// Computing the length of a strict linked structure — `List.size`, and the size-derived ordinal
-// operations `gamut`/`limit`/`ult`/`pen`/`ant` — each an O(n) traversal.
-sealed trait LinearSizeComplexity
+  // Positional access into a strict linked structure — indexing a `List` via `at` — a walk
+  // whose cost is the distance of the subject from the head. `prim`/`sec`/`ter` stay free:
+  // their distance is bounded.
+  sealed trait LinearAccess
 
-// Positional access into a strict linked structure — indexing a `List` via `at` (and `sec`/`ter`,
-// which call it) — an O(n) walk to the requested index. `prim`/first stays free (O(1) head access).
-sealed trait LinearAccessComplexity
+  // Computing the size of a lazy structure — `Chain.size` — which forces the whole stream and
+  // diverges on an infinite one: unbounded rather than merely linear.
+  sealed trait UnboundedSize
 
-// Computing the size of a lazy structure — `Chain.size` — which forces the whole stream and
-// diverges on an infinite one: unbounded rather than merely linear.
-sealed trait UnboundedSizeComplexity
-
-package asymptotics:
-  given linearSizeComplexity: LinearSizeComplexity = new LinearSizeComplexity {}
-  given linearAccessComplexity: LinearAccessComplexity = new LinearAccessComplexity {}
-  given unboundedSizeComplexity: UnboundedSizeComplexity = new UnboundedSizeComplexity {}
+package dysasymptotics:
+  given linearSize: Dysasymptotic.LinearSize = new Dysasymptotic.LinearSize {}
+  given linearAccess: Dysasymptotic.LinearAccess = new Dysasymptotic.LinearAccess {}
+  given unboundedSize: Dysasymptotic.UnboundedSize = new Dysasymptotic.UnboundedSize {}

--- a/lib/denominative/src/core/denominative_core.scala
+++ b/lib/denominative/src/core/denominative_core.scala
@@ -52,8 +52,8 @@ extension [populable: Vacuiscible](value: populable)
   inline def nil: Boolean = populable.nil(value)
 
 extension [countable: Countable](value: countable)
-  // `Countable` carries the asymptotics gating, so `list.size` demands the
-  // `LinearSizeComplexity` acknowledgement and `chain.size` the `UnboundedSizeComplexity` one,
+  // `Countable` carries the dysasymptotic gating, so `list.size` demands the
+  // `Dysasymptotic.LinearSize` acknowledgement and `chain.size` the `Dysasymptotic.UnboundedSize` one,
   // exactly as `gamut` and `limit` already do.
   inline def size: Int = countable.size(value)
 

--- a/lib/denominative/src/core/soundness_denominative_core.scala
+++ b/lib/denominative/src/core/soundness_denominative_core.scala
@@ -36,11 +36,10 @@ export
   denominative
   . { aka, capped, Countable, Vacuiscible, Applicable, Definable, Omissible, Terminable, Truncable, size, gamut, Interval, extent, iterate, prefix, nil, Ordinal, pare, Prim,
       Quat, Quin, retrace, Sec, Sen, Sept, Span, spot, Ter, u, z, Zerary, limit, ult, ant, pen,
-      LinearSizeComplexity, LinearAccessComplexity, UnboundedSizeComplexity }
+      Dysasymptotic }
 
-package asymptotics:
-  export denominative.asymptotics.{linearSizeComplexity, linearAccessComplexity,
-      unboundedSizeComplexity}
+package dysasymptotics:
+  export denominative.dysasymptotics.{linearSize, linearAccess, unboundedSize}
 
 package ordinalTextualizables:
   export

--- a/lib/denominative/src/test/denominative_test.scala
+++ b/lib/denominative/src/test/denominative_test.scala
@@ -304,9 +304,9 @@ object Tests extends Suite(m"Denominative Tests"):
       . assert(_ == 6)
 
     suite(m"Countable tests"):
-      // `List`'s `Countable` (hence `gamut`) is O(n), so it is gated behind `LinearSizeComplexity`,
+      // `List`'s `Countable` (hence `gamut`) is O(n), so it is gated behind `Dysasymptotic.LinearSize`,
       // enabled here for the whole suite by importing the acknowledgement.
-      import asymptotics.linearSizeComplexity
+      import dysasymptotics.linearSize
 
       test(m"a list's gamut spans all its elements"):
         val list: List[Int] = List(1, 2, 3)

--- a/lib/digression/src/core/digression.StackTrace.scala
+++ b/lib/digression/src/core/digression.StackTrace.scala
@@ -40,7 +40,7 @@ import spectacular.*
 import symbolism.*
 import vacuous.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object StackTrace:
   case class Method(className: Text, method: Text):

--- a/lib/dissonance/src/core/dissonance.Diff.scala
+++ b/lib/dissonance/src/core/dissonance.Diff.scala
@@ -42,7 +42,7 @@ import rudiments.*
 import turbulence.*
 import vacuous.*
 import symbolism.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Diff:
   given aggregable: (tactic: Tactic[Diff.Error])

--- a/lib/dissonance/src/core/dissonance.Redraft.scala
+++ b/lib/dissonance/src/core/dissonance.Redraft.scala
@@ -40,7 +40,7 @@ import rudiments.*
 import vacuous.*
 
 import Redraft.Error.Reason
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Redraft:
 

--- a/lib/dissonance/src/core/dissonance_core.scala
+++ b/lib/dissonance/src/core/dissonance_core.scala
@@ -38,7 +38,7 @@ import fulminate.*
 import symbolism.*
 import vacuous.*
 import rudiments.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 
 def evolve[element: ClassTag]

--- a/lib/enigmatic/src/core-jvm/enigmatic.JavaStdlibCrypto.scala
+++ b/lib/enigmatic/src/core-jvm/enigmatic.JavaStdlibCrypto.scala
@@ -42,7 +42,7 @@ import fulminate.*
 import gossamer.*
 import rudiments.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // The default `Crypto` provider, backed by the JDK's standard crypto (JCE /
 // `java.security`). This is the single home of all `javax.crypto.*` and

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -41,7 +41,7 @@ import errorDiagnostics.stackTracesDiagnostics
 import providers.javaStdlibProvider
 import crypto.permitDisallowedCrypto   // the suite deliberately exercises weak crypto
 import cloaks.cloakHeap
-import asymptotics.linearSizeComplexity
+import dysasymptotics.linearSize
 
 import alphabets.hexUpperCase
 

--- a/lib/escapade/src/test/escapade_test.scala
+++ b/lib/escapade/src/test/escapade_test.scala
@@ -40,7 +40,7 @@ import strategies.throwUnsafely
 import textMetrics.uniformMetric
 
 import WebColors.{Red, Yellow, Green, Blue, Tan}
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Escapade tests"):
   def run(): Unit =

--- a/lib/escritoire/src/core/escritoire.Tabulation.scala
+++ b/lib/escritoire/src/core/escritoire.Tabulation.scala
@@ -46,7 +46,7 @@ import rudiments.*
 import tessellate.*
 import vacuous.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tabulation:
   given printable: [text]

--- a/lib/exoskeleton/src/args/exoskeleton_args.scala
+++ b/lib/exoskeleton/src/args/exoskeleton_args.scala
@@ -39,7 +39,7 @@ import gossamer.*
 import rudiments.*
 import vacuous.*
 import symbolism.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 package interpreters:
   given simpleInterpreter: Interpreter:

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -49,7 +49,7 @@ import rudiments.*
 import spectacular.*
 import turbulence.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // The block's `result` type is the union of the singleton types of every `Status` it can
 // return, accumulated through the contravariant `Status.Registry` capability and kept precise

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -56,7 +56,7 @@ import quantitative.*
 import rudiments.*
 import vacuous.*
 import zephyrine.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Pdf:
   // A fresh, empty document: a catalog and an empty page tree, over which a creation scope's

--- a/lib/facsimile/src/core/facsimile.PdfWriter.scala
+++ b/lib/facsimile/src/core/facsimile.PdfWriter.scala
@@ -43,7 +43,7 @@ import hieroglyph.*
 import rudiments.*
 import vacuous.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // Serialises a write overlay as a PDF incremental update (ISO 32000-2 §7.5.6): the changed
 // and new objects, a cross-reference section covering just them, and a trailer chaining

--- a/lib/facsimile/src/core/facsimile.Xref.scala
+++ b/lib/facsimile/src/core/facsimile.Xref.scala
@@ -38,7 +38,7 @@ import gossamer.*
 import rudiments.*
 import vacuous.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 private[facsimile] object Xref:
   enum Entry:

--- a/lib/facsimile/src/core/facsimile_editing.scala
+++ b/lib/facsimile/src/core/facsimile_editing.scala
@@ -41,7 +41,7 @@ import phoenicia.*
 import quantitative.*
 import rudiments.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // The low-level write surface. These operations are extension methods on the write-granted
 // handle — `(Pdf & Granting[Grant.Write])^`, as galilei gates its `write` — so they exist

--- a/lib/facsimile/src/test/facsimile_test.scala
+++ b/lib/facsimile/src/test/facsimile_test.scala
@@ -49,7 +49,7 @@ import _root_.java.util.zip as juz
 import _root_.javax.crypto as jc
 import _root_.javax.crypto.spec as jcs
 import pneumatic.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // These fixtures assemble PDF and font byte streams from many small pieces. A `Concatenable`
 // result is fresh, so joining two `Data` values means freezing once at the join; this keeps the

--- a/lib/fulminate/src/test/fulminate_test.scala
+++ b/lib/fulminate/src/test/fulminate_test.scala
@@ -33,7 +33,7 @@
 package fulminate
 
 import soundness.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Fulminate Tests"):
   def run(): Unit =

--- a/lib/gesticulate/src/core/gesticulate.Multipart.scala
+++ b/lib/gesticulate/src/core/gesticulate.Multipart.scala
@@ -41,7 +41,7 @@ import fulminate.*
 import gossamer.*
 import prepositional.*
 import rudiments.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 import turbulence.*
 import vacuous.*
 import zephyrine.*

--- a/lib/gesticulate/src/core/gesticulate.internal.scala
+++ b/lib/gesticulate/src/core/gesticulate.internal.scala
@@ -48,7 +48,7 @@ import vacuous.*
 
 import caseSensitivity.caseInsensitive
 import proximities.levenshteinProximity
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object internal:
   // Validation runs at macro-expansion time, so it must not reflectively

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -43,7 +43,7 @@ import soundness.*
 
 import textMetrics.uniformMetric
 import caseSensitivity.caseSensitive
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class Person(name: Text, age: Int)
 
@@ -315,12 +315,12 @@ object Tests extends Suite(m"Gossamer Tests"):
       . assert(_ == t"lo")
 
       test(m"from slices a List by ordinal"):
-        import asymptotics.linearSizeComplexity
+        import dysasymptotics.linearSize
         (List(0, 1, 2, 3, 4): List[Int]).from(Ter)
       . assert(_ == List(2, 3, 4))
 
       test(m"after slices a List by ordinal"):
-        import asymptotics.linearSizeComplexity
+        import dysasymptotics.linearSize
         (List(0, 1, 2, 3, 4): List[Int]).after(Ter)
       . assert(_ == List(3, 4))
 

--- a/lib/harlequin/src/core/harlequin.Lexis.scala
+++ b/lib/harlequin/src/core/harlequin.Lexis.scala
@@ -37,7 +37,7 @@ import denominative.*
 import gossamer.*
 import prophesy.*
 import rudiments.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 import vacuous.*
 
 // Maps Harlequin's token stream onto Prophesy's `Lexeme` alphabet, and extracts the reversed

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -49,7 +49,7 @@ import denominative.*
 import gossamer.*
 import hellenism.*
 import rudiments.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 import stenography.*
 import vacuous.*
 import symbolism.*

--- a/lib/harlequin/src/test/harlequin_test.scala
+++ b/lib/harlequin/src/test/harlequin_test.scala
@@ -37,7 +37,7 @@ import scala.language.dynamics
 import soundness.*
 
 import ambience.systems.javaSystem
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // A `Dynamic` type with a `Completable` companion, exercising the dynamic-completions route: its
 // valid member names are not symbols, so only the companion can offer them. The companion is

--- a/lib/hieroglyph/src/test/hieroglyph_test.scala
+++ b/lib/hieroglyph/src/test/hieroglyph_test.scala
@@ -39,7 +39,7 @@ import soundness.*
 import strategies.throwUnsafely
 import textMetrics.eastAsianScriptsMetric
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class DecodeIssues(items: List[(Int, CharDecoder.Error)] = Nil)(using Diagnostics)
 extends Error(m"${items.size} decoding issues"):

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -62,7 +62,7 @@ import turbulence.*
 import typonym.*
 import vacuous.*
 import zephyrine.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Html extends Tag.Container
   ( label       = "html",

--- a/lib/hyperbole/src/stacks/hyperbole.StackResolver.scala
+++ b/lib/hyperbole/src/stacks/hyperbole.StackResolver.scala
@@ -52,7 +52,7 @@ import vacuous.*
 import StackTrace.Frame.Kind
 import charDecoders.utf8Decoder
 import textSanitizers.skipSanitizer
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object StackResolver:
   // The compiled name cannot say which definition a frame came from, but it can say what kind of

--- a/lib/hypotenuse/src/core/hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse_core.scala
@@ -48,7 +48,7 @@ import prepositional.*
 import rudiments.*
 import symbolism.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 export hypotenuse.internal.{B8, B16, B32, B64, S8, S16, S32, S64, U8, U16, U32, U64, F32, F64}
 

--- a/lib/jacinta/src/core/jacinta.internal.scala
+++ b/lib/jacinta/src/core/jacinta.internal.scala
@@ -57,7 +57,7 @@ import vacuous.*
 import wisteria.{Discriminable, Variant}
 import zephyrine.*
 import symbolism.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object internal:
 

--- a/lib/jacinta/src/test/jacinta.ParserTests.scala
+++ b/lib/jacinta/src/test/jacinta.ParserTests.scala
@@ -54,7 +54,7 @@ import filesystemOptions.dereferenceSymlinks.enabled
 import filesystemOptions.createNonexistentParents.enabled
 
 import filesystemBackends.virtualMachineFilesystem
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object ParserTests extends Suite(m"Jacinta JSON parser tests"):
   def run(): Unit =

--- a/lib/jacinta/src/test/jacinta.ValidationTests.scala
+++ b/lib/jacinta/src/test/jacinta.ValidationTests.scala
@@ -38,7 +38,7 @@ import soundness.*
 import charEncoders.utf8Encoder
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class VPerson(name: Text, age: Int, email: Text) derives CanEqual
 case class VAddress(street: Text, city: Text, zip: Text) derives CanEqual

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -46,7 +46,7 @@ import formatting.compactJsonFormatting
 
 import discriminables.jsonByKindDiscriminable
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class Foo(x: Int, y: Text) derives CanEqual
 

--- a/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
@@ -47,7 +47,7 @@ import rudiments.*
 import vacuous.*
 
 import Regex.Error.Reason.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Regex:
   private[kaleidoscope] val cache: TrieMap[String, jur.Pattern] = TrieMap()

--- a/lib/kaleidoscope/src/core/kaleidoscope.internal.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.internal.scala
@@ -48,7 +48,7 @@ import praxinoscope.*
 import prepositional.*
 import vacuous.*
 
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object internal:
   transparent inline def expandRegexJvm(inline context: StringContext): Any =

--- a/lib/legerdemain/src/test/legerdemain_test.scala
+++ b/lib/legerdemain/src/test/legerdemain_test.scala
@@ -36,7 +36,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class QPerson(name: Text, email: Text) derives CanEqual
 case class QTeam(leader: QPerson, title: Text) derives CanEqual

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -62,7 +62,7 @@ import zephyrine.*
 
 import Protobuf.Error.Reason
 import fulminate.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 trait Protobuf2:
   this: Protobuf.type =>

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -55,7 +55,7 @@ import columnAttenuation.ignoreAttenuation
 import tableStyles.minimalTableStyle
 import textMetrics.uniformMetric
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Bytecode:
   given teletypeable: (palette: BytecodePalette) => Bytecode is Teletypeable = bytecode =>

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -47,7 +47,7 @@ import strategies.throwUnsafely
 import systems.javaSystem
 import temporaryDirectories.systemTemporaryDirectory
 import threading.platformThreading
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Mandible tests"):
 

--- a/lib/metamorphose/src/core/metamorphose.Factoradic.scala
+++ b/lib/metamorphose/src/core/metamorphose.Factoradic.scala
@@ -36,7 +36,7 @@ import scala.annotation.*
 
 import contingency.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Factoradic:
   def apply(sequence: List[Int]): Factoradic raises Permutation.Error =

--- a/lib/metamorphose/src/core/metamorphose.Permutation.scala
+++ b/lib/metamorphose/src/core/metamorphose.Permutation.scala
@@ -42,7 +42,7 @@ import rudiments.*
 import vacuous.*
 import fulminate.*
 import symbolism.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Permutation:
   def bySize(n: Int): Chain[Permutation] = Chain.range[BigInt](0, Factorial(n)).map: i =>
@@ -105,7 +105,7 @@ case class Permutation(factoradic: Factoradic):
   def apply(n: Int): Int =
     // A permutation fixes every point outside its domain; `List` positional access is
     // O(n), accepted here explicitly through the asymptotic gate.
-    import denominative.asymptotics.linearAccessComplexity
+    import denominative.dysasymptotics.linearAccess
     expansion(Ordinal.zerary(n)).or(n)
 
   def apply[element](sequence: List[element]): List[element] raises Permutation.Error =

--- a/lib/nomenclature/src/lexicon/nomenclature.Vocabulary.scala
+++ b/lib/nomenclature/src/lexicon/nomenclature.Vocabulary.scala
@@ -43,7 +43,7 @@ import zephyrine.*
 import charDecoders.utf8Decoder
 import textSanitizers.skipSanitizer
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Vocabulary:
   def apply[source: Streamable by Data over Credit, transport](adjectives: source, animals: source)

--- a/lib/octogenarian/src/core/octogenarian.Git.scala
+++ b/lib/octogenarian/src/core/octogenarian.Git.scala
@@ -48,7 +48,7 @@ import kaleidoscope.*
 import nomenclature.*
 import prepositional.*
 import rudiments.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 import serpentine.*
 import symbolism.*
 import turbulence.*

--- a/lib/octogenarian/src/test/octogenarian_test.scala
+++ b/lib/octogenarian/src/test/octogenarian_test.scala
@@ -59,7 +59,7 @@ import filesystemOptions.deleteRecursively.enabled
 import gitCommands.environmentDefaultGitCommand
 
 import filesystemBackends.virtualMachineFilesystem
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Octogenarian Tests"):
   def run(): Unit =

--- a/lib/panopticon/src/core/panopticon.Optical.scala
+++ b/lib/panopticon/src/core/panopticon.Optical.scala
@@ -40,7 +40,7 @@ import fulminate.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
-import denominative.asymptotics.{linearSizeComplexity, linearAccessComplexity}
+import denominative.dysasymptotics.{linearSize, linearAccess}
 
 object Optical:
   given ordinalList: [element] => Ordinal is Optical from List[element] onto element =

--- a/lib/polysyllabic/src/bench/polysyllabic.Benchmarks.scala
+++ b/lib/polysyllabic/src/bench/polysyllabic.Benchmarks.scala
@@ -53,7 +53,7 @@ import turbulence.*
 import vacuous.*
 
 import hyphenations.englishHyphenation
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 import denominative.*
 
 object Benchmarks extends Suite(m"Polysyllabic benchmarks"):

--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -56,7 +56,7 @@ import vacuous.*
 import luminosity.darkBrightness
 import termcaps.environmentTermcap
 import themes.solarizedTheme
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 abstract class Suite(suiteName: Message) extends Testable(suiteName):
   val suiteIo = safely(stdios.virtualMachineStdio).or(panic(m"the JVM stdio is always available"))

--- a/lib/probably/src/core/probably.Documenting.scala
+++ b/lib/probably/src/core/probably.Documenting.scala
@@ -41,7 +41,7 @@ import rudiments.*
 import vacuous.*
 import denominative.*
 import symbolism.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // The single structural pass over a report: builds the renderer-agnostic `Doc.Document`
 // consumed by both output modes. All decisions about WHAT appears in a report are made

--- a/lib/probably/src/core/probably.Entry.scala
+++ b/lib/probably/src/core/probably.Entry.scala
@@ -38,7 +38,7 @@ import scala.collection.mutable as scm
 import anticipation.*
 import rudiments.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Entry:
   enum Kind:

--- a/lib/probably/src/core/probably.Runner.scala
+++ b/lib/probably/src/core/probably.Runner.scala
@@ -48,7 +48,7 @@ import stdios.virtualMachineStdio
 import termcaps.environmentTermcap
 import beneficence.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Runner:
   private[probably] val harnessThreadLocal: ThreadLocal[Option[Harness]] = ThreadLocal()

--- a/lib/probably/src/core/probably.Selection.scala
+++ b/lib/probably/src/core/probably.Selection.scala
@@ -41,7 +41,7 @@ import gossamer.*
 import rudiments.*
 import vacuous.*
 import symbolism.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Selection:
   enum Term:

--- a/lib/probably/src/core/probably.Spread.scala
+++ b/lib/probably/src/core/probably.Spread.scala
@@ -39,7 +39,7 @@ import chiaroscuro.*
 import distillate.*
 import vacuous.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // A test spread over the domain of one axis: its body runs once per axis value, and each
 // verdict is recorded at that value’s coordinate of a single named test. A partial body

--- a/lib/probably/src/core/probably.Strain.scala
+++ b/lib/probably/src/core/probably.Strain.scala
@@ -37,7 +37,7 @@ import anticipation.*
 import rudiments.*
 import gossamer.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Strain:
   given inclusion: Inclusion[Report, Strain]:

--- a/lib/probably/src/coverage/probably.Coverage.scala
+++ b/lib/probably/src/coverage/probably.Coverage.scala
@@ -38,7 +38,7 @@ import scala.collection.mutable.BitSet
 import scala.io.*
 
 import anticipation.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 import distillate.*
 import gossamer.*
 import rudiments.*

--- a/lib/profanity/src/core/profanity.LineEditor.scala
+++ b/lib/profanity/src/core/profanity.LineEditor.scala
@@ -42,7 +42,7 @@ import hieroglyph.*, textMetrics.wideCharacterWidthMetric
 import rudiments.*
 import spectacular.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object LineEditor:
   // Whether the editor is a single line (Enter submits) or accepts multiple lines.

--- a/lib/profanity/src/test/profanity_test.scala
+++ b/lib/profanity/src/test/profanity_test.scala
@@ -49,7 +49,7 @@ import backstops.silentBackstop
 import probates.cancelProbate
 
 import Shell.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Profanity Tests"):
   def run(): Unit =

--- a/lib/punctuation/src/ansi/punctuation.Renderer.scala
+++ b/lib/punctuation/src/ansi/punctuation.Renderer.scala
@@ -41,7 +41,7 @@ import hieroglyph.textMetrics.wideCharacterWidthMetric
 import polysyllabic.*
 import prepositional.*
 import rudiments.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 import symbolism.*
 import tessellate.*
 import vacuous.*

--- a/lib/punctuation/src/bench/punctuation.Benchmarks.scala
+++ b/lib/punctuation/src/bench/punctuation.Benchmarks.scala
@@ -51,7 +51,7 @@ import symbolism.*
 import temporaryDirectories.systemTemporaryDirectory
 import turbulence.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 import denominative.*
 
 object Benchmarks extends Suite(m"Punctuation benchmarks"):

--- a/lib/punctuation/src/test/punctuation_test.scala
+++ b/lib/punctuation/src/test/punctuation_test.scala
@@ -38,7 +38,7 @@ import strategies.throwUnsafely
 
 import doms.html.whatwg
 import classloaders.systemClassloader
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Punctuation tests"):
   def run(): Unit =

--- a/lib/rudiments/src/core/soundness_rudiments_core.scala
+++ b/lib/rudiments/src/core/soundness_rudiments_core.scala
@@ -114,11 +114,19 @@ extension [self](value: self)(using omissible: denominative.Omissible { type Sel
   def omit(index: omissible.Operand): self = omissible.omit(value, index)
 
 extension [element](sequence: proscenium.List[element])
-  // Mirrors the ungated `List` special case in `rudiments.Deindex` (same non-`inline`
-  // rationale); duplicated because `rudiments.prim` resolves to the `Applicable`-bound
+  // Mirrors the ungated `List` special cases in `rudiments.Deindex` (same non-`inline`
+  // rationale); duplicated because `rudiments.prim` (etc.) resolves to the `Applicable`-bound
   // overload when referenced qualified.
   def prim: vacuous.Optional[element] =
     if sequence.stdlib.isEmpty then vacuous.Unset else sequence.stdlib.head
+
+  def sec: vacuous.Optional[element] =
+    val rest = sequence.stdlib.drop(1)
+    if rest.isEmpty then vacuous.Unset else rest.head
+
+  def ter: vacuous.Optional[element] =
+    val rest = sequence.stdlib.drop(2)
+    if rest.isEmpty then vacuous.Unset else rest.head
 
 extension [self](inline value: self)
   (using applicable: denominative.Applicable { type Self = self; type Operand = denominative.Ordinal })

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -33,7 +33,7 @@
 package rudiments
 
 import soundness.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class Person(name: Text, age: Int)
 
@@ -147,7 +147,7 @@ object Tests extends Suite(m"Rudiments Tests"):
       . assert(_ == Unset)
 
       test(m"last on an occupied chain demands the unbounded acknowledgement"):
-        import denominative.asymptotics.unboundedSizeComplexity
+        import denominative.dysasymptotics.unboundedSize
         val xs: Chain[Int] = Chain(1, 2, 3)
         xs.last
       . assert(_ == 3)
@@ -335,7 +335,7 @@ object Tests extends Suite(m"Rudiments Tests"):
 
     suite(m"Attested tests"):
       test(m"an attested ordinal reads bare, with no Optional"):
-        import denominative.asymptotics.linearAccessComplexity
+        import denominative.dysasymptotics.linearAccess
         val xs: proscenium.List[Int] = proscenium.List(10, 20, 30)
 
         unsafely:
@@ -397,13 +397,13 @@ object Tests extends Suite(m"Rudiments Tests"):
       . assert(_ == Map(t"a" -> 1, t"b" -> 2))
 
       test(m"define on a list demands the linear-access acknowledgement"):
-        import denominative.asymptotics.linearAccessComplexity
+        import denominative.dysasymptotics.linearAccess
         val xs: List[Int] = List(1, 2, 3)
         xs.define(Sec, 20)
       . assert(_ == List(1, 20, 3))
 
       test(m"define outside a list returns it unchanged"):
-        import denominative.asymptotics.linearAccessComplexity
+        import denominative.dysasymptotics.linearAccess
         val xs: List[Int] = List(1, 2, 3)
         xs.define(Quat, 40)
       . assert(_ == List(1, 2, 3))

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -333,6 +333,29 @@ object Tests extends Suite(m"Rudiments Tests"):
             : proscenium.List[Int])
       . assert(_ == true)
 
+    suite(m"Bounded positional access tests"):
+      // No `linearAccess` acknowledgement in scope: `prim`/`sec`/`ter` walk at most three
+      // cells, so they are not dysasymptotic on `List` and stay ungated.
+      test(m"sec on a list is ungated"):
+        val xs: List[Int] = List(10, 20, 30)
+        xs.sec
+      . assert(_ == 20)
+
+      test(m"ter on a list is ungated"):
+        val xs: List[Int] = List(10, 20, 30)
+        xs.ter
+      . assert(_ == 30)
+
+      test(m"sec on a single-element list is unset"):
+        val xs: List[Int] = List(10)
+        xs.sec
+      . assert(_ == Unset)
+
+      test(m"ter on a two-element list is unset"):
+        val xs: List[Int] = List(10, 20)
+        xs.ter
+      . assert(_ == Unset)
+
     suite(m"Attested tests"):
       test(m"an attested ordinal reads bare, with no Optional"):
         import denominative.dysasymptotics.linearAccess
@@ -409,6 +432,7 @@ object Tests extends Suite(m"Rudiments Tests"):
       . assert(_ == List(1, 2, 3))
 
       test(m"define replaces a frozen array element"):
+        import denominative.dysasymptotics.linearSize
         val xs: Array[Int]^{} = Array.tabulate(3)(_ + 1)
         xs.define(Prim, 10).to[List]
       . assert(_ == List(10, 2, 3))

--- a/lib/savagery/src/test/savagery_test.scala
+++ b/lib/savagery/src/test/savagery_test.scala
@@ -38,7 +38,7 @@ import errorDiagnostics.stackTracesDiagnostics
 import iridescence.WebColors.{Red, Blue, Green, Black, White}
 import strategies.throwUnsafely
 import xylophone.XmlSchema
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Savagery tests"):
   def run(): Unit =

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -42,7 +42,7 @@ import charEncoders.utf8Encoder
 import webserverErrorPages.minimalErrorPage
 import threading.virtualThreading
 import probates.awaitProbate
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // A value served as a streaming `text/plain` body: `Servable` synthesises an
 // `Http.Body.Flowing` whose source runs the text stream through the char-encoder

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -64,7 +64,7 @@ import systems.javaSystem
 import threading.platformThreading
 import workingDirectories.javaWorkingDirectory
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice) extends Rig:
   type Result[output] = output

--- a/lib/sedentary/src/core/sedentary.Profile.scala
+++ b/lib/sedentary/src/core/sedentary.Profile.scala
@@ -50,7 +50,7 @@ import jacinta.*
 import parasite.*
 import prepositional.*
 import rudiments.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 import probably.*
 import serpentine.*
 import superlunary.*

--- a/lib/serpentine/src/core/serpentine.Path.scala
+++ b/lib/serpentine/src/core/serpentine.Path.scala
@@ -45,7 +45,7 @@ import fulminate.*
 import gossamer.*
 import prepositional.*
 import rudiments.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 import spectacular.*
 import symbolism.*
 import vacuous.*

--- a/lib/stratiform/src/core/stratiform.Mutation.scala
+++ b/lib/stratiform/src/core/stratiform.Mutation.scala
@@ -42,7 +42,7 @@ import vacuous.*
 import Mutation.Error.Reason
 import fulminate.*
 import rudiments.`:+`
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // Primitive presentation-preserving mutations per §22.2. Each op is a
 // local rewrite addressed by a Tel.Pointer; surrounding atoms, comments,

--- a/lib/stratiform/src/core/stratiform.Positional.scala
+++ b/lib/stratiform/src/core/stratiform.Positional.scala
@@ -35,7 +35,7 @@ package stratiform
 import anticipation.*
 import contingency.*
 import rudiments.`:+`
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // The schema-free §19.2/§20.2 atom phase shared by both derivation engines
 // (issue #1694). A derived product codec approximates the schema's member

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -57,7 +57,7 @@ import wisteria.*
 import zephyrine.*
 import denominative.*
 import fulminate.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // Presentation model from §17 of the TEL specification. The Scala AST is
 // structurally identical to the reference implementation's AST so that

--- a/lib/stratiform/src/core/stratiform.Telp.scala
+++ b/lib/stratiform/src/core/stratiform.Telp.scala
@@ -39,7 +39,7 @@ import gossamer.*
 import prepositional.*
 import vacuous.*
 import rudiments.`:+`
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // TELP, the TEL Path companion specification: a schema-aware textual path
 // over the semantic model. The first character of a path selects its

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -37,7 +37,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import charEncoders.utf8Encoder
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class APerson(name: Text, age: Int, email: Text) derives CanEqual
 case class AContact(person: APerson, company: Text) derives CanEqual

--- a/lib/stratiform/src/test/stratiform.CodecTests.scala
+++ b/lib/stratiform/src/test/stratiform.CodecTests.scala
@@ -36,7 +36,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import charEncoders.utf8Encoder
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // Scalar encodings (spec §21.7): the codec interface and its laws C1–C3,
 // the binding mechanism, validation-time E312/E313, and the BinTEL

--- a/lib/stratiform/src/test/stratiform.EquivalenceTests.scala
+++ b/lib/stratiform/src/test/stratiform.EquivalenceTests.scala
@@ -38,7 +38,7 @@ import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import charEncoders.utf8Encoder
 import Tel.given
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // The differential property issue #1694 proposes: for a document and a schema
 // derived from the corresponding Scala type, decoding through the codecs must

--- a/lib/stratiform/src/test/stratiform.KeyTests.scala
+++ b/lib/stratiform/src/test/stratiform.KeyTests.scala
@@ -36,7 +36,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import charEncoders.utf8Encoder
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // Key fields (spec §20): the `key` flag on `Field`, its schema validity
 // constraints (E219–E221, §20.1), the monotone-OR layer merge (§20.3), the

--- a/lib/stratiform/src/test/stratiform.SchemaCorpusTests.scala
+++ b/lib/stratiform/src/test/stratiform.SchemaCorpusTests.scala
@@ -36,7 +36,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import charEncoders.utf8Encoder
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // Corpus-driven schema-validity (E2xx) and validation (E3xx) conformance:
 // the sibling of `stratiform_test.scala`'s "Negative corpus (E1xx parsing)"

--- a/lib/stratiform/src/test/stratiform.TelpTests.scala
+++ b/lib/stratiform/src/test/stratiform.TelpTests.scala
@@ -36,7 +36,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import charEncoders.utf8Encoder
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // TELP (the TEL Path companion specification): grammar and identity (§3),
 // resolution over the semantic model (§4), the all-digit shadowing rule

--- a/lib/superlunary/src/core/superlunary.References.scala
+++ b/lib/superlunary/src/core/superlunary.References.scala
@@ -40,7 +40,7 @@ import prepositional.*
 import rudiments.*
 import vacuous.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object References:
   def apply[transport <: Object](): References over transport = new References:

--- a/lib/ultimatum/src/core/ultimatum.Form.scala
+++ b/lib/ultimatum/src/core/ultimatum.Form.scala
@@ -40,7 +40,7 @@ import profanity.*
 import rudiments.*
 import symbolism.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Form:
   // One derived leaf of the live pane tree: the pane itself, the rectangle the last solve

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -41,7 +41,7 @@ import rudiments.*
 import spectacular.*
 import symbolism.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // Construct a leaf panel: a fractional weight and optional per-axis bounds,
 // plus deferred `content` that runs (with its `Extent` in context) once the

--- a/lib/ultimatum/src/gauges/ultimatum.Dial.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Dial.scala
@@ -42,7 +42,7 @@ import spectacular.*
 import symbolism.*
 import tessellate.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Dial:
   private val levels: Text = t"▁▂▃▄▅▆▇█"

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -35,7 +35,7 @@ package ultimatum
 import java.io as ji
 
 import soundness.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Ultimatum Tests"):
   def run(): Unit =

--- a/lib/ulysses/src/core/ulysses.Palimpsest.scala
+++ b/lib/ulysses/src/core/ulysses.Palimpsest.scala
@@ -37,7 +37,7 @@ import denominative.*
 import fulminate.*
 import rudiments.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Palimpsest:
   // §3 encoding. Build a body of length `cadence.bodyLength(n)`, XOR each

--- a/lib/urticose/src/core/urticose.internal.scala
+++ b/lib/urticose/src/core/urticose.internal.scala
@@ -54,7 +54,7 @@ import vacuous.*
 import IpAddress.Error.Reason, Reason.*
 import denominative.*
 import symbolism.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object internal:
   // Resolve `Ipv4` to the nested opaque type directly rather than via the

--- a/lib/urticose/src/test/urticose_test.scala
+++ b/lib/urticose/src/test/urticose_test.scala
@@ -36,7 +36,7 @@ import soundness.*
 import fulminate.errorDiagnostics.stackTracesDiagnostics
 import strategies.throwUnsafely
 import urticose.teletypeables.urlTeletype
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Urticose tests"):
   given palette: UrlPalette = new Palette:

--- a/lib/wisteria/src/core/wisteria.internal.scala
+++ b/lib/wisteria/src/core/wisteria.internal.scala
@@ -41,7 +41,7 @@ import denominative.*
 import gigantism.*
 import rudiments.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object internal:
   inline def default[product, field](index: Int): Optional[field] =

--- a/lib/wisteria/src/test/wisteria_test.scala
+++ b/lib/wisteria/src/test/wisteria_test.scala
@@ -37,7 +37,7 @@ import scala.{compiletime, math}
 import soundness.*
 
 import scala.language.dynamics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Wisteria tests"):
 

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -44,7 +44,7 @@ import prepositional.*
 import rudiments.*
 import vacuous.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Xenophile:
 

--- a/lib/xenophile/src/kotlin/xenophile.KotlinDialect.scala
+++ b/lib/xenophile/src/kotlin/xenophile.KotlinDialect.scala
@@ -44,7 +44,7 @@ import rudiments.*
 import vacuous.*
 import denominative.*
 import symbolism.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // The Kotlin grammar: self-resolving, per foreign type name, from the `@Metadata` annotation of
 // the identically-named class on the compile classpath (which the macro classloader sees),

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -47,7 +47,7 @@ import prepositional.*
 import rudiments.*
 import vacuous.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // The terminal materializer for the WIT ecosystem: turns a fully-applied `Foreign` invocation into
 // a real Wasm Component Model import call (`scala.scalajs.wit.witImportCall`, lowered by the

--- a/lib/xylophone/src/core/xylophone.XPath.scala
+++ b/lib/xylophone/src/core/xylophone.XPath.scala
@@ -44,7 +44,7 @@ import prepositional.*
 import vacuous.*
 import zephyrine.*
 import rudiments.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // `XPath` is a `Format`, so a malformed *expression* is a `Parse.Error` like any other
 // parse failure, carrying the offset at which it was detected. `XPath.Error` is reserved

--- a/lib/xylophone/src/test/xylophone.DecoderTests.scala
+++ b/lib/xylophone/src/test/xylophone.DecoderTests.scala
@@ -38,7 +38,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import parsing.trackPositions
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class DPerson(name: Text, age: Int, email: Text) derives CanEqual
 case class DContact(person: DPerson, company: Text) derives CanEqual

--- a/lib/xylophone/src/test/xylophone.DirectParsingTests.scala
+++ b/lib/xylophone/src/test/xylophone.DirectParsingTests.scala
@@ -37,7 +37,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // Fixtures for the direct-parsing suite: a flat product, a nested product,
 // `@attribute` fields (plain and `@name`-renamed), `@name`-renamed elements,

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -68,7 +68,7 @@ import beneficence.*
 import serpentine.*
 import symbolism.*
 import urticose.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // `Yaml2` is only ever mixed into the `Yaml` object; pinning its self type to `Yaml.type` makes
 // `this` a stable singleton, so the `provide`-wrapped decoder SAMs defined here do not capture an

--- a/lib/ypsiloid/src/core/ypsiloid.internal.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.internal.scala
@@ -53,7 +53,7 @@ import rudiments.*
 import vacuous.*
 import zephyrine.*
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 // `y"…"` interpolator and extractor macros.
 //

--- a/lib/ypsiloid/src/test/ypsiloid.AccrualTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.AccrualTests.scala
@@ -37,7 +37,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class APerson(name: Text, age: Int, email: Text) derives CanEqual
 case class AContact(person: APerson, company: Text) derives CanEqual

--- a/lib/ypsiloid/src/test/ypsiloid.DefaultTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.DefaultTests.scala
@@ -38,7 +38,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import discriminables.yamlByTypeDiscriminable
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class DPerson(name: Text, age: Int, email: Text) derives CanEqual
 case class DContact(person: DPerson, company: Text) derives CanEqual

--- a/lib/ypsiloid/src/test/ypsiloid.FocusTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.FocusTests.scala
@@ -37,7 +37,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class FPerson(name: Text, age: Int, email: Text) derives CanEqual
 case class FAddress(street: Text, city: Text, zip: Text) derives CanEqual

--- a/lib/ypsiloid/src/test/ypsiloid_conformance.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_conformance.scala
@@ -64,7 +64,7 @@ import strategies.throwUnsafely
 import charEncoders.utf8Encoder
 
 import denominative.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Conformance:
   // Tags whose test cases exercise YAML features outside the Ypsiloid

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -37,7 +37,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 case class Person(name: Text, age: Int) derives CanEqual
 case class Inner(n: Int) derives CanEqual

--- a/lib/zeppelin/src/core/zeppelin.Zipfile.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zipfile.scala
@@ -55,7 +55,7 @@ import spectacular.*
 import turbulence.*
 import zephyrine.*
 import vacuous.*
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Zipfile:
   private val u32Max: Long = 0xffffffffL

--- a/lib/zeppelin/src/test/zeppelin_test.scala
+++ b/lib/zeppelin/src/test/zeppelin_test.scala
@@ -50,7 +50,7 @@ import _root_.java.io as ji
 import _root_.java.util.zip as juz
 
 import filesystemBackends.virtualMachineFilesystem
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Zeppelin tests"):
   def run(): Unit =

--- a/lib/ziggurat/src/test/ziggurat_test.scala
+++ b/lib/ziggurat/src/test/ziggurat_test.scala
@@ -54,7 +54,7 @@ import filesystemOptions.createNonexistentParents.enabled
 import filesystemOptions.deleteRecursively.enabled
 
 import filesystemBackends.virtualMachineFilesystem
-import denominative.asymptotics.linearSizeComplexity
+import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Ziggurat tests"):
   def run(): Unit =


### PR DESCRIPTION
Soundness gates collection operations whose cost is worse than their name suggests, and this release gives that criterion a name and a precise definition. An operation is *dysasymptotic* when its computational cost grows more than logarithmically with some measure of the data outside its semantic scope — the data the operation's specification identifies as its subject — while that scope itself stays bounded. The three gating tokens are renamed to match, and the `asymptotics` import package becomes `dysasymptotics`. Auditing the existing gates against the definition turned up two places where the code disagreed with it, both now corrected: replacing one element of a frozen array copies the whole array, so it now requires an acknowledgement, while `sec` and `ter` on a `List` walk at most three cells and no longer require one.

## Naming

The marker types that acknowledge an expensive operation now sit in a `Dysasymptotic` namespace, and the package you import them from is `dysasymptotics`:

| Before | After |
| --- | --- |
| `LinearSizeComplexity` | `Dysasymptotic.LinearSize` |
| `LinearAccessComplexity` | `Dysasymptotic.LinearAccess` |
| `UnboundedSizeComplexity` | `Dysasymptotic.UnboundedSize` |
| `import asymptotics.linearSizeComplexity` | `import dysasymptotics.linearSize` |
| `import asymptotics.linearAccessComplexity` | `import dysasymptotics.linearAccess` |
| `import asymptotics.unboundedSizeComplexity` | `import dysasymptotics.unboundedSize` |

So a file that takes the length of a `List` now reads:

```scala
import dysasymptotics.linearSize

val total = items.size
```

This is a source-compatible rename in shape only: any file importing the old names must be updated, but nothing about when an acknowledgement is required has changed, apart from the two corrections below.

## Definitions

Both terms are recorded in full in the rationale comment of `denominative.dysasymptotics.scala`:

An operation's **semantic scope** is the portion of the data involved that the operation's specification identifies as its subject: the data whose values must be observed, compared, transformed, replaced, or produced in order to yield the specified result. Data that is merely incorporated into the result unchanged, or traversed only to reach the subject, lies outside the semantic scope.

An operation on a particular data structure is **dysasymptotic** when its computational cost grows more than logarithmically with some measure of the data outside its semantic scope — typically the size of the containing structure, or the distance of the subject from the structure's point of access — while the scope itself remains bounded with respect to that measure.

Two consequences are worth spelling out. Dysasymptoticity is a property of an operation on a *representation*, not of the operation in the abstract, which is why the gates sit on typeclass instances rather than methods: `size` is free on a `Sequence` and gated on a `List`. And cost that merely tracks the semantic scope is never gated, however large that scope grows — folding an infinite `Chain` diverges semantically rather than dysasymptotically, whereas `Chain.size` has a bounded scope and an unbounded cost, so it stays behind `Dysasymptotic.UnboundedSize`.

## Corrected gates

Replacing a single element of a frozen `Array` rebuilds the entire array, which is exactly the pattern already gated for that type's append, prepend and `lead`. It now requires the same acknowledgement:

```scala
import dysasymptotics.linearSize

val updated = array.define(Prim, 10)
```

Conversely, `sec` and `ter` on a `List` walk at most three cells, a bounded cost that the definition does not classify as dysasymptotic. They previously routed through the gated positional-access instance; they now have ungated `List` cases alongside `prim`, so no import is needed:

```scala
val second = List(10, 20, 30).sec  // 20, no acknowledgement required
```

Positional access at an arbitrary ordinal is unaffected and still requires `Dysasymptotic.LinearAccess`.
