### PR TITLE
Scale every declared measurement duration by `--scale=<factor>`

### DIFF
--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -197,7 +197,7 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
       try
         runner.suite(testableView, run())
 
-        runner.listed.each: (id, kind) =>
+        runner.listed.each: (id, kind, _) =>
           val path =
             def names(id: Test.Id): List[Text] =
               id.suite.let { suite => names(suite.id) }.or(Nil) :+ id.moniker.or(id.name.text)
@@ -243,8 +243,8 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
       try
         runner.suite(testableView, run())
 
-        runner.listed.each: (id, kind) =>
-          sink(TestEvent.TestScheduled(TestEvent.Ref.of(id), TestEvent.kindName(kind)))
+        runner.listed.each: (id, kind, expected) =>
+          sink(TestEvent.TestScheduled(TestEvent.Ref.of(id), TestEvent.kindName(kind), expected))
 
         0
       catch case error: Throwable => 2

--- a/lib/probably/src/core/probably.Runner.scala
+++ b/lib/probably/src/core/probably.Runner.scala
@@ -59,7 +59,7 @@ extends Findable:
   @scala.caps.unsafe.untrackedCaptures
   private var active: List[Test.Id] = Nil
   @scala.caps.unsafe.untrackedCaptures
-  private var listed0: List[(Test.Id, Entry.Kind)] = Nil
+  private var listed0: List[(Test.Id, Entry.Kind, Optional[Long])] = Nil
   @scala.caps.unsafe.untrackedCaptures
   private var admitted0: Int = 0
   private val silent: Boolean = Ci.claudeCode || Ci()
@@ -74,15 +74,42 @@ extends Findable:
   // Whether a test (or one cell of an axial test) is excluded by the selection. In listing
   // mode every test is skipped, and those the selection admits are noted for enumeration.
   def skip(id: Test.Id, kind: Entry.Kind, coordinates: List[(Axis.Spec, Value)]): Boolean =
+    skip(id, kind, coordinates, Unset)
+
+  // As above, but with the caller's estimate of how many NANOSECONDS the test will spend
+  // measuring — declared metadata, not a promise — recorded against the schedule so a host
+  // can budget a whole run (fume's `--target`) before anything has been staged. The timed
+  // kinds supply it; plain checks have no meaningful duration and pass `Unset`.
+  def skip
+    ( id:          Test.Id,
+      kind:        Entry.Kind,
+      coordinates: List[(Axis.Spec, Value)],
+      expected:    Optional[Long] )
+  :   Boolean =
+
     if !selection.admits(id, kind, coordinates) then true
     else if selection.listOnly then
-      mutex { listed0 = (id, kind) :: listed0 }
+      mutex { listed0 = (id, kind, expected) :: listed0 }
       true
     else
       mutex { admitted0 += 1 }
       false
 
-  def listed: List[(Test.Id, Entry.Kind)] = mutex(listed0.reverse.distinct)
+  // One schedule row per test, in first-appearance order — an axial spread's cells each call
+  // `skip`, but they are one test with coordinates, not many tests — with the row's expected
+  // time the SUM over its admitted cells: what the test will spend measuring is the total of
+  // the cells the selection admits. Absent estimates stay absent rather than becoming zero.
+  def listed: List[(Test.Id, Entry.Kind, Optional[Long])] = mutex:
+    val entries = listed0.reverse
+
+    entries.map { (id, kind, _) => (id, kind) }.distinct.map: (id, kind) =>
+      val expected: Optional[Long] =
+        entries.fold(Unset: Optional[Long]): (sum, entry) =>
+          if entry(0) == id && entry(1) == kind
+          then entry(2).lay(sum) { value => sum.lay(value)(_ + value) }
+          else sum
+
+      (id, kind, expected)
   def admitted: Int = mutex(admitted0)
 
   val report: report = reporter.report()

--- a/lib/probably/src/core/probably.Runner.scala
+++ b/lib/probably/src/core/probably.Runner.scala
@@ -66,6 +66,11 @@ extends Findable:
 
   def skip(id: Test.Id): Boolean = skip(id, Entry.Kind.Check, Nil)
 
+  // The selection's duration multiplier, which the timed kinds apply to their declared
+  // targets. It lives on the runner because that is what sedentary already has in hand at
+  // the point where a measurement's length is decided.
+  def scale: Double = selection.scale
+
   // Whether a test (or one cell of an axial test) is excluded by the selection. In listing
   // mode every test is skipped, and those the selection admits are noted for enumeration.
   def skip(id: Test.Id, kind: Entry.Kind, coordinates: List[(Axis.Spec, Value)]): Boolean =

