### PR TITLE
Reliable implicit-search diagnostics: Frontier's catch-all is now soundness-wide

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -54,10 +54,10 @@ object settings:
   //      https://github.com/propensive/proscala/releases; each release ships a single
   //      `proscala-<tag>.tar.gz` asset whose contents are a `lib` directory (the unversioned core
   //      jars plus the versioned third-party jars). The `toolchain` module below downloads
-  //      `SOUNDNESS_SCALA_RELEASE` (default `3.9.0-RC5-p14`, the latest in the 3.9.0 stream) and
+  //      `SOUNDNESS_SCALA_RELEASE` (default `3.9.0-RC6-p15`, the latest in the 3.9.0 stream) and
   //      extracts it into a shared cache, exposing its jars to every coursier resolution — no
   //      local compiler build and no publishing step needed. Switch streams by setting
-  //      `SOUNDNESS_SCALA_RELEASE` (e.g. `3.10.0-dev-p13`).
+  //      `SOUNDNESS_SCALA_RELEASE` (e.g. `3.10.0-dev-p15`).
   //
   //   2. Local (fork developers). Point `SOUNDNESS_SCALA_HOME` at a `make`-built `release`
   //      directory to use its `release/lib` jars directly instead of downloading. After
@@ -71,14 +71,14 @@ object settings:
   // (`SOUNDNESS_SCALA_RELEASE`) is a separate concept, though from `3.9.0-RC4-p1` on the two
   // coincide (earlier releases shipped jars built as e.g. `3.9.0-RC1-propensive`). Override the
   // coordinate with `SOUNDNESS_SCALA_VERSION`.
-  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC5-p14")
+  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC6-p15")
 
   // The compiler *stream* — the major Scala version, without the patch level — which is what
   // decides the shape of the compiler-internal APIs a handful of modules wrap. Everything else
   // in Soundness is written once and compiles on every stream; where an API genuinely differs
   // (see the `Shim` component trait), this selects the sources that bridge it.
   val scalaStream = if scalaVersion.startsWith("3.10") then "3.10" else "3.9"
-  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC5-p14")
+  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC6-p15")
   // Empty by default → download `scalaRelease`. Set to a local `release` directory to use its
   // `release/lib` jars directly (fork-developer mode).
   val scalaHome = sys.env.getOrElse("SOUNDNESS_SCALA_HOME", "")

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -47,19 +47,13 @@ import vacuous.*
 import symbolism.*
 
 object internal:
