### PR TITLE
Make adversaria's field accessors panopticon lenses (#490)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1115,7 +1115,10 @@ object acyclicity extends Library:
       settings.sep(super.scalacOptions())
 
 object adversaria extends Library:
-  object core extends Component(rudiments.core):
+  // `panopticon.core` so the generated field accessors are `Lens`es — read/write and composable —
+  // rather than bare getters (#490). Both libraries previously depended on `rudiments.core` alone,
+  // so the edge adds one module and no cycle.
+  object core extends Component(rudiments.core, panopticon.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object examples extends Internal(core):

--- a/lib/adversaria/src/core/adversaria.Annotated.scala
+++ b/lib/adversaria/src/core/adversaria.Annotated.scala
@@ -36,6 +36,7 @@ import scala.quoted.*
 
 import anticipation.*
 import denominative.*
+import panopticon.*
 import rudiments.*
 import vacuous.*
 import prepositional.*
@@ -63,6 +64,13 @@ object Annotated:
 
   trait Field extends Fields, Targetable, Topical:
     def field: Text
+
+    // The lens onto the annotated field, which is usually what a caller wants once it has found
+    // it (#490). `Target` is the field's name as a `Label`, and panopticon's `deref` resolves that
+    // against `Self` — so the lens is summoned at the use site, where `Self` is known to be a
+    // product, rather than built here where it is not.
+    transparent inline def lens(using lens: Target is Lens from Self): Target is Lens from Self =
+      lens
 
   class AnnotatedField[operand <: StaticAnnotation, self, plane, limit, topic, target <: Label]
     ( annotations0: Set[operand], fields0: Map[Text, Set[operand]] )

--- a/lib/adversaria/src/core/adversaria.Dereferenceable.scala
+++ b/lib/adversaria/src/core/adversaria.Dereferenceable.scala
@@ -32,7 +32,9 @@
                                                                                                   */
 package adversaria
 
+import panopticon.*
 import rudiments.*
+import vacuous.*
 
 import scala.quoted.*
 
@@ -47,6 +49,17 @@ trait Dereferenceable extends Typeclass, Resultant:
   def names(entity: Self): List[Text]
   def select(entity: Self, name: Text): Result
   def values(entity: Self): List[Result] = members(entity).values
+
+  // A panopticon `Lens` onto the named field, which is `select` plus the write half the read-only
+  // accessors structurally lack — and, being an optic, composable with any other. `Unset` where
+  // the name is not a field, or names one which cannot be written (see the macro).
+  def lens(name: Text): Optional[Lens from Self onto Result] = Unset
+
+  def update(entity: Self, name: Text, value: Result): Optional[Self] =
+    lens(name).let(_.update(entity, value))
+
+  def modify(entity: Self, name: Text)(lambda: Result => Result): Optional[Self] =
+    lens(name).let(_.modify(entity)(lambda))
 
   def members(entity: Self): Map[Text, Result] =
     (names(entity).stdlib.map { member => member -> select(entity, member) }.toMap).to(Map)

--- a/lib/adversaria/src/core/adversaria.internal.scala
+++ b/lib/adversaria/src/core/adversaria.internal.scala
@@ -42,6 +42,7 @@ import anticipation.*
 import denominative.*
 import fulminate.*
 import gigantism.*
+import panopticon.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -169,12 +170,55 @@ object internal:
           val name = '{${Literal(StringConstant(field.name)).asExprOf[String]}.tt}
           '{($name, (value: entity) => ${'value.asTerm.select(field).asExprOf[value]})}
 
