### PR TITLE
Make `Text` sorting require an explicitly-chosen collation

### DIFF
--- a/lib/anticipation/src/text/anticipation.internal.scala
+++ b/lib/anticipation/src/text/anticipation.internal.scala
@@ -84,7 +84,6 @@ object internal:
 
       def multiply(text: Text, n: Int): Text = recur(text, n.max(0), "".tt)
 
-    given ordering: Ordering[Text] = Ordering.String.on[Text](identity)
     given fromString: CommandLineParser.FromString[Text] = make(_)
 
     given fromExpr: (fromExpr: FromExpr[String]) => FromExpr[Text]:

--- a/lib/charisma/src/core/charisma.Molecule.scala
+++ b/lib/charisma/src/core/charisma.Molecule.scala
@@ -34,6 +34,8 @@ package charisma
 
 import anticipation.*
 import gossamer.*
+import gossamer.collationOrdering
+import gossamer.collations.codepoints
 import hieroglyph.*
 import hypotenuse.*
 import rudiments.*

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -39,6 +39,8 @@ import scala.util.*
 import anticipation.*
 import denominative.*
 import gossamer.*
+import gossamer.collationOrdering
+import gossamer.collations.codepoints
 import hieroglyph.*
 import mercator.*
 import prepositional.*

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -39,6 +39,8 @@ import anticipation.*
 import denominative.*
 import escapade.*
 import gossamer.*
+import gossamer.collationOrdering
+import gossamer.collations.codepoints
 import guillotine.*
 import hieroglyph.*, textMetrics.uniformMetric
 import hypotenuse.*

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -43,6 +43,8 @@ import escapade.*
 import eucalyptus.*
 import fulminate.*
 import gossamer.*
+import gossamer.collationOrdering
+import gossamer.collations.codepoints
 import guillotine.*
 import prepositional.*
 import rudiments.*

--- a/lib/exoskeleton/src/manpage/exoskeleton_manpage.scala
+++ b/lib/exoskeleton/src/manpage/exoskeleton_manpage.scala
@@ -36,6 +36,8 @@ import anticipation.*
 import aviation.*, dateFormats.iso8601DateFormat
 import escapade.*
 import gossamer.*
+import gossamer.collationOrdering
+import gossamer.collations.codepoints
 import spectacular.*
 import vacuous.*
 import virility.*

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -33,6 +33,8 @@
 package exoskeleton
 
 import soundness.*
+import soundness.collationOrdering
+import soundness.collations.codepoints
 
 import classloaders.systemClassloader
 import environments.javaEnvironment

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -33,6 +33,8 @@
 package galilei
 
 import soundness.*
+import soundness.collationOrdering
+import soundness.collations.codepoints
 
 import filesystemBackends.virtualMachineFilesystem
 

--- a/lib/gossamer/src/core/gossamer.Collation.scala
+++ b/lib/gossamer/src/core/gossamer.Collation.scala
@@ -30,34 +30,14 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package gossamer
 
-export
-  gossamer
-  . { add, append, appendln, Ascii, ascii, AsciiBuilder, Bidi, blank,
-      broken, build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, chomp,
-      contains, tally, cut, Cuttable, Decimalizer, ends, erase, extract, fill, fit,
-      Collation, collationOrdering,
-      fuzzy, Grapheme, init, join, Joinable, kebab, length, lines, lower,
-      Ltr, Numerous, ossify, pad, pascal, plain, Proximity, proximity, Pue, pue, punycode,
-      Range, reversibleTextual, traversableTextual, Rtl, search, offsetOf, SimpleTExtractor, slices, snake,
-      spaced, starts, sub, subscripts, superscripts, sysData, t, text,
-      TextBuilder,
-      Textual, tr, trim, txt, uncamel, uncapitalize, unkebab, unsnake, upper, urlDecode,
-      urlEncode, utf16, utf8, pinpoint, words, Writing, WritingBuilder, a, justify, punch }
+import anticipation.*
+import beneficence.*
 
