### PR TITLE
A windowed write handle for Slice opens (#1878)

### DIFF
--- a/lib/galilei/src/core/galilei.FilesystemBackend.scala
+++ b/lib/galilei/src/core/galilei.FilesystemBackend.scala
@@ -115,13 +115,15 @@ trait FilesystemBackend extends Planar:
   def attribute(path: Path on Plane, name: Text)(using Tactic[Io.Error]): Optional[Data]
   def attribute(path: Path on Plane, name: Text, value: Data)(using Tactic[Io.Error]): Unit
 
-  // Range-scoped positional reading (issue #566): like `expanse`, but the view is windowed
-  // to `[offset, offset + extent)` — its `size` is the window's, and reads are relative to
-  // the window's start and clamped to it — and, when `flags` request it, an OS advisory lock
-  // over exactly that byte range is held for the scope.
+  // Range-scoped positional access (issues #566, #1878): like `expanse`, but the view is a
+  // `Slice.Window` confined to `[offset, offset + extent)` — its `size` is the window's,
+  // reads are relative to the window's start and clamped to it, and writes store as much as
+  // fits and return the count, `pwrite`-style. When `flags` request it, an OS advisory lock
+  // over exactly that byte range is held for the scope; a write is only meaningful when
+  // `flags` include `OpenFlag.Write`.
   def slice[result]
     ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
-    ( lambda: zephyrine.Expanse => result )
+    ( lambda: Slice.Window => result )
     ( using Tactic[Io.Error] )
   :   result
 

--- a/lib/galilei/src/core/galilei.Slice.scala
+++ b/lib/galilei/src/core/galilei.Slice.scala
@@ -47,16 +47,38 @@ import Io.Error.{Operation, Reason}
 // `Exclusive` or `Shared` mode takes an OS advisory lock over exactly that range —
 // `FileChannel.lock(position, size, shared)` — and enrols the range in the access register,
 // where it conflicts only with overlapping ranges (a whole-file open overlaps every range).
-// The handle is a positional view (`zephyrine.Expanse`) windowed to the slice: its `size` is
-// the window's, and reads are relative to the window's start and clamped to it. Opened
-// without a locking mode, a `Slice` is simply a windowed view, which even lockless backends
-// (WASI) support.
+// The handle is a `Slice.Window`: a positional view windowed to the slice, whose `size` is
+// the window's, and whose reads and writes are relative to the window's start and confined
+// to it (issue #1878) — reads clamp, and writes store as much as fits and return the count,
+// in the manner of `pwrite`. The `read` and `write` extensions are gated by the mode's
+// grants, as `Ram`'s are. Opened without a locking mode, a `Slice` is simply a windowed
+// view, which even lockless backends (WASI) support.
 //
-//     Slice(path, 0L, 1024L).open[File](Read & Exclusive): view ?=>
-//       view.read(0L, 16)  // the file's first sixteen bytes, under a range lock
+//     Slice(path, 0L, 1024L).open[File](Read & Write & Exclusive): window ?=>
+//       window.write(0L, data)  // stored at the file's start, under a range lock
+//       window.read(0L, 16)
 case class Slice[plane](path: Path on plane, offset: Long, extent: Long)
 
 object Slice:
+  // The handle for an open slice. `readFrom` and `writeTo` are the operational methods, which
+  // backends implement already windowed; the public, grant-gated names are the `read` and
+  // `write` extensions below, following `Ram`'s pattern.
+  trait Window:
+    def size: Long
+    def readFrom(offset: Long, length: Int): Data
+    def writeTo(offset: Long, data: Data): Int
+
+  // Transparent inline, as `Ram`'s gated accessors are: a non-inline extension's pure
+  // receiver type cannot accept the capability-captured handle.
+  extension (window: Window & Granting[Grant.Read])
+    transparent inline def read(offset: Long, length: Int): Data = window.readFrom(offset, length)
+
+  extension (window: Window & Granting[Grant.Write])
+    // Stores `data` at `offset` within the window, returning how many bytes were written:
+    // clamped, `pwrite`-style, to the window's extent, so a caller storing near the boundary
+    // can observe the truncation rather than lose data silently.
+    transparent inline def write(offset: Long, data: Data): Int = window.writeTo(offset, data)
+
   class SliceOpenable[filesystem: Filesystem, slice <: Slice[filesystem]]
     ( using backend: FilesystemBackend on filesystem, ioError: Tactic[Io.Error] )
   extends Openable:
@@ -64,17 +86,21 @@ object Slice:
     type Self = slice
     type Form = File
     type Operand = OpenFlag
-    type Result = zephyrine.Expanse
+    type Result = Window
 
     def open[grants <: Grant, result]
       ( value: slice, mode: Mode granting grants, flags: List[OpenFlag] )
-      ( block: ((zephyrine.Expanse & Granting[grants])^) ?=> result )
+      ( block: ((Window & Granting[grants])^) ?=> result )
     :   result =
 
       val lockFlags =
         if mode.atoms.has(Exclusive) then List(OpenFlag.Lock)
         else if mode.atoms.has(Shared) then List(OpenFlag.LockShared)
         else List()
+
+      val modeFlags =
+        (if mode.atoms.has(Read) then List(OpenFlag.Read).stdlib else Nil.stdlib) ++
+          (if mode.atoms.has(Write) then List(OpenFlag.Write).stdlib else Nil.stdlib)
 
       val locking = !lockFlags.stdlib.isEmpty
       val range: (Long, Long) = (value.offset, value.extent)
@@ -95,12 +121,13 @@ object Slice:
 
       try
         backend.slice(value.path, value.offset, value.extent,
-            (lockFlags.stdlib ++ flags.stdlib).to(List)): view =>
-          // Mixed in rather than cast: `Expanse & Granting` is a trait intersection, whose
-          // erased cast is to `Granting`, which the backend's view does not implement.
-          val granted = new zephyrine.Expanse with Granting[grants]:
-            def size: Long = view.size
-            def read(offset: Long, length: Int): Data = view.read(offset, length)
+            (modeFlags ++ lockFlags.stdlib ++ flags.stdlib).to(List)): window =>
+          // Mixed in rather than cast: `Window & Granting` is a trait intersection, whose
+          // erased cast is to `Granting`, which the backend's window does not implement.
+          val granted = new Window with Granting[grants]:
+            def size: Long = window.size
+            def readFrom(offset: Long, length: Int): Data = window.readFrom(offset, length)
+            def writeTo(offset: Long, data: Data): Int = window.writeTo(offset, data)
 
           block(using granted)
       finally if locking then AccessRegister.release(real, mode.atoms, range)

