### PR TITLE
Complete praxinoscope's RE2 syntax coverage

### DIFF
--- a/doc/errors/500.md
+++ b/doc/errors/500.md
@@ -166,11 +166,30 @@ candidates in an intersection.
 ### `SN-500.19` — `Unverifiable`
 
 A containment analysis was attempted on a pattern containing a
-construct the analysis cannot model, such as a word boundary (`\b` or
-`\B`).
+construct the analysis cannot model: a word boundary (`\b` or `\B`),
+or a line anchor under the `m` flag, both of which depend on the
+symbols surrounding a position rather than on the position alone.
 
-**Resolution.** Remove the word boundary from the patterns being
-compared.
+**Resolution.** Remove the boundary from the patterns being compared.
+
+### `SN-500.20` — `InvalidPosixClass`
+
+A `[[:name:]]` character class named something outside the POSIX set
+(`alnum`, `alpha`, `ascii`, `blank`, `cntrl`, `digit`, `graph`,
+`lower`, `print`, `punct`, `space`, `upper`, `word`, `xdigit`).
+
+**Resolution.** Correct the class name. Note that `[:name:]` outside a
+surrounding character class is an ordinary class of those characters,
+not a POSIX class.
+
+### `SN-500.21` — `UnknownUnicodeClass`
+
+A `\p{…}` or `\P{…}` escape named neither a Unicode general category
+(`L`, `Lu`, `Nd`, …) nor a script (`Greek`, `Han`, …).
+
+**Resolution.** Correct the class name. Script names are the Unicode
+ones, spelled as RE2 spells them — `\p{Greek}`, not Java's
+`\p{IsGreek}`.
 
 ## See also
 

--- a/lib/praxinoscope/src/core/praxinoscope.Motif.scala
+++ b/lib/praxinoscope/src/core/praxinoscope.Motif.scala
@@ -51,7 +51,7 @@ object Motif:
   // carries `Unset`.
   object Node:
     enum Anchor:
-      case Start, End, WordBoundary, NonWordBoundary
+      case Start, End, WordBoundary, NonWordBoundary, LineStart, LineEnd
 
   enum Node:
     case Empty
@@ -79,17 +79,26 @@ object Motif:
 
   def apply(text: Text): Motif raises Motif.Error = parse(text)
 
-  // A recursive-descent parser for the RE2 syntax subset: literals, `.`, escapes (including
-  // `\xHH` and `\x{…}`), the ASCII perl classes, character classes, alternation, groups
-  // (capturing and `(?:…)`), the `* + ? {n} {n,} {n,m}` quantifiers with an optional reluctant
-  // `?` suffix, and the anchors `^ $ \A \z \b \B`. Everything RE2 rejects by design is rejected
-  // here with a positioned error: backreferences, lookaround, possessive quantifiers, atomic
-  // groups, named groups and inline flags.
+  // A recursive-descent parser for RE2 syntax: literals, `.`, escapes (including `\xHH` and
+  // `\x{…}`), the ASCII perl classes, POSIX classes (`[[:alpha:]]`), Unicode general categories
+  // and scripts (`\p{Lu}`, `\pL`, `\p{Greek}`, and their `\P` complements), quoted runs
+  // (`\Q…\E`), character classes, alternation, groups (capturing, non-capturing and named),
+  // the inline flags `i`, `m`, `s` and `U` in both their `(?flags)` and `(?flags:…)` forms, the
+  // `* + ? {n} {n,} {n,m}` quantifiers with an optional reluctant `?` suffix, and the anchors
+  // `^ $ \A \z \b \B`. Everything RE2 rejects by design is rejected here with a positioned
+  // error: backreferences, lookaround, possessive quantifiers and atomic groups.
   def parse(text: Text): Motif raises Motif.Error =
     val input: String = text.s
     val length: Int = input.length
     var index: Int = 0
     var captures: Int = 0
+
+    // RE2's inline flags. Each applies from where it is set to the end of the enclosing group,
+    // which `group` implements by saving and restoring them around every group body.
+    var foldCase: Boolean = false
+    var dotAll: Boolean = false
+    var multiline: Boolean = false
+    var ungreedy: Boolean = false
 
     def current: Char = if index >= length then '\u0000' else input.charAt(index)
 
@@ -125,10 +134,12 @@ object Motif:
         case node :: Nil => node
         case _           => Node.Sequence(nodes.reverse)
 
+    // Under `U` the default greediness is swapped, so a bare quantifier is reluctant and a
+    // `?`-suffixed one is greedy.
     def reluctant(): Boolean = current match
-      case '?' => true.adv()
+      case '?' => (!ungreedy).adv()
       case '+' => abort(Motif.Error(index, PossessiveQuantifier))
-      case _   => false
+      case _   => ungreedy
 
     def quantified(node: Node): Node = current match
       case '*' => index += 1; Node.Repeat(node, 0, Unset, reluctant())
@@ -175,27 +186,72 @@ object Motif:
 
       count
 
+    // Every class-valued construct goes through here, so `i` folds them all uniformly —
+    // `[a-z]`, `\\p{Lu}` and `\\w` alike.
+    def klass(ranges: Ranges): Node = Node.Klass(if foldCase then ranges.folded else ranges)
+
     def atom(): Node = current match
       case '('             => group()
       case '['             => charClass()
