### PR TITLE
Generalize host-contract assembly beyond jsig/1

### DIFF
--- a/lib/mandible/src/lira/mandible.HostContracts.scala
+++ b/lib/mandible/src/lira/mandible.HostContracts.scala
@@ -48,9 +48,10 @@ import Lira.Error.Reason
 case class HostRelease(tag: Text, content: List[(TreePath, Data)])
 
 // Builds the release sequence of a host-contract module from harvested surfaces: each release
-// is atomized under `jsig/1`, graded against its predecessor by the ordinary algebra, given
-// the derived version §12.5 dictates, threaded onto the lineage — a major beginning a fresh
-// one — and assembled as a complete, tagged `.lira` host contract.
+// is atomized under the given discipline — `jsig/1` by default, `dts/1` or `wit/1` for
+// contracts whose carrier is declarations rather than stubs — graded against its predecessor
+// by the ordinary algebra, given the derived version §12.5 dictates, threaded onto the lineage
+// — a major beginning a fresh one — and assembled as a complete, tagged `.lira` host contract.
 //
 // A major is a removal in the host's history (the JDK 9 and 11 removals are the canonical
 // cases), and L110 requires the operator to sanction it: `allowMajor` is that sanction, per
@@ -61,12 +62,13 @@ object HostContracts:
     ( module:     Text,
       releases:   List[HostRelease],
       toolchain:  List[Lira.Manifest.Tool],
+      discipline: Discipline                 = JsigDiscipline,
       allowMajor: Text -> Boolean            = { _ => false },
       sign:       Lira.Manifest -> Lira.Manifest = { manifest => manifest } )
     ( using Tactic[Lira.Error], Tactic[Discipline.Error] )
   :   List[(Text, Data)] =
 
-    val registry = Discipline.Registry(List(JsigDiscipline))
+    val registry = Discipline.Registry(List(discipline))
     val context = Discipline.Context(t"host")
     val results = scala.collection.mutable.ListBuffer[(Text, Data)]()
 

--- a/lib/mandible/src/lira/mandible.HostSurfaces.scala
+++ b/lib/mandible/src/lira/mandible.HostSurfaces.scala
@@ -145,6 +145,34 @@ object CtSym:
 
     finally zip.close()
 
+// A directory of carrier files — the `.wit` of a WASI world, the `.d.ts` of a JavaScript
+// runtime's builtins — read into the content tree a host contract carries. A single file is
+// admitted as a one-entry tree. Entries are sorted by path: a filesystem's traversal order is
+// not deterministic, and a harvest of the same bytes must build the same tree.
+object HostTree:
+
+  def surface(path: Text, suffix: Text): List[(TreePath, Data)] raises Lira.Error =
+    val root = java.nio.file.Paths.get(path.s).nn
+    val entries = scala.collection.mutable.ListBuffer[(TreePath, Data)]()
+
+    if java.nio.file.Files.isDirectory(root) then
+      val stream = java.nio.file.Files.walk(root).nn
+
+      try
+        stream.iterator.nn.asScala.foreach: item =>
+          if java.nio.file.Files.isRegularFile(item) && item.toString.endsWith(suffix.s) then
+            val relative = root.relativize(item).nn.toString.replace('\\', '/').nn
+            val bytes = java.nio.file.Files.readAllBytes(item).nn
+            entries += ((TreePath(Text(relative)), Array.unsafeFrozen(bytes)))
+
+      finally stream.close()
+
+    else if java.nio.file.Files.isRegularFile(root) && root.toString.endsWith(suffix.s) then
+      val bytes = java.nio.file.Files.readAllBytes(root).nn
+      entries += ((TreePath(Text(root.getFileName.nn.toString)), Array.unsafeFrozen(bytes)))
+
+    List.from(entries.toList.sortBy(_(0).text.s))
+
 // A stub jar — `android.jar` for one API level, or any signature-bearing archive — read into
 // the content tree a host contract carries.
 object HostArchive:

--- a/lib/mandible/src/lira/soundness_mandible_lira.scala
+++ b/lib/mandible/src/lira/soundness_mandible_lira.scala
@@ -33,4 +33,4 @@
 package soundness
 
 export mandible.{ClassfileAtomizer, ClassfileDiscipline, CtSym, HostArchive, HostContracts,
-    HostRelease, JsigDiscipline, JvmProfile, UsedSets}
+    HostRelease, HostTree, JsigDiscipline, JvmProfile, UsedSets}


### PR DESCRIPTION
Two small mandible changes that let host contracts be harvested from declaration carriers, not only stub archives:

- **`HostContracts.assemble` takes a `discipline` parameter**, defaulting to `JsigDiscipline` so every existing call site is unchanged. A harvester of a `.d.ts` or `.wit` carrier names `dts/1` or `wit/1` instead.
- **`HostTree`** joins `CtSym` and `HostArchive` as the third surface reader: a directory (or single file) of carrier files, suffix-filtered, read into a host contract's content tree — sorted by path, since filesystem traversal order is not deterministic and a harvest of the same bytes must build the same tree.

`mandible.test` passes (54/54) on this branch; `xenophile.test` (203, including the `dts/1` and `wit/1` discipline suites) verified unaffected. Downstream, propensive/lira#17 adds `lira harvest dts|wit` on top of these, verified end-to-end there (minor extension, refused-then-sanctioned major, install-grade verification of the emitted contracts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