--- a/lib/probably/src/core/probably.Selection.scala
+++ b/lib/probably/src/core/probably.Selection.scala
@@ -56,7 +56,7 @@ object Selection:
 
     def axis: Text
 
-  val all: Selection = Selection(Nil, Nil, Nil, false)
+  val all: Selection = Selection(Nil, Nil, Nil, false, 1.0)
 
   private def hex(text: Text): Boolean =
     text.length == 6 && text.s.forall: char => char.isDigit || (char >= 'a' && char <= 'f')
@@ -74,6 +74,13 @@ object Selection:
   def parse(arguments: List[Text]): Selection =
     arguments.fold(all): (selection, argument) =>
       if argument == t"--list" then selection.copy(listOnly = true)
+      // `--scale=<factor>` is not a selection at all — it changes how long the tests it
+      // admits are given to run — but it arrives on the same command line, and a host like
+      // fume has no other channel to a suite. A non-positive or unparseable factor is
+      // ignored rather than fatal: a mistyped duration should not lose a run's results.
+      else if argument.starts(t"--scale=") then
+        number(argument.skip(8)).lay(selection): factor =>
+          if factor > 0.0 then selection.copy(scale = factor) else selection
       else if argument.starts(t"kind:") then
         val kinds = argument.skip(5) match
           case t"test"    => List(Entry.Kind.Check)
@@ -119,7 +126,13 @@ case class Selection
   ( terms:       List[Selection.Term],
     kinds:       List[Entry.Kind],
     constraints: List[Selection.Constraint],
-    listOnly:    Boolean ):
+    listOnly:    Boolean,
+    // The multiplier applied to every declared target DURATION — `Bench`'s, `Stress`'s and
+    // `Profile`'s — so that a whole run can be made proportionally longer (a careful
+    // overnight pass) or shorter (a quick check) without editing the suite. Geometric, and
+    // 1.0 by default: 2.0 runs each measurement twice as long, 0.25 a quarter as long.
+    // Latency thresholds are NOT scaled: they are pass/fail criteria, not durations.
+    scale:       Double ):
 
   def trivial: Boolean = terms.nil && kinds.nil && constraints.nil
 

--- a/lib/probably/src/core/probably.TestEvent.scala
+++ b/lib/probably/src/core/probably.TestEvent.scala
@@ -193,8 +193,11 @@ object TestEvent:
 
 enum TestEvent:
   // The SCHEDULE: one per test a `--list` selection admits, before anything runs, so a
-  // consumer can pre-render every expected row and fill it in as results arrive.
-  case TestScheduled(test: TestEvent.Ref, kind: Text)
+  // consumer can pre-render every expected row and fill it in as results arrive. For the
+  // timed kinds, `expected` estimates (from declared metadata, in nanoseconds, under any
+  // `--scale` in force) how long the test will spend measuring, so a host can budget a
+  // whole run before staging anything; plain checks carry no estimate.
+  case TestScheduled(test: TestEvent.Ref, kind: Text, expected: Optional[Long])
 
   case SuiteStarted(suite: TestEvent.Ref, timestamp: Long)
   case SuiteEnded(suite: TestEvent.Ref, timestamp: Long)

--- a/lib/probably/src/test/probably_test.scala
+++ b/lib/probably/src/test/probably_test.scala
@@ -52,3 +52,20 @@ object Tests extends Suite(m"Probably Tests"):
     test(m"biaxial spread with a gap").over(Axis(t"x")(1, 2, 3), Axis(t"y")(10, 20)):
       case (x, y) if x + y != 23 => x*y
     . assert((x, y, result) => result == x*y)
+
+    test(m"a run's duration multiplier defaults to 1"):
+      Selection.all.scale
+    . assert(_ == 1.0)
+
+    test(m"--scale sets the duration multiplier"):
+      Selection.parse(List(t"--scale=2.5")).scale
+    . assert(_ == 2.5)
+
+    test(m"--scale is not mistaken for a name term"):
+      Selection.parse(List(t"--scale=2")).terms
+    . assert(_ == Nil)
+
+    test(m"a non-positive or unparseable scale leaves the default"):
+      List(t"--scale=0", t"--scale=-1", t"--scale=soon").map(term => Selection.parse(List(term)).scale)
+    . assert(_ == List(1.0, 1.0, 1.0))
+

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -132,6 +132,13 @@ object Bench:
   private[sedentary] def scaled(target: Long, scale: Double): Long =
     if scale == 1.0 then target else ((target*scale).toLong).max(1000L)
 
