### PR TITLE
File and path handling: locking, positional reads, the filesystem axis, and a glob re-export

### DIFF
--- a/lib/galilei/src/core/galilei.Btrfs.scala
+++ b/lib/galilei/src/core/galilei.Btrfs.scala
@@ -30,32 +30,64 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package galilei
 
-export
-  galilei
-  . { accessed, Apfs, BlockDevice, Btrfs, C, CharDevice, children, CopyAttributes, copyInto,
-      copyTo, created, CreateFlag, CreateNonexistentParents, Creation, creation, CreationTimed,
-      D, delete, Ext4,
-      DeleteRecursively, DereferenceSymlinks, descendants, dir, Directory, Dos, Drive, Entry,
-      entry, executable, expanse, Explorable, existent, Fifo, file, File, FileOpenable,
-      FilesystemAttribute, FilesystemBackend,
-      glob, Handle, hardLinks, hardLinkTo, hidden, Io, Linux, Local,
-      MacOs, modified, MoveAtomically, moveInto, moveTo, Ntfs, OpenFlag,
-      OverwritePreexisting, p, Platform, Posix, readable, filesize, Sock, Stat,
-      Scratch, Substantiable, Subtree, Symlink, symlinkInto, symlinkTo, touch, TraversalOrder,
-      UnixEntry, Volume, volume, Windows, WindowsEntry, wipe, writable, write }
+import anticipation.*
+import contingency.*
+import gossamer.*
+import prepositional.*
+import serpentine.*
+import vacuous.*
 
-package interfaces.paths:
-  export
-    anticipation.interfaces.paths
-    . { pathOnLinux, pathOnLocal, pathOnMacOs, pathOnPosix, pathOnWindows }
+// The storage-filesystem axis of a path's type (issue #567): which filesystem an entry is
+// stored on determines which metadata it can carry, orthogonally to the plane — `Btrfs` is
+// meaningful only under `Linux`, `Apfs` under `MacOs` and `Linux`, `Ntfs` under `Windows` and
+// `Linux`. A path cannot know its filesystem from its syntax, so the axis is established by
+// runtime probing, through each filesystem's extractor — the axis is `over`'s structural
+// `Transport` refinement, deliberately not a declared member of `Path`: refining it in is
+// enough for the gated extensions below to dispatch, and declaring it perturbed inference at
+// unrelated sites downstream:
+//
+//     path match
+//       case Btrfs(path2) => …   // `path2: Path on Linux over Btrfs`
+//       case _            => …
+//
+// The probe is the same platform query behind `path.volume()`, so no new backend method is
+// needed; a probe which fails (an unreadable volume, say) simply does not match. Filesystems
+// which record creation times extend `CreationTimed`, which gates a *total* `creation()`
+// accessor — unlike `Stat.created`, whose optionality exists because most POSIX filesystems
+// record none.
+sealed trait CreationTimed
 
-package filesystemOptions:
-  export
-    galilei.filesystemOptions
-    . { copyAttributes, createNonexistentParents, deleteRecursively,
-        dereferenceSymlinks, moveAtomically, overwritePreexisting }
+sealed trait Btrfs extends CreationTimed
+sealed trait Ext4
+sealed trait Apfs extends CreationTimed
+sealed trait Ntfs extends CreationTimed
 
-package filesystemTraversal:
-  export galilei.filesystemTraversal.{postOrderTraversal, preOrderTraversal}
+private def storageFormat[plane](path: Path on plane)(using backend: FilesystemBackend on plane)
+:   Optional[Text] =
+  safely(backend.volume(path).volumeType.lower)
+
+object Btrfs:
+  def unapply[plane](path: Path on plane)(using FilesystemBackend on plane)
+  :   Option[Path on plane over Btrfs] =
+    if storageFormat(path) == t"btrfs" then Some(path.asInstanceOf[Path on plane over Btrfs])
+    else None
+
+object Ext4:
+  def unapply[plane](path: Path on plane)(using FilesystemBackend on plane)
+  :   Option[Path on plane over Ext4] =
+    if storageFormat(path) == t"ext4" then Some(path.asInstanceOf[Path on plane over Ext4])
+    else None
+
+object Apfs:
+  def unapply[plane](path: Path on plane)(using FilesystemBackend on plane)
+  :   Option[Path on plane over Apfs] =
+    if storageFormat(path) == t"apfs" then Some(path.asInstanceOf[Path on plane over Apfs])
+    else None
+
+object Ntfs:
+  def unapply[plane](path: Path on plane)(using FilesystemBackend on plane)
+  :   Option[Path on plane over Ntfs] =
+    if storageFormat(path) == t"ntfs" then Some(path.asInstanceOf[Path on plane over Ntfs])
+    else None

