### PR TITLE
Add a character-preservation test for hyphenated wrapping (#1788)

### DIFF
--- a/lib/tessellate/src/test/tessellate_test.scala
+++ b/lib/tessellate/src/test/tessellate_test.scala
@@ -127,6 +127,20 @@ object Tests extends Suite(m"Tessellate tests"):
 
       . assert(_ == SList(t"hyphen-", t"ation"))
 
+      // Regression check for #1788: a pre-tessellate implementation dropped the character
+      // before every hyphenation break (`artifact` became `art-`/`fact`), silently, at any
+      // width. Reassembling the wrapped lines — stripping the inserted hyphens and the spaces
+      // consumed at soft breaks — must reproduce the content's characters exactly.
+      test(m"hyphenated wrapping preserves every character at every width"):
+        val content = t"the realm to atomize a bare artifact in a derivative membership"
+        val expected = content.s.replace(" ", "")
+
+        (5 to 20).toList.map: width =>
+          wrapped(content, width).map(_.s.stripSuffix("-")).mkString.replace(" ", "")
+        . forall(_ == expected)
+
+      . assert(_ == true)
+
       test(m"wide characters wrap by display width, not char count"):
         wrapped(t"日本語 テスト", 6)
 


### PR DESCRIPTION
The defect reported in #1788 — hyphenated wrapping dropping the character before every break, so `artifact` rendered as `art-`/`fact` and `membership` as `membe-`/`ship` — is already fixed on `main`: the tessellate layout unification replaced escritoire's hand-rolled wrap (the code the issue quotes) with `tessellate.Flow.wrap`, whose cluster-based segmentation addresses line ends correctly. Verified against every example in the issue; no character is lost at any width.

This change adds the missing regression pin: a test that wraps a sentence containing the issue's affected words at every width from 5 to 20, reassembles the lines by stripping the inserted hyphens and the spaces consumed at soft breaks, and asserts the content's characters survive exactly — the property the original defect violated at every break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)