### PR TITLE
Searchpaths: virtual planes over XDG search directories (#602)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1117,7 +1117,7 @@ object adversaria extends Library:
 
 object ambience extends Library:
   object core extends Component(anticipation.path, anticipation.print, gossamer.core,
-      distillate.core):
+      distillate.core, serpentine.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // WASI-backed environment: an `Environment` given whose variables come from a Wasm Component

--- a/lib/ambience/src/core/ambience.Searchpath.scala
+++ b/lib/ambience/src/core/ambience.Searchpath.scala
@@ -32,85 +32,39 @@
                                                                                                   */
 package ambience
 
-import scala.language.experimental.pureFunctions
-
 import anticipation.*
 import contingency.*
 import gossamer.*
+import nomenclature.*
 import prepositional.*
 import rudiments.*
-import vacuous.*
+import serpentine.*
 
-object Xdg:
-  // The XDG searchpath planes (issue #602): a `Path on Xdg.Data` denotes a subpath searched
-  // across `dataHome` and every entry of `dataDirs`, in that precedence order — and likewise
-  // `Config` for `configHome` and `configDirs`. The joining machinery (`Searchpaths.Stems`,
-  // first-match resolution, merged listings) lives in galilei.
-  trait Data extends Searchpath
-  trait Config extends Searchpath
+import Path.%
 
-  def dataHome[path]
-    ( using instantiable: (path is Instantiable across Paths from Text)^ )
-    ( using environment: Environment, system: System )
-  :   path =
+// A *searchpath plane*: a virtual path plane joining an ordered list of real directories into
+// a single searchable, navigable view — XDG's `$XDG_DATA_DIRS`, or `$PATH` (issue #602).
+// Deliberately, a searchpath plane has no `Filesystem` instance: galilei's absolute-path
+// operations (bounded by `[plane: Filesystem]`) must not apply to a virtual path, which they
+// would resolve as a literal platform path. The joining machinery — `Searchpaths.Stems`,
+// first-match resolution and merged, shadowed listings — lives in galilei; the marker and the
+// serpentine givens live here, in implicit scope of every plane extending it, so that `Xdg`'s
+// own planes can extend it without ambience depending on galilei.
+trait Searchpath
 
-    safely(Environment.xdgDataHome[path]).or(instantiable(t"${Directories.homeText}/.local/share"))
+object Searchpath:
+  type Rules = MustNotContain["/"] & MustNotEqual["."] & MustNotEqual[".."] & MustNotEqual[""]
 
+  inline given nominative: [plane <: Searchpath] => plane is Nominative under Rules = !!
 
-  def configHome[path]
-    ( using instantiable: (path is Instantiable across Paths from Text)^ )
-    ( using environment: Environment, system: System )
-  :   path =
+  given submissible: [plane <: Searchpath] => %.type is Submissible on plane = _ => ()
 
-    safely(Environment.xdgConfigHome[path]).or(instantiable(t"${Directories.homeText}/.config"))
-
-
-  def cacheHome[path]
-    ( using instantiable: (path is Instantiable across Paths from Text)^ )
-    ( using environment: Environment, system: System )
-  :   path =
-
-    safely(Environment.xdgCacheHome[path]).or(instantiable(t"${Directories.homeText}/.cache"))
-
-
-  def stateHome[path]
-    ( using instantiable: (path is Instantiable across Paths from Text)^ )
-    ( using environment: Environment, system: System )
-  :   path =
-
-    safely(Environment.xdgStateHome[path]).or(instantiable(t"${Directories.homeText}/.local/state"))
-
-
-  def runtimeDir[path]
-    ( using instantiable: (path is Instantiable across Paths from Text)^ )
-    ( using environment: Environment )
-  :   Optional[path] =
-
-    safely(Environment.xdgRuntimeDir[path])
-
-
-  def bin[path]
-    ( using instantiable: (path is Instantiable across Paths from Text)^ )
-    ( using environment: Environment, system: System )
-  :   path =
-
-    // `XDG_BIN_HOME`, not `XDG_CONFIG_HOME`: this formerly read the config-home variable
-    // before falling back, so a set `XDG_CONFIG_HOME` misdirected `bin` entirely.
-    safely(Environment.xdgBinHome[path]).or(instantiable(t"${Directories.homeText}/.local/bin"))
-
-
-  def dataDirs[path]
-    ( using instantiable: (path is Instantiable across Paths from Text)^ )
-    ( using environment: Environment, system: System )
-  :   List[path] =
-
-    safely(Environment.xdgDataDirs[List[path]]).or:
-      List(t"/usr/local/share", t"/usr/share").map(instantiable(_))
-
-
-  def configDirs[path]
-    ( using instantiable: (path is Instantiable across Paths from Text)^ )
-    ( using Environment, System )
-  :   List[path] =
-
-    safely(Environment.xdgConfigDirs[List[path]]).or(List(t"/etc/xdg").map(instantiable(_)))
+  // Paths on a searchpath plane are rooted subpaths: the root encodes to nothing, as with a
+  // directory handle's base.
+  given radical: [plane <: Searchpath] => (%.type is Radical on plane) =
+    new Radical:
+      type Self = %.type
+      type Plane = plane
+      def length(text: Text): Int raises Path.Error = 0
+      def decode(text: Text): %.type raises Path.Error = %
+      def encode(root: %.type): Text = t""

--- a/lib/ambience/src/core/ambience.Variable.scala
+++ b/lib/ambience/src/core/ambience.Variable.scala
@@ -92,6 +92,12 @@ object Variable extends Protovariable:
 
     pathVariable(instantiable)
 
+  given xdgBinHome: [path]
+  =>  ( instantiable: (path is Instantiable across Paths from Text)^ )
+  =>  Variable["xdgBinHome", path] =
+
+    pathVariable(instantiable)
+
   given xdgStateHome: [path]
   =>  ( instantiable: (path is Instantiable across Paths from Text)^ )
   =>  Variable["xdgStateHome", path] =

--- a/lib/ambience/src/core/soundness_ambience_core.scala
+++ b/lib/ambience/src/core/soundness_ambience_core.scala
@@ -35,8 +35,8 @@ package soundness
 export
   ambience
   . { Architecture, Configurator, Directories, Environment, Property, Protovariable, System,
-      TemporaryDirectory, temporaryDirectory, Variable, variables, WorkingDirectory,
-      workingDirectory, Xdg }
+      Searchpath, TemporaryDirectory, temporaryDirectory, Variable, variables,
+      WorkingDirectory, workingDirectory, Xdg }
 
 package systems:
   export ambience.systems.{emptySystem, javaSystem}

