### PR TITLE
Recover inline positions from SMAPs in the vivisection debugger

### DIFF
--- a/lib/digression/src/core/digression.Smap.scala
+++ b/lib/digression/src/core/digression.Smap.scala
@@ -186,12 +186,39 @@ case class Smap(generated: Text, default: Text, strata: Map[Text, Smap.Stratum])
     stratum.let: stratum =>
       stratum.files.seek { (_, file) => file.name == generated }.let(_(0))
 
+  // The generated file's fuller path, when its file table records one.
+  lazy val path: Optional[Text] =
+    stratum.let: stratum =>
+      stratum.files.seek { (_, file) => file.name == generated }.let(_(1).path)
+
   // A line which maps to itself in the generated file—or which the SMAP says nothing about—is a
   // real line, not a synthetic one.
   private def real(line: Int): Boolean =
     stratum.lay(true): stratum =>
       stratum(line).lay(true): (fileId, input) =>
         input == line && generatedId.lay(false)(_ == fileId)
+
+  // The generated-line ranges standing for a source position: one `[start, end)` range per site
+  // the line was inlined at, excluding the identity run (a line's natural occurrence in the
+  // generated file itself, which the class's own line table already locates). Empty when the
+  // file is foreign to this SMAP. One line inlined at many call sites yields many ranges — a
+  // breakpoint on the line belongs at every one. This is `expand`'s inverse, for resolution:
+  // `expand` asks what a generated line stands for; `sites` asks where a source line went.
+  def sites(file: Text, line: Int): List[(Int, Int)] =
+    stratum.lay(List()): stratum =>
+      val ids =
+        stratum.files.stdlib.collect { case (id, entry) if entry.name == file => id }.toSet
+
+      val ranges = stratum.entries.stdlib.flatMap: entry =>
+        val identity = generatedId.lay(false)(_ == entry.fileId)
+        val covers = line >= entry.inputLine && line < entry.inputLine + entry.repeat
+        val sound = entry.increment >= 1 && entry.repeat >= 1
+
+        if !sound || identity || !ids.contains(entry.fileId) || !covers then sci.List() else
+          val start = entry.outputLine + (line - entry.inputLine)*entry.increment
+          sci.List((start, start + entry.increment))
+
+      List(ranges*)
 
   // Expands a synthetic line into the inline origins it stands for, innermost first, and the
   // real call-site line the chain leads back to. A real line—or a line in a classfile whose SMAP

--- a/lib/digression/src/test/digression_test.scala
+++ b/lib/digression/src/test/digression_test.scala
@@ -217,6 +217,54 @@ object Tests extends Suite(m"Digression Tests"):
 
       . assert(_ == Smap.Expansion(List(Smap.Origin(t"Util.scala", t"Util.scala", 3)), Unset))
 
+    suite(m"SMAP inversion"):
+      // Util.scala line 3 inlined at two distinct sites, the second with a two-line increment.
+      val multi: Optional[Smap] =
+        Smap.parse:
+          Text:
+            List
+              ( "SMAP", "Main.scala", "Scala",
+                "*S Scala",
+                "*F", "+ 1 Main.scala", "Main.scala", "+ 2 Util.scala", "foo/Util.scala",
+                "*L", "1#1,100:1", "3#2:101", "3#2,2:105,2",
+                "*E" )
+            . mkString("\n")
+
+      test(m"An inlined line answers the generated range standing for it"):
+        smap.let(_.sites(t"Util.scala", 3))
+
+      . assert(_ == List((121, 122)))
+
+      test(m"Each line of a coalesced run answers its own range"):
+        smap.let(_.sites(t"Util.scala", 4))
+
+      . assert(_ == List((122, 123)))
+
+      test(m"A line beyond the inlined run answers nothing"):
+        smap.let(_.sites(t"Util.scala", 5).stdlib.isEmpty)
+
+      . assert(_ == true)
+
+      test(m"The generated file's own lines are not sites"):
+        smap.let(_.sites(t"Main.scala", 3).stdlib.isEmpty)
+
+      . assert(_ == true)
+
+      test(m"A file foreign to the SMAP answers nothing"):
+        smap.let(_.sites(t"Nowhere.scala", 3).stdlib.isEmpty)
+
+      . assert(_ == true)
+
+      test(m"A line inlined at several sites answers every range"):
+        multi.let(_.sites(t"Util.scala", 3))
+
+      . assert(_ == List((101, 102), (105, 107)))
+
+      test(m"Nested inlining sites resolve per file"):
+        (nested.let(_.sites(t"B.scala", 3)), nested.let(_.sites(t"A.scala", 3)))
+
+      . assert(_ == (List((11, 12)), List((12, 13))))
+
     suite(m"Rendering inlined frames"):
       val method = StackTrace.Method(t"Main", t"run()")
 

