### PR TITLE
Typed test-event streaming, plus Escritoire cell decoration and an Ultimatum scrolling viewport

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -609,9 +609,18 @@ trait Benchmarks(dependencies: PublishModule*) extends BaseScalaModule:
   def finalMainClass = (moduleDir / ".." / "..").last + ".Benchmarks"
   def resources = Task.Sources(moduleDir / ".." / ".." / "res" / moduleId)
   def compileResources = Task.Sources(moduleDir / ".." / ".." / "res" / moduleId)
-  def moduleDeps: Seq[PublishModule] = probably.cli +: sedentary.core +: dependencies
+  // `probably.events` rides along for the same reason it does in `Tests`: a host process (fume)
+  // streams a benchmark run's `TestEvent`s out of the suite's classloader world via
+  // `probably.Streamer`, which therefore has to be ON the benchmark assembly's classpath.
+  def moduleDeps: Seq[PublishModule] = probably.cli +: probably.events +: sedentary.core +: dependencies
   def sources = Task.Sources(moduleDir)
   def consoleScalacOptions = scalacOptions()
+
+  // The beneficence plugin writes the `META-INF/services/probably.Suite` index, which is the
+  // ONLY way fume discovers suites: without it a benchmark assembly is runnable by main class
+  // but invisible to `fume run`/`fume list`.
+  override def scalacOptions = Task:
+    super.scalacOptions() :+ s"-Xplugin:${beneficence.plugin.assembly().path}"
 
 // ------------------------ BUNDLES ------------------------
 

--- a/build.mill
+++ b/build.mill
@@ -595,7 +595,7 @@ trait Tests(dependencies: JavaModule*) extends BaseScalaModule:
   // classpath transitively via `chiaroscuro`, but chiaroscuro no longer depends on it (so it can
   // cross-compile to Scala.js), so the dependency is now explicit here.
   def moduleDeps: Seq[JavaModule] =
-    larceny.plugin +: probably.cli +: proscenium.core +: dependencies
+    larceny.plugin +: probably.cli +: probably.events +: proscenium.core +: dependencies
   def sources = Task.Sources(moduleDir)
   def consoleScalacOptions = scalacOptions()
 

--- a/build.mill
+++ b/build.mill
@@ -825,7 +825,7 @@ object soundness extends Toolchain:
 
   object test extends Bundle(capricious.core, sedentary.core, tarantula.core,
     tarantula.image,
-    superlunary.core, yossarian.core, probably.core, probably.cli, superlunary.jvm, mandible.core,
+    superlunary.core, yossarian.core, probably.core, probably.cli, probably.events, superlunary.jvm, mandible.core,
     probably.coverage):
     def summary = "Testing: suites, assertions, coverage, generators and browser automation"
 
@@ -2716,6 +2716,18 @@ object probably extends Library:
   object cli extends Component(core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
+
+  // The BinTEL serialization bridge for the `TestEvent` stream: `Streamer` runs a suite with an
+  // event sink and writes a schema fingerprint plus length-prefixed BinTEL frames to a host's
+  // `OutputStream` -- the API an in-process (or, later, forked) test runner such as fume calls.
+  // JVM-only, because `stratiform.binary` is.
+  object events extends Component(cli, stratiform.core, stratiform.binary, stratiform.base256):
+    override def scalaJs = false
+    // Not `sep`-checked: the module's whole job is driving stratiform's inline schema/codec
+    // derivations, whose generated code is not separation-clean (the same reason the `Tests`
+    // trait, which exercises them, compiles without `sep`).
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium")
   // The scoverage `Invoker`'s initializer needs `SecureRandom` (absent on Scala Native), so
   // the measurement-file lookup is split by platform (`coverage-jvm`/`coverage-native`).
   object coverage extends Component(distillate.core, digression.core, dendrology.tree):

--- a/lib/corpuscular/src/test/corpuscular_test.scala
+++ b/lib/corpuscular/src/test/corpuscular_test.scala
@@ -34,6 +34,14 @@ package corpuscular
 
 import soundness.*
 
+// Both corpuscular and gastronomy export a toplevel `Crc32` into `soundness` — corpuscular's
+// concrete checksum object, gastronomy's algorithm marker for its digest framework — and the
+// umbrella keeps just one, by classpath order. A package member declared in another file of
+// this package has lower precedence than a wildcard import, so `import soundness.*` would
+// otherwise decide which `Crc32` this suite tests; naming it explicitly (an explicit import
+// outranks a wildcard) pins it to corpuscular's, whatever the classpath order.
+import corpuscular.Crc32
+
 import strategies.throwUnsafely
 import errorDiagnostics.emptyDiagnostics
 import charEncoders.utf8Encoder

--- a/lib/escritoire/src/core/escritoire.Column.scala
+++ b/lib/escritoire/src/core/escritoire.Column.scala
@@ -42,7 +42,8 @@ object Column:
     ( title:         text,
       textAlign:     Optional[TextAlignment]     = Unset,
       verticalAlign: Optional[VerticalAlignment] = Unset,
-      sizing:        Columnar                    = columnar.Paragraph )
+      sizing:        Columnar                    = columnar.Paragraph,
+      decorate:      row -> Optional[text -> text] = { (_: Any) => Unset } )
     ( get: row -> cell )
     ( using columnAlignment: Column.Alignment[cell] = Column.Alignment.topLeft )
     ( using text.Show[cell] )
@@ -55,7 +56,8 @@ object Column:
         contents,
         textAlign.or(columnAlignment.text),
         verticalAlign.or(columnAlignment.vertical),
-        sizing )
+        sizing,
+        decorate )
 
   // ColumnAlignment → Column.Alignment
   object Alignment:
@@ -75,9 +77,20 @@ case class Column[row, text: Textual]
     get:           row -> text,
     textAlign:     TextAlignment,
     verticalAlign: VerticalAlignment,
-    sizing:        Columnar ):
+    sizing:        Columnar,
+
+    // A per-row DECORATION of the whole rendered cell — content plus its gutter padding —
+    // applied by `Grid.render` after alignment. The renderer knows nothing of styling (the
+    // `text` type stays abstract); a Teletype caller writes e.g.
+    // `row => if winner(row) then { (line: Teletype) => e"${Bg(color)}($line)" } else Unset`,
+    // and the e-interpolator's style combination fills the unstyled padding while any styles
+    // inside the cell content win. No default here: it would clash with the factory
+    // `apply`'s defaults (two overloads with default arguments); the factory supplies it.
+    decorate:      row -> Optional[text -> text] ):
 
   def contramap[row2](lambda: row2 -> row): Column[row2, text] =
-    Column[row2, text](title, row => get(lambda(row)), textAlign, verticalAlign, sizing)
+    Column[row2, text]
+      ( title, row => get(lambda(row)), textAlign, verticalAlign, sizing,
+        row => decorate(lambda(row)) )
 
   def retitle(title: text): Column[row, text] = copy(title = title)

--- a/lib/escritoire/src/core/escritoire.Grid.scala
+++ b/lib/escritoire/src/core/escritoire.Grid.scala
@@ -59,13 +59,14 @@ case class Grid[text](sections: List[TableSection[text]], style: TableStyle):
     ( using metrics: Text is Measurable, textual: text is Textual { type Result = Char } )
   :   Chain[text] =
     val pad = t" "*style.padding
-    val leftEdge = Textual(t"${style.charset(top = style.sideLines, bottom = style.sideLines)}$pad")
 