--- a/lib/galilei/src/core/galilei.Searchpaths.scala
+++ b/lib/galilei/src/core/galilei.Searchpaths.scala
@@ -1,0 +1,175 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package galilei
+
+import ambience.*
+import anticipation.*
+import contingency.*
+import prepositional.*
+import rudiments.*
+import serpentine.*
+import vacuous.*
+
+// The joining machinery for searchpath planes (issue #602): an `ambience.Searchpath` plane —
+// `Xdg.Data`, `Xdg.Config` — is an ordered list of real directories presented as one
+// searchable, navigable tree. Resolution onto the real platform goes through a contextual
+// `Stems`, the searchpath analogue of a `Directory.Handle`'s single stem.
+object Searchpaths:
+  // The ordered real directories a searchpath plane resolves onto: `Searchpaths.Stems on
+  // Xdg.Data onto Linux`. `Target` — prepositional's `onto` — is the platform beneath the
+  // virtual plane, and the head stem is the writable one: the XDG Base Directory spec directs
+  // applications to write only to the user-specific base directory.
+  trait Stems extends Planar, Targetable:
+    type Plane <: Searchpath
+    type Target <: Platform
+    def stems: List[Path on Target]
+
+  // Public helpers, not `private`: the transparent-inline operations below would otherwise
+  // generate inline-accessor bridges whose fresh capability roots fail capture checking (as
+  // documented on `Subtree`).
+  def resolve[target <: Platform](stem: Path on target, path: Path on ?): Path on target =
+    path.descent.reverse.foldLeft(stem): (parent, name) => parent.child(name)(using Unsafe)
+
+  def locateResolved[target <: Platform: Filesystem]
+    ( stems: List[Path on target], path: Path on ? )
+    ( using backend: FilesystemBackend on target )
+  :   Optional[Path on target] =
+
+    stems.stdlib.map(resolve(_, path)).find(galilei.existent(_)()).optional
+
+  def locationsResolved[target <: Platform: Filesystem]
+    ( stems: List[Path on target], path: Path on ? )
+    ( using backend: FilesystemBackend on target )
+  :   List[Path on target] =
+
+    stems.stdlib.map(resolve(_, path)).filter(galilei.existent(_)()).to(List)
+
+  // The merged listing's names: the union of children across all stems, deduplicated, with
+  // earlier stems shadowing later ones — insertion order preserves precedence.
+  def entryNames[target <: Platform: Filesystem]
+    ( stems: List[Path on target], path: Path on ? )
+    ( using explorable: target is Explorable,
+            backend:    FilesystemBackend on target,
+            tactic:     Tactic[Io.Error] )
+  :   List[Text] =
+
+    val names = scala.collection.mutable.LinkedHashSet[Text]()
+
+    stems.stdlib.foreach: stem =>
+      val resolved = resolve(stem, path)
+
+      if galilei.existent(resolved)() then resolved.children.stdlib.foreach: child =>
+        names.add(child.name)
+
+    scala.List.from(names).to(List)
+
+// The operation names are chosen not to collide with anything reachable at the `soundness`
+// umbrella or through companion extension scope: zephyrine exports a toplevel `locate`, and
+// `Subtree`'s companion supplies `entries` and `extant` for directory-handle paths, which a
+// lexical toplevel of the same name would shadow and break (extensions do not fall through on
+// failure).
+extension [plane <: Searchpath](path: Path on plane)
+  // The first stem in which the path exists — first-match-wins, per the XDG Base Directory
+  // spec.
+  transparent inline def search()
+    ( using stems: Searchpaths.Stems { type Plane = plane } )
+    ( using filesystem: stems.Target is Filesystem )
+    ( using backend: FilesystemBackend on stems.Target )
+  :   Optional[Path on stems.Target] =
+
+    Searchpaths.locateResolved[stems.Target](stems.stems, path)
+
+  // Every extant match, in precedence order, for cascade-merging consumers.
+  transparent inline def locations()
+    ( using stems: Searchpaths.Stems { type Plane = plane } )
+    ( using filesystem: stems.Target is Filesystem )
+    ( using backend: FilesystemBackend on stems.Target )
+  :   List[Path on stems.Target] =
+
+    Searchpaths.locationsResolved[stems.Target](stems.stems, path)
+
+  // The merged directory listing: children across all stems, deduplicated by name, earlier
+  // stems shadowing later ones. This is what makes the virtual tree navigable.
+  transparent inline def listing()
+    ( using stems: Searchpaths.Stems { type Plane = plane } )
+    ( using filesystem: stems.Target is Filesystem )
+    ( using explorable: stems.Target is Explorable )
+    ( using backend: FilesystemBackend on stems.Target, tactic: Tactic[Io.Error] )
+  :   List[Path on plane] =
+
+    Searchpaths.entryNames[stems.Target](stems.stems, path).map: name =>
+      path.child(name)(using Unsafe)
+
+  // The head-stem realization of the path — where the XDG spec directs writes. Creating any
+  // missing intermediate directories is the caller's, e.g. through galilei's
+  // `createNonexistentParents` option on the write itself.
+  transparent inline def destination()
+    ( using stems: Searchpaths.Stems { type Plane = plane } )
+    ( using filesystem: stems.Target is Filesystem )
+  :   Path on stems.Target =
+
+    Searchpaths.resolve[stems.Target](stems.stems.stdlib.head, path)
+
+// A `Relative` or literal path written against `Linux` conventions may be reinterpreted on a
+// searchpath plane; library-qualified and top-level, since neither subject's companion can
+// host it (`Searchpath`'s is in ambience, below serpentine's `Compliant`).
+inline given searchpathCompliant: [plane <: Searchpath] => Linux is Compliant on plane = !!
+
+extension (xdg: Xdg.type)
+  // The XDG data searchpath, in spec precedence order — `dataHome`, then each entry of
+  // `dataDirs` — with the environment read once, at construction. An unparseable set of
+  // directories falls back to the spec defaults, per `Xdg.dataDirs`.
+  def dataSearch()(using Environment, System)
+  :   Searchpaths.Stems { type Plane = Xdg.Data; type Target = Linux } =
+
+    import interfaces.paths.pathOnLinux
+
+    new Searchpaths.Stems:
+      type Plane = Xdg.Data
+      type Target = Linux
+      // `unsafely`: the instantiable's decode tactic. `Xdg`'s own accessors guard each
+      // variable with `safely`, falling back to the spec defaults, so a malformed entry
+      // cannot actually raise here.
+      val stems: List[Path on Linux] =
+        unsafely(Xdg.dataHome[Path on Linux] :: Xdg.dataDirs[Path on Linux])
+
+  def configSearch()(using Environment, System)
+  :   Searchpaths.Stems { type Plane = Xdg.Config; type Target = Linux } =
+
+    import interfaces.paths.pathOnLinux
+
+    new Searchpaths.Stems:
+      type Plane = Xdg.Config
+      type Target = Linux
+      val stems: List[Path on Linux] =
+        unsafely(Xdg.configHome[Path on Linux] :: Xdg.configDirs[Path on Linux])

