### PR TITLE
Complete clustered short flags by extending the word (#1888)

### DIFF
--- a/lib/exoskeleton/src/args/exoskeleton.Argument.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Argument.scala
@@ -63,7 +63,20 @@ case class Argument
   def wrap(suggestion: Suggestion): Suggestion = format match
     case Argument.Format.Full            => suggestion
     case Argument.Format.FlagSuffix      => suggestion.copy(prefix = value.keep(2))
-    case Argument.Format.CharFlag(index) => suggestion // FIXME
+    // Completing inside a clustered short flag (#1888). The characters already typed become a
+    // hidden prefix and only the new one is inserted, so choosing `-c` at `-ab` extends the word
+    // to `-abc` rather than replacing it; `display` keeps the menu naming the flag as `-c`, and
+    // `incomplete` stops the shell terminating the word, so the next letter can follow. A
+    // suggestion that is not a flag (an operand value offered at the same position) is left
+    // alone: there is no cluster to extend.
+    case Argument.Format.CharFlag(index) =>
+      if !suggestion.core.starts(t"-") then suggestion
+      else
+        suggestion.copy
+         ( core       = suggestion.core.skip(1),
+           prefix     = value,
+           display    = suggestion.core,
+           incomplete = true )
 
     case Argument.Format.EqualityPrefix =>
       suggestion.copy(core = suggestion.core+t"="+value.after(value.offsetOf("=").or(Prim)))

--- a/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
@@ -51,11 +51,13 @@ object Suggestion:
       suffix:      Text                      = t"",
       expanded:    Boolean                   = false,
       group:       Optional[CommandGroup]    = Unset,
-      operand:     Boolean                   = false )
+      operand:     Boolean                   = false,
+      display:     Optional[Text]            = Unset )
   :   Suggestion =
 
     new Suggestion
-      (core, description, hidden, incomplete, aliases, prefix, suffix, expanded, group, operand)
+      (core, description, hidden, incomplete, aliases, prefix, suffix, expanded, group, operand,
+       display)
 
 
 case class Suggestion
@@ -73,6 +75,12 @@ case class Suggestion
     // part of the command's interface, and the help tree is built by probing these same
     // suggestions: without this distinction, `--help` enumerates the working directory (or
     // whatever else the machine happens to hold) as though it were syntax.
-    operand:     Boolean = false ):
+    operand:     Boolean = false,
+    // What to show in the menu when it differs from what is inserted. Completing inside a
+    // clustered short flag is the case that needs it: typing `-ab` and choosing `-c` inserts
+    // only `c` (behind the hidden prefix `-ab`, so the word becomes `-abc`), but the menu should
+    // still name the flag as `-c`. Only shells that can separate the two honour it — zsh, via
+    // `compadd`'s display array; elsewhere the whole word is shown, as those shells do anyway.
+    display:     Optional[Text] = Unset ):
 
   def text: Text = prefix+core+suffix

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -186,31 +186,43 @@ extends Cli:
         val title = explanation.let { explanation => List(sh"'' -X $explanation") }.or(Nil)
         val termcap: Termcap = termcapDefinitions.xtermTrueColorTermcap
 
-        lazy val width = items.map(_.core.length).maximize(identity).or(0)
+        lazy val width = items.map { item => item.display.or(item.core).length }.maximize(identity).or(0)
         lazy val aliasesWidth = items.map(_.aliases.join(t" ").length).maximize(identity).or(0) + 1
 
         val itemLines: List[Command] = items.bind:
-          case Suggestion(core0, description, hidden, incomplete, aliases, prefix, suffix, _, _, _) =>
+          case Suggestion(core0, description, hidden, incomplete, aliases, prefix, suffix, _, _, _,
+                          display) =>
             val hiddenParam = if hidden then sh"-n" else sh""
             val shortFlag = focusText.starts(t"-") && !focusText.starts(t"--")