--- a/lib/vivisection/src/core/vivisection.Debug.scala
+++ b/lib/vivisection/src/core/vivisection.Debug.scala
@@ -395,9 +395,9 @@ extends caps.ExclusiveCapability:
   // Resolves a source position to the executable locations currently loaded for it: every method
   // of every loaded class compiled from that file whose line table covers the line. Classes
   // named after the file are tried first, so the common case costs a handful of round trips; a
-  // full sweep of loaded classes backstops it. Classes not yet loaded are not found, and inlined
-  // code is not mapped (resolution on ClassPrepare and SMAP awareness belong to the stepping
-  // campaign).
+  // full sweep of loaded classes backstops it. Classes not yet loaded are not found here — the
+  // source-breakpoint form defers to their preparation — and each resolved class is also checked
+  // for inlined copies of the position through its SMAP (see `locateIn`).
   def locate(source: Text, line: Ordinal)(using Tactic[Debugger.Error]): List[Jdwp.Location] =
     val base = source.s.indexOf('.') match
       case -1    => source.s
@@ -434,7 +434,7 @@ extends caps.ExclusiveCapability:
 
     val sourced = safely(connection.sourceFile(cls)).let(_ == source).or(false)
 
-    val results =
+    val exact =
       if !sourced then sci.List[Jdwp.Location]() else
         connection.methods(cls).stdlib.flatMap: method =>
           safely(connection.lineTable(cls, method.method)) match
@@ -445,4 +445,25 @@ extends caps.ExclusiveCapability:
             case _ =>
               sci.List()
 
+    // The SMAP pass, unguarded by the class's own source file: its SMAP's file table decides
+    // whether the requested position was inlined into this class, and `sites` answers the
+    // generated-line ranges standing for it — one binding per site, at the first line-table
+    // entry each range covers.
+    val ranges = connection.smap(cls).lay(sci.List[(Int, Int)]())(_.sites(source, line.n1).stdlib)
+
+    val inlined =
+      if ranges.isEmpty then sci.List[Jdwp.Location]() else
+        connection.methods(cls).stdlib.flatMap: method =>
+          safely(connection.lineTable(cls, method.method)) match
+            case table: Jdwp.LineTable =>
+              ranges.flatMap: (start, end) =>
+                val within = table.lines.stdlib.find: entry =>
+                  entry.line >= start && entry.line < end
+
+                within.map { entry => Jdwp.Location(tag, cls, method.method, entry.index) }.toList
+
+            case _ =>
+              sci.List()
+
+    val results = (exact ++ inlined).distinctBy: location => (location.method.long, location.index)
     List(results*)

--- a/lib/vivisection/src/core/vivisection.Halt.scala
+++ b/lib/vivisection/src/core/vivisection.Halt.scala
@@ -77,6 +77,16 @@ object Halt:
   // was constructed with (absent when null), and whether the throw will be caught.
   case class ExceptionInfo(className: Text, message: Optional[Text], caught: Boolean)
 
