### PR TITLE
Stratiform: offset-to-node lookup for tracked documents (#1463)

### DIFF
--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -2288,6 +2288,84 @@ object Tel extends Tel2:
         val child = offset + data.readUnchecked(offset + descriptorHeader + ordinal.n0)
         walkIndex(children.readUnchecked(ordinal.n0), data, child, segments, i + 1, keyMode)
 
+  // The result of `tel.enclosing(line, column)` (#1463): the innermost compound
+  // whose extent contains the coordinate, as the keyword path that reaches it
+  // and the source region to highlight — the inline-atom run when the
+  // coordinate falls within it, the keyword otherwise (the same two regions
+  // `locate` and `locateKey` name).
+  case class Enclosure(path: Telp, position: Tel.Error.Position) derives CanEqual
+
+  // The reverse of `walkIndex` (#1463): resolve a 1-indexed source coordinate
+  // to the innermost compound enclosing it. Descriptors are laid out in
+  // pre-order and TEL is line-ordered, so extents need not be stored and no
+  // inverted index is built: a compound's extent runs from its own line to the
+  // line before the next pre-order descriptor, the children's extents tile the
+  // parent's body, and the descent binary-searches the children at each level.
+  //
+  // Two attributions follow deliberately from that tiling. Blank, remark-only
+  // and payload lines carry no descriptors, so they belong to the nearest
+  // *preceding* compound's subtree — which places a source or literal payload
+  // under its owning compound, and the gap between two siblings under the
+  // earlier sibling. And a coordinate before the first top-level compound (or
+  // in an empty document) encloses only the document root, which is not a
+  // compound, so the result is `Unset` — as for `locateKey` at the root.
+  private def enclosingIn
+    ( node:   Tel.Subtree,
+      data:   Array[Int]^{},
+      offset: Int,
+      line:   Int,
+      column: Int,
+      path:   scala.List[Text] )
+  :   Optional[Tel.Enclosure] =
+
+    val children = node.children.bind(_.compounds)
+
+    def childOffset(k: Int): Int = offset + data.readUnchecked(offset + descriptorHeader + k)
+    def lineOf(k: Int): Int = data.readUnchecked(childOffset(k) + 1)
+    def columnOf(k: Int): Int = data.readUnchecked(childOffset(k) + 2)
+
+    // The last child starting on or before the coordinate's line; child lines
+    // ascend in document order, so a binary search finds it.
+    var low = 0
+    var high = children.length - 1
+    var found = -1
+
+    while low <= high do
+      val mid = (low + high) >>> 1
+      if lineOf(mid) <= line then { found = mid; low = mid + 1 } else high = mid - 1
+
+    // Children sharing the coordinate's own line (possible only where the
+    // grammar admits same-line siblings): prefer the last whose keyword starts
+    // at or before the column, and give the line's leading indentation to the
+    // first of them rather than to the preceding subtree.
+    while found > 0 && lineOf(found) == line && lineOf(found - 1) == line
+          && columnOf(found) > column
+    do found -= 1
+
+    if found < 0 then
+      if path.isEmpty then Unset else
+        val keyLine     = data.readUnchecked(offset + 1)
+        val valueColumn = data.readUnchecked(offset + 4)
+        val valueLength = data.readUnchecked(offset + 5)
+
+        val position =
+          if valueColumn != 0 && line == keyLine
+              && column >= valueColumn && column < valueColumn + valueLength
+          then Tel.Error.Position(keyLine, valueColumn, length = Optional(valueLength))
+          else Tel.Error.Position
+                ( keyLine,
+                  data.readUnchecked(offset + 2),
+                  length = Optional(data.readUnchecked(offset + 3)) )
+
+        Tel.Enclosure(Telp(List.from(path.reverse)), position)
+    else
+      val child = children.readUnchecked(found)
+      enclosingIn(child, data, childOffset(found), line, column, child.keyword :: path)
+
+  private[stratiform] def enclosingAt(tel: Tel, line: Int, column: Int): Optional[Tel.Enclosure] =
+    tel.positionIndex.let: index =>
+      enclosingIn(tel.subtree, index.ints, 0, line, column, scala.Nil)
+
   // Concatenate the chunks of a `Chain[Data]` source into a single byte array.
   private[stratiform] def concatenate(source: Chain[Data]): Data =
     import denominative.nil
@@ -6951,6 +7029,14 @@ extends scala.Dynamic, Documentary, Topical, Original:
     val result = value.decoded(this)
     Tel.supplementPositions(this)
     result
+
+  // The offset-to-node lookup (#1463), the reverse of `locate`/`locateKey`: the
+  // innermost compound enclosing the 1-indexed source coordinate, with the
+  // keyword path that reaches it. Requires a document parsed under
+  // `parsing.trackPositions` (hence carrying a `positionIndex`); otherwise, and
+  // for a coordinate enclosed only by the document root, yields `Unset`.
+  def enclosing(line: Int, column: Int): Optional[Tel.Enclosure] =
+    Tel.enclosingAt(this, line, column)
 
   // Total field access used by the schema-typed navigation macros and by
   // internal optics: an empty `Tel` for a missing field, never raising.

--- a/lib/stratiform/src/test/stratiform.PositionTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionTests.scala
@@ -197,3 +197,56 @@ object PositionTests extends Suite(m"Stratiform position-index tests"):
       test(m"a position's span carries its length"):
         at(2, 8, 3).span.length
       . assert(_ == 3)
+
+    // `enclosing` is the reverse lookup (#1463): a 1-indexed source coordinate
+    // to the innermost compound containing it, with the keyword path that
+    // reaches it. The highlighted region follows the coordinate: the
+    // inline-atom run when the cursor is inside it, the keyword otherwise.
+    suite(m"Enclosing-node lookup"):
+      def enclosure(path: List[Text], position: Tel.Position): Tel.Enclosure =
+        Tel.Enclosure(Telp(path), position)
+
+      test(m"A coordinate on a top-level keyword encloses that compound"):
+        t"person\n  name Alice\n  age 30\n".read[Tel].enclosing(1, 2)
+      . assert(_ == enclosure(List(t"person"), at(1, 1, 6)))
+
+      test(m"A coordinate on a child's keyword encloses the child"):
+        t"person\n  name Alice\n  age 30\n".read[Tel].enclosing(2, 4)
+      . assert(_ == enclosure(List(t"person", t"name"), at(2, 3, 4)))
+
+      test(m"A coordinate inside the inline-atom run names the value region"):
+        t"person\n  name Alice\n  age 30\n".read[Tel].enclosing(2, 9)
+      . assert(_ == enclosure(List(t"person", t"name"), at(2, 8, 5)))
+
+      test(m"A coordinate in a child line's indentation encloses that child"):
+        t"person\n  name Alice\n".read[Tel].enclosing(2, 1)
+      . assert(_ == enclosure(List(t"person", t"name"), at(2, 3, 4)))
+
+      test(m"A coordinate on a later sibling encloses it, not the first"):
+        t"person\n  name Alice\n  age 30\n".read[Tel].enclosing(3, 5)
+      . assert(_ == enclosure(List(t"person", t"age"), at(3, 3, 3)))
+
+      test(m"A grandchild coordinate builds the full keyword path"):
+        t"a\n  b\n    c hello\n".read[Tel].enclosing(3, 5)
+      . assert(_ == enclosure(List(t"a", t"b", t"c"), at(3, 5, 1)))
+
+      test(m"A second top-level compound bounds its predecessor's extent"):
+        t"first\n  child x\nsecond y\n".read[Tel].enclosing(3, 1)
+      . assert(_ == enclosure(List(t"second"), at(3, 1, 6)))
+
+      test(m"A blank line between siblings belongs to the preceding subtree"):
+        t"first a\n\nsecond b\n".read[Tel].enclosing(2, 1)
+      . assert(_ == enclosure(List(t"first"), at(1, 1, 5)))
+
+      test(m"A coordinate after the last compound encloses its deepest node"):
+        t"a\n  b c\n".read[Tel].enclosing(3, 1)
+      . assert(_ == enclosure(List(t"a", t"b"), at(2, 3, 1)))
+
+      test(m"A coordinate enclosed only by the document root yields Unset"):
+        t"\nfirst a\n".read[Tel].enclosing(1, 1)
+      . assert(_ == Unset)
+
+      test(m"An untracked document yields Unset"):
+        given PositionTracking = PositionTracking.Off
+        t"greeting hello\n".read[Tel].enclosing(1, 1)
+      . assert(_ == Unset)


### PR DESCRIPTION
Stratiform's position tracking gains its reverse direction (#1463): where `tel.locate(path)` maps a node to its source span, `tel.enclosing(line, column)` now maps a source coordinate back to the innermost compound containing it — the lookup that go-to-definition, hover and references need. No inverted index is built or held: descriptors in the packed `PositionIndex` are laid out in pre-order and TEL is line-ordered, so child extents tile each node's body and a binary-search descent answers the query directly.

For a document parsed under `import parsing.trackPositions`, `enclosing` takes a 1-indexed line and column — the coordinates LSP itself supplies — and returns a `Tel.Enclosure`: the keyword path (`Telp`) reaching the innermost enclosing compound, and the source region to highlight. The region follows the cursor, mirroring the `locate`/`locateKey` distinction: the inline-atom run when the coordinate falls inside it, the keyword otherwise.

```scala
import soundness.*
import parsing.trackPositions

val tel = t"person\n  name Alice\n".read[Tel]
tel.enclosing(2, 9)  // Tel.Enclosure(/person/name, value run at line 2, column 8)
tel.enclosing(2, 4)  // Tel.Enclosure(/person/name, keyword at line 2, column 3)
```

Blank, remark and payload lines carry no descriptors, so they resolve to the nearest preceding compound's subtree — which places a source or literal payload under its owning compound. A coordinate enclosed only by the document root, or any lookup on an untracked document, yields `Unset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)