--- a/lib/galilei/src/core/galilei.FileOpenable.scala
+++ b/lib/galilei/src/core/galilei.FileOpenable.scala
@@ -32,11 +32,15 @@
                                                                                                   */
 package galilei
 
+import anticipation.*
 import aperture.*
+import gossamer.*
 import contingency.*
 import prepositional.*
 import serpentine.*
 import rudiments.*
+
+import Io.Error.{Operation, Reason}
 
 // The `Openable` instance for opening a file's content: `path.open[File](Read & Write)`. A
 // named class rather than an anonymous given instance: instantiating an anonymous subclass
@@ -58,12 +62,31 @@ extends Openable:
 
     // The mode's atoms translate to OS open flags. `aperture.Exclusive` is deliberately not
     // translated to `OpenFlag.Exclusive`: POSIX `O_EXCL` governs exclusive *creation*, not
-    // exclusive access, so honoring the `Exclusive` grant awaits the access register.
+    // exclusive access. Instead it enrols the open in the access register — so file opens
+    // participate in the same intra-JVM arbitration as directory scopes — and asks the
+    // backend for an OS advisory lock (`OpenFlag.Lock`) to cover the cross-process case
+    // (issue #566).
     val modeFlags =
       (if mode.atoms.has(Read) then List(OpenFlag.Read).stdlib else Nil.stdlib) ++
-        (if mode.atoms.has(Write) then List(OpenFlag.Write).stdlib else Nil.stdlib)
+        (if mode.atoms.has(Write) then List(OpenFlag.Write).stdlib else Nil.stdlib) ++
+        (if mode.atoms.has(Exclusive) then List(OpenFlag.Lock).stdlib else Nil.stdlib)
 
-    backend.open(value, (modeFlags ++ flags.stdlib).to(List)): handle =>
-      // `Granting` is a phantom marker, so the cast only refines the static type with the
-      // grants that `modeFlags` has just made true operationally.
-      block(using handle.asInstanceOf[Handle & Granting[grants]])
+    val locking = mode.atoms.has(Exclusive)
+
+    // The register works on real paths, so two routes to one file register as the same file
+    // and overlap correctly with enclosing directory scopes; a file which is about to be
+    // created cannot be resolved, so it falls back to its normalized absolute form.
+    val real: Text =
+      if !locking then t"" else
+        try value.nioPath.toRealPath().nn.toString.tt
+        catch case _: Exception => value.nioPath.toAbsolutePath.nn.normalize.nn.toString.tt
+
+    if locking && !AccessRegister.acquire(real, mode.atoms)
+    then abort(Io.Error(value, Operation.Open, Reason.Busy))
+
+    try
+      backend.open(value, (modeFlags ++ flags.stdlib).to(List)): handle =>
+        // `Granting` is a phantom marker, so the cast only refines the static type with the
+        // grants that `modeFlags` has just made true operationally.
+        block(using handle.asInstanceOf[Handle & Granting[grants]])
+    finally if locking then AccessRegister.release(real, mode.atoms)

--- a/lib/galilei/src/core/galilei.FilesystemBackend.scala
+++ b/lib/galilei/src/core/galilei.FilesystemBackend.scala
@@ -98,6 +98,14 @@ trait FilesystemBackend extends Planar:
 
   // Opens the entry's content for streaming, applies `lambda` to the open handle, and closes it,
   // whatever the outcome.
+  // Scoped positional (random-access) reading (issue #1608): opens the file for reading and
+  // passes a positional view, valid for the scope of the call, to `lambda`. Reads are
+  // pread-style — each independent of any sequential position, and no whole-file mapping is
+  // taken — so files beyond 2 GiB are addressable, unlike `Ram`'s single `Int`-addressed map.
+  def expanse[result](path: Path on Plane)(lambda: zephyrine.Expanse => result)
+    ( using Tactic[Io.Error] )
+  :   result
+
   def open[result](path: Path on Plane, flags: List[OpenFlag])(lambda: Handle => result)
     ( using Tactic[Io.Error] )
   :   result