-      case '.'             => Node.Klass(Ranges.any).adv()
-      case '^'             => Node.Boundary(Node.Anchor.Start).adv()
-      case '$'             => Node.Boundary(Node.Anchor.End).adv()
+      case '.'             => klass(if dotAll then Ranges.anySymbol else Ranges.any).adv()
+
+      case '^' =>
+        Node.Boundary(if multiline then Node.Anchor.LineStart else Node.Anchor.Start).adv()
+
+      case '$' =>
+        Node.Boundary(if multiline then Node.Anchor.LineEnd else Node.Anchor.End).adv()
       case '\\'            => escape()
       case '*' | '+' | '?' => abort(Motif.Error(index, UnexpectedChar))
-      case _               => Node.Literal(codepoint())
+
+      case _ =>
+        val symbol = codepoint()
+
+        // Under `i` a literal denotes its whole fold orbit, so it becomes a class.
+        if !foldCase then Node.Literal(symbol) else
+          val folded = Ranges.point(symbol).folded
+          if folded == Ranges.point(symbol) then Node.Literal(symbol) else Node.Klass(folded)
 
     def closeGroup(): Unit =
       if current == ')' then index += 1 else abort(Motif.Error(index, UnclosedGroup))
 
+    // Applies a run of flag letters, honouring a `-` that switches to clearing them. Returns
+    // false if a character is not a flag letter, so the caller can report it in position.
+    def applyFlags(): Boolean =
+      var setting = true
+      var valid = true
+
+      while valid && current != ')' && current != ':' && index < length do
+        current match
+          case '-' => setting = false.also(index += 1)
+          case 'i' => foldCase = setting.also(index += 1)
+          case 's' => dotAll = setting.also(index += 1)
+          case 'm' => multiline = setting.also(index += 1)
+          case 'U' => ungreedy = setting.also(index += 1)
+          case _   => valid = false
+
+      valid
+
     def group(): Node =
       index += 1
+
+      // Flags are scoped to the enclosing group, so every group body restores what it found.
+      val savedFold = foldCase
+      val savedDot = dotAll
+      val savedMulti = multiline
+      val savedUngreedy = ungreedy
+
+      def restore(): Unit =
+        foldCase = savedFold
+        dotAll = savedDot
+        multiline = savedMulti
+        ungreedy = savedUngreedy
 
       if current == '?' then lookahead() match
         case ':' =>
           index += 2
           val child = alternation()
           closeGroup()
+          restore()
           Node.Group(child, Unset)
 
         case '=' | '!' =>
@@ -203,16 +259,60 @@ object Motif:
 
         case '<' => lookahead(2) match
           case '=' | '!' => abort(Motif.Error(index - 1, Lookaround))
-          case _         => abort(Motif.Error(index - 1, UnsupportedGroup))
 
-        case 'P' => abort(Motif.Error(index - 1, UnsupportedGroup))
+          // `(?<name>…)` is a named capture: the name plays no part in the language, so the
+          // group is captured positionally as if unnamed, exactly as RE2 numbers it.
+          case _ =>
+            val close = input.indexOf('>', index + 2)
+            if close < 0 then abort(Motif.Error(index - 1, UnclosedGroup))
+            index = close + 1
+            captures += 1
+            val capture = captures
+            val child = alternation()
+            closeGroup()
+            restore()
+            Node.Group(child, capture)
+
+        // `(?P<name>…)` is the same thing under RE2's older spelling.
+        case 'P' =>
+          if lookahead(2) != '<' then abort(Motif.Error(index - 1, UnsupportedGroup))
+          val close = input.indexOf('>', index + 3)
+          if close < 0 then abort(Motif.Error(index - 1, UnclosedGroup))
+          index = close + 1
+          captures += 1
+          val capture = captures
+          val child = alternation()
+          closeGroup()
+          restore()
+          Node.Group(child, capture)
+
         case '>' => abort(Motif.Error(index - 1, AtomicGroup))
-        case _   => abort(Motif.Error(index - 1, Flag))
+
+        case _ =>
+          val start = index
+          index += 1
+          if !applyFlags() then abort(Motif.Error(index, Flag))
+
+          if current == ':' then
+            // `(?flags:…)` scopes the flags to this group alone.
+            index += 1
+            val child = alternation()
+            closeGroup()
+            restore()
+            Node.Group(child, Unset)
+          else if current == ')' then
+            // `(?flags)` sets them for the rest of the enclosing group, so the saved values
+            // are deliberately *not* restored here.
+            index += 1
+            Node.Empty
+          else abort(Motif.Error(start, Flag))
+
       else
         captures += 1
         val capture = captures
         val child = alternation()
         closeGroup()
+        restore()
         Node.Group(child, capture)
 
     def perlClass(char: Char): Boolean = "dDwWsS".indexOf(char) >= 0
@@ -226,6 +326,30 @@ object Motif:
       case 'S' => Ranges.space.negate().adv()
       case _   => abort(Motif.Error(index, InvalidEscape))
 
+    // `\\pN`, `\\p{Name}` and their negated `\\P` forms. The cursor is on the `p` or `P`.
+    def unicodeRanges(): Ranges =
+      val negated = current == 'P'
+      index += 1
+
+      val name =
+        if current != '{' then
+          val single = String.valueOf(current).nn
+          index += 1
+          single
+        else
+          val close = input.indexOf('}', index)
+          if close < 0 then abort(Motif.Error(index, UnclosedClass))
+          val braced = input.substring(index + 1, close).nn
+          index = close + 1
+          braced
+
+      // A `\\p{^Name}` is RE2's other spelling of negation.
+      val inverted = name.startsWith("^")
+      val plain = if inverted then name.substring(1).nn else name
+
+      Ranges.unicode(plain).lay(abort(Motif.Error(index, UnknownUnicodeClass))): ranges =>
+        if negated != inverted then ranges.negate() else ranges
+
     def charClass(): Node =
       index += 1
       val negated = current == '^'
