### PR TITLE
Shared, blocking and byte-range locking, and extended attributes

### DIFF
--- a/lib/galilei/src/core/galilei.AccessRegister.scala
+++ b/lib/galilei/src/core/galilei.AccessRegister.scala
@@ -37,6 +37,7 @@ import anticipation.*
 import aperture.*
 import gossamer.*
 import rudiments.*
+import vacuous.*
 
 // The process-global register of open directory scopes, acquired when a directory is opened
 // and released when its scope ends. Conflicts are detected on the real (symlink-resolved)
@@ -48,7 +49,9 @@ import rudiments.*
 // This arbitrates only between scopes within one JVM: it says nothing about other processes
 // (OS advisory locks may complement it later), and file opens do not yet participate.
 object AccessRegister:
-  private case class Registration(real: Text, atoms: Set[Mode])
+  // `range` is the locked byte range for a `Slice` open; a whole-entry registration has none,
+  // and overlaps every range.
+  private case class Registration(real: Text, atoms: Set[Mode], range: Optional[(Long, Long)])
 
   @scala.caps.unsafe.untrackedCaptures
   private var registrations: List[Registration] = Nil
@@ -59,30 +62,41 @@ object AccessRegister:
   private def overlapping(left: Text, right: Text): Boolean =
     left == right || left.starts(t"$right/") || right.starts(t"$left/")
 
-  def acquire(real: Text, atoms: Set[Mode]): Boolean = synchronized:
-    val real2 = normalize(real)
+  private def rangesOverlap(left: Optional[(Long, Long)], right: Optional[(Long, Long)])
+  :   Boolean =
+    left.lay(true): (leftOffset, leftSize) =>
+      right.lay(true): (rightOffset, rightSize) =>
+        leftOffset < rightOffset + rightSize && rightOffset < leftOffset + leftSize
 
-    val conflict = registrations.stdlib.exists: registration =>
-      overlapping(real2, registration.real)
-        && (atoms.has(Exclusive) || registration.atoms.has(Exclusive))
+  def acquire(real: Text, atoms: Set[Mode], range: Optional[(Long, Long)] = Unset): Boolean =
+    synchronized:
+      val real2 = normalize(real)
 
-    if conflict then false else
-      registrations ::= Registration(real2, atoms)
-      true
+      val conflict = registrations.stdlib.exists: registration =>
+        overlapping(real2, registration.real)
+          && rangesOverlap(range, registration.range)
+          && (atoms.has(Exclusive) || registration.atoms.has(Exclusive))
+
+      if conflict then false else
+        registrations ::= Registration(real2, atoms, range)
+        true
 
   // The blocking variant (issue #566): waits until no conflicting registration remains,
   // rather than failing. In-process waiters are woken by `release`; fairness is the
   // monitor's, which suffices for scope-shaped holds.
-  def acquireAwait(real: Text, atoms: Set[Mode]): Unit = synchronized:
-    while !acquire(real, atoms) do wait()
+  def acquireAwait(real: Text, atoms: Set[Mode], range: Optional[(Long, Long)] = Unset)
+  :   Unit =
+    synchronized:
+      while !acquire(real, atoms, range) do wait()
 
-  def release(real: Text, atoms: Set[Mode]): Unit = synchronized:
-    val real2 = normalize(real)
+  def release(real: Text, atoms: Set[Mode], range: Optional[(Long, Long)] = Unset): Unit =
+    synchronized:
+      val real2 = normalize(real)
 
-    def remove(list: List[Registration]): List[Registration] = list match
-      case Nil                                                => Nil
-      case head :: tail if head == Registration(real2, atoms) => tail
-      case head :: tail                                       => head :: remove(tail)
+      def remove(list: List[Registration]): List[Registration] = list match
+        case Nil => Nil
+        case head :: tail if head == Registration(real2, atoms, range) => tail
+        case head :: tail => head :: remove(tail)
 
-    registrations = remove(registrations)
-    notifyAll()
+      registrations = remove(registrations)
+      notifyAll()

--- a/lib/galilei/src/core/galilei.AccessRegister.scala
+++ b/lib/galilei/src/core/galilei.AccessRegister.scala
@@ -70,6 +70,12 @@ object AccessRegister:
       registrations ::= Registration(real2, atoms)
       true
 
+  // The blocking variant (issue #566): waits until no conflicting registration remains,
+  // rather than failing. In-process waiters are woken by `release`; fairness is the
+  // monitor's, which suffices for scope-shaped holds.
+  def acquireAwait(real: Text, atoms: Set[Mode]): Unit = synchronized:
+    while !acquire(real, atoms) do wait()
+
   def release(real: Text, atoms: Set[Mode]): Unit = synchronized:
     val real2 = normalize(real)
 
@@ -79,3 +85,4 @@ object AccessRegister:
       case head :: tail                                       => head :: remove(tail)
 
     registrations = remove(registrations)
+    notifyAll()

--- a/lib/galilei/src/core/galilei.Btrfs.scala
+++ b/lib/galilei/src/core/galilei.Btrfs.scala
@@ -59,10 +59,14 @@ import vacuous.*
 // record none.
 sealed trait CreationTimed
 
-sealed trait Btrfs extends CreationTimed
-sealed trait Ext4
-sealed trait Apfs extends CreationTimed
-sealed trait Ntfs extends CreationTimed
+// Filesystems which support extended (user-defined) attributes, gating the typed `attribute`
+// accessors (issue #567).
+sealed trait Attributed
+
+sealed trait Btrfs extends CreationTimed, Attributed
+sealed trait Ext4 extends Attributed
+sealed trait Apfs extends CreationTimed, Attributed
+sealed trait Ntfs extends CreationTimed, Attributed
 
 private def storageFormat[plane](path: Path on plane)(using backend: FilesystemBackend on plane)
 :   Optional[Text] =

--- a/lib/galilei/src/core/galilei.FileOpenable.scala
+++ b/lib/galilei/src/core/galilei.FileOpenable.scala
@@ -83,8 +83,12 @@ extends Openable:
         try value.nioPath.toRealPath().nn.toString.tt
         catch case _: Exception => value.nioPath.toAbsolutePath.nn.normalize.nn.toString.tt
 
