### PR TITLE
Give every soundness type a native Inspectable rendering

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2912,7 +2912,13 @@ object sibylline extends Library:
       settings.sep(super.scalacOptions())
 
 object spectacular extends Library:
-  object core extends Component(stenography.core, wisteria.core):
+  // `hypotenuse.core` is a dependency so that the `Inspectable` instances for the sized numeric
+  // types (`U8`…`U64`, `S8`…`S64`, `B8`…`B64`, `F32`/`F64`) can live in the `Inspectable`
+  // companion, and so resolve with no import: neither library's companions can see the other's
+  // types otherwise, and an orphan component would make every debug rendering of a sized number
+  // depend on remembering an import. The closure grows by `hypotenuse.core` and
+  // `anticipation.opaque` only, and nothing at or below hypotenuse depends on spectacular.
+  object core extends Component(stenography.core, wisteria.core, hypotenuse.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object test extends Tests(core):

--- a/build.mill
+++ b/build.mill
@@ -2085,7 +2085,11 @@ object geodesy extends Library:
   // `hypotenuse` (π and floor-mod) and `symbolism` (the operator typeclasses), while `core` sits
   // on the text stack for rendering and geohashing. Modules below that stack — `iridescence`,
   // whose hue is an angle — depend on this component alone.
-  object angle extends Component(hypotenuse.core):
+  // `spectacular.core` is a dependency so that `Angle`'s `Inspectable` can live in its
+  // companion. As a top-level given it had to be imported by name at every use site, and a
+  // library which forgot — savagery, rendering a rotation — silently got `“0.0”` instead of an
+  // angle. Inspection is the one rendering which must never depend on remembering an import.
+  object angle extends Component(hypotenuse.core, spectacular.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object core extends Component(distillate.core, angle, gossamer.core):

--- a/lib/abacist/src/core/abacist.protointernal.scala
+++ b/lib/abacist/src/core/abacist.protointernal.scala
@@ -128,6 +128,24 @@ object protointernal extends anteprotointernal:
         val nonzeroComponents = count.components.stdlib.filter(_(1) != 0)
         nonzeroComponents.map { (unit, count) => count.toString+unit }.mkString(" ").tt
 
+    // The components of a `Quanta` are recovered by a macro reading its type, so inspection has to
+    // be inline too — and therefore comes as the same pair as `showable`, with structured `Self`
+    // types: a `quanta <: Quanta[base]` bound in an inline given maximises `base` to `Any`, and
+    // `Quanta` is invariant, so such a given would never match. Every component is written out,
+    // including the zeroes the `Showable` drops, and the units are the type's own designations, so
+    // that a packed `Long` is never rendered as a bare number.
+    inline def inspectQuanta[base <: AnyUnit, quanta <: Quanta[base]]: quanta is Inspectable =
+      count =>
+        val components = count.components.stdlib
+        components.map { pair => pair(1).toString+pair(0) }.mkString("Quanta(", " ", ")").tt
+
+    inline given inspectable: [base <: AnyUnit, form <: Divisions]
+    =>  (Quanta[base] in form) is Inspectable =
+      inspectQuanta[base, Quanta[base] in form]
+
+    inline given inspectableBare: [base <: AnyUnit] => Quanta[base] is Inspectable =
+      inspectQuanta[base, Quanta[base]]
+
     inline given showable: [base <: AnyUnit, form <: Divisions]
     =>  (Quanta[base] in form) is Showable =
       showQuanta[base, Quanta[base] in form]

--- a/lib/abacist/src/test/abacist_test.scala
+++ b/lib/abacist/src/test/abacist_test.scala
@@ -213,3 +213,14 @@ object Tests extends Suite(m"Abacist Tests"):
         test(m"Mean of several values"):
           List(Quanta(10): Weight, Quanta(1, 6), Quanta(2, 4, 1)).mean
         . assert(_ == (Quanta(11, 6): Weight))
+
+    suite(m"Native-rendering coverage"):
+      type Weight = Quanta[Ounces[1]] in (Pounds[1], Stones[1])
+
+      test(m"abacist's types inspect natively"):
+        Inspectable.fallbacks((Quanta(1, 3, 2): Weight).inspect, (Quanta(9): TimeSeconds).inspect)
+      . assert(_ == Nil)
+
+      test(m"a quanta shows every component, including zeroes"):
+        (Quanta(3, 2): Weight).inspect
+      . assert(_ == t"Quanta(0st 3lb 2oz)")

--- a/lib/archimedes/src/core/archimedes.Cell.scala
+++ b/lib/archimedes/src/core/archimedes.Cell.scala
@@ -41,8 +41,9 @@ import hieroglyph.Measurable
 import hieroglyph.textMetrics.wideCharacterWidthMetric
 import denominative.*
 import rudiments.*
-import vacuous.*
+import spectacular.*
 import symbolism.*
+import vacuous.*
 
 import Mathml.*
 import denominative.dysasymptotics.linearSize
@@ -82,6 +83,14 @@ object Cell:
   // The text of `cell`'s row, or a full-width blank when the row is out of bounds.
   private def slice(cell: Cell, row: Int): Text =
     cell.lines(row.z).let(_.text).or(spaces(cell.width).text)
+
+  // `render` lays the block out as it will appear — several lines of monospaced text — which an
+  // inspection cannot be. The dimensions and the baseline row (the state which composition depends
+  // on, and which `render` shows only implicitly) are written first, then each line as a text
+  // literal, so that trailing padding spaces are visible.
+  given inspectable: [cell <: Cell] => cell is Inspectable = cell =>
+    val lines = cell.lines.stdlib.map(_.text.inspect).mkString(" ").tt
+    t"Cell(${cell.width}×${cell.height}@${cell.baseline} $lines)"
 
   val empty: Cell = Cell(Sequence(Writing.empty), 0, 0)
 

--- a/lib/archimedes/src/core/archimedes.Math.scala
+++ b/lib/archimedes/src/core/archimedes.Math.scala
@@ -108,6 +108,23 @@ object Math:
 
   def apply(children: Mathml*): Math = Math(children.to(List))
 
+  // Only a `Document[Math]` has a `Showable`, and it produces multi-line serialized MathML with an
+  // XML header. Inspection instead writes the node tree in a bracketed prefix form — each node as
+  // its MathML element name, its attributes, then its character data or its children — which is
+  // the structure a parse or layout bug is read from, on one line.
+  private def node(mathml: Mathml): Text =
+    val attributes = mathml.attributes.map { pair => t" ${pair(0)}=${pair(1).inspect}" }.join
+    val children = mathml.contents.map { child => t" ${node(child)}" }.join
+    val body = mathml.text.let { text => t" ${text.inspect}" }.or(children)
+
+    t"⟨${mathml.label}$attributes$body⟩"
+
+  given inspectable: [math <: Math] => math is Inspectable = math =>
+    val attributes = math.attributes.map { pair => t" ${pair(0)}=${pair(1).inspect}" }.join
+    val children = math.contents.map { child => t" ${node(child)}" }.join
+
+    t"Math(${math.display.inspect}$attributes$children)"
+
   // `Encodable in Math` instances: any value encodes to a `<math>` document, just
   // as `Encodable in Xml` yields an `Xml`. `Mathml.atom` collapses a root back to a
   // single node where one is needed (the `.mathml` extension, the `ergo""` macro).

--- a/lib/archimedes/src/core/archimedes.Math.scala
+++ b/lib/archimedes/src/core/archimedes.Math.scala
@@ -119,11 +119,18 @@ object Math:
 
     t"⟨${mathml.label}$attributes$body⟩"
 
+  // Renders an `Optional` exactly as `Inspectable.derived`'s `Mandatable` case would, spelt out
+  // rather than summoned: that instance cannot be constructed under `-scalajs`, where the SAM is
+  // expanded to an anonymous class whose parameter acquires a capture variable that `Self` does
+  // not carry (soundness#1892, proscala#46). Inline this again once the fork accepts it.
+  private def optional[value: Inspectable](value: Optional[value]): Text =
+    value.let { present => t"｢${present.inspect}｣" }.or(t"○")
+
   given inspectable: [math <: Math] => math is Inspectable = math =>
     val attributes = math.attributes.map { pair => t" ${pair(0)}=${pair(1).inspect}" }.join
     val children = math.contents.map { child => t" ${node(child)}" }.join
 
-    t"Math(${math.display.inspect}$attributes$children)"
+    t"Math(${optional(math.display)}$attributes$children)"
 
   // `Encodable in Math` instances: any value encodes to a `<math>` document, just
   // as `Encodable in Xml` yields an `Xml`. `Mathml.atom` collapses a root back to a

--- a/lib/archimedes/src/test/archimedes_test.scala
+++ b/lib/archimedes/src/test/archimedes_test.scala
@@ -460,3 +460,19 @@ object Tests extends Suite(m"Archimedes tests"):
           ergo"x + y"
         . map(_.focus)
       . assert(_ == List("x"))
+
+    suite(m"Native-rendering coverage"):
+      test(m"archimedes' types inspect natively"):
+        Inspectable.fallbacks
+         ( Math(Mfrac(Mn(t"1"), Mn(t"2"))).inspect,
+           Cell.of(Msup(Mi(t"x"), Mn(t"2"))).inspect )
+
+      . assert(_ == Nil)
+
+      test(m"a math value inspects as its node tree"):
+        Math(Mn(t"2")).inspect
+      . assert(_ == t"""Math(○ ⟨mn t"2"⟩)""")
+
+      test(m"a cell inspects with its dimensions and lines"):
+        Cell.line(t"xy").inspect
+      . assert(_ == t"""Cell(2×1@0 t"xy")""")

--- a/lib/aviation/src/core/aviation.Recurrence.scala
+++ b/lib/aviation/src/core/aviation.Recurrence.scala
@@ -72,6 +72,18 @@ object Recurrence:
       val period: Timespan = recurrence.period
       t"R$number/${recurrence.start.encode}/${period.encode}"
 
+  // The ISO 8601 repeating-interval form, as `encodable` produces, but built from the point's and
+  // the period's own inspections rather than their encodings — so it is available for any point
+  // type which can be inspected, and asks for none of the `Locale` context the `Showable`s do.
+  given inspectable
+  :   [ point: Inspectable, span <: Timespan, recurrence <: (Recurrence of point by span) ]
+  =>  recurrence is Inspectable =
+
+    recurrence =>
+      val number = recurrence.repetitions.lay(t""): repetitions => repetitions.show
+      val period: Timespan = recurrence.period
+      t"R$number/${recurrence.start.inspect}/${period.inspect}"
+
   // A natural-language description, e.g. "every 2 weeks, 5 times from <start>". `.encode` is the
   // ISO wire form; `.show` is for people. Each language is a `Vernacular`, gated on its `Locale`.
   given englishShowable: [point: Showable, span <: Timespan] => Locale[en]

--- a/lib/aviation/src/core/aviation.Rrule.scala
+++ b/lib/aviation/src/core/aviation.Rrule.scala
@@ -121,6 +121,35 @@ object Rrule:
 
     parts.join(t";")
 
+  // The RFC 5545 rule text, with the `DTSTART` which the wire form deliberately leaves out written
+  // in front of it — a rule and its start are one value here. Unlike `encodable` this asks only
+  // for an `Inspectable` point (an `UNTIL` bound is a point too), and unlike the `Showable`s it
+  // needs no `Locale`, `Months` or `Weekdays`, so it is available wherever the rule is.
+  given inspectable: [point: Inspectable, rrule <: Rrule[point]] => rrule is Inspectable = rule =>
+    def part(condition: Boolean, text: => Text): List[Text] =
+      if condition then List(text) else List()
+
+    def partOf[value](optional: Optional[value])(text: value => Text): List[Text] =
+      optional.lay(List())(value => List(text(value)))
+
+    val parts =
+      part(true, t"FREQ=${rule.frequency.toString.tt.upper}") +
+        part(rule.interval != 1, t"INTERVAL=${rule.interval}") +
+        partOf(rule.count) { count => t"COUNT=$count" } +
+        partOf(rule.until) { until => t"UNTIL=${until.inspect}" } +
+        part(!rule.byMonth.nil, t"BYMONTH=${rule.byMonth.map(_.numerical.show).join(t",")}") +
+        part(!rule.byWeekNo.nil, t"BYWEEKNO=${rule.byWeekNo.map(_.show).join(t",")}") +
+        part(!rule.byYearDay.nil, t"BYYEARDAY=${rule.byYearDay.map(_.show).join(t",")}") +
+        part(!rule.byMonthDay.nil, t"BYMONTHDAY=${rule.byMonthDay.map(_.show).join(t",")}") +
+        part(!rule.byDay.nil, t"BYDAY=${rule.byDay.map(renderDay).join(t",")}") +
+        part(!rule.byHour.nil, t"BYHOUR=${rule.byHour.map(_.show).join(t",")}") +
+        part(!rule.byMinute.nil, t"BYMINUTE=${rule.byMinute.map(_.show).join(t",")}") +
+        part(!rule.bySecond.nil, t"BYSECOND=${rule.bySecond.map(_.show).join(t",")}") +
+        part(!rule.bySetPos.nil, t"BYSETPOS=${rule.bySetPos.map(_.show).join(t",")}") +
+        part(rule.weekStart != Weekday.Mon, t"WKST=${code(rule.weekStart)}")
+
+    t"Rrule(${rule.start.inspect} ╱ ${parts.join(t";")})"
+
   def parse[point: Decodable in Text](text: Text, start: point)(using Tactic[Rrule.Error])
   :   Rrule[point] =
 

--- a/lib/aviation/src/core/aviation.Timespan.scala
+++ b/lib/aviation/src/core/aviation.Timespan.scala
@@ -92,6 +92,12 @@ object Timespan:
     else if time == t"" then t"P$date"
     else t"P${date}T$time"
 
+  // The ISO-8601 duration is also the inspection form: it is self-identifying, complete (a
+  // component which is not written is zero), and needs none of the `Locale`-sensitive context the
+  // opt-in `Showable` does. The bound covers the refined `Timespan of topic` types, which is how
+  // a timespan is almost always typed; the `Topic` radix set is phantom, so nothing is lost.
+  given inspectable: [timespan <: Timespan] => timespan is Inspectable = renderDuration(_)
+
   // The ISO-8601 duration is the encoded (machine) form; a human-readable `Showable` is opt-in via
   // `import timespanFormats.relativeTimespan`.
   given encodable: Timespan is Encodable in Text = renderDuration(_)

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -55,6 +55,14 @@ import symbolism.*
 import vacuous.*
 
 object internal:
+  // Zero-padding for the ISO rendering of an `Anniversary`, below.
+  private def pad(value: Int, digits: Int): Text =
+    val body = value.toString
+    val builder: StringBuilder = new StringBuilder()
+    while builder.length + body.length < digits do builder.append('0')
+
+    builder.append(body).toString.tt
+
   opaque type Year = Int
   opaque type Day = Int
   opaque type WorkingDays = Int
@@ -81,6 +89,10 @@ object internal:
   object WorkingDays:
     def apply(n: Int): WorkingDays = n
 
+    // A count of working days, distinguished from the `Day`-of-the-month suffix above.
+    given inspectable: [workingDays <: WorkingDays] => workingDays is Inspectable = days =>
+      t"${(days: Int)}ʷᵈ"
+
   extension (days: WorkingDays) def apply(): Int = days
 
   object Anniversary:
@@ -88,6 +100,13 @@ object internal:
       def round(year: Year): Date
 
     def apply(month: Month, day: Day): Anniversary = ((month.ordinal << 6) + day).toShort
+
+    // ISO 8601's yearless date (`--MM-DD`), which is self-identifying and, unlike the `Showable`,
+    // needs no `Endianness`, `Months` or `Separation` in scope — an inspection must always be
+    // available. The month is its number, not its name, since a name is a `Months` decision.
+    given inspectable: [anniversary <: Anniversary] => anniversary is Inspectable = anniversary =>
+      val value: Anniversary = anniversary
+      t"--${pad(value.month.numerical, 2)}-${pad(value.day, 2)}"
 
     given showable: (endianness: Endianness, months: Months, separation: Date.Separation)
     =>  Anniversary is Showable =
@@ -112,6 +131,10 @@ object internal:
 
     given multiplicable: Int is Multiplicable by Year.type to (Timespan of Year.type) =
       Multiplicable: (n, _) => Timespan(Year, n)
+
+    // The `Showable` is the bare number, which is indistinguishable from an `Int`; the suffix
+    // names the type the number belongs to, as hypotenuse's sized numerics do.
+    given inspectable: [year <: Year] => year is Inspectable = year => t"${(year: Int)}ʸ"
 
     given showable: Year is Showable = _.toString.tt
     given addable: Year is Addable by Int to Year = Addable(_ + _)
@@ -138,6 +161,9 @@ object internal:
 
     given decodable: (Int is Decodable in Text) => Day is Decodable in Text = day =>
       Day(day.as[Int])
+
+    // As `Year`'s, above: a day of the month is an `Int` underneath, and must not render as one.
+    given inspectable: [day <: Day] => day is Inspectable = day => t"${(day: Int)}ᵈ"
 
     given showable: Day is Showable = _.toString.tt
 

--- a/lib/aviation/src/core/aviation.protointernal.scala
+++ b/lib/aviation/src/core/aviation.protointernal.scala
@@ -36,10 +36,12 @@ import java.time as jt
 
 import anticipation.*
 import contingency.*
+import gossamer.*
 import hypotenuse.*
 import prepositional.*
 import quantitative.*
 import rudiments.*
+import spectacular.*
 import symbolism.*
 
 object protointernal:
@@ -73,6 +75,13 @@ object protointernal:
           (duration.normalize.value*1_000_000_000L).toLong
 
   object Instant:
+    // What an `Instant`'s ticks mean is fixed by its phantom `Transport` — the timeline's
+    // `Resolution` is a typeclass, not runtime state — so a rendering which is always available
+    // (no context parameters) can only show the raw tick count. The hourglass keeps it from
+    // reading as the `Long` it erases to; converting it to a date needs `.in(timezone)`.
+    given inspectable: [instant <: Instant] => instant is Inspectable = instant =>
+      t"⧗${raw(instant)}"
+
     def Min[transport]: Instant over transport = Long.MinValue.asInstanceOf[Instant over transport]
     def Max[transport]: Instant over transport = Long.MaxValue.asInstanceOf[Instant over transport]
 

--- a/lib/aviation/src/core/aviation.timestampInternal.scala
+++ b/lib/aviation/src/core/aviation.timestampInternal.scala
@@ -72,6 +72,15 @@ object timestampInternal:
 
   private def underlying(timestamp: Timestamp): Long = timestamp
 
+  // Zero-padding for the ISO renderings below; a negative number keeps its sign in front of the
+  // padded digits, so a year before the epoch is still legible.
+  private def pad(value: Int, digits: Int): Text =
+    val body = Math.abs(value).toString
+    val builder: StringBuilder = new StringBuilder(if value < 0 then "-" else "")
+    while builder.length + body.length < digits do builder.append('0')
+
+    builder.append(body).toString.tt
+
   // The shape of a `Timestamp - Timestamp` difference: a regular span of days/hours/mins/seconds.
   type Difference =
     Timespan of (aviation.internal.Day.type & Hour.type & Minute.type & Seconds[1])
@@ -81,6 +90,27 @@ object timestampInternal:
       date.jdn.toLong*aviation.internal.MillisPerDay +
         (time.hour*3600L + time.minute*60L + time.second)*1000L +
         time.nanos/1_000_000L
+
+    // ISO 8601 in the Gregorian calendar, which is self-identifying and — unlike `dateShowable`
+    // and `timestampShowable` — needs no `Calendar`, `Endianness`, `Years` or `Separation` in
+    // scope, as an inspection which must always be available cannot ask for them. The subtype
+    // bound covers `Date` and `Monthstamp` too, since each is a `Timestamp` refined by its `Form`;
+    // a `Date` shows its zeroed time-of-day, which is precisely its state. Milliseconds are
+    // written only when non-zero, and the grid is millisecond-precise, so nothing is truncated.
+    given inspectable: [timestamp <: Timestamp] => timestamp is Inspectable = timestamp =>
+      val value: Timestamp = timestamp
+      val calendar = calendars.gregorianCalendar
+      val date = value.date
+      val time = value.time
+      val year = calendar.annual(date)()
+      val month = calendar.mensual(date).numerical
+      val day = calendar.diurnal(date)()
+      val millis = time.nanos/1_000_000
+
+      val fraction = if millis == 0 then t"" else t".${pad(millis, 3)}"
+      val clock = t"${pad(time.hour, 2)}:${pad(time.minute, 2)}:${pad(time.second, 2)}"
+
+      t"${pad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}T$clock$fraction"
 
     // Date-time display (any precision): "time, date".
     given timestampShowable: (Clockface is Showable, Date is Showable) => Timestamp is Showable =

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -2927,3 +2927,61 @@ object Tests extends Suite(m"Aviation Tests"):
       test(m"A truncated ISO 8601 date accrues one error, not a masqueraded today()"):
         collectTime { Iso8601.parse(t"2011-"); () }.count
       . assert(_ == 1)
+
+    suite(m"Native-rendering coverage"):
+      test(m"aviation's types inspect natively"):
+        Inspectable.fallbacks
+         ( (ts"2024": Year).inspect,
+           (2024-Jan-15).inspect,
+           ts"2024-01-15T09:30:00".inspect,
+           dur"P1Y2M3DT4H5M6S".inspect,
+           Instant.of[Unix](1720000000000L).inspect,
+           (Day(8): Day).inspect,
+           WorkingDays(5).inspect,
+           (2024-Jan-15).anniversary.inspect,
+           rec"R3/2024-01-01/P1M".inspect,
+           Rrule(2024-Jan-15, Frequency.Monthly, count = 4).inspect )
+
+      . assert(_ == Nil)
+
+      test(m"a date inspects as an ISO 8601 timestamp"):
+        (2024-Jan-15).inspect
+      . assert(_ == t"2024-01-15T00:00:00")
+
+      test(m"a timestamp keeps its time of day"):
+        ts"2024-01-15T09:30:00".inspect
+      . assert(_ == t"2024-01-15T09:30:00")
+
+      // Ascribed: `Year.apply` is `inline`, so an unascribed `ts"2024"` types as the underlying
+      // `Int` and would reach `Int`'s instance rather than `Year`'s.
+      test(m"a year is not rendered as a bare number"):
+        (ts"2024": Year).inspect
+      . assert(_ == t"2024ʸ")
+
+      test(m"a day of the month is not rendered as a bare number"):
+        (Day(8): Day).inspect
+      . assert(_ == t"8ᵈ")
+
+      test(m"a count of working days has its own suffix"):
+        WorkingDays(5).inspect
+      . assert(_ == t"5ʷᵈ")
+
+      test(m"an instant shows its raw ticks"):
+        Instant.of[Unix](1720000000000L).inspect
+      . assert(_ == t"⧗1720000000000")
+
+      test(m"an anniversary inspects as an ISO yearless date"):
+        (2024-Jan-15).anniversary.inspect
+      . assert(_ == t"--01-15")
+
+      test(m"a timespan inspects as an ISO 8601 duration"):
+        dur"P1Y2M3DT4H5M6S".inspect
+      . assert(_ == t"P1Y2M3DT4H5M6S")
+
+      test(m"a recurrence inspects as an ISO repeating interval"):
+        rec"R3/2024-01-01/P1M".inspect
+      . assert(_ == t"R3/2024-01-01T00:00:00/P1M")
+
+      test(m"a recurrence rule carries its start"):
+        Rrule(2024-Jan-15, Frequency.Monthly, count = 4).inspect
+      . assert(_ == t"Rrule(2024-01-15T00:00:00 ╱ FREQ=MONTHLY;COUNT=4)")

--- a/lib/baroque/src/core/baroque.Complex.scala
+++ b/lib/baroque/src/core/baroque.Complex.scala
@@ -36,6 +36,7 @@ import scala.{compiletime, math}
 
 import scala.annotation.*
 
+import anticipation.tt
 import geodesy.*
 import gossamer.*
 import hypotenuse.*
@@ -82,6 +83,22 @@ object Complex:
 
     distributive.place(complex.real, parts2)
 
+
+  // Both parts are rendered by the component's own `Inspectable`, so the rendering says which
+  // numeric type the complex number is built from; unlike `showable`, no `Zeroic` is needed,
+  // since a zero part is shown rather than elided — it is state the reader may be looking for.
+  // A negative imaginary part is rendered with `-` in place of the `+`, by inspecting the
+  // rendering of the part itself, which is the only handle on its sign available generically.
+  given inspectable: [component: Inspectable, complex <: Complex[component]]
+  =>  complex is Inspectable =
+
+    complex =>
+      val imaginary = complex.imaginary.inspect.s
+
+      val body =
+        if imaginary.startsWith("-") then "-"+imaginary.substring(1).nn else "+"+imaginary
+
+      (complex.real.inspect.s+body+"i").tt
 
   given addable: [result, component2, component: Addable by component2 to result as addable]
   =>  Complex[component] is Addable by Complex[component2] to Complex[result] =

--- a/lib/baroque/src/test/baroque_test.scala
+++ b/lib/baroque/src/test/baroque_test.scala
@@ -152,3 +152,16 @@ object Tests extends Suite(m"Baroque tests"):
     test(m"Negate a complex quantity"):
       -Complex(10*Inch, 7*Inch)
     . assert(_ == Complex(-10*Inch, -7*Inch))
+
+    suite(m"Native-rendering coverage"):
+      test(m"baroque's types inspect natively"):
+        Inspectable.fallbacks(Complex(1, 3).inspect, Complex(1.0, -3.0).inspect)
+      . assert(_ == Nil)
+
+      test(m"A complex number shows both parts, as the parts inspect"):
+        Complex(1, 3).inspect
+      . assert(_ == t"1+3i")
+
+      test(m"A negative imaginary part is shown with a minus sign"):
+        Complex(1.0, -3.0).inspect
+      . assert(_ == t"1.0-3.0i")

--- a/lib/caesura/src/core/caesura.Sheet.scala
+++ b/lib/caesura/src/core/caesura.Sheet.scala
@@ -117,6 +117,20 @@ object Sheet:
           else Sheet(rows, format)
 
   given showable: Dsv.Format => Sheet is Showable = _.rows.to[List].map(_.show).join(t"\n")
+
+  // The `Showable` above needs a `Dsv.Format` to know which delimiter to write and which cells
+  // to quote, and it produces the serialized form — in which a cell containing a delimiter is
+  // indistinguishable from two cells. Inspection needs no format: each row's cells are shown
+  // as inspected `Text`s inside `⟨ ⟩`, the rows inside `⟦ ⟧` (the sheet is ordered), preceded
+  // by the column headings and the format, if either is set.
+  given inspectable: [sheet <: Sheet] => sheet is Inspectable = sheet =>
+    def cells(row: Array[Text]^{}): Text =
+      row.readable.map(_.inspect.s).mkString("⟨ ", " ", " ⟩").tt
+
+    val rows = sheet.rows.readable.map { row => cells(row.data).s }.mkString("⟦", ", ", "⟧")
+    val columns = sheet.columns.lay(t"○")(cells(_))
+
+    t"Sheet(format:${sheet.format.lay(t"○")(_.inspect)} ╱ columns:$columns ╱ rows:${rows.tt})"
   given streamable: Dsv.Format => Sheet is Streamable by Text over Credit = sheet =>
     Stream(sheet.rows.readable.iterator.map(_.show+t"\n"))
 

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -246,6 +246,19 @@ object Tests extends Suite(m"Caesura tests"):
       Bar(0.1, Foo(t"two", t"three"), 4, Foo(t"five", t"six")).dsv
     . assert(_ == Dsv(t"0.1", t"two", t"three", t"4", t"five", t"six"))
 
+    // A missing `Inspectable` is never a compile error — `derived` always succeeds and
+    // substitutes a marked `toString`, `Showable` or `Encodable` rendering — so coverage can
+    // only be held in place by asserting on the renderings themselves.
+    suite(m"Native-rendering coverage"):
+      test(m"caesura's types inspect natively"):
+        Inspectable.fallbacks(Sheet(Array(Dsv(t"hello", t"world"))).inspect)
+      . assert(_ == Nil)
+
+      test(m"a sheet inspects as its rows of cells"):
+        Sheet(Array(Dsv(t"hello", t"world"))).inspect
+      . assert:
+          _ == Text("Sheet(format:○ ╱ columns:○ ╱ rows:⟦⟨ t\"hello\" t\"world\" ⟩⟧)")
+
     test(m"convert simple row to string"):
       import dsvFormats.csvFormat
       Sheet(Array(Dsv(t"hello", t"world"))).show

--- a/lib/charisma/src/core/charisma.Chemical.scala
+++ b/lib/charisma/src/core/charisma.Chemical.scala
@@ -45,6 +45,12 @@ object Chemical:
   object Element:
     given showable: Element is Showable = _.symbol
 
+    // The `Showable` is the bare symbol, which is indistinguishable from any other short `Text`;
+    // the atom sign marks it as an element and the atomic number (which, with the symbol, fixes
+    // the periodic-table entry the value came from) follows it.
+    given inspectable: [element <: Element] => element is Inspectable = element =>
+      t"⚛${element.symbol}(${element.number})"
+
   case class Element(number: Int, symbol: Text, name: Text) extends Molecular:
     def apply[count <: Nat: ValueOf]: Molecule = Molecule(Map(this -> valueOf[count]), 0)
     def molecule: Molecule = apply[1]
@@ -53,6 +59,11 @@ object Chemical:
   object Equation:
     given showable: Equation is Showable = equation =>
       t"${equation.lhs} ${equation.reaction} ${equation.rhs}"
+
+    // The reaction is named rather than drawn as its arrow: an arrow glyph is what `Reaction`'s
+    // `Showable` produces, and a borrowed rendering is exactly what inspection must not look like.
+    given inspectable: [equation <: Equation] => equation is Inspectable = equation =>
+      t"Equation(${equation.lhs.inspect} ╱ ${equation.reaction.inspect} ╱ ${equation.rhs.inspect})"
 
   case class Equation(lhs: Formula, reaction: Reaction, rhs: Formula):
     def balanced: Boolean = lhs.atoms == rhs.atoms
@@ -66,6 +77,15 @@ object Chemical:
         (if count == 1 then t"" else count.show)+molecule.show
 
       . join(t" + ")
+
+    // Every coefficient is written out, including a `1` which the `Showable` leaves implicit, so
+    // that a one-molecule formula is never rendered identically to the `Molecule` it holds.
+    given inspectable: [formula <: Formula] => formula is Inspectable = formula =>
+      val parts = formula.molecules.to[List].map: (molecule, count) =>
+        val number: Text = count.show
+        t"$number${molecule.inspect}"
+
+      if parts.stdlib.isEmpty then t"∅" else parts.join(t" + ")
 
   case class Formula(molecules: Ledger[Molecule, Int]) extends Formulable:
     def formula: Formula = this

--- a/lib/charisma/src/core/charisma.Molecule.scala
+++ b/lib/charisma/src/core/charisma.Molecule.scala
@@ -81,6 +81,11 @@ object Molecule:
     . join +
       suffix
 
+  // The chemical formula which `Showable` builds — element symbols with subscript counts, then the
+  // charge and physical state — is a complete rendering of a molecule's state, needs no contextual
+  // givens, and is how a reader recognises the value, so inspection delegates to it.
+  given inspectable: [molecule <: Molecule] => molecule is Inspectable = showable.text(_)
+
   def apply(element: Chemical.Element): Molecule = element.molecule
 
 case class Molecule

--- a/lib/charisma/src/test/charisma_test.scala
+++ b/lib/charisma/src/test/charisma_test.scala
@@ -279,3 +279,25 @@ object Tests extends Suite(m"Charisma Tests"):
       test(m"A stoichiometric equation is stoichiometric"):
         (water === water).reaction
       . assert(_ == Reaction.Stoichiometric)
+
+    suite(m"Native-rendering coverage"):
+      test(m"charisma's types inspect natively"):
+        Inspectable.fallbacks
+         ( H.inspect,
+           (H[2]*O).inspect,
+           (H[2]*2 + O[2]).inspect,
+           (H[2]*2 + O[2] --> (H[2]*O)*2).inspect )
+
+      . assert(_ == Nil)
+
+      test(m"an element is marked as one"):
+        H.inspect
+      . assert(_ == t"⚛H(1)")
+
+      test(m"a molecule inspects as its formula"):
+        (H[2]*O).inspect
+      . assert(_ == t"H₂O")
+
+      test(m"a formula writes out every coefficient"):
+        (H[2]*2 + O[2]).inspect
+      . assert(_ == t"2H₂ + 1O₂")

--- a/lib/chiaroscuro/src/core/chiaroscuro.Decomposable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Decomposable.scala
@@ -98,6 +98,11 @@ trait Decomposable2 extends Decomposable3:
     case decomposable: (`entity` is Decomposable.Base) => decomposable
     case given ProductReflection[`entity`]             => Derivation.derived[entity]
     case given SumReflection[`entity`]                 => Derivation.disjunction[entity]
+
+    // Only `Any`, `AnyRef` and `Matchable` satisfy this — it asks whether `entity` is a
+    // *supertype* of `AnyRef`, not whether it is a reference type. It has to precede the
+    // `Optional` branch below, which `Unset.type <:< Any` would otherwise satisfy for any
+    // statically-`Any` value, decomposing it as an optional.
     case given (AnyRef <:< `entity`)                   => any[entity]
 
     case given (Unset.type <:< `entity`) =>
@@ -111,14 +116,16 @@ trait Decomposable2 extends Decomposable3:
 
               Decomposition.Sum(t"Optional", inside, value)
 
-    case given (`entity` is Showable) =>
-      value => Decomposition.Primitive(shortName[entity], value.show, value)
-
-    case given (`entity` is Encodable in Text) =>
-      value => Decomposition.Primitive(shortName[entity], value.encode, value)
-
+    // Every remaining leaf is rendered by `Inspectable`, which is the typeclass for showing a
+    // value to a programmer — which is what a test failure does. Previously this tail summoned
+    // `Showable`, then `Encodable`, then fell back to `toString`, duplicating `Inspectable`'s
+    // own chain with the first two in the opposite order, so the same value could decompose
+    // one way and inspect another. Delegating keeps a single answer to "how does this render",
+    // and is total: `Inspectable`'s `derived` always succeeds, so no `toString` tail is needed
+    // here — `Inspectable` supplies its own, and marks it.
     case _ =>
-      value => Decomposition.Primitive(t"Any", value.toString.tt, value)
+      val inspectable = summonInline[entity is Inspectable]
+      value => Decomposition.Primitive(shortName[entity], inspectable.text(value), value)
 
   def primitive[value](name: Text): value is Decomposable =
     value => Decomposition.Primitive(name, value.toString.tt, value)

--- a/lib/chiaroscuro/src/test/chiaroscuro_test.scala
+++ b/lib/chiaroscuro/src/test/chiaroscuro_test.scala
@@ -42,6 +42,15 @@ case class Organization(name: Text, ceo: Person, staff: List[Person])
 
 case class IdName(id: Text, name: Text)
 
+// A plain class, so no reflection can decompose it structurally, whose `Showable` and
+// `Inspectable` deliberately disagree — which of the two a decomposition uses is then visible.
+class Divergent(val n: Int)
+
+object Divergent:
+  given showable: Divergent is Showable = divergent => t"shown-${divergent.n}"
+  given inspectable: [divergent <: Divergent] => divergent is Inspectable = divergent =>
+    t"inspected-${divergent.n}"
+
 import Decomposition.*
 
 object Tests extends Suite(m"Chiaroscuro tests"):
@@ -51,6 +60,16 @@ object Tests extends Suite(m"Chiaroscuro tests"):
         24.decompose
 
       . assert(_ == Primitive(t"Int", t"24", 24))
+
+      // Decomposition renders its leaves through `Inspectable`, not `Showable`: a test failure
+      // is read by a programmer, so it should show what `.inspect` shows. Before this, the two
+      // could disagree — the same value decomposed one way and inspected another.
+      test(m"A leaf is decomposed through Inspectable, not Showable"):
+        Divergent(7).decompose
+
+      . assert:
+          case Primitive(_, text, _) => text == t"inspected-7"
+          case _                     => false
 
       test(m"Decompose a known type"):
         t"hello".decompose
@@ -88,8 +107,8 @@ object Tests extends Suite(m"Chiaroscuro tests"):
         list.decompose
 
       . assert:
-          _ == Decomposition.Sequence(t"List", List(Primitive(t"Char", t"a", 'a'),
-                                      Primitive(t"Char", t"b", 'b')), List('a', 'b'))
+          _ == Decomposition.Sequence(t"List", List(Primitive(t"Char", t"'a'", 'a'),
+                                      Primitive(t"Char", t"'b'", 'b')), List('a', 'b'))
 
       test(m"Decompose an optional value"):
         val x: Optional[Int] = 12
@@ -108,11 +127,14 @@ object Tests extends Suite(m"Chiaroscuro tests"):
 
       . assert(_ == Primitive(t"Double", t"3.1415926", 3.1415926))
 
-      test(m"Decompose a showable value"):
+      // Decomposition renders through `Inspectable`, not `Showable`, so a `Decimalizer` in
+      // scope no longer rounds it: a test failure should report the value it compared, not a
+      // display form of it.
+      test(m"A Decimalizer does not round a decomposed value"):
         given Decimalizer(3)
         3.1415926.decompose
 
-      . assert(_ == Primitive(t"Double", t"3.14", 3.1415926))
+      . assert(_ == Primitive(t"Double", t"3.1415926", 3.1415926))
 
       test(m"Decompose an Any-typed value"):
         val x: Any = t"hello"

--- a/lib/coaxial/src/core/coaxial.DomainSocket.scala
+++ b/lib/coaxial/src/core/coaxial.DomainSocket.scala
@@ -39,6 +39,12 @@ import spectacular.*
 object DomainSocket:
   given showable: DomainSocket is Showable = _.address
 
+  // The socket's path alone would be indistinguishable from any other path-like text, so the
+  // rendering prefixes it with `⇄`, marking it as the bidirectional endpoint it is — in the same
+  // spirit as `⌗8080` for a port.
+  given inspectable: [domainSocket <: DomainSocket] => domainSocket is Inspectable =
+    domainSocket => ("⇄"+domainSocket.address.s).tt
+
   def apply[path: Abstractable across Paths to Text](path: path): DomainSocket =
     DomainSocket(path.generic)
 

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -333,3 +333,12 @@ object Tests extends Suite(m"Coaxial tests"):
           Array.unsafeFrozen(nic.getHardwareAddress.nn).readable.toSeq.each: byte => value = (value << 8) | (byte & 0xFF)
           interfaceFor(urticose.MacAddress(value)).let(_ => true).or(false)
       . assert(_ == true)
+
+    suite(m"Native-rendering coverage"):
+      test(m"coaxial's types inspect natively"):
+        Inspectable.fallbacks(DomainSocket(t"/tmp/example.sock").inspect)
+      . assert(_ == Nil)
+
+      test(m"A domain socket shows its path, marked as an endpoint"):
+        DomainSocket(t"/tmp/example.sock").inspect
+      . assert(_ == t"⇄/tmp/example.sock")

--- a/lib/cosmopolite/src/core/cosmopolite.Locale.scala
+++ b/lib/cosmopolite/src/core/cosmopolite.Locale.scala
@@ -37,9 +37,15 @@ import beneficence.*
 import distillate.*
 import gossamer.*
 import prepositional.*
+import spectacular.*
 
 object Locale:
   given encodable: [language] => Locale[language] is Encodable in Text = _.language.code
+
+  // The wire form of a `Locale` is a bare language code, which says nothing about the type it
+  // came from, so the debug rendering wraps it in the constructor which produces it.
+  given inspectable: [language, locale <: Locale[language]] => locale is Inspectable =
+    locale => ("Locale("+locale.language.code.s+")").tt
 
   given decodable: Locale[en & pl & fr & de & es] is Decodable in Text =
     case t"pl" => Locale(pl)

--- a/lib/cosmopolite/src/test/cosmopolite_test.scala
+++ b/lib/cosmopolite/src/test/cosmopolite_test.scala
@@ -32,6 +32,19 @@
                                                                                                   */
 package cosmopolite
 
+import soundness.*
+
+object Tests extends Suite(m"Cosmopolite tests"):
+  def run(): Unit =
+    suite(m"Native-rendering coverage"):
+      test(m"cosmopolite's types inspect natively"):
+        Inspectable.fallbacks(Locale(en).inspect)
+      . assert(_ == Nil)
+
+      test(m"A locale shows its language code"):
+        Locale(en).inspect
+      . assert(_ == t"Locale(en)")
+
 // import languages.common.*
 
 // import probably.*

--- a/lib/enigmatic/src/asn1/enigmatic.Der.scala
+++ b/lib/enigmatic/src/asn1/enigmatic.Der.scala
@@ -39,6 +39,7 @@ import java.util as ju
 import scala.compiletime.*
 
 import anticipation.*
+import gossamer.*
 import monotonous.*
 import prepositional.*
 import rudiments.*
@@ -59,6 +60,13 @@ object Der:
   given streamable: Der is Streamable by Data over Credit = der => Stream(der.data)
   given aggregable: Der is Aggregable by Data = Aggregable.bytesData.map(Der(_))
   given showable: Alphabet[Hex] => Der is Showable = _.data.serialize[Hex]
+
+  // `showable` needs an `Alphabet[Hex]`, and a debug rendering must always be available, so the
+  // document's bytes are rendered here as full-width lowercase hexadecimal instead. The whole
+  // document is shown: a DER document is defined by its bytes, and two which differ in one byte
+  // decode to different values.
+  given inspectable: [der <: Der] => der is Inspectable = der =>
+    t"Der(${Inspection.hex(der.data)})"
 
 final class Der(val data: Data):
   override def equals(that: Any): Boolean = that.asMatchable match

--- a/lib/enigmatic/src/asn1/enigmatic.Inspection.scala
+++ b/lib/enigmatic/src/asn1/enigmatic.Inspection.scala
@@ -33,58 +33,24 @@
 package enigmatic
 
 import anticipation.*
-import gastronomy.*, providers.javaStdlibProvider
-import gossamer.*
-import monotonous.*
-import prepositional.*
-import rudiments.*
-import spectacular.*
-import vacuous.*
 
-object PrivateKey:
-  def generate[cipher <: Cipher]()(using cipher: cipher, cloak: Cloak^)
-  :   PrivateKey[cipher]^{cloak} =
+// Shared rendering internals, kept in the lowest component so every other one can reach them.
+private[enigmatic] object Inspection:
+  private val digits: String = "0123456789abcdef"
 
-    PrivateKey(cipher.genKey())
+  // Full-width lowercase hexadecimal of a binary payload, for the `Inspectable` instances of
+  // the types which wrap `Data`. Monotonous's `serialize` would need an `Alphabet` in scope,
+  // and a debug rendering must always be available, with no context; nothing is abbreviated,
+  // since an inspection which dropped bytes would hide exactly what is being looked for.
+  def hex(data: Data): Text =
+    val bytes = data.readable
+    val builder: StringBuilder = new StringBuilder()
+    var index = 0
 
-  // Adopts freshly-generated key material: the `Data` is ours, so it is zeroed in place
-  // (through a mutable view) as it is cloaked.
-  private[enigmatic] def apply[cipher <: Cipher](data: Data)(using cloak: Cloak^)
-  :   PrivateKey[cipher]^{cloak} =
+    while index < bytes.length do
+      val byte = bytes(index)
+      builder.append(digits.charAt((byte & 0xf0) >>> 4))
+      builder.append(digits.charAt(byte & 0x0f))
+      index += 1
 
-    new PrivateKey(cloak.cloak(data.mutable(using Unsafe)))
-
-  // Redacted. `showable` uncloaks the key to fingerprint it; an inspection is produced in far
-  // more places (test output, a debugger's variable pane, a nested rendering of an enclosing
-  // value), so it reveals nothing of the key material at all, not even a digest of it.
-  given inspectable: [key <: PrivateKey[?]] => key is Inspectable =
-    _ => t"PrivateKey(•••)"
-
-  given showable: [key <: Cipher] => PrivateKey[key] is Showable = key =>
-    import alphabets.base64Standard
-
-    key.secret.uncloak: bytes =>
-      t"PrivateKey(${Array.unsafeFrozen(bytes).digest[Sha2[256]].serialize[Base64]})"
-
-// A private key held opaquely by whichever `Cloak` was in scope at construction, capturing
-// that cloak. Operations that need the key material — `public`, `sign`, `pem` — materialize
-// it transiently through the cloak, and the transient copy is zeroed as soon as the
-// operation completes; only `pem`, gated on `Divulgence`, lets the material escape.
-class PrivateKey[cipher <: Cipher](private[enigmatic] val secret: Secret^):
-  def public(using cipher: cipher): PublicKey[cipher] =
-    secret.uncloak: bytes =>
-      PublicKey(cipher.privateToPublic(Array.unsafeFrozen(bytes)))
-
-
-  def sign[encodable: Encodable in Data](value: encodable)
-    ( using cipher: cipher & Signing, erased weakness: Permit[Weakness[cipher]] )
-  :   Signature[cipher] =
-
-    secret.uncloak: bytes =>
-      Signature(cipher.sign(encodable.encode(value), Array.unsafeFrozen(bytes)))
-
-
-  // The immutable `Data` in the result outlives the cloak's zeroing, which is exactly why
-  // revealing it demands the explicit `Divulgence` token.
-  def pem(reveal: Divulgence.type): Pem = secret.uncloak: bytes =>
-    Pem(Pem.Label.PrivateKey, Array.unsafeFrozen(bytes.clone))
+    builder.toString.tt

--- a/lib/enigmatic/src/core/enigmatic.Hmac.scala
+++ b/lib/enigmatic/src/core/enigmatic.Hmac.scala
@@ -48,5 +48,10 @@ object Hmac:
 
   given encodable: [hmac <: Algorithm] => Hmac in hmac is Encodable in Data = _.bytes
 
+  // `showable` needs an `Alphabet[Base64]`, so the code is rendered here as full-width lowercase
+  // hexadecimal, which needs no context. The algorithm is a phantom type, so it cannot appear.
+  given inspectable: [hmac <: Hmac] => hmac is Inspectable = hmac =>
+    t"Hmac(${Inspection.hex(hmac.bytes)})"
+
 class Hmac(val bytes: Data):
   type Form <: Algorithm

--- a/lib/enigmatic/src/core/enigmatic.Password.scala
+++ b/lib/enigmatic/src/core/enigmatic.Password.scala
@@ -62,6 +62,12 @@ object Password:
   // Never renders the secret: a `Password` is safe to log or embed in a message.
   given showable: Password is Showable = _ => t"Password(•••)"
 
+  // Redacted, exactly as `showable` is: a debugger, a log and a test report are all places a
+  // password must never reach, and the cleartext is only ever legitimately seen inside an
+  // `uncloak` block.
+  given inspectable: [password <: Password] => password is Inspectable =
+    _ => t"Password(•••)"
+
 // A password held opaquely by whichever `Cloak` was in scope at construction, capturing that
 // cloak, with no way to read the cleartext back except through `uncloak`, which lends it — as
 // a scoped `Cleartext` capability over a mutable char array — to a block, exactly as

--- a/lib/enigmatic/src/core/enigmatic.Pem.scala
+++ b/lib/enigmatic/src/core/enigmatic.Pem.scala
@@ -197,6 +197,12 @@ object Pem:
           // See `aggregable` above.
           parseAll(Cursor(stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Text] over Credit)^]))
 
