### PR TITLE
Return statuses directly from `execute` blocks

### DIFF
--- a/lib/exoskeleton/src/args/exoskeleton.Status.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Status.scala
@@ -42,20 +42,14 @@ import rudiments.*
 //     object CannotConnect extends Status(1, t"the server could not be reached")
 //
 // Returning one from an `execute` block both sets the process's exit code and makes the status
-// discoverable: each `Status.exit` demands a `Registry` for its own singleton type, so the
-// block's `execute` accumulates the union of every status it can return, and documents them
-// without the application having to list them twice.
+// discoverable: the block's result type — kept precise by `execute`'s `Precise` bound — is the
+// union of the singleton types of every status it can return, which `Admissible` reifies as the
+// list of their values, documenting them without the application having to list them twice.
 //
 // A status must be an object rather than a `val`, because capture checking currently rejects
 // `value.type <: value.type | other.type` for the singleton type of a `val` (soundness#1811),
 // which would stop that union from forming. Module singletons are unaffected.
 object Status:
-  // Contravariant, so that each `Registry[status.type]` demanded within a block adds a lower
-  // bound to the block's `result` type, which then instantiates to the union of them all —
-  // the same mechanism by which `Tactic[-error]` accumulates a `raises` union. The `Precise`
-  // context bound on `execute` is what stops that union being widened to `Status`.
-  trait Registry[-status]
-
   object Admissible:
     // Union types cannot be decomposed by recursive given resolution (the compiler will not
     // unify `a | b` with a concrete union, and instantiates both to `Nothing`), so the members
@@ -68,7 +62,5 @@ object Status:
     type Self
     def statuses: List[Status]
 
-// `caps.Pure`: a status is a plain datum which may never hold a live capability, and so its
-// singleton type carries no capture set to obstruct the union.
-open class Status(val code: Int, val description: Text) extends scala.caps.Pure:
-  def exit(using Status.Registry[this.type]): Exit = Exit(code)
+open class Status(val code: Int, val description: Text) extends Termination:
+  def exit: Exit = Exit(code)

--- a/lib/exoskeleton/src/args/exoskeleton.internal.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.internal.scala
@@ -49,16 +49,34 @@ object internal:
 
     // A status declared as `object CannotConnect extends Status(…)` appears in the union as a
     // `TypeRef` to its module class, and one referred to by a stable path as a `TermRef`; both
-    // yield the term to refer to again. Anything else — `Nothing` when a block returns no
-    // status, or a type which is not a singleton — contributes nothing.
+    // yield the term to refer to again. Any other `Termination` — `Exit` and its cases, or
+    // `Nothing` when a block never returns normally — sets an exit code without a meaning to
+    // document, and so contributes nothing. A non-singleton `Status` member has no value to
+    // recover: it means the union has been widened (soundness#1811), so the error is raised
+    // here rather than letting the statuses silently vanish from the documentation.
+    val statusType = TypeRepr.of[Status]
+    val terminationType = TypeRepr.of[rudiments.Termination]
+
     val values: sci.List[Expr[Status]] =
       decompose(TypeRepr.of[result]).distinct.flatMap: repr =>
-        if repr =:= TypeRepr.of[Nothing] then sci.Nil else repr match
+        if repr =:= TypeRepr.of[Nothing] then sci.Nil
+        else if repr <:< statusType then repr match
           case ref: TermRef => sci.List(Ref.term(ref).asExprOf[Status])
 
           case other =>
             val symbol = other.termSymbol