-    if locking && !AccessRegister.acquire(real, mode.atoms)
-    then abort(Io.Error(value, Operation.Open, Reason.Busy))
+    val awaiting = flags.stdlib.contains(OpenFlag.Await)
+
+    if locking then
+      if awaiting then AccessRegister.acquireAwait(real, mode.atoms)
+      else if !AccessRegister.acquire(real, mode.atoms)
+      then abort(Io.Error(value, Operation.Open, Reason.Busy))
 
     try
       backend.open(value, (modeFlags ++ flags.stdlib).to(List)): handle =>

--- a/lib/galilei/src/core/galilei.FilesystemBackend.scala
+++ b/lib/galilei/src/core/galilei.FilesystemBackend.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import contingency.*
 import prepositional.*
 import serpentine.*
+import vacuous.*
 
 // The pluggable low-level filesystem backend for a plane: the complete set of primitive
 // operations that galilei's user-facing API is defined in terms of, expressed without reference
@@ -105,6 +106,14 @@ trait FilesystemBackend extends Planar:
   def expanse[result](path: Path on Plane)(lambda: zephyrine.Expanse => result)
     ( using Tactic[Io.Error] )
   :   result
+
+  // Extended (user-defined) attributes (issue #567). Support depends on the storage
+  // filesystem, so the typed accessors are gated on the `Attributed` axis marker; at the
+  // backend seam the operations are plain, and a backend or filesystem without extended
+  // attributes reports `Unsupported`.
+  def attributes(path: Path on Plane)(using Tactic[Io.Error]): List[Text]
+  def attribute(path: Path on Plane, name: Text)(using Tactic[Io.Error]): Optional[Data]
+  def attribute(path: Path on Plane, name: Text, value: Data)(using Tactic[Io.Error]): Unit
 
   // Range-scoped positional reading (issue #566): like `expanse`, but the view is windowed
   // to `[offset, offset + extent)` — its `size` is the window's, and reads are relative to

--- a/lib/galilei/src/core/galilei.FilesystemBackend.scala
+++ b/lib/galilei/src/core/galilei.FilesystemBackend.scala
@@ -106,6 +106,24 @@ trait FilesystemBackend extends Planar:
     ( using Tactic[Io.Error] )
   :   result
 
+  // Range-scoped positional reading (issue #566): like `expanse`, but the view is windowed
+  // to `[offset, offset + extent)` — its `size` is the window's, and reads are relative to
+  // the window's start and clamped to it — and, when `flags` request it, an OS advisory lock
+  // over exactly that byte range is held for the scope.
+  def slice[result]
+    ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
+    ( lambda: zephyrine.Expanse => result )
+    ( using Tactic[Io.Error] )
+  :   result
+
+  protected def window(view: zephyrine.Expanse, offset: Long, extent: Long): zephyrine.Expanse =
+    new zephyrine.Expanse:
+      def size: Long = (view.size - offset).max(0L).min(extent)
+
+      def read(readOffset: Long, length: Int): Data =
+        val available = (size - readOffset).max(0L).min(length.toLong).toInt
+        view.read(offset + readOffset, available)
+
   def open[result](path: Path on Plane, flags: List[OpenFlag])(lambda: Handle => result)
     ( using Tactic[Io.Error] )
   :   result

--- a/lib/galilei/src/core/galilei.OpenFlag.scala
+++ b/lib/galilei/src/core/galilei.OpenFlag.scala
@@ -38,8 +38,13 @@ package galilei
 enum OpenFlag:
   case Read, Write, Append, Create, Exclusive, Truncate, Sync, Dsync, NoFollow
 
-  // Hold an OS advisory lock on the file for the duration of the open (issue #566). Not an OS
-  // open flag itself: backends which can lock do so after opening, and those which cannot
-  // (WASI has no file-locking call) refuse the open as `Unsupported` rather than silently not
-  // locking. Added by `FileOpenable` when the mode grants `Exclusive`.
-  case Lock
+  // Hold an OS advisory lock on the file for the duration of the open (issue #566): `Lock` is
+  // exclusive, `LockShared` shared. Not OS open flags themselves: backends which can lock do
+  // so after opening, and those which cannot (WASI has no file-locking call) refuse the open
+  // as `Unsupported` rather than silently not locking. Added by `FileOpenable` when the mode
+  // grants `Exclusive` or `Shared` respectively.
+  case Lock, LockShared
+
+  // Block until the lock (and the intra-JVM registration) can be acquired, rather than
+  // failing immediately with `Busy` (issue #566).
+  case Await

--- a/lib/galilei/src/core/galilei.Shared.scala
+++ b/lib/galilei/src/core/galilei.Shared.scala
@@ -32,63 +32,16 @@
                                                                                                   */
 package galilei
 
-import anticipation.*
 import aperture.*
-import gossamer.*
-import contingency.*
-import prepositional.*
-import serpentine.*
-import rudiments.*
 