+  // One logical position a physical frame stands for: for inlined code, the file and line where
+  // the code was written; for the frame itself, its own source and its real line. `source` is
+  // the file's recorded basename and `path` its fuller path, when known.
+  case class Position
+    ( name:    Text,
+      source:  Optional[Text],
+      path:    Optional[Text],
+      line:    Int,
+      inlined: Boolean )
+
 // The capability lent to an event handler while its thread stands suspended: a view over the
 // stopped thread's frames and their logical variables. Sealed (`ExclusiveCapability`), so it
 // cannot outlive the stop it describes — once the dispatcher resumes the thread, every
@@ -100,6 +110,27 @@ extends caps.ExclusiveCapability:
 
   def frames(): List[(FrameId, Jdwp.Location)] =
     connection.frames(thread, 0, connection.frameCount(thread))
+
+  // The logical positions a frame stands for, innermost first: one per inline origin recovered
+  // from the class's SMAP, then the physical frame itself at its real (call-site) line. A frame
+  // with no SMAP, one stopped at a real line, or a VM without the source-debug-extension
+  // capability yields exactly the single raw position `describe` reports.
+  def positions(location: Jdwp.Location): List[Halt.Position] =
+    val (name, line) = describe(location)
+    val smap = connection.smap(location.cls)
+    val source = safely(connection.sourceFile(location.cls))
+    val path = smap.let(_.path)
+
+    smap.let(_.expand(line)).lay(List(Halt.Position(name, source, path, line, false))):
+      expansion =>
+        val inlined = expansion.inlined.stdlib.map: origin =>
+          // The `ScalaClass` stratum records binary-ish names with `$u002E` escapes; failing
+          // that, the origin's file names the frame.
+          val cls = origin.cls.lay(origin.file) { cls => cls.s.replace("$u002E", ".").nn.tt }
+          Halt.Position(cls, origin.file, origin.path, origin.line, true)
+
+        val real = Halt.Position(name, source, path, expansion.line.or(line), false)
+        List((inlined :+ real)*)
 
   // A human-readable position for a frame — `pkg.Cls.method` and its source line, resolved from
   // the class's method and line tables; line 0 where no line information exists.

--- a/lib/vivisection/src/core/vivisection.Jdwp.scala
+++ b/lib/vivisection/src/core/vivisection.Jdwp.scala
@@ -816,6 +816,7 @@ object Jdwp:
     // is held behind an untracked field; every handler dies with this sealed session anyway.
     private val handlers: scc.TrieMap[(Int, Int), Connection.Slot] = scc.TrieMap()
     private val preparers: scc.TrieMap[Int, Connection.PrepareSlot] = scc.TrieMap()
+    private val smaps: scc.TrieMap[Long, Optional[digression.Smap]] = scc.TrieMap()
     private[vivisection] val unclaimed: Relay[Event.Composite] = Relay()
 
     @scala.caps.unsafe.untrackedCaptures
@@ -1103,6 +1104,11 @@ object Jdwp:
     // The class loader that defined a type, or the null reference for a bootstrap-loaded class.
     def classLoader(cls: ReferenceTypeId)(using Tactic[Debugger.Error]): ClassLoaderId =
       Ref(request(2, 2)(_.referenceTypeId(cls)).objectId().long)
+
+    // The class's parsed SMAP, memoized for the session — including its absence, so a class
+    // with no debug extension (or a VM without the capability) costs one round trip, ever.
+    def smap(cls: ReferenceTypeId)(using Tactic[Debugger.Error]): Optional[digression.Smap] =
+      smaps.getOrElseUpdate(cls.long, safely(sourceDebugExtension(cls)).let(digression.Smap.parse(_)))
 
     def sourceDebugExtension(cls: ReferenceTypeId)
       ( using Tactic[Debugger.Error] )

--- a/lib/vivisection/src/dap/vivisection.Dap.scala
+++ b/lib/vivisection/src/dap/vivisection.Dap.scala
@@ -360,11 +360,12 @@ object Dap:
       caps.unsafe.unsafeAssumePure(Json.EncodableDerivation.derived)
 
   case class StackFrame