@@ -238,12 +362,37 @@ object Motif:
         ranges = ranges.union(classItem())
 
       index += 1
-      Node.Klass(if negated then ranges.negate() else ranges)
+      klass(if negated then ranges.negate() else ranges)
+
+    // `[:name:]` and its negated `[:^name:]`, valid only inside a character class. RE2 treats a
+    // `[:` that does not close with `:]` as ordinary characters, so this only commits once the
+    // whole form is present.
+    def posixClass(): Optional[Ranges] =
+      val close = input.indexOf(":]", index + 2)
+
+      if current != '[' || lookahead() != ':' || close < 0 then Unset else
+        val negated = lookahead(2) == '^'
+        val from = index + (if negated then 3 else 2)
+        val name = input.substring(from, close).nn
+
+        Ranges.posix.stdlib.get(name) match
+          case scala.Some(ranges) =>
+            index = close + 2
+            if negated then ranges.negate() else ranges
+
+          case _ =>
+            abort(Motif.Error(index, InvalidPosixClass))
 
     def classItem(): Ranges =
+      posixClass().lay(nonPosixClassItem())(identity(_))
+
+    def nonPosixClassItem(): Ranges =
       if current == '\\' && perlClass(lookahead()) then
         index += 1
         perlRanges()
+      else if current == '\\' && (lookahead() == 'p' || lookahead() == 'P') then
+        index += 1
+        unicodeRanges()
       else
         val start = classChar()
 
@@ -269,18 +418,40 @@ object Motif:
 
       current match
         case '\u0000'  => abort(Motif.Error(index, UnclosedEscape))
-        case 'd'       => Node.Klass(Ranges.digit).adv()
-        case 'D'       => Node.Klass(Ranges.digit.negate()).adv()
-        case 'w'       => Node.Klass(Ranges.word).adv()
-        case 'W'       => Node.Klass(Ranges.word.negate()).adv()
-        case 's'       => Node.Klass(Ranges.space).adv()
-        case 'S'       => Node.Klass(Ranges.space.negate()).adv()
+        case 'd'       => klass(Ranges.digit).adv()
+        case 'D'       => klass(Ranges.digit.negate()).adv()
+        case 'w'       => klass(Ranges.word).adv()
+        case 'W'       => klass(Ranges.word.negate()).adv()
+        case 's'       => klass(Ranges.space).adv()
+        case 'S'       => klass(Ranges.space.negate()).adv()
         case 'b'       => Node.Boundary(Node.Anchor.WordBoundary).adv()
         case 'B'       => Node.Boundary(Node.Anchor.NonWordBoundary).adv()
         case 'A'       => Node.Boundary(Node.Anchor.Start).adv()
         case 'z'       => Node.Boundary(Node.Anchor.End).adv()
         case 'k'       => abort(Motif.Error(index, Backreference))
-        case 'p' | 'P' => abort(Motif.Error(index, InvalidEscape))
+        case 'p' | 'P' => klass(unicodeRanges())
+
+        // `\\Q…\\E` quotes a run of literal text, in which no character is special. An
+        // unterminated `\\Q` runs to the end of the pattern, as RE2 allows.
+        case 'Q' =>
+          index += 1
+          val close = input.indexOf("\\E", index)
+          val end = if close < 0 then length else close
+          val literal = input.substring(index, end).nn
+          index = if close < 0 then length else close + 2
+
+          if literal.isEmpty then Node.Empty else
+            var nodes: List[Node] = Nil
+            var at = 0
+
+            while at < literal.length do
+              val symbol = literal.codePointAt(at)
+              nodes = Node.Literal(symbol) :: nodes
+              at += Character.charCount(symbol)
+
+            nodes match
+              case node :: Nil => node
+              case _           => Node.Sequence(nodes.reverse)
 
         case char if char >= '1' && char <= '9' =>
           abort(Motif.Error(index, Backreference))
@@ -375,6 +546,9 @@ object Motif:
         case Unverifiable =>
           m"the pattern contains constructs which the analysis cannot verify"
 
+        case InvalidPosixClass   => m"the POSIX character class name is not recognised"
+        case UnknownUnicodeClass => m"the Unicode class name is not recognised"
+
     enum Reason(val number: Int) extends Clarification:
       case UnclosedGroup        extends Reason(1)
       case NotInGroup           extends Reason(2)
@@ -395,6 +569,8 @@ object Motif:
       case RepetitionTooLarge   extends Reason(17)
       case BudgetExceeded       extends Reason(18)
       case Unverifiable         extends Reason(19)
+      case InvalidPosixClass    extends Reason(20)
+      case UnknownUnicodeClass  extends Reason(21)
 
   case class Error(index: Int, reason: Motif.Error.Reason)(using Diagnostics)
   extends fulminate.Error(500, reason.number)

--- a/lib/praxinoscope/src/core/praxinoscope.Pike.scala
+++ b/lib/praxinoscope/src/core/praxinoscope.Pike.scala
@@ -106,6 +106,13 @@ object Pike:
       case Node.Anchor.WordBoundary    => word(at) != wordBefore(at)
       case Node.Anchor.NonWordBoundary => word(at) == wordBefore(at)
 
+      // Under the `m` flag, `^` and `$` match either end of the input or a newline boundary.
+      case Node.Anchor.LineStart =>
+        at == 0 || symbolizer.before(input, at) == '\n'.toInt
+
+      case Node.Anchor.LineEnd =>
+        at == length || symbolizer.symbol(input, at) == '\n'.toInt
+
     def add(list: Threads, pc: Int, saved: scala.Array[Int], at: Int): Unit =
       if !list.marked(pc) then
         list.mark(pc)

