### PR TITLE
Unify facsimile's and savagery's affine matrices on mosquito (#1867)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1990,7 +1990,8 @@ object exoskeleton extends Library:
 object facsimile extends Library:
   object core extends Component(aperture.core, turbulence.core,
       pneumatic.flate, pneumatic.lzw, zephyrine.core, gastronomy.core, enigmatic.core,
-      hypotenuse.core, phoenicia.core, quantitative.units, iridescence.core, aviation.core):
+      hypotenuse.core, phoenicia.core, quantitative.units, iridescence.core, aviation.core,
+      mosquito.core):
     override def scalaJs = false // JCE (`enigmatic`), for the `Guard` encryption layer
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -49,6 +49,7 @@ import gossamer.*
 import hypotenuse.maximize
 import hieroglyph.*
 import iridescence.*
+import mosquito.*
 import phoenicia.*
 import pneumatic.*
 import prepositional.*
@@ -572,28 +573,19 @@ object Pdf:
       created:  Optional[Info.Timing],
       modified: Optional[Info.Timing] )
 
+  // The six live entries of a PDF transformation matrix (ISO 32000-2 §8.3.4), shared with
+  // SVG as mosquito's `Affine` (#1867). PDF documents the transposed, row-vector layout
+  // ⎡ a b 0 / c d 0 / e f 1 ⎦, in which `this * that` transforms by `this` first: that
+  // composition is `Affine`'s `andThen`, and the six numbers appear in the same spec-defined
+  // order under both conventions, so the wire format is unaffected.
+  type Matrix = Affine[Double]
+
   // PdfMatrix → Pdf.Matrix
   object Matrix:
-    val Identity: Matrix = Matrix(1, 0, 0, 1, 0, 0)
+    val Identity: Matrix = Affine.identity[Double]
 
-  // The six live entries of a PDF transformation matrix (ISO 32000-2 §8.3.4):
-  //
-  //   ⎡ a b 0 ⎤
-  //   ⎢ c d 0 ⎥
-  //   ⎣ e f 1 ⎦
-  //
-  // applied to row vectors, so `this * that` transforms by `this` first.
-  case class Matrix(a: Double, b: Double, c: Double, d: Double, e: Double, f: Double):
-    def * (that: Matrix): Matrix =
-      Matrix
-        ( a*that.a + b*that.c,
-          a*that.b + b*that.d,
-          c*that.a + d*that.c,
-          c*that.b + d*that.d,
-          e*that.a + f*that.c + that.e,
-          e*that.b + f*that.d + that.f )
-
-    def apply(x: Double, y: Double): (Double, Double) = (a*x + c*y + e, b*x + d*y + f)
+    def apply(a: Double, b: Double, c: Double, d: Double, e: Double, f: Double): Matrix =
+      Affine(a, b, c, d, e, f)
 
   // PdfOperator → Pdf.Operator
   object Operator:

--- a/lib/facsimile/src/core/facsimile.TextExtractor.scala
+++ b/lib/facsimile/src/core/facsimile.TextExtractor.scala
@@ -34,6 +34,7 @@ package facsimile
 
 import anticipation.*
 import gossamer.*
+import mosquito.*
 import quantitative.*
 import rudiments.*
 import vacuous.*
@@ -67,11 +68,11 @@ private[facsimile] object TextExtractor:
     var lastY: Optional[Double] = Unset
 
     def offset(dx: Double, dy: Double): Unit =
-      tlm = Pdf.Matrix(1, 0, 0, 1, dx, dy)*tlm
+      tlm = Pdf.Matrix(1, 0, 0, 1, dx, dy).andThen(tlm)
       tm = tlm
 
     def show(bytes: Data): Unit = font.let: font =>
-      val combined = tm*ctm
+      val combined = tm.andThen(ctm)
       val decoded = font.decode(bytes)
 
       var advance = 0.0
