### PR TITLE
A JavaScript threading model for Parasite (#1450)

### DIFF
--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -186,6 +186,33 @@ object PlatformSupervisor extends ThreadSupervisor:
         name().let(_.s).let(thread.setName(_))
         thread.start()
 
+// The single-threaded, eager supervision model (issue #1450): each forked task runs to
+// completion at `fork` time, on the calling strand, so every promise such a task settles is
+// already complete before anyone can await it, and parking is never needed. This is the model
+// for JavaScript's event loop, which has no block-and-resume primitive — parking would halt
+// the loop and deadlock — though it runs identically on any platform, which is how it is
+// tested. Its ceiling is that of single-threaded structured concurrency: no parallelism and no
+// interleaving, so awaiting a promise that no completed task has settled — a wait which could
+// never end — panics rather than deadlocking, and `sleep` completes instantly, since delaying
+// without blocking the loop is impossible.
+object JavascriptSupervisor extends Supervisor:
+  def name: Name[Async] = n"javascript"
+
+  def fork(name: () => Optional[Text])(block: => Unit): Strand =
+    block
+    Strand.Eager
+
+  def strand(): Strand = Strand.Eager
+
+  def park(blocker: AnyRef): Unit =
+    panic(m"a wait can never end under the eager single-threaded model: every forked task has already run to completion, so this promise can no longer be settled")
+
+  def park(blocker: AnyRef, deadline: Long): Unit =
+    panic(m"a timed wait can never be settled under the eager single-threaded model, and cannot block without halting the event loop")
+
+  def sleep(nanoseconds: Long): Unit = ()
+  def interrupted(): Boolean = false
+
 // The failure path is, in a long-lived process, the code most likely to run for the first time late
 // in that process's life — and classloading is not guaranteed to still work by then. A daemon whose
 // jar has been replaced underneath it (rebuilt in place while it runs) holds an open `JarFile` whose

--- a/lib/parasite/src/core/parasite.Strand.scala
+++ b/lib/parasite/src/core/parasite.Strand.scala
@@ -39,6 +39,16 @@ import java.util.concurrent.locks as jucl
 import scala.compiletime.asMatchable
 
 object Strand:
+  // The strand handle of an eagerly-completed task (`JavascriptSupervisor`): by construction
+  // the task ran to completion at `fork` time, so joining is immediate, interruption has
+  // nothing to cancel, and — since such a strand is never parked — unparking is empty. A
+  // single object: on a single-threaded platform the calling strand is always the same one,
+  // and `Promise`'s waiter-set semantics only need identity to coincide.
+  case object Eager extends Strand:
+    def interrupt(): Unit = ()
+    def join(): Unit = ()
+    def unpark(): Unit = ()
+
   // Equality delegates to the underlying thread: `Promise` stores waiters in a `Set[Strand]`, and
   // two handles on the same thread must coincide there, however they were obtained.
   final class Threaded(val thread: Thread) extends Strand:

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -57,6 +57,11 @@ package threading:
   given virtualThreading: Threading = () => VirtualSupervisor
   given adaptiveThreading: Threading = () => AdaptiveSupervisor
 
+  // The model for Scala.js (issue #1450): tasks run eagerly at `fork`, so structured
+  // gather-style concurrency works on the event loop, with the limitations documented on
+  // `JavascriptSupervisor`.
+  given javascriptThreading: Threading = () => JavascriptSupervisor
+
 package probates:
   // Cleanup runs on the completing worker's own strand, with no ambient `Monitor`: the dying
   // worker itself licenses the suspension (a `Worker` IS a `Monitor`).

--- a/lib/parasite/src/core/soundness_parasite_core.scala
+++ b/lib/parasite/src/core/soundness_parasite_core.scala
@@ -36,13 +36,15 @@ export
   parasite
   . { AdaptiveSupervisor, async, Async, cancel, Probate, Daemon, daemon, delay,
       Destruction, Fault, Fulfillment, hibernate, Hook, intercept,
-      Interceptable, Monitor, monitor, Observation, Os, Perseverance, PlatformSupervisor, Promise,
+      Interceptable, JavascriptSupervisor, Monitor, monitor, Observation, Os, Perseverance,
+      PlatformSupervisor, Promise,
       relent, retry, Shutdown, sleep, snooze, Strand, supervise, Supervisor, Task, task,
       Tenacity, Threading, Timeout, Transgression, contain, Containment, VirtualSupervisor, Worker,
       AsyncTactic, Remedy, concurrent }
 
 package threading:
-  export parasite.threading.{adaptiveThreading, platformThreading, virtualThreading}
+  export parasite.threading.{adaptiveThreading, javascriptThreading, platformThreading,
+      virtualThreading}
 
 package probates:
   export parasite.probates.{awaitProbate, cancelProbate, failProbate, panicProbate}

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -1164,6 +1164,35 @@ object Tests extends Suite(m"Parasite tests"):
           supervise(async(42).await())
         . assert(_ == 42)
 
+      // The eager single-threaded model (issue #1450): platform-neutral, so its semantics are
+      // pinned here on the JVM, though its purpose is Scala.js.
+      suite(m"Javascript supervisor"):
+        import threading.javascriptThreading
+
+        test(m"a forked task runs eagerly and awaits immediately"):
+          supervise(async(42).await())
+        . assert(_ == 42)
+
+        test(m"tasks fork in order and gather their results"):
+          supervise:
+            val order = juca.AtomicInteger(0)
+            val tasks = Seq(async(order.incrementAndGet()), async(order.incrementAndGet()))
+            tasks.sequence.await()
+        . assert(_ == Seq(1, 2))
+
+        test(m"a task's failure is contained as on other supervisors"):
+          supervise:
+            import unsafeExceptions.canThrowAny
+            val task = async { throw Exception("boom") }
+            async(7).await()
+        . assert(_ == 7)
+
+        test(m"sleep completes instantly"):
+          val start = java.lang.System.currentTimeMillis
+          supervise(async(snooze(1.0*Second)).await())
+          java.lang.System.currentTimeMillis - start < 500
+        . assert(_ == true)
+
       suite(m"Promise.cancelled state queries"):
         test(m"Cancelled promise after fulfill remains cancelled.cancelled"):
           val promise = Promise[Int]()


### PR DESCRIPTION
Option 1 from the issue — the synchronous, API-preserving model — radically simplified by the `Strand`/`Supervisor` seam that landed after the issue was filed: the fiber-handle abstraction and platform-specific parking the issue lists as prerequisites already exist, so the whole change is one supervisor, one strand, and one given.

`JavascriptSupervisor` runs each forked task **eagerly to completion at `fork` time**, on the calling strand — so every promise such a task settles is already complete before anyone can await it, and parking is never needed. This is the model for JavaScript's event loop, which has no block-and-resume primitive:

```scala
import threading.javascriptThreading

supervise:
  Seq(async(work1()), async(work2())).sequence.await()  // gathers, on the event loop
```

`Strand.Eager` is the completed task's no-op handle (joining is immediate by construction). The model's documented ceiling follows the issue's analysis: no parallelism, no interleaving — a wait which could never end, on a promise no completed task has settled, **panics rather than deadlocking** — and `sleep` completes instantly, since delaying without blocking the loop is impossible.

The supervisor is platform-neutral, so its semantics are pinned by JVM tests alongside the three existing models (eager await, ordered fork-and-gather, failure containment, instant sleep), and `parasite.core.js` compiles. The issue's remaining increment — the `jslink` async probe proving link-and-run — is blocked on that module's pre-existing rot (compile errors from API drift, and unresolvable `wasm.4` linker artifacts), now recorded as #1882 together with the exact probe to add once it's revived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)