### PR TITLE
Local help for the current subcommand section

### DIFF
--- a/lib/ethereal/src/core/ethereal.DaemonService.scala
+++ b/lib/ethereal/src/core/ethereal.DaemonService.scala
@@ -77,6 +77,11 @@ extends Entrypoint, caps.ExclusiveCapability:
   // in tab-completion mode. Falls back to a name-only root if the executive cannot generate it.
   def help(): Help = helpThunk().or(Help(script, Unset, Nil, Nil))
 
+  // The help view narrowed to the subcommands this invocation has already matched during
+  // dispatch, so that a section of the application only documents itself. Falls back to the
+  // full tree when nothing has been matched, or the matched path is absent from it.
+  def localHelp()(using cli: Cli): Help = help().local(cli.matches).or(help())
+
   def started[instant: Instantiable across Instants from Long]: instant =
     instant(startTime)
 

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -91,6 +91,11 @@ trait Cli extends Console, caps.ExclusiveCapability:
   def present(flag: Flag): Unit = ()
   def explain(update: (Optional[Text] aka "prior") ?=> Optional[Text]): Unit = ()
 
+  // Records a successful `Subcommand` match during dispatch; `matches` is the contiguous
+  // sequence of subcommand names matched so far, from the first argument onwards.
+  def matched(argument: Argument): Unit = ()
+  def matches: List[Text] = Nil
+
   private val signalHandlers:
   juca.AtomicReference[List[PartialFunction[UnixSignal | WindowsSignal, SignalResponse]]] =
     juca.AtomicReference(Nil)

--- a/lib/exoskeleton/src/args/exoskeleton.Subcommand.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Subcommand.scala
@@ -45,6 +45,9 @@ case class Subcommand
     hidden:      Boolean                    = false,
     group:       Optional[CommandGroup]     = Unset ):
 
-  def unapply(argument: Argument)(using Cli): Boolean =
+  def unapply(argument: Argument)(using cli: Cli): Boolean =
     argument.suggest(Suggestion(name, description, hidden, group = group) :: prior)
-    argument() == name
+
+    if argument() != name then false else
+      cli.matched(argument)
+      true

--- a/lib/exoskeleton/src/core/exoskeleton.Help.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Help.scala
@@ -130,6 +130,36 @@ case class Help
     statuses:    List[Status]           = Nil,
     variables:   List[Text]             = Nil ):
 
+  // The view of this help tree from inside the given subcommand path, as matched during
+  // dispatch: the selected node, its command joined to the full path (so the usage line names
+  // the subcommand), and every ancestor's flags carried in as global options. The node's own
+  // flags are normalized to local, whatever the probes recorded; from within the section they
+  // are its ordinary options. `Unset` when the path does not exist in the tree.
+  def local(prefix: List[Text]): Optional[Help] =
+    def recur(node: Help, path: List[Text], command: Text, inherited: List[Help.Param])
+    :   Optional[Help] =
+
+      path match
+        case Nil =>
+          // Ancestors first and nearest-root wins on a name collision; built in reverse with
+          // `::` and reversed once, since deduplication needs a fold anyway.
+          def dedupe(seen: List[Help.Param], param: Help.Param): List[Help.Param] =
+            if seen.exists(_.name == param.name) then seen else param :: seen
+
+          val globals: List[Help.Param] =
+            inherited.map(_.copy(global = true)).fold(Nil: List[Help.Param])(dedupe)
+
+          val all: List[Help.Param] =
+            node.parameters.map(_.copy(global = false)).fold(globals)(dedupe)
+
+          node.copy(command = command, parameters = all.reverse)
+
+        case name :: rest =>
+          node.subcommands.seek(_.command == name).let: child =>
+            recur(child, rest, t"$command $name", inherited + node.parameters)
+
+    if prefix == Nil then this else recur(this, prefix, command, Nil)
+
   def teletype(width: Int = Int.MaxValue)(using Hyphenation): Teletype =
     val globalParams: scala.List[Help.Param] = parameters.stdlib.filter(_.global)
     val localParams: scala.List[Help.Param] = parameters.stdlib.filter(!_.global)
@@ -179,11 +209,21 @@ case class Help
         (heading, Help.compact(Help.commandRows(factored, 1) ::: commonRows))
 
     // A tool without subcommands never reaches dispatch, so all of its flags count as "global";
