### PR TITLE
Name the bare-`Long` time givens by their unit

### DIFF
--- a/doc/modules/concurrency.md
+++ b/doc/modules/concurrency.md
@@ -163,6 +163,26 @@ time in the morning whatever time it began, but one can still be woken in the ni
 *hibernates* until a particular time in the spring and cannot easily be roused. And a train's
 *delay* is quoted as a duration, but once it has one, nothing cancels it.
 
+#### Units
+
+All four take a *typed* duration or instant — `0.2*Second`, `10*Minute`, an `aviation.Instant` —
+and a typed value cannot be misread. A bare `Long` can, so no given interprets one until a unit
+is chosen by name:
+
+```scala
+import abstractables.millisecondsAbstractable
+snooze(200L)  // 200 milliseconds
+```
+
+The alternatives are `nanosecondsAbstractable` and `microsecondsAbstractable`; the three share a
+type, so exactly one may be imported into a file. Instants have a single reading,
+`epochMillisecondsAbstractable`, which takes a `Long` as milliseconds since the epoch. (The
+`instantiables` package mirrors all four for the opposite direction.)
+
+The distinction matters because the underlying representation of a duration is *nanoseconds* —
+an unqualified `snooze(200L)` under the nanosecond given returns almost immediately, and a loop
+around it is a busy-loop with nothing at the call site to say so.
+
 ### Retrying
 
 Work that fails for a transient reason should be tried again, and the *schedule* on which it is

--- a/lib/anticipation/src/test/anticipation_test.scala
+++ b/lib/anticipation/src/test/anticipation_test.scala
@@ -36,4 +36,40 @@ import soundness.*
 
 object Tests extends Suite(m"Anticipation Tests"):
   def run(): Unit =
-    ()
+    // The bare-`Long` time givens are named for their unit, and the names are the only thing
+    // standing between a call site and a duration a million times too short (issue #1920). These
+    // pin each name to its factor. They are referenced rather than imported, because the three
+    // duration givens deliberately share a type and cannot coexist in one scope.
+    suite(m"Bare-Long durations"):
+      test(m"Nanosecond durations are the generic representation"):
+        abstractables.nanosecondsAbstractable.genericize(5L)
+      . assert(_ == 5L)
+
+      test(m"Microsecond durations scale by a thousand"):
+        abstractables.microsecondsAbstractable.genericize(5L)
+      . assert(_ == 5_000L)
+
+      test(m"Millisecond durations scale by a million"):
+        abstractables.millisecondsAbstractable.genericize(5L)
+      . assert(_ == 5_000_000L)
+
+      test(m"Nanosecond durations are instantiated unchanged"):
+        instantiables.nanosecondsInstantiable(5L)
+      . assert(_ == 5L)
+
+      test(m"Microsecond durations are instantiated by dividing"):
+        instantiables.microsecondsInstantiable(5_000L)
+      . assert(_ == 5L)
+
+      test(m"Millisecond durations are instantiated by dividing"):
+        instantiables.millisecondsInstantiable(5_000_000L)
+      . assert(_ == 5L)
+
+    suite(m"Bare-Long instants"):
+      test(m"Instants are epoch milliseconds, not nanoseconds"):
+        abstractables.epochMillisecondsAbstractable.genericize(5L)
+      . assert(_ == 5L)
+
+      test(m"Epoch milliseconds are instantiated unchanged"):
+        instantiables.epochMillisecondsInstantiable(5L)
+      . assert(_ == 5L)

--- a/lib/anticipation/src/time/anticipation_time.scala
+++ b/lib/anticipation/src/time/anticipation_time.scala
@@ -34,10 +34,20 @@ package anticipation
 
 import prepositional.*
 
+// The generic representation of a `Durations` value is a count of *nanoseconds*; of an `Instants`
+// value, a count of *milliseconds since the epoch*. A bare `Long` therefore cannot say which unit
+// it is in, so there is no unit-agnostic given here: each name below states its own unit, and a
+// file chooses exactly one duration given (they share a type, so importing two is ambiguous).
 package abstractables:
-  given durationAbstractable: Long is Abstractable across Durations to Long = identity(_)
-  given instantAbstractable: Long is Abstractable across Instants to Long = identity(_)
+  given nanosecondsAbstractable: Long is Abstractable across Durations to Long = identity(_)
+  given microsecondsAbstractable: Long is Abstractable across Durations to Long = _*1000L
+  given millisecondsAbstractable: Long is Abstractable across Durations to Long = _*1_000_000L
+
+  given epochMillisecondsAbstractable: Long is Abstractable across Instants to Long = identity(_)
 
 package instantiables:
-  given durationInstantiable: Long is Instantiable across Durations from Long = identity(_)
-  given instantInstantiable: Long is Instantiable across Instants from Long = identity(_)
+  given nanosecondsInstantiable: Long is Instantiable across Durations from Long = identity(_)
+  given microsecondsInstantiable: Long is Instantiable across Durations from Long = _/1000L
+  given millisecondsInstantiable: Long is Instantiable across Durations from Long = _/1_000_000L
+
+  given epochMillisecondsInstantiable: Long is Instantiable across Instants from Long = identity(_)

--- a/lib/anticipation/src/time/soundness_anticipation_time.scala
+++ b/lib/anticipation/src/time/soundness_anticipation_time.scala
@@ -35,7 +35,13 @@ package soundness
 export anticipation.{Dates, Durations, Instants, Times}
 
 package abstractables:
-  export anticipation.abstractables.{durationAbstractable, instantAbstractable}
+  export
+    anticipation.abstractables
+    . { nanosecondsAbstractable, microsecondsAbstractable, millisecondsAbstractable,
+        epochMillisecondsAbstractable }
 
 package instantiables:
-  export anticipation.instantiables.{durationInstantiable, instantInstantiable}
+  export
+    anticipation.instantiables
+    . { nanosecondsInstantiable, microsecondsInstantiable, millisecondsInstantiable,
+        epochMillisecondsInstantiable }

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -37,7 +37,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
-import abstractables.instantAbstractable
+import abstractables.epochMillisecondsAbstractable
 import chronometries.unix
 import denominative.dysasymptotics.linearSize
 

--- a/lib/diuretic/src/core/diuretic.JavaLongDuration.scala
+++ b/lib/diuretic/src/core/diuretic.JavaLongDuration.scala
@@ -34,6 +34,8 @@ package diuretic
 
 import anticipation.*
 
+// The `Long` is a count of *nanoseconds*, matching the generic representation of `Durations`.
+// Note the asymmetry with `JavaLongInstant`, whose `Long` is milliseconds since the epoch.
 object JavaLongDuration extends Abstractable, Instantiable:
   type Self = Long
   type Origin = Long

--- a/lib/diuretic/src/core/diuretic.JavaLongInstant.scala
+++ b/lib/diuretic/src/core/diuretic.JavaLongInstant.scala
@@ -34,6 +34,8 @@ package diuretic
 
 import anticipation.*
 
+// The `Long` is a count of *milliseconds since the epoch*, matching the generic representation
+// of `Instants`. Note the asymmetry with `JavaLongDuration`, whose `Long` is nanoseconds.
 object JavaLongInstant extends Abstractable, Instantiable:
   type Self = Long
   type Result = Long

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -725,7 +725,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
       // The `Long`-as-instant given lets us mint an Aviation `Instant` from epoch
       // millis; Aviation's own `Instant` abstractable/instantiable instances are found
       // via its companion, so `embarcadero` needs no dependency on Aviation.
-      import abstractables.instantAbstractable
+      import abstractables.epochMillisecondsAbstractable
       import chronometries.unix
       val moment = Instant(1_700_000_001_000L)
 

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -318,7 +318,7 @@ def cli[bus <: Matchable](using executive: Executive)
 
       if recorded == null then true else
         safely:
-          import anticipation.instantiables.instantInstantiable
+          import anticipation.instantiables.epochMillisecondsInstantiable
           val size = script.filesize().long
           val mtime = script.modified[Long]()
 
@@ -655,7 +655,7 @@ def cli[bus <: Matchable](using executive: Executive)
 
           scriptPath.let: script =>
             safely:
-              import anticipation.instantiables.instantInstantiable
+              import anticipation.instantiables.epochMillisecondsInstantiable
               hashScript(script).let: hash =>
                 scriptIdentity.set(ScriptIdentity(script.filesize().long, script.modified[Long](), hash))
 

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -543,7 +543,7 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == t"cdef")
 
     suite(m"Storage filesystem axis"):
-      import anticipation.instantiables.instantInstantiable
+      import anticipation.instantiables.epochMillisecondsInstantiable
       val root: Path on Linux = unsafely((% / "tmp").on[Linux])
 
       test(m"At most one storage filesystem extractor matches a path"):

