### PR TITLE
Derive `Text` collations from cosmopolite locales

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1599,7 +1599,6 @@ object cosmopolite extends Library:
   object test extends Tests(core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions())
-    override def enabled = false
 
 object dendrology extends Library:
   object tree extends Component(anticipation.print, gossamer.core, tessellate.core):

--- a/lib/chiaroscuro/src/render/chiaroscuro_render.scala
+++ b/lib/chiaroscuro/src/render/chiaroscuro_render.scala
@@ -138,7 +138,7 @@ package teletypeables:
               case Same(value)                           => Nil
               case Different(left, right, difference)    => Nil
 
-              case Collation(_, comparison, left, right) =>
+              case Juxtaposition.Collation(_, comparison, left, right) =>
                 if comparison.all(_(1).singleChar) then Nil else comparison
 
             case class Row(treeLine: Text, left: Teletype, right: Teletype, memo: Teletype)
@@ -164,7 +164,7 @@ package teletypeables:
                       e"${Fg(palette.negative)}($right)",
                       difference.let(_.teletype).or(e"") )
 
-                case Collation(_, comparison, left, right) =>
+                case Juxtaposition.Collation(_, comparison, left, right) =>
                   if comparison.all(_(1).singleChar)
                   then
                     import proximities.levenshteinProximity

--- a/lib/cosmopolite/src/core/cosmopolite.Collatable.scala
+++ b/lib/cosmopolite/src/core/cosmopolite.Collatable.scala
@@ -32,92 +32,10 @@
                                                                                                   */
 package cosmopolite
 
-import anticipation.*
 import gossamer.*
-import hieroglyph.*
+import prepositional.*
 
-object en extends Language(t"en"):
-  type Code = en
-
-  given collatable: en is Collatable:
-    def collation: Collation = collations.unicode
-
-trait en
-
-object pl extends Language(t"pl"):
-  type Code = pl
-
-  // CLDR Polish: nine accented letters collate as letters in their own right, after their
-  // bases; ż sorts after ź, so its rule chains through the previous rule's target.
-  private lazy val tailored: Collation = Collation:
-    CollationTable.root.tailor:
-      List
-        ( CollationRule(t"a", t"ą", CollationLevel.Primary),
-          CollationRule(t"ą", t"Ą", CollationLevel.Tertiary),
-          CollationRule(t"c", t"ć", CollationLevel.Primary),
-          CollationRule(t"ć", t"Ć", CollationLevel.Tertiary),
-          CollationRule(t"e", t"ę", CollationLevel.Primary),
-          CollationRule(t"ę", t"Ę", CollationLevel.Tertiary),
-          CollationRule(t"l", t"ł", CollationLevel.Primary),
-          CollationRule(t"ł", t"Ł", CollationLevel.Tertiary),
-          CollationRule(t"n", t"ń", CollationLevel.Primary),
-          CollationRule(t"ń", t"Ń", CollationLevel.Tertiary),
-          CollationRule(t"o", t"ó", CollationLevel.Primary),
-          CollationRule(t"ó", t"Ó", CollationLevel.Tertiary),
-          CollationRule(t"s", t"ś", CollationLevel.Primary),
-          CollationRule(t"ś", t"Ś", CollationLevel.Tertiary),
-          CollationRule(t"z", t"ź", CollationLevel.Primary),
-          CollationRule(t"ź", t"Ź", CollationLevel.Tertiary),
-          CollationRule(t"ź", t"ż", CollationLevel.Primary),
-          CollationRule(t"ż", t"Ż", CollationLevel.Tertiary) )
-
-  given collatable: pl is Collatable:
-    def collation: Collation = tailored
-
-trait pl
-
-object fr extends Language(t"fr"):
-  type Code = fr
-
-  // CLDR root French is untailored (backward secondary accents are a Canadian French
-  // convention, not used by `fr` since CLDR 1.9).
-  given collatable: fr is Collatable:
-    def collation: Collation = collations.unicode
-
-trait fr
-
-object de extends Language(t"de"):
-  type Code = de
-
-  // CLDR standard German is untailored (umlauts differ at the secondary level, which is
-  // already the root table's behaviour; DIN phonebook order is a different collation type).
-  given collatable: de is Collatable:
-    def collation: Collation = collations.unicode
-
-trait de
-
-object es extends Language(t"es"):
-  type Code = es
-
-  // CLDR Spanish: ñ collates as a letter between n and o.
-  private lazy val tailored: Collation = Collation:
-    CollationTable.root.tailor:
-      List
-        ( CollationRule(t"n", t"ñ", CollationLevel.Primary),
-          CollationRule(t"ñ", t"Ñ", CollationLevel.Tertiary) )
-
-  given collatable: es is Collatable:
-    def collation: Collation = tailored
-
-trait es
-
-infix type via [value, language] = Locale[language] ?=> value
-
-// Lexically-scoped by necessity (`Collation` belongs to gossamer, the language tags to
-// cosmopolite, so neither companion can host it): a contextual `Locale` confers its
-// language's sort order.
-given localeCollation: [language]
-      =>  Locale[language]
-      =>  (collatable: language is Collatable)
-      =>  Collation =
-  collatable.collation
+// The sort order of a language (its subject is the language's phantom type tag): a `Locale`
+// in scope confers its language's collation through the `localeCollation` given.
+trait Collatable extends Typeclass.Pure:
+  def collation: Collation