--- a/lib/galilei/src/core/soundness_galilei_core.scala
+++ b/lib/galilei/src/core/soundness_galilei_core.scala
@@ -40,10 +40,11 @@ export
       DeleteRecursively, DereferenceSymlinks, descendants, dir, Directory, Dos, Drive, Entry,
       entry, executable, expanse, Explorable, existent, Fifo, file, File, FileOpenable,
       FilesystemAttribute, FilesystemBackend,
-      glob, Handle, hardLinks, hardLinkTo, hidden, Io, Linux, Local,
+      glob, Handle, hardLinks, hardLinkTo, hidden, Io, Linux, Local, locations,
+      dataSearch, configSearch, destination, listing, search,
       MacOs, modified, MoveAtomically, moveInto, moveTo, Ntfs, OpenFlag,
       OverwritePreexisting, p, Platform, Posix, readable, filesize, Sock, Stat,
-      Scratch, Shared, Slice, Substantiable, Subtree, Symlink, symlinkInto, symlinkTo, touch,
+      Scratch, Searchpaths, searchpathCompliant, Shared, Slice, Substantiable, Subtree, Symlink, symlinkInto, symlinkTo, touch,
       TraversalOrder,
       UnixEntry, Volume, volume, Windows, WindowsEntry, wipe, writable, write }
 

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -727,3 +727,66 @@ object Tests extends Suite(m"Galilei tests"):
           Slice(windowed, 0L, 4L).open[File](Read & Write & Exclusive): window ?=>
             window.write(4L, t"zz".in[Data])
       . assert(_ == 0)