@@ -80,7 +81,7 @@ private[facsimile] object TextExtractor:
         val word = if font.wordBoundary(code) then wordSpacing else 0.0
         advance += (font.width(code)/1000.0*size + charSpacing + word)*horizontal
 
-      val (x, y) = combined(0, rise)
+      val (x, y) = combined.transform(0, rise)
       val effective = size*scala.math.hypot(combined.c, combined.d)
       val width = advance*scala.math.hypot(combined.a, combined.b)
 
@@ -103,11 +104,11 @@ private[facsimile] object TextExtractor:
             Quantity[Points[1]](y*scale),
             Quantity[Points[1]](width*scale) )
 
-      tm = Pdf.Matrix(1, 0, 0, 1, advance, 0)*tm
+      tm = Pdf.Matrix(1, 0, 0, 1, advance, 0).andThen(tm)
 
     def kern(adjustment: Double): Unit =
       val gap = -adjustment/1000.0*size*horizontal
-      tm = Pdf.Matrix(1, 0, 0, 1, gap, 0)*tm
+      tm = Pdf.Matrix(1, 0, 0, 1, gap, 0).andThen(tm)
 
       // A large positive gap reads as a space the file never encoded.
       if gap > size*0.15 && !text.isEmpty && text.charAt(text.length - 1) != ' ' then
@@ -116,7 +117,7 @@ private[facsimile] object TextExtractor:
 
     operators.each:
       case Pdf.Operator.Save                  => stack = ctm :: stack
-      case Pdf.Operator.Concat(matrix)        => ctm = matrix*ctm
+      case Pdf.Operator.Concat(matrix)        => ctm = matrix.andThen(ctm)
       case Pdf.Operator.Offset(dx, dy)        => offset(dx, dy)
       case Pdf.Operator.NextLine              => offset(0, -leading)
       case Pdf.Operator.SetCharSpacing(space) => charSpacing = space

--- a/lib/mosquito/src/core/mosquito.Affine.scala
+++ b/lib/mosquito/src/core/mosquito.Affine.scala
@@ -30,26 +30,81 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package savagery
+package mosquito
 
-import anticipation.*
-import mosquito.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import symbolism.*
 
-object internal:
-  object Affine:
-    // SVG matrix(a, b, c, d, e, f) corresponds to the 3x3 homogeneous matrix
-    //   | a c e |
-    //   | b d f |
-    //   | 0 0 1 |
-    def apply(a: Float, b: Float, c: Float, d: Float, e: Float, f: Float): Affine =
-      Matrix[3, 3]((a, c, e), (b, d, f), (0.0f, 0.0f, 1.0f))
+object Affine:
+  // The six live entries of a 2D affine transformation, in the order shared by SVG's
+  // `matrix(a, b, c, d, e, f)` and PDF's `a b c d e f cm` (ISO 32000-2 §8.3.4). Here they form
+  // the homogeneous matrix
+  //   | a c e |
+  //   | b d f |
+  //   | 0 0 1 |
+  // acting on column vectors. PDF documents the transposed layout acting on row vectors, but
+  // the six numbers appear in the same spec-defined order in both, and the point-application
+  // formula in `transform` is common to the two readings. Composition order is the one place
+  // the conventions diverge, so it is a named operation (`andThen`) rather than a symbolic one.
+  def apply[element: ClassTag]
+    ( a: element, b: element, c: element, d: element, e: element, f: element )
+    ( using zeroic: element is Zeroic, unital: element is Unital )
+  :   Affine[element] =
 
-    extension (affine: Affine)
-      def a: Float = affine(0, 0)
-      def c: Float = affine(0, 1)
-      def e: Float = affine(0, 2)
-      def b: Float = affine(1, 0)
-      def d: Float = affine(1, 1)
-      def f: Float = affine(1, 2)
+    val array = Array.build[element](9): array =>
+      array(0) = a
+      array(1) = c
+      array(2) = e
+      array(3) = b
+      array(4) = d
+      array(5) = f
+      array(6) = zeroic.zero
+      array(7) = zeroic.zero
+      array(8) = unital.one
 