--- a/lib/cosmopolite/src/core/soundness_cosmopolite_core.scala
+++ b/lib/cosmopolite/src/core/soundness_cosmopolite_core.scala
@@ -32,4 +32,5 @@
                                                                                                   */
 package soundness
 
-export cosmopolite.{de, en, es, fr, Language, Locale, pl, Polyglot, via}
+export cosmopolite.{Collatable, de, en, es, fr, Language, Locale, localeCollation, pl,
+    Polyglot, via}

--- a/lib/cosmopolite/src/test/cosmopolite_test.scala
+++ b/lib/cosmopolite/src/test/cosmopolite_test.scala
@@ -33,40 +33,57 @@
 package cosmopolite
 
 import soundness.*
+import soundness.collationOrdering
+import soundness.localeCollation
 
 object Tests extends Suite(m"Cosmopolite tests"):
   def run(): Unit =
-    suite(m"Native-rendering coverage"):
-      test(m"cosmopolite's types inspect natively"):
-        Inspectable.fallbacks(Locale(en).inspect)
-      . assert(_ == Nil)
+    suite(m"Language sort orders"):
+      test(m"English uses dictionary order: cafe < café < caff"):
+        given Locale[en] = Locale(en)
+        List(t"caff", t"café", t"cafe").sorted
+      . assert(_ == List(t"cafe", t"café", t"caff"))
 
-      test(m"A locale shows its language code"):
-        Locale(en).inspect
-      . assert(_ == t"Locale(en)")
+      test(m"Polish ó sorts as a letter between o and p"):
+        given Locale[pl] = Locale(pl)
+        List(t"pod", t"ó", t"oz").sorted
+      . assert(_ == List(t"oz", t"ó", t"pod"))
 
-// import languages.common.*
+      test(m"Polish ż chains after ź after z"):
+        given Locale[pl] = Locale(pl)
+        List(t"ż", t"z", t"ź").sorted
+      . assert(_ == List(t"z", t"ź", t"ż"))
 
-// import probably.*
-// import rudiments.*
-// import gossamer.*
+      test(m"Polish uppercase is a tertiary difference: ó < Ó"):
+        given Locale[pl] = Locale(pl)
+        t"ó" < t"Ó"
+      . assert(_ == true)
 
-// import unsafeExceptions.canThrowAny
+      test(m"Spanish ñ sorts as a letter between n and o"):
+        given Locale[es] = Locale(es)
+        List(t"año", t"anzuelo", t"ano").sorted
+      . assert(_ == List(t"ano", t"anzuelo", t"año"))
 