-    ( id:     Int,
-      name:   Text,
-      line:   Int,
-      column: Int = 0,
-      source: Optional[Source] = Unset )
+    ( id:               Int,
+      name:             Text,
+      line:             Int,
+      column:           Int = 0,
+      source:           Optional[Source] = Unset,
+      presentationHint: Optional[Text] = Unset )
 
   object StackTraceBody:
     given encodable: StackTraceBody is Json.Encodable =

--- a/lib/vivisection/src/dap/vivisection.DapSession.scala
+++ b/lib/vivisection/src/dap/vivisection.DapSession.scala
@@ -450,11 +450,18 @@ private[vivisection] class DapSession(emit: Json => Unit)
         val arguments = json.arguments.as[Dap.StackTraceArguments]
 
         withStop(request, arguments.threadId): halt =>
-          val trace = halt.frames().stdlib.map: (frame, location) =>
-            val id = counter.incrementAndGet()
-            frames(id) = (arguments.threadId, frame, location)
-            val (name, line) = halt.describe(location)
-            Dap.StackFrame(id, name, line)
+          // One DAP frame per *logical* position: a physical frame inside inlined code expands
+          // into its inline origins (marked `subtle`) followed by the frame itself at its real
+          // line. Every logical frame shares the physical frame's registry entry, so scopes,
+          // variables, evaluation and restart against an inline frame resolve to the enclosing
+          // physical frame.
+          val trace = halt.frames().stdlib.flatMap: (frame, location) =>
+            halt.positions(location).stdlib.map: position =>
+              val id = counter.incrementAndGet()
+              frames(id) = (arguments.threadId, frame, location)
+              val source = position.source.let(Dap.Source(_, position.path))
+              val hint: Optional[Text] = if position.inlined then t"subtle" else Unset
+              Dap.StackFrame(id, position.name, position.line, 0, source, hint)
 
           respond(request, Dap.StackTraceBody(List(trace*), trace.length).in[Json])
 

--- a/lib/vivisection/src/test/vivisection.Doubling.scala
+++ b/lib/vivisection/src/test/vivisection.Doubling.scala
@@ -1,0 +1,41 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package vivisection
+
+// An inline method in a file of its own, so a breakpoint set against this file must bind inside
+// classes compiled from other files — positions recoverable only through their SMAPs. The body
+// spans two lines so it has a breakpoint-able statement of its own.
+object Doubling:
+  inline def double(x: Int): Int =
+    val doubled = x + x
+    doubled

--- a/lib/vivisection/src/test/vivisection.Inlined.scala
+++ b/lib/vivisection/src/test/vivisection.Inlined.scala
@@ -1,0 +1,41 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package vivisection
+
+// A debuggee whose only call to `Doubling.double` is fully inlined: the `Doubling$` class never
+// loads at runtime, so a breakpoint on the inline body can only ever bind at the inlined copy
+// inside this class, through its SMAP.
+object Inlined:
+  def main(args: Array[String]): Unit =
+    val result = Doubling.double(21)
+    System.out.nn.println(result)

--- a/lib/vivisection/src/test/vivisection_test.scala
+++ b/lib/vivisection/src/test/vivisection_test.scala
@@ -1110,6 +1110,66 @@ object Tests extends Suite(m"Vivisection tests"):
 
     . assert(_ == true)
 