+  // The armored form is multi-line and base64-encoded, so it is not what an inspection shows:
+  // the label identifies the block, and the payload is rendered as full-width hexadecimal, on
+  // one line and with nothing dropped.
+  given inspectable: [pem <: Pem] => pem is Inspectable = pem =>
+    t"Pem(${Pem.Label.showable.text(pem.label)}:${Inspection.hex(pem.data)})"
+
   // The armored form, one line at a time: the `serialize` counterpart for
   // streaming consumers (each line carries its terminator).
   given streamable: Pem is Streamable by Text over Credit = pem =>

--- a/lib/enigmatic/src/core/enigmatic.PublicKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.PublicKey.scala
@@ -46,6 +46,12 @@ object PublicKey:
 
   given encodable: [cipher <: Cipher] => PublicKey[cipher] is Encodable in Data = _.bytes
 
+  // The same hexadecimal `showable` produces, but rendered without needing an `Alphabet[Hex]`
+  // in scope: a debug rendering must always be available. A public key is not a secret, so it
+  // is shown in full.
+  given inspectable: [key <: PublicKey[?]] => key is Inspectable = key =>
+    t"PublicKey(${Inspection.hex(key.bytes)})"
+
 case class PublicKey[cipher <: Cipher](bytes: Data):
   def verify[encodable: Encodable in Data](value: encodable, signature: Signature[cipher])
     ( using algorithm: cipher & Signing, erased weakness: ProcessingPermit[Weakness[cipher]] )

--- a/lib/enigmatic/src/core/enigmatic.Signature.scala
+++ b/lib/enigmatic/src/core/enigmatic.Signature.scala
@@ -45,6 +45,11 @@ object Signature:
 
   given encodable: [cipher <: Cipher] => Signature[cipher] is Encodable in Data = _.bytes
 
+  // Hexadecimal rather than `showable`'s Base64, which needs an `Alphabet` in scope; the whole
+  // signature is shown, since a signature which differs anywhere is a different signature.
+  given inspectable: [signature <: Signature[?]] => signature is Inspectable = signature =>
+    t"Signature(${Inspection.hex(signature.bytes)})"
+
   // SignatureDigest → Signature.Digest
   // The digest an asymmetric signature is taken over. RSA and ECDSA sign a hash of the message
   // rather than the message itself, and the choice of hash is part of the signature algorithm's

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -1121,4 +1121,34 @@ object Tests extends Suite(m"Enigmatic tests"):
         Pem(Pem.Label.Certificate, value.in[Der]).serialize
       . assert(_ == certificate.trim)
 
+    // A missing `Inspectable` is never a compile error — `derived` always succeeds and
+    // substitutes a marked `toString`, `Showable` or `Encodable` rendering — so coverage can
+    // only be held in place by asserting on the renderings.
+    suite(m"Native-rendering coverage"):
+      test(m"enigmatic's types inspect natively"):
+        val key = PrivateKey.generate[Rsa[2048]]()
+
+        Inspectable.fallbacks
+         ( (Asn1.Integer(BigInt(42)): Asn1).in[Der].inspect,
+           pangram.hmac[Sha2[256]](t"a key".in[Data]).inspect,
+           Password(t"secret").inspect,
+           key.inspect,
+           key.public.inspect,
+           key.sign(pangram).inspect,
+           certificate.read[Pem].inspect,
+           Certificate(certificate.read[Asn1 in Pem]).inspect )
+      . assert(_ == Nil)
+
+      test(m"A DER document inspects as its full hexadecimal"):
+        (Asn1.Integer(BigInt(42)): Asn1).in[Der].inspect
+      . assert(_ == t"Der(02012a)")
+
+      test(m"A password never reveals its cleartext"):
+        Password(t"secret").inspect
+      . assert(_ == t"Password(\u2022\u2022\u2022)")
+
+      test(m"A private key never reveals its key material"):
+        PrivateKey.generate[Rsa[2048]]().inspect
+      . assert(_ == t"PrivateKey(\u2022\u2022\u2022)")
+
     CaptureTests()

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -56,6 +56,20 @@ object Flag:
     case name: Text => t"--$name"
     case name: Char => t"-$name"
 
