### PR TITLE
Show compiler-inferred type and using arguments on hover

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -3301,7 +3301,8 @@ object vivisection extends Library:
   // Expression evaluation: `anthology` compiles a synthetic class against the debuggee's
   // classpath and the Evaluator injects and runs it over JDWP. Kept out of `core` so the
   // compiler dependency does not reach a caller who only inspects variables.
-  object eval extends Component(core, anthology.`scala`, hellenism.jvm, stenography.core,
+  object eval extends Component(core, anthology.`scala`, hellenism.jvm, prophesy.core,
+      stenography.core,
       hyperbole.tasty):
     override def scalaJs = false // hosts the Scala compiler and debugs JVMs
     override def scalaNative = false

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -79,7 +79,11 @@ object SourceCode:
     // — when a caret is given — compute completions. Types are always read from the
     // typer-stopped run, so they stay source-level.
     val resolved
-    :   Optional[(Map[(Int, Int), Syntax], List[Diagnostic], Optional[Completions])] =
+    :   Optional
+          [ ( Map[(Int, Int), Syntax],
+              Map[(Int, Int), prophesy.Elaboration],
+              List[Diagnostic],
+              Optional[Completions] ) ] =
 
       if highlighting.depth == Depth.Tokenized then Unset else
         (highlighting.scalac, highlighting.classpath) match
@@ -91,8 +95,9 @@ object SourceCode:
             Unset
 
     val metaMap: Map[(Int, Int), Syntax] = resolved.lay(Map())(_(0))
-    val diagnostics: List[Diagnostic] = resolved.lay(Nil)(_(1))
-    val resolvedCompletions: Optional[Completions] = resolved.lay(Unset)(_(2))
+    val elaborations: Map[(Int, Int), prophesy.Elaboration] = resolved.lay(Map())(_(1))
+    val diagnostics: List[Diagnostic] = resolved.lay(Nil)(_(2))
+    val resolvedCompletions: Optional[Completions] = resolved.lay(Unset)(_(3))
 
     // Keyword completions come from the curated pattern tree over the reversed lexeme
     // context at the caret — no compiler run, so they are offered in every depth, including
@@ -199,7 +204,9 @@ object SourceCode:
         scanner.nextToken()
         val end = scanner.lastOffset max start
 
-        val meta: Optional[Token.Meta] = metaMap.at((start, end)).let(Token.Meta(_))
+        val meta: Optional[Token.Meta] =
+          metaMap.at((start, end)).let: syntax =>
+            Token.Meta(syntax, elaborations.at((start, end)))
 
         val annotation: Optional[TokenTag] = trees(start, end)
         val tokenAccent: Accent = annotation.lay(accent(token))(_.accent)
@@ -395,7 +402,10 @@ object SourceCode:
       classpath: LocalClasspath,
       full:      Boolean,
       caret:     Optional[Ordinal] )
-  :   (Map[(Int, Int), Syntax], List[Diagnostic], Optional[Completions]) =
+  :   ( Map[(Int, Int), Syntax],
+        Map[(Int, Int), prophesy.Elaboration],
+        List[Diagnostic],
+        Optional[Completions] ) =
 
     val cp = classpathText(classpath)
 
@@ -406,6 +416,7 @@ object SourceCode:
         context.setSetting(context.settings.YstopAfter, scala.collection.immutable.List("typer"))
 
     val metaMap = collectTypes(typerRun)
+    val elaborations = collectElaborations(typerRun)
 
     val completions = caret.let: caret =>
       // The interactive driver is the primary completion source: unlike the batch typer run,
@@ -427,7 +438,7 @@ object SourceCode:
 
         ._3
 
-    (metaMap, diagnostics, completions)
+    (metaMap, elaborations, diagnostics, completions)
 
   private def frontend
     ( text: Text, scalac: Scalac[?, ?], cp: Text )
@@ -696,6 +707,26 @@ object SourceCode:
       traverser.traverse(unit.tpdTree)
 
     types.to(Map)