+    // A lens for each discovered field which is also a parameter of the primary constructor, so
+    // that it can be written as well as read: the setter rebuilds the entity from its own fields
+    // with one replaced. A field which is not a constructor parameter — a `val` computed in the
+    // body — remains readable through `select` but has no lens, since there is nothing to write.
+    // The lens's `Self` is the field-name singleton, matching panopticon's own `deref`.
+    def lensMap: Expr[List[(Text, Lens from entity onto value)]] =
+      val symbol = TypeRepr.of[entity].typeSymbol
+      val parameters = symbol.primaryConstructor.paramSymss.flatten.filter(!_.isTypeParam)
+      val names = parameters.map(_.name).toSet
+
+      Expr.ofList:
+        symbol.fieldMembers
+        . filter(_.info <:< TypeRepr.of[value])
+        . filter { field => names.contains(field.name) }
+        . map: field =>
+            val name = '{${Literal(StringConstant(field.name)).asExprOf[String]}.tt}
+
+            val get: Expr[entity => value] =
+              '{ (entity: entity) => ${'entity.asTerm.select(field).asExprOf[value]} }
+
+            val set: Expr[(entity, value) => entity] =
+              '{ (entity: entity, replacement: value) =>
+                   ${
+                       val arguments = parameters.map: parameter =>
+                         if parameter.name == field.name then 'replacement.asTerm
+                         else 'entity.asTerm.select(symbol.fieldMember(parameter.name))
+
+                       Select(New(TypeTree.of[entity]), symbol.primaryConstructor)
+                       . appliedToArgs(arguments)
+                       . asExprOf[entity]
+                   } }
+
+            ConstantType(StringConstant(field.name)).asType.absolve match
+              case '[type label; label] =>
+                '{($name, Lens[label, entity, value]($get, $set))}
+
     ' {
         new Dereferenceable:
           type Self = entity
           type Result = value
           private val lambdas: scala.collection.immutable.Map[Text, Self => Result] =
             ${lambdaMap}.toMap
+
+          private val lenses
+          :   scala.collection.immutable.Map[Text, Lens from entity onto value] =
+            ${lensMap}.toMap
+
           def names(entity: Self): proscenium.List[Text] = (${namesList}).to(proscenium.List)
           def select(entity: entity, name: Text): Result = lambdas(name)(entity)
+          override def lens(name: Text): Optional[Lens from Self onto Result] =
+            lenses.get(name).getOrElse(Unset)
       }

--- a/lib/adversaria/src/test/adversaria_test.scala
+++ b/lib/adversaria/src/test/adversaria_test.scala
@@ -122,3 +122,59 @@ object Tests extends Suite(m"Adversaria tests"):
     test(m"Get all members of a particular type"):
       Example1.membersOfType[Int].to[Set]
     . assert(_ == Set(12, 42))
+
+    // The discovered accessors are panopticon `Lens`es (#490), so they write as well as read.
+    suite(m"Field accessors as lenses"):
+      val dereferenceable = summon[Letters is Dereferenceable to Int]
+      val letters = Letters(1, 2, 3, 4)
+
+      test(m"a lens reads the field it names"):
+        dereferenceable.lens(t"beta").let(_(letters))
+      . assert(_ == 2)
+
+      test(m"a lens writes the field it names, leaving the others"):
+        dereferenceable.lens(t"beta").let(_.update(letters, 20))
+      . assert(_ == Letters(1, 20, 3, 4))
+
+      test(m"a lens modifies in place"):
+        dereferenceable.lens(t"delta").let(_.modify(letters)(_*10))
+      . assert(_ == Letters(1, 2, 3, 40))
+
+      test(m"update through the typeclass"):
+        dereferenceable.update(letters, t"alpha", 100)
+      . assert(_ == Letters(100, 2, 3, 4))
+
+      test(m"modify through the typeclass"):
+        dereferenceable.modify(letters, t"gamma")(_ + 7)
+      . assert(_ == Letters(1, 2, 10, 4))
+
+      test(m"a name which is not a field has no lens"):
+        dereferenceable.lens(t"epsilon")
+      . assert(_ == Unset)
+
+      // Reading is unchanged: every discovered field still reports, whether or not it is
+      // writable, so nothing that depended on the read-only accessors changes.
+      test(m"reading still covers every discovered field"):
+        dereferenceable.members(letters)
+      . assert(_ == Map(t"alpha" -> 1, t"beta" -> 2, t"gamma" -> 3, t"delta" -> 4))
+
+      // An object's `val`s are not constructor parameters, so there is nothing to write: they
+      // remain readable, and simply have no lens.
+      test(m"a field which is not a constructor parameter is readable"):
+        summon[Example1.type is Dereferenceable to Int].select(Example1, t"foo")
+      . assert(_ == 42)
+
+      test(m"a field which is not a constructor parameter has no lens"):
+        summon[Example1.type is Dereferenceable to Int].lens(t"foo")
+      . assert(_ == Unset)
+
+      // Finding an annotated field and then writing through it, which is what the name alone
+      // could not do.
+      test(m"an annotated field yields a lens onto itself"):
+        val annotated = summon[Person is Annotated by ident]
+        annotated.lens.update(Person(t"Jack", t"jack@example.com"), t"jill@example.com")
+      . assert(_ == Person(t"Jack", t"jill@example.com"))
+
+      test(m"an annotated field's lens reads it"):
+        summon[Person is Annotated by ident].lens(Person(t"Jack", t"jack@example.com"))
+      . assert(_ == t"jack@example.com")

