### PR TITLE
Report btrfs subvolumes on the storage-filesystem axis (#567)

### DIFF
--- a/lib/galilei/src/core/galilei.Btrfs.scala
+++ b/lib/galilei/src/core/galilei.Btrfs.scala
@@ -78,6 +78,17 @@ object Btrfs:
     if storageFormat(path) == t"btrfs" then Some(path.asInstanceOf[Path on plane over Btrfs])
     else None
 
+  // A btrfs subvolume, named by the directory it is rooted at (issue #567). Btrfs partitions
+  // one filesystem into independently-snapshottable subtrees, so an entry's subvolume — not
+  // just its volume — is part of where it is stored, and `Subvolume` is the type in which that
+  // is answered.
+  //
+  // The subvolume's numeric ID, UUID and generation are not carried here: btrfs exposes those
+  // only through `BTRFS_IOC_GET_SUBVOL_INFO`, an `ioctl` no filesystem backend can currently
+  // issue, whereas the root — all `subvolume()` promises — is recoverable from `stat` alone.
+  // They are the natural fields to add once an `ioctl` seam exists.
+  case class Subvolume[plane](root: Path on plane over Btrfs)
+
 object Ext4:
   def unapply[plane](path: Path on plane)(using FilesystemBackend on plane)
   :   Option[Path on plane over Ext4] =

--- a/lib/galilei/src/core/galilei.FilesystemBackend.scala
+++ b/lib/galilei/src/core/galilei.FilesystemBackend.scala
@@ -115,6 +115,13 @@ trait FilesystemBackend extends Planar:
   def attribute(path: Path on Plane, name: Text)(using Tactic[Io.Error]): Optional[Data]
   def attribute(path: Path on Plane, name: Text, value: Data)(using Tactic[Io.Error]): Unit
 
+  // The entry's identity on its storage device (issue #567). Total, and `Unset` where the
+  // platform does not expose it: WASI's `descriptor-stat` carries neither number, and the
+  // JVM's `unix` attribute view is absent off POSIX. It is separate from `stat` because the
+  // two platforms which cannot answer it are precisely the two for which every other `Stat`
+  // field is cheap, so folding it in would make the common call fallible for nothing.
+  def identity(path: Path on Plane, dereference: Boolean): Optional[Stat.Identity]
+
   // Range-scoped positional access (issues #566, #1878): like `expanse`, but the view is a
   // `Slice.Window` confined to `[offset, offset + extent)` — its `size` is the window's,
   // reads are relative to the window's start and clamped to it, and writes store as much as

--- a/lib/galilei/src/core/galilei.Stat.scala
+++ b/lib/galilei/src/core/galilei.Stat.scala
@@ -43,3 +43,10 @@ case class Stat
     modified: Long,
     accessed: Long,
     created:  Optional[Long] )
+
+object Stat:
+  // An entry's identity on the storage device it lives on: the device number and the inode
+  // number, which together name a file uniquely. Btrfs's subvolume boundaries are read from
+  // the device number (issue #567) — every subvolume is given its own anonymous device number
+  // — and every btrfs subvolume root is inode 256.
+  case class Identity(device: Long, inode: Long)

--- a/lib/galilei/src/core/galilei_core.scala
+++ b/lib/galilei/src/core/galilei_core.scala
@@ -222,6 +222,15 @@ extension [plane: Filesystem](path: Path on plane)
   def volume()(using backend: FilesystemBackend on plane): Volume raises Io.Error =
     backend.volume(path)
 