--- a/lib/praxinoscope/src/core/praxinoscope.Ranges.scala
+++ b/lib/praxinoscope/src/core/praxinoscope.Ranges.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package praxinoscope
 
+import vacuous.*
+
 object Ranges:
   // The greatest symbol in the default (Unicode codepoint) domain. Other symbol domains (UTF-8
   // bytes, say) are strictly smaller, so this is a safe universal bound for `negate`.
@@ -52,6 +54,122 @@ object Ranges:
   val space: Ranges = new Ranges('\t'.toInt :: '\r'.toInt :: ' '.toInt :: ' '.toInt :: Nil)
   val any: Ranges = new Ranges(0 :: '\n'.toInt - 1 :: '\n'.toInt + 1 :: maxSymbol :: Nil)
   val anySymbol: Ranges = new Ranges(0 :: maxSymbol :: Nil)
+
+  // Every symbol the predicate admits, as coalesced runs. Scanning the whole domain is what
+  // makes the Unicode classes exact — the JDK's own tables answer the predicate, so there is no
+  // second copy of the Unicode database here to drift out of date — and it costs one pass per
+  // distinct class, which `unicode` memoises.
+  def where(predicate: Int => Boolean): Ranges =
+    val spans = scala.collection.mutable.ListBuffer.empty[Int]
+    var symbol = 0
+    var start = -1
+
+    while symbol <= maxSymbol do
+      if predicate(symbol) then (if start < 0 then start = symbol)
+      else if start >= 0 then
+        spans += start
+        spans += symbol - 1
+        start = -1
+
+      symbol += 1
+
+    if start >= 0 then
+      spans += start
+      spans += maxSymbol
+
+    new Ranges(spans.to(List))
+
+  // The POSIX classes of RE2's `[[:name:]]` form, all ASCII-only.
+  val posix: Map[String, Ranges] = Map
+    ( "alnum"  -> Ranges('0', '9').union(Ranges('A', 'Z')).union(Ranges('a', 'z')),
+      "alpha"  -> Ranges('A', 'Z').union(Ranges('a', 'z')),
+      "ascii"  -> Ranges(0x00, 0x7f),
+      "blank"  -> Ranges.point('\t').union(Ranges.point(' ')),
+      "cntrl"  -> Ranges(0x00, 0x1f).union(Ranges.point(0x7f)),
+      "digit"  -> digit,
+      "graph"  -> Ranges('!', '~'),
+      "lower"  -> Ranges('a', 'z'),
+      "print"  -> Ranges(' ', '~'),
+      "punct"  -> Ranges('!', '/').union(Ranges(':', '@')).union(Ranges('[', '`'))
+                  . union(Ranges('{', '~')),
+      "space"  -> Ranges('\t', '\r').union(Ranges.point(' ')),
+      "upper"  -> Ranges('A', 'Z'),
+      "word"   -> word,
+      "xdigit" -> Ranges('0', '9').union(Ranges('A', 'F')).union(Ranges('a', 'f')) )
+
+  private val unicodeClasses: scala.collection.concurrent.TrieMap[String, Optional[Ranges]] =
+    scala.collection.concurrent.TrieMap()
+
+  // A Unicode general category (`L`, `Lu`, `Nd`, …) or script (`Greek`, `Han`, …) by the name
+  // RE2's `\p{…}` uses, or `Unset` if no such class exists. `Any` is RE2's name for the whole
+  // domain. General categories are matched by prefix, so the one-letter `L` is the union of
+  // `Lu`, `Ll`, `Lt`, `Lm` and `Lo`, exactly as RE2 defines it.
+  def unicode(name: String): Optional[Ranges] =
+    unicodeClasses.getOrElseUpdate(name, compute(name))
+
+  private def compute(name: String): Optional[Ranges] =
+    if name == "Any" then anySymbol
+    else if categories.stdlib.contains(name) then where(symbol => categoryName(symbol) == name)
+    else if categoryGroups.stdlib.contains(name)
+    then where(symbol => categoryName(symbol).startsWith(name))
+    else
+      try
+        val script = Character.UnicodeScript.forName(name).nn
+        where(symbol => Character.UnicodeScript.of(symbol) == script)
+      catch case _: IllegalArgumentException => Unset
+
+  // The two-letter general-category abbreviation for a codepoint, as Unicode names them.
+  private def categoryName(symbol: Int): String = Character.getType(symbol) match
+    case Character.UPPERCASE_LETTER          => "Lu"
+    case Character.LOWERCASE_LETTER          => "Ll"
+    case Character.TITLECASE_LETTER          => "Lt"
+    case Character.MODIFIER_LETTER           => "Lm"
+    case Character.OTHER_LETTER              => "Lo"
+    case Character.NON_SPACING_MARK          => "Mn"
+    case Character.COMBINING_SPACING_MARK    => "Mc"
+    case Character.ENCLOSING_MARK            => "Me"
+    case Character.DECIMAL_DIGIT_NUMBER      => "Nd"
+    case Character.LETTER_NUMBER             => "Nl"
+    case Character.OTHER_NUMBER              => "No"
+    case Character.CONNECTOR_PUNCTUATION     => "Pc"
+    case Character.DASH_PUNCTUATION          => "Pd"
+    case Character.START_PUNCTUATION         => "Ps"
+    case Character.END_PUNCTUATION           => "Pe"
+    case Character.INITIAL_QUOTE_PUNCTUATION => "Pi"
+    case Character.FINAL_QUOTE_PUNCTUATION   => "Pf"
+    case Character.OTHER_PUNCTUATION         => "Po"
+    case Character.MATH_SYMBOL               => "Sm"
+    case Character.CURRENCY_SYMBOL           => "Sc"
+    case Character.MODIFIER_SYMBOL           => "Sk"
+    case Character.OTHER_SYMBOL              => "So"
+    case Character.SPACE_SEPARATOR           => "Zs"
+    case Character.LINE_SEPARATOR            => "Zl"
+    case Character.PARAGRAPH_SEPARATOR       => "Zp"
+    case Character.CONTROL                   => "Cc"
+    case Character.FORMAT                    => "Cf"
+    case Character.SURROGATE                 => "Cs"
+    case Character.PRIVATE_USE               => "Co"
+    case _                                   => "Cn"
+
+  private val categories: Set[String] = Set
+    ( "Lu", "Ll", "Lt", "Lm", "Lo", "Mn", "Mc", "Me", "Nd", "Nl", "No", "Pc", "Pd", "Ps", "Pe",
+      "Pi", "Pf", "Po", "Sm", "Sc", "Sk", "So", "Zs", "Zl", "Zp", "Cc", "Cf", "Cs", "Co", "Cn" )
+
+  private val categoryGroups: Set[String] = Set("L", "M", "N", "P", "S", "Z", "C")
+
+  // Codepoints equivalent under simple case folding, grouped into orbits keyed by their folded
+  // form. An orbit is not always a pair: `K`, `k` and the Kelvin sign all fold together, which
+  // is why folding cannot be done by mapping each symbol up and down in isolation.
+  private lazy val foldOrbits: scala.collection.immutable.Map[Int, scala.Array[Int]] =
+    val groups = scala.collection.mutable.HashMap.empty[Int, scala.List[Int]]
+    var symbol = 0
+
+    while symbol <= maxSymbol do
+      val folded = Character.toLowerCase(Character.toUpperCase(symbol))
+      if folded != symbol then groups(folded) = symbol :: groups.getOrElse(folded, scala.Nil)
+      symbol += 1
+
+    groups.map((key, members) => (key, (key :: members).toArray)).toMap
 
 // A set of symbols, represented as a sorted, disjoint, non-adjacent list of inclusive
 // `lo :: hi :: …` bounds. Symbols are `Int`-encoded members of an ordered alphabet: Unicode
