### PR TITLE
Capture compiler warnings in larceny, tagged by importance

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2426,8 +2426,7 @@ object larceny extends Library:
     override def scalaJs = false // compiler plugin: uses the JVM-only dotty compiler API
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
 
-  object test extends Tests:
-    override def finalMainClass: Task.Simple[String] = "run"
+  object test extends Tests
 
 object legerdemain extends Library:
   // The `Query` type and its `Parametric` typeclass: the form-encoded half of the library, with

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -201,6 +201,7 @@ object Tests extends Suite(m"Aviation Tests"):
         demilitarize:
           import calendars.julianCalendar
           (1900-Feb-29).jdn
+        . filter(_.error)
       . assert(_.isEmpty)
 
       test(m"A contextual Julian calendar yields the Julian Julian-day for the literal"):

--- a/lib/frontier/src/test/frontier_test.scala
+++ b/lib/frontier/src/test/frontier_test.scala
@@ -177,7 +177,7 @@ object Tests extends Suite(m"Frontier Tests"):
         import frontier.context.explainMissingContext
         trait Absent
         summon[scala.util.NotGiven[Absent]]
-      . map(_.message)
+      . filter(_.error).map(_.message)
     . assert(_ == Nil)
 
     test(m"explainMissingContext does not defeat default using arguments"):
@@ -186,7 +186,7 @@ object Tests extends Suite(m"Frontier Tests"):
         class Cfg
         def withDefault(using cfg: Cfg = new Cfg): Cfg = cfg
         withDefault
-      . map(_.message)
+      . filter(_.error).map(_.message)
     . assert(_ == Nil)
 
     test(m"explainMissingContext does not defeat summonFrom fallback"):
@@ -198,7 +198,7 @@ object Tests extends Suite(m"Frontier Tests"):
             case _: Absent => 1
             case _         => 2
         val n: Int = choose
-      . map(_.message)
+      . filter(_.error).map(_.message)
     . assert(_ == Nil)
 
     // `read` now resolves an ordinary `Readable` instance, so a missing

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -1361,7 +1361,7 @@ object Tests extends Suite(m"Gossamer Tests"):
       test(m"Text is not sortable without a collation in scope"):
         demilitarize:
           List(t"b", t"a").sorted
-        . map(_.reason)
+        . filter(_.error).map(_.reason)
       . assert(_ == List(CompileError.Reason.MissingImplicitArgument))
 
       test(m"dictionary order ranks accents before case: cafe < café < caff"):

--- a/lib/larceny/src/plugin/larceny.CompileError.scala
+++ b/lib/larceny/src/plugin/larceny.CompileError.scala
@@ -37,12 +37,36 @@ object CompileError:
   // raising `apply` would make `doReport` silently drop the diagnostic, and every
   // `demilitarize` test expecting it would quietly stop testing anything); map
   // unknown ordinals to `NoExplanation` so the message still comes through.
-  def apply(ordinal: Int, message: String, focus: String, start: Int, offset: Int): CompileError =
+  def apply
+    ( ordinal: Int,
+      message: String,
+      focus:   String,
+      start:   Int,
+      offset:  Int,
+      // No default: the case class's own synthesized `apply` already carries one for
+      // `importance`, and Scala permits default arguments on only one overload of `apply`.
+      level:   Int )
+  :   CompileError =
+
     val reason =
       if ordinal < CompileError.Reason.values.length then CompileError.Reason.fromOrdinal(ordinal)
       else CompileError.Reason.NoExplanation
 
-    new CompileError(reason, message, focus, start, offset)
+    new CompileError(reason, message, focus, start, offset, Importance(level))
+
+  // Severity, named as `anthology.Importance` and `harlequin`'s are. Larceny's plugin component
+  // has no Soundness dependencies at all (`object plugin extends Component()`), so the enum is
+  // restated here rather than imported; the case names are kept identical deliberately.
+  object Importance:
+    // dotc's diagnostic levels are `interfaces.Diagnostic`'s INFO(0), WARNING(1), ERROR(2). A
+    // level outside that range would come from a compiler newer than this enum, and must not
+    // raise for the same reason an unknown `Reason` ordinal must not: it would make `doReport`
+    // drop the diagnostic silently. Treat anything unrecognised as an error, the safe default.
+    def apply(level: Int): Importance =
+      if level >= 0 && level < values.length then fromOrdinal(level) else Error
+
+  enum Importance:
+    case Info, Warning, Error
 
   enum Reason:
     case NoExplanation