--- a/lib/facsimile/src/test/facsimile_test.scala
+++ b/lib/facsimile/src/test/facsimile_test.scala
@@ -37,6 +37,13 @@ import scala.collection.immutable.Seq
 
 import soundness.*
 
+// Adversaria's accessors are panopticon lenses (#490), which puts `panopticon.Filter` on this
+// classpath. This suite is `package facsimile`, but a package member declared in another file
+// loses to a wildcard import, so `import soundness.*` would otherwise supply panopticon's
+// `Filter` here in place of facsimile's own (which is `private[facsimile]`, so no umbrella
+// collision exists — only this shadowing). Naming it explicitly outranks the wildcard.
+import facsimile.Filter
+
 import charEncoders.utf8Encoder
 import errorDiagnostics.stackTracesDiagnostics
 import strategies.throwUnsafely


### PR DESCRIPTION
Adversaria discovered fields and generated read-only getters, so `Dereferenceable` could read a field by name but never write one. Its accessors are now panopticon `Lens` values, which gives them the write half they structurally lacked, and makes them composable with any other optic.

```scala
val fields = summon[Letters is Dereferenceable to Int]

fields.select(letters, t"beta")            // 2, exactly as before
fields.update(letters, t"beta", 20)        // Letters(1, 20, 3, 4)
fields.modify(letters, t"delta")(_*10)     // Letters(1, 2, 3, 40)
fields.lens(t"beta")                       // the lens itself, to compose or keep
```

Finding an annotated field and writing through it is now one step. `Annotated.Field` gains a lens, and needs no macro of its own to do it: the field's name is already carried as a `Label` in `Target`, so panopticon's `deref` resolves it against `Self` at the use site, where `Self` is known to be a product.

```scala
val annotated = summon[Person is Annotated by ident]
annotated.lens.update(person, t"jill@example.com")
```

The change is deliberately additive. `names`, `select`, `members` and `values` keep their behaviour and their coverage, so nothing that used the read-only accessors changes — `Dereferenceable` has one consumer outside adversaria, gnossienne, and it uses only `select`. Lenses cover the fields which are primary-constructor parameters; a `val` computed in a class or object body has nothing to write, so it remains readable through `select` and simply has no lens, which the tests pin.

Adversaria now depends on `panopticon.core`, which costs one module and introduces no cycle: both libraries previously depended on `rudiments.core` alone. Adversaria is no longer a leaf on rudiments, which is worth knowing given how many components depend on it. The generated lenses are pure, so they carry no capture annotations under `settings.sep`.

One consequence of the edge is worth knowing. Panopticon exports `Coercible`, `Composable`, `compose`, `Each`, `Filter`, `Lens`, `lens`, `Optic` and `Optical` into the `soundness` umbrella, and those names are now on the classpath of everything that transitively reaches adversaria. Facsimile's own `Filter` — `private[facsimile]`, so not an umbrella collision — was shadowed in facsimile's own suite as a result: the file is `package facsimile`, but a package member declared in another file loses to a wildcard import, so `import soundness.*` supplied panopticon's instead. It is named explicitly there now. `mill test.assembly` compiles every test module and finds no other shadowing among those nine names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