-package decimalConverters:
-  export gossamer.decimalConverters.javaDecimalConverter
-
-package proximities:
-  export gossamer.proximities.jaroProximity
-  export gossamer.proximities.jaroWinklerProximity
-  export gossamer.proximities.prefixProximity
-  export gossamer.proximities.levenshteinProximity
-  export gossamer.proximities.normalizedLevenshteinProximity
-
-package caseSensitivity:
-  export gossamer.caseSensitivity.{caseInsensitive, caseSensitive, smartCase}
-
-package collations:
-  export gossamer.collations.{codepoints, unicode}
+// A collation: a total ordering of `Text` values. There is deliberately no ambient default
+// (issue #575): a sort order is a policy, chosen either by importing a given from the
+// `collations` package, or — with cosmopolite — derived from a contextual `Locale`.
+trait Collation extends Findable:
+  def compare(left: Text, right: Text): Int
+  def key(text: Text): Array[Int]^{}

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -617,3 +617,59 @@ package caseSensitivity:
 
   given smartCase: CaseSensitivity = (left, right) =>
     left == right || left.isLower && left.majuscule == right
+
+// Lexically-scoped by necessity, with a library-qualified name: neither `Ordering`'s nor
+// `Text`'s companion can see gossamer, so this cannot live in implicit scope. It fires only
+// when a `Collation` is in scope, making `Text` sortable exactly when a sort order has been
+// chosen (issue #575).
+given collationOrdering: (collation: Collation) => Ordering[Text] =
+  Ordering.fromLessThan: (left, right) => collation.compare(left, right) < 0
+
+package collations:
+  // Dictionary order: the root table of the Unicode Collation Algorithm (UTS #10),
+  // non-ignorable, with three levels. Language-specific orderings tailor this table.
+  given unicode: Collation:
+    def compare(left: Text, right: Text): Int = hieroglyph.CollationTable.root.compare(left, right)
+    def key(text: Text): Array[Int]^{} = hieroglyph.CollationTable.root.key(text)
+
+  // Raw codepoint order: deterministic and table-free, for machine-facing sorting such as
+  // stable file listings. Not `String` order, which compares UTF-16 code units and so places
+  // supplementary characters before U+E000..U+FFFF.
+  given codepoints: Collation:
+    def compare(left: Text, right: Text): Int =
+      val leftString = left.s
+      val rightString = right.s
+      var leftIndex = 0
+      var rightIndex = 0
+      var result = 0
+
+      while result == 0 && leftIndex < leftString.length && rightIndex < rightString.length do
+        val leftCodepoint = Character.codePointAt(leftString, leftIndex)
+        val rightCodepoint = Character.codePointAt(rightString, rightIndex)
+
+        if leftCodepoint != rightCodepoint
+        then result = if leftCodepoint < rightCodepoint then -1 else 1
+
+        leftIndex += Character.charCount(leftCodepoint)
+        rightIndex += Character.charCount(rightCodepoint)
+
+      if result != 0 then result
+      else if leftIndex < leftString.length then 1
+      else if rightIndex < rightString.length then -1
+      else 0
+
+    def key(text: Text): Array[Int]^{} =
+      val string = text.s
+      val buffer = Array.scratch[Int](string.length)
+      var size = 0
+      var index = 0
+
+      while index < string.length do
+        val codepoint = Character.codePointAt(string, index)
+        buffer(size) = codepoint
+        size += 1
+        index += Character.charCount(codepoint)
+
+      val result = Array.scratch[Int](size)
+      java.lang.System.arraycopy(buffer, 0, result, 0, size)
+      Array.unsafeFrozen(result)

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -1356,3 +1356,37 @@ object Tests extends Suite(m"Gossamer Tests"):
           a"hello $name café"
         . map(_.focus)
       . assert(_ == List("é"))
