### PR TITLE
Give flag-operand completions the partial operand text (#1859)

### DIFF
--- a/lib/exoskeleton/src/args/exoskeleton.Discoverable.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Discoverable.scala
@@ -34,17 +34,23 @@ package exoskeleton
 
 import scala.language.experimental.pureFunctions
 
+import anticipation.*
 import denominative.*
 import distillate.*
 import prepositional.*
 
 object Discoverable:
-  def noSuggestions[operand]: operand is Discoverable = _ => Nil.stdlib
+  def noSuggestions[operand]: operand is Discoverable = (_, _) => Nil
 
-  given enumerable: [value: {Enumerable, Identifiable}] => value is Discoverable = _ =>
+  given enumerable: [value: {Enumerable, Identifiable}] => value is Discoverable = (_, _) =>
     value.values.readable.toList
     . map: element => value.encode(value.name(element))
     . map(Suggestion(_))
+    . to(List)
 
 trait Discoverable extends Typeclass:
-  def discover(tab: Ordinal): Iterable[Suggestion]
+  // Suggestions for a flag's operand at the cursor. `operand` is the partially-typed operand
+  // text (empty when the operand word has not been started), so an instance can resolve it —
+  // descending into a directory being typed, say — exactly as the positional `Pathname`
+  // extractor does; `tab` is the number of times tab has been pressed at this position.
+  def discover(operand: Text, tab: Ordinal): List[Suggestion]

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -231,6 +231,6 @@ extends Topical:
     // Marked as operand values, not subcommands: they are candidates for this flag's operand, so
     // the help tree must not descend into them (see `Suggestion.operand`).
     given suggestions: Topic is Discoverable =
-      _ => options.map(suggestible.suggest(_).copy(operand = true))
+      (_, _) => options.map(suggestible.suggest(_).copy(operand = true)).to(List)
 
     this()

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -105,12 +105,17 @@ extends Cli:
     val operands = interpreter.find(parameters, flag)
 
     interpreter.focus(parameters).let: argument =>
+      // The partially-typed operand text is passed for the `Discoverable` to resolve. In the
+      // first case the focused argument is the operand itself (the `--flag=operand` form); in
+      // the second the focus is the flag, with the cursor on the following word — the flag's
+      // operand at that position, or empty if the word has not been started.
       if operands.prim == argument then
-        val allSuggestions = discoverable.discover(tab).to(List)
+        val allSuggestions = discoverable.discover(argument(), tab)
         if allSuggestions != Nil then cursorSuggestions = allSuggestions
 
       if flag.matches(argument) && currentArgument == argument.position + 1 then
-        val allSuggestions = discoverable.discover(tab).to(List)
+        val operand = operands.seek(_.position == currentArgument).let(_()).or(t"")
+        val allSuggestions = discoverable.discover(operand, tab)
         if allSuggestions != Nil then cursorSuggestions = allSuggestions
 
     if !flag.secret then

--- a/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
@@ -51,82 +51,75 @@ import interfaces.paths.pathOnLocal
 import filesystemBackends.virtualMachineFilesystem
 
 object Pathname:
-  def unapply(argument: Argument)(using WorkingDirectory, Cli, System): Option[Path on Local] =
-    // The property is read straight off the `System` capability rather than through
-    // `Directories.homeText`, which panics when it is unset. An unknown home leaves `~` alone,
-    // to resolve (and fail) like any other name.
-    val home: Optional[Text] = summon[System](t"user.home").let: text =>
-      if text.length > 1 && text.ends(t"/") then text.skip(1, Bidi.Rtl) else text
+  // The property is read straight off the `System` capability rather than through
+  // `Directories.homeText`, which panics when it is unset. An unknown home leaves `~` alone,
+  // to resolve (and fail) like any other name.
+  private def home(using System): Optional[Text] = summon[System](t"user.home").let: text =>
+    if text.length > 1 && text.ends(t"/") then text.skip(1, Bidi.Rtl) else text
 
-    // A shell expands `~` before exec, but a quoted argument and every partial word handed to
-    // the completion script arrive with the tilde intact, so it is expanded here too.
-    def expand(text: Text): Text = home.lay(text): home =>
-      if text == t"~" then home else if text.starts(t"~/") then home+text.skip(1) else text
+  // A shell expands `~` before exec, but a quoted argument and every partial word handed to
+  // the completion script arrive with the tilde intact, so it is expanded here too.
+  private def expand(text: Text)(using System): Text = home.lay(text): home =>
+    if text == t"~" then home else if text.starts(t"~/") then home+text.skip(1) else text
 
-    // The inverse, so a completion under a tilde stays short and keeps its tilde.
-    def abbreviate(text: Text): Text = home.lay(text): home =>
-      if text == home then t"~"
-      else if text.starts(home+t"/") then t"~"+text.skip(home.length)
-      else text
+  // The inverse, so a completion under a tilde stays short and keeps its tilde.
+  private def abbreviate(text: Text)(using System): Text = home.lay(text): home =>
+    if text == home then t"~"
+    else if text.starts(home+t"/") then t"~"+text.skip(home.length)
+    else text
+
+  // The pathname completion candidates for the partially-typed `operand` — expanding `~`,
+  // resolving against the working directory, and descending into a directory as it is typed —
+  // shared by the positional extractor below and the flag-operand `pathnameDiscoverable`.
+  // `tab` is the number of tab presses at the position (a repeated press reveals hidden
+  // entries). Empty when the operand cannot be resolved.
+  def complete(operand: Text, tab: Ordinal)(using WorkingDirectory, System): List[Suggestion] =
+    def suggest(path: Text): Suggestion =
+      val point = path.s.lastIndexOf('/', path.length - 2) + 1
+      val prefix = path.keep(point)
+      val core = path.skip(point)
+      // Only a directory leaves the completion mid-path; a file candidate is complete,
+      // and accepting it should advance to the next argument. Every candidate is an operand
+      // value rather than a subcommand, so the help tree does not enumerate the working
+      // directory as though it were syntax (see `Suggestion.operand`).
+      Suggestion(core, Unset, incomplete = path.ends(t"/"), prefix = prefix, operand = true)
 
     safely:
-      def suggest(path: Text): Suggestion =
-        val point = path.s.lastIndexOf('/', path.length - 2) + 1
-        val prefix = path.keep(point)
-        val core = path.skip(point)
-        // Only a directory leaves the completion mid-path; a file candidate is complete,
-        // and accepting it should advance to the next argument. Every candidate is an operand
-        // value rather than a subcommand, so the help tree does not enumerate the working
-        // directory as though it were syntax (see `Suggestion.operand`).
-        Suggestion(core, Unset, incomplete = path.ends(t"/"), prefix = prefix, operand = true)
+      if operand == t"." then
+        suggest(t"../") ::
+          workingDirectory.children.stdlib.toList.filter(_.name.starts(t".")).map: path =>
+            val directory = safely(path.entry() == galilei.Directory).or(false)
+            suggest(if directory then path.name+t"/" else path.name)
+        . to(List)
 
-      // Each branch adds to `prior` rather than replacing it: another extractor evaluated
-      // against the same argument (typically a `Subcommand`) must keep its suggestions.
-      if argument() == t"." then argument.suggest:
-        val wd: Path on Local = workingDirectory
-        val listing =
-          suggest(t"../") ::
-            workingDirectory.children.stdlib.toList.filter(_.name.starts(t".")).map: path =>
-              val directory = safely(path.entry() == galilei.Directory).or(false)
-              suggest(if directory then path.name+t"/" else path.name)
-          . to(List)
+      else if operand == t".." then
+        suggest(t"../") ::
+          workingDirectory.children.stdlib.toList.filter(_.name.starts(t"..")).map: path =>
+            val directory = safely(path.entry() == galilei.Directory).or(false)
+            suggest(if directory then path.name+t"/" else path.name)
+        . to(List)
 
-        listing + prior
-
-      else if argument() == t".." then argument.suggest:
-        val listing =
-          suggest(t"../") ::
-            workingDirectory.children.stdlib.toList.filter(_.name.starts(t"..")).map: path =>
-              val directory = safely(path.entry() == galilei.Directory).or(false)
-              suggest(if directory then path.name+t"/" else path.name)
-          . to(List)
-
-        listing + prior
-
-      else if argument().nil then argument.suggest:
+      else if operand.nil then
         val children0 = workingDirectory.children.stdlib.toList
-        val showAll = argument.tab.or(Prim) > Prim
+        val showAll = tab > Prim
         val children =
           if !showAll then children0.filter(!_.name.starts(t".")) else children0
 
-        val listing =
-         children.map: path =>
+        children.map: path =>
           val directory = safely(path.entry() == galilei.Directory).or(false)
           suggest(if directory then path.name+t"/" else path.name)
-         . to(List)
-
-        listing + prior
+        . to(List)
 
       else
-        val tilde = home.present && (argument() == t"~" || argument().starts(t"~/"))
-        val absolute = argument().starts(t"/")
+        val tilde = home.present && (operand == t"~" || operand.starts(t"~/"))
+        val absolute = operand.starts(t"/")
         // A bare `~` names the home directory itself, so it lists that directory's children,
         // exactly as `~/` does; without this it would list the home directory's siblings.
-        val directory = argument().ends(t"/") || argument() == t"~"
+        val directory = operand.ends(t"/") || operand == t"~"
         // Resolution runs under its own optional tactic; no aliased writer.
         val prototype = scala.caps.unsafe.unsafeAssumeSeparate:
-          workingDirectory.resolve(expand(argument()))
-        val showAll = argument.tab.or(Prim) > Prim || prototype.name.starts(t".")
+          workingDirectory.resolve(expand(operand))
+        val showAll = tab > Prim || prototype.name.starts(t".")
         val base: Optional[Path on Local] = if directory then prototype else prototype.parent
         val children0 = base.let(base => base.children.stdlib.toList.to(List)).or(List[Path on Local]())
 
@@ -134,20 +127,33 @@ object Pathname:
           if directory then children0
           else children0.filter(_.name.starts(prototype.name))
 
-        argument.suggest:
-          val children2 =
-            if !showAll then children.filter(!_.name.starts(t".")) else children
+        val children2 =
+          if !showAll then children.filter(!_.name.starts(t".")) else children
 
-          val listing = children2.map: path =>
-            val directory = safely(path.entry() == galilei.Directory).or(false)
-            val slash = if directory then t"/" else t""
+        children2.map: path =>
+          val directory = safely(path.entry() == galilei.Directory).or(false)
+          val slash = if directory then t"/" else t""
 
-            suggest:
-              if tilde then abbreviate(path.encode)+slash
-              else if absolute then path.encode+slash
-              else workingDirectory.toward(path).encode+slash
+          suggest:
+            if tilde then abbreviate(path.encode)+slash
+            else if absolute then path.encode+slash
+            else workingDirectory.toward(path).encode+slash
 
-          listing + prior
+    . or(List())
+
+
+  def unapply(argument: Argument)(using WorkingDirectory, Cli, System): Option[Path on Local] =
+    // The candidates add to `prior` rather than replacing it: another extractor evaluated
+    // against the same argument (typically a `Subcommand`) must keep its suggestions.
+    argument.suggest(Pathname.complete(argument(), argument.tab.or(Prim)) + prior)
 
     scala.caps.unsafe.unsafeAssumeSeparate:
       safely(workingDirectory.resolve(expand(argument()))).option
+
+// The subject `Path on Local` belongs to serpentine, and `Discoverable`'s companion (in the
+// platform-neutral `args` module) cannot see galilei, so this given is structurally
+// un-anchorable: it lives at the top level with a library-qualified name, to be imported by
+// name (issue #1632). With it in scope, a `Flag[Path on Local]`'s operand completes as a
+// pathname exactly as a positional `Pathname` argument does.
+given pathnameDiscoverable: (WorkingDirectory, System) => (Path on Local) is Discoverable =
+  (operand, tab) => Pathname.complete(operand, tab)

--- a/lib/exoskeleton/src/completions/soundness_exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/soundness_exoskeleton_completions.scala
@@ -32,7 +32,8 @@
                                                                                                   */
 package soundness
 
-export exoskeleton.{CliEvent, Completion, Completions, execute, Execution, explain, Pathname}
+export exoskeleton.{CliEvent, Completion, Completions, execute, Execution, explain, Pathname,
+    pathnameDiscoverable}
 
 package executives:
   export exoskeleton.executives.completions

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -89,7 +89,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
                 case Beta() :: _  => execute(Exit.Ok)
 
                 case Gamma() :: _ =>
-                  given Hue is Discoverable = _ => List(t"red", t"green", t"blue").map(Suggestion(_))
+                  given Hue is Discoverable = (_, _) => List(Suggestion(t"red"), Suggestion(t"green"), Suggestion(t"blue"))
                   given Hue is Interpretable =
                     case argument :: Nil => Hue(argument())
                     case _               => Hue(t"unknown")
@@ -107,7 +107,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
                       Flag("two", description = t"the second one")()
                       execute(Exit.Ok)
                     case Gentoo() :: _ =>
-                      given Hue is Discoverable = _ => List(t"red", t"green", t"blue").map(Suggestion(_))
+                      given Hue is Discoverable = (_, _) => List(Suggestion(t"red"), Suggestion(t"green"), Suggestion(t"blue"))
                       given Hue is Interpretable =
                         case argument :: Nil => Hue(argument())
                         case _               => Hue(t"unknown")
@@ -118,12 +118,12 @@ object Tests extends Suite(m"Exoskeleton Tests"):
                     case _             => execute(Exit.Ok)
 
                 case Tree() :: _ =>
-                  given Segment is Discoverable = _ => List(Suggestion(t"src/", incomplete = true))
+                  given Segment is Discoverable = (_, _) => List(Suggestion(t"src/", incomplete = true))
                   given Segment is Interpretable =
                     case argument :: Nil => Segment(argument())
                     case _               => Segment(t"")
 
-                  given Node is Discoverable = _ => List(Suggestion(t"key.", incomplete = true))
+                  given Node is Discoverable = (_, _) => List(Suggestion(t"key.", incomplete = true))
                   given Node is Interpretable =
                     case argument :: Nil => Node(argument())
                     case _               => Node(t"")
@@ -1117,3 +1117,63 @@ object Tests extends Suite(m"Exoskeleton Tests"):
           try invoke(app)() yet t"returned"
           catch case error: MissingFlagError => t"raised"
         .assert(_ == t"raised")
+
+      suite(m"Pathname operand completion"):
+        import interfaces.paths.pathOnLinux
+        import interpreters.posixInterpreter
+        import stdios.muteStdio
+
+        // A directory of known content, used as the working directory below so that
+        // `Pathname.complete`'s listings are deterministic.
+        val fixture: Path on Linux = unsafely:
+          val dir: Path on Linux =
+            temporaryDirectory[Path on Linux]/t"exoskeleton-operand-${Uuid()}"
+
+          dir.create[Directory]()
+          (dir/t"one.txt").create[File]()
+          (dir/t"two.txt").create[File]()
+          (dir/t"src").create[Directory]()
+          (dir/t"src"/t"inner.txt").create[File]()
+          dir
+
+        given WorkingDirectory = () => fixture.encode
+
+        test(m"An empty operand lists the working directory's visible entries"):
+          Pathname.complete(t"", Prim).map(_.core).sort(identity)
+        .assert(_ == List(t"one.txt", t"src/", t"two.txt"))
+
+        test(m"A partial name narrows the candidates"):
+          Pathname.complete(t"on", Prim).map(_.core)
+        .assert(_ == List(t"one.txt"))
+
+        test(m"A directory operand descends into the directory"):
+          Pathname.complete(t"src/", Prim).map { s => t"${s.prefix}${s.core}" }
+        .assert(_ == List(t"src/inner.txt"))
+
+        test(m"The pathname Discoverable offers the extractor's candidates for a flag operand"):
+          pathnameDiscoverable.discover(t"src/", Prim).map(_.core)
+        .assert(_ == List(t"inner.txt"))
+
+        test(m"A flag operand's partial text reaches its Discoverable"):
+          val args = Cli.arguments(List(t"--hue", t"re"), 1, 2)
+
+          val completion =
+            Completion
+              (args,
+               args,
+               summon[Environment],
+               summon[WorkingDirectory],
+               Shell.Zsh,
+               1,
+               2,
+               summon[Stdio],
+               t"",
+               Prim,
+               Login(t"tester", Unset))
+
+          given Text is Discoverable = (operand, _) => List(Suggestion(t"[$operand]"))
+
+          def app(using cli: Cli): Unit = Flag[Text](t"hue")() yet ()
+          app(using completion)
+          completion.cursorSuggestions.map(_.core)
+        .assert(_ == List(t"[re]"))


### PR DESCRIPTION
Flag operands can now offer real, resolving tab-completions: a `Discoverable` receives the partially-typed operand text — so it can expand `~`, resolve against the working directory, and descend into a directory as the user types — and a `Flag[Path on Local]`'s operand completes as a pathname out of the box, exactly as positional `Pathname` arguments already did.

`Discoverable.discover` now takes the partial operand text alongside the tab count (and returns a prelude `List`, so proscenium-only code needs no `.stdlib` conversion):

```scala
trait Discoverable extends Typeclass:
  def discover(operand: Text, tab: Ordinal): List[Suggestion]
```

Existing instances migrate by adding a parameter: `_ => suggestions` becomes `(_, _) => suggestions`. The text is threaded through from the completion by `Completion.register` for both operand forms — `--flag operand` and `--flag=operand`.

The pathname-candidate logic of the positional `Pathname` extractor is now available as `Pathname.complete(operand, tab)`, and a new `pathnameDiscoverable` given (imported by name, e.g. `import soundness.pathnameDiscoverable`) uses it to complete path-typed flag and setting operands:

```scala
import soundness.pathnameDiscoverable

val classpath = Flag[Path on Local](t"classpath").require()
// --classpath out/<TAB> now lists the contents of out/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)