+  // The entry's identity on its storage device — its device number and inode number — which
+  // together name a file uniquely: two paths with equal identities are hard links to one file.
+  // `Unset`, rather than raising, where the platform does not record it: WASI's
+  // `descriptor-stat` carries neither number, and the JVM's `unix` view is absent off POSIX.
+  // Named for `entry()` rather than plainly `identity`, which would compete with
+  // `proscenium`'s function of that name wherever the `soundness` umbrella is imported.
+  def entryIdentity(using backend: FilesystemBackend on plane): Optional[Stat.Identity] =
+    backend.identity(path, true)
+
   def hardLinkTo(destination: Path on plane)
     ( using overwritePreexisting: OverwritePreexisting on plane,
             createNonexistentParents: CreateNonexistentParents on plane,
@@ -501,6 +510,33 @@ extension [plane: Filesystem, transport <: Attributed](path: Path on plane over 
   def attribute(name: Text, value: Data)(using backend: FilesystemBackend on plane)
   :   Unit raises Io.Error =
     backend.attribute(path, name, value)
+
+// Btrfs-specific metadata, gated by the storage-filesystem axis (issue #567). Btrfs gives every
+// subvolume its own anonymous device number and numbers every subvolume root's inode 256, so both
+// accessors here are answered from `stat` alone — no `ioctl` — at the cost of not being able to
+// report a subvolume's ID or UUID, which only `BTRFS_IOC_GET_SUBVOL_INFO` knows.
+extension [plane: Filesystem](path: Path on plane over Btrfs)
+
+  // The subvolume the entry is stored in, found by ascending while the device number holds:
+  // crossing out of a subvolume changes it, so the last ancestor to share the entry's device
+  // number is the subvolume's root.
+  def subvolume()(using FilesystemBackend on plane): Btrfs.Subvolume[plane] raises Io.Error =
+
+    val device =
+      path.entryIdentity.let(_.device).or:
+        abort(Io.Error(path, Operation.Metadata, Reason.Unsupported))
+
+    def ascend(current: Path on plane): Path on plane =
+      current.parent.lay(current): parent =>
+        if parent.entryIdentity.let(_.device) == device then ascend(parent) else current
+
+    Btrfs.Subvolume(ascend(path).asInstanceOf[Path on plane over Btrfs])
+
+  // Whether the entry is itself the root of a subvolume. Total rather than raising, like
+  // `exists`: an entry whose inode cannot be read is not a subvolume root as far as any
+  // operation gated on this can tell.
+  def subvolumeRoot(using FilesystemBackend on plane): Boolean =
+    path.entryIdentity.let(_.inode) == 256L
 
 // Metadata gated by the storage-filesystem axis (issue #567): available only on a path whose
 // filesystem is known — by extractor probing — to record it.

--- a/lib/galilei/src/core/soundness_galilei_core.scala
+++ b/lib/galilei/src/core/soundness_galilei_core.scala
@@ -38,13 +38,15 @@ export
       copyTo, created, CreateFlag, CreateNonexistentParents, Creation, creation, CreationTimed,
       D, delete, Ext4,
       DeleteRecursively, DereferenceSymlinks, descendants, dir, Directory, Dos, Drive, Entry,
-      entry, executable, expanse, Explorable, existent, Fifo, file, File, FileOpenable,
+      entry, entryIdentity, executable, expanse, Explorable, existent, Fifo, file, File,
+      FileOpenable,
       FilesystemAttribute, FilesystemBackend,
       glob, Handle, hardLinks, hardLinkTo, hidden, Io, Linux, Local, locations,
       dataSearch, configSearch, destination, listing, search,
       MacOs, modified, MoveAtomically, moveInto, moveTo, Ntfs, OpenFlag,
       OverwritePreexisting, p, Platform, Posix, readable, filesize, Sock, Stat,
-      Scratch, Searchpaths, searchpathCompliant, Shared, Slice, Substantiable, Subtree, Symlink, symlinkInto, symlinkTo, touch,
+      Scratch, Searchpaths, searchpathCompliant, Shared, Slice, Substantiable, Subtree, subvolume,
+      subvolumeRoot, Symlink, symlinkInto, symlinkTo, touch,
       TraversalOrder,
       UnixEntry, Volume, volume, Windows, WindowsEntry, wipe, writable, write }
 

--- a/lib/galilei/src/jvm/galilei_jvm.scala
+++ b/lib/galilei/src/jvm/galilei_jvm.scala
@@ -303,6 +303,21 @@ package filesystemBackends:
           attributeView(path).write(name.s, java.nio.ByteBuffer.wrap(Array.unsafeJvm(value)))
           ()
 
+      // Read through the `unix` attribute view rather than `BasicFileAttributes#fileKey`, whose
+      // `UnixFileKey` exposes the same two numbers only through its `toString`.
+      def identity(path: Path on Plane, dereference: Boolean): Optional[Stat.Identity] =
+        val options = dereferenceOptions(dereference)
+
+        try
+          val device = jnf.Files.getAttribute(javaPath(path), "unix:dev", options*).nn.absolve
+          val inode = jnf.Files.getAttribute(javaPath(path), "unix:ino", options*).nn.absolve
+
+          (device, inode) match
+            case (device: Long, inode: Long) => Stat.Identity(device, inode)
+            case _                           => Unset
+
+        catch case _: Exception => Unset
+
       def slice[result]
         ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
         ( lambda: Slice.Window => result )

--- a/lib/galilei/src/native/galilei_native.scala
+++ b/lib/galilei/src/native/galilei_native.scala
@@ -317,6 +317,19 @@ package filesystemBackends:
       def attribute(path: Path on Plane, name: Text, value: Data)(using Tactic[Io.Error]): Unit =
         abort(Io.Error(path, Operation.Metadata, Reason.Unsupported))
 
+      // As in `stat`, individual-argument varargs calls rather than an array splice: under the
+      // Scala Native javalib the varargs formals are pure Scala arrays, which no array value
+      // can satisfy under separation checking.
+      def identity(path: Path on Plane, dereference: Boolean): Optional[Stat.Identity] =
+        def read(name: String): Any | Null =
+          if dereference then jnf.Files.getAttribute(javaPath(path), name)
+          else jnf.Files.getAttribute(javaPath(path), name, jnf.LinkOption.NOFOLLOW_LINKS)
+
+        try (read("unix:dev").nn.absolve, read("unix:ino").nn.absolve) match
+          case (device: Long, inode: Long) => Stat.Identity(device, inode)
+          case _                           => Unset
+        catch case _: Exception => Unset
+
       def slice[result]
         ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
         ( lambda: Slice.Window => result )

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -562,6 +562,48 @@ object Tests extends Suite(m"Galilei tests"):
           case _           => true  // no creation-timed filesystem here; the gate did its job
       . assert(_ == true)
 
+      test(m"A btrfs subvolume root is itself a subvolume root"):
+        root match
+          case Btrfs(path) => unsafely(path.subvolume().root.subvolumeRoot)
+          case _           => true  // not btrfs here; the gate did its job
+      . assert(_ == true)
+
+      test(m"An entry shares its subvolume root's device number"):
+        root match
+          case Btrfs(path) =>
+            path.entryIdentity.let(_.device)
+            == unsafely(path.subvolume()).root.entryIdentity.let(_.device)
+
+          case _ => true  // not btrfs here; the gate did its job
+      . assert(_ == true)
+
+    suite(m"Entry identity"):
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.deleteRecursively.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+
+      val identifiedLeaf: Text = Uuid().show
+      val linkedLeaf: Text = Uuid().show
+      val separateLeaf: Text = Uuid().show
+      val identified: Path on Linux = unsafely((% / "tmp" / identifiedLeaf).on[Linux])
+      val linked: Path on Linux = unsafely((% / "tmp" / linkedLeaf).on[Linux])
+      val separate: Path on Linux = unsafely((% / "tmp" / separateLeaf).on[Linux])
+      unsafely(identified.write(t"content"))
+      unsafely(separate.write(t"content"))
+      unsafely(identified.hardLinkTo(linked))
+
+      test(m"An entry has a device and inode number"):
+        identified.entryIdentity.let(_.inode).or(0L) > 0L
+      . assert(_ == true)
+
+      test(m"A hard link has the same identity as its target"):
+        identified.entryIdentity == linked.entryIdentity
+      . assert(_ == true)
+
+      test(m"Two distinct files have distinct identities"):
+        identified.entryIdentity == separate.entryIdentity
+      . assert(_ == false)
+
     suite(m"Shared locking"):
       import errorDiagnostics.stackTracesDiagnostics
       import filesystemOptions.createNonexistentParents.enabled

--- a/lib/galilei/src/wasi/galilei_wasi.scala
+++ b/lib/galilei/src/wasi/galilei_wasi.scala
@@ -401,6 +401,11 @@ package filesystemBackends:
       def attribute(path: Path on Plane, name: Text, value: Data)(using Tactic[Io.Error]): Unit =
         abort(Io.Error(path, Operation.Metadata, Reason.Unsupported))
 
+      // `wasi:filesystem`'s `descriptor-stat` carries neither a device nor an inode number —
+      // `metadata-hash-at` offers only an opaque 128-bit identity, which cannot answer the
+      // device-number question subvolume detection asks — so the identity is unavailable.
+      def identity(path: Path on Plane, dereference: Boolean): Optional[Stat.Identity] = Unset
+
       def slice[result]
         ( path: Path on Plane, offset: Long, extent: Long, flags: List[OpenFlag] )
         ( lambda: Slice.Window => result )


### PR DESCRIPTION
Galilei can now report which btrfs subvolume an entry is stored in, completing the storage-filesystem axis introduced in #1875: a path known to be `over Btrfs` offers `subvolume()`, which names the subvolume by its root directory, and `subvolumeRoot`, which says whether the entry is itself such a root. Both are read from the entry's device and inode numbers, which are also newly available in their own right, on any path, as `entryIdentity`.

Btrfs partitions one filesystem into independently-snapshottable subtrees, so knowing an entry's volume does not tell you where it is stored. Once the storage-filesystem axis has been established by an extractor, the subvolume is available too:
```scala
path match
  case Btrfs(path) => path.subvolume().root
  case _           => path
```

Btrfs gives every subvolume its own anonymous device number and numbers every subvolume root's inode 256, so both accessors are answered from `stat` alone. A subvolume's numeric ID, UUID and generation are not reported: btrfs exposes those only through the `BTRFS_IOC_GET_SUBVOL_INFO` `ioctl`, which no filesystem backend can yet issue. `Btrfs.Subvolume` is the type those fields would join.

The device and inode numbers behind this are useful beyond btrfs, so every path now offers them:
```scala
val same: Boolean = original.entryIdentity == link.entryIdentity
```

Two paths with equal identities are hard links to one file. The value is `Unset` where the platform does not record it — WASI's `descriptor-stat` carries neither number, and the JVM's `unix` attribute view is absent off POSIX. It is spelt `entryIdentity`, after `entry()`, rather than plainly `identity`, which would compete with `proscenium`'s function of that name wherever the `soundness` umbrella is imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