+  // The expected measuring time of one cell, from its declared metadata: `warmups` then
+  // `iterations` batches, each of `target/iterations`. The calibration phase (doubling until
+  // one batch fits) and the ten untimed warmup runs are not counted — they are body-dependent
+  // and usually small. An estimate for budgeting, not a promise.
+  private[sedentary] def expected(target: Long, iterations: Int, warmups: Int): Long =
+    target*(iterations + warmups).toLong/iterations.max(1).toLong
+
   private[sedentary] def measured
     ( iterations: Int, warmups: Int, target: Long )
     ( body0: (References over Json) ?=> Quotes ?=> Expr[Any] )
@@ -265,7 +272,9 @@ object Bench:
       val testId = Test.Id(name, suite, codepoint)
       val target2: Long = Bench.scaled(target, runner.scale)
 
-      if !runner.skip(testId, Entry.Kind.Bench, Nil) then
+      val expected: Optional[Long] = Bench.expected(target2, iterations, warmups)
+
+      if !runner.skip(testId, Entry.Kind.Bench, Nil, expected) then
         val results0 = bench.dispatch(Bench.measured(iterations, warmups, target2)(body0))
 
         inclusion.include
@@ -305,7 +314,10 @@ object Bench:
         val coordinates = List(axis.coordinate(value))
 
         // An unselected cell is skipped BEFORE staging: it costs no compilation and no JVM.
-        if probe.isDefinedAt(value) && !runner.skip(testId, Entry.Kind.Bench, coordinates) then
+        if probe.isDefinedAt(value)
+            && !runner.skip(testId, Entry.Kind.Bench, coordinates,
+                            Bench.expected(target2, iterations, warmups))
+        then
           val results0 =
             bench.dispatch(Bench.measured(iterations, warmups, target2)(body(value)))
 
@@ -367,7 +379,9 @@ object Bench:
 
           val coordinates = List(first.coordinate(left), second.coordinate(right))
 
-          if probe.isDefinedAt((left, right)) && !runner.skip(testId, Entry.Kind.Bench, coordinates)
+          if probe.isDefinedAt((left, right))
+              && !runner.skip(testId, Entry.Kind.Bench, coordinates,
+                              Bench.expected(target2, iterations, warmups))
           then
             val results0 =
               bench.dispatch(Bench.measured(iterations, warmups, target2)(body((left, right))))

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -126,6 +126,12 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
 object Bench:
   // The staged measurement harness, shared by every cell of every plan: warmup, doubling
   // calibration, median-rate count selection, then `iterations` timed batches.
+  // A declared target duration under the run's multiplier, floored at a microsecond so that
+  // an absurdly small factor still leaves something measurable rather than a zero-length
+  // batch (which would divide by zero in `measured`).
+  private[sedentary] def scaled(target: Long, scale: Double): Long =
+    if scale == 1.0 then target else ((target*scale).toLong).max(1000L)
+
   private[sedentary] def measured
     ( iterations: Int, warmups: Int, target: Long )
     ( body0: (References over Json) ?=> Quotes ?=> Expr[Any] )
@@ -257,9 +263,10 @@ object Bench:
     :   Unit raises Compiler.Error raises Rig.Error =
 
       val testId = Test.Id(name, suite, codepoint)
+      val target2: Long = Bench.scaled(target, runner.scale)
 
       if !runner.skip(testId, Entry.Kind.Bench, Nil) then