--- a/lib/galilei/src/jvm/galilei_jvm.scala
+++ b/lib/galilei/src/jvm/galilei_jvm.scala
@@ -305,15 +305,16 @@ package filesystemBackends:
 
       def slice[result]
         ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
-        ( lambda: zephyrine.Expanse => result )
+        ( lambda: Slice.Window => result )
         ( using Tactic[Io.Error] )
       :   result =
 
-        // An exclusive range lock needs a writable channel, so one is requested when the
-        // flags ask for an exclusive lock, degrading — like whole-file locking on a
-        // read-only open — to a read-only channel and a *shared* OS lock where the file
-        // cannot be opened writable; the register still provides in-process exclusivity.
-        var writable = flags.stdlib.contains(OpenFlag.Lock)
+        // A writable channel is needed for writes through the window, and for an exclusive
+        // range lock — degrading, like whole-file locking on a read-only open, to a
+        // read-only channel and a *shared* OS lock where the file cannot be opened
+        // writable; the register still provides in-process exclusivity.
+        var writable =
+          flags.stdlib.contains(OpenFlag.Lock) || flags.stdlib.contains(OpenFlag.Write)
 
         val channel = protect(path, Operation.Open):
           val optionSet = java.util.HashSet[jnf.OpenOption]()
@@ -346,12 +347,13 @@ package filesystemBackends:
           if lock.isEmpty then abort(Io.Error(path, Operation.Open, Reason.Busy))
 
           try
-            val view = new zephyrine.Expanse:
-              def size: Long = channel.size
+            val view = new Slice.Window:
+              def size: Long = (channel.size - offset).max(0L).min(extent)
 
-              def read(readOffset: Long, length: Int): Data =
-                val buffer = java.nio.ByteBuffer.allocate(length).nn
-                var position = readOffset
+              def readFrom(readOffset: Long, length: Int): Data =
+                val available = (extent - readOffset).max(0L).min(length.toLong).toInt
+                val buffer = java.nio.ByteBuffer.allocate(available).nn
+                var position = offset + readOffset
                 var count = 0
 
                 while count >= 0 && buffer.hasRemaining do
@@ -364,7 +366,18 @@ package filesystemBackends:
                 buffer.get(array.raw, 0, filled)
                 Array.freeze(array)
 
-            lambda(window(view, offset, extent))
+              def writeTo(writeOffset: Long, data: Data): Int =
+                if writeOffset >= extent then 0 else
+                  val available = (extent - writeOffset).min(data.length.toLong).toInt
+                  val buffer = java.nio.ByteBuffer.wrap(Array.unsafeJvm(data), 0, available).nn
+                  var position = offset + writeOffset
+
+                  while buffer.hasRemaining do
+                    position += channel.write(buffer, position)
+
+                  available
+
+            lambda(view)
           finally lock.foreach: held =>
             if held != null then
               try held.release() catch case _: jnc.ClosedChannelException => ()