+
+  // The call sites the typer elaborated beyond their source text, keyed — like
+  // `collectTypes` — by the callee token's offsets, so each attaches to the token the user
+  // hovers. The dotc tree crosses into the reflection API by the same cast `syntaxOf` uses
+  // for types.
+  private def collectElaborations(run: Run): Map[(Int, Int), prophesy.Elaboration] =
+    given context: Contexts.Context =
+      dotty.tools.dotc.quoted.QuotesCache.init(run.runContext.fresh)
+
+    given quotes: scala.quoted.Quotes = scala.quoted.runtime.impl.QuotesImpl()(using context)
+
+    val found: scm.HashMap[(Int, Int), prophesy.Elaboration] = scm.HashMap()
+
+    run.units.each: unit =>
+      val root = unit.tpdTree.asInstanceOf[quotes.reflect.Tree]
+
+      prophesy.Elaboration.scan(root).each: elaboration =>
+        found((elaboration.start, elaboration.end)) = elaboration
+
+    found.to(Map)
 
 case class SourceCode
   ( language:    ProgrammingLanguage,

--- a/lib/harlequin/src/core/harlequin.Token.scala
+++ b/lib/harlequin/src/core/harlequin.Token.scala
@@ -58,7 +58,9 @@ object Token:
 
     t"Token($fields ╱ span:${token.span.inspect} ╱ role:$role)"
 
-  case class Meta(tpe: Syntax)
+  // `elaboration` is present on a callee token whose call the typer elaborated beyond its
+  // source text: inferred type arguments or synthesized `using` arguments.
+  case class Meta(tpe: Syntax, elaboration: Optional[prophesy.Elaboration] = Unset)
 
 // `span` locates the token in its `SourceCode`: a `Line`-mode `Span` carrying the
 // token's 0-based line and column and its length. It is `Span.empty` until the

--- a/lib/harlequin/src/test/harlequin_test.scala
+++ b/lib/harlequin/src/test/harlequin_test.scala
@@ -217,6 +217,37 @@ object Tests extends Suite(m"Harlequin Tests"):
       Scala.highlight(source, caret = source.length.z).completions.lay(Nil)(_.items.map(_.name))
     .assert(!_.has(t"diet"))
 
+    // Elaborations record what the typer added at a call site — inferred type arguments and
+    // synthesized `using` arguments — on the callee's token, and never anything written.
+    suite(m"Elaborations"):
+      def elaborationsOf(source: Text, word: Text): scala.List[prophesy.Elaboration] =
+        given Scalac[3.8, Universe.Classfile] = Scalac[3.8](Nil)
+        given LocalClasspath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
+        import highlighting.typecheckedScala
+
+        Scala.highlight(source).lines.to[List].stdlib.flatMap(_.stdlib)
+        . filter(_.text == word)
+        . flatMap(_.meta.let(_.elaboration).option)
+
+      val snippet =
+        t"def pick[element](x: element)(using Ordering[element]): element = x\nval chosen = pick(9)"
+
+      test(m"an inferred type argument is recorded on the callee token"):
+        elaborationsOf(snippet, t"pick").flatMap(_.typeArguments.stdlib).map(_.qualified)
+      . assert(_.exists(_.subsumes(t"Int")))
+
+      test(m"a synthesized using argument names the resolved given"):
+        elaborationsOf(snippet, t"pick").flatMap(_.givenArguments.stdlib).map(_.name)
+      . assert(_.exists(_.subsumes(t"Ordering")))
+
+      test(m"explicit arguments are never recorded"):
+        val explicit =
+          t"def pick[element](x: element)(using Ordering[element]): element = x\n"
+          + t"val chosen = pick[Int](9)(using Ordering.Int)"
+
+        elaborationsOf(explicit, t"pick")
+      . assert(_.isEmpty)
+
     // Fragment analysis is pure text+lexer work — no compiler givens — so a completion host
     // can split its input before deciding whether to invoke the typechecker at all.
     suite(m"Fragment analysis"):

--- a/lib/prophesy/src/core/prophesy.Elaboration.scala
+++ b/lib/prophesy/src/core/prophesy.Elaboration.scala
@@ -1,0 +1,150 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package prophesy
+
+import scala.collection.immutable as sci
+import scala.collection.mutable as scm
+import scala.quoted.*
+import scala.util.control.NonFatal
+
+import anticipation.*
+import stenography.*
+import vacuous.*
+
+@unexported
+object Elaboration:
+  // The resolved given the compiler supplied for one synthesized `using` argument: the head
+  // symbol's qualified name (for a derived instance, the derivation method's) and the
+  // argument's widened type.
+  case class Instance(name: Text, tpe: Syntax)
+
+  // Scans a typed tree for the call sites the typer elaborated beyond what was written,
+  // recording each call's inferred type arguments and synthesized `using` arguments. The
+  // predicates are chosen to survive TASTy pickling, so the same scan serves a live typer run
+  // and unpickled trees alike:
+  //
+  //  - An inferred type argument carries the whole span of the function tree it was wrapped
+  //    around (`wrapInTypeTree`), so `targ.pos == fun.pos`; a written argument always starts
+  //    after the callee ends. (`InferredTypeTree`-ness itself does not survive pickling.)
+  //  - A synthesized `using` argument is inferred at the application's end position, so it is
+  //    zero-extent exactly at the end of the clause's function tree; the clause itself is
+  //    recognized by its method type, since `ApplyKind` attachments do not survive pickling.
+  //
+  // An `Inlined` node contributes its original call and is not descended into: the expansion's
+  // trees carry the inline definition's own source positions, which would misattribute its
+  // internal calls to this file. The scan never fails: a node that cannot be read is skipped.
+  def scan(using quotes: Quotes)(root: quotes.reflect.Tree): List[Elaboration] =
+    import quotes.reflect.*
+
+    val calls: scm.LinkedHashMap[(Text, Int, Int), (sci.List[Syntax], sci.List[Instance])] =
+      scm.LinkedHashMap()
+
+    def peel(term: Term): Term = term match
+      case Apply(fun, _)     => peel(fun)
+      case TypeApply(fun, _) => peel(fun)
+      case _                 => term
+
+    // The callee's own token position: the name segment of a selection, or the whole
+    // identifier. Approximated as the trailing `name.length` characters of a selection, which
+    // misplaces backticked and interpolated names; harmless, since a mismatched key attaches to
+    // no token.
+    def callee(term: Term): Optional[(Text, Int, Int)] = peel(term) match
+      case select @ Select(_, name) =>
+        val pos = select.pos
+        if pos.end <= 0 then Unset else (name.tt, (pos.end - name.length).max(0), pos.end)
+
+      case ident @ Ident(name) =>
+        val pos = ident.pos
+        if pos.end <= 0 then Unset else (name.tt, pos.start, pos.end)
+
+      case _ =>
+        Unset
+
+    def merge(key: (Text, Int, Int), types: sci.List[Syntax], givens: sci.List[Instance]): Unit =
+      val (types0, givens0) = calls.getOrElse(key, (sci.List(), sci.List()))
+      calls(key) = (types0 ++ types, givens0 ++ givens)
+
+    def record(term: Term): Unit = term match
+      case TypeApply(fun, targs) =>
+        val inferred = targs.filter: targ =>
+          targ.pos.start == fun.pos.start && targ.pos.end == fun.pos.end
+
+        if !inferred.isEmpty then callee(fun).let: key =>
+          merge(key, inferred.map { targ => Syntax(targ.tpe) }, sci.List())
+
+      case apply @ Apply(fun, args) =>
+        val contextual = fun.tpe.widenTermRefByName match
+          case tpe: MethodType => tpe.isImplicit || tpe.isContextual
+          case _               => false
+
+        val synthesized = args.filter: arg =>
+          arg.pos.start == arg.pos.end && arg.pos.start == fun.pos.end
+
+        if contextual && !synthesized.isEmpty then callee(fun).let: key =>
+          val instances = synthesized.map: arg =>
+            Instance(peel(arg).symbol.fullName.tt, Syntax(arg.tpe.widenTermRefByName))
+
+          merge(key, sci.List(), instances)
+
+      case _ =>
+        ()
+
+    object walker extends TreeAccumulator[Unit]:
+      def foldTree(unit: Unit, tree: Tree)(owner: Symbol): Unit = tree match
+        case Inlined(call, _, _) =>
+          call.foreach(foldTree((), _)(owner))
+
+        case term: Term =>
+          try record(term) catch case NonFatal(_) => ()
+          foldOverTree((), tree)(owner)
+
+        case _ =>
+          foldOverTree((), tree)(owner)
+
+    try walker.foldTree((), root)(root.symbol) catch case NonFatal(_) => ()
+
+    val results = calls.toSeq.map: (key, entry) =>
+      Elaboration(key(0), key(1), key(2), List(entry(0)*), List(entry(1)*))
+
+    List(results.sortBy(_.start)*)
+
+// One call site the typer elaborated beyond its source text: `method` is the callee's simple
+// name and `start`/`end` its source offsets (the hoverable token), `typeArguments` the
+// *inferred* type arguments only, and `givenArguments` the *synthesized* `using` arguments
+// only — anything written in the source is never recorded.
+case class Elaboration
+  ( method:         Text,
+    start:          Int,
+    end:            Int,
+    typeArguments:  List[Syntax],
+    givenArguments: List[Elaboration.Instance] )

--- a/lib/vivisection/src/dap/vivisection.Dap.scala
+++ b/lib/vivisection/src/dap/vivisection.Dap.scala
@@ -186,6 +186,7 @@ object Dap:
       supportsExceptionInfoRequest:     Boolean = true,
       supportsRestartFrame:             Boolean = true,
       supportsCompletionsRequest:       Boolean = true,
+      supportsEvaluateForHovers:        Boolean = true,
       completionTriggerCharacters:      List[Text] = List(t"."),
       exceptionBreakpointFilters:       List[ExceptionFilter] = Dap.exceptionFilters )
 