--- a/lib/guillotine/src/test/guillotine_test.scala
+++ b/lib/guillotine/src/test/guillotine_test.scala
@@ -35,7 +35,7 @@ package guillotine
 import soundness.*
 
 import workingDirectories.defaultWorkingDirectory
-import abstractables.durationAbstractable
+import abstractables.millisecondsAbstractable
 import strategies.throwUnsafely
 import errorDiagnostics.emptyDiagnostics
 
@@ -429,14 +429,14 @@ object Tests extends Suite(m"Guillotine tests"):
 
       test(m"await with timeout fires Async.Error"):
         val proc = sh"sleep 1".fork[Unit]()
-        val outcome = capture[Async.Error](proc.await(50_000_000L))
+        val outcome = capture[Async.Error](proc.await(50L))
         proc.kill()
         outcome
       . assert(_.reason == Async.Error.Reason.Timeout)
 
       test(m"await with sufficient duration returns"):
         val proc = sh"sleep 0.05".fork[Unit]()
-        proc.await(2_000_000_000L)
+        proc.await(2000L)
       . assert(_ == ())
 
     suite(m"Stdin and stderr"):

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -1363,7 +1363,7 @@ object Tests extends Suite(m"Jacinta Tests"):
       import decodables.durationJsonDecodable
       import aviation.*
       import chronometries.unix
-      import abstractables.instantAbstractable
+      import abstractables.epochMillisecondsAbstractable
 
       test(m"Encode an Instant as a Long"):
         Instant(1700000000000L).in[Json].show

--- a/lib/parasite/src/core/parasite.Timeout.scala
+++ b/lib/parasite/src/core/parasite.Timeout.scala
@@ -45,7 +45,7 @@ import nomenclature.*
 import prepositional.*
 
 import Async.nominative
-import abstractables.instantAbstractable
+import abstractables.epochMillisecondsAbstractable
 
 object Timeout:
   def apply[duration: Abstractable across Durations to Long](timeout0: duration)(action: => Unit)

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -88,9 +88,19 @@ object unsupervised extends caps.ExclusiveCapability:
   given orphanMonitor: Monitor = Root(PlatformSupervisor)
 
 package retryTenacities:
-  given exponentialForeverTenacity: Tenacity = Tenacity.exponential(10L, 1.2)
-  given exponentialFiveTimesTenacity: Tenacity = Tenacity.exponential(10L, 1.2).limit(5)
-  given exponentialTenTimesTenacity: Tenacity = Tenacity.exponential(10L, 1.2).limit(10)
+  // This file reads a bare `Long` duration as nanoseconds (see the import of
+  // `nanosecondsAbstractable` above), which is the unit `Tenacity#delay` yields; the exponential
+  // backoffs are stated in milliseconds, so they are scaled here rather than written raw.
+  private val millisecond: Long = 1_000_000L
+
+  given exponentialForeverTenacity: Tenacity = Tenacity.exponential(10L*millisecond, 1.2)
+
+  given exponentialFiveTimesTenacity: Tenacity =
+    Tenacity.exponential(10L*millisecond, 1.2).limit(5)
+
+  given exponentialTenTimesTenacity: Tenacity =
+    Tenacity.exponential(10L*millisecond, 1.2).limit(10)
+
   given fixedNoDelayForeverTenacity: Tenacity = Tenacity.fixed(0L)
   given fixedNoDelayFiveTimesTenacity: Tenacity = Tenacity.fixed(0L).limit(5)
   given fixedNoDelayTenTimesTenacity: Tenacity = Tenacity.fixed(0L).limit(10)

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -49,8 +49,8 @@ import prepositional.*
 import symbolism.*
 import vacuous.*
 
-import abstractables.durationAbstractable
-import abstractables.instantAbstractable
+import abstractables.epochMillisecondsAbstractable
+import abstractables.nanosecondsAbstractable
 
 package threading:
   given platformThreading: Threading = () => PlatformSupervisor

--- a/lib/tarantula/src/core/tarantula.WebDriver.scala
+++ b/lib/tarantula/src/core/tarantula.WebDriver.scala
@@ -36,7 +36,7 @@ import scala.caps
 
 import adversaria.name
 import ambience.*
-import anticipation.*, abstractables.durationAbstractable
+import anticipation.*, abstractables.millisecondsAbstractable
 import aperture.session
 import clavichord.Keypress
 import contingency.*