@@ -284,6 +308,14 @@ object CompileError:
     def unapply(compileError: CompileError): Some[CompileError.Reason] = Some(compileError.reason)
 
 case class CompileError
-  ( reason: CompileError.Reason, message: String, focus: String, start: Int, offset: Int ):
+  ( reason:     CompileError.Reason,
+    message:    String,
+    focus:      String,
+    start:      Int,
+    offset:     Int,
+    importance: CompileError.Importance = CompileError.Importance.Error ):
 
   def point: Int = start + offset
+
+  def warning: Boolean = importance == CompileError.Importance.Warning
+  def error: Boolean = importance == CompileError.Importance.Error

--- a/lib/larceny/src/plugin/larceny.LarcenyTransformer.scala
+++ b/lib/larceny/src/plugin/larceny.LarcenyTransformer.scala
@@ -130,6 +130,44 @@ class LarcenyTransformer() extends PluginPhase:
     val yimports = ctx.settings.Yimports.value
     val noPredef = ctx.settings.YnoPredef.value
 
+    // Warnings used to be invisible to `demilitarize` in all but one case. The sub-compilation
+    // starts from `initCtx.fresh` -- a compiler-default context, not the parent's -- so none of
+    // the parent's warning flags applied, and every flag-gated warning (deprecation and unused
+    // above all) simply never fired, while default-on warnings leaked in unmarked. Propagate the
+    // flags that decide *which* warnings exist.
+    //
+    // `-Wconf` is the load-bearing one: without the parent's `:s` rules the sub-compilation would
+    // report warnings the outer build deliberately silences, so `demilitarize` blocks would start
+    // capturing diagnostics that the surrounding file is configured never to see.
+    //
+    // `-Werror`/`-Xfatal-warnings` is deliberately NOT propagated: promoting warnings to errors
+    // would stop compilation at the first one and defeat the point of capturing them as warnings.
+    //
+    // `Wunused` is `private[config]`, so it is read back through the `WunusedHas` predicates and
+    // restated as an explicit choice list. That is equivalent in effect, though not always
+    // textually identical to what the parent was given (`-Wunused:all` comes back expanded).
+    val unusedChoices: List[(String, Boolean)] =
+      List
+        ( "imports"   -> ctx.settings.WunusedHas.imports,
+          "privates"  -> ctx.settings.WunusedHas.privates,
+          "locals"    -> ctx.settings.WunusedHas.locals,
+          "explicits" -> ctx.settings.WunusedHas.explicits,
+          "implicits" -> ctx.settings.WunusedHas.implicits,
+          "params"    -> ctx.settings.WunusedHas.params,
+          "patvars"   -> ctx.settings.WunusedHas.patvars,
+          "linted"    -> ctx.settings.WunusedHas.linted )
+
+    val unused: List[String] = unusedChoices.collect:
+      case (choice, true) => choice
+
+    val warnings: List[String] =
+      (if ctx.settings.deprecation.value then List("-deprecation") else Nil) ++
+        (if ctx.settings.feature.value then List("-feature") else Nil) ++
+        (if ctx.settings.unchecked.value then List("-unchecked") else Nil) ++
+        (if ctx.settings.Wall.value then List("-Wall") else Nil) ++
+        (if unused.isEmpty then Nil else List("-Wunused:"+unused.mkString(","))) ++
+        ctx.settings.Wconf.value.map("-Wconf:"+_)
+
     object collector extends UntypedTreeMap:
       val regions: scm.ListBuffer[(Int, Int)] = scm.ListBuffer()
 
@@ -155,7 +193,8 @@ class LarcenyTransformer() extends PluginPhase:
       ctx.settings.plugin.value.filterNot(LarcenyTransformer.isLarceny)
 
     val errors: List[CompileError] =
