### PR TITLE
Convert remaining bespoke operators to symbolism typeclasses (#687)

### DIFF
--- a/lib/denominative/src/core/denominative.internal.scala
+++ b/lib/denominative/src/core/denominative.internal.scala
@@ -56,9 +56,6 @@ object internal:
   opaque type Span = Long
 
   extension (ordinal: Ordinal)
-    @targetName("minus2")
-    infix def - (right: Ordinal): Int = ordinal - right
-
     inline infix def thru (right: Ordinal): Interval = Interval(ordinal, right)
     inline infix def till (right: Ordinal): Interval = Interval(ordinal, right - 1)
     inline infix def span (right: Int): Interval = Interval(ordinal, ordinal + right - 1)

--- a/lib/escapade/src/core/escapade.internal.scala
+++ b/lib/escapade/src/core/escapade.internal.scala
@@ -47,6 +47,7 @@ import denominative.*
 import fulminate.*
 import gossamer.*
 import hypotenuse.*
+import prepositional.*
 import rudiments.*
 import symbolism.*
 import vacuous.*
@@ -406,11 +407,12 @@ object internal:
       inline def applyTransform(mask: Long, bits: Long): StyleWord = (style & ~mask) | bits
 
 
+object Teletype2:
+  given addable: Teletype2 is Addable by Teletype2 to Teletype2 = (left, right) =>
+    Teletype2(left.plain+right.plain, Array.frozen(left.ansi.readable ++ right.ansi.readable))
+
 case class Teletype2(plain: Text, ansi: Array[escapade.internal.AnsiStyle]^{}):
   import escapade.internal.AnsiStyle
-
-  @targetName("concat")
-  def + (that: Teletype2): Teletype2 = Teletype2(plain+that.plain, Array.frozen(ansi.readable ++ that.ansi.readable))
 
   def render(using escapes: Ansi.Escapes): Text =
     Text.build:

--- a/lib/mosquito/src/core/mosquito.Matrix.scala
+++ b/lib/mosquito/src/core/mosquito.Matrix.scala
@@ -127,6 +127,114 @@ object Matrix:
       new Matrix[result, rows, columns](left.rows, left.columns, arr)
 
 
+  // The three shapes of multiplication — by scalar, by matrix and by vector — are separate
+  // instances distinguished by `Operand`; the scalar instance's operand is unconstrained, but
+  // it applies only where the elements themselves multiply by it (issue #687).
+  given scalarMultiplicable
+  :   [ element, rows <: Int, columns <: Int, left <: Matrix[element, rows, columns], scalar,
+        result ]
+  =>  ( multiplication: element is Multiplicable by scalar to result, classTag: ClassTag[result] )
+  =>  left is Multiplicable:
+
+    type Operand = scalar
+    type Result = Matrix[result, rows, columns]
+
+    def multiply(left: left, right: scalar): Matrix[result, rows, columns] =
+      val elements2 = Array.build[result](left.elements.length): array =>
+        left.elements.readable.indices.each: index =>
+          array(index) = left.elements.readUnchecked(index)*right
+
+      new Matrix(left.rows, left.columns, elements2)
+
+  given scalarDivisible
+  :   [ element, rows <: Int, columns <: Int, left <: Matrix[element, rows, columns], scalar,
+        result ]
+  =>  ( division: element is Divisible by scalar to result, classTag: ClassTag[result] )
+  =>  left is Divisible:
+
+    type Operand = scalar
+    type Result = Matrix[result, rows, columns]
+
+    def divide(left: left, right: scalar): Matrix[result, rows, columns] =
+      val elements2 = Array.build[result](left.elements.length): array =>
+        left.elements.readable.indices.each: index =>
+          array(index) = left.elements.readUnchecked(index)/right
+
+      new Matrix(left.rows, left.columns, elements2)
+
+  given matrixMultiplicable
+  :   [ element, rows <: Int, columns <: Int, left <: Matrix[element, rows, columns],
+        rightElement, rightColumns <: Int, result ]
+  =>  ( multiplication: element is Multiplicable by rightElement to result,
+        addition:       result is Addable by result to result,
+        columnValue:    ValueOf[columns],
+        rightColumnsValue: ValueOf[rightColumns],
+        classTag:       ClassTag[result] )
+  =>  left is Multiplicable:
+
+    type Operand = Matrix[rightElement, columns, rightColumns]
+    type Result = Matrix[result, rows, rightColumns]
+
+    def multiply(left: left, right: Matrix[rightElement, columns, rightColumns])
+    :   Matrix[result, rows, rightColumns] =
+
+      val columns2 = valueOf[rightColumns]
+      val inner = valueOf[columns]
+      val rowCount = left.rows
+
+      val elements = Array.build[result](rowCount*columns2): array =>
+        var row = 0
+
+        while row < rowCount do
+          var column = 0
+
+          while column < columns2 do
+            var sum: result = left(row, 0)*right(0, column)
+            var k = 1
+
+            while k < inner do
+              sum = sum + left(row, k)*right(k, column)
+              k += 1
+
+            array(columns2*row + column) = sum
+            column += 1
+
+          row += 1
+
+      new Matrix(rowCount, columns2, elements)
+
+  given vectorMultiplicable
+  :   [ element, rows <: Int, columns <: Int, left <: Matrix[element, rows, columns],
+        rightElement, result ]
+  =>  ( multiplication: element is Multiplicable by rightElement to result,
+        addition:       result is Addable by result to result,
+        columnValue:    ValueOf[columns] )
+  =>  left is Multiplicable:
+
+    type Operand = Vector[rightElement, columns]
+    type Result = Vector[result, rows]
+
+    def multiply(left: left, right: Vector[rightElement, columns]): Vector[result, rows] =
+      val inner = valueOf[columns]
+      val rowCount = left.rows
+
+      val arr = Array.build[Any](rowCount): array =>
+        var row = 0
+
+        while row < rowCount do
+          var sum: result = left(row, 0)*right.data.readUnchecked(0).asInstanceOf[rightElement]
+          var k = 1
+
+          while k < inner do
+            sum = sum + left(row, k)*right.data.readUnchecked(k).asInstanceOf[rightElement]
+            k += 1
+
+          array(row) = sum
+          row += 1
+
+      new Vector[result, rows](arr)
+
+
   def identity[element, dimension <: Int]
     ( using unital:        element is Unital,
             zeroic:        element is Zeroic,
@@ -782,92 +890,4 @@ class Matrix[element, rows <: Int, columns <: Int]
     builder.append("]").toString
 
 
-  @targetName("scalarMul")
-  def * [right](right: right)
-    ( using multiplication: element is Multiplicable by right )
-    ( using ClassTag[multiplication.Result] )
-  :   Matrix[multiplication.Result, rows, columns] =
 
-
-    val elements2 = Array.build[multiplication.Result](elements.length): array =>
-      elements.readable.indices.each: index =>
-        array(index) = elements.readUnchecked(index)*right
-
-    new Matrix(rows, columns, elements2)
-
-
-  @targetName("scalarDiv")
-  def / [right](right: right)(using div: element is Divisible by right)(using ClassTag[div.Result])
-  :   Matrix[div.Result, rows, columns] =
-
-    val elements2 = Array.build[div.Result](elements.length): array =>
-      elements.readable.indices.each: index =>
-        array(index) = elements.readUnchecked(index)/right
-
-    new Matrix(rows, columns, elements2)
-
-
-  @targetName("mul")
-  def * [right, rightColumns <: Int: ValueOf]
-    ( right: Matrix[right, columns, rightColumns] )
-    ( using multiplication: element is Multiplicable by right,
-            addition:       multiplication.Result is Addable by multiplication.Result,
-            equality:       addition.Result =:= multiplication.Result,
-            rowValue:       ValueOf[rows],
-            columnValue:    ValueOf[columns],
-            classTag:       ClassTag[multiplication.Result] )
-  :   Matrix[multiplication.Result, rows, rightColumns] =
-
-    val columns2 = valueOf[rightColumns]
-    val inner = valueOf[columns]
-
-    val elements = Array.build[multiplication.Result](rows*columns2): array =>
-      var row = 0
-
-      while row < rows do
-        var column = 0
-
-        while column < columns2 do
-          var sum: multiplication.Result = apply(row, 0)*right(0, column)
-          var k = 1
-
-          while k < inner do
-            sum = sum + apply(row, k)*right(k, column)
-            k += 1
-
-          array(columns2*row + column) = sum
-          column += 1
-
-        row += 1
-
-    new Matrix(rows, columns2, elements)
-
-
-  @targetName("mulVec")
-  def * [right]
-    ( right: Vector[right, columns] )
-    ( using multiplication: element is Multiplicable by right,
-            addition:       multiplication.Result is Addable by multiplication.Result,
-            equality:       addition.Result =:= multiplication.Result,
-            columnValue:    ValueOf[columns] )
-  :   Vector[multiplication.Result, rows] =
-
-    val inner = valueOf[columns]
-
-    val arr = Array.build[Any](rows): array =>
-      var row = 0
-
-      while row < rows do
-        var sum: multiplication.Result =
-          apply(row, 0)*right.data.readUnchecked(0).asInstanceOf[right]
-
-        var k = 1
-
-        while k < inner do
-          sum = sum + apply(row, k)*right.data.readUnchecked(k).asInstanceOf[right]
-          k += 1
-
-        array(row) = sum
-        row += 1
-
-    new Vector[multiplication.Result, rows](arr)

--- a/lib/plutocrat/src/core/plutocrat.Price.scala
+++ b/lib/plutocrat/src/core/plutocrat.Price.scala
@@ -44,6 +44,24 @@ object Price:
     def divide(left: price, right: Double): Price in currency =
       Price(left.principal/right, left.tax/right)
 
+  given addable: [currency <: Label, price <: Price in currency] => price is Addable:
+    type Operand = Price in currency
+    type Result = Price in currency
+
+    def add(left: price, right: Price in currency): Price in currency =
+      Price(left.principal + right.principal, left.tax + right.tax)
+
+  given subtractable: [currency <: Label, price <: Price in currency] => price is Subtractable:
+    type Operand = Price in currency
+    type Result = Price in currency
+
+    def subtract(left: price, right: Price in currency): Price in currency =
+      Price(left.principal - right.principal, left.tax - right.tax)
+
+  given negatable: [currency <: Label, price <: Price in currency] => price is Negatable:
+    type Result = Price in currency
+    def negate(price: price): Price in currency = Price(-price.principal, -price.tax)
+
 
   def apply[currency <: Label](principal0: Money in currency, tax0: Money in currency)
   :   Price in currency =
@@ -60,17 +78,6 @@ trait Price:
   val tax: Money in Form
 
   def effectiveTaxRate: Double = tax/principal
-
-  @targetName("add")
-  infix def + (right: Price in Form): Price in Form =
-    Price(principal + right.principal, tax + right.tax)
-
-  @targetName("subtract")
-  infix def - (right: Price in Form): Price in Form =
-    Price(principal - right.principal, tax - right.tax)
-
-  @targetName("negate")
-  def `unary_-`: Price in Form = Price(-principal, -tax)
 
   def inclusive: Money in Form = principal + tax
   override def hashCode(): Int = (principal.asInstanceOf[Long] ^ tax.asInstanceOf[Long]*31).hashCode

--- a/lib/sibylline/src/core/sibylline.Llm.scala
+++ b/lib/sibylline/src/core/sibylline.Llm.scala
@@ -45,8 +45,10 @@ import hieroglyph.*, charDecoders.utf8Decoder, charEncoders.utf8Encoder,
     textSanitizers.strictSanitizer
 import jacinta.*
 import obligatory.*
+import prepositional.*
 import rudiments.*
 import spectacular.*
+import symbolism.*
 import telekinesis.*
 import turbulence.*
 import urticose.*
@@ -102,23 +104,24 @@ object Llm:
   // Token accounting. Only input and output counts are universal; the remainder are reported by
   // some providers only, so a session total folds them optionally: absent plus absent stays
   // absent, and a count is never invented.
+  object Usage:
+    given addable: Usage is Addable by Usage to Usage = (left, right) =>
+      def sum(first: Optional[Int], second: Optional[Int]): Optional[Int] =
+        first.lay(second)(_ + second.or(0))
+
+      Usage
+        ( left.input + right.input,
+          left.output + right.output,
+          sum(left.cacheRead, right.cacheRead),
+          sum(left.cacheWrite, right.cacheWrite),
+          sum(left.reasoning, right.reasoning) )
+
   case class Usage
     ( input:      Int,
       output:     Int,
       cacheRead:  Optional[Int] = Unset,
       cacheWrite: Optional[Int] = Unset,
-      reasoning:  Optional[Int] = Unset ):
-
-    def + (that: Usage): Usage =
-      def sum(left: Optional[Int], right: Optional[Int]): Optional[Int] =
-        left.lay(right)(_ + right.or(0))
-
-      Usage
-        ( input + that.input,
-          output + that.output,
-          sum(cacheRead, that.cacheRead),
-          sum(cacheWrite, that.cacheWrite),
-          sum(reasoning, that.reasoning) )
+      reasoning:  Optional[Int] = Unset )
 
   // One completed assistant turn: pure data, so it may leave the session block.
   case class Reply


### PR DESCRIPTION
Five of the six items remaining in #687's audit are done; arithmetic on these types now flows through symbolism's typeclasses rather than bespoke members.

- **plutocrat:** `Price` gains `Addable`, `Subtractable` and `Negatable` givens, replacing its raw `+`, `-` and `unary_-` members — its `Divisible` already led the way, so the type is now consistent with itself.
- **sibylline:** `Usage` gains an `Addable` for componentwise token addition (absent-plus-absent stays absent, as before).
- **mosquito:** `Matrix` completes its half-done conversion: `*` in its three shapes — by scalar, by matrix, and by vector — and scalar `/` are now companion givens distinguished by their `Operand` types, joining the existing `Addable` and `Subtractable`.
- **denominative:** the redundant `- (right: Ordinal): Int` extension is deleted in favour of the `Subtractable` given that already existed beside it. Investigated per the issue's caution: `Ordinal` has no public `Int` bound, so no given ambiguity protected the extension — it simply predated the given.
- **escapade:** the internal `Teletype2.+` becomes an `Addable`. (Noted in passing: `Teletype2` is currently unreferenced anywhere in the repository.)

The one remaining item is hypotenuse's roughly fifty fixed-width operators, which need the `AddOp`/`MulOp` inlining treatment combined with call-site policy givens (`CheckOverflow`/`DivisionByZero` dependent results) and `Conversion.into[…]` operand widening — left for a dedicated change, per the issue's own advice to prototype on one type first.

No call site anywhere in the repository needed changing: resolution moves from members to symbolism's operator extensions transparently, verified by a full build and the affected libraries' suites (516 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)