@@ -99,3 +217,25 @@ case class Ranges private(spans: List[Int]):
     new Ranges(recur(spans, 0))
 
   def intersect(that: Ranges): Ranges = negate().union(that.negate()).negate()
+
+  // The closure of this set under simple case folding, as RE2's `i` flag defines it. Only the
+  // orbits are examined, not the whole domain, so this is proportional to the number of
+  // case-varying codepoints rather than to the size of the set.
+  def folded: Ranges =
+    var result = this
+
+    Ranges.foldOrbits.foreach: (_, members) =>
+      var index = 0
+      var hit = false
+
+      while !hit && index < members.length do
+        hit = contains(members(index))
+        index += 1
+
+      if hit then
+        var at = 0
+        while at < members.length do
+          result = result.union(Ranges.point(members(at)))
+          at += 1
+
+    result

--- a/lib/praxinoscope/src/core/praxinoscope.Subsumption.scala
+++ b/lib/praxinoscope/src/core/praxinoscope.Subsumption.scala
@@ -120,7 +120,11 @@ object Subsumption:
 
     while index < program.ops.length do
       program.ops(index) match
-        case Program.Op.Test(Node.Anchor.WordBoundary | Node.Anchor.NonWordBoundary, _) =>
+        // Word and line boundaries are context-dependent in a way this analysis does not
+        // model, so a program containing one cannot be decided either way.
+        case Program.Op.Test
+             ( Node.Anchor.WordBoundary | Node.Anchor.NonWordBoundary | Node.Anchor.LineStart
+               | Node.Anchor.LineEnd, _ ) =>
           abort(Motif.Error(0, Unverifiable))
 
         case _ =>

--- a/lib/praxinoscope/src/core/praxinoscope.internal.scala
+++ b/lib/praxinoscope/src/core/praxinoscope.internal.scala
@@ -67,6 +67,8 @@ object internal:
       case Node.Anchor.End             => '{Node.Anchor.End}
       case Node.Anchor.WordBoundary    => '{Node.Anchor.WordBoundary}
       case Node.Anchor.NonWordBoundary => '{Node.Anchor.NonWordBoundary}
+      case Node.Anchor.LineStart       => '{Node.Anchor.LineStart}
+      case Node.Anchor.LineEnd         => '{Node.Anchor.LineEnd}
 
   given op: ToExpr[Program.Op]:
     def apply(op: Program.Op)(using Quotes): Expr[Program.Op] = op match
@@ -117,7 +119,11 @@ object internal:
 
     while opIndex < ops.length do
       ops(opIndex) match
-        case Program.Op.Test(Node.Anchor.WordBoundary | Node.Anchor.NonWordBoundary, _) =>
+        // The generated DFA has no notion of the symbol before the cursor, so a
+        // context-dependent anchor falls back to the Pike VM.
+        case Program.Op.Test
+             ( Node.Anchor.WordBoundary | Node.Anchor.NonWordBoundary | Node.Anchor.LineStart
+               | Node.Anchor.LineEnd, _ ) =>
           unsupported = true
 
         case _ =>