+
+    suite(m"Collation"):
+      test(m"Text is not sortable without a collation in scope"):
+        demilitarize:
+          List(t"b", t"a").sorted
+        . map(_.reason)
+      . assert(_ == List(CompileError.Reason.MissingImplicitArgument))
+
+      test(m"dictionary order ranks accents before case: cafe < café < caff"):
+        import collations.unicode
+        List(t"caff", t"café", t"cafe").sorted
+      . assert(_ == List(t"cafe", t"café", t"caff"))
+
+      test(m"comparison operators work once a collation is chosen"):
+        import collations.unicode
+        t"apple" < t"banana"
+      . assert(_ == true)
+
+      test(m"codepoint order sorts supplementary characters after the BMP"):
+        import collations.codepoints
+        List(t"𝓐", t"�").sorted
+      . assert(_ == List(t"�", t"𝓐"))
+
+      test(m"codepoint and dictionary orders differ on case"):
+        val upper = List(t"a", t"B")
+        import collations.unicode
+        val dictionary = upper.sorted
+
+        val codepoint =
+          import collations.codepoints
+          upper.sorted
+
+        (dictionary, codepoint)
+      . assert(_ == (List(t"a", t"B"), List(t"B", t"a")))

--- a/lib/mandible/src/core/mandible.ClassSurface.scala
+++ b/lib/mandible/src/core/mandible.ClassSurface.scala
@@ -37,6 +37,8 @@ import java.lang.classfile.attribute as jlca
 
 import anticipation.*
 import gossamer.*
+import gossamer.collationOrdering
+import gossamer.collations.codepoints
 import rudiments.*
 import vacuous.*
 

--- a/lib/probably/src/core/probably.Test.scala
+++ b/lib/probably/src/core/probably.Test.scala
@@ -40,6 +40,8 @@ import digression.*
 import distillate.*
 import fulminate.*
 import gossamer.*
+import gossamer.collationOrdering
+import gossamer.collations.codepoints
 import hieroglyph.*
 import hypotenuse.*
 import nomenclature.*

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -33,6 +33,8 @@
 package rudiments
 
 import soundness.*
+import soundness.collationOrdering
+import soundness.collations.codepoints
 import denominative.dysasymptotics.linearSize
 
 case class Person(name: Text, age: Int)

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -35,6 +35,8 @@ package xenophile
 import scala.caps
 
 import soundness.*
+import soundness.collationOrdering
+import soundness.collations.codepoints
 
 import ambience.systems.javaSystem
 


### PR DESCRIPTION
Part 2 of the #575 campaign (after #1898). `Text` values are no longer sortable by default: the ambient `Ordering[Text]` — UTF-16 code-unit order, which is not even codepoint order for supplementary characters — is gone, and sorting now requires choosing a collation explicitly. gossamer gains the `Collation` typeclass and a `collations` choice package backed by hieroglyph's Unicode Collation Algorithm. Part 3 will derive collations from cosmopolite `Locale`s.

### Release notes

- **Breaking:** sorting or comparing `Text` (`sorted`, `min`/`max`, `<` etc.) no longer compiles without a collation in scope. Choose one by name:

```scala
import collations.unicode     // dictionary order (UCA root table)
import collations.codepoints  // raw codepoint order, table-free, for machine-facing sorting
import gossamer.collationOrdering  // derives Ordering[Text] from the chosen Collation

List(t"caff", t"café", t"cafe").sorted  // List(cafe, café, caff) under collations.unicode
```

- `Collation` is a new gossamer typeclass (`compare` and sort-`key`); `collationOrdering` derives `Ordering[Text]` from any `Collation` in scope, and comparison operators follow via hypotenuse's `Ordering ⇒ Orderable` bridge.
- `collations.codepoints` orders by codepoint, not UTF-16 code units, so supplementary-plane characters order correctly after the BMP.
- Internal call sites that sort identifiers, filenames, element symbols and completion entries now use `collations.codepoints` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)