+
+    suite(m"Searchpaths"):
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+      import interfaces.paths.pathOnLinux
+
+      val spLeafA: Text = t"sp-a-${Uuid().show}"
+      val spLeafB: Text = t"sp-b-${Uuid().show}"
+      val stemA: Path on Linux = unsafely((% / "tmp" / spLeafA).on[Linux])
+      val stemB: Path on Linux = unsafely((% / "tmp" / spLeafB).on[Linux])
+
+      unsafely:
+        stemA.create[Directory]()
+        stemB.create[Directory]()
+        (stemA / "icons").create[Directory]()
+        (stemB / "icons").create[Directory]()
+        (stemA / "icons" / "app.png").write(t"A")
+        (stemB / "icons" / "app.png").write(t"B")
+        (stemB / "icons" / "extra.png").write(t"B2")
+        (stemB / "themes").create[Directory]()
+
+      given Searchpaths.Stems on Xdg.Data onto Linux = new Searchpaths.Stems:
+        type Plane = Xdg.Data
+        type Target = Linux
+        val stems: List[Path on Linux] = List(stemA, stemB)
+
+      test(m"locate finds the first stem's match"):
+        unsafely((% / "icons" / "app.png").on[Xdg.Data].search())
+      . assert(_ == unsafely(stemA / "icons" / "app.png"))
+
+      test(m"locate falls through to a later stem"):
+        unsafely((% / "icons" / "extra.png").on[Xdg.Data].search())
+      . assert(_ == unsafely(stemB / "icons" / "extra.png"))
+
+      test(m"a path present nowhere locates to Unset"):
+        unsafely((% / "icons" / "missing.png").on[Xdg.Data].search())
+      . assert(_ == Unset)
+
+      test(m"locations lists every extant match in precedence order"):
+        unsafely((% / "icons" / "app.png").on[Xdg.Data].locations())
+      . assert(_ == unsafely(List(stemA / "icons" / "app.png", stemB / "icons" / "app.png")))
+
+      test(m"entries merge across stems, earlier shadowing later"):
+        unsafely((% / "icons").on[Xdg.Data].listing().map(_.name).sort(identity))
+      . assert(_ == List(t"app.png", t"extra.png"))
+
+      test(m"a later-stem-only directory is found"):
+        unsafely((% / "themes").on[Xdg.Data].search().present)
+      . assert(_ == true)
+
+      test(m"destination is the head-stem realization"):
+        unsafely((% / "themes" / "new.css").on[Xdg.Data].destination())
+      . assert(_ == unsafely(stemA / "themes" / "new.css"))
+
+      test(m"the Xdg constructor reads the variables in spec order"):
+        import systems.javaSystem
+        given Environment = name =>
+          if name == t"XDG_DATA_HOME" then stemA.encode
+          else if name == t"XDG_DATA_DIRS" then stemB.encode
+          else Unset
+
+        Xdg.dataSearch().stems
+      . assert(_ == List(stemA, stemB))