-    val rightEdge =
-      Textual(t"$pad${style.charset(top = style.sideLines, bottom = style.sideLines)}")
-
-    val midEdge =
-      Textual(t"$pad${style.charset(top = style.innerLines, bottom = style.innerLines)}$pad")
+    // The edges are BARE rule glyphs: the gutter padding belongs to each cell, so that a
+    // cell's decoration (a background, say) covers its whole width — padding included —
+    // while the rules stay undecorated. Line widths are unchanged: the padding moved, it
+    // was not added, so the `rule` joint arithmetic below is unaffected.
+    val leftEdge = Textual(t"${style.charset(top = style.sideLines, bottom = style.sideLines)}")
+    val rightEdge = leftEdge
+    val midEdge = Textual(t"${style.charset(top = style.innerLines, bottom = style.innerLines)}")
 
     def recur(widths: Array[Int]^{}, rows: Chain[TableRow[text]]): Chain[text] =
       rows match
@@ -81,13 +82,17 @@ case class Grid[text](sections: List[TableSection[text]], style: TableStyle):
 
               val line = lineNumber - offset
 
-              if line >= 0 && line < cell.minHeight
-              then
-                cell.textAlign.pad
-                  ( cell(line), widths.readUnchecked(index), line == cell.minHeight - 1 )
+              val body: text =
+                if line >= 0 && line < cell.minHeight
+                then
+                  cell.textAlign.pad
+                    ( cell(line), widths.readUnchecked(index), line == cell.minHeight - 1 )
 
-              else
-                Textual((t" "*widths.readUnchecked(index)))
+                else
+                  Textual((t" "*widths.readUnchecked(index)))
+
+              val padded: text = textual.concat(textual.concat(Textual(pad), body), Textual(pad))
+              cell.decorate.lay(padded) { decoration => decoration(padded) }
 
             . join(leftEdge, midEdge, rightEdge)
 