-  opaque type Affine <: Matrix[Float, 3, 3] = Matrix[Float, 3, 3]
+    new Matrix[element, 3, 3](3, 3, array)
+
+  def identity[element: ClassTag](using element is Zeroic, element is Unital): Affine[element] =
+    Matrix.identity[element, 3]
+
+  extension [element](affine: Affine[element])
+    def a: element = affine(0, 0)
+    def c: element = affine(0, 1)
+    def e: element = affine(0, 2)
+    def b: element = affine(1, 0)
+    def d: element = affine(1, 1)
+    def f: element = affine(1, 2)
+
+    // Applies the transform to a point. Named `transform`, not `apply`: on a value which is
+    // also a `Matrix`, an application to two integer literals would resolve to the inherited
+    // element accessor `apply(row, column)` instead, silently.
+    def transform(x: element, y: element)
+      ( using multiplicable: element is Multiplicable by element to element,
+              addable:       element is Addable by element to element )
+    :   (element, element) =
+
+      (a*x + c*y + e, b*x + d*y + f)
+
+    // The composition which applies `affine` first and `next` second — the column-vector
+    // product `next * affine`, and precisely PDF's row-vector `this * that`. Specialised to
+    // the six live entries (the bottom row is fixed): twelve multiplications, not the general
+    // twenty-seven.
+    def andThen(next: Affine[element])
+      ( using multiplicable: element is Multiplicable by element to element,
+              addable:       element is Addable by element to element,
+              zeroic:        element is Zeroic,
+              unital:        element is Unital,
+              classTag:      ClassTag[element] )
+    :   Affine[element] =
+
+      Affine
+        ( next.a*affine.a + next.c*affine.b,
+          next.b*affine.a + next.d*affine.b,
+          next.a*affine.c + next.c*affine.d,
+          next.b*affine.c + next.d*affine.d,
+          next.a*affine.e + next.c*affine.f + next.e,
+          next.b*affine.e + next.d*affine.f + next.f )
+
+opaque type Affine[element] <: Matrix[element, 3, 3] = Matrix[element, 3, 3]

--- a/lib/mosquito/src/core/soundness_mosquito_core.scala
+++ b/lib/mosquito/src/core/soundness_mosquito_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export mosquito.{Matrix, slide, Vector}
+export mosquito.{Affine, Matrix, slide, Vector}

--- a/lib/savagery/src/core/savagery.Transform.scala
+++ b/lib/savagery/src/core/savagery.Transform.scala
@@ -61,4 +61,4 @@ enum Transform:
   case Scale(x: Float, y: Optional[Float])
   case Rotate(angle: Angle)
   case Skew(angle: Angle, orientation: Orientation = Orientation.Horizontal)
-  case Matrix(affine: Affine)
+  case Matrix(affine: Affine[Float])

--- a/lib/savagery/src/core/savagery_core.scala
+++ b/lib/savagery/src/core/savagery_core.scala
@@ -39,7 +39,9 @@ import prepositional.*
 import symbolism.*
 import vacuous.*
 
-export savagery.internal.Affine
+// The affine transform is mosquito's, shared with facsimile (#1867); savagery uses it at
+// `Float` and re-exports it for compatibility.
+export mosquito.Affine
 
 
 val Up:    Delta = Delta(0.0f, -1.0f)

--- a/lib/savagery/src/core/soundness_savagery_core.scala
+++ b/lib/savagery/src/core/soundness_savagery_core.scala
@@ -34,6 +34,6 @@ package soundness
 
 export
   savagery