--- a/lib/galilei/src/core/galilei.OpenFlag.scala
+++ b/lib/galilei/src/core/galilei.OpenFlag.scala
@@ -37,3 +37,9 @@ package galilei
 // passed as flags to `open`; all are interpreted by the `FilesystemBackend`.
 enum OpenFlag:
   case Read, Write, Append, Create, Exclusive, Truncate, Sync, Dsync, NoFollow
+
+  // Hold an OS advisory lock on the file for the duration of the open (issue #566). Not an OS
+  // open flag itself: backends which can lock do so after opening, and those which cannot
+  // (WASI has no file-locking call) refuse the open as `Unsupported` rather than silently not
+  // locking. Added by `FileOpenable` when the mode grants `Exclusive`.
+  case Lock

--- a/lib/galilei/src/core/galilei_core.scala
+++ b/lib/galilei/src/core/galilei_core.scala
@@ -476,3 +476,17 @@ package filesystemOptions:
       def apply[result](path: Path on plane)(block: => result)
       :   (Tactic[Io.Error]^) ?->{block} result =
         block
+
+
+// Metadata gated by the storage-filesystem axis (issue #567): available only on a path whose
+// filesystem is known — by extractor probing — to record it.
+extension [plane: Filesystem, transport <: CreationTimed](path: Path on plane over transport)
+  // Total, unlike `Stat.created`: the `CreationTimed` bound says the filesystem records
+  // creation times, so an absent value is a backend failure rather than an expected case.
+  def creation[instant: Instantiable across Instants from Long as instantiable]()
+    ( using backend: FilesystemBackend on plane )
+  :   instant raises Io.Error =
+
+    instantiable.apply:
+      backend.stat(path, true).created.or:
+        abort(Io.Error(path, Operation.Metadata, Reason.Unsupported))

--- a/lib/galilei/src/core/galilei_core.scala
+++ b/lib/galilei/src/core/galilei_core.scala
@@ -114,6 +114,21 @@ extension [plane: Filesystem](path: Path on plane)
   private[galilei] def nioPath: jnf.Path = jnf.Path.of(Path.encodable.encode(path).s).nn
 
 
+  // Scoped positional (random-access) reading (issue #1608): passes a `zephyrine.Expanse`
+  // view of the file — `size` plus pread-style `read(offset, length)` — valid for the scope
+  // of the call. Platform-neutral: every filesystem backend implements it, so seek-oriented
+  // format readers need neither `java.nio` nor a whole-file memory mapping, and files beyond
+  // 2 GiB are addressable.
+  // A real `using` clause rather than the `raises` sugar: a context-function result would
+  // hide the `lambda` parameter, which the separation checker rejects (as on `write` above).
+  def expanse[result](lambda: zephyrine.Expanse => result)
+    ( using backend: FilesystemBackend on plane )
+    ( using Tactic[Io.Error]^ )
+  :   result =
+
+    backend.expanse(path)(lambda)
+
+
   def descendants(using DereferenceSymlinks, TraversalOrder, plane is Explorable)
   :   Chain[Path on plane] raises Io.Error =
 