-      Subcompiler.compile(language, classpath, source, regions, plugins, ccNew, yimports, noPredef)
+      Subcompiler.compile
+        ( language, classpath, source, regions, plugins, ccNew, yimports, noPredef, warnings )
 
     object transformer extends UntypedTreeMap:
       override def transform(tree: Tree)(using Context): Tree = tree match
@@ -186,7 +225,8 @@ class LarcenyTransformer() extends PluginPhase:
                     Literal(Constant(error.message)),
                     Literal(Constant(error.focus)),
                     Literal(Constant(error.start)),
-                    Literal(Constant(error.offset)) ) )
+                    Literal(Constant(error.offset)),
+                    Literal(Constant(error.importance.ordinal)) ) )
 
           Apply
             ( Ident(name),

--- a/lib/larceny/src/plugin/larceny.Subcompiler.scala
+++ b/lib/larceny/src/plugin/larceny.Subcompiler.scala
@@ -107,7 +107,9 @@ object Subcompiler:
         val offset = position.point - position.start
         val ordinal = diagnostic.msg.errorId.ordinal
 
-        errors += CompileError(ordinal, diagnostic.msg.message, focus, position.start, offset)
+        errors +=
+          CompileError
+            ( ordinal, diagnostic.msg.message, focus, position.start, offset, diagnostic.level )
 
       catch case error: Throwable => ()
 
@@ -145,7 +147,8 @@ object Subcompiler:
       plugins:   List[String],
       ccNew:     Boolean = false,
       yimports:  List[String] = Nil,
-      noPredef:  Boolean = false )
+      noPredef:  Boolean = false,
+      warnings:  List[String] = Nil )
   :   List[CompileError] =
 
     object driver extends Driver:
@@ -153,10 +156,16 @@ object Subcompiler:
         val context = initCtx.fresh
         val context2 = context.setSetting(context.settings.classpath, classpath)
         val ccOptions = if ccNew then List("-Ycc-new") else Nil
+
         val importOptions =
-          (if yimports.isEmpty then Nil else List(s"-Yimports:${yimports.mkString(",")}"))
-          ++ (if noPredef then List("-Yno-predef") else Nil)
-        val args = scala.Array[String]("") ++ ccOptions ++ importOptions ++ plugins.map: p => s"-Xplugin:$p"
+          (if yimports.isEmpty then Nil else List(s"-Yimports:${yimports.mkString(",")}")) ++
+            (if noPredef then List("-Yno-predef") else Nil)
+
+        val pluginOptions = plugins.map: plugin => s"-Xplugin:$plugin"
+
+        val args =
+          scala.Array[String]("") ++ ccOptions ++ importOptions ++ warnings ++ pluginOptions
+
         setup(args, context2).map(_(1)).get
 
 
@@ -212,7 +221,12 @@ object Subcompiler:
 
                       recompile(tail, done + region, newSource)
 
-          recompile(newErrors, Set(), source)
+          // Only *errors* get their region blanked. Blanking exists so that an error in one
+          // `demilitarize` block cannot stop the remaining blocks' diagnostics from being found:
+          // the region is replaced with `{}` and the file recompiled. A warning does not stop
+          // compilation, so blanking its region buys nothing and actively loses whatever else
+          // that region would have reported on the next pass.
+          recompile(newErrors.filter(_.error), Set(), source)
 
 
     driver.run(source, regions, Nil)

--- a/lib/larceny/src/test/larceny_test.scala
+++ b/lib/larceny/src/test/larceny_test.scala
@@ -34,5 +34,66 @@ package larceny
 
 import soundness.*
 
+@deprecated("superseded by `current`", "0.1.0")
+def obsolete(): Int = 42
+
 object Tests extends Suite(m"Larceny Tests"):