--- a/lib/galilei/src/native/galilei_native.scala
+++ b/lib/galilei/src/native/galilei_native.scala
@@ -319,15 +319,16 @@ package filesystemBackends:
 
       def slice[result]
         ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
-        ( lambda: zephyrine.Expanse => result )
+        ( lambda: Slice.Window => result )
         ( using Tactic[Io.Error] )
       :   result =
 
-        // An exclusive range lock needs a writable channel, so one is requested when the
-        // flags ask for an exclusive lock, degrading — like whole-file locking on a
-        // read-only open — to a read-only channel and a *shared* OS lock where the file
-        // cannot be opened writable; the register still provides in-process exclusivity.
-        var writable = flags.stdlib.contains(OpenFlag.Lock)
+        // A writable channel is needed for writes through the window, and for an exclusive
+        // range lock — degrading, like whole-file locking on a read-only open, to a
+        // read-only channel and a *shared* OS lock where the file cannot be opened
+        // writable; the register still provides in-process exclusivity.
+        var writable =
+          flags.stdlib.contains(OpenFlag.Lock) || flags.stdlib.contains(OpenFlag.Write)
 
         val channel = protect(path, Operation.Open):
           val optionSet = java.util.HashSet[jnf.OpenOption]()
@@ -360,12 +361,13 @@ package filesystemBackends:
           if lock.isEmpty then abort(Io.Error(path, Operation.Open, Reason.Busy))
 
           try
-            val view = new zephyrine.Expanse:
-              def size: Long = channel.size
+            val view = new Slice.Window:
+              def size: Long = (channel.size - offset).max(0L).min(extent)
 
-              def read(readOffset: Long, length: Int): Data =
-                val buffer = java.nio.ByteBuffer.allocate(length).nn
-                var position = readOffset
+              def readFrom(readOffset: Long, length: Int): Data =
+                val available = (extent - readOffset).max(0L).min(length.toLong).toInt
+                val buffer = java.nio.ByteBuffer.allocate(available).nn
+                var position = offset + readOffset
                 var count = 0
 
                 while count >= 0 && buffer.hasRemaining do
@@ -378,7 +380,18 @@ package filesystemBackends:
                 buffer.get(array.raw, 0, filled)
                 Array.freeze(array)
 
-            lambda(window(view, offset, extent))
+              def writeTo(writeOffset: Long, data: Data): Int =
+                if writeOffset >= extent then 0 else
+                  val available = (extent - writeOffset).min(data.length.toLong).toInt
+                  val buffer = java.nio.ByteBuffer.wrap(Array.unsafeJvm(data), 0, available).nn
+                  var position = offset + writeOffset
+
+                  while buffer.hasRemaining do
+                    position += channel.write(buffer, position)
+
+                  available
+
+            lambda(view)
           finally lock.foreach: held =>
             if held != null then
               try held.release() catch case _: jnc.ClosedChannelException => ()

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -693,3 +693,37 @@ object Tests extends Suite(m"Galilei tests"):
           case Apfs(path) => unsafely(path.attribute[Data](t"missing")).absent
           case _          => true
       . assert(_ == true)
+
+    suite(m"Slice windows write"):
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+      import charDecoders.utf8Decoder
+      import textSanitizers.skipSanitizer
+
+      val windowLeaf: Text = Uuid().show
+      val windowed: Path on Linux = unsafely((% / "tmp" / windowLeaf).on[Linux])
+      unsafely(windowed.write(t"0123456789abcdef"))
+
+      test(m"A write lands at the window-adjusted offset and reads back"):
+        unsafely:
+          Slice(windowed, 4L, 6L).open[File](Read & Write & Exclusive): window ?=>
+            window.write(2L, t"XY".in[Data]) yet ()
+
+          windowed.read[Text]
+      . assert(_ == t"012345XY89abcdef")
+
+      test(m"A write is clamped to the window and reports the count"):
+        unsafely:
+          Slice(windowed, 12L, 4L).open[File](Read & Write & Exclusive): window ?=>
+            window.write(2L, t"WXYZ".in[Data])
+      . assert(_ == 2)
+
+      test(m"A clamped write stores only the bytes which fit"):
+        unsafely(windowed.read[Text])
+      . assert(_ == t"012345XY89abcdWX")
+
+      test(m"A write past the window's end stores nothing"):
+        unsafely:
+          Slice(windowed, 0L, 4L).open[File](Read & Write & Exclusive): window ?=>
+            window.write(4L, t"zz".in[Data])
+      . assert(_ == 0)