--- a/lib/vivisection/src/dap/vivisection.DapSession.scala
+++ b/lib/vivisection/src/dap/vivisection.DapSession.scala
@@ -578,15 +578,50 @@ private[vivisection] class DapSession(emit: Json => Unit)
       case t"evaluate" =>
         val arguments = json.arguments.as[Dap.EvaluateArguments]
 
-        withFrame(request, arguments.frameId): (thread, halt) =>
-          withClasspath(request): classpath =>
-            val result = halt.evaluator(classpath): eval ?=> eval(arguments.expression)
+        // A hover must never run debuggee code (it fires on mere cursor movement), so it serves
+        // only side-effect-free answers: the value and static type of a visible local, and the
+        // elaboration of a call named in the stopped method. Anything else returns no hover.
+        // Every other context (`repl`, `watch`, absent) evaluates as before.
+        if arguments.context == t"hover" then
+          withFrame(request, arguments.frameId): (thread, halt) =>
+            withClasspath(request): classpath =>
+              // The evaluator block returns only pure data — the local's rendering and the raw
+              // elaborations — so nothing capturing the session escapes it; the one-line
+              // rendering happens outside.
+              val (local, calls) =
+                halt.evaluator(classpath): eval ?=>
+                  val rendered: Optional[Text] =
+                    eval.variables().seek(_.name == arguments.expression).let: variable =>
+                      val value = variable.value.lay(t"")(_.inspect)
+                      t"$value: ${variable.static.or(variable.erased)}"
 