-import Io.Error.{Operation, Reason}
-
-// The `Openable` instance for opening a file's content: `path.open[File](Read & Write)`. A
-// named class rather than an anonymous given instance: instantiating an anonymous subclass
-// freshens `Handle`'s (capability) field types in the inferred `Result` member, which then
-// fails to conform to the declared `to Handle` refinement.
-class FileOpenable[filesystem: Filesystem, path <: Path on filesystem]
-  ( using backend: FilesystemBackend on filesystem, ioError: Tactic[Io.Error] )
-extends Openable:
-
-  type Self = path
-  type Form = File
-  type Operand = OpenFlag
-  type Result = Handle
-
-  def open[grants <: Grant, result]
-    ( value: path, mode: Mode granting grants, flags: List[OpenFlag] )
-    ( block: ((Handle & Granting[grants])^) ?=> result )
-  :   result =
-
-    // The mode's atoms translate to OS open flags. `aperture.Exclusive` is deliberately not
-    // translated to `OpenFlag.Exclusive`: POSIX `O_EXCL` governs exclusive *creation*, not
-    // exclusive access. Instead it enrols the open in the access register — so file opens
-    // participate in the same intra-JVM arbitration as directory scopes — and asks the
-    // backend for an OS advisory lock (`OpenFlag.Lock`) to cover the cross-process case
-    // (issue #566).
-    val modeFlags =
-      (if mode.atoms.has(Read) then List(OpenFlag.Read).stdlib else Nil.stdlib) ++
-        (if mode.atoms.has(Write) then List(OpenFlag.Write).stdlib else Nil.stdlib) ++
-        (if mode.atoms.has(Exclusive) then List(OpenFlag.Lock).stdlib
-         else if mode.atoms.has(Shared) then List(OpenFlag.LockShared).stdlib
-         else Nil.stdlib)
-
-    val locking = mode.atoms.has(Exclusive) || mode.atoms.has(Shared)
-
-    // The register works on real paths, so two routes to one file register as the same file
-    // and overlap correctly with enclosing directory scopes; a file which is about to be
-    // created cannot be resolved, so it falls back to its normalized absolute form.
-    val real: Text =
-      if !locking then t"" else
-        try value.nioPath.toRealPath().nn.toString.tt
-        catch case _: Exception => value.nioPath.toAbsolutePath.nn.normalize.nn.toString.tt
-
-    if locking && !AccessRegister.acquire(real, mode.atoms)
-    then abort(Io.Error(value, Operation.Open, Reason.Busy))
-
-    try
-      backend.open(value, (modeFlags ++ flags.stdlib).to(List)): handle =>
-        // `Granting` is a phantom marker, so the cast only refines the static type with the
-        // grants that `modeFlags` has just made true operationally.
-        block(using handle.asInstanceOf[Handle & Granting[grants]])
-    finally if locking then AccessRegister.release(real, mode.atoms)
+// The shared-lock mode (issue #566): any number of `Shared` opens of one file may coexist —
+// across processes, through a shared OS advisory lock — but a `Shared` open conflicts with an
+// `Exclusive` one in either direction. `Read` deliberately does not imply it: taking even a
+// shared lock would make every ordinary read contend with exclusive lockers. Defined here
+// rather than in aperture, since shared locking is a filesystem concern; aperture's grant
+// hierarchy is deliberately open to exactly this kind of domain-specific extension.
+//
+//     path.open[File](Read & Shared): handle ?=> …
+object Shared extends Mode:
+  type Grants = Shared.Grant
+  trait Grant extends aperture.Grant

--- a/lib/galilei/src/core/galilei.Slice.scala
+++ b/lib/galilei/src/core/galilei.Slice.scala
@@ -30,33 +30,84 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package galilei
 
-export
-  galilei
-  . { accessed, Apfs, BlockDevice, Btrfs, C, CharDevice, children, CopyAttributes, copyInto,
-      copyTo, created, CreateFlag, CreateNonexistentParents, Creation, creation, CreationTimed,
-      D, delete, Ext4,
-      DeleteRecursively, DereferenceSymlinks, descendants, dir, Directory, Dos, Drive, Entry,
-      entry, executable, expanse, Explorable, existent, Fifo, file, File, FileOpenable,
-      FilesystemAttribute, FilesystemBackend,
-      glob, Handle, hardLinks, hardLinkTo, hidden, Io, Linux, Local,
-      MacOs, modified, MoveAtomically, moveInto, moveTo, Ntfs, OpenFlag,
-      OverwritePreexisting, p, Platform, Posix, readable, filesize, Sock, Stat,
-      Scratch, Shared, Slice, Substantiable, Subtree, Symlink, symlinkInto, symlinkTo, touch,
-      TraversalOrder,
-      UnixEntry, Volume, volume, Windows, WindowsEntry, wipe, writable, write }
+import anticipation.*
+import aperture.*
+import contingency.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import serpentine.*
+import vacuous.*
 
-package interfaces.paths:
-  export
-    anticipation.interfaces.paths
-    . { pathOnLinux, pathOnLocal, pathOnMacOs, pathOnPosix, pathOnWindows }
+import Io.Error.{Operation, Reason}
 
-package filesystemOptions:
-  export
-    galilei.filesystemOptions
-    . { copyAttributes, createNonexistentParents, deleteRecursively,
-        dereferenceSymlinks, moveAtomically, overwritePreexisting }
+// A byte range of a file, as a subject for `open` (issue #566): opening a `Slice` with an
+// `Exclusive` or `Shared` mode takes an OS advisory lock over exactly that range —
+// `FileChannel.lock(position, size, shared)` — and enrols the range in the access register,
+// where it conflicts only with overlapping ranges (a whole-file open overlaps every range).
+// The handle is a positional view (`zephyrine.Expanse`) windowed to the slice: its `size` is
+// the window's, and reads are relative to the window's start and clamped to it. Opened
+// without a locking mode, a `Slice` is simply a windowed view, which even lockless backends
+// (WASI) support.
+//
+//     Slice(path, 0L, 1024L).open[File](Read & Exclusive): view ?=>
+//       view.read(0L, 16)  // the file's first sixteen bytes, under a range lock
+case class Slice[plane](path: Path on plane, offset: Long, extent: Long)
 
-package filesystemTraversal:
-  export galilei.filesystemTraversal.{postOrderTraversal, preOrderTraversal}
+object Slice:
+  class SliceOpenable[filesystem: Filesystem, slice <: Slice[filesystem]]
+    ( using backend: FilesystemBackend on filesystem, ioError: Tactic[Io.Error] )
+  extends Openable:
+
+    type Self = slice
+    type Form = File
+    type Operand = OpenFlag
+    type Result = zephyrine.Expanse
+
+    def open[grants <: Grant, result]
+      ( value: slice, mode: Mode granting grants, flags: List[OpenFlag] )
+      ( block: ((zephyrine.Expanse & Granting[grants])^) ?=> result )
+    :   result =
+
+      val lockFlags =
+        if mode.atoms.has(Exclusive) then List(OpenFlag.Lock)
+        else if mode.atoms.has(Shared) then List(OpenFlag.LockShared)
+        else List()
+
+      val locking = !lockFlags.stdlib.isEmpty
+      val range: (Long, Long) = (value.offset, value.extent)
+
+      // As in `FileOpenable`: the register works on real paths.
+      val real: Text =
+        if !locking then t"" else
+          try value.path.nioPath.toRealPath().nn.toString.tt
+          catch case _: Exception =>
+            value.path.nioPath.toAbsolutePath.nn.normalize.nn.toString.tt
+
+      val awaiting = flags.stdlib.contains(OpenFlag.Await)
+
+      if locking then
+        if awaiting then AccessRegister.acquireAwait(real, mode.atoms, range)
+        else if !AccessRegister.acquire(real, mode.atoms, range)
+        then abort(Io.Error(value.path, Operation.Open, Reason.Busy))
+
+      try
+        backend.slice(value.path, value.offset, value.extent,
+            (lockFlags.stdlib ++ flags.stdlib).to(List)): view =>
+          // Mixed in rather than cast: `Expanse & Granting` is a trait intersection, whose
+          // erased cast is to `Granting`, which the backend's view does not implement.
+          val granted = new zephyrine.Expanse with Granting[grants]:
+            def size: Long = view.size
+            def read(offset: Long, length: Int): Data = view.read(offset, length)
+
+          block(using granted)
+      finally if locking then AccessRegister.release(real, mode.atoms, range)
+
+  // Capture-annotated by the tactic, as `Platform`'s `File` openable is.
+  given openable: [filesystem: Filesystem, slice <: Slice[filesystem]]
+  =>  ( backend: FilesystemBackend on filesystem,
+        tactic:  Tactic[Io.Error] )
+  =>  ( SliceOpenable[filesystem, slice]^{tactic} ) =
+    SliceOpenable[filesystem, slice]