-            if symbol.exists then sci.List(Ref(symbol).asExprOf[Status]) else sci.Nil
+
+            if symbol.exists then sci.List(Ref(symbol).asExprOf[Status]) else
+              report.errorAndAbort
+               ( "exoskeleton: every status an execute block returns must be a singleton object "
+                 + "extending Status, but the result type includes "+other.show+", which is not "
+                 + "a singleton. Declare each status as a top-level object; if this type is "
+                 + "Status itself, the union of statuses has been widened (soundness#1811)." )
+        else if repr <:< terminationType then sci.Nil
+        else
+          report.errorAndAbort
+           ( "exoskeleton: an execute block must return a Termination, such as an Exit or a "
+             + "Status, but the result type includes "+repr.show+", which is neither." )
 
     '{
         new Status.Admissible:

--- a/lib/exoskeleton/src/completions/exoskeleton.Execution.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Execution.scala
@@ -36,9 +36,9 @@ import prepositional.*
 import rudiments.*
 
 object Execution:
-  // Refines `Result` to the union of statuses the executed block can return, so that the set
-  // is carried in the type as well as recorded for documentation. `Execution to Nothing` is
-  // the result for a block which returns only a plain `Exit`.
+  // Refines `Result` to the union of terminations the executed block can return, so that the
+  // set is carried in the type as well as recorded for documentation. `Execution to Nothing`
+  // is the result for a block which never returns normally.
   def of[result](exitStatus: Exit, statuses: List[Status]): Execution to result =
     new Execution(exitStatus, statuses):
       type Result = result

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -51,17 +51,18 @@ import turbulence.*
 import vacuous.*
 import denominative.dysasymptotics.linearSize
 
-// The block's `result` type is the union of the singleton types of every `Status` it can
-// return, accumulated through the contravariant `Status.Registry` capability and kept precise
-// (rather than widened to `Status`) by the `Precise` bound. Those statuses are recorded on the
-// `Cli` even in completion mode — where the block itself is never run — so that a help-tree
-// probe can discover them for documentation.
+// The block returns any `Termination` — a `Status` object, an `Exit`, or a union of them —
+// and its `result` type, kept precise (rather than widened by lubbing to `Status`) by the
+// `Precise` bound, is the union of the types of every termination it can return. `Admissible`
+// reifies the statuses in that union, and they are recorded on the `Cli` even in completion
+// mode — where the block itself is never run — so that a help-tree probe can discover them for
+// documentation.
 // `scala.Precise`, not the `Precise` which `-Yimports:proscenium` supplies: the prelude's
 // `export scala.Precise` yields a distinct alias symbol which the compiler's union-widening
 // suppression does not recognise, so the bound would silently do nothing and the union of
 // statuses would be widened to `Status` (soundness#1811).
-def execute[result: scala.Precise]
-   ( block: (erased effectful: Effectful) ?=> Status.Registry[result] ?=> Invocation ?=> Exit )
+def execute[result <: Termination: scala.Precise]
+   ( block: (erased effectful: Effectful) ?=> Invocation ?=> result )
    ( using cli: Cli )
    ( using admissible: result is Status.Admissible )
 :   Execution to result =
@@ -73,8 +74,7 @@ def execute[result: scala.Precise]
     case completion: Completion => Execution.of[result](Exit.Ok, statuses)
 
     case invocation: Invocation =>
-      val registry = new Status.Registry[result] {}
-      Execution.of[result](block(using !!)(using registry)(using invocation), statuses)
+      Execution.of[result](block(using !!)(using invocation).exit, statuses)
 
 def explain(explanation: (Optional[Text] aka "prior") ?=> Optional[Text])(using cli: Cli): Unit =
   cli.explain(explanation(using Unset.aka["prior"]))

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -579,7 +579,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
 
           arguments match
             case Alpha() :: _ => execute(Exit.Ok)
-            case Beta() :: _  => execute(Exit.Ok)
+            case Beta() :: rest => execute(if rest == Nil then CannotConnect else Exit.Fail(3))
             case Gamma() :: _ => execute(Exit.Ok)
 
             case Distribution() :: rest => rest match
@@ -603,13 +603,13 @@ object Tests extends Suite(m"Exoskeleton Tests"):
               val config = cli.environment.variable(t"MYTOOL_CONFIG")
 
               execute:
-                if config.absent then CannotConnect.exit else BadConfig.exit
+                if config.absent then CannotConnect else BadConfig
 
             case UserDel() :: _ =>
               Flag(t"force", description = t"do not ask for confirmation")()
               Flag[Delay](t"wait", description = t"delay the deletion")()
               cli.environment.variable(t"MYTOOL_HOME")
-              execute(CannotConnect.exit)
+              execute(CannotConnect)
 
             case _ => execute(Exit.Fail(1))
 
@@ -666,6 +666,10 @@ object Tests extends Suite(m"Exoskeleton Tests"):
 
       test(m"A single status is discovered without widening to Status"):
         HelpApp.tree.subcommands.filter(_.command == t"userdel").bind(_.statuses).map(_.code)
+      .assert(_ == List(1))
+
+      test(m"A status unioned with a plain Exit is discovered, and the Exit is skipped"):
+        HelpApp.tree.subcommands.filter(_.command == t"beta").bind(_.statuses).map(_.code)
       .assert(_ == List(1))
 
       test(m"A command returning a plain Exit contributes no statuses"):

--- a/lib/rudiments/src/core/rudiments.Termination.scala
+++ b/lib/rudiments/src/core/rudiments.Termination.scala
@@ -32,19 +32,8 @@
                                                                                                   */
 package rudiments
 
-object Exit:
-  def apply(value: Int): Exit = if value == 0 then Ok else Fail(value)
-
-enum Exit extends Termination:
-  case Ok
-  case Fail(status: Int)
-
-  def exit: Exit = this
-
-  def apply(): Int = this match
-    case Ok           => 0
-    case Fail(status) => status
-
-  def terminate(): Nothing =
-    System.exit(apply())
-    ???
+// The outcome of a completed command: anything which can determine the process's exit status.
+// `scala.caps.Pure`: a termination is a plain datum which may never hold a live capability, so its
+// singleton type carries no capture set to obstruct a union of terminations.
+trait Termination extends scala.caps.Pure:
+  def exit: Exit

--- a/lib/rudiments/src/core/soundness_rudiments_core.scala
+++ b/lib/rudiments/src/core/soundness_rudiments_core.scala
@@ -38,7 +38,7 @@ export
   // dependent-typed inline extensions, which synthesized export forwarders break (the same
   // policy as zephyrine's `Region`/`Slate`). Consumers import them from `rudiments` directly.
   . { !!, &, all, also, and, annex, b, bi, Bijection, bijection, Bytes, bytes, collate, Counter,
-      DecimalConverter, Defaulting, Defaulting2, Digit, each, establish, Exit, fixpoint,
+      DecimalConverter, Defaulting, Defaulting2, Digit, each, establish, Exit, Termination, fixpoint,
       fuse, gib,
       give, immutable, indexBy, intercalate, javaInputStream, kib,
       longestTrain,


### PR DESCRIPTION
`execute` blocks can now return a `Status` object directly, instead of ending with `MyStatus.exit`. A new `Termination` trait in rudiments unifies everything which can determine a process's exit status: both `Exit` and `Status` extend it, and the `Status.Registry` mechanism has been retired — the union of statuses a block can return is now preserved by ordinary result-type inference under the `Precise` bound.

### Return statuses directly from `execute` blocks

An `execute` block previously had to convert each `Status` to an `Exit` explicitly:

```scala
execute:
  if config.absent then CannotConnect.exit else BadConfig.exit
```

Now the statuses are returned directly:

```scala
execute:
  if config.absent then CannotConnect else BadConfig
```

A block may return a `Status`, an `Exit`, or a mixture of both across its branches; every reachable `Status` is still discovered automatically and documented in generated help and manpages. The new `Termination` type in rudiments — the supertype of `Exit` and `Status` — represents anything which can determine an exit status, and other termination types may extend it in future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)