--- a/lib/galilei/src/core/soundness_galilei_core.scala
+++ b/lib/galilei/src/core/soundness_galilei_core.scala
@@ -37,7 +37,7 @@ export
   . { accessed, BlockDevice, C, CharDevice, children, CopyAttributes, copyInto, copyTo,
       created, CreateFlag, CreateNonexistentParents, Creation, D, delete,
       DeleteRecursively, DereferenceSymlinks, descendants, dir, Directory, Dos, Drive, Entry,
-      entry, executable, Explorable, existent, Fifo, file, File, FileOpenable,
+      entry, executable, expanse, Explorable, existent, Fifo, file, File, FileOpenable,
       FilesystemAttribute, FilesystemBackend,
       glob, Handle, hardLinks, hardLinkTo, hidden, Io, Linux, Local,
       MacOs, modified, MoveAtomically, moveInto, moveTo, OpenFlag,

--- a/lib/galilei/src/core/soundness_galilei_core.scala
+++ b/lib/galilei/src/core/soundness_galilei_core.scala
@@ -39,7 +39,7 @@ export
       DeleteRecursively, DereferenceSymlinks, descendants, dir, Directory, Dos, Drive, Entry,
       entry, executable, Explorable, existent, Fifo, file, File, FileOpenable,
       FilesystemAttribute, FilesystemBackend,
-      Handle, hardLinks, hardLinkTo, hidden, Io, Linux, Local,
+      glob, Handle, hardLinks, hardLinkTo, hidden, Io, Linux, Local,
       MacOs, modified, MoveAtomically, moveInto, moveTo, OpenFlag,
       OverwritePreexisting, p, Platform, Posix, readable, filesize, Sock, Stat,
       Scratch, Substantiable, Subtree, Symlink, symlinkInto, symlinkTo, touch, TraversalOrder,

--- a/lib/galilei/src/jvm/galilei_jvm.scala
+++ b/lib/galilei/src/jvm/galilei_jvm.scala
@@ -243,6 +243,38 @@ package filesystemBackends:
 
           if !success then abort(Io.Error(path, Operation.Metadata, Reason.PermissionDenied))
 
+      def expanse[result](path: Path on Plane)(lambda: zephyrine.Expanse => result)
+        ( using Tactic[Io.Error] )
+      :   result =
+
+        val channel = protect(path, Operation.Open):
+          val optionSet = java.util.HashSet[jnf.OpenOption]()
+          optionSet.add(jnf.StandardOpenOption.READ)
+          jnc.FileChannel.open(javaPath(path), optionSet).nn
+
+        try
+          val view = new zephyrine.Expanse:
+            def size: Long = channel.size
+
+            // A read overlapping the end of the file returns the bytes which exist.
+            def read(offset: Long, length: Int): Data =
+              val buffer = java.nio.ByteBuffer.allocate(length).nn
+              var position = offset
+              var count = 0
+
+              while count >= 0 && buffer.hasRemaining do
+                count = channel.read(buffer, position)
+                if count > 0 then position += count
+
+              val filled = buffer.position
+              val array = Array.allocate[Byte](filled)
+              buffer.flip()
+              buffer.get(array.raw, 0, filled)
+              Array.freeze(array)
+
+          lambda(view)
+        finally channel.close()
+
       def open[result](path: Path on Plane, flags: List[OpenFlag])(lambda: Handle => result)
         ( using Tactic[Io.Error] )
       :   result =

--- a/lib/galilei/src/jvm/galilei_jvm.scala
+++ b/lib/galilei/src/jvm/galilei_jvm.scala
@@ -247,7 +247,7 @@ package filesystemBackends:
         ( using Tactic[Io.Error] )
       :   result =
 
-        val options: scala.collection.immutable.List[jnf.OpenOption] = flags.stdlib.map:
+        val options: scala.collection.immutable.List[jnf.OpenOption] = flags.stdlib.filter(_ != OpenFlag.Lock).map:
           case OpenFlag.Read      => jnf.StandardOpenOption.READ
           case OpenFlag.Write     => jnf.StandardOpenOption.WRITE
           case OpenFlag.Append    => jnf.StandardOpenOption.APPEND
@@ -270,10 +270,33 @@ package filesystemBackends:
           protect(path, Operation.Open)(jnc.FileChannel.open(javaPath(path), options2*).nn)
 
         try
-          lambda:
-            Handle
-              ( () => unsafely(zephyrine.toProgression(Streamable.channel.stream(channel))),
-                data => unsafely(Writable.channel.write(channel, zephyrine.Stream(data.stdlib.iterator))) )
-              ( () => unsafely(Streamable.channel.stream(channel)),
-                () => unsafely(Sink.channel.intake(channel)) )
+          // The advisory lock for the duration of the open (issue #566): exclusive when the
+          // channel is writable; a read-only channel cannot take an exclusive lock, so a
+          // shared lock is taken instead — in-process exclusivity is already arbitrated by
+          // the access register, and a shared lock still excludes any cross-process
+          // exclusive locker.
+          val lock =
+            if flags.stdlib.contains(OpenFlag.Lock) then
+              val writable = options2.contains(jnf.StandardOpenOption.WRITE) || appending
+
+              try Option:
+                if writable then channel.tryLock().nn
+                else channel.tryLock(0L, Long.MaxValue, true).nn
+              catch case _: jnc.OverlappingFileLockException => None
+            else Some(null)
+
+          if lock.isEmpty then abort(Io.Error(path, Operation.Open, Reason.Busy))
+
+          try
+            lambda:
+              Handle
+                ( () => unsafely(zephyrine.toProgression(Streamable.channel.stream(channel))),
+                  data => unsafely(Writable.channel.write(channel, zephyrine.Stream(data.stdlib.iterator))) )
+                ( () => unsafely(Streamable.channel.stream(channel)),
+                  () => unsafely(Sink.channel.intake(channel)) )
+          finally lock.foreach: held =>
+            // Closing the channel already releases the lock, and a fully-consumed stream
+            // closes the channel itself, so release after that is a no-op.
+            if held != null then
+              try held.release() catch case _: jnc.ClosedChannelException => ()
         finally channel.close()

--- a/lib/galilei/src/native/galilei_native.scala
+++ b/lib/galilei/src/native/galilei_native.scala
@@ -276,6 +276,38 @@ package filesystemBackends:
 
           if !success then abort(Io.Error(path, Operation.Metadata, Reason.PermissionDenied))
 
+      def expanse[result](path: Path on Plane)(lambda: zephyrine.Expanse => result)
+        ( using Tactic[Io.Error] )
+      :   result =
+
+        val channel = protect(path, Operation.Open):
+          val optionSet = java.util.HashSet[jnf.OpenOption]()
+          optionSet.add(jnf.StandardOpenOption.READ)
+          jnc.FileChannel.open(javaPath(path), optionSet).nn
+
+        try
+          val view = new zephyrine.Expanse:
+            def size: Long = channel.size
+
+            // A read overlapping the end of the file returns the bytes which exist.
+            def read(offset: Long, length: Int): Data =
+              val buffer = java.nio.ByteBuffer.allocate(length).nn
+              var position = offset
+              var count = 0
+
+              while count >= 0 && buffer.hasRemaining do
+                count = channel.read(buffer, position)
+                if count > 0 then position += count
+
+              val filled = buffer.position
+              val array = Array.allocate[Byte](filled)
+              buffer.flip()
+              buffer.get(array.raw, 0, filled)
+              Array.freeze(array)
+
+          lambda(view)
+        finally channel.close()
+
       def open[result](path: Path on Plane, flags: List[OpenFlag])(lambda: Handle => result)
         ( using Tactic[Io.Error] )
       :   result =

--- a/lib/galilei/src/native/galilei_native.scala
+++ b/lib/galilei/src/native/galilei_native.scala
@@ -280,7 +280,7 @@ package filesystemBackends:
         ( using Tactic[Io.Error] )
       :   result =
 
-        val options: scala.collection.immutable.List[jnf.OpenOption] = flags.stdlib.map:
+        val options: scala.collection.immutable.List[jnf.OpenOption] = flags.stdlib.filter(_ != OpenFlag.Lock).map:
           case OpenFlag.Read      => jnf.StandardOpenOption.READ
           case OpenFlag.Write     => jnf.StandardOpenOption.WRITE
           case OpenFlag.Append    => jnf.StandardOpenOption.APPEND
@@ -307,16 +307,40 @@ package filesystemBackends:
           protect(path, Operation.Open)(jnc.FileChannel.open(javaPath(path), optionSet).nn)
 
         try
-          // The `source`/`intake` closures capture the `FileChannel` capability, which native's
-          // capture checker (unlike the JVM's, on identical code) reports as leaking out of the
-          // closure. The channel is genuinely scoped — closed in the `finally` after `lambda`
-          // returns — so the capture is asserted safe with `unsafeAssumePure`.
-          lambda:
-           // The channel is this handle's single owner (see the comment above).
-           scala.caps.unsafe.unsafeAssumeSeparate:
-            Handle
-              ( () => unsafely(zephyrine.toProgression(Streamable.channel.stream(channel))),
-                data => unsafely(Writable.channel.write(channel, zephyrine.Stream(data.stdlib.iterator))) )
-              ( () => unsafely(caps.unsafe.unsafeAssumePure(Streamable.channel.stream(channel))),
-                () => unsafely(caps.unsafe.unsafeAssumePure(Sink.channel.intake(channel))) )
+          // The advisory lock for the duration of the open (issue #566): exclusive when the
+          // channel is writable; a read-only channel cannot take an exclusive lock, so a
+          // shared lock is taken instead — in-process exclusivity is already arbitrated by
+          // the access register, and a shared lock still excludes any cross-process
+          // exclusive locker.
+          val lock =
+            if flags.stdlib.contains(OpenFlag.Lock) then
+              val writable = options2.contains(jnf.StandardOpenOption.WRITE) || appending
+
+              try Option:
+                if writable then channel.tryLock().nn
+                else channel.tryLock(0L, Long.MaxValue, true).nn
+              catch case _: jnc.OverlappingFileLockException => None
+            else Some(null)
+
+          if lock.isEmpty then abort(Io.Error(path, Operation.Open, Reason.Busy))
+
+          try
+            // The `source`/`intake` closures capture the `FileChannel` capability, which
+            // native's capture checker (unlike the JVM's, on identical code) reports as
+            // leaking out of the closure. The channel is genuinely scoped — closed in the
+            // `finally` after `lambda` returns — so the capture is asserted safe with
+            // `unsafeAssumePure`.
+            lambda:
+             // The channel is this handle's single owner (see the comment above).
+             scala.caps.unsafe.unsafeAssumeSeparate:
+              Handle
+                ( () => unsafely(zephyrine.toProgression(Streamable.channel.stream(channel))),
+                  data => unsafely(Writable.channel.write(channel, zephyrine.Stream(data.stdlib.iterator))) )
+                ( () => unsafely(caps.unsafe.unsafeAssumePure(Streamable.channel.stream(channel))),
+                  () => unsafely(caps.unsafe.unsafeAssumePure(Sink.channel.intake(channel))) )
+          finally lock.foreach: held =>
+            // Closing the channel already releases the lock, and a fully-consumed stream
+            // closes the channel itself, so release after that is a no-op.
+            if held != null then
+              try held.release() catch case _: jnc.ClosedChannelException => ()
         finally channel.close()

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -539,3 +539,23 @@ object Tests extends Suite(m"Galilei tests"):
       test(m"A read overlapping the end returns the bytes which exist"):
         unsafely(source.expanse(_.read(12L, 100)).utf8)
       . assert(_ == t"cdef")
+
+    suite(m"Storage filesystem axis"):
+      import anticipation.instantiables.instantInstantiable
+      val root: Path on Linux = unsafely((% / "tmp").on[Linux])
+
+      test(m"At most one storage filesystem extractor matches a path"):
+        List(
+          Btrfs.unapply(root).isDefined,
+          Ext4.unapply(root).isDefined,
+          Apfs.unapply(root).isDefined,
+          Ntfs.unapply(root).isDefined).count(identity)
+      . assert(_ <= 1)
+
+      test(m"A matched creation-timed filesystem offers a total creation time"):
+        root match
+          case Apfs(path)  => unsafely(path.creation[Long]()) > 0L
+          case Btrfs(path) => unsafely(path.creation[Long]()) > 0L
+          case Ntfs(path)  => unsafely(path.creation[Long]()) > 0L
+          case _           => true  // no creation-timed filesystem here; the gate did its job
+      . assert(_ == true)

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -513,3 +513,29 @@ object Tests extends Suite(m"Galilei tests"):
           target.open[File](Read & Exclusive) { () }
           target.open[File](Read & Exclusive) { true }
       . assert(_ == true)
+
+    suite(m"Positional reading"):
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+
+      val expanseLeaf: Text = Uuid().show
+      val source: Path on Linux = unsafely((% / "tmp" / expanseLeaf).on[Linux])
+      unsafely(source.write(t"0123456789abcdef"))
+
+      test(m"The expanse reports the file's size"):
+        unsafely(source.expanse(_.size))
+      . assert(_ == 16L)
+
+      test(m"A positional read returns the requested slice"):
+        unsafely(source.expanse(_.read(4L, 6)).utf8)
+      . assert(_ == t"456789")
+
+      test(m"Reads at different offsets are independent"):
+        unsafely:
+          source.expanse: expanse =>
+            (expanse.read(10L, 3).utf8, expanse.read(0L, 3).utf8)
+      . assert(_ == (t"abc", t"012"))
+
+      test(m"A read overlapping the end returns the bytes which exist"):
+        unsafely(source.expanse(_.read(12L, 100)).utf8)
+      . assert(_ == t"cdef")

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -462,3 +462,54 @@ object Tests extends Suite(m"Galilei tests"):
       test(m"A pattern matching nothing yields an empty list"):
         unsafely(root.glob(Glob.parse(t"nowhere/*.jar")))
       . assert(_ == List())
+
+    suite(m"File locking"):
+      import errorDiagnostics.stackTracesDiagnostics
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.deleteRecursively.enabled
+
+      val lockDirLeaf: Text = Uuid().show
+      val lockDir: Path on Linux = unsafely((% / "tmp" / lockDirLeaf).on[Linux])
+
+      unsafely:
+        lockDir.create[Directory]()
+        (lockDir / "target.txt").write(t"content")
+
+      val target: Path on Linux = unsafely(lockDir / "target.txt")
+
+      test(m"An Exclusive file open succeeds and reads its content"):
+        unsafely:
+          target.open[File](Read & Exclusive)(file.stream.read[Data]).utf8
+      . assert(_ == t"content")
+
+      test(m"A second Exclusive open of the same file is Busy"):
+        unsafely:
+          capture[Io.Error]:
+            scala.caps.unsafe.unsafeAssumeSeparate:
+              target.open[File](Read & Exclusive): a ?=>
+                target.open[File](Read & Exclusive) { () }
+          . reason
+      . assert(_ == Io.Error.Reason.Busy)
+
+      test(m"Ordinary Read opens of one file coexist"):
+        unsafely:
+          scala.caps.unsafe.unsafeAssumeSeparate:
+            target.open[File](Read): a ?=>
+              target.open[File](Read) { true }
+      . assert(_ == true)
+
+      test(m"An Exclusive file open conflicts with an enclosing Exclusive directory scope"):
+        unsafely:
+          capture[Io.Error]:
+            scala.caps.unsafe.unsafeAssumeSeparate:
+              lockDir.open[Directory](Read & Exclusive): a ?=>
+                target.open[File](Read & Exclusive) { () }
+          . reason
+      . assert(_ == Io.Error.Reason.Busy)
+
+      test(m"The lock is released when the scope ends"):
+        unsafely:
+          target.open[File](Read & Exclusive) { () }
+          target.open[File](Read & Exclusive) { true }
+      . assert(_ == true)

--- a/lib/galilei/src/wasi/galilei_wasi.scala
+++ b/lib/galilei/src/wasi/galilei_wasi.scala
@@ -45,6 +45,7 @@ import prepositional.*
 import rudiments.*
 import serpentine.*
 import vacuous.*
+import turbulence.Aggregable
 import soundness.{call, dispose}
 import xenophile.*
 
@@ -344,6 +345,52 @@ package filesystemBackends:
       :   Unit =
 
         abort(Io.Error(path, Operation.Metadata, Reason.Unsupported))
+
+      def expanse[result](path: Path on Plane)(lambda: zephyrine.Expanse => result)
+        ( using Tactic[Io.Error] )
+      :   result =
+
+        protect(path, Operation.Open):
+          val (descriptor, relative) = resolve(path, Operation.Open)
+          val directory: Foreign of "descriptor" from Wit = descriptor
+
+          // open-flags none; descriptor-flags: read (1).
+          val opened =
+            directory
+            . `open-at`(follow(true), relative, U32(0.bits), U32(1.bits))
+            . call[Wasm.Handle of "descriptor"]()
+
+          try
+            val target: Foreign of "descriptor" from Wit = opened
+
+            val view = new zephyrine.Expanse:
+              def size: Long = statOf(descriptor, relative, true).size
+
+              // WASI has no single positional-read call in this binding, but
+              // `read-via-stream` takes an offset, so each read drains a stream opened
+              // there; a read overlapping the end of the file returns the bytes which
+              // exist.
+              def read(offset: Long, length: Int): Data =
+                val streamHandle =
+                  target.`read-via-stream`(U64(offset.bits)).call[Wasm.Handle of "input-stream"]()
+
+                val stream: Foreign of "input-stream" from Wit = streamHandle
+                var chunks: List[Data] = Nil
+                var remaining = length
+
+                try
+                  while remaining > 0 do
+                    val chunk = stream.`blocking-read`(U64(remaining.toLong.bits)).call[Data]()
+                    if chunk.length == 0 then remaining = 0 else
+                      chunks = chunk :: chunks
+                      remaining -= chunk.length
+                catch case error: Wasm.Error => ()
+
+                streamHandle.dispose()
+                summon[Data is Aggregable by Data].accept(zephyrine.Stream(chunks.stdlib.reverse.iterator))
+
+            lambda(view)
+          finally opened.dispose()
 
       def open[result](path: Path on Plane, flags: List[OpenFlag])(lambda: Handle => result)
         ( using Tactic[Io.Error] )

--- a/lib/galilei/src/wasi/galilei_wasi.scala
+++ b/lib/galilei/src/wasi/galilei_wasi.scala
@@ -350,6 +350,11 @@ package filesystemBackends:
       :   result =
 
         protect(path, Operation.Open):
+          // WASI has no file-locking call, so a requested lock is refused rather than
+          // silently not taken (issue #566).
+          if flags.has(OpenFlag.Lock)
+          then abort(Io.Error(path, Operation.Open, Reason.Unsupported))
+
           val (descriptor, relative) = resolve(path, Operation.Open)
           val directory: Foreign of "descriptor" from Wit = descriptor
 


### PR DESCRIPTION
Four file-and-path-handling improvements, one per commit.

**File locking through open-scoped exclusivity (#566).** Opening a file with the `Exclusive` grant now acquires real exclusivity for the scope of the open, generalizing what `Ram` already did. The open enrols in the `AccessRegister` — file opens participate in the same intra-JVM arbitration as directory scopes, and conflict with overlapping `Exclusive` directory scopes — and the backend takes an OS advisory lock (the new `OpenFlag.Lock`) covering the cross-process case. A failed acquisition aborts with `Reason.Busy` before the block runs, and release is scope-ended, so there is no unlock to forget:

```scala
path.open[File](Read & Exclusive): handle ?=>
  …  // locked for the scope
```

On a read-only open the OS lock taken is shared — an exclusive lock needs write access — which still excludes cross-process exclusive lockers while the register covers in-process exclusivity. WASI has no file-locking call, so it refuses a requested lock as `Unsupported` rather than silently not taking it. Shared lock modes, blocking acquisition and byte-range slices remain open, as recorded in the issue.

**Portable positional file reading (#1608).** `FilesystemBackend` gains a scoped `expanse` operation, surfaced as an extension:

```scala
path.expanse: view =>            // view: zephyrine.Expanse
  val header = view.read(0L, 8)  // pread-style; no sequential position
  view.size                      // Long — files beyond 2 GiB are addressable
```

The JVM and Native backends use positional `FileChannel` reads (no whole-file mapping, unlike `Ram`'s `Int`-addressed map), and WASI drains a `read-via-stream` opened at the requested offset — so seek-oriented format readers such as facsimile's PDF xref chasing no longer need `java.nio` or a JVM-only module. A read overlapping the end of the file returns the bytes which exist. Migrating facsimile onto this seam is the natural follow-up.

**A storage-filesystem axis on `Path` (#567).** A path known to live on Btrfs is now `Path on Linux over Btrfs`: a fourth refinement axis, orthogonal to the plane, established by runtime probing through extractors which reuse the platform query behind `path.volume()`:

```scala
path match
  case Btrfs(path2) => path2.creation[Long]()  // total — Btrfs records creation times
  case _            => …
```

`Btrfs`, `Ext4`, `Apfs` and `Ntfs` are provided; those which record creation times extend `CreationTimed`, which gates a *total* `creation()` accessor — `Stat.created`'s optionality exists because most POSIX filesystems record none, and a path whose filesystem is known to record it should not pay for that. One departure from the issue's sketch: the refinement is structural rather than a declared `Transport` member on `serpentine.Path` — refining it in is enough for the gated extensions to dispatch, and declaring the member perturbed type inference at unrelated sites downstream. Further filesystem-specific metadata (subvolumes, extended attributes) can follow the same pattern.

**`Path#glob` re-exported (#1871).** The extension from #1863 is now reachable through `import soundness.*`, like every neighbouring galilei extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)