--- a/lib/galilei/src/core/galilei_core.scala
+++ b/lib/galilei/src/core/galilei_core.scala
@@ -478,6 +478,30 @@ package filesystemOptions:
         block
 
 
+// Extended attributes, gated by the storage-filesystem axis (issue #567): available only on a
+// path whose filesystem is known — by extractor probing — to support them. The setter is the
+// two-argument overload: `path.attribute(t"user.origin", data)`.
+extension [plane: Filesystem, transport <: Attributed](path: Path on plane over transport)
+  def attributes()(using backend: FilesystemBackend on plane): List[Text] raises Io.Error =
+    backend.attributes(path)
+
+  // Generic in its result — decoded through `Aggregable`, like turbulence's `read` — so the
+  // fresh capabilities of a byte-array result bind at the call site; a concrete `Data` result
+  // cannot cross the umbrella's synthesized export forwarder under capture checking.
+  def attribute[content: Aggregable by Data](name: Text)
+    ( using backend: FilesystemBackend on plane )
+  :   Optional[content] raises Io.Error =
+
+    backend.attribute(path, name).absolve match
+      case Unset => Unset
+
+      case data: Data =>
+        summon[content is Aggregable by Data].accept(zephyrine.Stream(scala.Iterator(data)))
+
+  def attribute(name: Text, value: Data)(using backend: FilesystemBackend on plane)
+  :   Unit raises Io.Error =
+    backend.attribute(path, name, value)
+
 // Metadata gated by the storage-filesystem axis (issue #567): available only on a path whose
 // filesystem is known — by extractor probing — to record it.
 extension [plane: Filesystem, transport <: CreationTimed](path: Path on plane over transport)

--- a/lib/galilei/src/core/soundness_galilei_core.scala
+++ b/lib/galilei/src/core/soundness_galilei_core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export
   galilei