-            val aliasText = if shortFlag then core0 else aliases.join(t" ").fit(aliasesWidth)
+            // The short-flag menu names the flag, then its long form. A clustered candidate has
+            // already been named in full by `display`, so repeating the bare character there
+            // would just print it twice.
+            val aliasText =
+              if shortFlag && display.absent then core0 else aliases.join(t" ").fit(aliasesWidth)
             val prefix2 = if prefix.nil then sh"" else sh"-p $prefix"
             val suffix2 = if suffix.nil then sh"" else sh"-s $suffix"
             val core = if shortFlag then aliases.prim.or(core0) else core0
 
+            // What the menu shows, where that differs from what is inserted — a clustered short
+            // flag inserts one character behind a hidden prefix but is still named in full
+            // (#1888). `compadd`'s display array already carries the described form, so only the
+            // undescribed line needs `-d` adding.
+            val shown = display.or(core)
+
             val mainLine = description.absolve match
               case Unset =>
                 if prefix.nil then sh"'' $hiddenParam -- $core"
-                else sh"'' $hiddenParam $prefix2 $suffix2 -- $core"
+                else if display.absent then sh"'' $hiddenParam $prefix2 $suffix2 -- $core"
+                else sh"'$shown' $hiddenParam $prefix2 $suffix2 -l -d desc -- $core"
 
               case description: Text =>
                 val params = sh"$prefix2 $suffix2 -l -d desc $hiddenParam -- $core"
-                sh"'${core.fit(width)} $aliasText -- $description' $params"
+                sh"'${shown.fit(width)} $aliasText -- $description' $params"
 
               case description: Teletype =>
                 val desc = description.render(termcap)
                 val params = sh"$prefix2 $suffix2 -l -d desc $hiddenParam -- $core"
-                sh"'${core.fit(width)} $aliasText -- $desc' $params"
+                sh"'${shown.fit(width)} $aliasText -- $desc' $params"
 
             val duplicateLine: List[Command] =
               if !incomplete then List()
@@ -236,7 +248,7 @@ extends Cli:
         val sole = items.stdlib.count(!_.hidden) == 1
 
         items.bind:
-          case suggestion@Suggestion(core, description, hidden, incomplete, aliases, _, _, _, _, _) =>
+          case suggestion@Suggestion(core, description, hidden, incomplete, aliases, _, _, _, _, _, _) =>
             if hidden then Nil else
               val mainLines = (suggestion.text :: aliases.stdlib).map: text =>
                 description.absolve match
@@ -255,7 +267,7 @@ extends Cli:
         // PowerShell inserts a `CompletionResult` verbatim, so a trailing-space twin is
         // just a visible duplicate; `incomplete` has no rendering there.
         items.bind:
-          case suggestion@Suggestion(core, description, hidden, _, aliases, _, _, _, _, _) =>
+          case suggestion@Suggestion(core, description, hidden, _, aliases, _, _, _, _, _, _) =>
             if hidden then Nil else
 
                 (suggestion.text :: aliases.stdlib).map: text =>

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -848,6 +848,78 @@ object Tests extends Suite(m"Exoskeleton Tests"):
                t"    --one <value>    the first one",
                t"    --two <value>    the second one")
 