+  // The `Showable` shows the flag's canonical form alone, which is what a usage message needs;
+  // inspection keeps that form as the leading field — it is how the flag is written on a
+  // command line — and adds the state which decides how the flag is parsed and listed: its
+  // aliases, in the same form, and whether it is repeatable or secret. The description is the
+  // help text, so it is shown as an inspected `Text`.
+  given inspectable: [flag <: Flag] => flag is Inspectable = flag =>
+    val aliases = flag.aliases.stdlib.map(serialize(_).s).mkString("[", ", ", "]").tt
+    val description = flag.description.lay(t"○")(_.inspect)
+
+    val fields =
+      t"aliases:$aliases ╱ repeatable:${flag.repeatable.inspect} ╱ secret:${flag.secret.inspect}"
+
+    t"Flag(${serialize(flag.name)} ╱ $fields ╱ description:$description)"
+
   @targetName("make")
   def apply[topic]
     ( name:        Text | Char,

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -933,6 +933,23 @@ object Tests extends Suite(m"Exoskeleton Tests"):
           HelpApp.tree.roff.serialize.cut(t"\n")
         . assert(_.has(t"\\fBmytool\\fP [\\-\\-verbose <value>] <command> [options]"))
 
+      // A missing `Inspectable` is never a compile error — `derived` always succeeds and
+      // substitutes a marked `toString`, `Showable` or `Encodable` rendering — so coverage can
+      // only be held in place by asserting on the renderings themselves.
+      suite(m"Native-rendering coverage"):
+        test(m"exoskeleton's types inspect natively"):
+          Inspectable.fallbacks
+           ( Flag[Text](t"count").inspect,
+             Flag[Text]('c', aliases = List(t"count"), description = t"how many").inspect )
+        . assert(_ == Nil)
+
+        test(m"a flag inspects with the state which governs its parsing"):
+          Flag[Text](t"count", repeatable = true, aliases = List('c')).inspect
+        . assert:
+            _ == Text
+                  ( "Flag(--count ╱ aliases:[-c] ╱ repeatable:true ╱ secret:false ╱ "
+                    +"description:○)" )
+
       suite(m"Prospective and requisite flags"):
         import interpreters.posixInterpreter
         import stdios.muteStdio

--- a/lib/gastronomy/src/core/gastronomy.Digest.scala
+++ b/lib/gastronomy/src/core/gastronomy.Digest.scala
@@ -50,6 +50,25 @@ object Digest:
 
   given encodable: [digest <: Algorithm] => Digest in digest is Encodable in Data = _.data
 
+  // `showable` needs an `Alphabet[Base64]`, and a debug rendering must always be available, so
+  // the bytes are rendered here as full-width lowercase hexadecimal instead — every byte shown,
+  // in the order they are held. The `ᴰ` suffix distinguishes the digits from any other
+  // hexadecimal rendering; the algorithm is a phantom type, so it cannot be shown at runtime.
+  given inspectable: [digest <: Digest] => digest is Inspectable = digest =>
+    val bytes = digest.data.readable
+    val builder: StringBuilder = new StringBuilder()
+    var index = 0
+
+    while index < bytes.length do
+      val byte = bytes(index)
+      builder.append(hexadecimal.charAt((byte & 0xf0) >>> 4))
+      builder.append(hexadecimal.charAt(byte & 0x0f))
+      index += 1
+
+    (builder.toString+"ᴰ").tt
+
+  private val hexadecimal: String = "0123456789abcdef"
+
 class Digest(val data: Data):
   type Form <: Algorithm
 

--- a/lib/gastronomy/src/test/gastronomy_test.scala
+++ b/lib/gastronomy/src/test/gastronomy_test.scala
@@ -256,3 +256,12 @@ object Tests extends Suite(m"Gastronomy tests"):
       test(m"a whole value's checksum matches its digest"):
         payload.checksum[Sha2[256]].serialize[Hex]
       . assert(_ == payload.digest[Sha2[256]].serialize[Hex])
+
+    suite(m"Native-rendering coverage"):
+      test(m"gastronomy's types inspect natively"):
+        Inspectable.fallbacks(t"Hello world".digest[Sha2[256]].inspect)
+      . assert(_ == Nil)
+
+      test(m"A digest shows every byte, in lowercase hexadecimal"):
+        t"Hello world".digest[Sha2[256]].inspect
+      . assert(_ == t"64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3cᴰ")

--- a/lib/geodesy/src/angle/geodesy.angleInternal.scala
+++ b/lib/geodesy/src/angle/geodesy.angleInternal.scala
@@ -32,8 +32,10 @@
                                                                                                   */
 package geodesy
 
+import anticipation.*
 import hypotenuse.*
 import prepositional.*
+import spectacular.*
 import symbolism.*
 
 object angleInternal:
@@ -59,6 +61,11 @@ object angleInternal:
 
     given multiplicable2: Double is Multiplicable by Angle to Angle =
       Multiplicable: (left, right) => (left*right)%c
+
+    // Degrees at full precision, unlike `angleShowable`, which fixes one decimal place because
+    // it is for display: an inspection which rounded would hide the state it exists to show.
+    given inspectable: [angle <: Angle] => angle is Inspectable = angle =>
+      ((angle: Angle).degrees.toString+"°").tt
 
   extension (angle: Angle)
     def degrees: Double = angle*180/π

--- a/lib/geodesy/src/core/geodesy.internal.scala
+++ b/lib/geodesy/src/core/geodesy.internal.scala
@@ -50,6 +50,12 @@ object internal:
     given encodable: Location is Encodable in Text = location =>
       t"${location.latitude.degrees},${location.longitude.degrees}"
 
+    // The encoded form rounds to six decimal places (the file's `Decimalizer`) and is a bare pair
+    // of numbers; inspection reuses `Angle`'s own full-precision rendering for each component, and
+    // the crosshair marks the pair as a position on the globe rather than two loose angles.
+    given inspectable: [location <: Location] => location is Inspectable = location =>
+      t"⌖${(location: Location).latitude.inspect},${(location: Location).longitude.inspect}"
+
     private def fromAngle(latitude: Angle, longitude: Angle): Location =
       (encodeLatitude(latitude).toLong << 32) | (encodeLongitude(longitude) & 0xffffffffL)
 

--- a/lib/geodesy/src/core/geodesy_core.scala
+++ b/lib/geodesy/src/core/geodesy_core.scala
@@ -49,7 +49,8 @@ given angleShowable: Angle is Showable = angle =>
 
 // Likewise for inspection, which shows the degrees at full precision: `angleShowable` rounds
 // to one decimal place for display, and inspecting a value should not hide state.
-given angleInspectable: Angle is Inspectable = angle => t"${angle.degrees.inspect}°"
+given angleInspectable: [angle <: Angle] => angle is Inspectable = angle =>
+  t"${(angle: Angle).degrees.inspect}°"
 
 export CardinalWind.{North, South, East, West}
 export IntercardinalWind.{Northeast, Southeast, Southwest, Northwest}

--- a/lib/geodesy/src/core/geodesy_core.scala
+++ b/lib/geodesy/src/core/geodesy_core.scala
@@ -47,6 +47,10 @@ given angleShowable: Angle is Showable = angle =>
   given decimalizer: Decimalizer = Decimalizer(decimalPlaces = 1)
   t"${angle.degrees}°"
 
+// Likewise for inspection, which shows the degrees at full precision: `angleShowable` rounds
+// to one decimal place for display, and inspecting a value should not hide state.
+given angleInspectable: Angle is Inspectable = angle => t"${angle.degrees.inspect}°"
+
 export CardinalWind.{North, South, East, West}
 export IntercardinalWind.{Northeast, Southeast, Southwest, Northwest}
 

--- a/lib/geodesy/src/core/geodesy_core.scala
+++ b/lib/geodesy/src/core/geodesy_core.scala
@@ -47,11 +47,6 @@ given angleShowable: Angle is Showable = angle =>
   given decimalizer: Decimalizer = Decimalizer(decimalPlaces = 1)
   t"${angle.degrees}°"
 
-// Likewise for inspection, which shows the degrees at full precision: `angleShowable` rounds
-// to one decimal place for display, and inspecting a value should not hide state.
-given angleInspectable: [angle <: Angle] => angle is Inspectable = angle =>
-  t"${(angle: Angle).degrees.inspect}°"
-
 export CardinalWind.{North, South, East, West}
 export IntercardinalWind.{Northeast, Southeast, Southwest, Northwest}
 

--- a/lib/geodesy/src/core/soundness_geodesy_core.scala
+++ b/lib/geodesy/src/core/soundness_geodesy_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   geodesy
-  . { angleShowable, CardinalWind, Compass, Directional, East, EastNortheast, EastSoutheast,
-      Geolocation, HalfWind, IntercardinalWind, Locatable, Location, North,
+  . { angleInspectable, angleShowable, CardinalWind, Compass, Directional, East, EastNortheast,
+      EastSoutheast, Geolocation, HalfWind, IntercardinalWind, Locatable, Location, North,
       Northeast, NorthNortheast, NorthNorthwest, Northwest, South, Southeast, SouthSoutheast,
       SouthSouthwest, Southwest, West, WestNorthwest, WestSouthwest }
 

--- a/lib/geodesy/src/core/soundness_geodesy_core.scala
+++ b/lib/geodesy/src/core/soundness_geodesy_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   geodesy
-  . { angleInspectable, angleShowable, CardinalWind, Compass, Directional, East, EastNortheast,
-      EastSoutheast, Geolocation, HalfWind, IntercardinalWind, Locatable, Location, North,
+  . { angleShowable, CardinalWind, Compass, Directional, East, EastNortheast, EastSoutheast,
+      Geolocation, HalfWind, IntercardinalWind, Locatable, Location, North,
       Northeast, NorthNortheast, NorthNorthwest, Northwest, South, Southeast, SouthSoutheast,
       SouthSouthwest, Southwest, West, WestNorthwest, WestSouthwest }
 

--- a/lib/geodesy/src/test/geodesy_test.scala
+++ b/lib/geodesy/src/test/geodesy_test.scala
@@ -67,6 +67,18 @@ object Tests extends Suite(m"Geodesy tests"):
 
     . assert(_ == t"7.25°")
 
+    // A missing `Inspectable` never fails to compile — `derived` substitutes a marked
+    // `toString`, `Showable` or `Encodable` rendering — so coverage is held in place by
+    // asserting on the renderings themselves.
+    test(m"geodesy's types inspect natively"):
+      Inspectable.fallbacks
+       ( Angle.degrees(90).inspect,
+         CardinalWind.North.inspect,
+         IntercardinalWind.Northeast.inspect,
+         HalfWind.NorthNortheast.inspect )
+
+    . assert(_ == Nil)
+
     test(m"render principal angle"):
       val angle = Angle.degrees(375)
       angle.principal.show

--- a/lib/geodesy/src/test/geodesy_test.scala
+++ b/lib/geodesy/src/test/geodesy_test.scala
@@ -60,6 +60,13 @@ object Tests extends Suite(m"Geodesy tests"):
 
     . assert(_ == t"0.0°")
 
+    // Inspection keeps the precision which `show` rounds away.
+    test(m"inspect an angle at full precision"):
+      val angle = Angle.degrees(7.25)
+      angle.inspect
+
+    . assert(_ == t"7.25°")
+
     test(m"render principal angle"):
       val angle = Angle.degrees(375)
       angle.principal.show

--- a/lib/geodesy/src/test/geodesy_test.scala
+++ b/lib/geodesy/src/test/geodesy_test.scala
@@ -75,9 +75,17 @@ object Tests extends Suite(m"Geodesy tests"):
        ( Angle.degrees(90).inspect,
          CardinalWind.North.inspect,
          IntercardinalWind.Northeast.inspect,
-         HalfWind.NorthNortheast.inspect )
+         HalfWind.NorthNortheast.inspect,
+         Location(Angle.degrees(51.5), Angle.degrees(0.126)).inspect )
 
     . assert(_ == Nil)
+
+    // Latitude and longitude are packed into 32 bits each, so the angles which come back out are
+    // the nearest representable ones; inspection shows them as they are, without rounding.
+    test(m"inspect a location as a pair of angles"):
+      Location(Angle.degrees(51.5), Angle.degrees(0.126)).inspect
+
+    . assert(_ == t"⌖51.4999999718275°,0.12600003747548583°")
 
     test(m"render principal angle"):
       val angle = Angle.degrees(375)

--- a/lib/gossamer/src/core/gossamer.Writing.scala
+++ b/lib/gossamer/src/core/gossamer.Writing.scala
@@ -54,6 +54,20 @@ object Writing:
 
   given showable: Writing is Showable = _.text
 
+  // A `Writing` is a `Text` together with the grapheme boundaries computed for it, and its
+  // `Showable` shows only the text, which is indistinguishable from a `Text`. Inspection
+  // separates the clusters with `·`, since the segmentation is both the state which
+  // distinguishes one `Writing` from another and the reason for looking at one.
+  given inspectable: [writing <: Writing] => writing is Inspectable = writing =>
+    val string = writing.text.s
+    val builder: StringBuilder = new StringBuilder("w\"")
+
+    writing.boundaries.adjacent: (start, limit) =>
+      if start > 0 then builder.append('·')
+      builder.append(string.substring(start, limit).nn)
+
+    builder.append('"').toString.tt
+
   given concatenable: Writing is Concatenable:
     type Result = Writing
     type Operand = Writing

--- a/lib/gossamer/src/core/gossamer.internal.scala
+++ b/lib/gossamer/src/core/gossamer.internal.scala
@@ -133,6 +133,15 @@ object internal:
 
       given showable: Grapheme is Showable = grapheme => grapheme.tt
 
+      // A grapheme is a *cluster* of codepoints, and escaping it the way a `Text` is escaped
+      // would hide exactly the structure a reader is looking at (a ZWJ sequence would become a
+      // row of `\uXXXX`s), so the cluster is shown as it is, inside guillemets which
+      // distinguish it from the `t"…"` of the `Text` it erases to. The grapheme is widened to
+      // `Grapheme` before `text` is called: the accessor is an inline extension on an opaque
+      // type, and its expansion is not available through a subtype.
+      given inspectable: [grapheme <: Grapheme] => grapheme is Inspectable = grapheme =>
+        ("‹"+(grapheme: Grapheme).text.s+"›").tt
+
       // Width of a grapheme is the maximum width of its constituent codepoints. For
       // combining-mark sequences (e.g. e + ́) this gives the base character's width;
       // for joiner-glued graphemes (RI flag pairs, ZWJ family emoji, Hangul jamo
@@ -167,6 +176,16 @@ object internal:
       given showable: Ascii is Showable =
         // Read-only use of the underlying JVM array: the `String` constructor copies.
         ascii => String(ascii.asInstanceOf[scala.Array[Byte]], StandardCharsets.US_ASCII).nn.tt
+
+      // `Ascii` erases to an array of bytes, so without an instance it renders as an array of
+      // numbers, and its `Showable` produces bare text, indistinguishable from a `Text`. The
+      // bytes are shown as the characters they encode, escaped as a text literal's characters
+      // are escaped, and marked `ascii"…"`, which is close to the source form.
+      given inspectable: [ascii <: Ascii] => ascii is Inspectable = ascii =>
+        val builder: StringBuilder = new StringBuilder("ascii\"")
+        showable.text(ascii).each { char => builder.append(Inspectable.escape(char, true).s) }
+
+        builder.append('"').toString.tt
 
       given concatenable: Ascii is Concatenable:
         type Result = Ascii

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -1113,6 +1113,29 @@ object Tests extends Suite(m"Gossamer Tests"):
           words2.all: word =>
             dictionary(word) == word.upper
 
+    // A missing `Inspectable` is never a compile error — `derived` always succeeds and
+    // substitutes a marked `toString`, `Showable` or `Encodable` rendering — so coverage can
+    // only be held in place by asserting on the renderings themselves.
+    suite(m"Native-rendering coverage"):
+      test(m"gossamer's types inspect natively"):
+        Inspectable.fallbacks
+         ( a"hello".inspect,
+           Grapheme("é").inspect,
+           Writing(t"a\r\nb").inspect )
+      . assert(_ == Nil)
+
+      test(m"an Ascii value inspects as an `ascii` literal"):
+        a"hi there".inspect
+      . assert(_ == t"ascii\"hi there\"")
+
+      test(m"a grapheme inspects as its cluster in guillemets"):
+        Grapheme("👨‍👩‍👧").inspect
+      . assert(_ == Text("‹👨‍👩‍👧›"))
+
+      test(m"a Writing inspects with its grapheme boundaries marked"):
+        Writing(t"a\r\nb").inspect
+      . assert(_ == t"w\"a·\r\n·b\"")
+
     suite(m"Writing and grapheme clusters"):
       test(m"empty Text has zero graphemes"):
         Writing(t"").graphemeCount

--- a/lib/guillotine/src/core/guillotine.Executable.scala
+++ b/lib/guillotine/src/core/guillotine.Executable.scala
@@ -105,7 +105,9 @@ object Command:
 
     . join(t" ")
 
-  given inspectable: Command is Inspectable = command =>
+  // Subtype-bounded, so that the type `sh"…"` expands to — a refinement of `Command`, not
+  // `Command` itself — still finds this instance rather than falling through to `showable`.
+  given inspectable: [command <: Command] => command is Inspectable = command =>
     val commandText: Text = formattedArguments(command.arguments.to(List))
     if commandText.contains(t"\"") then t"sh\"\"\"$commandText\"\"\"" else t"sh\"$commandText\""
 
@@ -140,7 +142,9 @@ object Pipeline:
   given communicable: Pipeline is Communicable =
     pipeline => m"${pipeline.commands.map(_.show).join(t" | ")}"
 
-  given inspectable: Pipeline is Inspectable = _.commands.map(_.inspect).join(t" | ")
+  // Subtype-bounded for the same reason as `Command.inspectable`, above.
+  given inspectable: [pipeline <: Pipeline] => pipeline is Inspectable =
+    _.commands.map(_.inspect).join(t" | ")
   given showable: Pipeline is Showable = _.commands.map(_.show).join(t" | ")
 
 case class Pipeline(commands: Command*) extends Executable:

--- a/lib/guillotine/src/core/guillotine.Pid.scala
+++ b/lib/guillotine/src/core/guillotine.Pid.scala
@@ -44,6 +44,11 @@ object Pid:
   given showable: Pid is Showable = _.toString.tt
   given encodable: Pid is Encodable in Text = _.toString.tt
 
+  // `Pid`'s `toString` already prefixes the number with `↯`, which distinguishes it from a plain
+  // number, so the debug rendering is the same text as `showable`'s; it takes no context, so it
+  // is delegated to by name rather than by summoning `Pid is Showable`.
+  given inspectable: [pid <: Pid] => pid is Inspectable = showable.text(_)
+
   given sshAgentPid: (tactic: Tactic[Number.Error]) => ((Variable["sshAgentPid", Pid])^{tactic}) =
     text => Pid(text.as[Int])
 

--- a/lib/guillotine/src/test/guillotine_test.scala
+++ b/lib/guillotine/src/test/guillotine_test.scala
@@ -564,3 +564,12 @@ object Tests extends Suite(m"Guillotine tests"):
       test(m"Command#escape wraps each argument in single quotes"):
         Command(t"echo", t"a b").escape
       . assert(_ == t"'echo' 'a b'")
+
+    suite(m"Native-rendering coverage"):
+      test(m"guillotine's types inspect natively"):
+        Inspectable.fallbacks(Pid(1234L).inspect, sh"ls -la".inspect)
+      . assert(_ == Nil)
+
+      test(m"A PID shows its number, marked as a process"):
+        Pid(1234L).inspect
+      . assert(_ == t"↯1234")

--- a/lib/harlequin/src/core/harlequin.Token.scala
+++ b/lib/harlequin/src/core/harlequin.Token.scala
@@ -44,6 +44,20 @@ object Token:
   val Newline: Token = Token("\n", Accent.Unparsed)
   given showable: Token is Showable = _.text
 
+  // The `Showable` above is the token's text alone, which is what a rendered source listing
+  // needs, but it hides the accent, span and role — the state a reader of highlighted source
+  // is usually checking. Inspection shows each field, in product form. A `Meta` wraps a
+  // `Syntax`, whose textual form needs an `Imports` context which inspection cannot supply, so
+  // a present `Meta` is shown as `｢Meta｣`, without its type.
+  given inspectable: [token <: Token] => token is Inspectable = token =>
+    val meta = if token.meta.present then t"｢Meta｣" else t"○"
+    val role = token.role.lay(t"○"): role => t"｢${role.inspect}｣"
+
+    val fields =
+      t"text:${token.text.inspect} ╱ accent:${token.accent.inspect} ╱ meta:$meta"
+
+    t"Token($fields ╱ span:${token.span.inspect} ╱ role:$role)"
+
   case class Meta(tpe: Syntax)
 
 // `span` locates the token in its `SourceCode`: a `Line`-mode `Span` carrying the

--- a/lib/harlequin/src/test/harlequin_test.scala
+++ b/lib/harlequin/src/test/harlequin_test.scala
@@ -64,6 +64,20 @@ object Tests extends Suite(m"Harlequin Tests"):
       tokens.seek(_.text == text).let: token =>
         token.meta.let(_.tpe.qualified)
 
+    // A missing `Inspectable` is never a compile error — `derived` always succeeds and
+    // substitutes a marked `toString`, `Showable` or `Encodable` rendering — so coverage can
+    // only be held in place by asserting on the renderings themselves.
+    suite(m"Native-rendering coverage"):
+      test(m"harlequin's types inspect natively"):
+        Inspectable.fallbacks
+         ( Token(t"val", Accent.Keyword).inspect,
+           Token(t"xs", Accent.Term, role = Role.Binding).inspect )
+      . assert(_ == Nil)
+
+      test(m"a token inspects with all of its state"):
+        Token(t"val", Accent.Keyword).inspect
+      . assert(_ == Text("Token(text:t\"val\" ╱ accent:Keyword ╱ meta:○ ╱ span:⟪∅⟫ ╱ role:○)"))
+
     test(m"tokenized highlighting attaches no type metadata"):
       Scala.highlight(snippet).lines.to[List].stdlib.flatMap(_.stdlib).flatMap(_.meta.option)
     .assert(_ == Nil)

--- a/lib/hellenism/src/core/hellenism.internal.scala
+++ b/lib/hellenism/src/core/hellenism.internal.scala
@@ -41,6 +41,7 @@ import fulminate.*
 import gigantism.*
 import prepositional.*
 import serpentine.*
+import spectacular.*
 import vacuous.*
 
 object internal extends Hellenism2:
@@ -49,6 +50,11 @@ object internal extends Hellenism2:
   object ClassRef:
     def apply(javaClass: Class[?]): ClassRef = javaClass
     inline def apply[template <: AnyKind]: ClassRef = ${hellenism.internal.makeClass[template]}
+
+    // A `Class`'s own `toString` is `class java.lang.String`, which reads as two words rather
+    // than one value; the rendering instead resembles the source which produces a `ClassRef`.
+    given inspectable: [classRef <: ClassRef] => classRef is Inspectable = classRef =>
+      ("classOf["+classRef.getName.nn+"]").tt
 
   extension (classRef: ClassRef)
     def classloader: Classloader = new Classloader(classRef.getClassLoader().nn)

--- a/lib/hellenism/src/jvm/hellenism.LocalClasspath.scala
+++ b/lib/hellenism/src/jvm/hellenism.LocalClasspath.scala
@@ -41,12 +41,25 @@ import gossamer.*
 import prepositional.*
 import rudiments.*
 import serpentine.*
+import spectacular.*
 import symbolism.*
 
 import filesystemBackends.virtualMachineFilesystem
 
 object LocalClasspath:
   given encodable: System => LocalClasspath is Encodable in Text = _()
+
+  // `encodable` needs a `System`, since the separator between entries is a system property, and
+  // a debug rendering must always be available; the entries are therefore joined here with `:`
+  // regardless of platform, and the whole rendering is tagged so that it cannot be mistaken for
+  // the platform-specific text which `encodable` produces.
+  given inspectable: [localClasspath <: LocalClasspath] => localClasspath is Inspectable =
+    _.entries.map:
+      case Classpath.Entry.Directory(directory) => directory
+      case Classpath.Entry.Jar(jar)             => jar
+      case Classpath.Entry.JavaRuntime          => t"‹jrt›"
+
+    . join(t"classpath⟨", t":", t"⟩")
 
   given decodable: (System, Tactic[Property.Error])
   =>  LocalClasspath is Decodable in Text =

--- a/lib/hellenism/src/test/hellenism_test.scala
+++ b/lib/hellenism/src/test/hellenism_test.scala
@@ -73,3 +73,19 @@ object Tests extends Suite(m"Hellenism Tests"):
       val classpath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       classpath.services[TestService].stdlib.map(_.name).to(Set)
     . assert(_ == Set(t"A", t"B"))
+
+    suite(m"Native-rendering coverage"):
+      val classpath = LocalClasspath(Classpath.Entry.Jar(t"/x.jar"),
+                                     Classpath.Entry.Directory(t"/a/b/"))
+
+      test(m"hellenism's types inspect natively"):
+        Inspectable.fallbacks(classpath.inspect, ClassRef(classOf[String]).inspect)
+      . assert(_ == Nil)
+
+      test(m"A classpath shows its entries, separated by colons"):
+        classpath.inspect
+      . assert(_ == t"classpath⟨/x.jar:/a/b/⟩")
+
+      test(m"A class reference shows the source which produces it"):
+        ClassRef(classOf[String]).inspect
+      . assert(_ == t"classOf[java.lang.String]")

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -305,6 +305,21 @@ object Html extends Tag.Container
     Producer.collect[Text](): producer =>
       writeHtml(producer, doms.html.whatwg, node, 0, false, Mode.Whitespace)
 
+  // `Element`, `Fragment`, `TextNode`, `Comment` and `Doctype` are all covered here, in the
+  // companion of the trait they share, exactly as `showable` above covers them: the bound admits
+  // every node type and every topic- or DOM-refined form of one. The rendering is the node's own
+  // un-indented HTML source, escaped into an `html"…"` literal — compact, on one line, and
+  // showing the tag, its attributes and its children. It is distinguishable both from the `Text`
+  // holding the same markup and from xylophone's `xml"…"`, following ypsiloid's `yaml"…"`.
+  given inspectable: [html <: Html] => html is Inspectable = node =>
+    val markup: Text = Producer.collect[Text](): producer =>
+      writeHtml(producer, doms.html.whatwg, node, 0, false, Mode.Whitespace)
+
+    val builder: StringBuilder = new StringBuilder()
+    markup.each { char => builder.append(Inspectable.escape(char).s) }
+
+    ("html\""+builder.toString+"\"").tt
+
   // HTML5 text-content escaping: `&`, `<` and `>`. Raw-text elements such as `script` and `style`
   // use `Mode.Raw` and are written verbatim by `writeHtml`.
   private def writeEscapedText(producer: Producer[Text]^, text: Text): Unit =

--- a/lib/honeycomb/src/core/honeycomb.internal.scala
+++ b/lib/honeycomb/src/core/honeycomb.internal.scala
@@ -639,6 +639,35 @@ object internal:
   object Attributes:
     val empty: Attributes = scala.IArray.empty[String | Null]
 
+    // The attributes render as they would appear in an element's start tag, braced and prefixed
+    // `html`: distinct from a `Map`'s `{k → v}` (whose keys and values would show as `t"…"`
+    // literals) and from xylophone's `xml{…}`. A valueless attribute shows as a bare name, as it
+    // does in HTML source. The storage is read directly, since an accessor on the opaque type is
+    // unavailable through a subtype of it.
+    given inspectable: [attributes <: Attributes] => attributes is Inspectable = attributes =>
+      val array = storage(attributes)
+      val builder: StringBuilder = new StringBuilder("html{")
+      var index = 0
+
+      while index < array.length do
+        if index > 0 then builder.append(", ")
+        builder.append(array(index))
+        val value = array(index + 1)
+
+        if value != null then
+          builder.append("=\"")
+          var offset = 0
+
+          while offset < value.length do
+            builder.append(Inspectable.escape(value.charAt(offset)).s)
+            offset += 1
+
+          builder.append('"')
+
+        index += 2
+
+      builder.append('}').toString.tt
+
     def apply(pairs: (Text, Optional[Text])*): Attributes =
       if pairs.isEmpty then empty else
         val n = pairs.length

--- a/lib/honeycomb/src/test/honeycomb_test.scala
+++ b/lib/honeycomb/src/test/honeycomb_test.scala
@@ -40,6 +40,30 @@ import strategies.throwUnsafely
 
 object Tests extends Suite(m"Honeycombd Tests"):
   def run(): Unit =
+    // A missing `Inspectable` is never a compile error, so coverage is held in place by
+    // asserting on the renderings: `fallbacks` returns those which used a marked fallback.
+    suite(m"Native-rendering coverage"):
+      import doms.html.whatwg
+      import whatwg.*
+
+      test(m"an element inspects as escaped, single-line HTML source"):
+        Div(style = t"bar")("hello").inspect
+      . assert(_ == t"html\"<div style=\\\"bar\\\">hello</div>\"")
+
+      test(m"attributes inspect as an element's start-tag text"):
+        internal.Attributes(t"class" -> t"a", t"hidden" -> Unset).inspect
+      . assert(_ == t"html{class=\"a\", hidden}")
+
+      test(m"honeycomb's types inspect natively"):
+        Inspectable.fallbacks
+         ( Div(style = t"bar")("hello").inspect,
+           Fragment(Div("content"), P("more content")).inspect,
+           Comment(t"hi").inspect,
+           Doctype(t"html").inspect,
+           TextNode(t"hi").inspect,
+           internal.Attributes(t"class" -> t"a", t"hidden" -> Unset).inspect )
+      . assert(_ == Nil)
+
     test(m"show comment"):
       Comment("hello world").show
     . assert(_ == t"<!--hello world-->")

--- a/lib/inimitable/src/core/inimitable.Uuid.scala
+++ b/lib/inimitable/src/core/inimitable.Uuid.scala
@@ -56,6 +56,11 @@ object Uuid extends Extractor[Text, Uuid]:
   // `inimitable`; being companion-to-companion, this is the same implicit scope as before.
   given showable: Uuid is Showable = _.text
 
+  // The canonical hyphenated form shows both halves of the UUID in full, and its shape makes it
+  // unmistakable, so the debug rendering is the same text; it needs no context, so it delegates
+  // to `showable` by name rather than by summoning `Uuid is Showable`.
+  given inspectable: [uuid <: Uuid] => uuid is Inspectable = showable.text(_)
+
   def parse(text: Text): Uuid raises Uuid.Error =
     extract(text).lest(Uuid.Error(text))
 

--- a/lib/inimitable/src/test/inimitable_test.scala
+++ b/lib/inimitable/src/test/inimitable_test.scala
@@ -96,3 +96,12 @@ object Tests extends Suite(m"Inimitable Tests"):
           uuid"not-a-uuid"
         .map(_.message)
       . assert(_ == List(t"[↯SN-349] not-a-uuid is not a valid UUID"))
+
+    suite(m"Native-rendering coverage"):
+      test(m"inimitable's types inspect natively"):
+        Inspectable.fallbacks(uuid"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c".inspect)
+      . assert(_ == Nil)
+
+      test(m"A UUID shows its canonical hyphenated form"):
+        uuid"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c".inspect
+      . assert(_ == t"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c")

--- a/lib/iridescence/src/core/iridescence.Rgb12Opaque.scala
+++ b/lib/iridescence/src/core/iridescence.Rgb12Opaque.scala
@@ -35,12 +35,17 @@ package iridescence
 import anticipation.*
 import prepositional.*
 import rudiments.*
+import spectacular.*
 
 object Rgb12Opaque:
   opaque type Rgb12 = Int
 
   object Rgb12:
     inline given underlying: Underlying[Rgb12, Int] = !!
+
+    // The three-digit hexadecimal the type already knows how to produce; without an instance
+    // the packed `Int` it erases to would render as a bare number.
+    given inspectable: [rgb12 <: Rgb12] => rgb12 is Inspectable = rgb12 => (rgb12: Rgb12).hex
     given chromatic: Rgb12 is Chromatic = _.chroma
 
     def apply(red: Int, green: Int, blue: Int): Rgb12 =
@@ -51,6 +56,11 @@ object Rgb12Opaque:
 
     def green: Int = (color >> 4)&15
     def blue: Int = color&15
-    def hex: Text = ("#"+List(red, green, blue).map(_.hex).stdlib.mkString).tt
+    // `Integer.toHexString`, not hypotenuse's `Int.hex`: inside this object the opaque type is
+    // transparent, so `hex` on an `Int` channel resolves back to this very extension and
+    // recurses until the stack is exhausted.
+    def hex: Text =
+      ("#"+Integer.toHexString(red).nn+Integer.toHexString(green).nn+Integer.toHexString(blue).nn)
+      . tt
     def color: Color in Srgb = Srgb(red/15.0, green/15.0, blue/15.0)
     def chroma: Chroma = Chroma(red*17, green*17, blue*17)

--- a/lib/iridescence/src/core/iridescence.Rgb32Opaque.scala
+++ b/lib/iridescence/src/core/iridescence.Rgb32Opaque.scala
@@ -35,6 +35,7 @@ package iridescence
 import anticipation.*
 import prepositional.*
 import rudiments.*
+import spectacular.*
 
 object Rgb32Opaque:
   opaque type Rgb32 = Int
@@ -42,6 +43,13 @@ object Rgb32Opaque:
   object Rgb32:
     inline given underlying: Underlying[Rgb32, Int] = !!
     given chromatic: Rgb32 is Chromatic = _.chroma
+
+    // The three channels have unequal widths — 10, 12 and 10 bits — so they are shown
+    // separately rather than as a single hexadecimal number, which would imply otherwise, and
+    // the packed `Int` the type erases to would say nothing at all.
+    given inspectable: [rgb32 <: Rgb32] => rgb32 is Inspectable = rgb32 =>
+      val value: Rgb32 = rgb32
+      ("rgb32("+value.red+", "+value.green+", "+value.blue+")").tt
 
     def apply(red: Int, green: Int, blue: Int): Rgb32 =
       ((red&1023) << 22) + ((green&4095) << 10) + (blue&1023)

--- a/lib/iridescence/src/test/iridescence_test.scala
+++ b/lib/iridescence/src/test/iridescence_test.scala
@@ -40,6 +40,21 @@ given Colorimetry = colorimetry.daylight
 
 object Tests extends Suite(m"Iridescence tests"):
   def run(): Unit =
+    // A missing `Inspectable` is never a compile error, so coverage is held in place by
+    // asserting on the renderings: `fallbacks` returns those which used a marked fallback.
+    suite(m"Native-rendering coverage"):
+      test(m"a packed 12-bit colour inspects as hexadecimal"):
+        Rgb12(15, 0, 15).inspect
+      . assert(_ == t"#f0f")
+
+      test(m"a packed 32-bit colour inspects as its three channels"):
+        Rgb32(1023, 4095, 0).inspect
+      . assert(_ == t"rgb32(1023, 4095, 0)")
+
+      test(m"iridescence's packed colour types inspect natively"):
+        Inspectable.fallbacks(Rgb12(15, 0, 15).inspect, Rgb32(1023, 4095, 0).inspect)
+      . assert(_ == Nil)
+
     suite(m"Roundtrip tests"):
 
       given Srgb is Checkable against Srgb = (left, right) =>

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -2494,6 +2494,15 @@ object Json extends Json2, Dynamic:
 
   given showable: Formatting => Json is Showable = _.root.show
 
+  // `Json` is a plain class, so there is no reflection to derive from, and its `Showable`
+  // needs a `Formatting` which a debugger has no way to supply — without an instance it
+  // rendered as its `toString`. Inspection fixes the compact formatting rather than taking one
+  // from the call site: an inspection is single-line by convention, and the indented form
+  // would break that wherever a document appears inside another rendering.
+  given inspectable: [json <: Json] => json is Inspectable = json =>
+    given formatting: Formatting = Formatting(Unset, trailingNewline = false)
+    (json: Json).root.show
+
   given abstractable: (encoder: CharEncoder, formatting: Formatting)
   =>  Json is Abstractable across HttpStreams to HttpStreams.Content =
 

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -1317,6 +1317,14 @@ object Json extends Json2, Dynamic:
             // consuming parser as a neutral reference.
             Json.Ast.parse(stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Data] over Credit)^])
 