+    // The SMAP path end to end: a breakpoint on the body of an inline method — in a file whose
+    // class never loads at runtime — binds at the inlined copy inside the caller's class, and
+    // the stop expands into its logical positions: the inline origin first, then the physical
+    // frame at its call-site line.
+    test(m"a breakpoint on an inline body binds cross-file and expands its positions"):
+      supervise:
+        debugFixture(t"vivisection.Inlined", t"vivisection.Doubling.scala", Ordinal.uniary(40)):
+          stop ?=>
+            stop.positions(stop.location).stdlib.map: position =>
+              (position.source, position.line, position.inlined)
+
+    . assert(_ == scala.List(
+          (t"vivisection.Doubling.scala", 40, true),
+          (t"vivisection.Inlined.scala", 40, false)))
+
+    // The same stop through the protocol: the stack trace carries a subtle frame at the inline
+    // origin and the real frame at its call site, each with its source; scopes against the
+    // inline frame resolve to the enclosing physical frame.
+    test(m"DAP expands an inline stop into subtle and real frames"):
+      import dynamicJsonAccess.enabled
+      val classpathText = System.properties.java.`class`.path()
+
+      supervise:
+        dapScenario: client ?=>
+          client.request(t"initialize")
+          client.awaitResponse(t"initialize")
+
+          val launchArgs =
+            Json.make(mainClass = t"vivisection.Inlined".in[Json], classpath = classpathText.in[Json])
+
+          client.request(t"launch", launchArgs)
+          client.awaitResponse(t"launch")
+
+          val source = Json.make(path = t"vivisection.Doubling.scala".in[Json])
+          val points = List(Json.make(line = 40.in[Json]))
+          client.request(t"setBreakpoints", Json.make(source = source, breakpoints = j"[$points*]"))
+          client.awaitResponse(t"setBreakpoints")
+          client.request(t"configurationDone")
+          client.awaitResponse(t"configurationDone")
+
+          val stopped = client.awaitEvent(t"stopped")
+          val thread = stopped.body.threadId.as[Int]
+
+          client.request(t"stackTrace", Json.make(threadId = thread.in[Json]))
+          val trace = client.awaitResponse(t"stackTrace")
+          val inline = trace.body.stackFrames(0)
+          val real = trace.body.stackFrames(1)
+
+          client.request(t"scopes", Json.make(frameId = inline.id.as[Int].in[Json]))
+          val scopes = client.awaitResponse(t"scopes")
+
+          client.request(t"disconnect")
+          client.awaitResponse(t"disconnect")
+
+          ( inline.presentationHint.as[Text], inline.source.name.as[Text], inline.line.as[Int],
+            real.source.name.as[Text], real.line.as[Int], scopes.success.as[Boolean] )
+
+    . assert(_ == (t"subtle", t"vivisection.Doubling.scala", 40,
+          t"vivisection.Inlined.scala", 40, true))
+
     test(m"a DAP request envelope decodes its routing fields"):
       import strategies.throwUnsafely
       val message = j"""{"seq": 3, "type": "request", "command": "initialize"}"""


### PR DESCRIPTION
The debugger now makes full use of the JSR-45 SMAPs proscala emits under `-Xjsr45`: stack frames inside inlined code expand into their logical positions, every reported line is the line the programmer wrote, and breakpoints bind inside inlined code — including code inlined from another file, whose class may never even load.

`digression.Smap` gains `sites`, the inverse of `expand`: where `expand` asks what a generated line stands for, `sites` asks where a source line went — one generated-line range per call site it was inlined into. The debugger fetches each class's `SourceDebugExtension` over the wire (memoized per session) and applies it in both directions: `Halt.positions` expands a stopped frame into its inline origins, innermost first, ending at the physical frame's real call-site line; and `Debug.locateIn` gains a second resolution pass through `sites`, unguarded by the class's own source file, so a breakpoint on an inline method's body binds at every inlined copy.

Through DAP, a stop inside inlined code now shows the full logical stack: inline frames marked `subtle` with the source file and line where the code was written, then the enclosing frame at its call site — and every stack frame now carries its `source`, so an editor can open the file. Scopes, variables, evaluation and frame restart against an inline frame transparently resolve to the enclosing physical frame.

```scala
// Doubling.scala               // Inlined.scala
inline def double(x: Int) =     def main(args: Array[String]): Unit =
  val doubled = x + x             val result = Doubling.double(21)   // ← body inlined here
  doubled                         println(result)
```

A breakpoint on `val doubled = x + x` — in a file whose class never loads at runtime — stops the program at the inlined copy, and the stack trace reads `Doubling.scala:40 (inlined)` above `Inlined.scala:40`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
