### PR TITLE
Wrap TreeDiagram#flow against the follow-on prefix too (#1865)

### DIFF
--- a/lib/dendrology/src/test/dendrology_test.scala
+++ b/lib/dendrology/src/test/dendrology_test.scala
@@ -97,6 +97,17 @@ object Tests extends Suite(m"Dendrology tests"):
       . flow(13)(_.value).stdlib.to(List)
     . assert(_ == List(t"└─parent", t"  └─the quick", t"    brown fox"))
 
+    test(m"Tree flow: wider follow-on tiles never overflow the width"):
+      // The `space` replacing `last` on follow-on rows is a cell wider, so the wrap budget
+      // must come from the follow-on prefix, or every continuation row overflows by one.
+      given TreeStyle[Text] =
+        TextualTreeStyle(space = t"  ", last = t"└", branch = t"├", extender = t"│ ")
+
+      TreeDiagram.by[Tree](_.children)
+        ( Tree(t"parent", List(Tree(t"ab abcdef ghi jklmno"))) )
+      . flow(13)(_.value).stdlib.to(List)
+    . assert(_ == List(t"└parent", t"  └ab abcdef", t"    ghi", t"    jklmno"))
+
     test(m"Lane DAG: a wide glyph's column measures display cells, not chars"):
       import laneDagStyles.defaultLaneDagStyle
       import hieroglyph.textMetrics.wideCharacterWidthMetric

--- a/lib/dendrology/src/tree/dendrology.TreeDiagram.scala
+++ b/lib/dendrology/src/tree/dendrology.TreeDiagram.scala
@@ -79,10 +79,16 @@ case class TreeDiagram[node](lines: Chain[(List[TreeTile], node)]):
     lines.stdlib.to(Chain).flatMap: (tiles, node) =>
       val content = line(node)
       val textual = summon[line is Textual]
+
+      // Follow-on rows substitute tiles (a `Branch` becomes an `extender`, a `Last` becomes a
+      // `space`), and nothing requires the substitutes to have the same display width, so both
+      // prefixes are measured and the content wraps against the tighter budget — conservative
+      // for the first row under a wider follow-on prefix, but no row can exceed `width`.
       val prefix = style.serialize(tiles, textual(t"")).plain.metrics
+      val followOnPrefix = style.followOn(tiles, textual(t"")).plain.metrics
 
       val rows: scala.List[line] =
-        Flow.wrap(content, (width - prefix).max(1)).stdlib.to(scala.List)
+        Flow.wrap(content, (width - prefix.max(followOnPrefix)).max(1)).stdlib.to(scala.List)
 
       if rows.isEmpty then Chain(style.serialize(tiles, content))
       else


### PR DESCRIPTION
`TreeDiagram#flow` can no longer overflow its width under a style whose follow-on tiles are wider than the tiles they replace. The wrapping budget was computed from the initial row's tile prefix alone, but continuation rows substitute tiles — a `Branch` becomes an `extender`, a `Last` becomes a `space` — and nothing requires a substitute to have the same display width, so a style like:

```scala
// `last` is one cell, but the `space` that replaces it on follow-on rows is two
TextualTreeStyle(space = t"  ", last = t"└", branch = t"├", extender = t"│ ")
```

rendered every continuation row one cell past the requested width, silently. Both prefixes are now measured, and the content wraps against the tighter of the two budgets, so no row can exceed `width` — conservative for the first row when the follow-on prefix is the wider, which is the right trade: a uniformly-confined block is more useful than a first row that fills the width while its continuations spill past it.

The built-in styles' tiles are all the same width, so their output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)