+    // `Json.Ast` is an opaque union of primitives and arrays, so there is no reflection to derive
+    // from, and its `Showable` (below) needs a `Formatting` which a debugger has no way to supply.
+    // Inspection fixes the compact formatting, exactly as `Json.inspectable` does, and marks the
+    // result `ᵃˢᵗ` so that a bare node is distinguishable from the `Json` document wrapping it.
+    given inspectable: [ast <: Json.Ast] => ast is Inspectable = ast =>
+      given formatting: Json.Formatting = Json.Formatting(Unset, trailingNewline = false)
+      ((ast: Json.Ast).show.s+"ᵃˢᵗ").tt
+
     // Renders a `Json.Ast` node to its serialized text. The whole serialization fold lives in this
     // instance so that `ast.show` is the single route to JSON text; the producer is driven
     // synchronously and the result collected into one `Text`. Number nodes are emitted from their

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -189,6 +189,17 @@ object Tests extends Suite(m"Jacinta Tests"):
         t"""{"inner":{"n":42}}""".read[Json].as[Outer]
       . assert(_ == Outer(Inner(42)))
 
+    // A missing `Inspectable` is never a compile error, so coverage is held in place by
+    // asserting on the renderings: `fallbacks` returns those which used a marked fallback.
+    suite(m"Native-rendering coverage"):
+      test(m"a Json document inspects compactly, whatever formatting is in scope"):
+        t"foo".in[Json].inspect
+      . assert(_ == t""""foo"""")
+
+      test(m"jacinta's types inspect natively"):
+        Inspectable.fallbacks(t"foo".in[Json].inspect, 42.in[Json].inspect)
+      . assert(_ == Nil)
+
     suite(m"Serialization"):
       test(m"Serialize string"):
         t"foo".in[Json].show

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -196,8 +196,14 @@ object Tests extends Suite(m"Jacinta Tests"):
         t"foo".in[Json].inspect
       . assert(_ == t""""foo"""")
 
+      test(m"a bare Json.Ast is marked apart from the document wrapping it"):
+        Json.Ast("foo").inspect
+      . assert(_ == t"\"foo\"ᵃˢᵗ")
+
       test(m"jacinta's types inspect natively"):
-        Inspectable.fallbacks(t"foo".in[Json].inspect, 42.in[Json].inspect)
+        Inspectable.fallbacks
+         ( t"foo".in[Json].inspect, 42.in[Json].inspect, Json.Ast("foo").inspect,
+           Json.Ast(42L).inspect )
       . assert(_ == Nil)
 
     suite(m"Serialization"):

--- a/lib/mosquito/src/core/mosquito.Matrix.scala
+++ b/lib/mosquito/src/core/mosquito.Matrix.scala
@@ -49,6 +49,30 @@ import vacuous.*
 import mosquito.internal.Vector
 
 object Matrix:
+  // The `Showable` sets a matrix as a multi-line grid inside stretched brackets, which inspection
+  // (always one line) cannot use: rows are separated by `⫽` and elements within a row by `∣`,
+  // between the corner brackets which stand in for the tall ones. Elements are visited with an
+  // index loop over `elements`, as `toString` is, so that no derivation over the frozen `Array`
+  // leaks its capture set into this instance's `text`.
+  given inspectable: [element: Inspectable, matrix <: Matrix[element, ?, ?]]
+  =>  matrix is Inspectable = matrix =>
+
+    val builder: StringBuilder = new StringBuilder("⌈")
+    var row = 0
+
+    while row < matrix.rows do
+      if row > 0 then builder.append(" ⫽ ")
+      var column = 0
+
+      while column < matrix.columns do
+        if column > 0 then builder.append(" ∣ ")
+        builder.append(element.text(matrix.elements.readUnchecked(matrix.columns*row + column)).s)
+        column += 1
+
+      row += 1
+
+    builder.append("⌋").toString.tt
+
   given showable: [element: Showable] => Text is Measurable => Matrix[element, ?, ?] is Showable =
     matrix =>
       val textElements = matrix.elements.remap(_.show)

--- a/lib/mosquito/src/core/mosquito.internal.scala
+++ b/lib/mosquito/src/core/mosquito.internal.scala
@@ -130,6 +130,22 @@ object internal:
 
         new Vector[result, size](arr)
 
+    // A single-line counterpart to the (column-shaped, multi-line) `Showable`, sharing the `∣`
+    // element separator with `Matrix`'s rows. Unlike the `Showable` it needs neither the size as a
+    // singleton nor a text metric, so it is available for any vector.
+    given inspectable: [element: Inspectable, vector <: Vector[element, ?]]
+    =>  vector is Inspectable = vector =>
+
+      val builder: StringBuilder = new StringBuilder("⟨")
+      var index = 0
+
+      while index < vector.data.length do
+        if index > 0 then builder.append(" ∣ ")
+        builder.append(element.text(vector.data.readable(index).asInstanceOf[element]).s)
+        index += 1
+
+      builder.append("⟩").toString.tt
+
     given showable: [size <: Int: ValueOf, element: Showable] => Text is Measurable
     =>  Vector[element, size] is Showable =
 

--- a/lib/mosquito/src/test/mosquito_test.scala
+++ b/lib/mosquito/src/test/mosquito_test.scala
@@ -692,3 +692,20 @@ object Tests extends Suite(m"Mosquito tests"):
         mat.solve(Vector(2.0, 3.0)).lay(Double.MaxValue): solution =>
           math.abs(solution(0) - 3.0) + math.abs(solution(1) - 2.0)
       . assert(_ < 0.000001)
+
+    suite(m"Native-rendering coverage"):
+      test(m"mosquito's types inspect natively"):
+        Inspectable.fallbacks
+         ( Vector(1, 2, 3).inspect,
+           Matrix[2, 2]((1, 2), (3, 4)).inspect,
+           Affine[Double](1.0, 0.0, 0.0, 1.0, 0.0, 0.0).inspect )
+
+      . assert(_ == Nil)
+
+      test(m"a vector inspects on one line"):
+        Vector(1, 2, 3).inspect
+      . assert(_ == t"⟨1 ∣ 2 ∣ 3⟩")
+
+      test(m"a matrix inspects row by row"):
+        Matrix[2, 2]((1, 2), (3, 4)).inspect
+      . assert(_ == t"⌈1 ∣ 2 ⫽ 3 ∣ 4⌋")

--- a/lib/nomenclature/src/core/nomenclature.internal.scala
+++ b/lib/nomenclature/src/core/nomenclature.internal.scala
@@ -37,6 +37,7 @@ import contingency.*
 import distillate.*
 import fulminate.*
 import prepositional.*
+import spectacular.*
 import scala.quoted.*
 
 object internal:
@@ -44,6 +45,22 @@ object internal:
 
   object Name:
     given encodable: [plane] => Name[plane] is Encodable in Text = identity(_)
+
+    // `Name` is a subtype of `Text`, so without an instance of its own it would reach
+    // spectacular's `Text` instance and render `t"…"` — a name would be indistinguishable from
+    // the text it is validated to be. The `n"…"` prefix says which of the two it is, and the
+    // characters are escaped exactly as a text literal's are.
+    // `Name` is covariant in its plane, so `Name[Any]` bounds every name.
+    given inspectable: [name <: Name[Any]] => name is Inspectable = name =>
+      val builder: StringBuilder = new StringBuilder("n\"")
+      val string: String = (name: Text).s
+      var index: Int = 0
+
+      while index < string.length do
+        builder.append(Inspectable.escape(string.charAt(index), true).s)
+        index += 1
+
+      builder.append('"').toString.tt
 
     inline given decodable: [plane] => (plane is Nominative, Tactic[Name.Error])
     =>  Name[plane] is Decodable in Text =

--- a/lib/nomenclature/src/lexicon/nomenclature.Moniker.scala
+++ b/lib/nomenclature/src/lexicon/nomenclature.Moniker.scala
@@ -39,6 +39,7 @@ import contingency.*
 import distillate.*
 import prepositional.*
 import fulminate.*
+import spectacular.*
 
 object Moniker:
   opaque type Moniker = Int
@@ -50,6 +51,15 @@ object Moniker:
     wrap(ordinal)
 
   extension (moniker: Moniker) def ordinal: Int = moniker
+
+  // The `Encodable` below needs the `Vocabulary` which supplies the words for the number, and a
+  // `Tactic` for a number the vocabulary cannot name; a debug rendering can rely on neither, so
+  // inspection shows the ordinal the moniker *is*, suffixed so that it is distinguishable from
+  // the `Int` it erases to. The value is widened to `Moniker` before `ordinal` is called: the
+  // accessor is an inline extension on an opaque type, and its expansion is not available
+  // through a subtype.
+  given inspectable: [moniker <: Moniker] => moniker is Inspectable = moniker =>
+    ((moniker: Moniker).ordinal.toString+"ᵐᵏ").tt
 
   // An honest capability: the instance retains the resolution-scoped tactic
   // (every given that includes a tactic is a capability; Jon, 2026-07-13).

--- a/lib/nomenclature/src/test/nomenclature_test.scala
+++ b/lib/nomenclature/src/test/nomenclature_test.scala
@@ -198,6 +198,24 @@ object Tests extends Suite(m"Nomenclature tests"):
       capture[Moniker.Error](t"notathing-leopard".as[Moniker over Session]).message.show
     . assert(_ == t"the moniker is not valid because the word notathing does not appear in the vocabulary")
 
+    // A missing `Inspectable` is never a compile error — `derived` always succeeds and
+    // substitutes a marked `toString`, `Showable` or `Encodable` rendering — so coverage can
+    // only be held in place by asserting on the renderings themselves.
+    suite(m"Native-rendering coverage"):
+      test(m"nomenclature's types inspect natively"):
+        given (Vocabulary over Session) = Vocabulary(adjectives, animals)
+        Inspectable.fallbacks(Name[EndsO](t"foo").inspect, Moniker[Session](10351).inspect)
+      . assert(_ == Nil)
+
+      test(m"a name is distinguishable from the text it is"):
+        Name[EndsO](t"foo").inspect
+      . assert(_ == t"n\"foo\"")
+
+      test(m"a moniker inspects as its ordinal"):
+        given (Vocabulary over Session) = Vocabulary(adjectives, animals)
+        Moniker[Session](10351).inspect
+      . assert(_ == Text("10351ᵐᵏ"))
+
     suite(m"MustStart"):
       inline given prefixed: Prefixed is Nominative under MustStart["x-"] = !!
 

--- a/lib/octogenarian/src/core/octogenarian.Git.scala
+++ b/lib/octogenarian/src/core/octogenarian.Git.scala
@@ -902,6 +902,10 @@ object Git:
     =>  ((Git.Tag is Decodable in Text)^{tactic}) = parse(_)
     given showable: Git.Tag is Showable = _.text
 
+    // The name alone would be indistinguishable from a branch name, a tag and a raw refspec,
+    // each of which is a different argument to git, so every ref names its own kind.
+    given inspectable: [tag <: Git.Tag] => tag is Inspectable = tag => t"Tag(${tag.text})"
+
   case class Tag(text: Text) extends octogenarian.internal.Refspec
 
   object Branch:
@@ -911,6 +915,9 @@ object Git:
     given decoder: (tactic: Tactic[Git.RefError])
     =>  ((Git.Branch is Decodable in Text)^{tactic}) = parse(_)
     given showable: Git.Branch is Showable = _.text
+
+    given inspectable: [branch <: Git.Branch] => branch is Inspectable = branch =>
+      t"Branch(${branch.text})"
 
   case class Branch(text: Text) extends octogenarian.internal.Refspec
 
@@ -928,6 +935,10 @@ object Git:
     given decoder: (tactic: Tactic[Git.RefError])
     =>  ((Git.Hash is Decodable in Text)^{tactic}) = apply(_)
     given showable: Git.Hash is Showable = _.text
+
+    // The full forty hexadecimal digits: an abbreviated hash is ambiguous between objects, and
+    // an inspection which abbreviated would hide exactly the difference being looked for.
+    given inspectable: [hash <: Git.Hash] => hash is Inspectable = hash => t"Hash(${hash.text})"
 
   class Hash(val text: Text) extends Root(t"$text/"), octogenarian.internal.Refspec:
     type Plane = Notes

--- a/lib/octogenarian/src/core/octogenarian.internal.scala
+++ b/lib/octogenarian/src/core/octogenarian.internal.scala
@@ -75,6 +75,12 @@ object internal:
     given parameterizable: Refspec is Parameterizable = _.text
     given showable: Refspec is Showable = _.text
 
+    // Covers the revision specifiers which are not named refs — `HEAD~2`, `main..feature` — as
+    // well as any `Refspec` seen only through the trait; `Git.Hash`, `Git.Branch` and `Git.Tag`
+    // each have their own, more specific, instance.
+    given inspectable: [refspec <: Refspec] => refspec is Inspectable = refspec =>
+      t"Refspec(${refspec.text})"
+
   trait Refspec:
     def text: Text
 

--- a/lib/octogenarian/src/test/octogenarian_test.scala
+++ b/lib/octogenarian/src/test/octogenarian_test.scala
@@ -102,6 +102,30 @@ object Tests extends Suite(m"Octogenarian Tests"):
 
     // ----- Refspec validation (unit tests, no git) ------------------------
 
+    // A missing `Inspectable` is never a compile error — `derived` always succeeds and
+    // substitutes a marked `toString`, `Showable` or `Encodable` rendering — so coverage can
+    // only be held in place by asserting on the renderings.
+    suite(m"Native-rendering coverage"):
+
+      test(m"octogenarian's ref types inspect natively"):
+        Inspectable.fallbacks
+         ( Git.Hash.unsafe(t"5c1d2b7e3a4f60918273645566778899aabbccdd").inspect,
+           Git.Branch.unsafe(t"main").inspect,
+           Git.Tag.unsafe(t"v1.0").inspect,
+           Refspec.head(2).inspect )
+      .assert(_ == Nil)
+
+      test(m"a hash inspects with all forty digits"):
+        Git.Hash.unsafe(t"5c1d2b7e3a4f60918273645566778899aabbccdd").inspect
+      .assert(_ == t"Hash(5c1d2b7e3a4f60918273645566778899aabbccdd)")
+
+      test(m"a branch, a tag and a raw refspec each name their kind"):
+        List
+         ( Git.Branch.unsafe(t"main").inspect,
+           Git.Tag.unsafe(t"v1.0").inspect,
+           Refspec.head(2).inspect )
+      .assert(_ == List(t"Branch(main)", t"Tag(v1.0)", t"Refspec(HEAD~2)"))
+
     suite(m"Refspec validation"):
 
       test(m"a valid branch name parses unchanged"):

--- a/lib/plutocrat/src/core/plutocrat.internal.scala
+++ b/lib/plutocrat/src/core/plutocrat.internal.scala
@@ -77,6 +77,13 @@ object internal:
         if result.isin != isin then abort(Isin.Error(Isin.Error.LuhnCheck))
         result
 
+    // The twelve-character ISIN is packed into a `Long`, so a rendering which showed the number
+    // would say nothing about the value; it is unpacked and rendered in the form of the
+    // `isin"…"` interpolator which produces it. The `Isin` is widened before its accessor is
+    // called: the extension unseals the underlying `Long`, and is unavailable through a subtype.
+    given inspectable: [isin <: Isin] => isin is Inspectable = isin =>
+      ("isin\""+(isin: Isin).isin.s+"\"").tt
+
     // IsinError → Isin.Error
     object Error:
       enum Reason(val number: Int) extends Clarification:
@@ -166,6 +173,17 @@ object internal:
         val subunit = (money.value%currency.modulus).toString.show.pad(2, Rtl, '0')
 
         currencyStyle.format(currency.code, currency.symbol, units, subunit)
+
+    // Unlike `showable`, this needs neither a `Currency` nor a `Currency.Style`: the currency
+    // code is packed into the value, and the amount is shown exactly, in minor units, since the
+    // modulus which places the decimal point is known only to the `Currency`. The `¤` marks the
+    // value as money and the `ₘ` marks the amount as minor units — without it, three euros and
+    // one cent would read as three hundred and one euros, which is the one misreading a
+    // rendering of money must not permit. The `Money` is widened before its accessors are
+    // called: they are extensions on an opaque type, whose expansion is unavailable through a
+    // subtype.
+    given inspectable: [money <: Money] => money is Inspectable = money =>
+      ("¤"+(money: Money).currency.s+(money: Money).value.toString+"ₘ").tt
 
     given addable: [currency <: Label]
     =>  (Money in currency) is Addable by (Money in currency) to (Money in currency) =

--- a/lib/plutocrat/src/test/plutocrat_test.scala
+++ b/lib/plutocrat/src/test/plutocrat_test.scala
@@ -186,3 +186,16 @@ object Tests extends Suite(m"Plutocrat tests"):
       test(m"Compiletime ISIN Luhn check failure"):
         demilitarize(isin"GB00BH4HKS34").map(_.message)
       . assert(_ == List(t"[↯SN-515.4] the ISIN number is not valid because its last digit failed the Luhn check"))
+
+    suite(m"Native-rendering coverage"):
+      test(m"plutocrat's types inspect natively"):
+        Inspectable.fallbacks(Eur(3.01).inspect, isin"US0378331005".inspect)
+      . assert(_ == Nil)
+
+      test(m"A monetary value shows its currency and exact minor units"):
+        Eur(3.01).inspect
+      . assert(_ == t"¤EUR301ₘ")
+
+      test(m"An ISIN shows the form its interpolator takes"):
+        isin"US0378331005".inspect
+      . assert(_ == t"isin\"US0378331005\"")

--- a/lib/punctuation/src/core/punctuation.Markdown.scala
+++ b/lib/punctuation/src/core/punctuation.Markdown.scala
@@ -39,7 +39,7 @@ import gossamer.*
 import honeycomb.*
 import prepositional.*
 import rudiments.*
-import spectacular.Showable
+import spectacular.{Inspectable, Showable, inspect}
 import vacuous.*
 
 import attributives.textAttributive
@@ -141,6 +141,71 @@ object Markdown:
 
   given proseShowable: Markdown.Formatting => (Markdown of Prose) is Showable =
     (markdown: Markdown of Prose) => Serializer(markdown)
+
+  // Both `Showable`s above re-serialize the document to CommonMark source, which needs a
+  // `Markdown.Formatting` for the wrap width and which — being source again — says nothing
+  // about how the source was parsed. Inspection shows the tree instead: each node in product
+  // form, with the line it came from, since a `Markdown` value is normally being looked at to
+  // check what the parser made of the input. One instance serves both `Markdown of Layout` and
+  // `Markdown of Prose`, which are refinements of the same trait.
+  given inspectable: [markdown <: Markdown] => markdown is Inspectable = markdown =>
+    val linkRefs = markdown.linkRefs.stdlib.map: linkRef =>
+      val title = linkRef.title.lay(t"○")(_.inspect)
+      t"LinkRef(${linkRef.label.inspect} ╱ $title ╱ ${linkRef.destination.inspect})".s
+
+    . mkString("[", ", ", "]")
+
+    t"Markdown(linkRefs:${linkRefs.tt} ╱ children:${inspectNodes(markdown.children)})"
+
+  private def inspectNodes[node <: Markdown.Node](nodes: List[node]): Text =
+    nodes.stdlib.map(inspectNode(_).s).mkString("[", ", ", "]").tt
+
+  private def inspectNode(node: Markdown.Node): Text = node match
+    case Prose.Textual(text)    => t"Textual(${text.inspect})"
+    case Prose.Softbreak        => t"Softbreak"
+    case Prose.Linebreak        => t"Linebreak"
+    case Prose.Code(code)       => t"Code(${code.inspect})"
+    case Prose.HtmlInline(html) => t"HtmlInline(${html.inspect})"
+    case Prose.Emphasis(prose*) => t"Emphasis(${inspectNodes(prose.toList.to(List))})"
+    case Prose.Strong(prose*)   => t"Strong(${inspectNodes(prose.toList.to(List))})"
+    case Layout.ThematicBreak(line)  => t"ThematicBreak(${line.inspect})"
+    case Layout.HtmlBlock(line, html) => t"HtmlBlock(${line.inspect} ╱ ${html.inspect})"
+
+    case Prose.Link(destination, title, prose*) =>
+      val nodes = inspectNodes(prose.toList.to(List))
+      t"Link(${destination.inspect} ╱ ${title.lay(t"○")(_.inspect)} ╱ $nodes)"
+
+    case Prose.Image(destination, title, prose*) =>
+      val nodes = inspectNodes(prose.toList.to(List))
+      t"Image(${destination.inspect} ╱ ${title.lay(t"○")(_.inspect)} ╱ $nodes)"
+
+    case Layout.BlockQuote(line, layout*) =>
+      t"BlockQuote(${line.inspect} ╱ ${inspectNodes(layout.toList.to(List))})"
+
+    case Layout.Paragraph(line, prose*) =>
+      t"Paragraph(${line.inspect} ╱ ${inspectNodes(prose.toList.to(List))})"
+
+    case Layout.Heading(line, level, prose*) =>
+      t"Heading(${line.inspect} ╱ ${level.inspect} ╱ ${inspectNodes(prose.toList.to(List))})"
+
+    case Layout.CodeBlock(line, info, content) =>
+      t"CodeBlock(${line.inspect} ╱ ${info.inspect} ╱ ${content.inspect})"
+
+    case Layout.BulletList(line, tight, items*) =>
+      t"BulletList(${line.inspect} ╱ ${tight.inspect} ╱ ${inspectItems(items.toList)})"
+
+    case Layout.OrderedList(line, start, tight, delimiter, items*) =>
+      val head = t"${line.inspect} ╱ ${start.inspect} ╱ ${tight.inspect}"
+      val mark = delimiter.lay(t"○")(_.inspect)
+      t"OrderedList($head ╱ $mark ╱ ${inspectItems(items.toList)})"
+
+    // `Markdown.Node` is an open trait, so a node which is neither a `Layout` nor a `Prose`
+    // is marked as having no rendering of its own, exactly as spectacular's own fallback does.
+    case node =>
+      t"“${node.toString.tt}”"
+
+  private def inspectItems(items: scala.collection.immutable.List[List[Layout]]): Text =
+    items.map(inspectNodes(_).s).mkString("[", ", ", "]").tt
 
   given prose: (Markdown of Prose) is Renderable:
     type Form = Phrasing

--- a/lib/punctuation/src/test/punctuation_test.scala
+++ b/lib/punctuation/src/test/punctuation_test.scala
@@ -77,6 +77,21 @@ object Tests extends Suite(m"Punctuation tests"):
         . children.size
       . assert(_ == 2)
 
+    // A missing `Inspectable` is never a compile error — `derived` always succeeds and
+    // substitutes a marked `toString`, `Showable` or `Encodable` rendering — so coverage can
+    // only be held in place by asserting on the renderings themselves.
+    suite(m"Native-rendering coverage"):
+      test(m"punctuation's types inspect natively"):
+        Inspectable.fallbacks
+         ( Parser.parse(t"# Title\n\nA *word*.\n").inspect,
+           Parser.parse(t"- one\n- two\n\n> quoted\n\n```scala\nval x = 1\n```\n").inspect )
+      . assert(_ == Nil)
+
+      test(m"a document inspects as its parsed tree"):
+        Parser.parse(t"# Title\n").inspect
+      . assert:
+          _ == Text("Markdown(linkRefs:[] ╱ children:[Heading(1ˢᵗ ╱ 1 ╱ [Textual(t\"Title\")])])")
+
     suite(m"Serializer round-trip"):
       def roundTrip(markdown: Text): Markdown of Layout =
         Parser.parse(Parser.parse(markdown).show)

--- a/lib/savagery/src/core/savagery.Delta.scala
+++ b/lib/savagery/src/core/savagery.Delta.scala
@@ -44,6 +44,11 @@ object Delta:
 
   given showable: Delta is Showable = delta => t"${delta.dx.toString} ${delta.dy.toString}"
 
+  // Labelled like `Point`'s, but with the `dx`/`dy` names which distinguish a displacement from
+  // the absolute position it would otherwise render identically to.
+  given inspectable: [delta <: Delta] => delta is Inspectable = delta =>
+    t"Delta(dx:${delta.dx.inspect} ╱ dy:${delta.dy.inspect})"
+
   given addable: Delta is Addable by Delta to Delta = Addable: (left, right) =>
     Delta(left.dx + right.dx, left.dy + right.dy)
 

--- a/lib/savagery/src/core/savagery.Figure.scala
+++ b/lib/savagery/src/core/savagery.Figure.scala
@@ -43,8 +43,52 @@ import spectacular.*
 import vacuous.*
 import xylophone.*
 
+import geodesy.angleInspectable
+
 sealed trait Figure:
   def xml: Xml
+
+object Figure:
+  private def fields(pairs: (Text, Text)*): Text =
+    pairs.map { (label, value) => s"${label.s}:${value.s}" }.mkString(" ╱ ").tt
+
+  // A figure's `xml` is its serialized form: multi-line, and (for an `Outline`) with every path
+  // operation compressed into one `d` attribute. Inspection names the case and labels each field
+  // instead, so the strokes and the transform list — the state a misplaced figure is debugged
+  // from — stay individually legible. A `Css.Style` has no inspection of its own, so its property
+  // text is rendered here rather than borrowed.
+  given inspectable: [figure <: Figure] => figure is Inspectable = figure =>
+    figure.absolve match
+      case Rectangle(position, width, height, transforms) =>
+        val body =
+          fields
+            ( t"position"   -> position.inspect,
+              t"width"      -> width.inspect,
+              t"height"     -> height.inspect,
+              t"transforms" -> transforms.inspect )
+
+        t"Rectangle($body)"
+
+      case Outline(ops, style, id, transforms) =>
+        val body =
+          fields
+            ( t"ops"        -> ops.inspect,
+              t"style"      -> style.lay(t"○") { css => t"｢${css.text.inspect}｣" },
+              t"id"         -> id.lay(t"○") { svgId => t"｢${svgId.inspect}｣" },
+              t"transforms" -> transforms.inspect )
+
+        t"Outline($body)"
+
+      case Ellipse(center, xRadius, yRadius, angle, transforms) =>
+        val body =
+          fields
+            ( t"center"     -> center.inspect,
+              t"xRadius"    -> xRadius.inspect,
+              t"yRadius"    -> yRadius.inspect,
+              t"angle"      -> angle.inspect,
+              t"transforms" -> transforms.inspect )
+
+        t"Ellipse($body)"
 
 case class Rectangle
   ( position:   Point,

--- a/lib/savagery/src/core/savagery.Figure.scala
+++ b/lib/savagery/src/core/savagery.Figure.scala
@@ -43,7 +43,6 @@ import spectacular.*
 import vacuous.*
 import xylophone.*
 
-import geodesy.angleInspectable
 
 sealed trait Figure:
   def xml: Xml

--- a/lib/savagery/src/core/savagery.Point.scala
+++ b/lib/savagery/src/core/savagery.Point.scala
@@ -46,6 +46,11 @@ object Point:
 
   given showable: Point is Showable = point => t"${point.x.toString} ${point.y.toString}"
 
+  // The `Showable` is the SVG path-data form, where a point is a bare pair of numbers; inspection
+  // names the type and labels the coordinates, so a `Point` cannot be mistaken for a `Delta`.
+  given inspectable: [point <: Point] => point is Inspectable = point =>
+    t"Point(x:${point.x.inspect} ╱ y:${point.y.inspect})"
+
   given fromTuple: [numeric: Numeric, numeric2: Numeric]
   =>  Conversion[(numeric, numeric2), Point] =
     tuple => Point(numeric.toFloat(tuple(0)), numeric2.toFloat(tuple(1)))

--- a/lib/savagery/src/core/savagery.Stroke.scala
+++ b/lib/savagery/src/core/savagery.Stroke.scala
@@ -41,7 +41,6 @@ import vacuous.*
 
 import decimalConverters.javaDecimalConverter
 
-import geodesy.angleInspectable
 
 object Stroke:
   private def form(name: Text, parts: Text*): Text =

--- a/lib/savagery/src/core/savagery.Stroke.scala
+++ b/lib/savagery/src/core/savagery.Stroke.scala
@@ -49,6 +49,13 @@ object Stroke:
   // As with `Transform`, spelt out rather than derived: the arc cases carry an `Angle`, whose
   // instance is a named import rather than a companion given, and the encoded path-data form
   // (`A 3.0 4.0 0.0 1 0 …`) drops the case names a reader is matching against the source.
+  // Renders an `Optional` exactly as `Inspectable.derived`'s `Mandatable` case would, spelt out
+  // rather than summoned: that instance cannot be constructed under `-scalajs`, where the SAM is
+  // expanded to an anonymous class whose parameter acquires a capture variable that `Self` does
+  // not carry (soundness#1892, proscala#46). Inline this again once the fork accepts it.
+  private def optional[value: Inspectable](value: Optional[value]): Text =
+    value.let { present => t"｢${present.inspect}｣" }.or(t"○")
+
   given inspectable: [stroke <: Stroke] => stroke is Inspectable =
     _.absolve match
       case Close                        => t"Close"
@@ -56,14 +63,14 @@ object Stroke:
       case Move(shift)                  => form(t"Move", shift.inspect)
       case DrawTo(point)                => form(t"DrawTo", point.inspect)
       case Draw(shift)                  => form(t"Draw", shift.inspect)
-      case QuadraticTo(ctrl1, point)    => form(t"QuadraticTo", ctrl1.inspect, point.inspect)
-      case Quadratic(ctrl1, shift)      => form(t"Quadratic", ctrl1.inspect, shift.inspect)
+      case QuadraticTo(ctrl1, point)    => form(t"QuadraticTo", optional(ctrl1), point.inspect)
+      case Quadratic(ctrl1, shift)      => form(t"Quadratic", optional(ctrl1), shift.inspect)
 
       case CubicTo(ctrl1, ctrl2, point) =>
-        form(t"CubicTo", ctrl1.inspect, ctrl2.inspect, point.inspect)
+        form(t"CubicTo", optional(ctrl1), ctrl2.inspect, point.inspect)
 
       case Cubic(ctrl1, ctrl2, shift) =>
-        form(t"Cubic", ctrl1.inspect, ctrl2.inspect, shift.inspect)
+        form(t"Cubic", optional(ctrl1), ctrl2.inspect, shift.inspect)
 
       case ArcTo(rx, ry, angle, largeArc, sweep, point) =>
         form

--- a/lib/savagery/src/core/savagery.Stroke.scala
+++ b/lib/savagery/src/core/savagery.Stroke.scala
@@ -41,7 +41,41 @@ import vacuous.*
 
 import decimalConverters.javaDecimalConverter
 
+import geodesy.angleInspectable
+
 object Stroke:
+  private def form(name: Text, parts: Text*): Text =
+    parts.map(_.s).mkString(s"${name.s}(", " ╱ ", ")").tt
+
+  // As with `Transform`, spelt out rather than derived: the arc cases carry an `Angle`, whose
+  // instance is a named import rather than a companion given, and the encoded path-data form
+  // (`A 3.0 4.0 0.0 1 0 …`) drops the case names a reader is matching against the source.
+  given inspectable: [stroke <: Stroke] => stroke is Inspectable =
+    _.absolve match
+      case Close                        => t"Close"
+      case MoveTo(point)                => form(t"MoveTo", point.inspect)
+      case Move(shift)                  => form(t"Move", shift.inspect)
+      case DrawTo(point)                => form(t"DrawTo", point.inspect)
+      case Draw(shift)                  => form(t"Draw", shift.inspect)
+      case QuadraticTo(ctrl1, point)    => form(t"QuadraticTo", ctrl1.inspect, point.inspect)
+      case Quadratic(ctrl1, shift)      => form(t"Quadratic", ctrl1.inspect, shift.inspect)
+
+      case CubicTo(ctrl1, ctrl2, point) =>
+        form(t"CubicTo", ctrl1.inspect, ctrl2.inspect, point.inspect)
+
+      case Cubic(ctrl1, ctrl2, shift) =>
+        form(t"Cubic", ctrl1.inspect, ctrl2.inspect, shift.inspect)
+
+      case ArcTo(rx, ry, angle, largeArc, sweep, point) =>
+        form
+         ( t"ArcTo", rx.inspect, ry.inspect, angle.inspect, largeArc.inspect, sweep.inspect,
+           point.inspect )
+
+      case Arc(rx, ry, angle, largeArc, sweep, shift) =>
+        form
+         ( t"Arc", rx.inspect, ry.inspect, angle.inspect, largeArc.inspect, sweep.inspect,
+           shift.inspect )
+
   private def bit(value: Boolean): Text = if value then t"1" else t"0"
 
   given encodable: Stroke is Encodable in Text =

--- a/lib/savagery/src/core/savagery.Svg.scala
+++ b/lib/savagery/src/core/savagery.Svg.scala
@@ -469,6 +469,10 @@ object Svg:
 
     extension (id: Id) def text: Text = id
 
+    // An `Id` is a `Text` underneath, so a bare rendering of its text would be indistinguishable
+    // from a `Text`; the constructor form names the type it belongs to.
+    given inspectable: [id <: Id] => id is Inspectable = id => t"Svg.Id(${(id: Id).text.inspect})"
+
   opaque type Id = Text
 
   // SvgDef → Svg.Def, with LinearGradient, its only subtype: a sealed trait pins its

--- a/lib/savagery/src/core/savagery.Transform.scala
+++ b/lib/savagery/src/core/savagery.Transform.scala
@@ -41,7 +41,23 @@ import vacuous.*
 
 import decimalConverters.javaDecimalConverter
 
+import geodesy.angleInspectable
+
 object Transform:
+  private def form(name: Text, parts: Text*): Text =
+    parts.map(_.s).mkString(s"${name.s}(", " ╱ ", ")").tt
+
+  // Written out case by case, rather than left to structural derivation, because `Angle`'s
+  // instance is a top-level given in geodesy (its companion sits below the text stack) and so is
+  // only in scope where it has been imported by name — here.
+  given inspectable: [transform <: Transform] => transform is Inspectable =
+    _.absolve match
+      case Translate(delta)         => form(t"Translate", delta.inspect)
+      case Scale(x, y)              => form(t"Scale", x.inspect, y.inspect)
+      case Rotate(angle)            => form(t"Rotate", angle.inspect)
+      case Skew(angle, orientation) => form(t"Skew", angle.inspect, orientation.inspect)
+      case Matrix(affine)           => form(t"Matrix", affine.inspect)
+
   private given floatShowable: Float is Showable = _.toString.tt
 
   given encodable: Transform is Encodable in Text =

--- a/lib/savagery/src/core/savagery.Transform.scala
+++ b/lib/savagery/src/core/savagery.Transform.scala
@@ -41,7 +41,6 @@ import vacuous.*
 
 import decimalConverters.javaDecimalConverter
 
-import geodesy.angleInspectable
 
 object Transform:
   private def form(name: Text, parts: Text*): Text =

--- a/lib/savagery/src/test/savagery_test.scala
+++ b/lib/savagery/src/test/savagery_test.scala
@@ -564,3 +564,30 @@ object Tests extends Suite(m"Savagery tests"):
       .assert:
           case Svg.Error(Svg.Error.Reason.NotAnSvg(_)) => true
           case _                                     => false
+
+    suite(m"Native-rendering coverage"):
+      test(m"savagery's types inspect natively"):
+        Inspectable.fallbacks
+         ( Point(3, 4).inspect,
+           Delta(1, -2).inspect,
+           Svg.Id(t"logo").inspect,
+           Rectangle((0, 0), 10, 5).inspect,
+           Ellipse((1, 2), 3, 4, Angle(0)).inspect,
+           Outline().moveTo((0, 0)).lineTo((3, 4)).inspect,
+           Transform.Rotate(Angle(0)).inspect,
+           Transform.Matrix(Affine[Float](1, 0, 0, 1, 0, 0)).inspect,
+           Stroke.MoveTo(Point(0, 0)).inspect )
+
+      . assert(_ == Nil)
+
+      test(m"a point shows both coordinates"):
+        Point(3, 4).inspect
+      . assert(_ == t"Point(x:3.0F ╱ y:4.0F)")
+
+      test(m"a delta shows both components"):
+        Delta(1, -2).inspect
+      . assert(_ == t"Delta(dx:1.0F ╱ dy:-2.0F)")
+
+      test(m"an SVG id names its type"):
+        Svg.Id(t"logo").inspect
+      . assert(_ == t"""Svg.Id(t"logo")""")

--- a/lib/serpentine/src/core/serpentine.Path.scala
+++ b/lib/serpentine/src/core/serpentine.Path.scala
@@ -123,6 +123,14 @@ object Path:
 
   given showable: [filesystem: Filesystem] => Path on filesystem is Showable = _.encode
 
+  // As for `Relative`: the `Showable` and `Encodable` above need a `Filesystem` for the
+  // separator and the escaping rules, and an unqualified `Path` has none, while a debug
+  // rendering must always be available. The root is shown as it is stored — it already carries
+  // the filesystem's own notation, `/` or `C:\` — and the descent is joined with `/`, without
+  // escaping, so that the segments are shown exactly as they are held.
+  given inspectable: [path <: Path] => path is Inspectable = path =>
+    path.descent.reverse.join(path.root, t"/", t"")
+
   given communicable: [filesystem: Filesystem] => Path on filesystem is Communicable =
     path => Message(path.encode)
 

--- a/lib/serpentine/src/core/serpentine.Relative.scala
+++ b/lib/serpentine/src/core/serpentine.Relative.scala
@@ -102,6 +102,17 @@ object Relative:
 
     _.encode
 
+  // Both the `Showable` and the `Encodable` above need a `Filesystem` to supply the separator
+  // and the parent and self names, and a `Relative` which has not been qualified with a
+  // filesystem has neither; a debug rendering, though, must always be available. Inspection
+  // therefore uses the POSIX-like notation which every filesystem's own notation is read
+  // against — `..` for each step of ascent, `/` between segments, `.` for the self-relative
+  // path — regardless of the filesystem the value is (or is not) qualified with.
+  given inspectable: [relative <: Relative] => relative is Inspectable = relative =>
+    if relative.descent.nil then
+      if relative.ascent == 0 then t"." else List.fill(relative.ascent)(t"..").join(t"/")
+    else relative.descent.stdlib.reverse.join(t"../"*relative.ascent, t"/", t"")
+
   // The explicit type ascription after this method is used to force silent failure of this `given`
   // definition, so that contextual search can continue normally if it fails. This would not be the
   // case for a non-`transparent` `inline given`, which would cause contextual resolution to fail.

--- a/lib/serpentine/src/test/serpentine_test.scala
+++ b/lib/serpentine/src/test/serpentine_test.scala
@@ -212,6 +212,26 @@ object Tests extends Suite(m"internal Benchmarks"):
 
       . assert(_ == Relative(2, List(t"foo")))
 
+    // A missing `Inspectable` is never a compile error — `derived` always succeeds and
+    // substitutes a marked `toString`, `Showable` or `Encodable` rendering — so coverage can
+    // only be held in place by asserting on the renderings themselves.
+    suite(m"Native-rendering coverage"):
+      test(m"serpentine's types inspect natively"):
+        Inspectable.fallbacks((% / "foo" / "bar").inspect, (? / ^ / "foo").inspect, ?.inspect)
+      . assert(_ == Nil)
+
+      test(m"a path inspects as its path text"):
+        (% / "foo" / "bar").inspect
+      . assert(_ == t"/foo/bar")
+
+      test(m"a relative path inspects with its ascent"):
+        (? / ^ / ^ / "foo").inspect
+      . assert(_ == t"../../foo")
+
+      test(m"the self-relative path inspects as a dot"):
+        ?.inspect
+      . assert(_ == t".")
+
     suite(m"Encoding"):
       test(m"Serialize simple Linux path"):
         val path: Path on Linux = % / "foo"

--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -42,11 +42,52 @@ import scala.collection.mutable as scm
 
 import anticipation.*
 import denominative.*
+import fulminate.*
+import hypotenuse.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
 import wisteria.*
 
+// Style guide for `Inspectable` instances
+// ═══════════════════════════════════════
+//
+// `Inspectable` renders a value for a programmer to read — in a debugger, or in test output.
+// It is not `Showable` (text for human consumption, locale- and configuration-sensitive) and
+// not `Encodable in Text` (a wire form intended to be decoded again). The principles:
+//
+//  1. Show every piece of state which is relevant at the value's *static* type. A rendering
+//     which omits state is worse than a verbose one: the reader is debugging precisely
+//     because their model of the value is wrong.
+//  2. Be unambiguous against every other type's rendering. Two different types must never
+//     render identically; this is what the suffixes and brackets below buy.
+//  3. Stay compact and on one line. Inspection output appears inline, in tables, and nested
+//     inside other renderings.
+//  4. Resemble valid source where that is cheap (`'x'`, `3L`, `t"…"`, `BigInt(42)`), and use
+//     Unicode decoration where it is not (`⟨ 1 2 3 ⟩`, `1ˢᵗ`, `42ᵘ⁸`).
+//
+// Two markers indicate that no native instance was found and something else was rendered in
+// its place. Both are signs of incomplete coverage rather than a working rendering:
+//
+//     “…”   no instance at all; the value's `toString`. Always a design failure.
+//     ⸢…⸣   borrowed from the type's `Showable` — a human-facing form, not a debug form.
+//     ⸤…⸥   borrowed from the type's `Encodable in Text` — a wire form, possibly encoded.
+//
+// A type whose `Showable` or `Encodable` output is escaped or encoded (URL-encoding, say)
+// *must* define its own `Inspectable`; see `legerdemain.Query` for the canonical case.
+//
+// Notation in use, by category:
+//
+//     containers     [a, b] list       {a, b} set        {k → v} map
+//                    ⟨ a b ⟩ sequence  ⟨ a b ⟩ᵢ indexed  ⦋…⦌ array   ⁅…⁆ frozen array
+//                    a ⋰ b ⋰ ..? lazy  ∿∿∿ unforced      ⯁ end
+//     products       Name(field:value ╱ field2:value)    (a ╱ b) tuple
+//     optionality    ｢value｣ present   ○ absent
+//     text           t"…" with escapes                   'x' char
+//     numbers        3 int   3L long   3.1F float   3.toByte byte   BigInt(42)
+//     sized numbers  42ᵘ⁸ unsigned     -7ˢ³² signed      2Fᵇ⁸ bits   3.14ᶠ⁶⁴ float
+//     positions      1ˢᵗ ordinal       1ˢᵗ‥5ᵗʰ interval  ⟪4:8+5⟫ span
+//
 object Inspectable extends Inspectable2:
   object Derivation extends Derivable[Inspectable]:
     inline def conjunction[derivation <: Product: ProductReflection]: derivation is Inspectable =
@@ -63,6 +104,7 @@ object Inspectable extends Inspectable2:
         [variant <: derivation] => variant => contextual.give(variant.inspect)
 
   given char: Char is Inspectable = char => ("'"+escape(char).s+"'").tt
+  given int: Int is Inspectable = int => int.toString.tt
   given long: Long is Inspectable = long => (long.toString+"L").tt
   given string: String is Inspectable = string => text.text(string.tt).s.substring(1).nn.tt
   given byte: Byte is Inspectable = byte => (byte.toString+".toByte").tt
@@ -91,7 +133,107 @@ object Inspectable extends Inspectable2:
   given bigInt: BigInt is Inspectable = bigInt => ("BigInt("+bigInt+")").tt
   given bigDecimal: BigDecimal is Inspectable = bigDecimal => ("BigDecimal("+bigDecimal+")").tt
   given unset: Unset is Inspectable = unset => "○".tt
+
+  // Only for a value statically typed as `reflect.Enum` itself, for which no reflection is
+  // available; a value of a known enum type is rendered structurally by `enumeration`, below.
   given reflectEnum: reflect.Enum is Inspectable = _.toString.show
+
+  // Enums reach `Showable`'s `enumeration` instance, which renders them with `toString` and so
+  // loses the field labels of a parameterised case — `Circle(5)` rather than `Circle(radius:5)`.
+  // Deriving them here, in the companion, takes priority over that borrowed rendering, while
+  // still yielding to an enum which defines its own instance (a more specific given wins).
+  inline given enumeration: [enumeration <: reflect.Enum: Reflection]
+  =>  enumeration is Inspectable =
+    Derivation.derived[enumeration]
+
+  // The sized numeric types all erase to a primitive, so a rendering which showed only the
+  // number would be indistinguishable from an `Int` or a `Long` — and, for the unsigned types,
+  // would show the wrong number entirely. Each carries a superscript suffix naming its
+  // interpretation (`ᵘ` unsigned, `ˢ` signed, `ᵇ` bits, `ᶠ` floating-point) and its width.
+  given u8: U8 is Inspectable = u8 => (u8.text.s+"ᵘ⁸").tt
+  given u16: U16 is Inspectable = u16 => (u16.text.s+"ᵘ¹⁶").tt
+  given u32: U32 is Inspectable = u32 => (u32.text.s+"ᵘ³²").tt
+  given u64: U64 is Inspectable = u64 => (u64.text.s+"ᵘ⁶⁴").tt
+  given s8: S8 is Inspectable = s8 => (s8.int.toString+"ˢ⁸").tt
+  given s16: S16 is Inspectable = s16 => (s16.int.toString+"ˢ¹⁶").tt
+  given s32: S32 is Inspectable = s32 => (s32.int.toString+"ˢ³²").tt
+  given s64: S64 is Inspectable = s64 => (s64.long.toString+"ˢ⁶⁴").tt
+
+  // The bit types are rendered as full-width hexadecimal — zero-padded, so that the width is
+  // legible from the rendering itself, and uppercase, so that the digits are distinct from the
+  // superscript suffix which follows them. The hexadecimal is formatted here rather than
+  // through hypotenuse's own `hex`, whose inline expansion of `String.format` does not survive
+  // separation checking at this use site.
+  given b8: B8 is Inspectable = b8 => (hexadecimal(b8.s8.int.toLong, 2)+"ᵇ⁸").tt
+  given b16: B16 is Inspectable = b16 => (hexadecimal(b16.s16.int.toLong, 4)+"ᵇ¹⁶").tt
+  given b32: B32 is Inspectable = b32 => (hexadecimal(b32.s32.int.toLong, 8)+"ᵇ³²").tt
+  given b64: B64 is Inspectable = b64 => (hexadecimal(b64.s64.long, 16)+"ᵇ⁶⁴").tt
+
+  private def hexadecimal(value: Long, digits: Int): String =
+    val masked = if digits >= 16 then value else value & ((1L << (digits*4)) - 1)
+    val string = java.lang.Long.toHexString(masked).nn.toUpperCase.nn
+    val builder: StringBuilder = new StringBuilder()
+    while builder.length + string.length < digits do builder.append('0')
+
+    builder.append(string).toString
+
+  given f32: F32 is Inspectable = f32 =>
+    (floatingPoint(f32.float.toDouble, f32.float.isNaN)+"ᶠ³²").tt
+
+  given f64: F64 is Inspectable = f64 => (floatingPoint(f64.double, f64.double.isNaN)+"ᶠ⁶⁴").tt
+
+  private def floatingPoint(double: Double, nan: Boolean): String =
+    if nan then "NaN"
+    else if double == Double.PositiveInfinity then "∞"
+    else if double == Double.NegativeInfinity then "-∞"
+    else double.toString
+
+  // An `Ordinal` is rendered in its one-based form, with the English ordinal suffix, since that
+  // is the number the programmer counts with; the zero-based `n0` is an implementation detail
+  // of the type, and showing it would make every rendering off by one.
+  given ordinal: Ordinal is Inspectable = ordinal =>
+    (ordinal.n1.toString+ordinalSuffix(ordinal.n1)).tt
+
+  private def ordinalSuffix(n1: Int): String =
+    if n1 % 100 >= 11 && n1 % 100 <= 13 then "ᵗʰ" else n1 % 10 match
+      case 1 => "ˢᵗ"
+      case 2 => "ⁿᵈ"
+      case 3 => "ʳᵈ"
+      case _ => "ᵗʰ"
+
+  given interval: Interval is Inspectable = interval =>
+    if interval.nil then "∅".tt
+    else (ordinal.text(interval.start).s+"‥"+ordinal.text(interval.end).s).tt
+
+  // A `Span` packs one of five differently-shaped ranges into a `Long`, so its rendering shows
+  // the shape as well as the numbers: `⟪∅⟫` empty, `⟪@4+5⟫` an offset and length, `⟪4:8+5⟫` a
+  // line, column and length, `⟪4‥8⟫` a range of whole lines, and `⟪4:8‥6:2⟫` an area. The
+  // numbers are one-based ordinals, without suffixes, which the `:` and `‥` keep unambiguous.
+  given span: Span is Inspectable = span =>
+    def n(ordinal: Optional[Ordinal]): String = ordinal.let(_.n1.toString).or("?")
+
+    val body = span.mode match
+      case Span.Mode.Empty  => "∅"
+      case Span.Mode.Offset => "@"+n(span.offset)+"+"+span.length.let(_.toString).or("?")
+      case Span.Mode.Lines  => n(span.startLine)+"‥"+n(span.endLine)
+
+      case Span.Mode.Line =>
+        n(span.startLine)+":"+n(span.startColumn)+"+"+span.length.let(_.toString).or("?")
+
+      case Span.Mode.Area =>
+        n(span.startLine)+":"+n(span.startColumn)+"‥"+n(span.endLine)+":"+n(span.endColumn)
+
+    ("⟪"+body+"⟫").tt
+
+  // `Bytes` is a count, not a quantity to be rounded for display: an inspection which showed
+  // `4MB` would hide the difference between two nearby sizes, which is usually the reason for
+  // looking.
+  given bytes: Bytes is Inspectable = bytes => (bytes.long.toString+"B").tt
+  given digit: Digit is Inspectable = digit => (digit.int.toString+"ᵈᵍ").tt
+
+  // A `Message` renders as its own text, in the style of a `t"…"` literal but marked `m"…"`,
+  // since the interpolated parts are no longer distinguishable once the message is built.
+  given message: Message is Inspectable = message => ("m\""+message.text.s+"\"").tt
 
   def escape(char: Char, eEscape: Boolean = false): Text = char match
     case '\n'                => "\\n".tt
@@ -239,9 +381,15 @@ object Inspectable extends Inspectable2:
   given none: None.type is Inspectable = none => "None".tt
 
 trait Inspectable2:
+  // The `Encodable` and `Showable` branches borrow a rendering which was designed for another
+  // purpose — a wire form and a human-facing form respectively — and neither is guaranteed to
+  // show the value's state as a programmer needs to see it. They are kept for coverage, but
+  // their output is bracketed so that a borrowed rendering is visible as such at a glance, and
+  // so that the types still relying on them can be found by inspecting output. A type whose
+  // encoded form is escaped (`legerdemain.Query`, URL-encoded) must define its own instance.
   inline given derived: [value] => value is Inspectable = compiletime.summonFrom:
-    case given (`value` is Encodable in Text) => _.encode
-    case given (`value` is Showable)          => _.show
+    case given (`value` is Encodable in Text) => value => ("⸤"+value.encode.s+"⸥").tt
+    case given (`value` is Showable)          => value => ("⸢"+value.show.s+"⸣").tt
 
     case mandatable: (`value` is Mandatable) =>
       val inspectable = compiletime.summonInline[mandatable.Result is Inspectable]

--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -103,36 +103,50 @@ object Inspectable extends Inspectable2:
       variant(value):
         [variant <: derivation] => variant => contextual.give(variant.inspect)
 
-  given char: Char is Inspectable = char => ("'"+escape(char).s+"'").tt
-  given int: Int is Inspectable = int => int.toString.tt
-  given long: Long is Inspectable = long => (long.toString+"L").tt
-  given string: String is Inspectable = string => text.text(string.tt).s.substring(1).nn.tt
-  given byte: Byte is Inspectable = byte => (byte.toString+".toByte").tt
-  given short: Short is Inspectable = short => (short.toString+".toShort").tt
+  // Every instance below is parameterised over the subtypes of the type it renders, rather
+  // than written against that type alone. `Self` is invariant, so `Char is Inspectable` does
+  // not cover a singleton literal type like `'x'`, `Text is Inspectable` does not cover
+  // `nomenclature.Name`, and an instance for a refined type covers neither the bare type nor a
+  // further refinement of it. Each such near-miss falls silently through `derived` to the
+  // `“…”` toString case rather than failing to compile, so the bound is what keeps a rendering
+  // from disappearing when a type is refined.
+  given char: [char <: Char] => char is Inspectable = char => ("'"+escape(char).s+"'").tt
+  given int: [int <: Int] => int is Inspectable = int => int.toString.tt
+  given long: [long <: Long] => long is Inspectable = long => (long.toString+"L").tt
+  given byte: [byte <: Byte] => byte is Inspectable = byte => (byte.toString+".toByte").tt
+  given short: [short <: Short] => short is Inspectable = short => (short.toString+".toShort").tt
 
-  given text: Text is Inspectable = text =>
+  given string: [string <: String] => string is Inspectable = string =>
+    text.text(string.tt).s.substring(1).nn.tt
+
+  given text: [text <: Text] => text is Inspectable = text =>
     val builder: StringBuilder = new StringBuilder()
     text.each { char => builder.append(escape(char, true).s) }
 
     ("t\""+builder.toString+"\"").tt
 
-  given float: Float is Inspectable =
+  given float: [float <: Float] => float is Inspectable =
     case Float.PositiveInfinity => "Float.PositiveInfinity".tt
     case Float.NegativeInfinity => "Float.NegativeInfinity".tt
     case float if float.isNaN   => "Float.NaN".tt
     case float                  => (float.toString+"F").tt
 
-  given double: Double is Inspectable =
+  given double: [double <: Double] => double is Inspectable =
     case Double.PositiveInfinity => "Double.PositiveInfinity".tt
     case Double.NegativeInfinity => "Double.NegativeInfinity".tt
     case double if double.isNaN  => "Double.NaN".tt
     case double                  => double.toString.tt
 
-  given boolean: Boolean is Inspectable = boolean => if boolean then "true".tt else "false".tt
-  given unit: Unit is Inspectable = unit => "()".tt
-  given bigInt: BigInt is Inspectable = bigInt => ("BigInt("+bigInt+")").tt
-  given bigDecimal: BigDecimal is Inspectable = bigDecimal => ("BigDecimal("+bigDecimal+")").tt
-  given unset: Unset is Inspectable = unset => "○".tt
+  given boolean: [boolean <: Boolean] => boolean is Inspectable = boolean =>
+    if boolean then "true".tt else "false".tt
+
+  given unit: [unit <: Unit] => unit is Inspectable = unit => "()".tt
+  given bigInt: [bigInt <: BigInt] => bigInt is Inspectable = bigInt => ("BigInt("+bigInt+")").tt
+
+  given bigDecimal: [bigDecimal <: BigDecimal] => bigDecimal is Inspectable = bigDecimal =>
+    ("BigDecimal("+bigDecimal+")").tt
+
+  given unset: [unset <: Unset] => unset is Inspectable = unset => "○".tt
 
   // Only for a value statically typed as `reflect.Enum` itself, for which no reflection is
   // available; a value of a known enum type is rendered structurally by `enumeration`, below.
@@ -150,24 +164,34 @@ object Inspectable extends Inspectable2:
   // number would be indistinguishable from an `Int` or a `Long` — and, for the unsigned types,
   // would show the wrong number entirely. Each carries a superscript suffix naming its
   // interpretation (`ᵘ` unsigned, `ˢ` signed, `ᵇ` bits, `ᶠ` floating-point) and its width.
-  given u8: U8 is Inspectable = u8 => (u8.text.s+"ᵘ⁸").tt
-  given u16: U16 is Inspectable = u16 => (u16.text.s+"ᵘ¹⁶").tt
-  given u32: U32 is Inspectable = u32 => (u32.text.s+"ᵘ³²").tt
-  given u64: U64 is Inspectable = u64 => (u64.text.s+"ᵘ⁶⁴").tt
-  given s8: S8 is Inspectable = s8 => (s8.int.toString+"ˢ⁸").tt
-  given s16: S16 is Inspectable = s16 => (s16.int.toString+"ˢ¹⁶").tt
-  given s32: S32 is Inspectable = s32 => (s32.int.toString+"ˢ³²").tt
-  given s64: S64 is Inspectable = s64 => (s64.long.toString+"ˢ⁶⁴").tt
+  // Each value is widened to the exact type before its accessor is called: these are `inline`
+  // extensions on an opaque type, whose expansion unseals the underlying primitive, and that
+  // expansion is not available through a subtype of the opaque type.
+  given u8: [u8 <: U8] => u8 is Inspectable = u8 => ((u8: U8).text.s+"ᵘ⁸").tt
+  given u16: [u16 <: U16] => u16 is Inspectable = u16 => ((u16: U16).text.s+"ᵘ¹⁶").tt
+  given u32: [u32 <: U32] => u32 is Inspectable = u32 => ((u32: U32).text.s+"ᵘ³²").tt
+  given u64: [u64 <: U64] => u64 is Inspectable = u64 => ((u64: U64).text.s+"ᵘ⁶⁴").tt
+  given s8: [s8 <: S8] => s8 is Inspectable = s8 => ((s8: S8).int.toString+"ˢ⁸").tt
+  given s16: [s16 <: S16] => s16 is Inspectable = s16 => ((s16: S16).int.toString+"ˢ¹⁶").tt
+  given s32: [s32 <: S32] => s32 is Inspectable = s32 => ((s32: S32).int.toString+"ˢ³²").tt
+  given s64: [s64 <: S64] => s64 is Inspectable = s64 => ((s64: S64).long.toString+"ˢ⁶⁴").tt
 
   // The bit types are rendered as full-width hexadecimal — zero-padded, so that the width is
   // legible from the rendering itself, and uppercase, so that the digits are distinct from the
   // superscript suffix which follows them. The hexadecimal is formatted here rather than
   // through hypotenuse's own `hex`, whose inline expansion of `String.format` does not survive
   // separation checking at this use site.
-  given b8: B8 is Inspectable = b8 => (hexadecimal(b8.s8.int.toLong, 2)+"ᵇ⁸").tt
-  given b16: B16 is Inspectable = b16 => (hexadecimal(b16.s16.int.toLong, 4)+"ᵇ¹⁶").tt
-  given b32: B32 is Inspectable = b32 => (hexadecimal(b32.s32.int.toLong, 8)+"ᵇ³²").tt
-  given b64: B64 is Inspectable = b64 => (hexadecimal(b64.s64.long, 16)+"ᵇ⁶⁴").tt
+  given b8: [b8 <: B8] => b8 is Inspectable = b8 =>
+    (hexadecimal((b8: B8).s8.int.toLong, 2)+"ᵇ⁸").tt
+
+  given b16: [b16 <: B16] => b16 is Inspectable = b16 =>
+    (hexadecimal((b16: B16).s16.int.toLong, 4)+"ᵇ¹⁶").tt
+
+  given b32: [b32 <: B32] => b32 is Inspectable = b32 =>
+    (hexadecimal((b32: B32).s32.int.toLong, 8)+"ᵇ³²").tt
+
+  given b64: [b64 <: B64] => b64 is Inspectable = b64 =>
+    (hexadecimal((b64: B64).s64.long, 16)+"ᵇ⁶⁴").tt
 
   private def hexadecimal(value: Long, digits: Int): String =
     val masked = if digits >= 16 then value else value & ((1L << (digits*4)) - 1)
@@ -177,10 +201,13 @@ object Inspectable extends Inspectable2:
 
     builder.append(string).toString
 
-  given f32: F32 is Inspectable = f32 =>
-    (floatingPoint(f32.float.toDouble, f32.float.isNaN)+"ᶠ³²").tt
+  given f32: [f32 <: F32] => f32 is Inspectable = f32 =>
+    val float: Float = (f32: F32).float
+    (floatingPoint(float.toDouble, float.isNaN)+"ᶠ³²").tt
 
-  given f64: F64 is Inspectable = f64 => (floatingPoint(f64.double, f64.double.isNaN)+"ᶠ⁶⁴").tt
+  given f64: [f64 <: F64] => f64 is Inspectable = f64 =>
+    val double: Double = (f64: F64).double
+    (floatingPoint(double, double.isNaN)+"ᶠ⁶⁴").tt
 
   private def floatingPoint(double: Double, nan: Boolean): String =
     if nan then "NaN"
@@ -191,8 +218,12 @@ object Inspectable extends Inspectable2:
   // An `Ordinal` is rendered in its one-based form, with the English ordinal suffix, since that
   // is the number the programmer counts with; the zero-based `n0` is an implementation detail
   // of the type, and showing it would make every rendering off by one.
-  given ordinal: Ordinal is Inspectable = ordinal =>
-    (ordinal.n1.toString+ordinalSuffix(ordinal.n1)).tt
+  given ordinal: [ordinal <: Ordinal] => ordinal is Inspectable = ordinal(_)
+
+  // Shared by `ordinal` and `interval`; the givens themselves are parameterised, so neither
+  // can be referred to by name without a type application.
+  private def ordinal(value: Ordinal): Text =
+    (value.n1.toString+ordinalSuffix(value.n1)).tt
 
   private def ordinalSuffix(n1: Int): String =
     if n1 % 100 >= 11 && n1 % 100 <= 13 then "ᵗʰ" else n1 % 10 match
@@ -201,15 +232,15 @@ object Inspectable extends Inspectable2:
       case 3 => "ʳᵈ"
       case _ => "ᵗʰ"
 
-  given interval: Interval is Inspectable = interval =>
-    if interval.nil then "∅".tt
-    else (ordinal.text(interval.start).s+"‥"+ordinal.text(interval.end).s).tt
+  given interval: [interval <: Interval] => interval is Inspectable = interval =>
+    val value: Interval = interval
+    if value.nil then "∅".tt else (ordinal(value.start).s+"‥"+ordinal(value.end).s).tt
 
   // A `Span` packs one of five differently-shaped ranges into a `Long`, so its rendering shows
   // the shape as well as the numbers: `⟪∅⟫` empty, `⟪@4+5⟫` an offset and length, `⟪4:8+5⟫` a
   // line, column and length, `⟪4‥8⟫` a range of whole lines, and `⟪4:8‥6:2⟫` an area. The
   // numbers are one-based ordinals, without suffixes, which the `:` and `‥` keep unambiguous.
-  given span: Span is Inspectable = span =>
+  given span: [span <: Span] => span is Inspectable = span =>
     def n(ordinal: Optional[Ordinal]): String = ordinal.let(_.n1.toString).or("?")
 
     val body = span.mode match
@@ -228,12 +259,13 @@ object Inspectable extends Inspectable2:
   // `Bytes` is a count, not a quantity to be rounded for display: an inspection which showed
   // `4MB` would hide the difference between two nearby sizes, which is usually the reason for
   // looking.
-  given bytes: Bytes is Inspectable = bytes => (bytes.long.toString+"B").tt
-  given digit: Digit is Inspectable = digit => (digit.int.toString+"ᵈᵍ").tt
+  given bytes: [bytes <: Bytes] => bytes is Inspectable = bytes => (bytes.long.toString+"B").tt
+  given digit: [digit <: Digit] => digit is Inspectable = digit => (digit.int.toString+"ᵈᵍ").tt
 
   // A `Message` renders as its own text, in the style of a `t"…"` literal but marked `m"…"`,
   // since the interpolated parts are no longer distinguishable once the message is built.
-  given message: Message is Inspectable = message => ("m\""+message.text.s+"\"").tt
+  given message: [message <: Message] => message is Inspectable = message =>
+    ("m\""+message.text.s+"\"").tt
 
   def escape(char: Char, eEscape: Boolean = false): Text = char match
     case '\n'                => "\\n".tt
@@ -258,6 +290,10 @@ object Inspectable extends Inspectable2:
   // the by-name parameter directly — a seal on the lambda cannot reach that self-type check.
   // The thunk keeps resolution lazy, which recursive derivations depend on (the codec-thunk
   // seal pattern; see rep/DECISIONS.md).
+  // `Set`, `Map` and `List` keep an exact `Self`, unlike `sequence` below. They are opaque
+  // types, so their upper bound is abstract outside proscenium, and a *stdlib* collection
+  // reaching one of these instances would fail the bound check outright rather than fall
+  // through to another candidate — a subtype bound here turns a silent miss into a hard error.
   given set: [element] => (inspectable: => element is Inspectable) => Set[element] is Inspectable =
     val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
     _.map(insp().text(_)).stdlib.mkString("{", ", ", "}").tt
@@ -287,6 +323,10 @@ object Inspectable extends Inspectable2:
     val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
     _.map(insp().text(_)).stdlib.mkString("⟨ ", " ", " ⟩").tt
 
+  // The one instance which is deliberately *not* parameterised over its subtypes: a
+  // `Sequence` is an `IndexedSeq`, so a subtype bound here would match every `Sequence` too
+  // and be ambiguous with `sequence` above. Keeping `Self` exact confines this instance to a
+  // stdlib `IndexedSeq` named as such, which is what the `ᵢ` in its rendering marks.
   given indexedSeq: [element] => (inspectable: => element is Inspectable)
   =>  IndexedSeq[element] is Inspectable =
     val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
@@ -310,8 +350,9 @@ object Inspectable extends Inspectable2:
 
       . mkString("⦋"+arrayPrefix(array.toString), "∣", "⦌").tt
 
-  given arraySeq: [element] => (inspectable: => element is Inspectable)
-  =>  scm.ArraySeq[element] is Inspectable =
+  given arraySeq: [element, arraySeq <: scm.ArraySeq[element]]
+  =>  (inspectable: => element is Inspectable)
+  =>  arraySeq is Inspectable =
     val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
 
     array =>
@@ -321,6 +362,7 @@ object Inspectable extends Inspectable2:
 
       . mkString("⦋"+arrayPrefix(array.toString), "∣", "⦌ₛ").tt
 
+  // Exact `Self`, for the reason given at `set` above: `Chain` is opaque too.
   given stream: [element] => (inspectable: => element is Inspectable)
   =>  Chain[element] is Inspectable =
 

--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -265,6 +265,22 @@ object Inspectable extends Inspectable2:
   given message: [message <: Message] => message is Inspectable = message =>
     ("m\""+message.text.s+"\"").tt
 
+  // A missing instance is never a compile error: `derived` always succeeds, and quietly
+  // substitutes a `toString`, a `Showable` or an `Encodable` rendering, each marked as such.
+  // Nothing therefore stops coverage from regressing — a type gains a refinement, or a new
+  // type is added, and its rendering silently degrades. `fallbacks` is what a library's tests
+  // assert on to prevent that: it returns those of the given renderings which carry a marker,
+  // so a failure names the renderings which are not native rather than merely counting them.
+  //
+  //     test(m"aviation's core types inspect natively"):
+  //       Inspectable.fallbacks(instant.inspect, date.inspect, month.inspect)
+  //     . assert(_ == Nil)
+  //
+  def fallbacks(renderings: Text*): List[Text] =
+    renderings.filter { rendering => rendering.s.exists(marker(_)) }.to(List)
+
+  def marker(char: Char): Boolean = char == '“' || char == '⸢' || char == '⸤'
+
   def escape(char: Char, eEscape: Boolean = false): Text = char match
     case '\n'                => "\\n".tt
     case '\t'                => "\\t".tt

--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package spectacular
 
-import scala.collection.immutable.IndexedSeq
-
 import scala.reflect
 
 import scala.{caps, compiletime}
@@ -79,7 +77,7 @@ import wisteria.*
 // Notation in use, by category:
 //
 //     containers     [a, b] list       {a, b} set        {k → v} map
-//                    ⟨ a b ⟩ sequence  ⟨ a b ⟩ᵢ indexed  ⦋…⦌ array   ⁅…⁆ frozen array
+//                    ⟨ a b ⟩ sequence  ⟦k → v⟧ ledger    ⦋…⦌ array   ⁅…⁆ frozen array
 //                    a ⋰ b ⋰ ..? lazy  ∿∿∿ unforced      ⯁ end
 //     products       Name(field:value ╱ field2:value)    (a ╱ b) tuple
 //     optionality    ｢value｣ present   ○ absent
@@ -313,6 +311,23 @@ object Inspectable extends Inspectable2:
 
       . stdlib.mkString("{", ", ", "}").tt
 
+  // A `Ledger` keeps its insertion order, so it is bracketed differently from the unordered
+  // `Map` above: the rendering has to say which of the two a value is, since the entries of a
+  // `Map` may be printed in any order and those of a `Ledger` may not.
+  given ledger: [key, value]
+  =>  ( inspectableKey: => key is Inspectable, inspectableValue: => value is Inspectable )
+  =>  Ledger[key, value] is Inspectable =
+
+    val inspKey: () -> (key is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectableKey)
+
+    val inspValue: () -> (value is Inspectable) =
+      caps.unsafe.unsafeAssumePure(() => inspectableValue)
+
+    ledger =>
+      ledger.stdlib.map: (key, value) =>
+        inspKey().text(key).s+" → "+inspValue().text(value).s
+
+      . mkString("⟦", ", ", "⟧").tt
 
   // `Self` is subtype-parametric so branded literals (`Sequence(1, 2, 3)`, typed
   // `Sequence[Int] & Populated`) match; rendering produces no collection, so no proof leaks.
@@ -322,15 +337,6 @@ object Inspectable extends Inspectable2:
 
     val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
     _.map(insp().text(_)).stdlib.mkString("⟨ ", " ", " ⟩").tt
-
-  // The one instance which is deliberately *not* parameterised over its subtypes: a
-  // `Sequence` is an `IndexedSeq`, so a subtype bound here would match every `Sequence` too
-  // and be ambiguous with `sequence` above. Keeping `Self` exact confines this instance to a
-  // stdlib `IndexedSeq` named as such, which is what the `ᵢ` in its rendering marks.
-  given indexedSeq: [element] => (inspectable: => element is Inspectable)
-  =>  IndexedSeq[element] is Inspectable =
-    val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
-    _.map(insp().text(_)).mkString("⟨ ", " ", " ⟩ᵢ").tt
 
   given list: [element] => (inspectable: => element is Inspectable)
   =>  List[element] is Inspectable =

--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -213,6 +213,17 @@ object Inspectable extends Inspectable2:
     else if double == Double.NegativeInfinity then "-∞"
     else double.toString
 
+  // The remaining hypotenuse numerics: two rationals, which render as a fraction, and two
+  // arbitrary-precision decimals. Each keeps hypotenuse's own textual form and adds the suffix
+  // which says which type produced it — without one, `3/4` and `3.14` would be as anonymous as
+  // the primitives the sized types erase to.
+  given q32: [q32 <: Q32] => q32 is Inspectable = q32 => ((q32: Q32).text.s+"ʳ³²").tt
+  given q64: [q64 <: Q64] => q64 is Inspectable = q64 => ((q64: Q64).text.s+"ʳ⁶⁴").tt
+  given bcd: [bcd <: Bcd] => bcd is Inspectable = bcd => ((bcd: Bcd).text+"ᵇᶜᵈ").tt
+
+  given decimal: [decimal <: Decimal] => decimal is Inspectable = decimal =>
+    ((decimal: Decimal).text.s+"ᵈ").tt
+
   // An `Ordinal` is rendered in its one-based form, with the English ordinal suffix, since that
   // is the number the programmer counts with; the zero-based `n0` is an implementation detail
   // of the type, and showing it would make every rendering off by one.

--- a/lib/spectacular/src/test/spectacular_test.scala
+++ b/lib/spectacular/src/test/spectacular_test.scala
@@ -269,6 +269,23 @@ object Tests extends Suite(m"Spectacular Tests"):
         42.inspect
       . assert(_ == t"42")
 
+      // `Self` is invariant, so an instance written against the bare type would not match a
+      // singleton literal type, and the value would fall through to the `“…”` toString case.
+      test(m"inspect a value typed as an integer literal"):
+        val three: 3 = 3
+        three.inspect
+      . assert(_ == t"3")
+
+      test(m"inspect a value typed as a character literal"):
+        val char: 'x' = 'x'
+        char.inspect
+      . assert(_ == t"'x'")
+
+      test(m"inspect a value typed as a boolean literal"):
+        val yes: true = true
+        yes.inspect
+      . assert(_ == t"true")
+
     suite(m"Sized numeric tests"):
       test(m"inspect an unsigned byte"):
         U8(200.toByte.bits).inspect

--- a/lib/spectacular/src/test/spectacular_test.scala
+++ b/lib/spectacular/src/test/spectacular_test.scala
@@ -265,6 +265,114 @@ object Tests extends Suite(m"Spectacular Tests"):
         BigDecimal("1.5").inspect
       . assert(_ == t"BigDecimal(1.5)")
 
+      test(m"serialize int"):
+        42.inspect
+      . assert(_ == t"42")
+
+    suite(m"Sized numeric tests"):
+      test(m"inspect an unsigned byte"):
+        U8(200.toByte.bits).inspect
+      . assert(_ == t"200ᵘ⁸")
+
+      test(m"inspect an unsigned 16-bit integer"):
+        U16(40000.toShort.bits).inspect
+      . assert(_ == t"40000ᵘ¹⁶")
+
+      test(m"inspect an unsigned 32-bit integer"):
+        U32(7.bits).inspect
+      . assert(_ == t"7ᵘ³²")
+
+      test(m"inspect an unsigned 64-bit integer"):
+        U64(7L.bits).inspect
+      . assert(_ == t"7ᵘ⁶⁴")
+
+      test(m"inspect a signed 32-bit integer"):
+        S32(-7.bits).inspect
+      . assert(_ == t"-7ˢ³²")
+
+      test(m"inspect a signed 64-bit integer"):
+        S64(-7L.bits).inspect
+      . assert(_ == t"-7ˢ⁶⁴")
+
+      test(m"inspect an 8-bit bitmap"):
+        47.toByte.bits.inspect
+      . assert(_ == t"2Fᵇ⁸")
+
+      test(m"inspect a 32-bit bitmap"):
+        255.bits.inspect
+      . assert(_ == t"000000FFᵇ³²")
+
+      test(m"inspect a 64-bit bitmap"):
+        (-1L).bits.inspect
+      . assert(_ == t"FFFFFFFFFFFFFFFFᵇ⁶⁴")
+
+      test(m"inspect a 64-bit floating-point number"):
+        F64(3.5).inspect
+      . assert(_ == t"3.5ᶠ⁶⁴")
+
+      test(m"inspect a floating-point infinity"):
+        F64(Double.PositiveInfinity).inspect
+      . assert(_ == t"∞ᶠ⁶⁴")
+
+    suite(m"Quantity and message tests"):
+      test(m"inspect a byte count"):
+        Bytes(4194304L).inspect
+      . assert(_ == t"4194304B")
+
+      test(m"inspect a digit"):
+        Digit(7).inspect
+      . assert(_ == t"｢7ᵈᵍ｣")
+
+      test(m"inspect a message"):
+        m"the file was not found".inspect
+      . assert(_ == t"m\"the file was not found\"")
+
+    suite(m"Position tests"):
+      test(m"inspect the first ordinal"):
+        Ordinal.zerary(0).inspect
+      . assert(_ == t"1ˢᵗ")
+
+      test(m"inspect the third ordinal"):
+        Ordinal.zerary(2).inspect
+      . assert(_ == t"3ʳᵈ")
+
+      test(m"inspect a teens ordinal"):
+        Ordinal.zerary(10).inspect
+      . assert(_ == t"11ᵗʰ")
+
+      test(m"inspect the twenty-first ordinal"):
+        Ordinal.zerary(20).inspect
+      . assert(_ == t"21ˢᵗ")
+
+      test(m"inspect an interval"):
+        (Ordinal.zerary(0) thru Ordinal.zerary(4)).inspect
+      . assert(_ == t"1ˢᵗ‥5ᵗʰ")
+
+      test(m"inspect an empty interval"):
+        Interval().inspect
+      . assert(_ == t"∅")
+
+      test(m"inspect an empty span"):
+        Span.empty.inspect
+      . assert(_ == t"⟪∅⟫")
+
+      test(m"inspect an offset span"):
+        Span.offset(Ordinal.zerary(3), 5).inspect
+      . assert(_ == t"⟪@4+5⟫")
+
+      test(m"inspect a line span"):
+        Span.line(Ordinal.zerary(3), Ordinal.zerary(7), 5).inspect
+      . assert(_ == t"⟪4:8+5⟫")
+
+      test(m"inspect a whole-lines span"):
+        Span.lines(Ordinal.zerary(3), 5).inspect
+      . assert(_ == t"⟪4‥8⟫")
+
+      test(m"inspect an area span"):
+        Span.area(Ordinal.zerary(3), Ordinal.zerary(7), Ordinal.zerary(5), Ordinal.zerary(1))
+        . inspect
+      . assert(_ == t"⟪4:8‥6:2⟫")
+
     suite(m"Collection tests"):
       test(m"serialize map"):
         Map(1 -> 2, 3 -> 4).inspect
@@ -345,7 +453,7 @@ object Tests extends Suite(m"Spectacular Tests"):
 
       test(m"inspect parameterised enum case"):
         (Shape.Circle(5): Shape).inspect
-      . assert(_ == t"Circle(5)")
+      . assert(_ == t"Circle(radius:5)")
 
     suite(m"Show tests"):
       test(m"Show a string"):
@@ -376,7 +484,9 @@ object Tests extends Suite(m"Spectacular Tests"):
         t"${true} ${false}"
       . assert(_ == t"1 0")
 
+      // Inspection borrows the `Showable` rendering only as a last resort, and marks it as
+      // borrowed: a human-facing form is not a debug form.
       test(m"Show a locally-declared showable"):
         given Exception is Showable = e => txt"<exception>"
         Exception("error message").inspect
-      . assert(_ == t"<exception>")
+      . assert(_ == t"⸢<exception>⸣")

--- a/lib/spectacular/src/test/spectacular_test.scala
+++ b/lib/spectacular/src/test/spectacular_test.scala
@@ -388,7 +388,10 @@ object Tests extends Suite(m"Spectacular Tests"):
            255.bits.inspect,
            (-1L).bits.inspect,
            F32(3.5f).inspect,
-           F64(3.5).inspect )
+           F64(3.5).inspect,
+           Q32(3, 4).inspect,
+           Q64(3L, 4L).inspect,
+           Decimal(314L, 2).inspect )
       . assert(_ == Nil)
 
       test(m"the collection types all inspect natively"):

--- a/lib/spectacular/src/test/spectacular_test.scala
+++ b/lib/spectacular/src/test/spectacular_test.scala
@@ -344,6 +344,68 @@ object Tests extends Suite(m"Spectacular Tests"):
         m"the file was not found".inspect
       . assert(_ == t"m\"the file was not found\"")
 
+    // A missing instance never fails to compile, so coverage can only be held in place by
+    // asserting on the renderings themselves. Each of these lists the types a library owns;
+    // a failure names the renderings which fell back rather than merely reporting a count.
+    suite(m"Native-rendering coverage"):
+      test(m"the types spectacular renders itself all inspect natively"):
+        Inspectable.fallbacks
+         ( t"text".inspect,
+           'x'.inspect,
+           42.inspect,
+           42L.inspect,
+           42.toByte.inspect,
+           42.toShort.inspect,
+           3.1.inspect,
+           3.1f.inspect,
+           true.inspect,
+           ().inspect,
+           BigInt(42).inspect,
+           BigDecimal("1.5").inspect,
+           Unset.inspect,
+           Bytes(1024L).inspect,
+           m"a message".inspect,
+           Ordinal.zerary(0).inspect,
+           Interval().inspect,
+           Span.empty.inspect,
+           Person(t"Simon", 72).inspect,
+           Colour.Red.inspect,
+           Shape.Circle(5).inspect )
+      . assert(_ == Nil)
+
+      test(m"the sized numeric types all inspect natively"):
+        Inspectable.fallbacks
+         ( U8(200.toByte.bits).inspect,
+           U16(40000.toShort.bits).inspect,
+           U32(7.bits).inspect,
+           U64(7L.bits).inspect,
+           S8((-7).toByte.bits).inspect,
+           S16((-7).toShort.bits).inspect,
+           S32(-7.bits).inspect,
+           S64(-7L.bits).inspect,
+           47.toByte.bits.inspect,
+           47.toShort.bits.inspect,
+           255.bits.inspect,
+           (-1L).bits.inspect,
+           F32(3.5f).inspect,
+           F64(3.5).inspect )
+      . assert(_ == Nil)
+
+      test(m"the collection types all inspect natively"):
+        Inspectable.fallbacks
+         ( (List(1, 2): List[Int]).inspect,
+           Set(1, 2).inspect,
+           Map(1 -> 2).inspect,
+           Ledger(1 -> 2).inspect,
+           Sequence(1, 2).inspect )
+      . assert(_ == Nil)
+
+      // The counterpart: a type with no instance must be *reported*, or the assertions above
+      // would pass vacuously.
+      test(m"a type with no instance is reported as a fallback"):
+        Inspectable.fallbacks(Underived(7).inspect)
+      . assert(_ == List(t"“Underived(7)”"))
+
     suite(m"Position tests"):
       test(m"inspect the first ordinal"):
         Ordinal.zerary(0).inspect

--- a/lib/spectacular/src/test/spectacular_test.scala
+++ b/lib/spectacular/src/test/spectacular_test.scala
@@ -411,9 +411,17 @@ object Tests extends Suite(m"Spectacular Tests"):
         Map(1 -> 2).inspect
       . assert(_ == t"{1 → 2}")
 
-      // Raw `Vector` is no longer `Sequence` (opaque) and matches no curated instance (the
-      // `IndexedSeq` instance's `Self` is invariant), so it falls back to the quoted
-      // `toString` rendering; `Sequence` itself renders as `⟨ 1 2 3 ⟩`.
+      // Bracketed differently from a `Map`, whose entries have no significant order.
+      test(m"serialize ledger"):
+        Ledger(1 -> 2, 3 -> 4).inspect
+      . assert(_ == t"⟦1 → 2, 3 → 4⟧")
+
+      test(m"a ledger keeps its insertion order"):
+        Ledger(3 -> 4, 1 -> 2).inspect
+      . assert(_ == t"⟦3 → 4, 1 → 2⟧")
+
+      // Raw `Vector` is not a `Sequence` (which is opaque) and matches no curated instance, so
+      // it falls back to the quoted `toString` rendering; `Sequence` renders as `⟨ 1 2 3 ⟩`.
       test(m"serialize vector"):
         Vector(1, 2, 3).inspect
       . assert(_ == t"“Vector(1, 2, 3)”")

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -2776,6 +2776,17 @@ object Tel extends Tel2:
 
     document.show
 
+  // `Tel` is a plain class, so there is no reflection to derive from, and TEL's block syntax is
+  // multi-line, which an inspection is not. The document is rendered with its line breaks
+  // escaped, so all of it is visible on one line and is distinguishable from the `Text` holding
+  // the same document; this follows the `yaml"…"` precedent in ypsiloid. Delegation is to
+  // `showable` by name, since it needs no context of its own.
+  given inspectable: [tel <: Tel] => tel is Inspectable = tel =>
+    val builder: StringBuilder = new StringBuilder()
+    showable.text(tel: Tel).each { char => builder.append(Inspectable.escape(char).s) }
+
+    ("tel\""+builder.toString+"\"").tt
+
   // Macro-friendly factory: bypasses the private constructor so generated
   // code from the `tel"…"` interpolator can produce Tel values without
   // tripping the inline-private-constructor restriction.

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -117,6 +117,17 @@ object Tests extends Suite(m"Stratiform Tests"):
     cell.writes += 1
 
   def run(): Unit =
+    // A missing `Inspectable` is never a compile error, so coverage is held in place by
+    // asserting on the renderings: `fallbacks` returns those which used a marked fallback.
+    suite(m"Native-rendering coverage"):
+      test(m"a Tel document inspects on one line, with its breaks escaped"):
+        t"name Jane\n".read[Tel].inspect
+      . assert(_ == t"tel\"name Jane\\n\"")
+
+      test(m"stratiform's types inspect natively"):
+        Inspectable.fallbacks(t"name Jane\n".read[Tel].inspect, Tel.empty.inspect)
+      . assert(_ == Nil)
+
     suite(m"Positive corpus"):
       CorpusLoader.positive.each: testcase =>
         test(m"parses ${testcase.stem}"):

--- a/lib/synesthesia/src/core/synesthesia.Mcp.scala
+++ b/lib/synesthesia/src/core/synesthesia.Mcp.scala
@@ -177,6 +177,19 @@ object Mcp:
     given decodable: Tactic[Json.Error] => TextInt is Json.Decodable =
       Json.Decodable(Morphology.Any): json => TextInt(safely(json.as[Int]).or(json.as[Text]))
 
+    // Every other type in `Mcp` is a case class or an enum, and derives its inspection
+    // structurally. `TextInt` cannot: its `id` is a `Text | Int` union, for which no instance
+    // exists, so the derivation would render the field with its `toString`. Matching the union
+    // here keeps the product form and shows which side of it the identifier came from.
+    given inspectable: [textInt <: TextInt] => textInt is Inspectable = textInt =>
+      val value: Text | Int = (textInt: TextInt).id
+
+      val id = value.absolve match
+        case text: Text => text.inspect
+        case int: Int   => int.inspect
+
+      t"TextInt(id:$id)"
+
   case class TextInt(id: Text | Int)
 
   val ParseError = -32700

--- a/lib/synesthesia/src/test/synesthesia_test.scala
+++ b/lib/synesthesia/src/test/synesthesia_test.scala
@@ -36,6 +36,29 @@ import soundness.*
 
 object Tests extends Suite(m"Synesthesia Tests"):
   def run(): Unit =
+    // A missing `Inspectable` is never a compile error, so coverage is held in place by
+    // asserting on the renderings: `fallbacks` returns those which used a marked fallback.
+    // synesthesia's own types are case classes and enums, rendered structurally by derivation;
+    // only `Mcp.TextInt`, whose `id` is a `Text | Int` union, needs an instance of its own.
+    suite(m"Native-rendering coverage"):
+      test(m"a Discourse message inspects structurally"):
+        Human(t"hello").inspect
+      . assert(_ == t"Human(message:t\"hello\")")
+
+      test(m"a TextInt inspects with its union field resolved"):
+        Mcp.TextInt(42).inspect
+      . assert(_ == t"TextInt(id:42)")
+
+      test(m"synesthesia's types inspect natively"):
+        Inspectable.fallbacks
+         ( Human(t"hello").inspect,
+           Agent(t"hi").inspect,
+           Mcp.BaseMetadata(t"name").inspect,
+           Mcp.LoggingLevel.Debug.inspect,
+           Mcp.TaskStatus.Working.inspect,
+           Mcp.TextInt(42).inspect )
+      . assert(_ == Nil)
+
     // Manual-only MCP server runner — NOT an automated test. It serves MCP on :8080
     // and `Thread.sleep`s to keep the server alive for an external MCP client to
     // connect to; it asserts nothing and blocked CI for ~16 minutes. Disabled here;

--- a/lib/telekinesis/src/core/telekinesis.Cookie.scala
+++ b/lib/telekinesis/src/core/telekinesis.Cookie.scala
@@ -59,6 +59,21 @@ object Cookie:
 
     new Cookie[value](name, domain, expiry.let(_.generic/1_000_000L), secure, httpOnly, path)
 
+  // A `Cookie` is the template a value is written into, not a cookie which has been sent, so
+  // its rendering shows the attributes it will impose: the name, and each optional attribute
+  // which is set. `Optional` fields are rendered only when present, and the two flags appear
+  // as bare words, so the rendering says exactly which attributes the template carries.
+  given inspectable: [cookie <: Cookie[?]] => cookie is Inspectable = cookie =>
+    Iterable
+     ( cookie.name.inspect,
+       cookie.domain.let { domain => t"domain:${domain.inspect}" },
+       cookie.path.let { path => t"path:${path.inspect}" },
+       cookie.expiry.let { expiry => t"expiry:${expiry.inspect}" },
+       if cookie.secure then t"secure" else Unset,
+       if cookie.httpOnly then t"httpOnly" else Unset )
+
+    . compact.join(t"Cookie(", t" ╱ ", t")")
+
   object Value:
     given showable: Value is Showable = cookie =>
       Iterable
@@ -70,6 +85,12 @@ object Cookie:
           if cookie.httpOnly then t"HttpOnly" else Unset )
 
       . compact.join(t"; ")