-            val rendered = result match
-              case Variable.Snapshot.Str(_, text) => text
-              case other                          => other.inspect
+                  val found = eval.elaborations().filter(_.method == arguments.expression)
 
-            respond(request, Dap.EvaluateBody(rendered).in[Json])
+                  (rendered, found)
+
+              val callText: Optional[Text] = calls match
+                case Nil   => Unset
+                case found => found.map(renderElaboration).join(t"\n")
+
+              val answer: Optional[Text] = (local, callText) match
+                case (l: Text, c: Text) => t"$l\n$c"
+                case (l: Text, _)       => l
+                case (_, c: Text)       => c
+                case _                  => Unset
+
+              answer match
+                case text: Text => respond(request, Dap.EvaluateBody(text).in[Json])
+                case _          => fail(request, t"no hover information is available")
+        else
+          withFrame(request, arguments.frameId): (thread, halt) =>
+            withClasspath(request): classpath =>
+              val result = halt.evaluator(classpath): eval ?=> eval(arguments.expression)
+
+              val rendered = result match
+                case Variable.Snapshot.Str(_, text) => text
+                case other                          => other.inspect
+
+              respond(request, Dap.EvaluateBody(rendered).in[Json])
 
       case t"completions" =>
         val arguments = json.arguments.as[Dap.CompletionsArguments]
