### PR TITLE
Runtime Glob matching, decoding and filesystem expansion (#1860)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2030,7 +2030,8 @@ object fulminate extends Library:
       settings.sep(super.scalacOptions())
 
 object galilei extends Library:
-  object core extends Component(aperture.core, serpentine.core, ambience.core, turbulence.core):
+  object core extends Component(aperture.core, serpentine.core, ambience.core, turbulence.core,
+      kaleidoscope.core):
     // The native `FilesystemBackend` (`filesystemBackends.native`) is folded into the native cross
     // via `nativeSources` — native has a single OS filesystem, so (unlike the JVM/WASI backends,
     // which are separate modules) it need not be an opt-in dependency.
@@ -2377,7 +2378,8 @@ object jacinta extends Library:
 
 object kaleidoscope extends Library:
   object core
-  extends Component(contingency.core, contextual.core, praxinoscope.core, prepositional.core):
+  extends Component(contingency.core, contextual.core, distillate.core, praxinoscope.core,
+      prepositional.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object test extends Tests(core):
@@ -2698,7 +2700,8 @@ object proscenium extends Library:
 
 object probably extends Library:
   object core extends Component(anticipation.check, chiaroscuro.core, chiaroscuro.render,
-      ambience.core, digression.ansi, escapade.io, nomenclature.core, coverage):
+      ambience.core, digression.ansi, escapade.io, kaleidoscope.core, nomenclature.core,
+      coverage):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")

--- a/lib/galilei/src/core/galilei_core.scala
+++ b/lib/galilei/src/core/galilei_core.scala
@@ -38,6 +38,7 @@ import java.nio.file as jnf
 import anticipation.*
 import contingency.*
 import denominative.*
+import kaleidoscope.*
 import prepositional.*
 import rudiments.*
 import serpentine.*
@@ -120,6 +121,54 @@ extension [plane: Filesystem](path: Path on plane)
       summon[TraversalOrder] match
         case TraversalOrder.PreOrder  => child #:: child.descendants
         case TraversalOrder.PostOrder => child.descendants #::: Chain(child)
+
+
+  // Expands `pattern` against the directory tree beneath this path, walking segment-wise:
+  // each ordinary segment filters the current directories' `children` by match, and a segment
+  // which is exactly `**` matches any number of intermediate directories — so only the
+  // directories on the pattern's spine are ever listed, rather than every descendant being
+  // walked and filtered. The pattern is relative to this path, which should name a directory.
+  // A `**` mixed into a segment (`a**b`) matches within a single name, exactly as `*` does:
+  // only a whole-segment `**` spans directories.
+  def glob(pattern: Glob)
+    ( using explorable: plane is Explorable,
+            symlinks:   DereferenceSymlinks,
+            backend:    FilesystemBackend on plane )
+  :   List[Path on plane] raises Io.Error =
+
+    import Glob.Token
+
+    def segments(tokens: scala.List[Token]): scala.List[scala.List[Token]] =
+      val head = tokens.takeWhile(_ != Token.Exact('/'))
+      val tail = tokens.dropWhile(_ != Token.Exact('/'))
+      if tail.isEmpty then scala.List(head) else head :: segments(tail.tail)
+
+    def directory(candidate: Path on plane): Boolean =
+      safely(candidate.entry() == Directory).or(false)
+
+    def recur(dirs: scala.List[Path on plane], todo: scala.List[scala.List[Token]])
+    :   scala.List[Path on plane] =
+
+      todo match
+        case scala.Nil => dirs
+
+        case scala.::(segment, rest) =>
+          if segment == scala.List(Token.Globstar) then
+            // `**` matches zero or more directories: the rest of the pattern is expanded both
+            // here and, with the `**` retained, in every subdirectory.
+            val deeper = dirs.flatMap: dir =>
+              recur(dir.children.stdlib.toList.filter(directory), todo)
+
+            recur(dirs, rest) ++ deeper
+          else
+            val matcher = Glob(segment*)
+
+            val matched = dirs.flatMap: dir =>
+              dir.children.stdlib.toList.filter { child => matcher.matches(child.name) }
+
+            recur(if rest.isEmpty then matched else matched.filter(directory), rest)
+
+    recur(scala.List(path), segments(pattern.tokens.toList)).distinct.to(List)
 
 
   // Named `filesize` (not `size`): a same-named export beside the collections' `size` at the

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -413,3 +413,52 @@ object Tests extends Suite(m"Galilei tests"):
           outer.open[Directory](Read & Exclusive) { () }
           outer.open[Directory](Read & Exclusive) { true }
       . assert(_ == true)
+
+    suite(m"Glob expansion"):
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.dereferenceSymlinks.enabled
+
+      val globLeaf: Text = Uuid().show
+      val root: Path on Linux = unsafely((% / "tmp" / globLeaf).on[Linux])
+
+      unsafely:
+        root.create[Directory]()
+        (root / "a.jar").write(t"a")
+        (root / "a.txt").write(t"a")
+        (root / "sub1").create[Directory]()
+        (root / "sub1" / "b.jar").write(t"b")
+        (root / "sub1" / "inner").create[Directory]()
+        (root / "sub1" / "inner" / "c.jar").write(t"c")
+        (root / "sub2").create[Directory]()
+        (root / "sub2" / "d.jar").write(t"d")
+
+      def names(paths: List[Path on Linux]): List[Text] = paths.map(_.name).sort(identity)
+
+      test(m"A star glob matches entries of the root only"):
+        unsafely(names(root.glob(Glob.parse(t"*.jar"))))
+      . assert(_ == List(t"a.jar"))
+
+      test(m"A question mark matches a single character"):
+        unsafely(names(root.glob(Glob.parse(t"?.txt"))))
+      . assert(_ == List(t"a.txt"))
+
+      test(m"A character range filters a wildcard segment"):
+        unsafely(names(root.glob(Glob.parse(t"*/[bd].jar"))))
+      . assert(_ == List(t"b.jar", t"d.jar"))
+
+      test(m"A literal segment descends directly"):
+        unsafely(names(root.glob(Glob.parse(t"sub1/*.jar"))))
+      . assert(_ == List(t"b.jar"))
+
+      test(m"A globstar spans any number of directories"):
+        unsafely(names(root.glob(Glob.parse(t"**/*.jar"))))
+      . assert(_ == List(t"a.jar", t"b.jar", t"c.jar", t"d.jar"))
+
+      test(m"A globstar below a literal segment spans its subtree only"):
+        unsafely(names(root.glob(Glob.parse(t"sub1/**/*.jar"))))
+      . assert(_ == List(t"b.jar", t"c.jar"))
+
+      test(m"A pattern matching nothing yields an empty list"):
+        unsafely(root.glob(Glob.parse(t"nowhere/*.jar")))
+      . assert(_ == List())

--- a/lib/kaleidoscope/src/core/kaleidoscope.Glob.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Glob.scala
@@ -33,9 +33,16 @@
 package kaleidoscope
 
 import anticipation.*
+import distillate.*
+import prepositional.*
 import rudiments.*
+import vacuous.*
 
 object Glob:
+  // `parse` is total — any character outside the wildcard syntax is an `Exact` token — so
+  // glob-valued flags and configuration values decode without an explicit step.
+  given decodable: Glob is Decodable in Text = parse(_)
+
   import Glob.Token.*
 
   def parse(text: Text): Glob =
@@ -95,4 +102,15 @@ object Glob:
         chars.flatMap(Exact(_).regex).mkString(s"[${if inverse then "^" else ""}", "", "]")
 
 case class Glob(tokens: Glob.Token*):
-  def regex: Text = Text(tokens.map(_.regex).mkString)
+  lazy val regex: Text = Text(tokens.map(_.regex).mkString)
+
+  // Matches the whole of `text`, on the backend selected by an imported `RegexBackend`
+  // (`import regexBackends.re2`), defaulting to `java.util.regex` — the same selection
+  // mechanism as the `r"…"` and `g"…"` interpolators. The engines cache compilation by
+  // rendered pattern, so matching many candidates against one `Glob` compiles it only once.
+  def matches[form](text: Text)
+    ( using backend: RegexBackend[form] = regexBackends.jur )
+    ( using engine:  form is Regex.Engine )
+  :   Boolean =
+
+    Regex(regex, Nil).to[form].matches(text)(using Scanner(Unset))

--- a/lib/kaleidoscope/src/test/kaleidoscope_test.scala
+++ b/lib/kaleidoscope/src/test/kaleidoscope_test.scala
@@ -512,6 +512,36 @@ object Tests extends Suite(m"Kaleidoscope tests"):
 
       . assert(_ == t"hello[^a-z]world")
 
+      test(m"A star glob matches at runtime"):
+        Glob.parse(t"*.jar").matches(t"foo.jar")
+
+      . assert(_ == true)
+
+      test(m"A star does not cross a slash at runtime"):
+        Glob.parse(t"*.jar").matches(t"dir/foo.jar")
+
+      . assert(_ == false)
+
+      test(m"A globstar crosses slashes at runtime"):
+        Glob.parse(t"**/*.jar").matches(t"dir/deeper/foo.jar")
+
+      . assert(_ == true)
+
+      test(m"A question mark matches exactly one character at runtime"):
+        (Glob.parse(t"a?c").matches(t"abc"), Glob.parse(t"a?c").matches(t"abbc"))
+
+      . assert(_ == (true, false))
+
+      test(m"Ranges and negated ranges match at runtime"):
+        (Glob.parse(t"[a-c]").matches(t"b"), Glob.parse(t"[!a-c]").matches(t"b"))
+
+      . assert(_ == (true, false))
+
+      test(m"A glob decodes from text"):
+        t"h?llo*.jar".as[Glob]
+
+      . assert(_ == Glob.parse(t"h?llo*.jar"))
+
       test(m"Extract from a glob"):
         t"/home/work/docs" match
           case g"/$home/work/docs" => home

--- a/lib/probably/src/core/probably.Selection.scala
+++ b/lib/probably/src/core/probably.Selection.scala
@@ -111,8 +111,6 @@ object Selection:
             least.let { least => most.let(Constraint.Interval(axis, least, _)) }
           else Constraint.Membership(axis, value.cut(t",").to[Set])
 
-  private[probably] def globRegex(pattern: Text): Text =
-    pattern.cut(t"*").map { part => java.util.regex.Pattern.quote(part.s).nn.tt }.join(t".*")
 
 // A subset of a suite's tests, parsed from command-line terms: which tests run (and, for
 // axial tests and benchmarks, which of their cells), or — with `--list` — which are only
@@ -146,12 +144,15 @@ case class Selection
       case Selection.Term.Identifier(name) =>
         chain.exists: link => link.id == name || link.moniker.lay(false)(_ == name)
 
+      // Kaleidoscope glob semantics (`?`, `[a-z]`, `[!a-z]` now work): `*` matches within one
+      // `/`-joined link, so spanning a suite path takes `**`, e.g. `jacinta/**` or
+      // `**/parseJson`. (Formerly a private translation in which `*` crossed `/`.)
       case Selection.Term.Glob(pattern) =>
-        val regex = Selection.globRegex(pattern)
+        val glob = kaleidoscope.Glob.parse(pattern)
 
-        names.exists(_.s.matches(regex.s))
-        || path.s.matches(regex.s)
-        || monikerPath.s.matches(regex.s)
+        names.exists(glob.matches(_))
+        || glob.matches(path)
+        || glob.matches(monikerPath)
 
   private def admitted(coordinates: List[(Axis.Spec, Value)]): Boolean =
     constraints.all: constraint =>


### PR DESCRIPTION
Kaleidoscope's `Glob` is now a first-class runtime value, not just a compile-time pattern: it can match text directly, decode from configuration or command-line values, and — through galilei — expand against a directory tree, listing only the directories on the pattern's spine.

`Glob#matches` matches the whole of a text, selecting its backend exactly as the `r"…"` and `g"…"` interpolators do — `java.util.regex` by default, or RE2 under `import regexBackends.re2` — and the engines cache compilation per rendered pattern, so matching many candidates against one `Glob` compiles it only once:

```scala
val glob = Glob.parse(t"*.jar")
names.filter(glob.matches(_))
```

`Glob` also now has a `Decodable in Text` instance (`Glob.parse` is total), so a `Flag[Glob]`, `Setting[Glob]` or any glob-valued configuration decodes without an explicit step.

In galilei, `path.glob(pattern)` expands a glob against the filesystem:

```scala
workingDirectory.glob(Glob.parse(t"*/test/assembly.dest/*.jar")): List[Path on Local]
```

The walk is segment-wise: ordinary segments filter `children` by match, and a segment which is exactly `**` matches any number of intermediate directories — so no directory off the pattern's spine is ever listed, unlike walking every descendant and filtering. A `**` mixed into a segment (`a**b`) matches within a single name, like `*`.

Probably's test `Selection` now uses kaleidoscope's glob grammar instead of its own private translation, so `?` and character ranges work in test selections. One deliberate change of semantics: `*` no longer spans `/`-joined suite paths — selecting across suites now takes `**`, e.g. `jacinta/**` or `**/parseJson`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)