--- a/lib/escritoire/src/core/escritoire.Scaffold.scala
+++ b/lib/escritoire/src/core/escritoire.Scaffold.scala
@@ -73,3 +73,9 @@ case class Scaffold[row, text: {ClassTag, Textual as textual}](columns0: Column[
         data.map: row =>
           columns.map[Array[text]^{}]: column =>
             Array.from(column.get(row).lines.stdlib)
+
+      // Evaluated HERE, the last point at which the row value exists; carried as plain
+      // lists (no `ClassTag` exists for an `Optional` of a function).
+      override val decorations: List[List[Optional[text -> text]]] =
+        data.map: row =>
+          columns0.map { column => column.decorate(row) }.to(List)

--- a/lib/escritoire/src/core/escritoire.TableCell.scala
+++ b/lib/escritoire/src/core/escritoire.TableCell.scala
@@ -32,12 +32,17 @@
                                                                                                   */
 package escritoire
 
+import scala.language.experimental.pureFunctions
+
+import vacuous.*
+
 case class TableCell[text]
   ( width:         Int,
     span:          Int,
     lines:         Sequence[text],
     minHeight:     Int,
     textAlign:     TextAlignment,
-    verticalAlign: VerticalAlignment = VerticalAlignment.Top ):
+    verticalAlign: VerticalAlignment = VerticalAlignment.Top,
+    decorate:      Optional[text -> text] = Unset ):
 
   def apply(line: Int): text = lines.stdlib(line)

--- a/lib/escritoire/src/core/escritoire.Tabulation.scala
+++ b/lib/escritoire/src/core/escritoire.Tabulation.scala
@@ -65,6 +65,9 @@ abstract class Tabulation[text: ClassTag]():
   def rows: List[Array[Array[text]^{}]^{}]
   def dataLength: Int
 
+  // Per-row, per-column cell decorations, aligned with `rows`; empty means undecorated.
+  def decorations: List[List[Optional[text -> text]]] = Nil
+
 
   def grid(width: Int)
     ( using style: TableStyle, metrics: Text is Measurable )
@@ -108,15 +111,28 @@ abstract class Tabulation[text: ClassTag]():
 
     if totalWidth > width then attenuation(totalWidth, width)
 
-    def lines(data: List[Array[Array[text]^{}]^{}]): Chain[TableRow[text]] =
+    def lines
+      ( data: List[Array[Array[text]^{}]^{}],
+        decorations2: List[List[Optional[text -> text]]] )
+    :   Chain[TableRow[text]] =
+
+      val decorationIterator = decorations2.stdlib.iterator
+
       Chain.from(data.stdlib).map: cells =>
+        val rowDecorations: scala.List[Optional[text -> text]] =
+          if decorationIterator.hasNext then decorationIterator.next().stdlib else scala.Nil
+
         val tableCells = Array.from:
           survivors.map: (index, cellWidth) =>
             val column = columns.readUnchecked(index)
             val lines = column.sizing.fit[text](cells.readable(index), cellWidth, column.textAlign)
 
+            val decoration: Optional[text -> text] =
+              if index < rowDecorations.length then rowDecorations(index) else Unset
+
             TableCell
-              ( cellWidth, 1, lines, lines.size, column.textAlign, column.verticalAlign )
+              ( cellWidth, 1, lines, lines.size, column.textAlign, column.verticalAlign,
+                decoration )
 
         val height = tableCells.readable.maxBy(_.minHeight).minHeight
 
@@ -124,4 +140,6 @@ abstract class Tabulation[text: ClassTag]():
 
     val widths = Array.from(survivors.map(_(1)))
 
-    Grid(List(TableSection(widths, lines(titles)), TableSection(widths, lines(rows))), style)
+    Grid
+      ( List(TableSection(widths, lines(titles, Nil)), TableSection(widths, lines(rows, decorations))),
+        style )

--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -129,11 +129,24 @@ object Classpath extends Root(t""):
 
     // The anonymous classloader's only capture is the read view of the freshly-built URL
     // array, laundered here.
+    //
+    // Child-first delegation must still honour the `ClassLoader` contract: consult
+    // `findLoadedClass` under the per-name loading lock before defining. Without the check, a
+    // second request for an already-loaded class — or two threads racing on the same name, as
+    // concurrent test workers routinely do — reaches `defineClass` twice and dies with a
+    // `LinkageError: attempted duplicate class definition`.
     scala.caps.unsafe.unsafeAssumePure:
      new jn.URLClassLoader(urls, parent):
       override def loadClass(name: String | Null, resolve: Boolean): Class[?] | Null =
-        try findClass(name) catch case error: ClassNotFoundException =>
-          super.loadClass(name, resolve)
+        getClassLoadingLock(name).nn.synchronized:
+          val loaded = findLoadedClass(name)
+
+          if loaded != null then
+            if resolve then resolveClass(loaded)
+            loaded
+          else
+            try findClass(name) catch case error: ClassNotFoundException =>
+              super.loadClass(name, resolve)
 
   // ClasspathEntry → Classpath.Entry
   object Entry:

--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -67,7 +67,43 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
   // two are indistinguishable, since `System.out` IS the process's stdout.
   def suiteIo: Stdio = safely(stdios.systemStdio).or(panic(m"the JVM stdio is always available"))
 
-  private def makeRunner(selection: Selection): Runner[Report] =
+  private def makeRunner(selection: Selection): Runner[Report] = makeRunner(selection, Unset)
+
+  // A `Reporter[Report]` which renders nothing: the report accumulates as usual (so `passed`
+  // and selection accounting still work), but every datum leaves as a `TestEvent` through the
+  // sink, execution brackets become progress events, and the runner's own ANSI drawing is
+  // suppressed (`live = false`) — the consumer owns all presentation.
+  private def eventReporter(sink: TestEvent -> Unit)(using Environment, TestPalette, Stdio)
+  :   Reporter[Report] =
+
+    new Reporter[Report]:
+      def report(): Report =
+        val report = Report()
+        report.stream(sink)
+        report
+
+      def declare(report: Report, suite: Testable): Unit = report.declare(suite)
+
+      def fail(report: Report, error: Throwable, active: Set[Test.Id]): Unit =
+        report.fail(error, active)
+
+      def complete(report: Report): Unit = report.complete(None)
+
+      override def started(report: Report, id: Test.Id, suite: Boolean): Unit =
+        if !suite then
+          report.emit:
+            TestEvent.TestStarted(TestEvent.Ref.of(id), jl.System.currentTimeMillis)
+
+      override def ended(report: Report, id: Test.Id, suite: Boolean): Unit =
+        report.emit:
+          if suite then TestEvent.SuiteEnded(TestEvent.Ref.of(id), jl.System.currentTimeMillis)
+          else TestEvent.TestEnded(TestEvent.Ref.of(id), jl.System.currentTimeMillis)
+
+      override def live(report: Report): Boolean = false
+
+  private def makeRunner(selection: Selection, sink: Optional[TestEvent -> Unit])
+  :   Runner[Report] =
+
     given stdio: Stdio = suiteIo
 
     given palette: (theme: Theme) => TestPalette = new TestPalette:
@@ -100,7 +136,9 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
       def positive:    Color in Srgb = pass
       def negative:    Color in Srgb = fail
 
-    try Runner(selection) catch case error: Environment.Error =>
+    val reporter: Reporter[Report] = sink.lay(Reporter.report)(eventReporter(_))
+
+    try Runner(selection)(using reporter) catch case error: Environment.Error =>
       jl.System.out.nn.println(StackTrace(error).teletype.render)
       ???
 
@@ -180,6 +218,30 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
         catch case error: Environment.Error =>
           jl.System.out.nn.println(StackTrace(error).teletype)
           3
+      catch case error: Throwable =>
+        runner.terminate(error)
+        2
+
+  // Runs the suite with an EVENT SINK: no rendering happens in this process — the report
+  // still accumulates (for `passed` and selection accounting), but every result leaves as a
+  // `TestEvent` through `sink`, ending with `RunCompleted`. Exit codes as `invoke`:
+  // 0 = passed, 1 = failures, 2 = the suite threw, 3 = environment error. A `--list`
+  // selection is not supported on this path (the caller uses the legacy `invoke` for that).
+  final def invoke(arguments: Text, sink: TestEvent -> Unit): Int =
+    val selection = Selection.parse(arguments.cut(t"\n").filter(_ != t""))
+
+    if selection.listOnly then 2 else
+      runner0 = makeRunner(selection, sink)
+
+      try
+        runner.suite(testableView, run())
+
+        try
+          if runner.admitted == 0 && !selection.trivial then sink(TestEvent.NothingMatched(0))
+          runner.complete()
+          if runner.report.passed then 0 else 1
+        catch case error: Environment.Error => 3
+
       catch case error: Throwable =>
         runner.terminate(error)
         2

--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -65,7 +65,12 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
   // FD-backed streams would bypass that redirection entirely (the report would go to the host
   // process's terminal, not the host's client). In a conventional `java -cp … <Suite>` run the
   // two are indistinguishable, since `System.out` IS the process's stdout.
-  def suiteIo: Stdio = safely(stdios.systemStdio).or(panic(m"the JVM stdio is always available"))
+  // A host may also have NULLED `System.out` outright — superlunary's `Executor` does, so
+  // that stray prints from staged code cannot corrupt its protocol stream — and a staged
+  // expression which touches a suite object's statics initializes the whole suite there. In
+  // that case the FD-backed streams are the only ones left to fall back to.
+  def suiteIo: Stdio =
+    safely(stdios.systemStdio).or(stdios.virtualMachineStdio)
 
   private def makeRunner(selection: Selection): Runner[Report] = makeRunner(selection, Unset)
 

--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -231,11 +231,24 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
   // still accumulates (for `passed` and selection accounting), but every result leaves as a
   // `TestEvent` through `sink`, ending with `RunCompleted`. Exit codes as `invoke`:
   // 0 = passed, 1 = failures, 2 = the suite threw, 3 = environment error. A `--list`
-  // selection is not supported on this path (the caller uses the legacy `invoke` for that).
+  // selection emits one `TestScheduled` per admitted test — the run's schedule, with each
+  // test's REAL `Ref` (full path segments, file and line), which no text format could carry
+  // unambiguously (test and suite names may contain any character).
   final def invoke(arguments: Text, sink: TestEvent -> Unit): Int =
     val selection = Selection.parse(arguments.cut(t"\n").filter(_ != t""))
 
-    if selection.listOnly then 2 else
+    if selection.listOnly then
+      runner0 = makeRunner(selection, sink)
+
+      try
+        runner.suite(testableView, run())
+
+        runner.listed.each: (id, kind) =>
+          sink(TestEvent.TestScheduled(TestEvent.Ref.of(id), TestEvent.kindName(kind)))
+
+        0
+      catch case error: Throwable => 2
+    else
       runner0 = makeRunner(selection, sink)
 
       try

--- a/lib/probably/src/core/probably.Benchmark.scala
+++ b/lib/probably/src/core/probably.Benchmark.scala
@@ -64,6 +64,22 @@ object Benchmark:
 
       val headline = if benchmark.operationSize.present then Metric.Throughput else Metric.Mean
 
+      report.emit:
+        TestEvent.BenchmarkRecorded
+          ( TestEvent.Ref.of(testId),
+            TestEvent.Coordinate.of(coordinates),
+            benchmark.nanoseconds,
+            benchmark.iterations,
+            benchmark.runs,
+            benchmark.mean,
+            benchmark.min,
+            benchmark.max,
+            benchmark.sd,
+            benchmark.confidence,
+            benchmark.operationSize,
+            benchmark.operationRate,
+            java.lang.System.currentTimeMillis )
+
       report.record
         ( testId,
           Entry.Kind.Bench,

--- a/lib/probably/src/core/probably.Hotspots.scala
+++ b/lib/probably/src/core/probably.Hotspots.scala
@@ -33,6 +33,8 @@
 package probably
 
 import anticipation.*
+import murmuration.*
+import vacuous.*
 
 object Hotspots:
   given inclusion: Inclusion[Report, Hotspots]:
@@ -42,6 +44,18 @@ object Hotspots:
         coordinates: List[(Axis.Spec, Value)],
         hotspots:    Hotspots )
     :   Report =
+
+      report.emit:
+        val frames =
+          hotspots.frames.map: (frame: Hotspots.Frame) =>
+            TestEvent.Frame(frame.className, frame.method, Text(""), Unset)
+
+        TestEvent.HotspotsRecorded
+          ( TestEvent.Ref.of(testId),
+            TestEvent.Coordinate.of(coordinates),
+            hotspots.total,
+            frames,
+            java.lang.System.currentTimeMillis )
 
       report.record
         ( testId,

--- a/lib/probably/src/core/probably.Hotspots.scala
+++ b/lib/probably/src/core/probably.Hotspots.scala
@@ -48,7 +48,7 @@ object Hotspots:
       report.emit:
         val frames =
           hotspots.frames.map: (frame: Hotspots.Frame) =>
-            TestEvent.Frame(frame.className, frame.method, Text(""), Unset)
+            TestEvent.Hotspot(frame.className, frame.method, frame.samples)
 
         TestEvent.HotspotsRecorded
           ( TestEvent.Ref.of(testId),

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -56,6 +56,15 @@ object Report:
       val metrics = Ledger(Metric.Duration -> verdict.duration.toDouble)
       val report2 = report.record(testId, Entry.Kind.Check, coordinates, Run(verdict, metrics))
 
+      report.emit:
+        TestEvent.TestCompleted
+          ( TestEvent.Ref.of(testId),
+            TestEvent.kindName(Entry.Kind.Check),
+            TestEvent.Coordinate.of(coordinates),
+            TestEvent.Outcome.of(verdict),
+            TestEvent.MetricValue.of(metrics),
+            java.lang.System.currentTimeMillis )
+
       verdict match
         case Verdict.Pass(_)       => report2
         case Verdict.Fail(_)       => report2
@@ -63,10 +72,20 @@ object Report:
         case Verdict.AspireFail(_) => report2
 
         case Verdict.Throws(error, _) =>
-          report2.addDetail(testId, Verdict.Detail.Throws(StackTrace(error)))
+          val stack = StackTrace(error)
+
+          report.emit:
+            TestEvent.DetailThrows(TestEvent.Ref.of(testId), false, TestEvent.Trace.of(stack))
+
+          report2.addDetail(testId, Verdict.Detail.Throws(stack))
 
         case Verdict.CheckThrows(error, _) =>
-          report2.addDetail(testId, Verdict.Detail.CheckThrows(StackTrace(error)))
+          val stack = StackTrace(error)
+
+          report.emit:
+            TestEvent.DetailThrows(TestEvent.Ref.of(testId), true, TestEvent.Trace.of(stack))
+
+          report2.addDetail(testId, Verdict.Detail.CheckThrows(stack))
 
   given anchor: Inclusion[Report, Anchor]:
     def include
@@ -75,6 +94,19 @@ object Report:
         coordinates: List[(Axis.Spec, Value)],
         anchor:      Anchor )
     :   Report =
+
+      report.emit:
+        val coordinate = TestEvent.Coordinate.of(anchor.axis, anchor.value)
+
+        TestEvent.AnchorRecorded
+          ( TestEvent.Ref.of(testId),
+            anchor.axis.label,
+            coordinate.discrete,
+            coordinate.integral,
+            coordinate.decimal,
+            anchor.baseline.compare.toString.tt,
+            anchor.baseline.metric.toString.tt,
+            anchor.baseline.mode.toString.tt )
 
       report.anchor(testId, anchor)
 
@@ -85,6 +117,26 @@ object Report:
         coordinates: List[(Axis.Spec, Value)],
         detail:      Verdict.Detail )
     :   Report =
+
+      report.emit:
+        val ref = TestEvent.Ref.of(testId)
+
+        detail match
+          case Verdict.Detail.Throws(stack) =>
+            TestEvent.DetailThrows(ref, false, TestEvent.Trace.of(stack))
+
+          case Verdict.Detail.CheckThrows(stack) =>
+            TestEvent.DetailThrows(ref, true, TestEvent.Trace.of(stack))
+
+          case Verdict.Detail.Captures(values) =>
+            TestEvent.DetailCaptures(ref, values)
+
+          case Verdict.Detail.Compare(expected, found, juxtaposition) =>
+            val rows = TestEvent.CompareRow.flatten(juxtaposition)
+            TestEvent.DetailCompare(ref, expected, found, rows)
+
+          case Verdict.Detail.Message(message) =>
+            TestEvent.DetailMessage(ref, message)
 
       report.addDetail(testId, detail)
 
@@ -148,6 +200,20 @@ enum ReportLine:
 // `final` so the capture checker infers a precise self-type rather than the universal capture an
 // extensible class would get.
 final class Report(using environment: Environment)(using palette: TestPalette):
+  // Event emission: when a sink has been installed (`stream`), every recorded datum also
+  // leaves as a `TestEvent`, and `complete` emits `RunCompleted` INSTEAD of rendering — the
+  // consumer owns presentation. With no sink (the default), behavior is exactly as before.
+  // The sink is a PURE function (`->`): `Report` appears as a pure type throughout the
+  // `Inclusion` machinery, so it may not retain a capability — and a real sink (writing
+  // through a host's untracked `OutputStream` under a `Mutex`) satisfies purity naturally.
+  @scala.caps.unsafe.untrackedCaptures
+  private var sink: Optional[TestEvent -> Unit] = Unset
+
+  private[probably] def stream(sink1: TestEvent -> Unit): Unit = sink = sink1
+  private[probably] def streaming: Boolean = sink != Unset
+
+  private[probably] def emit(event: => TestEvent): Unit = sink.let(_(event))
+
   @scala.caps.unsafe.untrackedCaptures
   private var failure0: Optional[(Throwable, Set[Test.Id])] = Unset
   @scala.caps.unsafe.untrackedCaptures
@@ -176,9 +242,17 @@ final class Report(using environment: Environment)(using palette: TestPalette):
   // An unconditional update would replace the earlier suite's whole subtree, silently
   // discarding everything it had recorded; merging into the existing node keeps both.
   def declare(suite: Testable): Report = this.also:
+    emit(TestEvent.SuiteStarted(TestEvent.Ref.of(suite.id), java.lang.System.currentTimeMillis))
     resolve(suite.parent).tests.getOrElseUpdate(suite.id, ReportLine.Suite(suite))
 
-  def fail(error: Throwable, active: Set[Test.Id]): Unit = failure0 = (error, active)
+  def fail(error: Throwable, active: Set[Test.Id]): Unit =
+    emit:
+      TestEvent.RunTerminated
+        ( TestEvent.Trace.of(StackTrace(error)),
+          active.to[List].map(TestEvent.Ref.of(_)),
+          java.lang.System.currentTimeMillis )
+
+    failure0 = (error, active)
 
   // Records one run at one coordinate of one test, creating the test's entry on first
   // sight. Repeated runs of the same coordinates accumulate in that cell; `headline`, when
@@ -214,5 +288,6 @@ final class Report(using environment: Environment)(using palette: TestPalette):
     val document = Documenting.document(this)
     pass = document.totals.failed == 0 && failure0.absent && document.totals.total > 0
 
-    if Ci.claudeCode then TerseRenderer.render(document)
+    if streaming then emit(TestEvent.RunCompleted(passed, java.lang.System.currentTimeMillis))
+    else if Ci.claudeCode then TerseRenderer.render(document)
     else AnsiRenderer.render(document, coverage)(using summon[Stdio], environment, palette)

--- a/lib/probably/src/core/probably.Reporter.scala
+++ b/lib/probably/src/core/probably.Reporter.scala
@@ -51,3 +51,11 @@ trait Reporter[report] extends Findable:
   def fail(report: report, error: Throwable, active: Set[Test.Id]): Unit
   def declare(report: report, suite: Testable): Unit
   def complete(report: report): Unit
+
+  // Execution brackets, called by `Runner` as a test (or nested suite, when `suite`) begins
+  // and ends; and `live`, gating `Runner`'s in-place ANSI progress. All defaulted, so existing
+  // reporters are unaffected; an event-emitting reporter overrides them to produce progress
+  // events and to suppress the runner's own drawing.
+  def started(report: report, id: Test.Id, suite: Boolean): Unit = ()
+  def ended(report: report, id: Test.Id, suite: Boolean): Unit = ()
+  def live(report: report): Boolean = true

--- a/lib/probably/src/core/probably.Runner.scala
+++ b/lib/probably/src/core/probably.Runner.scala
@@ -88,7 +88,7 @@ extends Findable:
   def maybeRun[result](test: Test[result]^): Optional[Trial[result]] =
     if skip(test.id) then Unset else run[result](test)
 
-  def redraw(size: Int): Unit = if !silent then
+  def redraw(size: Int): Unit = if !silent && reporter.live(report) then
     if size > 0 then Out.print(e"\e[${size}A\r\e[2K")
 
     active.stdlib.reverse.foreach: test =>
@@ -102,6 +102,8 @@ extends Findable:
       val size = active.size
       active ::= test.id
       redraw(size)
+
+    reporter.started(report, test.id, false)
 
     val context = Harness()
     Runner.harnessThreadLocal.set(Some(context))
@@ -118,6 +120,8 @@ extends Findable:
           active = active.filter(_ != test.id)
           redraw(size)
 
+        reporter.ended(report, test.id, false)
+
     catch case error: Exception =>
       val ns: Long = System.nanoTime - ns0
 
@@ -131,6 +135,8 @@ extends Findable:
           active = active.filter(_ != test.id)
           redraw(size)
 
+        reporter.ended(report, test.id, false)
+
     finally
       Runner.harnessThreadLocal.set(None)
 
@@ -143,12 +149,15 @@ extends Findable:
       redraw(size)
 
     reporter.declare(report, suite)
+    reporter.started(report, suite.id, true)
     block(using suite)
 
     mutex:
       val size = active.size
       active = active.filter(_ != suite.id)
       redraw(size)
+
+    reporter.ended(report, suite.id, true)
 
   def terminate(error: Throwable): Unit = mutex:
     reporter.fail(report, error, active.to[Set])

--- a/lib/probably/src/core/probably.Strain.scala
+++ b/lib/probably/src/core/probably.Strain.scala
@@ -82,6 +82,26 @@ object Strain:
           val axis = Axis.Spec(t"N", Axis.Domain.Integral, emergent = true)
           coordinates :+ (axis -> Value.Integral(strain.concurrency))
 
+      report.emit:
+        TestEvent.StrainRecorded
+          ( TestEvent.Ref.of(testId),
+            TestEvent.Coordinate.of(coordinates2),
+            strain.concurrency,
+            strain.operations,
+            strain.nanoseconds,
+            strain.allocation,
+            strain.peakHeap,
+            strain.retained,
+            strain.gcCount,
+            strain.gcTime,
+            strain.p50,
+            strain.p90,
+            strain.p99,
+            strain.p999,
+            strain.compliance,
+            strain.sustained,
+            java.lang.System.currentTimeMillis )
+
       report.record
         ( testId,
           Entry.Kind.Stress,

--- a/lib/probably/src/core/probably.TestEvent.scala
+++ b/lib/probably/src/core/probably.TestEvent.scala
@@ -192,6 +192,10 @@ object TestEvent:
     case Entry.Kind.Profile => t"profile"
 
 enum TestEvent:
+  // The SCHEDULE: one per test a `--list` selection admits, before anything runs, so a
+  // consumer can pre-render every expected row and fill it in as results arrive.
+  case TestScheduled(test: TestEvent.Ref, kind: Text)
+
   case SuiteStarted(suite: TestEvent.Ref, timestamp: Long)
   case SuiteEnded(suite: TestEvent.Ref, timestamp: Long)
 

--- a/lib/probably/src/core/probably.TestEvent.scala
+++ b/lib/probably/src/core/probably.TestEvent.scala
@@ -74,6 +74,10 @@ object TestEvent:
 
   case class Frame(className: Text, method: Text, file: Text, line: Optional[Int])
 
+  // One hot method of a profile: the (demangled) class and method names and how many
+  // execution samples landed in it (self time).
+  case class Hotspot(className: Text, method: Text, samples: Long)
+
   // One component of a flattened cause chain: the outermost exception first, each with its
   // class name, rendered message and frames.
   case class TraceComponent(className: Text, message: Text, frames: List[Frame])
@@ -247,7 +251,7 @@ enum TestEvent:
     ( test:        TestEvent.Ref,
       coordinates: List[TestEvent.Coordinate],
       total:       Long,
-      frames:      List[TestEvent.Frame],
+      frames:      List[TestEvent.Hotspot],
       timestamp:   Long )
 
   case AnchorRecorded

--- a/lib/probably/src/core/probably.TestEvent.scala
+++ b/lib/probably/src/core/probably.TestEvent.scala
@@ -159,12 +159,18 @@ object TestEvent:
         case Axis.Domain.Decimal  => t"decimal"
 
       value match
-        case Value.Discrete(label)  => Coordinate(spec.label, domain, spec.emergent, label, Unset, Unset)
-        case Value.Integral(number) => Coordinate(spec.label, domain, spec.emergent, Unset, number, Unset)
-        case Value.Decimal(number)  => Coordinate(spec.label, domain, spec.emergent, Unset, Unset, number)
+        case Value.Discrete(label) =>
+          Coordinate(spec.label, domain, spec.emergent, label, Unset, Unset)
+
+        case Value.Integral(number) =>
+          Coordinate(spec.label, domain, spec.emergent, Unset, number, Unset)
+
+        case Value.Decimal(number) =>
+          Coordinate(spec.label, domain, spec.emergent, Unset, Unset, number)
 
     def of(coordinates: List[(Axis.Spec, Value)]): List[Coordinate] =
-      coordinates.map { (coordinate: (Axis.Spec, Value)) => of(coordinate(0), coordinate(1)) }
+      coordinates.map: (coordinate: (Axis.Spec, Value)) =>
+        of(coordinate(0), coordinate(1))
 
   // One metric of a result, keyed by the `Metric` enum case's NAME (stable across versions in
   // a way its display label is not).
@@ -172,7 +178,8 @@ object TestEvent:
 
   object MetricValue:
     def of(metrics: Ledger[Metric, Double]): List[MetricValue] =
-      metrics.to[List].map { (entry: (Metric, Double)) => MetricValue(entry(0).toString.tt, entry(1)) }
+      metrics.to[List].map: (entry: (Metric, Double)) =>
+        MetricValue(entry(0).toString.tt, entry(1))
 
   def kindName(kind: Entry.Kind): Text = kind match
     case Entry.Kind.Check   => t"check"

--- a/lib/probably/src/core/probably.TestEvent.scala
+++ b/lib/probably/src/core/probably.TestEvent.scala
@@ -1,0 +1,258 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package probably
+
+import anticipation.*
+import chiaroscuro.*
+import denominative.dysasymptotics.linearSize
+import digression.*
+import fulminate.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+// The typed event stream a test run produces: the low-level counterpart of the `Report`
+// accumulator, for consumers — a test-running tool such as fume — which render results
+// themselves (as terminal output, HTML, or anything else). Events are RICH but WIRE-SAFE: every
+// payload is a flat case class of scalars, `Optional`s, `List`s and `Map[Text, Text]`, so the
+// whole enum derives a BinTEL schema and codec with no hand-written instances (nested sums,
+// recursion, tuples and live `Exception`s are all excluded by construction). Recursive
+// structures are flattened STRUCTURALLY, not pre-rendered: a stack trace becomes its cause
+// chain in order, a `Juxtaposition` becomes depth-indexed rows from which a renderer can
+// rebuild the tree, and a metrics `Ledger` becomes a list of labelled values. One deliberate
+// simplification: a `Message`'s rope structure is rendered to `Text` at this boundary.
+object TestEvent:
+  // A test's (or suite's) identity on the wire: the stable 6-hex hash, the display name, the
+  // optional moniker, the full name-or-moniker path from the root suite to this entry (`path`
+  // includes the entry itself, so tree reconstruction needs no other context), and the
+  // declaration site.
+  case class Ref
+    ( id:      Text,
+      name:    Text,
+      moniker: Optional[Text],
+      path:    List[Text],
+      file:    Text,
+      line:    Int )
+
+  object Ref:
+    def of(id: Test.Id): Ref =
+      def names(id: Test.Id): List[Text] =
+        id.suite.let { suite => names(suite.id) }.or(Nil) :+ id.moniker.or(id.name.text)
+
+      Ref(id.id, id.name.text, id.moniker, names(id), id.codepoint.source, id.codepoint.line)
+
+  case class Frame(className: Text, method: Text, file: Text, line: Optional[Int])
+
+  // One component of a flattened cause chain: the outermost exception first, each with its
+  // class name, rendered message and frames.
+  case class TraceComponent(className: Text, message: Text, frames: List[Frame])
+
+  case class Trace(components: List[TraceComponent])
+
+  object Trace:
+    def of(stack: StackTrace): Trace =
+      def component(stack: StackTrace): TraceComponent =
+        val frames = stack.frames.map: frame =>
+          Frame(frame.method.className, frame.method.method, frame.file, frame.line)
+
+        TraceComponent(stack.className, stack.message.text, frames)
+
+      def recur(stack: StackTrace, chain: List[TraceComponent]): List[TraceComponent] =
+        stack.cause.lay((component(stack) :: chain).reverse): cause =>
+          recur(cause, component(stack) :: chain)
+
+      Trace(recur(stack, Nil))
+
+  // A verdict without its live `Exception`: the outcome vocabulary is `pass`, `fail`,
+  // `throws`, `check-throws`, `aspire-pass` or `aspire-fail`, with the stack trace present for
+  // the two throwing outcomes.
+  case class Outcome(outcome: Text, duration: Long, stack: Optional[Trace])
+
+  object Outcome:
+    def of(verdict: Verdict): Outcome = verdict match
+      case Verdict.Pass(duration)       => Outcome(t"pass", duration, Unset)
+      case Verdict.Fail(duration)       => Outcome(t"fail", duration, Unset)
+      case Verdict.AspirePass(duration) => Outcome(t"aspire-pass", duration, Unset)
+      case Verdict.AspireFail(duration) => Outcome(t"aspire-fail", duration, Unset)
+
+      case Verdict.Throws(exception, duration) =>
+        Outcome(t"throws", duration, Trace.of(StackTrace(exception)))
+
+      case Verdict.CheckThrows(exception, duration) =>
+        Outcome(t"check-throws", duration, Trace.of(StackTrace(exception)))
+
+  // One row of a flattened `Juxtaposition`, pre-order with depth, from which the comparison
+  // tree can be rebuilt: `kind` is `same`, `different` or `collation` (whose type name travels
+  // in `difference`).
+  case class CompareRow
+    ( depth:      Int,
+      label:      Text,
+      kind:       Text,
+      left:       Text,
+      right:      Text,
+      difference: Optional[Text] )
+
+  object CompareRow:
+    def flatten(juxtaposition: Juxtaposition): List[CompareRow] =
+      def recur(label: Text, juxtaposition: Juxtaposition, depth: Int): List[CompareRow] =
+        juxtaposition match
+          case Juxtaposition.Same(value) =>
+            List(CompareRow(depth, label, t"same", value, value, Unset))
+
+          case Juxtaposition.Different(left, right, difference) =>
+            List(CompareRow(depth, label, t"different", left, right, difference))
+
+          case Juxtaposition.Collation(typeName, comparison, left, right) =>
+            CompareRow(depth, label, t"collation", left, right, typeName)
+              :: comparison.bind[List[CompareRow], CompareRow, List[CompareRow]]:
+                   (entry: (Text, Juxtaposition)) => recur(entry(0), entry(1), depth + 1)
+
+      recur(t"", juxtaposition, 0)
+
+  // An axis coordinate: the `Axis.Spec` fields plus the `Value`, its enum flattened into three
+  // `Optional`s of which exactly one is present, according to `domain` (`discrete`, `integral`
+  // or `decimal`).
+  case class Coordinate
+    ( axis:     Text,
+      domain:   Text,
+      emergent: Boolean,
+      discrete: Optional[Text],
+      integral: Optional[Long],
+      decimal:  Optional[Double] )
+
+  object Coordinate:
+    def of(spec: Axis.Spec, value: Value): Coordinate =
+      val domain = spec.domain match
+        case Axis.Domain.Discrete => t"discrete"
+        case Axis.Domain.Integral => t"integral"
+        case Axis.Domain.Decimal  => t"decimal"
+
+      value match
+        case Value.Discrete(label)  => Coordinate(spec.label, domain, spec.emergent, label, Unset, Unset)
+        case Value.Integral(number) => Coordinate(spec.label, domain, spec.emergent, Unset, number, Unset)
+        case Value.Decimal(number)  => Coordinate(spec.label, domain, spec.emergent, Unset, Unset, number)
+
+    def of(coordinates: List[(Axis.Spec, Value)]): List[Coordinate] =
+      coordinates.map { (coordinate: (Axis.Spec, Value)) => of(coordinate(0), coordinate(1)) }
+
+  // One metric of a result, keyed by the `Metric` enum case's NAME (stable across versions in
+  // a way its display label is not).
+  case class MetricValue(metric: Text, value: Double)
+
+  object MetricValue:
+    def of(metrics: Ledger[Metric, Double]): List[MetricValue] =
+      metrics.to[List].map { (entry: (Metric, Double)) => MetricValue(entry(0).toString.tt, entry(1)) }
+
+  def kindName(kind: Entry.Kind): Text = kind match
+    case Entry.Kind.Check   => t"check"
+    case Entry.Kind.Bench   => t"bench"
+    case Entry.Kind.Stress  => t"stress"
+    case Entry.Kind.Profile => t"profile"
+
+enum TestEvent:
+  case SuiteStarted(suite: TestEvent.Ref, timestamp: Long)
+  case SuiteEnded(suite: TestEvent.Ref, timestamp: Long)
+
+  // Progress only: `TestStarted`/`TestEnded` bracket a test's execution (driving a live
+  // display), while `TestCompleted` carries its result and follows `TestEnded`.
+  case TestStarted(test: TestEvent.Ref, timestamp: Long)
+  case TestEnded(test: TestEvent.Ref, timestamp: Long)
+
+  case TestCompleted
+    ( test:        TestEvent.Ref,
+      kind:        Text,
+      coordinates: List[TestEvent.Coordinate],
+      outcome:     TestEvent.Outcome,
+      metrics:     List[TestEvent.MetricValue],
+      timestamp:   Long )
+
+  case DetailCaptures(test: TestEvent.Ref, values: Map[Text, Text])
+  case DetailCompare(test: TestEvent.Ref, expected: Text, found: Text, rows: List[TestEvent.CompareRow])
+  case DetailMessage(test: TestEvent.Ref, message: Text)
+  case DetailThrows(test: TestEvent.Ref, check: Boolean, stack: TestEvent.Trace)
+
+  case BenchmarkRecorded
+    ( test:          TestEvent.Ref,
+      coordinates:   List[TestEvent.Coordinate],
+      nanoseconds:   Long,
+      iterations:    Long,
+      runs:          Int,
+      mean:          Double,
+      min:           Double,
+      max:           Double,
+      sd:            Double,
+      confidence:    Int,
+      operationSize: Optional[Text],
+      operationRate: Optional[Text],
+      timestamp:     Long )
+
+  case StrainRecorded
+    ( test:        TestEvent.Ref,
+      coordinates: List[TestEvent.Coordinate],
+      concurrency: Int,
+      operations:  Long,
+      nanoseconds: Long,
+      allocation:  Long,
+      peakHeap:    Long,
+      retained:    Long,
+      gcCount:     Long,
+      gcTime:      Long,
+      p50:         Optional[Long],
+      p90:         Optional[Long],
+      p99:         Optional[Long],
+      p999:        Optional[Long],
+      compliance:  Optional[Double],
+      sustained:   Boolean,
+      timestamp:   Long )
+
+  case HotspotsRecorded
+    ( test:        TestEvent.Ref,
+      coordinates: List[TestEvent.Coordinate],
+      total:       Long,
+      frames:      List[TestEvent.Frame],
+      timestamp:   Long )
+
+  case AnchorRecorded
+    ( test:     TestEvent.Ref,
+      axis:     Text,
+      discrete: Optional[Text],
+      integral: Optional[Long],
+      decimal:  Optional[Double],
+      compare:  Text,
+      metric:   Text,
+      mode:     Text )
+
+  case NothingMatched(admitted: Int)
+  case RunTerminated(error: TestEvent.Trace, active: List[TestEvent.Ref], timestamp: Long)
+  case RunCompleted(passed: Boolean, timestamp: Long)

--- a/lib/probably/src/events/probably.Streamer.scala
+++ b/lib/probably/src/events/probably.Streamer.scala
@@ -93,6 +93,14 @@ object Streamer:
 
   private def encode(event: TestEvent): Data = unsafely(event.tel.bintel(schema))
 
+  // The decode inverse, offered here for hosts whose own modules ARE separation-checked: the
+  // derived decoder's inline expansion is not sep-clean (like the rest of the derivation
+  // machinery), so it lives in this non-sep module, expanded exactly once. Decode failures
+  // throw; a host wraps calls in `safely`.
+  def read(data: Data): TestEvent =
+    import strategies.throwUnsafely
+    unsafely(Bintel.read[TestEvent](data))
+
   // One frame: a 4-byte big-endian length prefix, then the payload, flushed so the host's
   // chunk stream sees it promptly.
   private def frame(output: ji.OutputStream, payload: Data): Unit =

--- a/lib/probably/src/events/probably.Streamer.scala
+++ b/lib/probably/src/events/probably.Streamer.scala
@@ -1,0 +1,136 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package probably
+
+import java.io as ji
+
+import anticipation.*
+import contingency.*
+import gastronomy.*
+import gossamer.*
+import rudiments.*
+import stratiform.*
+import ulysses.*
+import vacuous.*
+
+// Writes a test run's `TestEvent`s as length-prefixed BinTEL frames to a host's
+// `ji.OutputStream` — the single JDK-typed surface, because the host (a test-running tool such
+// as fume) may call `stream` reflectively from ANOTHER CLASSLOADER WORLD, whose Soundness
+// classes are not this one's. The first frame is a schema FINGERPRINT: both ends derive the
+// BinTEL schema from their own `TestEvent` and compare fingerprints, so a version skew that
+// changes the wire layout is detected before any event is decoded, rather than surfacing as a
+// baffling decode failure.
+object Streamer:
+  // The derived BinTEL schema for `TestEvent`, computed once; every event encodes under it.
+  private lazy val schema: Tels = Tels.tels[TestEvent](t"test-event")
+
+  // A canonical structural rendering of the derived schema — name, document structure, and
+  // select definitions with their variants, in declaration order — hashed with BLAKE3. This is
+  // a fingerprint of the WIRE LAYOUT: two Soundness versions whose `TestEvent`s differ in any
+  // field, order or case produce different fingerprints.
+  lazy val fingerprint: Data =
+    def renderType(kind: Tels.Type): Text = kind match
+      case Tels.Struct(members, _) =>
+        val rendered = members.to[List].map { (member: Tels.Member) => renderMember(member) }
+        t"{${rendered.join(t";")}}"
+
+      case Tels.Scalar(_, encoding, _) => t"scalar(${encoding.or(t"")})"
+      case Tels.Flag                   => t"flag"
+      case Tels.Reference(name)        => t"ref($name)"
+
+    def renderMember(member: Tels.Member): Text = member match
+      case Tels.Field(required, repeatable, keyword, fieldType, _, _, _) =>
+        t"$keyword:${required.toString}:${repeatable.toString}:${renderType(fieldType)}"
+
+      case Tels.SelectRef(required, repeatable, reference) =>
+        t"select:$reference:${required.toString}:${repeatable.toString}"
+
+      case Tels.Exclude(keyword) =>
+        t"exclude:$keyword"
+
+    def renderSelect(select: Tels.SelectDefinition): Text =
+      val variants =
+        select.variants.to[List].map: (variant: Tels.Variant) =>
+          t"${variant.keyword}=${renderType(variant.variantType)}"
+
+      t"${select.name}[${variants.join(t",")}]"
+
+    val selects =
+      schema.selects.to[List].map { (select: Tels.SelectDefinition) => renderSelect(select) }
+    val rendering: Text = t"${schema.name}|${renderType(schema.document)}|${selects.join(t"|")}"
+
+    Blake3.hashOf(rendering.sysData, 32)
+
+  private def encode(event: TestEvent): Data = unsafely(event.tel.bintel(schema))
+
+  // One frame: a 4-byte big-endian length prefix, then the payload, flushed so the host's
+  // chunk stream sees it promptly.
+  private def frame(output: ji.OutputStream, payload: Data): Unit =
+    val length: Int = payload.length
+
+    val header: Data =
+      Array[Byte]
+        ( ((length >> 24) & 0xff).toByte,
+          ((length >> 16) & 0xff).toByte,
+          ((length >> 8) & 0xff).toByte,
+          (length & 0xff).toByte )
+
+    output.write(header.mutable(using Unsafe))
+    output.write(payload.mutable(using Unsafe))
+    output.flush()
+
+  // Runs the named suite (a `probably.Suite` object, loaded from THIS classloader — the
+  // suite's own world, where `Suite` is nameable) with the given selection arguments
+  // (newline-separated, as `Suite#invoke`), writing the fingerprint frame and then one frame
+  // per event. Returns the suite's exit status (0 = passed, 1 = failures, 2 = the suite or the
+  // machinery threw). Erases to `stream(String, String, OutputStream): int`, so a host in
+  // another classloader world can call it through a structural type with JDK types alone.
+  def stream(suite: Text, arguments: Text, output: ji.OutputStream): Int =
+    val writer: Mutex = Mutex()
+    def send(payload: Data): Unit = writer(frame(output, payload))
+
+    val status: Int =
+      safely:
+        send(fingerprint)
+
+        val moduleClass = Class.forName(suite.s + "$", true, getClass.getClassLoader).nn
+        val instance = moduleClass.getField("MODULE$").nn.get(null).nn
+
+        instance.absolve match
+          case suite: Suite =>
+            suite.invoke(arguments, { (event: TestEvent) => send(encode(event)) })
+
+      . or(2)
+
+    safely(output.close())
+    status

--- a/lib/probably/src/events/soundness_probably_events.scala
+++ b/lib/probably/src/events/soundness_probably_events.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export probably.Streamer

--- a/lib/ultimatum/src/core/soundness_ultimatum_core.scala
+++ b/lib/ultimatum/src/core/soundness_ultimatum_core.scala
@@ -37,7 +37,7 @@ export
   . { Arrangement, BorderStyle, dirtyCells, editor, EditorField, Extent, Fixture, FlowExtent,
       conduct, Focus, Form, Frame, grid, InlineAnchoring, InlineGrowth, InlineRoot, InlineShrink,
       layout, Limits, menu, MenuField, Occupancy, paint, Pane, Panes, panel, Placement, Rect,
-      ScreenRoot, Sizing, stack, strip, Tick }
+      ScreenRoot, scrolling, ScrollFixture, Sizing, stack, strip, Tick }
 
 package inlineAnchoring:
   export

--- a/lib/ultimatum/src/core/ultimatum.ScrollFixture.scala
+++ b/lib/ultimatum/src/core/ultimatum.ScrollFixture.scala
@@ -1,0 +1,159 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import scala.caps
+
+import anticipation.*
+import clavichord.*
+import denominative.*
+import escapade.*
+import gossamer.*
+import profanity.*
+import rudiments.*
+import vacuous.*
+
+object ScrollFixture:
+  // The supplier genuinely captures the caller's data source and escapes into the
+  // long-lived fixture, exactly as `TableFixture.apply`'s content thunk does — sound for
+  // the same reason (it is only invoked from `render` while the host is live), hence the
+  // single, localised `unsafeAssumePure`.
+  def apply
+    ( track: Text = BorderStyle.light.vertical,
+      thumb: Text = BorderStyle.heavy.vertical )
+    ( content: => scala.List[Teletype] )
+  :   ScrollFixture =
+
+    new ScrollFixture(caps.unsafe.unsafeAssumePure { () => content }, track, thumb)
+
+// A VIEWPORT over content taller than the space offered to render it: the fixture holds
+// the scroll position, shows the window of the content that position selects, and draws a
+// scrollbar in its rightmost column — a track of `track` glyphs with a `thumb` whose height
+// is proportional to the visible fraction of the content, positioned proportionally to the
+// scroll offset. When the content fits, no scrollbar is drawn and the full width is used.
+//
+// The position is either DOCKED TO THE BOTTOM (the initial state), where the viewport
+// tracks the end of the content as it grows — a live log follows its tail — or an explicit
+// offset, which holds still while content is appended. Scrolling down to the bottom
+// re-docks. Under a `form`, the Up and Down keys scroll when the fixture is focused; a
+// `paint`-driven host calls `scroll` directly.
+class ScrollFixture(content: () -> scala.List[Teletype], track: Text, thumb: Text)
+extends Focus:
+
+  // A no-op until the fixture is bound into a running form; see `bindWake`.
+  @scala.caps.unsafe.untrackedCaptures
+  private var wakeForm: () -> Unit = () => ()
+
+  // `Unset` = docked to the bottom, tracking growth.
+  @scala.caps.unsafe.untrackedCaptures
+  private var offset0: Optional[Int] = Unset
+
+  // The content length and viewport height most recently rendered, for clamping scroll
+  // requests that arrive between paints.
+  @scala.caps.unsafe.untrackedCaptures
+  private var lastLength: Int = 0
+  @scala.caps.unsafe.untrackedCaptures
+  private var lastViewport: Int = 0
+
+  // As in `TableFixture.bindWake`: the callback captures the running form's event loop and
+  // escapes into this longer-lived fixture, re-bound on every run.
+  override private[ultimatum] def bindWake(wake: () => Unit): Unit =
+    wakeForm = caps.unsafe.unsafeAssumePure(wake)
+
+  def refresh(): Unit = wakeForm()
+
+  def atBottom: Boolean = offset0.absent
+
+  def toBottom(): Unit =
+    offset0 = Unset
+    wakeForm()
+
+  // Moves the viewport by `delta` lines (negative = up). Scrolling up from the docked
+  // state materializes the current bottom offset first; reaching the bottom re-docks, so
+  // subsequent growth is tracked again.
+  def scroll(delta: Int): Unit =
+    val limit = (lastLength - lastViewport).max(0)
+    val next = (offset0.or(limit) + delta).min(limit).max(0)
+    offset0 = if next >= limit then Unset else next
+    wakeForm()
+
+  def handle(event: Terminal.Event): Unit = event match
+    case Keypress.Up   => scroll(-1)
+    case Keypress.Down => scroll(1)
+    case _             => ()
+
+  // The pane's `Sizing` distributes the height; the fixture claims no intrinsic size of
+  // its own — whatever rect it receives becomes the viewport.
+  def measure(width: Int): (Int, Int) = (0, 1)
+
+  def render(canvas: Board^, focused: Boolean): Unit =
+    val lines: scala.List[Teletype] = content()
+    val length: Int = lines.length
+    val viewport: Int = canvas.height
+    lastLength = length
+    lastViewport = viewport
+
+    val fits: Boolean = length <= viewport
+    val limit: Int = (length - viewport).max(0)
+
+    // Clamped at render: the content may have shrunk since the offset was chosen.
+    val offset: Int = offset0.lay(limit)(_.min(limit).max(0))
+
+    // The rightmost column belongs to the scrollbar whenever one is needed; content is
+    // clipped to the remaining width so a long line can never wrap into it. (`keep` counts
+    // characters rather than display cells, so a wide glyph at the edge may spill one cell;
+    // the bar is drawn afterwards, so its own column always wins.)
+    val width: Int = if fits then canvas.width else canvas.width - 1
+
+    canvas.clear()
+
+    var row: Int = 0
+
+    lines.drop(offset).foreach: line =>
+      if row < viewport then
+        canvas.move(Prim, row.z)
+        canvas.put(line.keep(width))
+        row += 1
+
+    if !fits then
+      val thumbHeight: Int = ((viewport*viewport + length - 1)/length).max(1).min(viewport)
+
+      val thumbTop: Int =
+        if limit == 0 then 0 else ((viewport - thumbHeight)*offset + limit/2)/limit
+
+      var bar: Int = 0
+
+      while bar < viewport do
+        canvas.move((canvas.width - 1).z, bar.z)
+        canvas.put(if bar >= thumbTop && bar < thumbTop + thumbHeight then thumb else track)
+        bar += 1

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -86,6 +86,10 @@ def menu[item: Showable]
 
 // A split whose children sit side by side as columns (distributing width): a
 // strip of panes across the terminal, on the `File` axis.
+// A scrolling viewport pane. Takes the FIXTURE rather than its content: the caller keeps
+// the handle to drive `scroll`/`toBottom` (a form focuses it for Up/Down instead).
+def scrolling(fixture: ScrollFixture): Pane = Pane.Widget(Sizing(), fixture)
+
 def strip(panes: Pane*): Pane = Pane.Branch(Sizing(), Arrangement.Strip, Panes(panes*))
 
 // A column split over a live container, whose children can change while running.


### PR DESCRIPTION
Follows #1873 (in-process suite invocation, now merged). Twelve commits in three strands, all driven by building fume's live reporting on the event stream.

## Probably: a typed event stream

Probably becomes usable as a low-level runner emitting typed `TestEvent`s, with all rendering left to the consumer:

- **`TestEvent`**: a wire-safe event model — one root enum whose payloads are flat case classes of scalars/`Optional`/`List`/`Map`, so the whole enum derives a BinTEL schema with no hand-written instances. Stack traces flatten to cause-chain lists, `Juxtaposition` to depth-indexed rows, metrics to labelled values; `Message` renders to `Text` at the boundary.
- **Emission** happens inside the existing `Report` path behind an optional pure sink (no sink ⇒ byte-identical behaviour), with progress brackets from new defaulted `Reporter` hooks.
- **`Suite#invoke(Text, sink)`** runs a suite with an event sink and no rendering; a `--list` selection emits one `TestScheduled` per admitted test — the run's schedule with real `Ref`s (the legacy text format's slash-joined path cannot be split unambiguously).
- **`probably.events`** (new component, in the test bundle and shipped with every test and benchmark assembly): `Streamer` writes the events as length-prefixed BinTEL frames to a host-supplied `OutputStream`, preceded by a BLAKE3 fingerprint of the derived schema, so version skew is detected before anything is decoded. The host calls it reflectively across an isolating classloader boundary through a JDK-typed structural signature.

