### PR TITLE
Add Multihash, the self-describing digest envelope (#568)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -817,7 +817,8 @@ object soundness extends Toolchain:
     def summary = "Command-line applications: terminals, shells, files and processes"
 
   object data extends Bundle(caesura.core, dissonance.core, enigmatic.asn1, enigmatic.core,
-    facsimile.core, facsimile.file, gastronomy.core, chiaroscuro.core, chiaroscuro.render, jacinta.core,
+    facsimile.core, facsimile.file, gastronomy.core, gastronomy.multihash, chiaroscuro.core,
+    chiaroscuro.render, jacinta.core,
     monotonous.core,
     panopticon.core, camouflage.core, ulysses.core, polyvinyl.core, polaris.core, zeppelin.core,
     xylophone.core, anamnesis.core, jacinta.time, jacinta.schema, gnossienne.core, jacinta.records,
@@ -2080,7 +2081,13 @@ object gastronomy extends Library:
     override def jsSources = Task.Sources(moduleDir, moduleDir / os.up / "core-native")
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
-  object test extends Tests(core):
+  // The multihash envelope (#568): a digest prefixed with its algorithm's multicodec identifier
+  // and its length, so it can be exchanged without agreeing on the algorithm out of band. Its
+  // own component, because it is only wanted by content-addressing callers.
+  object multihash extends Component(core):
+    override def scalacOptions = Task:
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
+  object test extends Tests(core, multihash):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions())
 

--- a/lib/gastronomy/src/multihash/gastronomy.Multicodec.scala
+++ b/lib/gastronomy/src/multihash/gastronomy.Multicodec.scala
@@ -1,0 +1,90 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package gastronomy
+
+import anticipation.*
+import corpuscular.*
+import gossamer.*
+import prepositional.*
+import vacuous.*
+
+// The multicodec identifier of a hash function, as registered in the multiformats table
+// (https://github.com/multiformats/multicodec/blob/master/table.csv), which is the normative
+// source — the codes below are transcribed from it, not from memory.
+//
+// The typeclass *is* the mapping, and it is deliberately partial: an algorithm with no
+// registered code simply has no instance, so enveloping its digest does not compile. That is
+// the whole of the algorithm-code question. Note in particular:
+//
+//   - Adler-32 has no multicodec code at all, so it can never be enveloped;
+//   - CRC-32 (`0x0132`) and CRC-64/ECMA (`0x0164`) are registered with the tag `hash`, not
+//     `multihash`. Multihash's own specification says it is intended for "well-established
+//     cryptographic hash functions", because "non-cryptographic hash functions are not suitable
+//     for content addressing systems", and reserves the `hash` tag for the cases where naming
+//     one is nevertheless wanted. Since content addressing is the reason multihash exists, no
+//     instance is provided for either: a checksum is not a content address, and a caller who
+//     genuinely wants that envelope can construct the `Multihash` directly from its code.
+//
+// `Sha384`/`Sha512` share the codes of `Sha2[384]`/`Sha2[512]`: they are the same functions,
+// and the table has one entry apiece.
+object Multicodec:
+  given sha1: Sha1 is Multicodec = Multicodec(0x11, t"sha1")
+  given sha2_256: Sha2[256] is Multicodec = Multicodec(0x12, t"sha2-256")
+  given sha2_512: Sha2[512] is Multicodec = Multicodec(0x13, t"sha2-512")
+  given sha2_384: Sha2[384] is Multicodec = Multicodec(0x20, t"sha2-384")
+  given sha2_224: Sha2[224] is Multicodec = Multicodec(0x1013, t"sha2-224")
+  given sha384: Sha384 is Multicodec = Multicodec(0x20, t"sha2-384")
+  given sha512: Sha512 is Multicodec = Multicodec(0x13, t"sha2-512")
+
+  // Draft entries in the table, but unambiguous and widely implemented.
+  given blake3: Blake3 is Multicodec = Multicodec(0x1e, t"blake3")
+  given md5: Md5 is Multicodec = Multicodec(0xd5, t"md5")
+
+  // The registered names of every code above, so a decoded envelope can be described even
+  // though its algorithm is not recoverable as a type. Codes outside this set are legal and
+  // representable; they simply have no name here.
+  private val names: Map[Int, Text] =
+    Map(0x11 -> t"sha1", 0x12 -> t"sha2-256", 0x13 -> t"sha2-512", 0x20 -> t"sha2-384",
+        0x1013 -> t"sha2-224", 0x1e -> t"blake3", 0xd5 -> t"md5", 0x00 -> t"identity")
+
+  def name(code: Int): Optional[Text] = names.stdlib.get(code).getOrElse(Unset)
+
+  def apply[algorithm <: Algorithm](code0: Int, name0: Text): algorithm is Multicodec =
+    new Multicodec:
+      type Self = algorithm
+      val code: Int = code0
+      val name: Text = name0
+
+trait Multicodec extends Typeclass:
+  def code: Int
+  def name: Text

--- a/lib/gastronomy/src/multihash/gastronomy.Multihash.scala
+++ b/lib/gastronomy/src/multihash/gastronomy.Multihash.scala
@@ -1,0 +1,123 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package gastronomy
+
+import anticipation.*
+import contingency.*
+import corpuscular.*
+import fulminate.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+// A self-describing digest envelope: `<varint code><varint length><digest bytes>`, per
+// https://github.com/multiformats/multihash. The point is that a digest can cross a boundary
+// without the parties agreeing on the algorithm out of band, which is what content-addressing
+// systems (IPFS, IPLD, libp2p) and `did:key` rely on.
+//
+// The code is held as a plain `Int`, not as a gastronomy `Algorithm`: a received envelope may
+// name a function this library cannot compute, and such a value must be *representable* rather
+// than an error, since a consumer may only need to compare or forward it. Producing one, by
+// contrast, goes through `Multicodec`, so only an algorithm with a registered code can be
+// enveloped.
+object Multihash:
+  // The unsigned-varint of the multiformats specification: LEB128, low-order group first, the
+  // high bit of each byte marking continuation. The spec caps a value at 63 bits — nine groups —
+  // so a longer run is malformed rather than merely large.
+  private val varintLimit: Int = 9
+
+  private[gastronomy] def varint(value: Long): scala.List[Byte] =
+    def recur(rest: Long, acc: scala.List[Byte]): scala.List[Byte] =
+      if rest < 0x80 then (acc :+ rest.toByte)
+      else recur(rest >>> 7, acc :+ ((rest & 0x7f) | 0x80).toByte)
+
+    recur(value, scala.Nil)
+
+  // Reads one varint at `offset`, returning it with the offset just past it.
+  private[gastronomy] def readVarint(data: Data, offset: Int): (Long, Int) raises Multihash.Error =
+    def recur(index: Int, shift: Int, acc: Long, groups: Int): (Long, Int) =
+      if index >= data.length then abort(Multihash.Error(Multihash.Reason.Truncated))
+      else if groups >= varintLimit then abort(Multihash.Error(Multihash.Reason.Oversize))
+      else
+        val byte = data.readable(index)
+        val value = acc | ((byte & 0x7f).toLong << shift)
+        if (byte & 0x80) == 0 then (value, index + 1) else recur(index + 1, shift + 7, value, groups + 1)
+
+    recur(offset, 0, 0L, 0)
+
+  def apply[algorithm <: Algorithm](digest: Digest in algorithm)
+     (using codec: algorithm is Multicodec)
+  :   Multihash =
+    Multihash(codec.code, digest.data)
+
+  // Reads an envelope. The declared length must match the bytes that follow exactly: a short
+  // count would silently truncate the digest and a long one would run past the end, and either
+  // would compare equal to nothing while looking well-formed.
+  def parse(data: Data): Multihash raises Multihash.Error =
+    val (code, afterCode) = readVarint(data, 0)
+    val (length, afterLength) = readVarint(data, afterCode)
+    val available = data.length - afterLength
+
+    if length > available then abort(Multihash.Error(Multihash.Reason.Truncated))
+    if length < available then abort(Multihash.Error(Multihash.Reason.Trailing))
+
+    Multihash(code.toInt, Array.frozen(data.readable.slice(afterLength, afterLength + length.toInt)))
+
+  enum Reason:
+    case Truncated, Trailing, Oversize
+
+  given Reason is Communicable =
+    case Reason.Truncated => m"the data end before the declared digest length"
+    case Reason.Trailing  => m"bytes remain after the declared digest length"
+    case Reason.Oversize  => m"the varint exceeds the nine groups the specification permits"
+
+  case class Error(reason: Reason)(using Diagnostics)
+  extends fulminate.Error(41, reason.ordinal)(m"the multihash could not be read because $reason")
+
+case class Multihash(code: Int, digest: Data):
+  // The registered name of the hash function, when it is one this library knows. A decoded
+  // envelope naming anything else keeps its code and its bytes, and simply has no name.
+  def algorithm: Optional[Text] = Multicodec.name(code)
+
+  def serialize: Data =
+    val prefix = Multihash.varint(code.toLong) ++ Multihash.varint(digest.length.toLong)
+    Array.unsafeFrozen((prefix ++ digest.readable.toSeq).toArray)
+
+  override def equals(that: Any): Boolean = (that: Any @unchecked) match
+    case multihash: Multihash =>
+      code == multihash.code && digest.readable.sameElements(multihash.digest.readable)
+
+    case _ => false
+
+  override def hashCode: Int = code*31 + digest.readable.toSeq.hashCode

--- a/lib/gastronomy/src/multihash/soundness_gastronomy_multihash.scala
+++ b/lib/gastronomy/src/multihash/soundness_gastronomy_multihash.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export gastronomy.{Multicodec, Multihash}

--- a/lib/gastronomy/src/test/gastronomy_test.scala
+++ b/lib/gastronomy/src/test/gastronomy_test.scala
@@ -332,6 +332,88 @@ object Tests extends Suite(m"Gastronomy tests"):
           t"123456789".digest[Sha2[256]]
       . assert(_ == Nil)
 
+    // The multihash envelope (#568), checked against the specification's own published test
+    // vectors (multiformats/multihash `tests/values/test_cases.csv`): the input bytes are hashed,
+    // enveloped, and the result compared to the multihash the vector gives.
+    suite(m"Multihash"):
+      import providers.javaStdlibProvider
+      import strategies.throwUnsafely
+      import errorDiagnostics.stackTracesDiagnostics
+
+      def hex(text: Text): Data =
+        Array.unsafeFrozen:
+          text.s.grouped(2).map(java.lang.Integer.parseInt(_, 16).toByte).toArray
+
+      def rendered(multihash: Multihash): Text =
+        multihash.serialize.readable.map(byte => String.format("%02x", Int.box(byte & 255))).mkString.tt
+
+      // The vectors' `input` column is the ASCII *string* of those hex characters — the
+      // generator pipes lines of text into the `multihash` tool — not bytes to be decoded.
+      // Hashing the decoded bytes instead yields a digest that matches no vector.
+      val input = t"431fb5d4c9b735ba1a34d0df045118806ae2336f2c"
+      val input2 = t"2d6db2d7882fa8b7d56e74b8e24036deb475de8c94"
+
+      test(m"SHA-1 envelope matches the published vector"):
+        rendered(Multihash(input.digest[Sha1]))
+      . assert(_ == t"1114e861e452cfd84dca9a176258c3d06e020a0c93d8")
+
+      test(m"SHA-2-256 envelope matches the published vector"):
+        rendered(Multihash(input.digest[Sha2[256]]))
+      . assert(_ == t"1220ffb31f07aa15348368c90c73a834dbf9f8710365860fa0fd4ddce9ac2782cc17")
+
+      val sha512Vector =
+        t"1340abffa1926b038a2f1833092d93859ba2ee56e07a86b158200fc7d4d5d1eaf350b0f0e51"
+        + t"1ea6f5043a9f4a7c7886f93355652114709d75b2db4c33741124fd4fe"
+
+      test(m"SHA-2-512 envelope matches the published vector"):
+        rendered(Multihash(input.digest[Sha2[512]]))
+      . assert(_ == sha512Vector)
+
+      test(m"a second SHA-2-256 vector"):
+        rendered(Multihash(input2.digest[Sha2[256]]))
+      . assert(_ == t"12203afa34fba2f3572ac56d80f52002e8727dd95f17a2e7c9376a3147a96d3e78ac")
+
+      // Decoding recovers the code and the bytes, and round-trips.
+      test(m"parsing a published vector recovers its code"):
+        unsafely(Multihash.parse(hex(t"1114e861e452cfd84dca9a176258c3d06e020a0c93d8"))).code
+      . assert(_ == 0x11)
+
+      test(m"parsing recovers the registered algorithm name"):
+        unsafely(Multihash.parse(hex(t"1220ffb31f07aa15348368c90c73a834dbf9f8710365860fa0fd4ddce9ac2782cc17")))
+        . algorithm
+      . assert(_ == t"sha2-256")
+
+      test(m"an envelope round-trips through parse"):
+        val original = Multihash(input.digest[Sha2[256]])
+        unsafely(Multihash.parse(original.serialize)) == original
+      . assert(_ == true)
+
+      // A truncated digest is legal — the length is explicit — and the vectors include them.
+      test(m"a truncated digest is parsed at its declared length"):
+        unsafely(Multihash.parse(hex(t"110ae861e452cfd84dca9a17"))).digest.length
+      . assert(_ == 10)
+
+      // An algorithm this library cannot compute is representable, not an error: a consumer may
+      // only need to compare or forward it.
+      test(m"an unsupported algorithm decodes to its code and bytes"):
+        val decoded = unsafely(Multihash.parse(hex(t"1604aabbccdd")))
+        (decoded.code, decoded.digest.length, decoded.algorithm)
+      . assert(_ == (0x16, 4, Unset))
+
+      // Multi-byte varints: SHA-2-224 is 0x1013, which does not fit in one group.
+      test(m"a two-group varint code round-trips"):
+        val original = Multihash(0x1013, hex(t"aabbcc"))
+        unsafely(Multihash.parse(original.serialize)).code
+      . assert(_ == 0x1013)
+
+      test(m"a length shorter than the remaining bytes is rejected"):
+        capture[Multihash.Error](Multihash.parse(hex(t"1103aabbccdd"))).reason
+      . assert(_ == Multihash.Reason.Trailing)
+
+      test(m"a length longer than the remaining bytes is rejected"):
+        capture[Multihash.Error](Multihash.parse(hex(t"1108aabbccdd"))).reason
+      . assert(_ == Multihash.Reason.Truncated)
+
     suite(m"Native-rendering coverage"):
       test(m"gastronomy's types inspect natively"):
         Inspectable.fallbacks(t"Hello world".digest[Sha2[256]].inspect)


### PR DESCRIPTION
A multihash prefixes a digest with its algorithm's multicodec identifier and its length, so a digest can be exchanged without the parties agreeing on the algorithm out of band. That is what content-addressing systems (IPFS, IPLD, libp2p) and `did:key` are built on, and it is now available for any gastronomy digest.

```scala
import soundness.*
import providers.javaStdlibProvider

val envelope = Multihash(t"content".digest[Sha2[256]])
envelope.serialize                        // 0x12 0x20 followed by the 32 digest bytes

val received = Multihash.parse(bytes)     // raises Multihash.Error
received.algorithm                        // t"sha2-256", or Unset if unrecognised
```

The algorithm-code mapping is a typeclass, so it is partial by construction: an algorithm with no registered multicodec code has no instance, and enveloping its digest does not compile. That is the right answer for Adler-32, which is absent from the multicodec table entirely. CRC-32 and CRC-64 do have codes, but are registered with the tag `hash` rather than `multihash` — the specification reserves that tag for non-cryptographic functions, on the grounds that they "are not suitable for content addressing systems" — so neither gets an instance either. A caller who genuinely wants that envelope can construct `Multihash` from the code directly.

Decoding keeps the code as a plain `Int` rather than resolving it to an `Algorithm`. A received envelope may name a function this library cannot compute, and such a value has to be representable rather than an error, since a consumer may only need to compare or forward it. A truncated digest is likewise legal, the length being explicit; a declared length that disagrees with the bytes present is not, in either direction.

Codes are transcribed from the multicodec table rather than from memory, and the tests check the specification's own published vectors, along with round-tripping, truncation, an unrecognised algorithm, a two-group varint and both length-mismatch failures.

This is the binary form only. The text form requires multibase, whose usual encoding is Base58, which monotonous does not yet provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
