### PR TITLE
Register a handler per member for union patterns in recover (#1793)

### DIFF
--- a/lib/contingency/src/core/contingency.internal.scala
+++ b/lib/contingency/src/core/contingency.internal.scala
@@ -130,7 +130,11 @@ object internal:
     val requiredHandlers = unpack(TypeRepr.of[error]).map(_.typeSymbol)
 
     def patternType(pattern: Tree): List[TypeRepr] = pattern match
-      case Typed(_, matchType)   => List(matchType.tpe)
+      // A union-typed pattern (`case _: (AlphaError | BetaError)`) covers each member of the
+      // union, so it contributes one handler per member; taken whole, the `OrType`'s
+      // `typeSymbol` is no symbol at all, and the handler would silently register nothing
+      // (issue #1793).
+      case Typed(_, matchType)   => internal.unpack(matchType.tpe)
       case Bind(_, pattern)      => patternType(pattern)
       case Alternatives(patters) => patters.flatMap(patternType)
       case Wildcard()            => halt(686, m"wildcard")
@@ -153,8 +157,10 @@ object internal:
     . to(sci.Map)
 
 
+  // Dealiased first, so an alias of a union (`type Both = AlphaError | BetaError`) decomposes
+  // the same way as the union written inline.
   def unpack(using Quotes)(repr: quotes.reflect.TypeRepr): List[quotes.reflect.TypeRepr] =
-    repr.asMatchable match
+    repr.dealias.asMatchable match
       case quotes.reflect.OrType(left, right) => unpack(left) ++ unpack(right)
       case other                              => List(other)
 

--- a/lib/contingency/src/test/contingency_test.scala
+++ b/lib/contingency/src/test/contingency_test.scala
@@ -98,6 +98,30 @@ object Tests extends Suite(m"Contingency"):
         . protect(failB(3))
       . assert(_ == "b:3")
 
+      // Issue #1793: a union-typed pattern must register a handler for each member of the
+      // union, discharging both obligations in the protected block.
+      test(m"a union-typed pattern registers a handler for each member"):
+        recover:
+          case error: (ErrorA | ErrorB) => "union"
+        . protect:
+            failA(1)
+            failB(2)
+      . assert(_ == "union")
+
+      test(m"a union-typed pattern recovers its second member alone"):
+        recover:
+          case error: (ErrorA | ErrorB) => "union"
+        . protect(failB(3))
+      . assert(_ == "union")
+
+      test(m"an alias of a union decomposes like the union written inline"):
+        type EitherError = ErrorA | ErrorB
+
+        recover:
+          case error: EitherError => "union"
+        . protect(failA(4))
+      . assert(_ == "union")
+
       test(m"mitigate transforms an inner error to an outer type"):
         recover:
           case ErrorB(n) => n


### PR DESCRIPTION
A `recover` handler whose pattern is a union type now works: `case error: (AlphaError | BetaError) =>` registers a `Tactic` for each member of the union, so one case can give several error types a shared response. Previously such a pattern registered no handler at all — the pattern's type was taken whole, and an `OrType` has no type symbol — which also explains the issue's second complaint: the baffling `Tactic[<none>]` diagnostic under a fallback strategy was that non-symbol propagating into the inferred context type.

```scala
def union(): Int =
  recover:
    case _: (AlphaError | BetaError) => 1
  . protect:
      alpha()  // raises AlphaError — discharged
      beta()   // raises BetaError — discharged
      0
```

The pattern analysis also dealiases first, so `type EitherError = AlphaError | BetaError` used as a pattern decomposes exactly like the union written inline. And since the analysis is shared, `recover`, `mitigate`, `accrue`, `track` and `handle` all gain union patterns together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)