--- a/lib/praxinoscope/src/test/praxinoscope_test.scala
+++ b/lib/praxinoscope/src/test/praxinoscope_test.scala
@@ -275,11 +275,12 @@ object Tests extends Suite(m"Praxinoscope tests"):
       test(m"Reject lookbehind")(capture[Motif.Error](Motif.parse(t"(?<=a)")))
       . assert(_.reason == Reason.Lookaround)
 
-      test(m"Reject a named group")(capture[Motif.Error](Motif.parse(t"(?<name>a)")))
-      . assert(_.reason == Reason.UnsupportedGroup)
+      test(m"Reject an unclosed named group"):
+        capture[Motif.Error](Motif.parse(t"(?<name a)"))
+      . assert(_.reason == Reason.UnclosedGroup)
 
-      test(m"Reject a P-style named group")(capture[Motif.Error](Motif.parse(t"(?P<name>a)")))
-      . assert(_.reason == Reason.UnsupportedGroup)
+      test(m"Reject an unknown group prefix")(capture[Motif.Error](Motif.parse(t"(?Qa)")))
+      . assert(_.reason == Reason.Flag)
 
       test(m"Reject an atomic group")(capture[Motif.Error](Motif.parse(t"(?>a)")))
       . assert(_.reason == Reason.AtomicGroup)
@@ -287,11 +288,15 @@ object Tests extends Suite(m"Praxinoscope tests"):
       test(m"Reject a possessive quantifier")(capture[Motif.Error](Motif.parse(t"a*+")))
       . assert(_.reason == Reason.PossessiveQuantifier)
 
-      test(m"Reject an inline flag")(capture[Motif.Error](Motif.parse(t"(?i)a")))
+      test(m"Reject an unknown inline flag")(capture[Motif.Error](Motif.parse(t"(?x)a")))
       . assert(_.reason == Reason.Flag)
 
-      test(m"Reject a unicode property escape")(capture[Motif.Error](Motif.parse(t"\\p{L}")))
-      . assert(_.reason == Reason.InvalidEscape)
+      test(m"Reject an unknown unicode class")(capture[Motif.Error](Motif.parse(t"\\p{Nope}")))
+      . assert(_.reason == Reason.UnknownUnicodeClass)
+
+      test(m"Reject an unknown POSIX class"):
+        capture[Motif.Error](Motif.parse(t"[[:nope:]]"))
+      . assert(_.reason == Reason.InvalidPosixClass)
 
     suite(m"Matching"):
       def motif(pattern: Text): Motif = Motif.parse(pattern)
@@ -391,11 +396,23 @@ object Tests extends Suite(m"Praxinoscope tests"):
       test(m"Agree on a corpus of patterns and inputs"):
         val patterns = List
           ( t"a*b", t"(a|b)*c", t"[a-m]+", t"a{2,4}", t"(ab)+", t"a?b?c?", t"\\d+", t"\\w+",
-            t"[^x]*x", t"a(b|c)d", t"(?:ab|cd)+", t"x[0-9]{2}y", t"a+b+c+", t"(a?)(a?)aa" )
+            t"[^x]*x", t"a(b|c)d", t"(?:ab|cd)+", t"x[0-9]{2}y", t"a+b+c+", t"(a?)(a?)aa",
+            // The RE2 syntax added later. Only the constructs `java.util.regex` spells the
+            // same way are listed: RE2's POSIX classes (`[[:alpha:]]`) have no `java.util.regex`
+            // equivalent — Java writes those `\\p{Alpha}` — and RE2's bare script names
+            // (`\\p{Greek}`) are `\\p{IsGreek}` there, so including either would compare
+            // two different languages rather than two implementations of one. Both are
+            // covered directly in the "POSIX and Unicode classes" suite.
+            t"\\p{Lu}+", t"\\p{L}+", t"\\P{L}+", t"[\\p{Lu}0-9]+", t"\\Qa.b\\E",
+            t"\\Qa+\\Eb",
+            t"(?i)abc", t"(?i)[a-m]+", t"(?i)\\p{Lu}+", t"a(?i)bc", t"(?i:ab)c", t"(?s).+",
+            t"(?i)mix", t"(?i)WORDY1" )
 
         val inputs = List
           ( t"", t"a", t"b", t"ab", t"abc", t"aab", t"aaab", t"abab", t"abababc", t"aabb",
-            t"123", t"x42y", t"xyz", t"aaaa", t"abcd", t"cdab", t"wordy1", t"mix", t"aax" )
+            t"123", t"x42y", t"xyz", t"aaaa", t"abcd", t"cdab", t"wordy1", t"mix", t"aax",
+            t"ABC", t"AbC", t"MIX", t"Wordy1", t"A1B", t"a.b", t"axb", t"a+b", t"\u00c5",
+            t"ABCdef", t"A", t"1", t"a\nb" )
 
         var failures: List[Text] = Nil
 
@@ -470,6 +487,112 @@ object Tests extends Suite(m"Praxinoscope tests"):
       test(m"Word boundaries are unverifiable"):
         capture[Motif.Error](motif(t"\\bfoo\\b").subsumes(motif(t"foo")))
       . assert(_.reason == Reason.Unverifiable)
