### PR TITLE
Rename ultimatum's form to conduct, and retire the chained-cons workarounds

### DIFF
--- a/lib/proscenium/src/core/proscenium.List.scala
+++ b/lib/proscenium/src/core/proscenium.List.scala
@@ -130,10 +130,16 @@ object List:
 
 val Nil: List[Nothing] = List.of(sci.Nil)
 
-// The cons constructor. Right-associative extensions read in usage order, so the receiver
-// is the HEAD (the left operand). It cannot be a top-level extension (the name would clash
-// with the extractor object), so it rides on a given, whose extensions are candidates
-// wherever the given is visible — everywhere, via `-Yimports`.
+// The cons constructor. The extension is *declared* in usage order — the receiver is the
+// HEAD, the left operand at a call site — but because `::` is right-associative, the
+// compiler swaps the operands during desugaring: in a typer print the receiver appears
+// syntactically as the RIGHT operand, with the parameter sections exchanged, which is easy
+// to misread as the extension being on the tail (issue #1809). It cannot be a top-level
+// extension (the name would clash with the extractor object), so it rides on a given, whose
+// extensions are candidates wherever the given is visible — everywhere, via `-Yimports`.
+// Note that a chained cons formerly resolved to the underlying `sci.List` member through a
+// prefix-sealing gap in implicit search, leaking the underlying type; fixed in proscala
+// (3.9.0-RC5-p14, `givenprefix`).
   // Subtype-parametric so branded lists (`List[T] & Populated`) splat too.
   given listIsSpreadable: [element, list <: List[element]]
   =>  (Spreadable[list] { type Out = sci.List[element] }) =

--- a/lib/ultimatum/src/core/soundness_ultimatum_core.scala
+++ b/lib/ultimatum/src/core/soundness_ultimatum_core.scala
@@ -35,7 +35,7 @@ package soundness
 export
   ultimatum
   . { Arrangement, BorderStyle, dirtyCells, editor, EditorField, Extent, Fixture, FlowExtent,
-      Focus, form, Form, Frame, grid, InlineAnchoring, InlineGrowth, InlineRoot, InlineShrink,
+      conduct, Focus, Form, Frame, grid, InlineAnchoring, InlineGrowth, InlineRoot, InlineShrink,
       layout, Limits, menu, MenuField, Occupancy, paint, Pane, Panes, panel, Placement, Rect,
       ScreenRoot, Sizing, stack, strip, Tick }
 

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -159,7 +159,11 @@ def border
 // terminal via the alternate screen buffer (restored on exit) and fills its
 // height; in `Inline` mode it renders a variable-height block at the cursor
 // without the alternate buffer, leaving scrollback intact.