@@ -729,6 +764,21 @@ private[vivisection] class DapSession(emit: Json => Unit)
 
       completions.items.map: item =>
         Dap.CompletionItem(item.name, kindName(item.kind), start, length)
+
+  // A one-line rendering of an elaborated call: the callee, its inferred type arguments in
+  // brackets, the written value arguments elided as `…`, and each synthesized `using` argument
+  // named by the given it resolved to. Only the inferred pieces are real; the `(…)` is a
+  // placeholder standing in for whatever the programmer wrote.
+  private def renderElaboration(elaboration: prophesy.Elaboration): Text =
+    val types = elaboration.typeArguments match
+      case Nil  => t""
+      case args => t"[${args.map(_.qualified).join(t", ")}]"
+
+    val givens = elaboration.givenArguments match
+      case Nil  => t""
+      case args => t"(using ${args.map(_.name).join(t", ")})"
+
+    t"${elaboration.method}$types(…)$givens"
 
   private def kindName(kind: prophesy.Completion.Kind): Text =
     import prophesy.Completion.Kind

--- a/lib/vivisection/src/eval/vivisection.Evaluator.scala
+++ b/lib/vivisection/src/eval/vivisection.Evaluator.scala
@@ -236,6 +236,14 @@ extends caps.ExclusiveCapability:
 
       . or(Jdwp.Value.Void)
 
+  // The elaborated call sites of the frame's method — the pieces the compiler inserted at each
+  // call, inferred type arguments and synthesized `using` arguments — read from the debuggee's
+  // own TASTy, so they reflect what actually runs. A hover surface's raw material.
+  def elaborations(): List[prophesy.Elaboration] =
+    halt.topFrame.lay(List()): (_, location) =>
+      val owner = Variable.demangle(connection.signature(location.cls))
+      purview.elaborations(owner, methodName(location.cls, location.method))
+
   // The frame's visible variables, each enriched with its declared static type where one can be
   // recovered from TASTy — the `stenography` rendering the user sees as `Variable.static`. A
   // binding whose static type could not be recovered (a non-parameter local, for now) keeps

--- a/lib/vivisection/src/eval/vivisection.Purview.scala
+++ b/lib/vivisection/src/eval/vivisection.Purview.scala
@@ -84,7 +84,12 @@ class Purview(classpath: LocalClasspath):
         val array = args.toArray(new scala.Array[String | Null](0)).nn
         setup(array.asInstanceOf[scala.Array[String]], initCtx.fresh).map(_(1)).get
 