+
+    suite(m"POSIX and Unicode classes"):
+      def motif(pattern: Text): Motif = Motif.parse(pattern)
+
+      test(m"A POSIX class matches its members")(motif(t"[[:alpha:]]").matches(t"a"))
+      . assert(_ == true)
+
+      test(m"A POSIX class rejects a non-member")(motif(t"[[:alpha:]]").matches(t"1"))
+      . assert(_ == false)
+
+      test(m"A negated POSIX class complements it")(motif(t"[[:^digit:]]").matches(t"a"))
+      . assert(_ == true)
+
+      test(m"A POSIX class combines with other class items"):
+        motif(t"[[:digit:]abc]+").matches(t"1a2b")
+      . assert(_ == true)
+
+      // `[:alpha:]` outside a bracket pair is an ordinary class of those characters, as RE2
+      // reads it — the POSIX form only exists nested inside a character class.
+      test(m"A bare colon form is an ordinary class")(motif(t"x[:alpha:]y").matches(t"xay"))
+      . assert(_ == true)
+
+      test(m"A general category matches")(motif(t"\\p{Lu}").matches(t"A")).assert(_ == true)
+
+      test(m"A general category rejects another category")(motif(t"\\p{Lu}").matches(t"a"))
+      . assert(_ == false)
+
+      test(m"A one-letter category is the union of its subcategories"):
+        motif(t"\\pL+").matches(t"abc\u00c5")
+      . assert(_ == true)
+
+      test(m"A negated category complements it")(motif(t"\\P{L}").matches(t"1"))
+      . assert(_ == true)
+
+      test(m"A script class matches its script")(motif(t"\\p{Greek}+").matches(t"\u03b1\u03b2"))
+      . assert(_ == true)
+
+      test(m"A script class rejects another script")(motif(t"\\p{Greek}+").matches(t"abc"))
+      . assert(_ == false)
+
+      test(m"A category nests inside a character class"):
+        motif(t"[\\p{Lu}0-9]+").matches(t"A1B")
+      . assert(_ == true)
+
+      test(m"Quoted text is literal")(motif(t"\\Qa.b\\E").matches(t"a.b")).assert(_ == true)
+
+      test(m"Quoted text does not act as a metacharacter"):
+        motif(t"\\Qa.b\\E").matches(t"axb")
+      . assert(_ == false)
+
+      test(m"Quoting ends at the terminator")(motif(t"\\Qa+b\\Ec").matches(t"a+bc"))
+      . assert(_ == true)
+
+    suite(m"Inline flags"):
+      def motif(pattern: Text): Motif = Motif.parse(pattern)
+
+      test(m"`i` folds a literal")(motif(t"(?i)abc").matches(t"AbC")).assert(_ == true)
+
+      test(m"`i` does not make unrelated letters match")(motif(t"(?i)abc").matches(t"abd"))
+      . assert(_ == false)
+
+      test(m"`i` folds a character class")(motif(t"(?i)[a-z]+").matches(t"AbC"))
+      . assert(_ == true)
+
+      test(m"`i` folds a Unicode class")(motif(t"(?i)\\p{Lu}").matches(t"a")).assert(_ == true)
+
+      test(m"`i` applies from where it is set")(motif(t"a(?i)bc").matches(t"aBC"))
+      . assert(_ == true)
+
+      test(m"`i` does not apply before where it is set")(motif(t"a(?i)bc").matches(t"Abc"))
+      . assert(_ == false)
+
+      test(m"A scoped flag applies to its group")(motif(t"(?i:ab)c").matches(t"ABc"))
+      . assert(_ == true)
+
+      test(m"A scoped flag is restored after its group")(motif(t"(?i:ab)c").matches(t"ABC"))
+      . assert(_ == false)
+
+      test(m"A cleared flag has no effect")(motif(t"(?-i)a").matches(t"a")).assert(_ == true)
+
+      // The Kelvin sign folds together with `K` and `k`, so a fold orbit is not always a pair.
+      test(m"`i` folds a whole orbit, not just a pair")(motif(t"(?i)K").matches(t"\u212a"))
+      . assert(_ == true)
+
+      test(m"`i` folds beyond ASCII")(motif(t"(?i)\u03a3").matches(t"\u03c3"))
+      . assert(_ == true)
+
+      test(m"`s` lets a dot match a newline")(motif(t"(?s).").matches(t"\n")).assert(_ == true)
+
+      test(m"A dot does not match a newline by default")(motif(t".").matches(t"\n"))
+      . assert(_ == false)
+
+      test(m"`m` anchors at a line boundary"):
+        motif(t"(?m)^b$$").seek(t"a\nb\nc").present
+      . assert(_ == true)
+
+      test(m"Anchors bind to the whole input by default"):
+        motif(t"^b$$").seek(t"a\nb\nc").present
+      . assert(_ == false)
+
+      test(m"A named group captures positionally"):
+        motif(t"(?<x>a)(b)").groups(t"ab").let(_.stdlib.size)
+      . assert(_ == 2)
+
+      test(m"A P-style named group captures too")(motif(t"(?P<x>a)b").matches(t"ab"))
+      . assert(_ == true)
 
     suite(m"Containment of an intersection"):
       def motif(pattern: Text): Motif = Motif.parse(pattern)

--- a/lib/stratiform/res/test/stratiform/corpus/DIVERGENCES.md
+++ b/lib/stratiform/res/test/stratiform/corpus/DIVERGENCES.md
@@ -33,21 +33,25 @@ tel commit `75e591b`, ahead of `UPSTREAM_SHA`. The rest of the corpus was left
 at the recorded commit, so `UPSTREAM_SHA` still names the commit the bulk of the
 fixtures came from.
 
-Pattern matching is backed by `praxinoscope`, whose RE2 subset is narrower than
-the syntax §21.8 refers to:
+Pattern matching is backed by `praxinoscope`, which implements RE2 syntax
+including inline flags (`i`, `m`, `s`, `U`, in both the `(?flags)` and
+`(?flags:…)` forms), POSIX classes (`[[:alpha:]]`), Unicode general categories
+and scripts (`\p{Lu}`, `\pL`, `\p{Greek}`, and their `\P` complements),
+quoted runs (`\Q…\E`), and named capturing groups.
 