-  . { Affine, Circle, Delta, Down, Ellipse, Figure, Left, Orientation, Outline, Point, Rectangle,
+  . { Circle, Delta, Down, Ellipse, Figure, Left, Orientation, Outline, Point, Rectangle,
       Right, Segment, Stop, Stroke, Svg, Sweep, Transform, Transformable, Up, unary_+, transform,
       translate, scale, rotate, skew }

--- a/lib/savagery/src/test/savagery_test.scala
+++ b/lib/savagery/src/test/savagery_test.scala
@@ -232,6 +232,31 @@ object Tests extends Suite(m"Savagery tests"):
         (result.dx, result.dy)
       .assert(_ == (-3.0f, -4.0f))
 
+      // By name: under `import soundness.*`, same-named generic extensions (savagery's own
+      // `transform`, functions' `andThen`) outrank the companion extensions.
+      import mosquito.Affine.{andThen, transform}
+
+      test(m"Affine transform applies the homogeneous formula"):
+        Affine(2.0f, 0.0f, 0.0f, 3.0f, 5.0f, 7.0f).transform(1.0f, 1.0f)
+      .assert(_ == (7.0f, 10.0f))
+
+      test(m"Affine andThen applies the first transform first"):
+        val translate = Affine(1.0f, 0.0f, 0.0f, 1.0f, 10.0f, 0.0f)
+        val scale = Affine(2.0f, 0.0f, 0.0f, 2.0f, 0.0f, 0.0f)
+        translate.andThen(scale).transform(1.0f, 1.0f)
+      .assert(_ == (22.0f, 2.0f))
+
+      test(m"Affine identity is neutral for composition"):
+        val affine = Affine(2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f)
+        val identity = Affine.identity[Float]
+        (affine.andThen(identity), identity.andThen(affine))
+      .assert(_ == (Affine(2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
+          Affine(2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f)))
+
+      test(m"Affine matrices compare structurally"):
+        Affine(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f)
+      .assert(_ == Affine(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f))
+
     suite(m"Gradient stops"):
       test(m"Stop with red at offset 0"):
         Stop(0.0, Red).xml.show


### PR DESCRIPTION
The six-parameter 2D affine transformation — the form shared by SVG's `matrix(a, b, c, d, e, f)` and PDF's `a b c d e f cm` — is now a single type, mosquito's `Affine[element]`: an opaque refinement of `Matrix[element, 3, 3]`, serving savagery at `Float` and facsimile at `Double`. Facsimile's hand-rolled `Pdf.Matrix` case class and its bespoke multiply are deleted; `Pdf.Matrix` survives as an alias of `Affine[Double]`, so the wire format (six operands read, six written) and accessors are unchanged.

The two libraries used transposed conventions carrying the same six numbers: savagery's column vectors against `| a c e / b d f / 0 0 1 |`, and PDF's row vectors against the transpose, where `this * that` transforms by `this` first. `Affine` settles on the column-vector convention internally, and makes composition a *named* operation so the order is unmistakable: `first.andThen(next)` applies `first` first — precisely PDF's old `*` — with a product specialised to the six live entries (twelve multiplications, not the general twenty-seven). Point application is `transform(x, y)`, deliberately not `apply`: on a value that is also a `Matrix`, application to two integer literals would resolve to the inherited element accessor instead.

```scala
val translate = Affine(1.0, 0.0, 0.0, 1.0, 10.0, 0.0)
val scale     = Affine(2.0, 0.0, 0.0, 2.0, 0.0, 0.0)
translate.andThen(scale).transform(1.0, 1.0)  // (22.0, 2.0): translated, then scaled
```

Since `Affine`'s operations are extension methods on an opaque alias, scopes with same-named generic extensions in view (`import soundness.*` has `andThen` on functions, and savagery its own `transform`) should import them by name: `import mosquito.Affine.{andThen, transform}`.

`facsimile.core` gains the light `mosquito.core` dependency, and savagery's `internal.Affine` is deleted in favour of a re-export. Composition semantics are pinned by new tests, and facsimile's text-extraction suite passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)