+
+    // `showable` renders the `Set-Cookie` form, which already shows every attribute the value
+    // carries and omits only those which are unset; wrapping it names the type, so the
+    // rendering cannot be mistaken for the header text itself.
+    given inspectable: [value <: Cookie.Value] => value is Inspectable = value =>
+      t"Cookie.Value(${showable.text(value)})"
 
     given encodable: Cookie.Value is Encodable in Http.Header = cookie =>
       Http.Header("Set-Cookie", cookie.show)

--- a/lib/telekinesis/src/core/telekinesis.Session.scala
+++ b/lib/telekinesis/src/core/telekinesis.Session.scala
@@ -35,10 +35,17 @@ package telekinesis
 import anticipation.*
 import beneficence.*
 import distillate.*
+import gossamer.*
 import prepositional.*
+import spectacular.*
 
 object Session:
   given encodable: Session is Encodable in Text = _.key
   given decodable: Session is Decodable in Text = Session(_)
+
+  // The encoded form is the bare key, which would be indistinguishable from `Text`, so the
+  // inspected form names the type and quotes the key as the `Text` it is.
+  given inspectable: [session <: Session] => session is Inspectable = session =>
+    t"Session(${session.key.inspect})"
 
 case class Session(key: Text) extends Findable

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -996,3 +996,22 @@ object Tests extends Suite(m"Telekinesis tests"):
         given TlsAcceptance = TlsAcceptance().permitRevoked
         url"https://revoked.badssl.com/".fetch().status
       . aspire(_ == Http.Ok)
