### PR TITLE
Read the terminal width from COLUMNS in environment Termcaps (#1789)

### DIFF
--- a/lib/ambience/src/core/ambience_core.scala
+++ b/lib/ambience/src/core/ambience_core.scala
@@ -105,6 +105,11 @@ package termcaps:
   given environmentTermcap: Environment => Termcap:
     val ansi: Boolean = true
 
+    // The terminal width forwarded in `COLUMNS`, where the invoking context set it. When it is
+    // absent or malformed — output redirected to a file or a pipe, say — the width stays
+    // unbounded, and nothing wraps (#1789).
+    override lazy val width: Int = safely(Environment.columns[Text].s.toInt).or(Int.MaxValue)
+
     lazy val color: ColorDepth =
       if safely(Environment.colorterm[Text]) == t"truecolor" then ColorDepth.TrueColor else
         val process = ProcessBuilder("tput", "colors").redirectErrorStream(true).nn.start().nn

--- a/lib/ambience/src/test/ambience_test.scala
+++ b/lib/ambience/src/test/ambience_test.scala
@@ -316,3 +316,19 @@ object Tests extends Suite(m"Ambience Tests"):
         val error = unsafely(Property.Error(t"user.home"))
         error.message.text
       . assert(_ == m"the system property user.home was not defined".text)
+
+    suite(m"Termcap tests"):
+      test(m"The environment termcap reads its width from COLUMNS"):
+        given Environment = fixedEnvironment(t"COLUMNS" -> t"120")
+        termcaps.environmentTermcap.width
+      . assert(_ == 120)
+
+      test(m"The width is unbounded when COLUMNS is not set"):
+        given Environment = fixedEnvironment()
+        termcaps.environmentTermcap.width
+      . assert(_ == Int.MaxValue)
+
+      test(m"The width is unbounded when COLUMNS is malformed"):
+        given Environment = fixedEnvironment(t"COLUMNS" -> t"wide")
+        termcaps.environmentTermcap.width
+      . assert(_ == Int.MaxValue)

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -505,6 +505,13 @@ def cli[bus <: Matchable](using executive: Executive)
         val termcap: Termcap = new Termcap:
           def ansi: Boolean = true
 
+          // The client terminal's width, detected by the launcher with `TIOCGWINSZ` and
+          // forwarded as `COLUMNS` in the invocation environment (#1789). Absent when the
+          // client's output is not a terminal, in which case the width stays unbounded and
+          // nothing wraps.
+          override lazy val width: Int =
+            safely(Environment.columns[Text].s.toInt).or(Int.MaxValue)
+
           lazy val color: ColorDepth =
             import workingDirectories.systemWorkingDirectory
 


### PR DESCRIPTION
Terminal output under an Ethereal daemon now wraps to the real terminal width. The daemon's per-invocation `Termcap` overrode `ansi` and `color` but not `width`, so anything that lays itself out to `termcap.width` — help text, escritoire tables — behaved as though the terminal were unbounded, even though the launcher already detects the client terminal's size with `TIOCGWINSZ` and forwards it as `COLUMNS` in the invocation environment. Ambience's `environmentTermcap` had the same gap, and both now read their `width` from `COLUMNS`.

When `COLUMNS` is absent or malformed, the width remains unbounded — deliberately. The launcher omits it exactly when the client's output is not a terminal (a pipe or a redirect), where wrapping would be wrong, so unbounded is the correct degradation rather than a guessed 80 columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)