-    val base = driver.context.fresh.setReporter(Reporter.NoReporter)
+    // `ReadPositions` makes the unpickler read the TASTy Positions section, so unpickled trees
+    // carry their source spans — which is how `elaborations` tells inferred arguments from
+    // written ones. It must be present before the first class loads: completers snapshot the
+    // context's mode at symbol-creation time and replay it when the tree is later forced.
+    val base =
+      driver.context.fresh.addMode(dtd.core.Mode.ReadPositions).setReporter(Reporter.NoReporter)
     val run = dtd.Compiler().newRun(using base)
     // `.stdlib`: `Compiler.Run#compileSources` is a `dotty.tools.dotc` API, which takes the
     // compiler's own `sci.List`.
@@ -153,6 +158,28 @@ class Purview(classpath: LocalClasspath):
       entries.to(Map)
 
     catch case scala.util.control.NonFatal(_) => Map()
+
+  // The call sites in the method's body which the typer elaborated beyond their source text:
+  // inferred type arguments and synthesized `using` arguments, read from the same unpickled
+  // tree `bindings` walks — so what is reported is what the running bytecode was actually
+  // compiled from, not a re-typing of the source. Offsets are into the method's source file.
+  // Degrades to an empty list on any failure.
+  def elaborations(className: Text, methodName: Text): List[prophesy.Elaboration] =
+    try
+      given Contexts.Context = context
+      val quotes = scala.quoted.runtime.impl.QuotesImpl()
+
+      val cls = Symbols.requiredClass(className.s)
+      val method = cls.requiredMethod(methodName.s)
+
+      method.defTree match
+        case defDef: tpd.DefDef =>
+          prophesy.Elaboration.scan(using quotes)(defDef.asInstanceOf[quotes.reflect.Tree])
+
+        case _ =>
+          List()
+
+    catch case scala.util.control.NonFatal(_) => List()
 
   // The human-facing rendering of each value parameter's declared type, through `stenography` —
   // capture-set-aware and source-accurate — keyed by name. This is what a debugger surfaces to the

--- a/lib/vivisection/src/test/vivisection.Elaborated.scala
+++ b/lib/vivisection/src/test/vivisection.Elaborated.scala
@@ -1,0 +1,56 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package vivisection
+
+// A debuggee for hover tests: `combine(3, 4)` is written with no type argument and no `using`
+// clause, but the typer elaborates it to `combine[Int](3, 4)(using intSemigroup)`. The call
+// sits inside a regular class method (as `Menagerie` does), so the frame's class resolves the
+// same way; the suite breaks at the `println`, where the call above it is live in the method's
+// retained tree, so the elaboration is recoverable from the debuggee's own TASTy.
+object Elaborated:
+  trait Semigroup[value]:
+    def append(left: value, right: value): value
+
+  given intSemigroup: Semigroup[Int] = new Semigroup[Int]:
+    def append(left: Int, right: Int): Int = left + right
+
+  def combine[value](left: value, right: value)(using semigroup: Semigroup[value]): value =
+    semigroup.append(left, right)
+
+  def main(args: Array[String]): Unit =
+    Runner().run()
+
+  class Runner():
+    def run(): Unit =
+      val total = combine(3, 4)
+      System.out.nn.println(total)

--- a/lib/vivisection/src/test/vivisection_test.scala
+++ b/lib/vivisection/src/test/vivisection_test.scala
@@ -1106,6 +1106,66 @@ object Tests extends Suite(m"Vivisection tests"):
 
     . assert(_ == (true, true, true))
 