-    // presenting them as anything other than plain options would be noise.
+    // presenting them as anything other than plain options would be noise. A *local* leaf view
+    // is the exception: it carries ancestor flags marked global alongside its own local flags,
+    // and then the distinction is worth a split — globals precede the subcommand on the command
+    // line, locals follow it.
     val leaf: Boolean = subcommands.stdlib.isEmpty
+    val split: Boolean = !leaf || (!globalParams.isEmpty && !localParams.isEmpty)
 
     val standard: scala.List[(scala.List[Teletype], scala.List[Help.Row])] =
-      if leaf then
+      if leaf && split then
+        scala.List
+          ( (scala.List(e"$Bold(Global options:)"),
+             Help.compact(Help.paramItems(globalParams, 1))),
+            (scala.List(e"$Bold(Options:)"),
+             Help.compact(Help.paramItems(localParams, 1))) )
+      else if leaf then
         scala.List
           ( (scala.List(e"$Bold(Options:)"),
              Help.compact(Help.paramItems(parameters.stdlib, 1))) )
@@ -248,7 +288,11 @@ case class Help
             else e"$padded  ${lines.head}" :: lines.tail.map: line => e"$margin$line"
 
     val usage: Teletype =
-      if leaf then e"$Bold(Usage:) $command${Help.summarize(parameters.stdlib, t"options")}"
+      if leaf && split then
+        val globals: Text = Help.summarize(globalParams, t"global options")
+        e"$Bold(Usage:) $command$globals${Help.summarize(localParams, t"options")}"
+      else if leaf then
+        e"$Bold(Usage:) $command${Help.summarize(parameters.stdlib, t"options")}"
       else
         val globals: Text = Help.summarize(globalParams, t"global options")
 

--- a/lib/exoskeleton/src/core/exoskeleton.Invocation.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Invocation.scala
@@ -34,6 +34,7 @@ package exoskeleton
 
 import ambience.*
 import anticipation.*
+import rudiments.*
 import turbulence.*
 import vacuous.*
 
@@ -48,6 +49,24 @@ case class Invocation
 extends Cli, Stdio:
 
   export stdio.{termcap, out, err, in}
+
+  @scala.caps.unsafe.untrackedCaptures
+  private var matchedArguments: List[Argument] = Nil
+
+  override def matched(argument: Argument): Unit = matchedArguments = argument :: matchedArguments
+
+  // The recorded matches, deduplicated (re-matches of one position record the identical
+  // argument) and restricted to the contiguous run from the first argument, so that a match
+  // against a later argument alone cannot fabricate a false prefix.
+  override def matches: List[Text] =
+    def recur(arguments: List[Argument], position: Int): List[Text] = arguments match
+      case argument :: rest if argument.position == position =>
+        argument() :: recur(rest, position + 1)
+
+      case _ =>
+        Nil
+
+    recur(matchedArguments.distinct.sort(_.position), 0)
 
   private lazy val parameters: interpreter.Topic = interpreter.interpret(arguments)
 

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -622,6 +622,21 @@ object Tests extends Suite(m"Exoskeleton Tests"):
             Login(t"tester", Unset))
            (app)
 
+        // Run the application for real (in invocation mode, not completion mode) and return the
+        // spent invocation, so its recorded state can be inspected.
+        def invoke(textArguments: Text*): Invocation =
+          val invocation =
+            Invocation
+              (Cli.arguments(textArguments),
+               summon[Environment],
+               summon[WorkingDirectory],
+               summon[Stdio],
+               true,
+               Login(t"tester", Unset))
+
+          app(using invocation)
+          invocation
+
       test(m"Help root lists visible subcommands"):
         HelpApp.tree.subcommands.map(_.command)
       .assert(_ == List(t"alpha", t"beta", t"distribution", t"useradd", t"userdel"))
@@ -742,6 +757,95 @@ object Tests extends Suite(m"Exoskeleton Tests"):
                t"Exit statuses:",
                t"  1                      the server could not be reached",
                t"  2                      the configuration file was invalid")