-def form(mode: Occupancy = Occupancy.Fullscreen)(pane: Pane)
+// Named `conduct` — it conducts the interaction — rather than `form`, which collided at the
+// `soundness` umbrella with telekinesis's HTML-form renderer, arbitrarily shadowing this
+// entry point for umbrella users (issue #1876); `Form`, the live pane-tree model it drives,
+// keeps its name.
+def conduct(mode: Occupancy = Occupancy.Fullscreen)(pane: Pane)
   ( using terminal: Terminal,
           monitor:   Monitor,
           probate:   Probate,

--- a/lib/ultimatum/src/demo/ultimatum_demo.scala
+++ b/lib/ultimatum/src/demo/ultimatum_demo.scala
@@ -59,7 +59,7 @@ def demo(): Unit = cli:
   execute:
     supervise:
       interactive: terminal ?=>
-        form(Occupancy.Inline)(demoLayout)
+        conduct(Occupancy.Inline)(demoLayout)
         Exit.Ok
 
 // stack(title, strip(sidebar, stack(heading, compose, activity)), status), with the

--- a/lib/ultimatum/src/test/ultimatum_doccheck.scala
+++ b/lib/ultimatum/src/test/ultimatum_doccheck.scala
@@ -53,7 +53,7 @@ object Examples:
   def inALayout(using Terminal, Monitor, Probate): Unit =
     val progress = Reading(Fraction(0.0))
     progress() = Fraction.of(3, 10)
-    form(Occupancy.Inline)(stack(gauge(progress)))
+    conduct(Occupancy.Inline)(stack(gauge(progress)))
 
   def standalone(using Stdio, Monitor, Probate): Unit =
     whilst(Reading(Fraction.indeterminate)):

--- a/lib/virility/src/core/virility.Roff.scala
+++ b/lib/virility/src/core/virility.Roff.scala
@@ -37,6 +37,7 @@ import gossamer.*
 import prepositional.*
 import rudiments.*
 import spectacular.*
+import symbolism.*
 import vacuous.*
 
 object Roff:
@@ -70,16 +71,11 @@ object Roff:
   private def line(text: Text): Text =
     if text.starts(t".") || text.starts(t"'") then t"\\&$text" else text
 
-  // Cons on the opaque `List` routes through the compat conversion to the stdlib `List`, so
-  // sequences are assembled here by concatenation instead of `::`.
-  private def concat[element](lists: List[element]*): List[element] =
-    lists.toList.flatMap(_.stdlib).to(List)
-
   // A `.P` directly after `.SH`/`.SS` is redundant (mandoc lints it), so a section's leading
   // paragraph contributes only its text line.
   private def sectionBody(blocks: List[Block]): List[Text] = blocks match
     case Block.Paragraph(prose) :: rest =>
-      concat(List(line(prose.map(_.serialize).join)), rest.flatMap(_.serialize))
+      line(prose.map(_.serialize).join) :: rest.flatMap(_.serialize)
 
     case other => other.flatMap(_.serialize)
 
@@ -108,15 +104,15 @@ object Roff:
 
     def serialize: List[Text] = this match
       case Section(title, blocks) =>
-        concat(List(t".SH ${quote(title)}"), sectionBody(blocks))
+        t".SH ${quote(title)}" :: sectionBody(blocks)
 
       case Subsection(title, blocks) =>
-        concat(List(t".SS ${quote(title)}"), sectionBody(blocks))
+        t".SS ${quote(title)}" :: sectionBody(blocks)
 
       case Paragraph(prose) => List(t".P", line(prose.map(_.serialize).join))
 
       case Example(lines) =>
-        concat(List(t".EX"), lines.map { text => line(escape(text)) }, List(t".EE"))
+        t".EX" :: (lines.map { text => line(escape(text)) } + List(t".EE"))
 
       // A tagged paragraph with nothing to say still names its subject; emitting an empty body
       // line would leave a stray blank line in the rendered page.
@@ -126,7 +122,7 @@ object Roff:
         if body.stdlib.isEmpty then List(t".TP", label)
         else List(t".TP", label, line(body.map(_.serialize).join))
 
-      case Indented(blocks) => concat(List(t".RS"), blocks.flatMap(_.serialize), List(t".RE"))
+      case Indented(blocks) => t".RS" :: (blocks.flatMap(_.serialize) + List(t".RE"))
 
 case class Roff
   ( title:   Text,
@@ -141,6 +137,6 @@ case class Roff
       List(title.upper, section.show, date.or(t""), source.or(t""), manual.or(t""))
       . stdlib.reverse.dropWhile(_ == t"").reverse
 
-    val header = Roff.concat(List(t".TH"), arguments.to(List).map(Roff.quote)).join(t" ")
+    val header = (t".TH" :: arguments.to(List).map(Roff.quote)).join(t" ")
 
-    Roff.concat(List(header), blocks.flatMap(_.serialize)).join(t"", t"\n", t"\n")
+    (header :: blocks.flatMap(_.serialize)).join(t"", t"\n", t"\n")

--- a/lib/xylophone/src/core/xylophone.XPath.scala
+++ b/lib/xylophone/src/core/xylophone.XPath.scala
@@ -601,7 +601,7 @@ derives CanEqual:
 
     expression match
       case XPath.Expression.Route(origin, steps) =>
-        XPath(XPath.Expression.Route(origin, (step :: steps.stdlib).to(List)))
+        XPath(XPath.Expression.Route(origin, step :: steps))
 
       case _ =>
         this

--- a/lib/xylophone/src/core/xylophone.XPathReader.scala
+++ b/lib/xylophone/src/core/xylophone.XPathReader.scala
@@ -433,7 +433,7 @@ private[xylophone] object XPathReader:
 
         case Token.DoubleSlash =>
           advance()
-          Expression.Route(Origin.Root, (descendantStep :: parseRelative().stdlib).to(List))
+          Expression.Route(Origin.Root, descendantStep :: parseRelative())
 
         case token if startsStep(token) =>
           Expression.Route(Origin.Here, parseRelative())
@@ -547,7 +547,7 @@ private[xylophone] object XPathReader:
         val descend = current == Token.DoubleSlash
         advance()
         val rest = parseRelative()
-        val steps = if descend then (descendantStep :: rest.stdlib).to(List) else rest
+        val steps = if descend then descendantStep :: rest else rest
         Expression.Route(Origin.Filter(primary, predicates), steps)
       else if predicates.nil then primary
       else Expression.Route(Origin.Filter(primary, predicates), Nil)


### PR DESCRIPTION
Two behaviour-preserving cleanups, one per commit.

**`form` → `conduct` (#1876).** The `soundness` umbrella exported a toplevel `form` from both telekinesis and ultimatum; the collision resolved arbitrarily to telekinesis's, leaving ultimatum's interactive-layout driver unreachable through `import soundness.*` and warning on every compilation. Telekinesis keeps the name — an HTML form is the domain noun, and `submission.form(…)` reads exactly right — while ultimatum's driver becomes `conduct`, which is what its own documentation says it does ("drive an interactive layout"):

```scala
conduct(Occupancy.Inline)(stack(gauge(progress)))
```

`Form`, the live pane-tree model it drives, keeps its name.

**Chained-cons workarounds retired (#1809).** The proscala fix for the prefix-sealing gap in implicit search (in `3.9.0-RC5-p14`) makes chained `::` on the opaque `List` resolve to the `consConstructor` extension, so the workarounds it once forced can go: virility's `Roff.concat` — whose comment described the removed behaviour — is deleted, its seven call sites now reading as the cons chains and appends they always wanted to be, and xylophone's three `List.of(x :: rest.stdlib)` bridges become plain `x :: rest`. These are the first chained-cons uses in the repository, so they double as the in-repo verification of the compiler fix. The `consConstructor` comment now spells out the right-associative desugaring that made the original report confusing — the receiver is the head at a call site, but appears syntactically as the right operand in a typer print — and records the fixed leak.

Verified with the full build plus the xylophone (391), proscenium (61), virility (15) and exoskeleton (155, exercising manpage rendering through the reworked `Roff`) suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)