-  inline def explanation[target]: target = ${explain[target]}
-
-  // Non-transparent inline: expands in the `inlining` phase (post-typer), so
-  // its `report.errorAndAbort` is a terminal error that always reaches the
-  // user — unlike an `errorAndAbort` fired during the nested implicit search
-  // that selected the transparent `explainMissingContext` catch-all, which
-  // Dotty buffers and shadows. The catch-all returns a call to this in place
-  // of a found value.
-  inline def fail[target](message: String): target = ${failMacro[target]('message)}
-
-  def failMacro[target: Type](message: Expr[String]): Macro[target] =
-    import quotes.reflect.*
-    report.errorAndAbort(message.valueOrAbort)
+  // `transparent` is essential: only transparent inline calls are expanded at
+  // typer, so a non-transparent `explanation` would leave the macro splice
+  // unexpanded while `explainMissingContext` is tried as a candidate — the
+  // search would spuriously succeed and the abort would fire only at the
+  // `inlining` phase. Transparency also lets Case B1's precise type reach the
+  // call site.
+  transparent inline def explanation[target]: target = ${explain[target]}
 
   private object SafeInlined:
     def unapply(using Quotes)(scrutinee: quotes.reflect.ImplicitSearchFailure)
@@ -88,9 +82,14 @@ object internal:
     // doesn't propose (or recurse into) itself. Resolved by name and guarded
     // against absence — the real recursion stop is the name check in `seek`.
     val self: List[Symbol] =
-      List("frontier.context.explainMissingContext", "soundness.context.explainMissingContext")
+      List("frontier.context.explainMissingContext", "soundness.explainMissingContext")
       . flatMap: path =>
           try List(Symbol.requiredMethod(path)) catch case _: Throwable => Nil
+      . concat:
+          // The `soundness` catch-all is a top-level definition, so it may only
+          // be reachable as a member of the package's synthetic file object.
+          try Symbol.requiredPackage("soundness").methodMember("explainMissingContext")
+          catch case _: Throwable => Nil
 
     sealed trait Result
 
@@ -519,22 +518,20 @@ object internal:
 
     // Build the diagnostic tree rooted at the type Frontier was asked to
     // resolve, with its tried candidates and proposed alternatives beneath it.
-    // The catch-all fires at the *deepest* missing implicit in any using-clause
-    // chain (the inner search resolves through the catch-all first), and the
-    // chain that led there isn't available at macro-expansion time, so the
-    // root is that deepest type — Frontier reports the innermost cause.
+    // In a using-clause chain the surviving report is the one for the deepest
+    // missing implicit (the catch-all expands there first, and its rendered
+    // tree is preserved verbatim by the `@internal.diagnostic` machinery), so
+    // the user sees the innermost cause.
     def buildDiagnostic(missing: Missing): Diagnostic =
       val children = missing.available.map(toDiagnostic) ++ missing.candidates.map(toDiagnostic)
       Diagnostic.Resolving(missing.name, Unset, children.to(proscenium.List))
 
-    // The transparent catch-all cannot emit a terminal error from inside the
-    // nested implicit search where it fires (Dotty buffers and shadows it).
-    // Instead it returns a call to the *non-transparent* `fail`, which expands
-    // later, in the `inlining` phase, where `report.errorAndAbort` is terminal
-    // and always reaches the user.
+    // The catch-all is marked `@internal.diagnostic`, so aborting here makes
+    // the candidate fail the search normally (`NotGiven`, `summonFrom` and
+    // default `using` arguments all behave), while the rendered tree becomes
+    // the authoritative message if the overall search fails.
     def emit(missing: Missing): Expr[target] =
-      val text = Diagnostic.render(buildDiagnostic(missing)).s
-      '{frontier.internal.fail[target](${Expr(text)})}
+      report.errorAndAbort(Diagnostic.render(buildDiagnostic(missing)).s)
 
     seek(TypeRepr.of[target], Nil, 1).absolve match
       case Found(_, expr) =>

--- a/lib/frontier/src/core/frontier_core.scala
+++ b/lib/frontier/src/core/frontier_core.scala
@@ -33,4 +33,5 @@
 package frontier
 
 package context:
+  @scala.annotation.internal.diagnostic
   transparent inline given explainMissingContext: [any] => any = internal.explanation[any]

--- a/lib/frontier/src/core/soundness_frontier_core.scala
+++ b/lib/frontier/src/core/soundness_frontier_core.scala
@@ -34,5 +34,8 @@ package soundness
 
 import frontier.*
 
-package context:
-  transparent inline given explainMissingContext: [any] => any = internal.explanation[any]
+// An old-style `implicit`, not a `given`: wildcard imports exclude givens, and
+// this catch-all must be in scope for anyone who writes `import soundness.*`
+// without a separate `given` selector.
+@scala.annotation.internal.diagnostic
+transparent inline implicit def explainMissingContext[any]: any = internal.explanation[any]

--- a/lib/frontier/src/test/frontier_test.scala
+++ b/lib/frontier/src/test/frontier_test.scala
@@ -105,6 +105,14 @@ object Tests extends Suite(m"Frontier Tests"):
       . map(_.message)
     . assert(_ == Nil)
 
+    test(m"catch-all is in scope via plain import soundness.* without a given selector"):
+      demilitarize:
+        import soundness.*
+        trait Absent
+        summon[Absent]
+      . map(_.message)
+    . assert(_.exists(_.contains("contextual value not found")))
+
     test(m"explainMissingContext lists classpath givens for missing implicit"):
       demilitarize:
         import frontier.context.explainMissingContext
@@ -119,12 +127,12 @@ object Tests extends Suite(m"Frontier Tests"):
       . map(_.message)
     . assert(_.exists(_.contains("textual = Char")))
 
-    // Diagnostic-behavior tests: the catch-all fires at the deepest missing
-    // implicit. With a chain `summon[Alpha]` ← `mkAlpha(using Beta)` ← `Beta?`,
-    // the user sees the diagnostic for Beta, not for Alpha — the inner
-    // using-clause search resolves through the catch-all first, and the chain
-    // that led there is not available at macro-expansion time, so Frontier
-    // reports the innermost cause (Beta).
+    // Diagnostic-behavior tests: the catch-all fails the search normally (it
+    // is marked `@internal.diagnostic`, so its abort becomes the authoritative
+    // failure message rather than a spurious success). In a using-clause chain
+    // the surviving diagnostic is the one for the deepest missing implicit —
+    // with `summon[Alpha]` ← `mkAlpha(using Beta)` ← `Beta?`, the user sees
+    // the tree rooted at Beta, the innermost cause.
 
     test(m"explainMissingContext fires for a missing using-clause implicit"):
       demilitarize:
@@ -159,6 +167,39 @@ object Tests extends Suite(m"Frontier Tests"):
         msgs.exists: m =>
           m.contains("resolving") && m.contains("DecimalConverter")
           && m.contains("decimalConverters.javaDecimalConverter")
+
+    // Regression tests for the old deferred-fail scheme, which made failing
+    // searches spuriously succeed: with the catch-all in scope, constructs
+    // that depend on ordinary search *failure* must still compile.
+
+    test(m"explainMissingContext does not defeat NotGiven"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        trait Absent
+        summon[scala.util.NotGiven[Absent]]
+      . map(_.message)
+    . assert(_ == Nil)
+
+    test(m"explainMissingContext does not defeat default using arguments"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        class Cfg
+        def withDefault(using cfg: Cfg = new Cfg): Cfg = cfg
+        withDefault
+      . map(_.message)
+    . assert(_ == Nil)
+
+    test(m"explainMissingContext does not defeat summonFrom fallback"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        trait Absent
+        inline def choose: Int =
+          scala.compiletime.summonFrom:
+            case _: Absent => 1
+            case _         => 2
+        val n: Int = choose
+      . map(_.message)
+    . assert(_ == Nil)
 
     // `read` now resolves an ordinary `Readable` instance, so a missing
     // decoder is an ordinary failed implicit search that Frontier explains —


### PR DESCRIPTION
Frontier's `explainMissingContext` diagnostics are now reliable and always available: the catch-all no longer needs to be imported explicitly — any `import soundness.*` brings it into scope — and a failed implicit search now reports Frontier's rendered search tree as the error itself, without corrupting constructs that depend on search failure such as `NotGiven`, `summonFrom` fallbacks or default `using` arguments.

Previously, explaining a missing contextual value required an explicit opt-in import, and the implementation deferred its error to a later compiler phase — which meant a failing search appeared to *succeed* during typing. That spurious success inverted `scala.util.NotGiven`, prevented `summonFrom` from reaching its fallback cases, and stopped default `using` arguments from applying. The catch-all now aborts during the search itself, and the Proscala compiler (via the new `@scala.annotation.internal.diagnostic` annotation) preserves its rendered diagnostic as the authoritative error message when the search genuinely fails — taking precedence over `@implicitNotFound` messages.

No import is needed any more. With just:
```scala
import soundness.*
```
a failed search such as:
```scala
summon[Char is Concatenable]
```
reports the full diagnostic tree — the type being resolved, the candidates that were tried, what each still requires, and known instances from the classpath that could satisfy them — in place of the stock "no given instance" message. Code that relies on the *absence* of a contextual value compiles exactly as before:
```scala
summon[NotGiven[MissingType]]     // still resolves
def f(using cfg: Config = Config()) // default still applies
```

The opt-in `frontier.context.explainMissingContext` given remains available for projects using Frontier standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)