### PR TITLE
Stop re-exporting Precise, which silently did nothing (#1811)

### DIFF
--- a/lib/honeycomb/src/core/honeycomb.Tag.scala
+++ b/lib/honeycomb/src/core/honeycomb.Tag.scala
@@ -258,7 +258,7 @@ extends Element(label, Attributes.from(presets), Array(), foreign),
   val isTable: Boolean = label == t"table"
 
 
-  inline def applyDynamicNamed[label <: Label: Precise: ValueOf](inline method: label)
+  inline def applyDynamicNamed[label <: Label: scala.Precise: ValueOf](inline method: label)
     ( inline attributes: (String, Any)* )
   :   Result =
 

--- a/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
+++ b/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
@@ -167,7 +167,7 @@ class Issuer
         lambda(using Issuer.Context[this.type]())
 
 
-  def require[scope <: Scope & Singleton: Precise](scopes: scope*)
+  def require[scope <: Scope & Singleton: scala.Precise](scopes: scope*)
     ( using store: OAuth, session: Session, request: Http.Request )
     ( using Issuer.Context of this.type )
     ( lambda: Authorization of scope ?=> Http.Response )

--- a/lib/proscenium/src/core/proscenium.prelude.scala
+++ b/lib/proscenium/src/core/proscenium.prelude.scala
@@ -77,7 +77,15 @@ export scala.{deprecated, unchecked, volatile, transient, native, main}
 export scala.unsafeExceptions
 
 // Miscellaneous `scala`-package types with existing instances or uses.
-export scala.{CanThrow, DummyImplicit, MatchError, NamedTuple, Precise, Specializable, ValueOf}
+//
+// `Precise` is deliberately NOT among them (#1811). Exporting it yields a distinct alias
+// symbol which the compiler's union-widening suppression does not recognise, so a context
+// bound written `[t: Precise]` against the alias compiles and then does nothing: inference
+// widens the union anyway, with no warning. Since every module compiles with
+// `-Yimports:proscenium`, re-exporting it here would make that silent failure the default.
+// Write `scala.Precise` explicitly, which works; naming the bare `Precise` now fails to
+// compile rather than degrading quietly.
+export scala.{CanThrow, DummyImplicit, MatchError, NamedTuple, Specializable, ValueOf}
 
 // Exception aliases the `scala` package object provides for `java.util` types.
 export scala.NoSuchElementException

--- a/lib/serpentine/src/core/serpentine.Path.scala
+++ b/lib/serpentine/src/core/serpentine.Path.scala
@@ -157,11 +157,17 @@ object Path:
         else Some((radical.decode(path.root), Relative(0, path.descent*))) )
     :   path is Quotient of root over (Relative on filesystem) | Text
 
-  extension [path <: Path: Precise](left: path)
-    transparent inline def conjunction[right <: Path: Precise](right: right): Optional[Path] =
+  // These carried a `Precise` bound which, resolved through the prelude's export, silently did
+  // nothing (#1811) — so this is what they have always meant. It cannot simply be corrected to
+  // `scala.Precise`: with the bound actually in force, the parameter's singleton type acquires a
+  // reach capture its argument's type lacks, and callers stop compiling (`exoskeleton.Pathname`
+  // is the one in this repository). That is the capture-checking half of the same issue, so the
+  // bound can only be restored once the compiler is fixed.
+  extension [path <: Path](left: path)
+    transparent inline def conjunction[right <: Path](right: right): Optional[Path] =
       ${serpentine.internal.conjunction[path, right]('left, 'right)}
 
-    transparent inline def toward[target <: Path: Precise](target: target): Optional[Relative] =
+    transparent inline def toward[target <: Path](target: target): Optional[Relative] =
       ${serpentine.internal.toward[path, target]('left, 'target)}
 
   // PathError → Path.Error


### PR DESCRIPTION
A `Precise` context bound resolved through proscenium's `export scala.Precise` compiles and then has no effect. The exported alias is a distinct symbol which the compiler's union-widening suppression does not recognise, so inference widens the union anyway, with no warning — and since every module compiles with `-Yimports:proscenium`, that was the default meaning of `Precise` throughout the codebase. Dropping the export makes a bare `Precise` fail to compile instead of degrading quietly; `scala.Precise`, which works, must now be named explicitly.

Two of the three uses in the tree were harmless and are now genuinely enforced. Honeycomb's `applyDynamicNamed[label <: Label: Precise: ValueOf]` and orthodoxy's `require[scope <: Scope & Singleton: Precise]` already forced precision by other means — `ValueOf` and `& Singleton` — so taking `scala.Precise` costs nothing and makes the bound real.

Serpentine's was doing nothing, and cannot yet be corrected. Its `conjunction` and `toward` extensions lose the bound, which is precisely what they have always meant. Putting `scala.Precise` there instead makes the parameter's singleton type acquire a reach capture that the argument's type lacks, and callers stop compiling — `exoskeleton.Pathname` being the one in this repository:

```
Found:    serpentine.Path{type Plane = galilei.Local}^'s1
Required: (path : serpentine.Path{type Plane = galilei.Local}^'s1)^{path}
```

That is the capture-checking half of #1811, now tracked in the fork as propensive/proscala#49, so the bound waits on the compiler. Comments at the prelude and at serpentine record both halves.

No working user code can break: nothing depending on the prelude's `Precise` was getting precision in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