-// object Tests extends Suite(m"Cosmopolite Tests"):
-//   def run(): Unit =
-//     test(m"extract language from string (English)"):
-//       val two = en"two" & fr"deux"
-//       two[En]
-//     . assert(_ == t"two")
+      test(m"English keeps ñ with n: año < anzuelo"):
+        given Locale[en] = Locale(en)
+        List(t"año", t"anzuelo", t"ano").sorted
+      . assert(_ == List(t"ano", t"año", t"anzuelo"))
 
-//     test(m"extract language from string (French)"):
-//       val two = en"two" & fr"deux"
-//       two[Fr]
-//     . assert(_ == t"deux")
+      test(m"German umlauts differ at the secondary level"):
+        given Locale[de] = Locale(de)
+        (t"äb" > t"ab", t"äa" < t"ab")
+      . assert(_ == (true, true))
 
-//     test(m"extract default language"):
-//       val two = en"two" & fr"deux"
-//       given Language[Fr] = Language[Fr]("fr")
-//       two()
-//     . assert(_ == t"deux")
+      // Forward secondary accents: modern CLDR French. The reversed relative order of coté
+      // and côte under traditional (now Canadian) French would need backward secondaries.
+      test(m"French uses forward secondary accents: coté < côte"):
+        given Locale[fr] = Locale(fr)
+        List(t"côté", t"coté", t"côte", t"cote").sorted
+      . assert(_ == List(t"cote", t"coté", t"côte", t"côté"))
+
+    suite(m"Locale integration"):
+      test(m"a via-typed value sees its language's collation"):
+        def first: Text via pl = List(t"ó", t"oz").sorted.head
+        given Locale[pl] = Locale(pl)
+        first
+      . assert(_ == t"oz")

--- a/lib/gossamer/src/core/gossamer.Collation.scala
+++ b/lib/gossamer/src/core/gossamer.Collation.scala
@@ -35,6 +35,11 @@ package gossamer
 import anticipation.*
 import beneficence.*
 
+object Collation:
+  def apply(table: hieroglyph.CollationTable): Collation = new Collation:
+    def compare(left: Text, right: Text): Int = table.compare(left, right)
+    def key(text: Text): Array[Int]^{} = table.key(text)
+
 // A collation: a total ordering of `Text` values. There is deliberately no ambient default
 // (issue #575): a sort order is a policy, chosen either by importing a given from the
 // `collations` package, or — with cosmopolite — derived from a contextual `Locale`.

--- a/src/test/soundness.Tests.scala
+++ b/src/test/soundness.Tests.scala
@@ -67,7 +67,7 @@ object Tests extends Suite(m"Soundness tests"):
     contingency.Tests()
     telekinesis.Http2Tests()
     corpuscular.Tests()
-    //cosmopolite.Tests()
+    cosmopolite.Tests()
     degustation.Tests()
     delicious.Tests()
     dendrology.Tests()


### PR DESCRIPTION
The final part of the #575 campaign (after #1898 and #1901): a cosmopolite `Locale` in scope now confers its language's sort order, so locale-aware code gets correct sorting with no further ceremony. This also revives cosmopolite's test suite, which had been disabled against a long-dead API.

### Release notes

- **cosmopolite** gains the `Collatable` typeclass: a language whose sort order is known. All five languages have instances: Polish and Spanish tailor the root collation (ą ć ę ł ń ó ś ź ż and ñ collate as letters in their own right, with uppercase as a tertiary difference); English, French and German use root dictionary order, per CLDR.
- The `localeCollation` given derives a `Collation` from a contextual `Locale`:

```scala
import soundness.{collationOrdering, localeCollation}

given Locale[pl] = Locale(pl)
List(t"pod", t"ó", t"oz").sorted  // List(oz, ó, pod): ó is a letter between o and p

def order: List[Text] via es = ...  // Polyglot/via blocks inherit the language's order
```

- **gossamer** gains `Collation(table)`, constructing a `Collation` from any (possibly tailored) `hieroglyph.CollationTable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)