+
+    // A missing `Inspectable` is never a compile error — `derived` always succeeds and
+    // substitutes a marked `toString`, `Showable` or `Encodable` rendering — so coverage can
+    // only be held in place by asserting on the renderings.
+    suite(m"Native-rendering coverage"):
+      test(m"telekinesis's types inspect natively"):
+        Inspectable.fallbacks
+         ( new Cookie[Text](t"session", Unset, Unset, true, true, Unset).inspect,
+           Cookie.Value(t"session", t"abc", secure = true).inspect,
+           Session(t"a3f1").inspect )
+      . assert(_ == Nil)
+
+      test(m"A cookie template inspects with its attributes"):
+        new Cookie[Text](t"session", Unset, 3600L, true, false, Unset).inspect
+      . assert(_ == t"""Cookie(t"session" ╱ expiry:3600L ╱ secure)""")
+
+      test(m"A session inspects with its key quoted"):
+        Session(t"a3f1").inspect
+      . assert(_ == t"""Session(t"a3f1")""")

--- a/lib/urticose/src/core/urticose.EmailAddress.scala
+++ b/lib/urticose/src/core/urticose.EmailAddress.scala
@@ -54,6 +54,7 @@ object EmailAddress:
 
   given encodable: EmailAddress is Encodable in Text = _.text
   given showable: EmailAddress is Showable = _.text