+    // Hover elaboration and value/type inspection, none of which runs debuggee code: a hover on
+    // a call name shows what the typer inferred (`combine[Int](…)(using intSemigroup)`), a hover
+    // on a local shows its value and static type, and a hover on an arbitrary expression is
+    // refused rather than executed — while the console still evaluates that same expression.
+    test(m"a DAP client hovers without executing debuggee code"):
+      import dynamicJsonAccess.enabled
+      val classpathText = System.properties.java.`class`.path()
+
+      supervise:
+        dapScenario: client ?=>
+          client.request(t"initialize")
+          client.awaitResponse(t"initialize")
+
+          val launchArgs =
+            Json.make(mainClass = t"vivisection.Elaborated".in[Json], classpath = classpathText.in[Json])
+
+          client.request(t"launch", launchArgs)
+          client.awaitResponse(t"launch")
+
+          val source = Json.make(path = t"vivisection.Elaborated.scala".in[Json])
+          val points = List(Json.make(line = 56.in[Json]))
+          val setArgs = Json.make(source = source, breakpoints = j"[$points*]")
+
+          client.request(t"setBreakpoints", setArgs)
+          client.awaitResponse(t"setBreakpoints")
+          client.request(t"configurationDone")
+          client.awaitResponse(t"configurationDone")
+
+          val stopped = client.awaitEvent(t"stopped")
+          val thread = stopped.body.threadId.as[Int]
+
+          client.request(t"stackTrace", Json.make(threadId = thread.in[Json]))
+          val trace = client.awaitResponse(t"stackTrace")
+          val frame = trace.body.stackFrames(0).id.as[Int]
+
+          def evaluate(expression: Text, context: Optional[Text]): Json =
+            val base =
+              Json.make(expression = expression.in[Json], frameId = frame.in[Json])
+
+            val arguments = context.lay(base): ctx =>
+              base.updateDynamic("context")(ctx.in[Json])
+
+            client.request(t"evaluate", arguments)
+            client.awaitResponse(t"evaluate")
+
+          val callHover = evaluate(t"combine", t"hover").body.result.as[Text]
+          val localHover = evaluate(t"total", t"hover").body.result.as[Text]
+          val exprHover = evaluate(t"total + 1", t"hover").success.as[Boolean]
+          val consoleEval = evaluate(t"total + 1", Unset).body.result.as[Text]
+
+          client.request(t"disconnect")
+          client.awaitResponse(t"disconnect")
+
+          ( callHover.contains(t"[scala.Int]") && callHover.contains(t"intSemigroup"),
+            localHover.contains(t"7") && localHover.contains(t"scala.Int"),
+            exprHover,
+            consoleEval )
+
+    . assert(_ == (true, true, false, t"8"))
+
     // The transport itself, over real pipes: `initialize` and `disconnect` without ever opening
     // a debuggee, so this exercises the framing and the server's teardown-on-EOF in isolation.
     test(m"a DAP server initializes and disconnects over stdio"):


### PR DESCRIPTION
Source `bar(baz)` may elaborate to `bar[Foo](baz)(using quux)`; this makes those inferred pieces visible. A compiler-free model in prophesy carries them, filled by two producers — a live typer run (for a future LSP server) and the debuggee's own TASTy (for the debugger) — and the DAP adapter surfaces them on hover without ever executing debuggee code.

## Release notes

### Inferred call elaboration, as a reusable model

`prophesy.Elaboration` records the type arguments and `using` arguments the typer inserts at a call site that the programmer never wrote, keyed to the callee token. `Elaboration.scan` is a single `quotes.reflect` extractor with no compiler dependency, so it runs against a live typer run and against unpickled TASTy alike — the predicates that tell an inferred argument from a written one (an inferred type argument carries the callee's own span; a synthesized `using` argument is zero-extent at an implicit clause's end) are chosen to survive pickling.

### Elaborations on harlequin tokens

`harlequin.Token.Meta` gains an optional `elaboration`, populated for callee tokens during the typechecked highlight — so a completion or hover host (an LSP server) reads inferred arguments straight off the token, beside its type.

### Hover in the debugger, without side effects

The DAP adapter advertises `supportsEvaluateForHovers` and answers a hover (`evaluate` with `context: "hover"`) from static information only: a local's value and static type, or a call's elaboration read from the debuggee's own TASTy —

```
combine[scala.Int](…)(using intSemigroup)
```

An `evaluate` for hover never compiles or runs code in the debuggee, which a hover (firing on mere cursor movement) must not do; an expression it cannot answer statically is refused rather than executed. The console (`repl`/`watch`) still evaluates arbitrary expressions as before.
