### PR TITLE
Revive jslink: fork linker resolution and API drift (#1882)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2334,6 +2334,12 @@ object iridescence extends Library:
 
 object jacinta extends Library:
   object core extends Component(zephyrine.core, turbulence.core, urticose.url, adversaria.core, hypotenuse.core):
+    // The parser's SWAR word reads: the JVM variant is a byte-array view `VarHandle`, which
+    // neither Scala.js nor Scala Native provides, so the crosses compile the portable
+    // shift-and-or variant instead (the split `jslink.fastLinkJS` enforces).
+    override def sources = Task.Sources(moduleDir, moduleDir / os.up / "core-jvm")
+    override def jsSources = Task.Sources(moduleDir, moduleDir / os.up / "core-portable")
+    override def nativeSources = Task.Sources(moduleDir, moduleDir / os.up / "core-portable")
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // The panopticon lens/optic instances for `Json`, and jacinta's only use of panopticon.
@@ -3549,7 +3555,18 @@ object jslink extends ScalaJSModule, Toolchain:
     settings.scalaOptions ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium")
   def sources = Task.Sources(mill.api.BuildCtx.workspaceRoot / "jslink" / "src")
   override def mainClass = Some("jslink.Main")
-  override def moduleDeps = Seq(gossamer.core.js, jacinta.core.js, wisteria.core.js, ypsiloid.core.js, hypotenuse.core.js, spectacular.core.js, aviation.core.js, xenophile.typescript.js, xenophile.js.js)
+
+  // Mill resolves the linker under the hardcoded `org.scala-js` group, and through the *global*
+  // `jvmWorker()` resolver, so neither the `Toolchain` file repository nor a `repositories`
+  // override can satisfy the fork version. The scala-wasm fork publishes the same artifacts on
+  // Maven Central under `io.github.scala-wasm`, so remap the group and keep everything else
+  // (the js-env dependencies are stock artifacts at their own versions).
+  override def scalaJSLinkerClasspath: T[Seq[PathRef]] = Task:
+    jvmWorker().defaultResolver().classpath(Seq(
+      mvn"io.github.scala-wasm:scalajs-sbt-test-adapter_2.13:${settings.scalaJsVersion}",
+      mvn"io.github.scala-wasm:scalajs-linker_2.13:${settings.scalaJsVersion}")
+      ++ scalaJSJsEnvMvnDeps())
+  override def moduleDeps = Seq(gossamer.core.js, jacinta.core.js, wisteria.core.js, ypsiloid.core.js, hypotenuse.core.js, spectacular.core.js, aviation.core.js, parasite.core.js, xenophile.typescript.js, xenophile.js.js)
 
 // The Scala Native counterpart of `jslink`: `nativelink.binary` links a representative slice of the
 // Native-capable modules (`nativelink/src`) into a real executable via the `tools` linker, so any

--- a/jslink/src/JsLinkCheck.scala
+++ b/jslink/src/JsLinkCheck.scala
@@ -2,14 +2,17 @@ package jslink
 
 import soundness.*
 
+import charEncoders.utf8Encoder
+
 // A Scala.js entry point that exercises a representative slice of the JS-capable
 // modules, so `jslink.fastLinkJS` forces their code reachable and the linker
 // reports any reachable reference to a `java.*`/`javax.*` class Scala.js lacks —
 // the runtime (link-level) counterpart to the static reference audit.
 // The TypeScript definitions reused from xenophile's test resources; the `Interface` given points
 // the `Foreign` navigation at them so `foo.ping()` type-checks against the `ping(): string` member.
+// Declared with the hellenism-free string-literal overload, so hellenism need not join the link.
 type TsDefs = Interface in Typescript at "/xenophile/definitions.ts"
-given tsDefs: TsDefs = Interface[Typescript](cp"/xenophile/definitions.ts")
+given tsDefs: TsDefs = Interface[Typescript]("/xenophile/definitions.ts")
 
 object Main:
   case class Point(x: Int, y: Int)
@@ -17,21 +20,21 @@ object Main:
   def main(args: Array[String]): Unit =
     val out = java.lang.System.out.nn
 
-    // xenophile (JS materializer): `Foreign["Foo", Typescript].ping().invoke[Text]` expands to a
+    // xenophile (JS materializer): `Foreign["Foo", Typescript].ping().call[Text]()` expands to a
     // real Scala.js dynamic call — `js.Dynamic.global.selectDynamic("Foo").applyDynamic("ping")()` —
     // decoded through the `Text` boundary codec. Linking it proves the emitted interop is valid.
-    // The chain must be inline (not bound to a `val`), exactly like the `Wasm` `invoke`.
-    out.println(Foreign["Foo", Typescript].ping().invoke[Text].s)
+    // The chain must be inline (not bound to a `val`), exactly like the `Wasm` `call`.
+    out.println(Foreign["Foo", Typescript].ping().call[Text]().s)
 
     // gossamer (Text) + kaleidoscope (regex, via interpolation/text ops)
     out.println(t"hello, ${args.length} args".s)
 
     // jacinta (JSON parse) + wisteria (derived decoder into a case class)
-    val point: Point = unsafely(t"""{ "x": 1, "y": 2 }""".decode[Json].as[Point])
+    val point: Point = unsafely(t"""{ "x": 1, "y": 2 }""".read[Json].as[Point])
     out.println(point.x.toString)
 
     // ypsiloid (YAML parse — exercises the pooled-parser path)
-    val yaml = unsafely(t"x: 1\ny: 2\n".decode[Yaml])
+    val yaml = unsafely(t"x: 1\ny: 2\n".read[Yaml])
     out.println(yaml.toString)
 
     // hypotenuse (numeric / bit types)
@@ -43,3 +46,11 @@ object Main:
 
     // aviation (calendar arithmetic — the SAM-fixed givens)
     out.println(calendars.gregorianCalendar.daysInYear(Year(2000)).toString)
+
+    // parasite (the eager single-threaded JavaScript threading model, #1450): forking, gathering
+    // and awaiting must link without reaching any JVM threading primitive.
+    locally:
+      import threading.javascriptThreading
+      import probates.cancelProbate
+      val gathered = unsafely(supervise(List(async(6), async(7)).sequence.await()))
+      out.println(gathered.toString)

--- a/lib/jacinta/src/core-jvm/jacinta.WordAccess.scala
+++ b/lib/jacinta/src/core-jvm/jacinta.WordAccess.scala
@@ -1,0 +1,52 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package jacinta
+
+// Little-endian 64-bit view over the parser's byte buffer, for SWAR scans: eight input bytes
+// per step instead of one. Little-endian regardless of the platform so
+// `numberOfTrailingZeros(mask) >> 3` is always the offset of the first flagged byte. The
+// portable twin in `src/core-portable` serves the Scala.js and Scala Native crosses, which
+// have no `java.lang.invoke`.
+private[jacinta] object WordAccess:
+  private val Handle: java.lang.invoke.VarHandle =
+    // `Class.forName("[J")` rather than `classOf[Array[Long]]`: under
+    // capture checking the latter's type does not adapt to the JDK
+    // signature's wildcard.
+    java.lang.invoke.MethodHandles
+      . byteArrayViewVarHandle(Class.forName("[J").nn, java.nio.ByteOrder.LITTLE_ENDIAN)
+      . nn
+
+  def get(bytes: scala.Array[Byte], index: Int): Long =
+    // The cast erases the parameter's read capability: the signature-polymorphic `get` accepts
+    // only a capture-free array, and it does nothing but read.
+    Handle.get(bytes.asInstanceOf[scala.Array[Byte]^{}], index)

--- a/lib/jacinta/src/core-portable/jacinta.WordAccess.scala
+++ b/lib/jacinta/src/core-portable/jacinta.WordAccess.scala
@@ -1,0 +1,49 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package jacinta
+
+// Little-endian 64-bit reads over the parser's byte buffer, for SWAR scans: eight input bytes
+// per step instead of one. Little-endian regardless of the platform so
+// `numberOfTrailingZeros(mask) >> 3` is always the offset of the first flagged byte. The
+// shift-and-or here is the Scala.js/Scala Native variant; the JVM twin in `src/core-jvm`
+// reads the whole word through a byte-array view `VarHandle`, which only the JVM provides.
+private[jacinta] object WordAccess:
+  def get(bytes: scala.Array[Byte], index: Int): Long =
+    var word: Long = 0L
+    var i = 7
+
+    while i >= 0 do
+      word = (word << 8) | (bytes(index + i) & 0xFFL)
+      i -= 1
+
+    word

--- a/lib/jacinta/src/core/jacinta.Json.Parser.scala
+++ b/lib/jacinta/src/core/jacinta.Json.Parser.scala
@@ -91,17 +91,9 @@ private[jacinta] object Parser:
   private inline val NullWord  = 0x6C6C_756E
   private inline val FalseWord = 0x0000_0065_736C_6166L
 
-  // Little-endian 64-bit view over the byte buffer, for SWAR scans: eight
-  // input bytes per step instead of one. Little-endian regardless of the
-  // platform so `numberOfTrailingZeros(mask) >> 3` is always the offset of
-  // the first flagged byte.
-  private val WordAccess: java.lang.invoke.VarHandle =
-    // `Class.forName("[J")` rather than `classOf[Array[Long]]`: under
-    // capture checking the latter's type does not adapt to the JDK
-    // signature's wildcard.
-    java.lang.invoke.MethodHandles
-      . byteArrayViewVarHandle(Class.forName("[J").nn, java.nio.ByteOrder.LITTLE_ENDIAN)
-      . nn
+  // The SWAR word reads go through `WordAccess.get` — a per-platform object, because the JVM's
+  // byte-array view `VarHandle` exists on neither Scala.js nor Scala Native (see
+  // `src/core-jvm` and `src/core-portable`).
 
   private inline val HighBits = 0x8080808080808080L
   private inline val EveryByte = 0x0101010101010101L

--- a/nativelink/crypto/Main.scala
+++ b/nativelink/crypto/Main.scala
@@ -19,7 +19,7 @@ object Main:
     // HMAC-SHA256 against a known vector — the same assertion the JVM suite makes, here proving
     // libcrypto was loaded and its symbols resolved at run time with nothing else linking it.
     val mac = enigmatic.OpensslCrypto.hmac(t"HmacSHA256").mac(t"key".in[Data], t"message".in[Data])
-    val hex = mac.to(List).map(b => String.format("%02x", Int.box(b & 255))).mkString
+    val hex = mac.to[List].stdlib.map(b => String.format("%02x", Int.box(b & 255))).mkString
     val expected = "6e9ef29b75fffc5b7abae527d58fdadb2fe42e7219011976917343065f58ed4a"
     out.println("crypto-only: hmac verified = "+(hex == expected))
 
@@ -30,4 +30,4 @@ object Main:
     val secret = t"attack at dawn!!".in[Data]
     val ciphertext = aes.encrypt(t"AES/CBC/PKCS7", key, iv, secret)
     val plaintext = aes.decrypt(t"AES/CBC/PKCS7", key, 16, ciphertext)
-    out.println("crypto-only: aes round-trip = "+(plaintext.to(List) == secret.to(List)))
+    out.println("crypto-only: aes round-trip = "+(plaintext.to[List] == secret.to[List]))

--- a/nativelink/src/Main.scala
+++ b/nativelink/src/Main.scala
@@ -36,30 +36,30 @@ object Main:
 
     // xenophile native C FFI: real libc calls lowered by `NativeInvoke` — a nullary call and
     // (v2) calls with primitive arguments.
-    val pid: Int = Foreign["library", Native].getpid().invoke[Int]
+    val pid: Int = Foreign["library", Native].getpid().call[Int]()
     out.println("pid via native FFI: "+pid)
 
-    val absolute: Int = Foreign["library", Native].abs(-7).invoke[Int]
+    val absolute: Int = Foreign["library", Native].abs(-7).call[Int]()
     out.println("abs(-7) via native FFI: "+absolute)
 
-    val power: Double = Foreign["library", Native].pow(2.0, 10.0).invoke[Double]
+    val power: Double = Foreign["library", Native].pow(2.0, 10.0).call[Double]()
     out.println("pow(2, 10) via native FFI: "+power)
 
     // (v3) a string argument marshalled to a `CString`, and a string result read back.
-    val length: Long = Foreign["library", Native].strlen(t"hello, world").invoke[Long]
+    val length: Long = Foreign["library", Native].strlen(t"hello, world").call[Long]()
     out.println("strlen(hello, world) via native FFI: "+length)
 
-    val home: Text = Foreign["library", Native].getenv(t"HOME").invoke[Text]
+    val home: Text = Foreign["library", Native].getenv(t"HOME").call[Text]()
     out.println("getenv(HOME) via native FFI: "+home.s)
 
-    // (v4) raw pointers: a pointer-returning call (`malloc`), a `Pointer` argument satisfying a
-    // `void*` parameter (`memset`, whose pointer result is discarded into a `Pointer` too), and
-    // `free` returning `void` — the round-trip proving `Pointer` flows in both directions.
-    val block: Pointer = Foreign["library", Native].malloc(32L).invoke[Pointer]
+    // (v4) raw pointers: a pointer-returning call (`malloc`), an `Address` argument satisfying a
+    // `void*` parameter (`memset`, whose pointer result is discarded into an `Address` too), and
+    // `free` returning `void` — the round-trip proving `Address` flows in both directions.
+    val block: Address = Foreign["library", Native].malloc(32L).call[Address]()
     out.println("malloc(32) via native FFI: isNull = "+block.isNull)
-    val filled: Pointer = Foreign["library", Native].memset(block, 0, 32L).invoke[Pointer]
+    val filled: Address = Foreign["library", Native].memset(block, 0, 32L).call[Address]()
     out.println("memset(block, 0, 32) via native FFI: same = "+(filled.address == block.address))
-    Foreign["library", Native].free(block).invoke[Unit]
+    Foreign["library", Native].free(block).call[Unit]()
     out.println("free(block) via native FFI: ok")
 
     // galilei: a real filesystem round-trip driven straight through the native `FilesystemBackend`
@@ -80,9 +80,9 @@ object Main:
     if fs.exists(file, false) then unsafely(fs.delete(file))
     unsafely:
       fs.open(file, List(OpenFlag.Write, OpenFlag.Create)): handle =>
-        handle.writer(LazyList(t"hello native fs".in[Data]))
+        handle.writer(Chain(t"hello native fs".in[Data]))
     out.println("fs: file size after write = "+unsafely(fs.stat(file, false)).size)
-    val readBytes = unsafely(fs.open(file, List(OpenFlag.Read))(_.reader().map(_.length).sum))
+    val readBytes = unsafely(fs.open(file, List(OpenFlag.Read))(_.reader().stdlib.map(_.length).sum))
     out.println("fs: bytes read back       = "+readBytes)
     unsafely(fs.delete(file))
 
@@ -93,10 +93,10 @@ object Main:
     import environments.javaEnvironment
     out.println("ambience HOME = "+summon[Environment].variable(t"HOME").or(t"?").s)
 
-    // coaxial: a UDP loopback round-trip straight through the native `SocketBackend` — bind a
+    // coaxial: a UDP loopback round-trip straight through the native `Socket.Backend` — bind a
     // datagram socket, dispatch a payload to it, receive it back.
     import coaxial.socketBackends.native
-    val sb = summon[SocketBackend]
+    val sb = summon[Socket.Backend]
     val udpPort = Port.unsafe[Udp](55555)
     val server = sb.listenUdp(udpPort, Unset, Nil)
     val courier = sb.routeUdpPort(udpPort, Unset, Nil)
@@ -104,7 +104,7 @@ object Main:
     unsafely(sb.dispatch(courier, summon[Data is Streamable by Data over Credit].stream(payload)))
     val packet = unsafely(sb.receive(server))
     sb.unbind(server)
-    out.println("udp: received "+packet.data.length+" bytes = "+packet.data.to(List).map(_.toChar).mkString)
+    out.println("udp: received "+packet.data.length+" bytes = "+packet.data.to[List].stdlib.map(_.toChar).mkString)
 
     // ...and a TCP loopback round-trip: listen, dial back into the listener, write the payload and
     // hang up (so the server-side read sees EOF), then accept and read it back through the duplex.
@@ -119,7 +119,7 @@ object Main:
     val received = unsafely(duplex.source.memoize)
     duplex.close()
     sb.shutdown(tcpServer)
-    out.println("tcp: received "+received.length+" bytes = "+received.to(List).map(_.toChar).mkString)
+    out.println("tcp: received "+received.length+" bytes = "+received.to[List].stdlib.map(_.toChar).mkString)
 
     // parasite: real concurrency through the native supervisors — `virtualThreading` resolves to
     // the platform-thread twin (no Loom on native), and two workers running concurrently under
@@ -140,7 +140,7 @@ object Main:
     // `OpensslCrypto` source that runs on the JVM via Panama, here materialized as direct C
     // calls. The HMAC is checked against RFC 4231-style known output, and AES/CBC round-trips.
     val mac = enigmatic.OpensslCrypto.hmac(t"HmacSHA256").mac(t"key".in[Data], t"message".in[Data])
-    val hex = mac.to(List).map(b => String.format("%02x", Int.box(b & 255))).mkString
+    val hex = mac.to[List].stdlib.map(b => String.format("%02x", Int.box(b & 255))).mkString
     out.println("hmac-sha256(key, message) = "+hex)
     out.println("hmac verified = "+(hex == "6e9ef29b75fffc5b7abae527d58fdadb2fe42e7219011976917343065f58ed4a"))
 
@@ -150,7 +150,7 @@ object Main:
     val secret = t"attack at dawn!!".in[Data]
     val sealed0 = aes.encrypt(t"AES/CBC/PKCS7", aesKey, aesIv, secret)
     val opened = aes.decrypt(t"AES/CBC/PKCS7", aesKey, 16, sealed0)
-    out.println("aes-256-cbc round-trip = "+(opened.to(List) == secret.to(List)))
+    out.println("aes-256-cbc round-trip = "+(opened.to[List] == secret.to[List]))
 
     // coaxial TLS: a real HTTPS exchange through the OpenSSL-backed `SecureEndpoint` — the one
     // networked scenario, so gated on `SOUNDNESS_CI_ONLINE` like wasm-e2e's outgoing-HTTP check.
@@ -162,5 +162,5 @@ object Main:
       tlsDuplex.send(summon[Data is Streamable by Data over Credit].stream(request))
       val response = unsafely(tlsDuplex.source.memoize)
       tlsDuplex.close()
-      val status = response.to(List).takeWhile(_ != 13).map(_.toChar).mkString
+      val status = response.to[List].stdlib.takeWhile(_ != 13).map(_.toChar).mkString
       out.println("tls: "+status+" ("+response.length+" bytes)")


### PR DESCRIPTION
The `jslink` Scala.js link probe (#1531) is revived after rotting in three ways (#1882): its source predated the `call`/`read`/`Interface` API renames; mill's `scalaJSLinkerClasspath` hardcodes the `org.scala-js` group through the global worker resolver, so the fork's `1.22.0-wasm.4` linker could never resolve — it is now remapped to the identical `io.github.scala-wasm` artifacts on Maven Central; and the revived link immediately caught a real regression: jacinta's SWAR parser had made every JS build of jacinta unlinkable through its byte-array view `VarHandle`. The word reads are now split per platform, restoring jacinta on Scala.js, and the probe additionally exercises parasite's JavaScript threading model (#1450). The `nativelink` probe, which had rotted the same way, is refreshed too: both native binaries link and run again, with every probe passing.

JSON parsing with jacinta works again on Scala.js. The SWAR word-scan optimisation in jacinta's parser had introduced a reachable reference to `java.lang.invoke.VarHandle`, which Scala.js does not provide, so any Scala.js application linking jacinta's parser would fail with linking errors. The JVM keeps the `VarHandle` fast path; the Scala.js and Scala Native builds now compile a portable shift-and-or variant with identical semantics:

```scala
import soundness.*
import charEncoders.utf8Encoder

case class Point(x: Int, y: Int)
val point = unsafely(t"""{ "x": 1, "y": 2 }""".read[Json].as[Point])  // now links on Scala.js
```

The `jslink.fastLinkJS` probe that enforces this is itself working again, and now also links parasite's eager single-threaded `javascriptThreading` model, so `supervise`/`async`/`sequence` are proven free of JVM threading primitives on the JS target. The `nativelink` counterpart is likewise brought up to date with the current `call`/`Address`/collections APIs, and both its binaries — the representative slice and the crypto-only regression check — link and run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)