-  . { accessed, Apfs, BlockDevice, Btrfs, C, CharDevice, children, CopyAttributes, copyInto,
+  . { accessed, Apfs, attribute, attributes, Attributed, BlockDevice, Btrfs, C, CharDevice, children, CopyAttributes, copyInto,
       copyTo, created, CreateFlag, CreateNonexistentParents, Creation, creation, CreationTimed,
       D, delete, Ext4,
       DeleteRecursively, DereferenceSymlinks, descendants, dir, Directory, Dos, Drive, Entry,

--- a/lib/galilei/src/core/soundness_galilei_core.scala
+++ b/lib/galilei/src/core/soundness_galilei_core.scala
@@ -43,7 +43,8 @@ export
       glob, Handle, hardLinks, hardLinkTo, hidden, Io, Linux, Local,
       MacOs, modified, MoveAtomically, moveInto, moveTo, Ntfs, OpenFlag,
       OverwritePreexisting, p, Platform, Posix, readable, filesize, Sock, Stat,
-      Scratch, Substantiable, Subtree, Symlink, symlinkInto, symlinkTo, touch, TraversalOrder,
+      Scratch, Shared, Substantiable, Subtree, Symlink, symlinkInto, symlinkTo, touch,
+      TraversalOrder,
       UnixEntry, Volume, volume, Windows, WindowsEntry, wipe, writable, write }
 
 package interfaces.paths:

--- a/lib/galilei/src/jvm/galilei_jvm.scala
+++ b/lib/galilei/src/jvm/galilei_jvm.scala
@@ -279,7 +279,9 @@ package filesystemBackends:
         ( using Tactic[Io.Error] )
       :   result =
 
-        val options: scala.collection.immutable.List[jnf.OpenOption] = flags.stdlib.filter(_ != OpenFlag.Lock).map:
+        val options: scala.collection.immutable.List[jnf.OpenOption] = flags.stdlib.filter: flag =>
+          flag != OpenFlag.Lock && flag != OpenFlag.LockShared && flag != OpenFlag.Await
+        . map:
           case OpenFlag.Read      => jnf.StandardOpenOption.READ
           case OpenFlag.Write     => jnf.StandardOpenOption.WRITE
           case OpenFlag.Append    => jnf.StandardOpenOption.APPEND
@@ -308,13 +310,18 @@ package filesystemBackends:
           // the access register, and a shared lock still excludes any cross-process
           // exclusive locker.
           val lock =
-            if flags.stdlib.contains(OpenFlag.Lock) then
+            if flags.stdlib.contains(OpenFlag.Lock) || flags.stdlib.contains(OpenFlag.LockShared)
+            then
               val writable = options2.contains(jnf.StandardOpenOption.WRITE) || appending
+              val shared = flags.stdlib.contains(OpenFlag.LockShared) || !writable
 
+              // An overlapping lock held by this JVM throws even when both are shared; the
+              // register has already admitted this open, and the first holder's OS lock
+              // covers the cross-process case, so a shared overlap is benign.
               try Option:
-                if writable then channel.tryLock().nn
-                else channel.tryLock(0L, Long.MaxValue, true).nn
-              catch case _: jnc.OverlappingFileLockException => None
+                if shared then channel.tryLock(0L, Long.MaxValue, true).nn
+                else channel.tryLock().nn
+              catch case _: jnc.OverlappingFileLockException => if shared then Some(null) else None
             else Some(null)
 
           if lock.isEmpty then abort(Io.Error(path, Operation.Open, Reason.Busy))

--- a/lib/galilei/src/jvm/galilei_jvm.scala
+++ b/lib/galilei/src/jvm/galilei_jvm.scala
@@ -315,11 +315,17 @@ package filesystemBackends:
               val writable = options2.contains(jnf.StandardOpenOption.WRITE) || appending
               val shared = flags.stdlib.contains(OpenFlag.LockShared) || !writable
 
+              val await = flags.stdlib.contains(OpenFlag.Await)
+
               // An overlapping lock held by this JVM throws even when both are shared; the
               // register has already admitted this open, and the first holder's OS lock
-              // covers the cross-process case, so a shared overlap is benign.
+              // covers the cross-process case, so a shared overlap is benign. With `Await`,
+              // the blocking variants wait for the cross-process lock instead of failing.
               try Option:
-                if shared then channel.tryLock(0L, Long.MaxValue, true).nn
+                if shared then
+                  if await then channel.lock(0L, Long.MaxValue, true).nn
+                  else channel.tryLock(0L, Long.MaxValue, true).nn
+                else if await then channel.lock().nn
                 else channel.tryLock().nn
               catch case _: jnc.OverlappingFileLockException => if shared then Some(null) else None
             else Some(null)

--- a/lib/galilei/src/jvm/galilei_jvm.scala
+++ b/lib/galilei/src/jvm/galilei_jvm.scala
@@ -275,6 +275,34 @@ package filesystemBackends:
           lambda(view)
         finally channel.close()
 
+      private def attributeView(path: Path on Plane)(using Tactic[Io.Error])
+      :   jnf.attribute.UserDefinedFileAttributeView =
+        Optional(jnf.Files.getFileAttributeView
+            (javaPath(path), classOf[jnf.attribute.UserDefinedFileAttributeView]))
+        . or(abort(Io.Error(path, Operation.Metadata, Reason.Unsupported)))
+
+      def attributes(path: Path on Plane)(using Tactic[Io.Error]): List[Text] =
+        protect(path, Operation.Metadata):
+          val view = attributeView(path)
+          scala.List.from(view.list().nn.iterator().nn.asScala).map(_.nn.tt).to(List)
+
+      def attribute(path: Path on Plane, name: Text)(using Tactic[Io.Error]): Optional[Data] =
+        protect(path, Operation.Metadata):
+          val view = attributeView(path)
+
+          if !view.list().nn.contains(name.s) then Unset else
+            val buffer = java.nio.ByteBuffer.allocate(view.size(name.s)).nn
+            view.read(name.s, buffer)
+            buffer.flip()
+            val array = Array.allocate[Byte](buffer.remaining)
+            buffer.get(array.raw, 0, buffer.remaining)
+            Array.freeze(array)
+
+      def attribute(path: Path on Plane, name: Text, value: Data)(using Tactic[Io.Error]): Unit =
+        protect(path, Operation.Metadata):
+          attributeView(path).write(name.s, java.nio.ByteBuffer.wrap(Array.unsafeJvm(value)))
+          ()
+
       def slice[result]
         ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
         ( lambda: zephyrine.Expanse => result )

--- a/lib/galilei/src/jvm/galilei_jvm.scala
+++ b/lib/galilei/src/jvm/galilei_jvm.scala
@@ -275,6 +275,73 @@ package filesystemBackends:
           lambda(view)
         finally channel.close()
 
+      def slice[result]
+        ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
+        ( lambda: zephyrine.Expanse => result )
+        ( using Tactic[Io.Error] )
+      :   result =
+
+        // An exclusive range lock needs a writable channel, so one is requested when the
+        // flags ask for an exclusive lock, degrading — like whole-file locking on a
+        // read-only open — to a read-only channel and a *shared* OS lock where the file
+        // cannot be opened writable; the register still provides in-process exclusivity.
+        var writable = flags.stdlib.contains(OpenFlag.Lock)
+
+        val channel = protect(path, Operation.Open):
+          val optionSet = java.util.HashSet[jnf.OpenOption]()
+          optionSet.add(jnf.StandardOpenOption.READ)
+          if writable then optionSet.add(jnf.StandardOpenOption.WRITE)
+
+          try jnc.FileChannel.open(javaPath(path), optionSet).nn
+          catch case error: Exception =>
+            import scala.unsafeExceptions.canThrowAny
+            if !writable then throw error else
+              writable = false
+              optionSet.remove(jnf.StandardOpenOption.WRITE)
+              jnc.FileChannel.open(javaPath(path), optionSet).nn
+
+        try
+          val shared = flags.stdlib.contains(OpenFlag.LockShared) || !writable
+          val await = flags.stdlib.contains(OpenFlag.Await)
+
+          val lock =
+            if flags.stdlib.contains(OpenFlag.Lock) || flags.stdlib.contains(OpenFlag.LockShared)
+            then
+              // As for whole-file locks: an in-JVM shared overlap is benign, since the
+              // register has already admitted this open.
+              try Option:
+                if await then channel.lock(offset, extent, shared).nn
+                else channel.tryLock(offset, extent, shared).nn
+              catch case _: jnc.OverlappingFileLockException => if shared then Some(null) else None
+            else Some(null)
+
+          if lock.isEmpty then abort(Io.Error(path, Operation.Open, Reason.Busy))
+
+          try
+            val view = new zephyrine.Expanse:
+              def size: Long = channel.size
+
+              def read(readOffset: Long, length: Int): Data =
+                val buffer = java.nio.ByteBuffer.allocate(length).nn
+                var position = readOffset
+                var count = 0
+
+                while count >= 0 && buffer.hasRemaining do
+                  count = channel.read(buffer, position)
+                  if count > 0 then position += count
+
+                val filled = buffer.position
+                val array = Array.allocate[Byte](filled)
+                buffer.flip()
+                buffer.get(array.raw, 0, filled)
+                Array.freeze(array)
+
+            lambda(window(view, offset, extent))
+          finally lock.foreach: held =>
+            if held != null then
+              try held.release() catch case _: jnc.ClosedChannelException => ()
+        finally channel.close()
+
       def open[result](path: Path on Plane, flags: List[OpenFlag])(lambda: Handle => result)
         ( using Tactic[Io.Error] )
       :   result =

--- a/lib/galilei/src/native/galilei_native.scala
+++ b/lib/galilei/src/native/galilei_native.scala
@@ -312,7 +312,9 @@ package filesystemBackends:
         ( using Tactic[Io.Error] )
       :   result =
 
-        val options: scala.collection.immutable.List[jnf.OpenOption] = flags.stdlib.filter(_ != OpenFlag.Lock).map:
+        val options: scala.collection.immutable.List[jnf.OpenOption] = flags.stdlib.filter: flag =>
+          flag != OpenFlag.Lock && flag != OpenFlag.LockShared && flag != OpenFlag.Await
+        . map:
           case OpenFlag.Read      => jnf.StandardOpenOption.READ
           case OpenFlag.Write     => jnf.StandardOpenOption.WRITE
           case OpenFlag.Append    => jnf.StandardOpenOption.APPEND
@@ -345,13 +347,18 @@ package filesystemBackends:
           // the access register, and a shared lock still excludes any cross-process
           // exclusive locker.
           val lock =
-            if flags.stdlib.contains(OpenFlag.Lock) then
+            if flags.stdlib.contains(OpenFlag.Lock) || flags.stdlib.contains(OpenFlag.LockShared)
+            then
               val writable = options2.contains(jnf.StandardOpenOption.WRITE) || appending
+              val shared = flags.stdlib.contains(OpenFlag.LockShared) || !writable
 
+              // An overlapping lock held by this JVM throws even when both are shared; the
+              // register has already admitted this open, and the first holder's OS lock
+              // covers the cross-process case, so a shared overlap is benign.
               try Option:
-                if writable then channel.tryLock().nn
-                else channel.tryLock(0L, Long.MaxValue, true).nn
-              catch case _: jnc.OverlappingFileLockException => None
+                if shared then channel.tryLock(0L, Long.MaxValue, true).nn
+                else channel.tryLock().nn
+              catch case _: jnc.OverlappingFileLockException => if shared then Some(null) else None
             else Some(null)
 
           if lock.isEmpty then abort(Io.Error(path, Operation.Open, Reason.Busy))

--- a/lib/galilei/src/native/galilei_native.scala
+++ b/lib/galilei/src/native/galilei_native.scala
@@ -308,6 +308,15 @@ package filesystemBackends:
           lambda(view)
         finally channel.close()
 
+      def attributes(path: Path on Plane)(using Tactic[Io.Error]): List[Text] =
+        abort(Io.Error(path, Operation.Metadata, Reason.Unsupported))
+
+      def attribute(path: Path on Plane, name: Text)(using Tactic[Io.Error]): Optional[Data] =
+        abort(Io.Error(path, Operation.Metadata, Reason.Unsupported))
+
+      def attribute(path: Path on Plane, name: Text, value: Data)(using Tactic[Io.Error]): Unit =
+        abort(Io.Error(path, Operation.Metadata, Reason.Unsupported))
+
       def slice[result]
         ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
         ( lambda: zephyrine.Expanse => result )

--- a/lib/galilei/src/native/galilei_native.scala
+++ b/lib/galilei/src/native/galilei_native.scala
@@ -308,6 +308,73 @@ package filesystemBackends:
           lambda(view)
         finally channel.close()
 
+      def slice[result]
+        ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
+        ( lambda: zephyrine.Expanse => result )
+        ( using Tactic[Io.Error] )
+      :   result =
+
+        // An exclusive range lock needs a writable channel, so one is requested when the
+        // flags ask for an exclusive lock, degrading — like whole-file locking on a
+        // read-only open — to a read-only channel and a *shared* OS lock where the file
+        // cannot be opened writable; the register still provides in-process exclusivity.
+        var writable = flags.stdlib.contains(OpenFlag.Lock)
+
+        val channel = protect(path, Operation.Open):
+          val optionSet = java.util.HashSet[jnf.OpenOption]()
+          optionSet.add(jnf.StandardOpenOption.READ)
+          if writable then optionSet.add(jnf.StandardOpenOption.WRITE)
+
+          try jnc.FileChannel.open(javaPath(path), optionSet).nn
+          catch case error: Exception =>
+            import scala.unsafeExceptions.canThrowAny
+            if !writable then throw error else
+              writable = false
+              optionSet.remove(jnf.StandardOpenOption.WRITE)
+              jnc.FileChannel.open(javaPath(path), optionSet).nn
+
+        try
+          val shared = flags.stdlib.contains(OpenFlag.LockShared) || !writable
+          val await = flags.stdlib.contains(OpenFlag.Await)
+
+          val lock =
+            if flags.stdlib.contains(OpenFlag.Lock) || flags.stdlib.contains(OpenFlag.LockShared)
+            then
+              // As for whole-file locks: an in-JVM shared overlap is benign, since the
+              // register has already admitted this open.
+              try Option:
+                if await then channel.lock(offset, extent, shared).nn
+                else channel.tryLock(offset, extent, shared).nn
+              catch case _: jnc.OverlappingFileLockException => if shared then Some(null) else None
+            else Some(null)
+
+          if lock.isEmpty then abort(Io.Error(path, Operation.Open, Reason.Busy))
+
+          try
+            val view = new zephyrine.Expanse:
+              def size: Long = channel.size
+
+              def read(readOffset: Long, length: Int): Data =
+                val buffer = java.nio.ByteBuffer.allocate(length).nn
+                var position = readOffset
+                var count = 0
+
+                while count >= 0 && buffer.hasRemaining do
+                  count = channel.read(buffer, position)
+                  if count > 0 then position += count
+
+                val filled = buffer.position
+                val array = Array.allocate[Byte](filled)
+                buffer.flip()
+                buffer.get(array.raw, 0, filled)
+                Array.freeze(array)
+
+            lambda(window(view, offset, extent))
+          finally lock.foreach: held =>
+            if held != null then
+              try held.release() catch case _: jnc.ClosedChannelException => ()
+        finally channel.close()
+
       def open[result](path: Path on Plane, flags: List[OpenFlag])(lambda: Handle => result)
         ( using Tactic[Io.Error] )
       :   result =

--- a/lib/galilei/src/native/galilei_native.scala
+++ b/lib/galilei/src/native/galilei_native.scala
@@ -352,11 +352,17 @@ package filesystemBackends:
               val writable = options2.contains(jnf.StandardOpenOption.WRITE) || appending
               val shared = flags.stdlib.contains(OpenFlag.LockShared) || !writable
 
+              val await = flags.stdlib.contains(OpenFlag.Await)
+
               // An overlapping lock held by this JVM throws even when both are shared; the
               // register has already admitted this open, and the first holder's OS lock
-              // covers the cross-process case, so a shared overlap is benign.
+              // covers the cross-process case, so a shared overlap is benign. With `Await`,
+              // the blocking variants wait for the cross-process lock instead of failing.
               try Option:
-                if shared then channel.tryLock(0L, Long.MaxValue, true).nn
+                if shared then
+                  if await then channel.lock(0L, Long.MaxValue, true).nn
+                  else channel.tryLock(0L, Long.MaxValue, true).nn
+                else if await then channel.lock().nn
                 else channel.tryLock().nn
               catch case _: jnc.OverlappingFileLockException => if shared then Some(null) else None
             else Some(null)

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -625,3 +625,43 @@ object Tests extends Suite(m"Galilei tests"):
           while !order.isEmpty do seen = seen :+ order.poll().toString
           seen
       . assert(_ == scala.List("releasing", "acquired"))
+
+    suite(m"Slice locking"):
+      import errorDiagnostics.stackTracesDiagnostics
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+
+      val sliceLeaf: Text = Uuid().show
+      val sliced: Path on Linux = unsafely((% / "tmp" / sliceLeaf).on[Linux])
+      unsafely(sliced.write(t"0123456789abcdef"))
+
+      test(m"A slice view is windowed to its range"):
+        unsafely:
+          Slice(sliced, 4L, 6L).open[File](Read): view ?=>
+            (view.size, view.read(0L, 6).utf8, view.read(4L, 100).utf8)
+      . assert(_ == (6L, t"456789", t"89"))
+
+      test(m"Overlapping exclusive slices conflict"):
+        unsafely:
+          capture[Io.Error]:
+            scala.caps.unsafe.unsafeAssumeSeparate:
+              Slice(sliced, 0L, 8L).open[File](Read & Exclusive): a ?=>
+                Slice(sliced, 4L, 8L).open[File](Read & Exclusive) { () }
+          . reason
+      . assert(_ == Io.Error.Reason.Busy)
+
+      test(m"Disjoint exclusive slices coexist"):
+        unsafely:
+          scala.caps.unsafe.unsafeAssumeSeparate:
+            Slice(sliced, 0L, 4L).open[File](Read & Exclusive): a ?=>
+              Slice(sliced, 8L, 4L).open[File](Read & Exclusive) { true }
+      . assert(_ == true)
+
+      test(m"A whole-file Exclusive open conflicts with any slice"):
+        unsafely:
+          capture[Io.Error]:
+            scala.caps.unsafe.unsafeAssumeSeparate:
+              sliced.open[File](Read & Exclusive): a ?=>
+                Slice(sliced, 0L, 4L).open[File](Read & Exclusive) { () }
+          . reason
+      . assert(_ == Io.Error.Reason.Busy)

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -593,3 +593,35 @@ object Tests extends Suite(m"Galilei tests"):
                 shared.open[File](Read & Shared) { () }
           . reason
       . assert(_ == Io.Error.Reason.Busy)
+
+    suite(m"Awaited locking"):
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+      import threading.platformThreading
+
+      val awaitLeaf: Text = Uuid().show
+      val awaited: Path on Linux = unsafely((% / "tmp" / awaitLeaf).on[Linux])
+      unsafely(awaited.write(t"content"))
+
+      test(m"An awaited open blocks until the holder's scope ends, then proceeds"):
+        unsafely:
+          val order = java.util.concurrent.ConcurrentLinkedQueue[String]()
+
+          val runnable: Runnable = () =>
+            unsafely:
+              awaited.open[File](Read & Exclusive, OpenFlag.Await):
+                order.add("acquired") yet ()
+
+          val waiter = java.lang.Thread(runnable)
+
+          scala.caps.unsafe.unsafeAssumeSeparate:
+            awaited.open[File](Read & Exclusive): a ?=>
+              waiter.start()
+              java.lang.Thread.sleep(300)
+              order.add("releasing") yet ()
+
+          waiter.join(5000)
+          var seen = scala.List[String]()
+          while !order.isEmpty do seen = seen :+ order.poll().toString
+          seen
+      . assert(_ == scala.List("releasing", "acquired"))

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -665,3 +665,31 @@ object Tests extends Suite(m"Galilei tests"):
                 Slice(sliced, 0L, 4L).open[File](Read & Exclusive) { () }
           . reason
       . assert(_ == Io.Error.Reason.Busy)
+
+    suite(m"Extended attributes"):
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+
+      val xattrLeaf: Text = Uuid().show
+      val xattred: Path on Linux = unsafely((% / "tmp" / xattrLeaf).on[Linux])
+      unsafely(xattred.write(t"content"))
+
+      test(m"An attribute round-trips on a matched attributed filesystem"):
+        def roundtrip[transport <: Attributed](path: Path on Linux over transport)
+        :   (Optional[Text], Boolean) =
+          unsafely:
+            path.attribute(t"origin", t"soundness".in[Data])
+            (path.attribute[Data](t"origin").let(_.utf8), path.attributes().has(t"origin"))
+
+        xattred match
+          case Apfs(path)  => roundtrip(path)
+          case Btrfs(path) => roundtrip(path)
+          case Ext4(path)  => roundtrip(path)
+          case _           => (t"soundness", true) // no attributed filesystem here; gate held
+      . assert(_ == (t"soundness", true))
+
+      test(m"An unset attribute is absent"):
+        xattred match
+          case Apfs(path) => unsafely(path.attribute[Data](t"missing")).absent
+          case _          => true
+      . assert(_ == true)

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -559,3 +559,37 @@ object Tests extends Suite(m"Galilei tests"):
           case Ntfs(path)  => unsafely(path.creation[Long]()) > 0L
           case _           => true  // no creation-timed filesystem here; the gate did its job
       . assert(_ == true)
+
+    suite(m"Shared locking"):
+      import errorDiagnostics.stackTracesDiagnostics
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+
+      val sharedLeaf: Text = Uuid().show
+      val shared: Path on Linux = unsafely((% / "tmp" / sharedLeaf).on[Linux])
+      unsafely(shared.write(t"content"))
+
+      test(m"Shared opens of one file coexist"):
+        unsafely:
+          scala.caps.unsafe.unsafeAssumeSeparate:
+            shared.open[File](Read & Shared): a ?=>
+              shared.open[File](Read & Shared) { true }
+      . assert(_ == true)
+
+      test(m"An Exclusive open cannot join a Shared one"):
+        unsafely:
+          capture[Io.Error]:
+            scala.caps.unsafe.unsafeAssumeSeparate:
+              shared.open[File](Read & Shared): a ?=>
+                shared.open[File](Read & Exclusive) { () }
+          . reason
+      . assert(_ == Io.Error.Reason.Busy)
+
+      test(m"A Shared open cannot join an Exclusive one"):
+        unsafely:
+          capture[Io.Error]:
+            scala.caps.unsafe.unsafeAssumeSeparate:
+              shared.open[File](Read & Exclusive): a ?=>
+                shared.open[File](Read & Shared) { () }
+          . reason
+      . assert(_ == Io.Error.Reason.Busy)

--- a/lib/galilei/src/wasi/galilei_wasi.scala
+++ b/lib/galilei/src/wasi/galilei_wasi.scala
@@ -392,6 +392,18 @@ package filesystemBackends:
             lambda(view)
           finally opened.dispose()
 
+      def slice[result]
+        ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
+        ( lambda: zephyrine.Expanse => result )
+        ( using Tactic[Io.Error] )
+      :   result =
+
+        // WASI has no file-locking call, so a locked slice is refused; an unlocked slice is
+        // simply a windowed positional view.
+        if flags.has(OpenFlag.Lock) || flags.has(OpenFlag.LockShared)
+        then abort(Io.Error(path, Operation.Open, Reason.Unsupported))
+        else expanse(path) { view => lambda(window(view, offset, extent)) }
+
       def open[result](path: Path on Plane, flags: List[OpenFlag])(lambda: Handle => result)
         ( using Tactic[Io.Error] )
       :   result =

--- a/lib/galilei/src/wasi/galilei_wasi.scala
+++ b/lib/galilei/src/wasi/galilei_wasi.scala
@@ -399,7 +399,7 @@ package filesystemBackends:
         protect(path, Operation.Open):
           // WASI has no file-locking call, so a requested lock is refused rather than
           // silently not taken (issue #566).
-          if flags.has(OpenFlag.Lock)
+          if flags.has(OpenFlag.Lock) || flags.has(OpenFlag.LockShared)
           then abort(Io.Error(path, Operation.Open, Reason.Unsupported))
 
           val (descriptor, relative) = resolve(path, Operation.Open)

--- a/lib/galilei/src/wasi/galilei_wasi.scala
+++ b/lib/galilei/src/wasi/galilei_wasi.scala
@@ -392,6 +392,15 @@ package filesystemBackends:
             lambda(view)
           finally opened.dispose()
 
+      def attributes(path: Path on Plane)(using Tactic[Io.Error]): List[Text] =
+        abort(Io.Error(path, Operation.Metadata, Reason.Unsupported))
+
+      def attribute(path: Path on Plane, name: Text)(using Tactic[Io.Error]): Optional[Data] =
+        abort(Io.Error(path, Operation.Metadata, Reason.Unsupported))
+
+      def attribute(path: Path on Plane, name: Text, value: Data)(using Tactic[Io.Error]): Unit =
+        abort(Io.Error(path, Operation.Metadata, Reason.Unsupported))
+
       def slice[result]
         ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
         ( lambda: zephyrine.Expanse => result )


### PR DESCRIPTION
The second leg of #566 and #567, completing the items recorded when the first leg landed in #1875. Four commits.

**A `Shared` lock mode (#566).** `path.open[File](Read & Shared)` takes a shared OS advisory lock for the scope: any number of `Shared` opens of one file coexist, across processes, but conflict with an `Exclusive` open in either direction. `Read` deliberately does not imply it — a shared lock would make every ordinary read contend with exclusive lockers. The mode lives in galilei, since aperture's grant hierarchy is deliberately open to domain-specific extension. Within one JVM, an overlapping lock throws even when both are shared, so a shared overlap is treated as benign: the access register has already admitted the open, and the first holder's OS lock covers the cross-process case.

**Blocking acquisition (#566).** `path.open[File](Read & Exclusive, OpenFlag.Await)` blocks until the lock can be acquired instead of failing with `Busy`: the access register gains a waiting acquire — in-process waiters are woken on release, with the monitor's fairness — and the backends use `FileChannel`'s blocking lock variants for the cross-process case.

**Byte-range locking with `Slice` (#566).**

```scala
Slice(path, 0L, 1024L).open[File](Read & Exclusive): view ?=>
  view.read(0L, 16)  // the file's first sixteen bytes, under a range lock
```

A `Slice` is a new `Openable` subject carrying a `Long`-based range. Opening it with a locking mode takes an OS advisory lock over exactly that range and enrols the range in the access register, whose subtree-overlap test gains a byte-range analogue: slices conflict only where their ranges overlap, and a whole-file open overlaps every range. The handle is a positional view (`zephyrine.Expanse`, from #1875) windowed to the slice — its `size` is the window's, and reads are relative to its start and clamped to it. `Shared` and `Await` compose as for whole-file locks; an exclusive range lock needs a writable channel, so one is requested, degrading to a shared OS lock where the file cannot be opened writable (the register still provides in-process exclusivity). Opened without a locking mode, a `Slice` is simply a windowed view, which even the lockless WASI backend supports.

**Extended attributes on the filesystem axis (#567).** `FilesystemBackend` gains extended-attribute operations — list, read, write — implemented over the JVM's `UserDefinedFileAttributeView` (Native and WASI report `Unsupported`), surfaced as typed accessors gated by a new `Attributed` marker in the same pattern as `CreationTimed`: only a path probed onto `Btrfs`, `Ext4`, `Apfs` or `Ntfs` offers them.

```scala
path match
  case Apfs(path) =>
    path.attribute(t"origin", data)     // write
    path.attribute[Data](t"origin")     // read: Optional[Data]
    path.attributes()                   // list
```

The getter is generic in its result, decoded through `Aggregable` like turbulence's `read` — for symmetry, and because a concrete `Data` result cannot cross the umbrella's synthesized export forwarder under capture checking.

Still open after this leg: Btrfs subvolume metadata (real ioctls), and a windowed *write* handle for slices, which awaits a positional-write seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)