+  given inspectable: EmailAddress is Inspectable = _.text
 
   def parse(text: Text): EmailAddress raises EmailAddress.Error =
     val buffer: StringBuilder = StringBuilder()

--- a/lib/urticose/src/core/urticose.EmailAddress.scala
+++ b/lib/urticose/src/core/urticose.EmailAddress.scala
@@ -54,7 +54,7 @@ object EmailAddress:
 
   given encodable: EmailAddress is Encodable in Text = _.text
   given showable: EmailAddress is Showable = _.text
-  given inspectable: EmailAddress is Inspectable = _.text
+  given inspectable: [email <: EmailAddress] => email is Inspectable = (_: EmailAddress).text
 
   def parse(text: Text): EmailAddress raises EmailAddress.Error =
     val buffer: StringBuilder = StringBuilder()

--- a/lib/urticose/src/core/urticose.EmailAddress.scala
+++ b/lib/urticose/src/core/urticose.EmailAddress.scala
@@ -54,7 +54,11 @@ object EmailAddress:
 
   given encodable: EmailAddress is Encodable in Text = _.text
   given showable: EmailAddress is Showable = _.text
-  given inspectable: [email <: EmailAddress] => email is Inspectable = (_: EmailAddress).text
+  // The lambda parameter is left unascribed so it infers as `Self`: under `-scalajs` a SAM over
+  // an ordinary trait is expanded to an anonymous class before conformance is checked, and its
+  // `text` must then match `text(value: Self)` exactly, which an `EmailAddress` ascription does
+  // not (the JVM keeps a closure typed as the SAM, and so accepts either).
+  given inspectable: [email <: EmailAddress] => email is Inspectable = email => email.text
 
   def parse(text: Text): EmailAddress raises EmailAddress.Error =
     val buffer: StringBuilder = StringBuilder()

--- a/lib/urticose/src/core/urticose.Endpoint.scala
+++ b/lib/urticose/src/core/urticose.Endpoint.scala
@@ -40,4 +40,13 @@ object Endpoint:
   given showable: [port: Showable] => Endpoint[port] is Showable = endpoint =>
     t"${endpoint.remote}:${endpoint.port.show}"
 
+  // `showable` needs a `Showable` for the port type, so it is not delegated to; the port is
+  // inspected instead, which is always available. Both fields are rendered in their own
+  // inspected forms, so the remote is quoted as `Text` and the port carries whatever marks its
+  // own type (`⌗8080` for a `Port`, `8080` for an `Int`).
+  given inspectable: [port, endpoint <: Endpoint[port]]
+  =>  (port is Inspectable)
+  =>  endpoint is Inspectable =
+    endpoint => t"Endpoint(${endpoint.remote.inspect}:${endpoint.port.inspect})"
+
 case class Endpoint[+port](remote: Text, port: port)

--- a/lib/urticose/src/core/urticose.Hostname.scala
+++ b/lib/urticose/src/core/urticose.Hostname.scala
@@ -51,6 +51,7 @@ import Hostname.Error.Reason.*
 
 object Hostname:
   given showable: Hostname is Showable = _.dnsLabels.map(_.show).join(t".")
+  given inspectable: Hostname is Inspectable = showable.text(_)
   given decodable: (tactic: Tactic[Hostname.Error])
   =>  ((Hostname is Decodable in Text)^{tactic}) =
     parse(_)

--- a/lib/urticose/src/core/urticose.Hostname.scala
+++ b/lib/urticose/src/core/urticose.Hostname.scala
@@ -51,7 +51,7 @@ import Hostname.Error.Reason.*
 
 object Hostname:
   given showable: Hostname is Showable = _.dnsLabels.map(_.show).join(t".")
-  given inspectable: Hostname is Inspectable = showable.text(_)
+  given inspectable: [hostname <: Hostname] => hostname is Inspectable = showable.text(_)
   given decodable: (tactic: Tactic[Hostname.Error])
   =>  ((Hostname is Decodable in Text)^{tactic}) =
     parse(_)

--- a/lib/urticose/src/core/urticose.internal.scala
+++ b/lib/urticose/src/core/urticose.internal.scala
@@ -152,7 +152,9 @@ object internal:
 
       inline given underlying: Underlying[MacAddress, Long] = !!
       given showable: MacAddress is Showable = _.text
-      given inspectable: [mac <: MacAddress] => mac is Inspectable = (_: MacAddress).text
+      // Unascribed, so the parameter infers as `Self` — see the note on `EmailAddress`'s
+      // `inspectable`: an ascribed parameter fails the anon-class expansion under `-scalajs`.
+      given inspectable: [mac <: MacAddress] => mac is Inspectable = mac => mac.text
       given encodable: MacAddress is Encodable in Text = _.text
       given decoder: (tactic: Tactic[MacAddress.Error])
       =>  ((MacAddress is Decodable in Text)^{tactic}) =

--- a/lib/urticose/src/core/urticose.internal.scala
+++ b/lib/urticose/src/core/urticose.internal.scala
@@ -110,6 +110,11 @@ object internal:
       given showable: Ipv4 is Showable = ip =>
         t"${ip.byte0.toString}.${ip.byte1.toString}.${ip.byte2.toString}.${ip.byte3.toString}"
 
+      // Dotted-quad notation identifies an IPv4 address on sight, so inspection needs no
+      // decoration to distinguish it; without an instance it would render as the `Int` it
+      // erases to. Referenced by name rather than summoned, as in `Ipv6Subnet` below.
+      given inspectable: Ipv4 is Inspectable = showable.text(_)
+
       given encodable: Ipv4 is Encodable in Text = _.show
       given decodable: (tactic: Tactic[IpAddress.Error])
       =>  ((Ipv4 is Decodable in Text)^{tactic}) =
@@ -147,6 +152,7 @@ object internal:
 
       inline given underlying: Underlying[MacAddress, Long] = !!
       given showable: MacAddress is Showable = _.text
+      given inspectable: MacAddress is Inspectable = _.text
       given encodable: MacAddress is Encodable in Text = _.text
       given decoder: (tactic: Tactic[MacAddress.Error])
       =>  ((MacAddress is Decodable in Text)^{tactic}) =
@@ -210,6 +216,13 @@ object internal:
       inline given underlying: Underlying[Port, Int] = !!
       given showable: Port is Showable = _.number.show
       given encodable: Port is Encodable in Text = _.number.show
+
+      // A port shown as a bare number would be indistinguishable from the `Int` it erases to,
+      // so inspection prefixes it. `Self` is invariant, and a port is routinely refined more
+      // than once — `tcp"smtp"` is a `Port over Tcp of number` — so this is parameterised over
+      // any subtype of `Port` rather than written once per refinement; an instance for
+      // `Port over transport` alone would leave a named port rendering as its `toString`.
+      given inspectable: [port <: Port] => port is Inspectable = port => t"⌗${port.number}"
 
       // `Self` is invariant in a typeclass, so the bare-`Port` instances above do not cover a
       // transport-refined `Port over transport` (e.g. `Port over Tcp`); provide it explicitly.