--- a/lib/galilei/src/wasi/galilei_wasi.scala
+++ b/lib/galilei/src/wasi/galilei_wasi.scala
@@ -403,15 +403,78 @@ package filesystemBackends:
 
       def slice[result]
         ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
-        ( lambda: zephyrine.Expanse => result )
+        ( lambda: Slice.Window => result )
         ( using Tactic[Io.Error] )
       :   result =
 
         // WASI has no file-locking call, so a locked slice is refused; an unlocked slice is
-        // simply a windowed positional view.
+        // a windowed positional view, whose writes go through `write-via-stream` at the
+        // window-adjusted offset (issue #1878).
         if flags.has(OpenFlag.Lock) || flags.has(OpenFlag.LockShared)
         then abort(Io.Error(path, Operation.Open, Reason.Unsupported))
-        else expanse(path) { view => lambda(window(view, offset, extent)) }
+        else protect(path, Operation.Open):
+          val (descriptor, relative) = resolve(path, Operation.Open)
+          val directory: Foreign of "descriptor" from Wit = descriptor
+          val writing = flags.has(OpenFlag.Write)
+
+          // open-flags none; descriptor-flags: read (1) | write (2).
+          val descriptorFlags = 1 | (if writing then 2 else 0)
+
+          val opened =
+            directory
+            . `open-at`(follow(true), relative, U32(0.bits), U32(descriptorFlags.bits))
+            . call[Wasm.Handle of "descriptor"]()
+
+          try
+            val target: Foreign of "descriptor" from Wit = opened
+
+            val view = new Slice.Window:
+              def size: Long =
+                (statOf(descriptor, relative, true).size - offset).max(0L).min(extent)
+
+              def readFrom(readOffset: Long, length: Int): Data =
+                val available = (extent - readOffset).max(0L).min(length.toLong).toInt
+
+                val streamHandle =
+                  target.`read-via-stream`(U64((offset + readOffset).bits))
+                  . call[Wasm.Handle of "input-stream"]()
+
+                val stream: Foreign of "input-stream" from Wit = streamHandle
+                var chunks: List[Data] = Nil
+                var remaining = available
+
+                try
+                  while remaining > 0 do
+                    val chunk = stream.`blocking-read`(U64(remaining.toLong.bits)).call[Data]()
+                    if chunk.length == 0 then remaining = 0 else
+                      chunks = chunk :: chunks
+                      remaining -= chunk.length
+                catch case error: Wasm.Error => ()
+
+                streamHandle.dispose()
+                summon[Data is Aggregable by Data].accept(zephyrine.Stream(chunks.stdlib.reverse.iterator))
+
+              def writeTo(writeOffset: Long, data: Data): Int =
+                if writeOffset >= extent then 0 else
+                  val available = (extent - writeOffset).min(data.length.toLong).toInt
+
+                  val limited =
+                    if available == data.length then data else
+                      val array = Array.allocate[Byte](available)
+                      java.lang.System.arraycopy(Array.unsafeJvm(data), 0, array.raw, 0, available)
+                      Array.freeze(array)
+
+                  val streamHandle =
+                    target.`write-via-stream`(U64((offset + writeOffset).bits))
+                    . call[Wasm.Handle of "output-stream"]()
+
+                  val stream: Foreign of "output-stream" from Wit = streamHandle
+                  stream.`blocking-write-and-flush`(limited).call[Unit]()
+                  streamHandle.dispose()
+                  available
+
+            lambda(view)
+          finally opened.dispose()
 
       def open[result](path: Path on Plane, flags: List[OpenFlag])(lambda: Handle => result)
         ( using Tactic[Io.Error] )


### PR DESCRIPTION
A `Slice` open now hands out a read-*write* window. The backend `slice` seam yields a `Slice.Window` — implemented already windowed — in place of the read-only `Expanse` view, and the handle gains grant-gated `read` and `write` accessors in `Ram`'s pattern: only a mode granting `Write` offers `write`.

```scala
Slice(path, 0L, 1024L).open[File](Read & Write & Exclusive): window ?=>
  window.write(0L, data)  // stored at the file's start, under a range lock
  window.read(0L, 16)
```

Writes are relative to the window's start and confined to it: a write stores as much as fits and returns the count, `pwrite`-style — so truncation at the boundary is observable rather than silent — and a write past the window stores nothing. The JVM and Native backends write positionally through the `FileChannel` (opened writable when the mode asks for it, with the established degradation for read-only files); WASI gains real positional writes through `write-via-stream` at the window-adjusted offset, so an unlocked writable window works even on the lockless backend.

This was the last recorded remainder of #566's design notes, split out as #1878 when #1877 landed the read-only form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)