-- **Inline flags** (`(?i)`, `(?s)`, …) are rejected (`Motif.Error.Reason.Flag`),
-  though §21.8 explicitly permits them. A schema using one is reported **E222**.
-- **Unicode property classes** (`\p{…}`, `\P{…}`) are rejected likewise, as is
-  `\Z`.
-- **Word boundaries** (`\b`, `\B`) parse and match, but the containment
-  analysis cannot model them (`Unverifiable`), so a layer replacement involving
-  one is not provable and fails closed as **E223**.
+One divergence remains, and it is in the *containment* analysis rather than in
+matching:
 
-The first two are genuine conformance gaps against §21.8's requirement that two
-conforming implementations accept exactly the same values; they fail closed
-(E222, never silently permissive), so they are safe but not complete. No
-upstream fixture exercises them.
+- **Word boundaries** (`\b`, `\B`) and, under the `m` flag, the line anchors
+  `^` and `$` parse and match correctly, but the containment analysis cannot
+  model them (`Unverifiable`) because they depend on the symbols surrounding a
+  position rather than on the position alone. A layer replacement involving one
+  is therefore not provable and fails closed as **E223**. Matching such a
+  pattern against a value is unaffected.
+
+(An earlier revision of this file claimed `\Z` was an unsupported gap. That was
+wrong: RE2 has no `\Z` — it spells end-of-text `\z` — so rejecting it is
+correct behaviour, not a divergence.)
 
 The §21.8 resource budget this implementation documents is
 `praxinoscope.Subsumption.maxStates` = 100,000 product states, matching the Rust


### PR DESCRIPTION
Praxinoscope implemented a subset of RE2 rather than the whole syntax, which mattered once TEL adopted RE2 pattern constraints: §21.8 requires that two conforming implementations accept exactly the same values, so a construct the specification permits but the engine rejects is a conformance gap. Inline flags, POSIX classes, Unicode categories and scripts, quoted runs and named groups are now all supported. One of these was worse than a rejection — a POSIX class such as `[[:alpha:]]` parsed without error as a nested character class, so it silently enforced the wrong constraint rather than failing.

## Inline flags

The `i`, `m`, `s` and `U` flags are supported in both the `(?flags)` and `(?flags:…)` forms, and in their clearing `(?-flags)` form. Flags apply from where they are set to the end of the enclosing group:

```scala
Motif.parse(t"(?i)abc").matches(t"AbC")     // true
Motif.parse(t"a(?i)bc").matches(t"Abc")     // false — `i` starts after `a`
Motif.parse(t"(?i:ab)c").matches(t"ABC")    // false — the group restores it
```

Case folding closes over whole fold orbits rather than mapping a symbol up and down, because an orbit is not always a pair — `K`, `k` and the Kelvin sign `K` all fold together:

```scala
Motif.parse(t"(?i)K").matches(t"K")    // true
```

`m` makes `^` and `$` match at line boundaries, `s` lets `.` match a newline, and `U` swaps the default greediness.

## POSIX classes

`[[:alpha:]]` and the other thirteen POSIX names are supported inside a character class, along with their negated `[[:^alpha:]]` forms:

```scala
Motif.parse(t"[[:digit:][:upper:]]+").matches(t"A1B")   // true
```

Previously these did not error — `[[:alpha:]]` parsed as a nested class and accepted `a]` in place of `a`. A `[:alpha:]` *outside* a surrounding character class remains an ordinary class of those characters, as RE2 reads it.

## Unicode categories and scripts

`\p{…}` and `\P{…}` accept Unicode general categories, including the one-letter groups, and script names:

```scala
Motif.parse(t"\\p{Lu}+").matches(t"ABC")      // true
Motif.parse(t"\\pL+").matches(t"abcÅ")        // true
Motif.parse(t"\\p{Greek}+").matches(t"αβγ")   // true
Motif.parse(t"[\\p{Lu}0-9]+").matches(t"A1B") // true
```

Script names are spelled as RE2 spells them (`\p{Greek}`, not Java's `\p{IsGreek}`). Classes are resolved against the JDK's own Unicode tables, so there is no second copy of the Unicode database in the codebase to drift out of date.

Under `i`, Unicode classes fold like any other class, so `(?i)\p{Lu}` matches a lowercase letter.

## Quoted runs and named groups

`\Q…\E` quotes a run of literal text, in which nothing is special; an unterminated `\Q` runs to the end of the pattern, as RE2 allows. Named groups are accepted in both the `(?<name>…)` and `(?P<name>…)` spellings and capture positionally, since a group's name plays no part in the language it matches.

## What remains undecidable

Word boundaries (`\b`, `\B`) and, under `m`, the line anchors `^` and `$` match correctly but cannot be *compared*: they depend on the symbols surrounding a position rather than on the position alone, which the product-automaton construction behind `subsumes` does not model. Containment involving one is reported as `Unverifiable` rather than guessed, and the compile-time DFA generator falls back to the Pike VM for them. In TEL this surfaces as a layer refinement that fails closed with E223; matching a value against such a pattern is unaffected.

## Compatibility

This is additive: every pattern that parsed before parses to the same program. Two error reasons are new — `InvalidPosixClass` (`SN-500.20`) and `UnknownUnicodeClass` (`SN-500.21`) — and three constructs that previously raised an error now succeed, so code asserting that `(?i)…`, `\p{…}` or `(?<name>…)` is rejected will need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