-  def run(): Unit = ()
+  def run(): Unit =
+    suite(m"Error capture"):
+      test(m"a type error is captured as an error"):
+        demilitarize:
+          val int: Int = "not an int"
+        . map(_.importance)
+      . assert(_ == List(CompileError.Importance.Error))
+
+      test(m"correct code captures nothing"):
+        demilitarize:
+          val int: Int = 42
+      . assert(_ == Nil)
+
+    suite(m"Warning capture"):
+      test(m"a deprecation warning is captured"):
+        demilitarize:
+          obsolete()
+        . map(_.importance)
+      . assert(_ == List(CompileError.Importance.Warning))
+
+      test(m"a deprecation warning names the deprecated method"):
+        demilitarize:
+          obsolete()
+        . map(_.message)
+      . assert(_.exists(_.contains("obsolete")))
+
+      test(m"an unreachable case is captured as a warning"):
+        demilitarize:
+          (1: Int) match
+            case _     => 0
+            case other => other
+        . map(_.importance)
+      . assert(_ == List(CompileError.Importance.Warning))
+
+      test(m"a warning does not stop the code from compiling"):
+        demilitarize:
+          obsolete()
+        . map(_.warning)
+      . assert(_ == List(true))
+
+    suite(m"Errors and warnings are distinguishable"):
+      test(m"warnings can be filtered out, leaving the errors"):
+        demilitarize:
+          obsolete()
+          val int: Int = "not an int"
+        . filter(_.error).map(_.reason)
+      . assert(_ == List(CompileError.Reason.TypeMismatch))
+
+      // A block that fails to type reports no late-phase warning. dotc stops its phase pipeline
+      // once a unit has errors, and deprecation is checked after typer, so the warning never
+      // fires -- blanking the region cannot recover it either, since the error and the warning
+      // share a region. The limitation is per-block, not per-file: the deprecation tests above
+      // capture their warning from a file in which these blocks are failing to compile.
+      test(m"an error in a block suppresses that block's late-phase warnings"):
+        demilitarize:
+          obsolete()
+          val int: Int = "not an int"
+        . map(_.importance)
+      . assert(_ == List(CompileError.Importance.Error))


### PR DESCRIPTION
Larceny's `demilitarize` now captures compiler warnings as well as errors, and tags every captured diagnostic with an `Importance` so the two can be told apart. Previously a warning was either invisible — the sub-compilation ran with none of the parent's warning flags, so deprecation and unused warnings never fired at all — or, for the warnings dotc emits by default, indistinguishable from a genuine error. This closes #615.

## Capturing warnings

`CompileError` now carries an `importance`, one of `Info`, `Warning` or `Error`, taken from the compiler's own diagnostic level:

```scala
demilitarize:
  obsolete()
. map(_.importance)
// List(CompileError.Importance.Warning)
```

Two predicates come with it, `error` and `warning`, for the common case of partitioning a capture:

```scala
val captured = demilitarize:
  val n: Int = "not an int"

captured.filter(_.error)    // the things that stopped it compiling
captured.filter(_.warning)  // the things that merely complained
```

The parent compilation's `-deprecation`, `-feature`, `-unchecked`, `-Wall`, `-Wunused` and `-Wconf` settings are now propagated into the sub-compilation, so a `demilitarize` block sees the same warnings the surrounding module would. `-Wconf` matters as much as the rest: without it, sub-compilations would report warnings that the enclosing build deliberately silences.

`-Werror` (`-Xfatal-warnings`) is deliberately *not* propagated, since promoting warnings to errors would stop compilation at the first one and defeat the purpose of capturing them.

## Migration

A block that asserts a snippet compiles should now say so in terms of errors rather than requiring the capture to be empty, because a snippet that compiles may still warn:

```scala
// before
demilitarize:
  import calendars.julianCalendar
  (1900-Feb-29).jdn
. assert(_.isEmpty)

// after
demilitarize:
  import calendars.julianCalendar
  (1900-Feb-29).jdn
. filter(_.error)
. assert(_.isEmpty)
```

This is most likely to bite where a block opens with a given or marker import: dotty's usage tracking does not see such an import as used, so `-Wunused:imports` reports it. Four tests in this repository needed the change.

## Known limitation

A block that fails to type reports no late-phase warning. The compiler stops its phase pipeline once a unit has errors, and deprecation is checked after typer, so the warning never fires — and blanking the failing region cannot recover it, since the error and the warning share that region. The limitation is per-block rather than per-file: a block with no errors still reports its warnings normally, even when other blocks in the same file fail to compile.