@@ -133,7 +133,7 @@ object WebDriver:
     // The interval between readiness probes, and the number of them. A driver binds its port in
     // well under a second; five seconds is generous enough that a loaded machine does not fail
     // spuriously, and short enough that a missing binary is reported promptly.
-    private val interval: Long = 50L*1000L*1000L
+    private val interval: Long = 50L // milliseconds
     private val attempts: Int = 100
 
     // Free functions of the companion, for the same reason as `Session.malformed`: a

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -53,7 +53,7 @@ import vacuous.*
 import zephyrine.*
 
 import LineSeparation.*
-import abstractables.instantAbstractable
+import abstractables.epochMillisecondsAbstractable
 import probates.awaitProbate
 
 inline def more[value](using value: value aka "more"): value =

--- a/lib/vivisection/src/core/vivisection.Debuggee.scala
+++ b/lib/vivisection/src/core/vivisection.Debuggee.scala
@@ -37,7 +37,7 @@ import java.net as jn
 import scala.caps
 
 import ambience.*
-import anticipation.*, abstractables.durationAbstractable
+import anticipation.*, abstractables.millisecondsAbstractable
 import coaxial.*
 import contingency.*
 import fulminate.*
@@ -56,7 +56,7 @@ import zephyrine.*
 // … }` forks the process with the agent listening, waits for it to bind its port, attaches, and
 // lends a `Debug`; the debuggee is killed when the block ends.
 object Debuggee:
-  private val interval: Long = 50L*1000L*1000L
+  private val interval: Long = 50L // milliseconds
   private val attempts: Int = 200
 
   // A plain-socket readiness probe. With `server=y` the agent binds before `main` runs, so a


### PR DESCRIPTION
A bare `Long` passed to `snooze` was interpreted as nanoseconds, so `snooze(200L)` — which reads as 200 milliseconds, and matches how `Thread.sleep`, `wait` and `poll` all behave — returned in 200 nanoseconds, turning any loop around it into a silent busy-loop. The given that made this reachable, `durationAbstractable`, named no unit, and its neighbour `instantAbstractable` read a `Long` as epoch *milliseconds*, so the two disagreed by a factor of a million. Each given is now named for its own unit, with microsecond and millisecond variants alongside the nanosecond one, so a call site has to say what it means; the same units bug inside parasite's own `retryTenacities` defaults, a 10-nanosecond exponential backoff, is corrected to 10 milliseconds.

### Bare-`Long` durations now name their unit

`abstractables.durationAbstractable` has been replaced by three givens, one per unit:

```scala
import abstractables.millisecondsAbstractable
snooze(200L)  // 200 milliseconds
```

The alternatives are `nanosecondsAbstractable` and `microsecondsAbstractable`. All three have the same type, so exactly one may be imported into a file — the compiler will reject an ambiguous pair rather than silently pick a unit. `instantiables` mirrors all three for the opposite direction.

Typed durations are unaffected and remain the recommended form: `snooze(0.2*Second)` needs no import and cannot be misread.

### Instants say they are epoch milliseconds

`instantAbstractable` is now `epochMillisecondsAbstractable` (and `instantInstantiable` is `epochMillisecondsInstantiable`), making the ms/ns asymmetry with durations visible at the import.

### Migration

| Old | New |
|---|---|
| `abstractables.durationAbstractable` | `abstractables.nanosecondsAbstractable` (or `microseconds…` / `milliseconds…`) |
| `abstractables.instantAbstractable` | `abstractables.epochMillisecondsAbstractable` |
| `instantiables.durationInstantiable` | `instantiables.nanosecondsInstantiable` (or `microseconds…` / `milliseconds…`) |
| `instantiables.instantInstantiable` | `instantiables.epochMillisecondsInstantiable` |

A `snooze(n)` that meant milliseconds should switch to `millisecondsAbstractable` and drop the `*1_000_000L` — that rewrite is applied here to tarantula, vivisection and guillotine.

### Behaviour change: retry backoff

`retryTenacities.exponentialForeverTenacity` and its `…FiveTimes` / `…TenTimes` siblings were built from `Tenacity.exponential(10L, 1.2)` — ten *nanoseconds*, effectively no delay. They now start at 10 milliseconds, so code relying on these givens will actually back off between attempts. `fixedNoDelay*` is unchanged if no delay is what you want.

Closes #1920.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