-        val results0 = bench.dispatch(Bench.measured(iterations, warmups, target)(body0))
+        val results0 = bench.dispatch(Bench.measured(iterations, warmups, target2)(body0))
 
         inclusion.include
           ( runner.report,
@@ -280,6 +287,7 @@ object Bench:
     :   Unit raises Compiler.Error raises Rig.Error =
 
       val testId = Test.Id(name, suite, codepoint)
+      val target2: Long = Bench.scaled(target, runner.scale)
       val values = axis.values
 
       // Definedness may not depend on the staging context, so gaps are probed under a
@@ -299,7 +307,7 @@ object Bench:
         // An unselected cell is skipped BEFORE staging: it costs no compilation and no JVM.
         if probe.isDefinedAt(value) && !runner.skip(testId, Entry.Kind.Bench, coordinates) then
           val results0 =
-            bench.dispatch(Bench.measured(iterations, warmups, target)(body(value)))
+            bench.dispatch(Bench.measured(iterations, warmups, target2)(body(value)))
 
           inclusion.include
             ( runner.report,
@@ -339,6 +347,7 @@ object Bench:
     :   Unit raises Compiler.Error raises Rig.Error =
 
       val testId = Test.Id(name, suite, codepoint)
+      val target2: Long = Bench.scaled(target, runner.scale)
       val lefts = first.values
       val rights = second.values
 
@@ -361,7 +370,7 @@ object Bench:
           if probe.isDefinedAt((left, right)) && !runner.skip(testId, Entry.Kind.Bench, coordinates)
           then
             val results0 =
-              bench.dispatch(Bench.measured(iterations, warmups, target)(body((left, right))))
+              bench.dispatch(Bench.measured(iterations, warmups, target2)(body((left, right))))
 
             inclusion.include
               ( runner.report,

--- a/lib/sedentary/src/core/sedentary.Profile.scala
+++ b/lib/sedentary/src/core/sedentary.Profile.scala
@@ -99,7 +99,7 @@ extends Rig:
     val frames2: Int = frames0.or(25)
 
     val body: (References over Transport) ?=> Quotes ?=> Expr[List[Text]] =
-      val target2: Expr[Long] = Expr(target.generic)
+      val target2: Expr[Long] = Expr(Bench.scaled(target.generic, runner.scale))
       ' {
           // Blackhole sink, exactly as in `Bench`: each body result is written here via
           // lazySet so that the JIT cannot prove the body's value is unused and elide it. The

--- a/lib/sedentary/src/core/sedentary.Profile.scala
+++ b/lib/sedentary/src/core/sedentary.Profile.scala
@@ -174,7 +174,8 @@ extends Rig:
               (count.toString + "\t" + key).tt
         }
 
-    if !runner.skip(testId, Entry.Kind.Profile, Nil) then
+    // A profile records for its (scaled) target duration, so the declared time is the estimate.
+    if !runner.skip(testId, Entry.Kind.Profile, Nil, Bench.scaled(target.generic, runner.scale)) then
       val results = dispatch(body)
 
       val hotspots =

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -159,7 +159,9 @@ extends Rig:
     val complianceBp: Long = compliance0.lay(-1L)(_*100L)
 
     val body: (References over Transport) ?=> Quotes ?=> Expr[List[Long]] =
-      val target2: Expr[Long] = Expr(target.generic)
+      // Scaled by the run's duration multiplier; the `threshold` below deliberately is
+      // not, being a latency criterion rather than a length of time to run for.
+      val target2: Expr[Long] = Expr(Bench.scaled(target.generic, runner.scale))
       ' {
           // Blackhole sink, exactly as in `Bench`: each body result is written here via
           // lazySet so that the JIT cannot prove the body's value is unused and elide it. The

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -142,6 +142,7 @@ extends Rig:
     val sweep0: Optional[Int] = sweep
     val limit: Int = sweep0.or(if searching then 1024 else start)
     val sweeping: Boolean = sweep0.present || searching
+    val scaledTarget: Long = Bench.scaled(target.generic, runner.scale)
 
     // The threshold's histogram bucket index, computed with the same log-linear formula the
     // workers use; operations in buckets strictly below it completed within the threshold
@@ -161,7 +162,7 @@ extends Rig:
     val body: (References over Transport) ?=> Quotes ?=> Expr[List[Long]] =
       // Scaled by the run's duration multiplier; the `threshold` below deliberately is
       // not, being a latency criterion rather than a length of time to run for.
-      val target2: Expr[Long] = Expr(Bench.scaled(target.generic, runner.scale))
+      val target2: Expr[Long] = Expr(scaledTarget)
       ' {
           // Blackhole sink, exactly as in `Bench`: each body result is written here via
           // lazySet so that the JIT cannot prove the body's value is unused and elide it. The
@@ -435,7 +436,15 @@ extends Rig:
     // accumulate as cells of one entry rather than as separately-named tests.
     val testId = Test.Id(name, suite, codepoint)
 
-    if !runner.skip(testId, Entry.Kind.Stress, Nil) then
+    // The expected measuring time: one window per concurrency step, so a plain stress is a
+    // single (scaled) target and a sweep or capacity search is bounded by a doubling ascent
+    // plus a binary search plus the sustained-confirmation windows — roughly logarithmic in
+    // `limit`. A budgeting estimate, not a promise.
+    val steps: Long =
+      if sweeping then 2L*(64 - java.lang.Long.numberOfLeadingZeros(limit.max(1).toLong)) + 6L
+      else 1L
+
+    if !runner.skip(testId, Entry.Kind.Stress, Nil, scaledTarget*steps) then
       dispatch(body).stdlib.grouped(14).toList.foreach: step =>
         val n = step(0).toInt
         val compliance2: Optional[Double] = if step(12) < 0L then Unset else step(12)/10000.0

--- a/lib/sedentary/src/test/sedentary_test.scala
+++ b/lib/sedentary/src/test/sedentary_test.scala
@@ -65,6 +65,12 @@ object Tests extends Suite(m"Sedentary Tests"):
       Bench.scaled(1000L, 0.000001)
     . assert(_ == 1000L)
 
+    // The schedule's budgeting estimate: warmups and iterations each cost one batch of
+    // `target/iterations`, so the default (warmups == iterations) expects double the target.
+    test(m"a cell's expected time counts warmup and measured batches"):
+      List(Bench.expected(1_000_000L, 5, 5), Bench.expected(1_000_000L, 2, 1))
+    . assert(_ == List(2_000_000L, 1_500_000L))
+
     // Two implementations on one axis: distinct staged trees, so each compiles once, and
     // the anchor produces a comparison column against `Formula`.
     bench(m"sum of the first thousand integers")

--- a/lib/sedentary/src/test/sedentary_test.scala
+++ b/lib/sedentary/src/test/sedentary_test.scala
@@ -50,6 +50,21 @@ object Tests extends Suite(m"Sedentary Tests"):
   def run(): Unit =
     val bench = Bench()
 
+    // The run-length multiplier a host passes as `--scale=<factor>`, applied to a declared
+    // target. Checked directly rather than through a measurement: what a scaled benchmark
+    // does is take proportionally longer, which is not a thing a test can assert cheaply.
+    test(m"a duration multiplier scales the declared target"):
+      List(Bench.scaled(2_000_000_000L, 0.5), Bench.scaled(2_000_000_000L, 4.0))
+    . assert(_ == List(1_000_000_000L, 8_000_000_000L))
+
+    test(m"an unscaled target is left exactly as declared"):
+      Bench.scaled(50_000_000L, 1.0)
+    . assert(_ == 50_000_000L)
+
+    test(m"a scaled target never falls below a microsecond"):
+      Bench.scaled(1000L, 0.000001)
+    . assert(_ == 1000L)
+
     // Two implementations on one axis: distinct staged trees, so each compiles once, and
     // the anchor produces a comparison column against `Formula`.
     bench(m"sum of the first thousand integers")


### PR DESCRIPTION
## What

A geometric multiplier, `--scale=<factor>`, applied to every declared target *duration* — `Bench`'s,
`Stress`'s and `Profile`'s — so a suite's measurements can be run proportionally longer or shorter
without editing the suite. `--scale=2` gives each measurement twice as long, `--scale=0.25` a
quarter as long, and the relative weights the author chose are preserved.

## Why

A benchmark's target is written into the suite (`Bench(m"…")(50*Milli(Second))`) and baked into the
staged measurement loop by `Bench.measured`, which reads no argument, property or environment
variable. So there was no way to say "run the whole suite quickly" or "give everything four times
as long tonight" — only to edit each declaration.

## How

- `Selection` gains a `scale` field and parses `--scale=<factor>` alongside `--list`. A
  non-positive or unparseable factor is ignored rather than fatal — a mistyped duration should not
  lose a run's results.
- `Runner` exposes it, because that is what sedentary already has in hand at the point where a
  measurement's length is decided (it is already asking `runner.skip`).
- `Bench`, `Stress` and `Profile` scale their targets through `Bench.scaled`, which floors the
  result at a microsecond so that an absurdly small factor cannot produce a zero-length batch (and
  a division by zero in `measured`).
- A `Stress` `threshold` is deliberately **not** scaled: it is a pass/fail latency criterion, not a
  length of time to run for.

It rides the selection arguments because that is the only channel a host such as fume has to a
suite, and it works identically in-process and forked.

## Compatibility

A suite built against an older Soundness parses `--scale=2` as a constraint on an axis named
`--scale`; no test has that axis, and `Selection.admitted` admits a test whose coordinates lack a
constrained axis (`.lay(true)`). So an old suite silently ignores the argument and runs normally.
Verified against a `gossamer` test jar built before this change: 234/234 tests still ran.

## Testing

- Four new cases in `probably`'s suite (default, parsing, not-a-name-term, invalid factors) and
  three in `sedentary`'s (`Bench.scaled` doubling, identity at 1.0, and the microsecond floor).
  `probably`'s suite passes 8/8.
- End to end through [fume](https://github.com/propensive/fume), which gained a `--duration-scale`
  flag that forwards this argument: `sedentary`'s own benchmark suite took 75s at the default and
  119s at `--scale=40`, with the sample counts rising from 1568 to 10966 and from 62172 to 5441562
  — the measurement loop really is being given the extra time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