### PR DESCRIPTION
Implements the plan from #602: a *searchpath plane* joins an ordered list of real directories — XDG's `$XDG_DATA_DIRS`, or `$PATH` — into a single searchable, navigable view, as a first-class virtual `Path` plane with deliberately no `Filesystem` instance (the `Subtree` precedent: platform operations must not resolve a virtual path literally).

```scala
given Searchpaths.Stems on Xdg.Data onto Linux = Xdg.dataSearch()

val icons = unsafely((% / "icons").on[Xdg.Data]).listing()          // merged across all data dirs
val mime  = unsafely((% / "applications" / "mimeapps.list").on[Xdg.Data]).search()
```

The split follows the dependency grain: the phantom `Searchpath` marker and its serpentine givens (naming rules forbidding separators and dot-segments; a root that encodes to nothing) live in **ambience**, in implicit scope of the new `Xdg.Data` and `Xdg.Config` planes which extend the marker; **galilei**'s `Searchpaths` supplies the machinery. `Stems` carries the precedence-ordered real directories — and, answering the issue's naming question, the underlying platform is its `Target`, via prepositional's **`onto`** ("resolution *onto* a real platform", the plan's own phrasing): a context value reads `Searchpaths.Stems on Xdg.Data onto Linux`.

The operations follow `Subtree`'s transparent-inline-over-contextual-handle pattern: **`search()`** is first-match-wins per the Base Directory spec; **`locations()`** lists every extant match in precedence order, for cascade-merging consumers; **`listing()`** merges children across stems, deduplicated, earlier stems shadowing later ones — what makes the virtual tree navigable; **`destination()`** is the head-stem realization, where the spec directs writes. `Xdg.dataSearch()`/`configSearch()` construct the stems from the environment, read once, in spec order. Operation names were checked against every umbrella and companion-scope collision (`locate` is zephyrine's; `entries`/`extant` would lexically shadow `Subtree`'s and break directory-handle code).

Drive-by, per the plan: `Xdg.bin` read `XDG_CONFIG_HOME` instead of `XDG_BIN_HOME` before its `~/.local/bin` fallback — a set config-home misdirected it entirely — fixed, with the missing `xdgBinHome` variable added.

Follow-ups recorded in the plan and not taken here: merged-tree traversal, `Openable` integration, a `$PATH` instance, Windows portability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)