## Fixes found along the way

- **hellenism**: the child-first delegating classloader now consults `findLoadedClass` under the per-name loading lock, as the `ClassLoader` contract requires — concurrent test workers previously died with duplicate-class `LinkageError`s.
- **probably**: `suiteIo` survives a nulled `System.out` (superlunary's `Executor` nulls it to protect its protocol stream; suite objects initialised by staged benchmark expressions panicked, breaking every staged benchmark — including under `mill …bench.run`).
- **`HotspotsRecorded`** carries per-frame sample counts via a dedicated `Hotspot` mirror (they were being discarded).
- **build**: `Benchmarks` modules compile with the beneficence plugin (so their assemblies carry the `META-INF/services/probably.Suite` index) and ship `probably.events`.
- **corpuscular**: its suite now names `corpuscular.Crc32` explicitly. `probably.events` joins every `Tests` module's dependencies ahead of the module's own, which puts gastronomy (via stratiform) earlier on corpuscular's test classpath; both libraries export a toplevel `Crc32` into `soundness` — corpuscular's checksum object, gastronomy's algorithm marker — and the umbrella keeps one, by classpath order. A package member from another file loses to a wildcard import, so `import soundness.*` was silently deciding which `Crc32` the suite tested. (The umbrella collision itself is untouched here and tracked separately.)

## Escritoire and Ultimatum features

- **Escritoire per-cell decoration**: `Column` gains `decorate: row -> Optional[text -> text]`, applied by `Grid.render` to the whole rendered cell — gutter padding moved from the shared edge separators into the cells (line widths unchanged, rule arithmetic untouched), so a Teletype decorator like `line => e"${Bg(c)}($line)"` gives a full-width cell background with inner styles preserved. Escritoire stays generic over `text`.
- **Ultimatum `ScrollFixture`**: a `Focus` viewport over content taller than its rect — docked-to-bottom tracks growth, a held offset survives appended content, a proportional box-drawing scrollbar occupies the rightmost column, Up/Down scroll under a form, and a `paint`-driven host drives `scroll()` directly via the new `scrolling` pane constructor.

Fume exercises the whole stack end-to-end: pre-scheduled tables filling in live, winner-row highlighting, a scrolling fullscreen board with a run-progress bar, and graceful fallback (legacy in-process, then forked JVM) for suites predating any of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