@@ -294,6 +307,7 @@ object internal:
 
   object Ipv4Subnet:
     given showable: Ipv4Subnet is Showable = subnet => t"${subnet.ipv4}/${subnet.size}"
+    given inspectable: Ipv4Subnet is Inspectable = showable.text(_)
     given encodable: Ipv4Subnet is Encodable in Text = _.show
     given decodable: (tactic: Tactic[IpAddress.Error])
     =>  ((Ipv4Subnet is Decodable in Text)^{tactic}) =
@@ -341,6 +355,10 @@ object internal:
 
       if middleLength < 2 then hex(groups)
       else t"${hex(groups.keep(middleIndex))}::${hex(groups.skip(middleIndex + middleLength))}"
+
+    // Colon-separated hexadecimal groups identify an IPv6 address on sight; the abbreviated
+    // form the `Showable` produces is also the form a programmer recognises.
+    given inspectable: Ipv6 is Inspectable = showable.text(_)
 
     def apply(g0: Int, g1: Int, g2: Int, g3: Int, g4: Int, g5: Int, g6: Int, g7: Int): Ipv6 =
       Ipv6(pack(List(g0, g1, g2, g3)), pack(List(g4, g5, g6, g7)))
@@ -410,6 +428,7 @@ object internal:
     given showable: Ipv6Subnet is Showable = subnet =>
       t"${Ipv6.showable.text(subnet.ipv6)}/${subnet.size}"
 
+    given inspectable: Ipv6Subnet is Inspectable = showable.text(_)
     given encodable: Ipv6Subnet is Encodable in Text = _.show
     given decodable: (tactic: Tactic[IpAddress.Error])
     =>  ((Ipv6Subnet is Decodable in Text)^{tactic}) =

--- a/lib/urticose/src/core/urticose.internal.scala
+++ b/lib/urticose/src/core/urticose.internal.scala
@@ -113,7 +113,7 @@ object internal:
       // Dotted-quad notation identifies an IPv4 address on sight, so inspection needs no
       // decoration to distinguish it; without an instance it would render as the `Int` it
       // erases to. Referenced by name rather than summoned, as in `Ipv6Subnet` below.
-      given inspectable: Ipv4 is Inspectable = showable.text(_)
+      given inspectable: [ipv4 <: Ipv4] => ipv4 is Inspectable = showable.text(_)
 
       given encodable: Ipv4 is Encodable in Text = _.show
       given decodable: (tactic: Tactic[IpAddress.Error])
@@ -152,7 +152,7 @@ object internal:
 
       inline given underlying: Underlying[MacAddress, Long] = !!
       given showable: MacAddress is Showable = _.text
-      given inspectable: MacAddress is Inspectable = _.text
+      given inspectable: [mac <: MacAddress] => mac is Inspectable = (_: MacAddress).text
       given encodable: MacAddress is Encodable in Text = _.text
       given decoder: (tactic: Tactic[MacAddress.Error])
       =>  ((MacAddress is Decodable in Text)^{tactic}) =
@@ -307,7 +307,7 @@ object internal:
 
   object Ipv4Subnet:
     given showable: Ipv4Subnet is Showable = subnet => t"${subnet.ipv4}/${subnet.size}"
-    given inspectable: Ipv4Subnet is Inspectable = showable.text(_)
+    given inspectable: [subnet <: Ipv4Subnet] => subnet is Inspectable = showable.text(_)
     given encodable: Ipv4Subnet is Encodable in Text = _.show
     given decodable: (tactic: Tactic[IpAddress.Error])
     =>  ((Ipv4Subnet is Decodable in Text)^{tactic}) =
@@ -358,7 +358,7 @@ object internal:
 
     // Colon-separated hexadecimal groups identify an IPv6 address on sight; the abbreviated
     // form the `Showable` produces is also the form a programmer recognises.
-    given inspectable: Ipv6 is Inspectable = showable.text(_)
+    given inspectable: [ipv6 <: Ipv6] => ipv6 is Inspectable = showable.text(_)
 
     def apply(g0: Int, g1: Int, g2: Int, g3: Int, g4: Int, g5: Int, g6: Int, g7: Int): Ipv6 =
       Ipv6(pack(List(g0, g1, g2, g3)), pack(List(g4, g5, g6, g7)))
@@ -428,7 +428,7 @@ object internal:
     given showable: Ipv6Subnet is Showable = subnet =>
       t"${Ipv6.showable.text(subnet.ipv6)}/${subnet.size}"
 
-    given inspectable: Ipv6Subnet is Inspectable = showable.text(_)
+    given inspectable: [subnet <: Ipv6Subnet] => subnet is Inspectable = showable.text(_)
     given encodable: Ipv6Subnet is Encodable in Text = _.show
     given decodable: (tactic: Tactic[IpAddress.Error])
     =>  ((Ipv6Subnet is Decodable in Text)^{tactic}) =

--- a/lib/urticose/src/test/urticose_test.scala
+++ b/lib/urticose/src/test/urticose_test.scala
@@ -99,6 +99,10 @@ object Tests extends Suite(m"Urticose tests"):
         Ipv4(192, 168, 0, 1).int
       . assert(_ == bin"11000000 10101000 00000000 00000001")
 
+      test(m"Inspect an Ipv4 address"):
+        Ipv4(127, 244, 197, 0).inspect
+      . assert(_ == t"127.244.197.0")
+
     suite(m"IPv6 tests"):
       test(m"Parse an IPv6 address"):
         t"2001:db8:0000:1:1:1:1:1".as[Ipv6]
@@ -106,6 +110,10 @@ object Tests extends Suite(m"Urticose tests"):
 
       test(m"Render an IPv6 address"):
         t"2001:db8:0000:1:1:1:1:1".as[Ipv6].show
+      . assert(_ == t"2001:db8:0:1:1:1:1:1")
+
+      test(m"Inspect an IPv6 address"):
+        t"2001:db8:0000:1:1:1:1:1".as[Ipv6].inspect
       . assert(_ == t"2001:db8:0:1:1:1:1:1")
 
       test(m"Parse zero IPv6 address"):
@@ -382,6 +390,10 @@ object Tests extends Suite(m"Urticose tests"):
       . assert(_ == EmailAddress.Error(UnclosedIpAddress))
 
     suite(m"URL tests"):
+      test(m"inspect a URL"):
+        url"https://example.com/foo/bar".inspect
+      . assert(_ == t"https://example.com/foo/bar")
+
       test(m"parse Authority with username and password"):
         t"username:password@example.com".as[Authority]
       . assert(_ == Authority(example.com, t"username:password"))
@@ -616,6 +628,10 @@ object Tests extends Suite(m"Urticose tests"):
         t"www.example.com".as[Hostname]
       . assert(_ == Hostname(DnsLabel(t"www"), DnsLabel(t"example"), DnsLabel(t"com")))
 
+      test(m"Inspect a hostname"):
+        t"www.example.com".as[Hostname].inspect
+      . assert(_ == t"www.example.com")
+
       test(m"A hostname cannot end in a period"):
         capture[Hostname.Error](t"www.example.".as[Hostname])
       . assert(_ == Hostname.Error(t"www.example.", Hostname.Error.Reason.EmptyDnsLabel(2)))
@@ -716,10 +732,18 @@ object Tests extends Suite(m"Urticose tests"):
         MacAddress(1, 2, 3, 4, 5, 6).show
       . assert(_ == t"01-02-03-04-05-06")
 
+      test(m"Inspect a MAC address"):
+        MacAddress(1, 2, 3, 4, 5, 6).inspect
+      . assert(_ == t"01-02-03-04-05-06")
+
     suite(m"Named port services"):
       test(m"Check SMTP over TCP port"):
         tcp"smtp"
       . assert(_ == Port[Tcp](25))
+
+      test(m"Inspect a port"):
+        tcp"smtp".inspect
+      . assert(_ == t"⌗25")
 
       test(m"Check Docker over TCP port"):
         tcp"docker"

--- a/lib/urticose/src/test/urticose_test.scala
+++ b/lib/urticose/src/test/urticose_test.scala
@@ -78,6 +78,24 @@ object Tests extends Suite(m"Urticose tests"):
       // .assert(_ == List(CompileError.Id.MissingImplicitArgument))
 
 
+    // A missing `Inspectable` is never a compile error — `derived` always succeeds and
+    // substitutes a marked `toString`, `Showable` or `Encodable` rendering — so coverage can
+    // only be held in place by asserting on the renderings. A failure names the ones which
+    // fell back.
+    suite(m"Native-rendering coverage"):
+      test(m"urticose's network types all inspect natively"):
+        Inspectable.fallbacks
+         ( ip"192.168.0.1".inspect,
+           ip"2001:db8::1".inspect,
+           ip"255.123.143.0".subnet(12).inspect,
+           MacAddress(1, 2, 3, 4, 5, 6).inspect,
+           tcp"smtp".inspect,
+           t"www.example.com".as[Hostname].inspect,
+           t"simple@example.com".as[EmailAddress].inspect,
+           url"https://example.com/path".inspect,
+           url"https://example.com/path".scheme.inspect )
+      . assert(_ == Nil)
+
     suite(m"IPv4 tests"):
       test(m"Parse in IPv4 address"):
         t"1.2.3.4".as[Ipv4]

--- a/lib/urticose/src/test/urticose_test.scala
+++ b/lib/urticose/src/test/urticose_test.scala
@@ -93,8 +93,18 @@ object Tests extends Suite(m"Urticose tests"):
            t"www.example.com".as[Hostname].inspect,
            t"simple@example.com".as[EmailAddress].inspect,
            url"https://example.com/path".inspect,
-           url"https://example.com/path".scheme.inspect )
+           url"https://example.com/path".scheme.inspect,
+           t"user@example.com:8080".as[Authority].inspect,
+           Endpoint(t"example.com", 8080).inspect )
       . assert(_ == Nil)
+
+      test(m"An authority inspects as its URL form, introduced by `//`"):
+        t"user@example.com:8080".as[Authority].inspect
+      . assert(_ == t"//user@example.com:8080")
+
+      test(m"An endpoint inspects both its remote and its port"):
+        Endpoint(t"example.com", 8080).inspect
+      . assert(_ == t"""Endpoint(t"example.com":8080)""")
 
     suite(m"IPv4 tests"):
       test(m"Parse in IPv4 address"):

--- a/lib/urticose/src/url/urticose.Authority.scala
+++ b/lib/urticose/src/url/urticose.Authority.scala
@@ -50,6 +50,13 @@ object Authority:
   given showable: Authority is Showable = auth =>
     t"${auth.userInfo.lay(t"")(_+t"@")}${auth.host.show}${auth.port.let(_.show).lay(t"")(t":"+_)}"
 
+  // The authority as it appears in a URL, with the `//` which introduces it: that prefix says
+  // which part of a URL the value is, and keeps the rendering from being mistaken for a bare
+  // hostname or for `Text`. The user info and port appear exactly when they are set, delimited
+  // by the `@` and `:` which the syntax gives them, so no state is hidden.
+  given inspectable: [authority <: Authority] => authority is Inspectable = authority =>
+    t"//${showable.text(authority)}"
+
   given decodable: (hostnameTactic: Tactic[Hostname.Error])
   =>  (ipTactic: Tactic[IpAddress.Error])
   =>  (urlTactic: Tactic[Url.Error])

--- a/lib/urticose/src/url/urticose.Scheme.scala
+++ b/lib/urticose/src/url/urticose.Scheme.scala
@@ -41,7 +41,8 @@ object Scheme:
 
   // The trailing colon is what makes a bare scheme name recognisable as a scheme rather than
   // as some other text, and matches how it appears in the URL it belongs to.
-  given inspectable: Scheme[Label] is Inspectable = scheme => t"${scheme.name}:"
+  given inspectable: [scheme <: Scheme[Label]] => scheme is Inspectable = scheme =>
+    t"${scheme.name}:"
 
   object Http extends Scheme["http"](t"http")
   object Https extends Scheme["https"](t"https")

--- a/lib/urticose/src/url/urticose.Scheme.scala
+++ b/lib/urticose/src/url/urticose.Scheme.scala
@@ -39,6 +39,10 @@ import spectacular.*
 object Scheme:
   given showable: Scheme[Label] is Showable = _.name
 
+  // The trailing colon is what makes a bare scheme name recognisable as a scheme rather than
+  // as some other text, and matches how it appears in the URL it belongs to.
+  given inspectable: Scheme[Label] is Inspectable = scheme => t"${scheme.name}:"
+
   object Http extends Scheme["http"](t"http")
   object Https extends Scheme["https"](t"https")
 

--- a/lib/urticose/src/url/urticose.Url.scala
+++ b/lib/urticose/src/url/urticose.Url.scala
@@ -61,7 +61,8 @@ object Url:
   // `Url` is a plain class, not a case class, so there is no reflection to derive from and no
   // instance would leave it rendering as its `toString`. The canonical URL text shows every
   // part the type carries — scheme, authority, location, query and fragment.
-  given inspectable: [scheme <: Label] => Url[scheme] is Inspectable = showable.text(_)
+  given inspectable: [scheme <: Label, url <: Url[scheme]] => url is Inspectable =
+    showable.text(_)
 
   given decodable: [scheme <: Label] => (tactic: Tactic[Url.Error])
   =>  ((Url[scheme] is Decodable in Text)^{tactic}) =

--- a/lib/urticose/src/url/urticose.Url.scala
+++ b/lib/urticose/src/url/urticose.Url.scala
@@ -58,6 +58,11 @@ object Url:
 
   given encodable: [scheme <: Label] => Url[scheme] is Encodable in Text = _.show
 
+  // `Url` is a plain class, not a case class, so there is no reflection to derive from and no
+  // instance would leave it rendering as its `toString`. The canonical URL text shows every
+  // part the type carries — scheme, authority, location, query and fragment.
+  given inspectable: [scheme <: Label] => Url[scheme] is Inspectable = showable.text(_)
+
   given decodable: [scheme <: Label] => (tactic: Tactic[Url.Error])
   =>  ((Url[scheme] is Decodable in Text)^{tactic}) =
     value =>

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -1879,6 +1879,23 @@ object Xml extends Tag.Container
       writeXml(producer, formatting, node, 0)
       if formatting.trailingNewline then producer.put("\n")
 
+  // `Element`, `Fragment`, `TextNode`, `Cdata`, `Comment`, `Doctype`, `ProcessingInstruction` and
+  // `Header` are all covered here, in the companion of the trait they share, exactly as `showable`
+  // above covers them. The `Showable` needs a `Formatting` which a debugger cannot supply, so
+  // inspection fixes the compact one and renders the node's own XML source, escaped into an
+  // `xml"…"` literal: compact and on one line, showing the tag, its attributes and its children,
+  // and distinguishable from the `Text` holding the same markup and from honeycomb's `html"…"`.
+  given inspectable: [xml <: Xml] => xml is Inspectable = node =>
+    val formatting: Formatting = Formatting(Unset, trailingNewline = false)
+
+    val markup: Text = Producer.collect[Text](): producer =>
+      writeXml(producer, formatting, node, 0)
+
+    val builder: StringBuilder = new StringBuilder()
+    markup.each { char => builder.append(Inspectable.escape(char).s) }
+
+    ("xml\""+builder.toString+"\"").tt
+
   private enum Token:
     case Close, Comment, Empty, Open, Header, Cdata, Pi, Doctype
 

--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -925,6 +925,31 @@ object internal:
   object Attributes:
     val empty: Attributes = scala.IArray.empty[String]
 
+    // The attributes render as they would appear in an element's start tag, braced and prefixed
+    // `xml`: distinct from a `Map`'s `{k → v}` (whose keys and values would show as `t"…"`
+    // literals) and from honeycomb's `html{…}`. The storage is read directly, since an accessor on
+    // the opaque type is unavailable through a subtype of it.
+    given inspectable: [attributes <: Attributes] => attributes is Inspectable = attributes =>
+      val array = storage(attributes)
+      val builder: StringBuilder = new StringBuilder("xml{")
+      var index = 0
+
+      while index < array.length do
+        if index > 0 then builder.append(", ")
+        builder.append(array(index))
+        builder.append("=\"")
+        val value = array(index + 1)
+        var offset = 0
+
+        while offset < value.length do
+          builder.append(Inspectable.escape(value.charAt(offset)).s)
+          offset += 1
+
+        builder.append('"')
+        index += 2
+
+      builder.append('}').toString.tt
+
     // `Attributes` is a `Text`-keyed map, so it indexes through the shared `at` (giving
     // `Optional`).
     given indexable: Attributes is Applicable:

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -64,6 +64,29 @@ object Tests extends Suite(m"Xylophone tests"):
   def run(): Unit =
     given XmlSchema = XmlSchema.Freeform
 
+    // A missing `Inspectable` is never a compile error, so coverage is held in place by
+    // asserting on the renderings: `fallbacks` returns those which used a marked fallback.
+    suite(m"Native-rendering coverage"):
+      test(m"an element inspects as escaped, single-line XML source"):
+        x"<message>hello</message>".inspect
+      . assert(_ == t"xml\"<message>hello</message>\"")
+
+      test(m"attributes inspect as an element's start-tag text"):
+        Attributes(t"id" -> t"x", t"class" -> t"y").inspect
+      . assert(_ == t"xml{id=\"x\", class=\"y\"}")
+
+      test(m"xylophone's types inspect natively"):
+        Inspectable.fallbacks
+         ( x"<message>hello</message>".inspect,
+           elem(t"item", Map(t"id" -> t"1"), TextNode(t"hi")).inspect,
+           TextNode(t"hi").inspect,
+           Comment(t"hi").inspect,
+           Cdata(t"hi").inspect,
+           Doctype(t"html").inspect,
+           ProcessingInstruction(t"foo", t"bar").inspect,
+           Attributes(t"id" -> t"x").inspect )
+      . assert(_ == Nil)
+
     suite(m"Interpolator tests"):
       test(m"Simple interpolator"):
         x"<message>1</message>"

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -469,6 +469,17 @@ object Yaml extends Yaml2, Dynamic:
     // package; bring a `Yaml.Formatting` into scope to enable `.show`.
     given showable: (formatting: Formatting) => Ast is Showable = renderAst(_)
 
+    // `Yaml.Ast` is an opaque union with no reflection to derive from, and the `Showable` above
+    // needs a `Formatting` which a debugger cannot supply. The node is rendered as
+    // `Yaml.inspectable` renders a document — on one line, with its breaks escaped — and suffixed
+    // `ᵃˢᵗ`, so that a bare node is distinguishable from the `Yaml` which wraps it.
+    given inspectable: [ast <: Ast] => ast is Inspectable = ast =>
+      given formatting: Formatting = new Formatting {}
+      val builder: StringBuilder = new StringBuilder()
+      renderAst(ast: Ast).each { char => builder.append(Inspectable.escape(char).s) }
+
+      ("yaml\""+builder.toString+"\"ᵃˢᵗ").tt
+
     def name: Text = "YAML"
 
     case class Position

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -374,6 +374,17 @@ object Yaml extends Yaml2, Dynamic:
   // In the companion (implicit scope), delegating to the block emitter in the package.
   given showable: Formatting => Yaml is Showable = unseal(_).show
 
+  // `Yaml` is a plain class, so there is no reflection to derive from; its `Showable` needs a
+  // `Formatting` which a debugger cannot supply, and YAML's block style is multi-line, which
+  // inspection is not. The document is rendered with its line breaks escaped, so all of it is
+  // visible on one line and is distinguishable from the `Text` holding the same document.
+  given inspectable: [yaml <: Yaml] => yaml is Inspectable = yaml =>
+    given formatting: Formatting = new Formatting {}
+    val builder: StringBuilder = new StringBuilder()
+    unseal(yaml: Yaml).show.each { char => builder.append(Inspectable.escape(char).s) }
+
+    ("yaml\""+builder.toString+"\"").tt
+
   // Controls how a `Yaml` value is serialized. YAML's block style is fixed and round-trip-
   // constrained, so this currently carries no options; importing `formatting.blockYamlFormatting`
   // enables `.show` and HTTP encoding, and this is the place to add options later.

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -64,6 +64,17 @@ case class Boxed[value](value: value) derives CanEqual
 
 object Tests extends Suite(m"Ypsiloid Tests"):
   def run(): Unit =
+    // A missing `Inspectable` is never a compile error, so coverage is held in place by
+    // asserting on the renderings: `fallbacks` returns those which used a marked fallback.
+    suite(m"Native-rendering coverage"):
+      test(m"a Yaml document inspects on one line, with its breaks escaped"):
+        42.in[Yaml].inspect
+      . assert(_ == t"yaml\"42\\n\"")
+
+      test(m"ypsiloid's types inspect natively"):
+        Inspectable.fallbacks(42.in[Yaml].inspect, t"foo".in[Yaml].inspect)
+      . assert(_ == Nil)
+
     suite(m"Plain scalar parsing"):
       test(m"Parse a plain integer"):
         t"42".read[Yaml].as[Int]

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -71,8 +71,14 @@ object Tests extends Suite(m"Ypsiloid Tests"):
         42.in[Yaml].inspect
       . assert(_ == t"yaml\"42\\n\"")
 
+      test(m"a bare Yaml.Ast is marked apart from the document wrapping it"):
+        Yaml.Ast.Integer(42).inspect
+      . assert(_ == t"yaml\"42\\n\"ᵃˢᵗ")
+
       test(m"ypsiloid's types inspect natively"):
-        Inspectable.fallbacks(42.in[Yaml].inspect, t"foo".in[Yaml].inspect)
+        Inspectable.fallbacks
+         ( 42.in[Yaml].inspect, t"foo".in[Yaml].inspect, Yaml.Ast.Integer(42).inspect,
+           Yaml.Ast.Str(t"foo").inspect )
       . assert(_ == Nil)
 
     suite(m"Plain scalar parsing"):


### PR DESCRIPTION
`Inspectable` renders a value the way a programmer reads it, in a debugger or in test output, and it now covers the types soundness defines rather than a tenth of them: instances grew from 33 across 10 libraries to 137 across 40. Where a type had no instance, inspection quietly borrowed its `Showable` or `Encodable` rendering — a human-facing form and a wire form, neither obliged to show what a debugger needs — or fell back to `toString`; those substitutions are now marked, so a gap is visible rather than silent, and a set of coverage tests keeps them from reappearing. Test failures render through the same typeclass, so what `probably` prints when an assertion fails is now the same thing `.inspect` gives you.

## Marked fallbacks

An inspection that could not find a native instance now says so. `⸢…⸣` wraps a rendering borrowed from `Showable`, `⸤…⸥` one borrowed from `Encodable in Text`, and `“…”` remains a bare `toString`. All three mean the same thing: no instance was found, and what you are reading was designed for another purpose.

This is what makes coverage checkable, because a missing instance is never a compile error — the derived fallback always succeeds. `Inspectable.fallbacks` reports which of several renderings used a marker, so a library's tests can assert it has none:

```scala
test(m"urticose's network types all inspect natively"):
  Inspectable.fallbacks(ip"192.168.0.1".inspect, tcp"smtp".inspect, url"https://example.com".inspect)
. assert(_ == Nil)
```

## Enums

Enums never reached derivation, because `Showable` has an instance for every `reflect.Enum` and inspection borrowed it. A parameterised case therefore lost its field labels:

```scala
Shape.Circle(5).inspect  // was: Circle(5)
Shape.Circle(5).inspect  // now: Circle(radius:5)
```

## New renderings

Opaque types no longer show the primitive they erase to. Sized numbers carry their width and signedness (`42ᵘ⁸`, `-7ˢ³²`, `DEADBEEFᵇ³²`, `3.5ᶠ⁶⁴`); positions read as positions (`1ˢᵗ`, `1ˢᵗ‥5ᵗʰ`, `⟪4:8+5⟫`); and `Bytes`, `Money`, `Angle`, `Ipv4`, `Port`, `Uuid`, `Digest`, `Instant` and the rest render in the form their own users write. Documents and markup render as one-line literals with their breaks escaped — `json`, `yaml"…"`, `xml"…"`, `html"…"`, `tel"…"` — so a document keeps its structure without taking twenty lines of a debugger pane.

Two decisions worth stating. Inspection never rounds: a `Decimalizer` in scope no longer shortens a decomposed `Double`, and `Angle` shows full precision where `show` gives one decimal place, because a rendering that rounds hides the state you are inspecting. And `Password` and `PrivateKey` render redacted as `Password(•••)`, even though `PrivateKey`'s `Showable` uncloaks the key to fingerprint it — inspection output reaches a debugger pane, a log line and a test failure, and a secret should not be one careless `.inspect` away from any of them.

## Test output

`probably` renders failures through `chiaroscuro`'s `Decomposable`, which carried its own summon chain with `Showable` and `Encodable` in the opposite order to `Inspectable`'s, so a value could decompose one way and inspect another. Its leaves now delegate to `Inspectable`. Two renderings change as a result: a `Char` leaf shows as `'a'` rather than `a`, and a decomposed `Double` is no longer rounded by a `Decimalizer`.

## Fixes

Four defects surfaced that no compiler could report, since a missing instance degrades a rendering rather than failing to compile. `sh"ls -la"` rendered as a borrowed `Showable`, because `Command`'s instance had an exact `Self` and the interpolator produces a refinement. A rotation in `savagery` rendered `Rotate(angle:“0.0”)`, because `Angle`'s instance sat at package level and had to be imported by name; it now lives in its companion. `Rgb12.hex` was infinitely recursive — inside its own object the opaque type is transparent, so the extension applied to its `Int` channels — and nothing had ever called it. And `Ledger`, the one proscenium collection without an instance, rendered as a `VectorMap`.

## Scala.js

Two of the new renderings could not be built for the JS cross, in different ways.

`EmailAddress` and `MacAddress` ascribed their subtype-bounded given's lambda parameter to the bound rather than letting it infer as `Self`. Under `-scalajs` an `Inspectable` lambda is expanded to an anonymous class before conformance is checked, and its `text` must then match `text(value: Self)` exactly, which the ascription does not; the JVM keeps a closure typed as the SAM and never compares members. Every other bounded instance here already infers its parameter, so these two now match.

`archimedes.Math` and `savagery.Stroke` added the first `.inspect` calls on `Optional` values in JS-capable modules, which routes through `Inspectable.derived`'s `Mandatable` case. That instance cannot be constructed under `-scalajs` at all: capture inference decorates the expanded parameter with a capture variable that `Self` does not carry. Neither ascribing the parameter to `Self` nor hand-writing the anonymous class avoids it, so the fix belongs in the compiler fork (propensive/proscala#46). Both files spell the rendering out meanwhile — `｢value｣` present, `○` absent, byte-identical to `derived` — tracked for removal in #1892.

Note that `mill soundness.js.compile` is what catches this class of breakage, and it is not part of `soundness.all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