+
+      test(m"A matched subcommand is recorded on the invocation"):
+        HelpApp.invoke(t"useradd", t"--home", t"/home/x").matches
+      .assert(_ == List(t"useradd"))
+
+      test(m"Nested matched subcommands are recorded in order"):
+        HelpApp.invoke(t"distribution", t"ubuntu").matches
+      .assert(_ == List(t"distribution", t"ubuntu"))
+
+      test(m"An unrecognized subcommand records no matches"):
+        HelpApp.invoke(t"bogus").matches
+      .assert(_ == Nil)
+
+      test(m"An empty invocation records no matches"):
+        HelpApp.invoke().matches
+      .assert(_ == Nil)
+
+      test(m"A local view selects the subtree for a matched prefix"):
+        HelpApp.tree.local(List(t"useradd")).let(_.command)
+      .assert(_ == t"mytool useradd")
+
+      test(m"A local view carries ancestor flags as global options"):
+        HelpApp.tree.local(List(t"useradd")).let(_.parameters.filter(_.global).map(_.name))
+         .or(Nil)
+      .assert(_ == List(t"--verbose"))
+
+      test(m"A local view keeps the subcommand's own flags local"):
+        HelpApp.tree.local(List(t"useradd"))
+         .let(_.parameters.filter(!_.global).map(_.name).sort(identity)).or(Nil)
+      .assert(_ == List(t"--force", t"--groups", t"--home"))
+
+      test(m"A nested local view joins the full command path"):
+        HelpApp.tree.local(List(t"distribution", t"ubuntu")).let(_.command)
+      .assert(_ == t"mytool distribution ubuntu")
+
+      test(m"A local view of an unknown path is unset"):
+        HelpApp.tree.local(List(t"bogus"))
+      .assert(_ == Unset)
+
+      test(m"A local view of the empty path is the whole tree"):
+        HelpApp.tree.local(Nil)
+      .assert(_ == HelpApp.tree)
+
+      test(m"An invocation's matched prefix selects its local help"):
+        HelpApp.tree.local(HelpApp.invoke(t"useradd", t"extra").matches).let(_.command)
+      .assert(_ == t"mytool useradd")
+
+      test(m"Local help for a leaf renders its section with ancestor globals"):
+        HelpApp.tree.local(List(t"useradd")).let: local =>
+          summon[Help is Printable].print(local, stdios.muteStdio.termcap).cut(t"\n")
+        . or(Nil)
+      .assert:
+        _ == List
+              (t"Usage: mytool useradd [--verbose <value>] [options]",
+               t"",
+               t"add a user account",
+               t"",
+               t"Global options:",
+               t"  --verbose <value>    verbose output",
+               t"",
+               t"Options:",
+               t"  --groups <value>...  add the user to a group",
+               t"  --force <value>      do not ask for confirmation",
+               t"  --home <value>       specify the home directory",
+               t"",
+               t"Exit statuses:",
+               t"  1                    the server could not be reached",
+               t"  2                    the configuration file was invalid")
+
+      test(m"Local help for a non-leaf renders its subcommands"):
+        HelpApp.tree.local(List(t"distribution")).let: local =>
+          summon[Help is Printable].print(local, stdios.muteStdio.termcap).cut(t"\n")
+        . or(Nil)
+      .assert:
+        _ == List
+              (t"Usage: mytool distribution [--verbose <value>] <command> [options]",
+               t"",
+               t"a different command to run",
+               t"",
+               t"Global options:",
+               t"  --verbose <value>  verbose output",
+               t"",
+               t"Commands:",
+               t"  red hat            Red Hat Linux",
+               t"    --only <value>   there is only one",
+               t"",
+               t"  ubuntu             Ubuntu",
+               t"    --one <value>    the first one",
+               t"    --two <value>    the second one")
 
       suite(m"Manpage tests"):
         val manual = Manual


### PR DESCRIPTION
A CLI application can now display help for just the section of its interface the user has reached, detected automatically from the subcommands matched during dispatch. A successful `Subcommand` match is recorded on the `Cli`, `Help#local` narrows the full help tree to the matched path, and ethereal's `DaemonService` exposes the result as `localHelp()`.

### Local help for subcommand sections

When a command-line application dispatches on subcommands, help requested from within a section should describe that section alone. A new `localHelp()` method on `DaemonService` provides exactly this:

```scala
case Remote() :: rest => rest match
  case Help() :: _ => execute(Out.println(service.localHelp()) yet Exit.Ok)
  ...
```

The local view is a refinement of the full `help()` output: its usage line names the full command path (`Usage: mytool remote add [options]`), flags declared by ancestor commands are carried in as *global options*, its own flags and nested subcommands render as usual, and the *exit statuses* table is restricted to those reachable within the section.

Two new building blocks support this and are also available directly: `Cli#matches` — the contiguous sequence of subcommand names matched so far, recorded automatically whenever a `Subcommand` extractor succeeds — and `Help#local(prefix)`, which selects the section of a help tree for a given subcommand path, returning `Unset` if the path doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)