+      // Clustered short flags (#1888). The `Interpreter` that completion consults is resolved
+      // where the `Cli` is built, not per subcommand, so exercising clustering needs an
+      // application of its own. Three single-character flags, so typing `-ab` leaves exactly
+      // `-c` to offer.
+      Enclave(t"clstr").dispatch:
+        ' {
+            import executives.completions
+            import interpreters.posixClusteringInterpreter
+
+            cli:
+              Flag('a', description = t"the first flag")()
+              Flag('b', description = t"the second flag")()
+              Flag('c', description = t"the third flag")()
+              execute(Exit.Ok)
+
+            t"finished"
+          }
+
+      . sandbox:
+          val tool = summon[Enclave.Tool].path
+
+          // Typing `-ab` and choosing `-c` must extend the word to `-abc`, not replace it with
+          // `-c`, and must not terminate the word — the next letter may follow. Each shell is
+          // driven through the completions executive directly, so these assert on exactly what
+          // the shell is told.
+          suite(m"Clustered short-flag completion"):
+            // Each `compadd` invocation is one line of NUL-separated arguments.
+            def zsh(text: Text): List[List[Text]] =
+              sh"$tool '{completions}' zsh 2 3 /dev/null -- clstr $text".exec[Text]()
+              . cut(t"\n").stdlib.filter(_.length > 0)
+              . map(_.cut(t"\u0000").stdlib.to(List)).to(List)
+
+            def adjacent(line: List[Text], first: Text, second: Text): Boolean =
+              line.stdlib.sliding(2).exists: pair =>
+                pair.headOption == Some(first) && pair.lastOption == Some(second)
+
+            // `compadd -p <prefix>` is zsh's *hidden* prefix: inserted, but neither displayed
+            // nor matched against, so the word grows by the single new character.
+            test(m"zsh takes the typed cluster as a hidden prefix"):
+              zsh(t"-ab").stdlib.exists(adjacent(_, t"-p", t"-ab"))
+            . assert(_ == true)
+
+            test(m"zsh inserts only the character being added"):
+              zsh(t"-ab").stdlib.exists(adjacent(_, t"--", t"c"))
+            . assert(_ == true)
+
+            // The menu still names the flag, rather than showing the bare letter.
+            test(m"zsh names the flag in full in the menu"):
+              zsh(t"-ab").prim.let(_.prim).or(t"").starts(t"-c ")
+            . assert(_ == true)
+
+            test(m"zsh offers a no-trailing-space variant, so the cluster can grow"):
+              zsh(t"-ab").stdlib.exists(adjacent(_, t"-S", t""))
+            . assert(_ == true)
+
+            // Fish and bash insert whole words, so the candidate is the extended cluster.
+            test(m"fish offers the extended cluster"):
+              sh"$tool '{completions}' fish 2 3 /dev/null -- clstr -ab".exec[Text]()
+              . cut(t"\n").stdlib.to(List).map(_.cut(t"\t").prim.or(t""))
+            . assert(_.contains(t"-abc"))
+
+            test(m"bash offers the extended cluster"):
+              sh"$tool '{completions}' bash 2 3 /dev/null -- clstr -ab".exec[Text]()
+              . cut(t"\n").stdlib.to(List)
+            . assert(_.contains(t"-abc"))
+
+            // A two-character argument is not a cluster: the interpreter only expands beyond
+            // two characters, so `-a` still completes as an ordinary short flag.
+            test(m"a two-character flag is completed without a prefix"):
+              zsh(t"-a").stdlib.exists(adjacent(_, t"-p", t"-a"))
+            . assert(_ == false)
+
       suite(m"Manpage tests"):
         val manual = Manual
           ( version  = v"1.2.3",


### PR DESCRIPTION
Completing at a clustered short flag now extends the word instead of replacing it. `Argument#wrap` had an unhandled `Format.CharFlag` case, so typing `-ab` and asking for completions offered `-c` as a candidate for the whole word — which every shell then discarded, since it did not match what had been typed. The result was that clustered flags parsed correctly but could not be completed at all.

With `interpreters.posixClusteringInterpreter`, typing `-ab` and choosing `-c` now produces `-abc`. The characters already typed become a hidden prefix and only the new character is inserted, so the word grows rather than being replaced, and the shell is told not to terminate the word — so the next letter can follow immediately:

```
$ myapp -ab<TAB>
-c  the third flag        # the menu names the flag
$ myapp -abc              # ...and completing extends the cluster
```

`Suggestion` gains a `display` field for the case where what is shown differs from what is inserted. It is needed because zsh's `compadd -p` prefix is inserted but never displayed, so extending the word correctly would otherwise leave the menu showing a bare `c` rather than naming the flag `-c`. zsh honours it through the display array; fish, bash and PowerShell show whole words anyway and are unaffected.

Growing a cluster letter-by-letter works on zsh and fish. Bash appends a trailing space of its own that `incomplete` cannot suppress, so it completes `-abc` correctly but terminates the word there.

The `Interpreter` that completion consults is resolved where the `Cli` is built, not per subcommand, so the tests add a second application under the clustering interpreter rather than a subcommand within the existing one. They drive the completions executive directly and assert on exactly what each shell is told — the hidden prefix, the single inserted character, the menu text and the no-trailing-space variant — rather than screen-scraping a terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
