### PR TITLE
Build against Proscala 3.9.0-p16: -Z flags and the supplementary library

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -54,10 +54,10 @@ object settings:
   //      https://github.com/propensive/proscala/releases; each release ships a single
   //      `proscala-<tag>.tar.gz` asset whose contents are a `lib` directory (the unversioned core
   //      jars plus the versioned third-party jars). The `toolchain` module below downloads
-  //      `SOUNDNESS_SCALA_RELEASE` (default `3.9.0-RC6-p15`, the latest in the 3.9.0 stream) and
+  //      `SOUNDNESS_SCALA_RELEASE` (default `3.9.0-p16`, the latest in the 3.9.0 stream) and
   //      extracts it into a shared cache, exposing its jars to every coursier resolution — no
   //      local compiler build and no publishing step needed. Switch streams by setting
-  //      `SOUNDNESS_SCALA_RELEASE` (e.g. `3.10.0-dev-p15`).
+  //      `SOUNDNESS_SCALA_RELEASE` (e.g. `3.10.1-dev-p16`).
   //
   //   2. Local (fork developers). Point `SOUNDNESS_SCALA_HOME` at a `make`-built `release`
   //      directory to use its `release/lib` jars directly instead of downloading. After
@@ -71,14 +71,14 @@ object settings:
   // (`SOUNDNESS_SCALA_RELEASE`) is a separate concept, though from `3.9.0-RC4-p1` on the two
   // coincide (earlier releases shipped jars built as e.g. `3.9.0-RC1-propensive`). Override the
   // coordinate with `SOUNDNESS_SCALA_VERSION`.
-  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC6-p15")
+  val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-p16")
 
   // The compiler *stream* — the major Scala version, without the patch level — which is what
   // decides the shape of the compiler-internal APIs a handful of modules wrap. Everything else
   // in Soundness is written once and compiles on every stream; where an API genuinely differs
   // (see the `Shim` component trait), this selects the sources that bridge it.
   val scalaStream = if scalaVersion.startsWith("3.10") then "3.10" else "3.9"
-  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC6-p15")
+  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-p16")
   // Empty by default → download `scalaRelease`. Set to a local `release` directory to use its
   // `release/lib` jars directly (fork-developer mode).
   val scalaHome = sys.env.getOrElse("SOUNDNESS_SCALA_HOME", "")
@@ -92,6 +92,26 @@ object settings:
   // Nearest published base version (no RC4 Native artifacts yet); TASTy-identical to RC4.
   val scalaNativeScalaVersion = "3.9.0-RC3"
   val scalaOptions = Seq(
+    // The fork's opt-in behaviours, enabled by name (`-Z<name>`; a bare `-Z` lists
+    // them). Soundness relies on every capture-checking repair the fork carries, on
+    // spreadable varargs (proscenium's `multiSpreads` splices), on given-prefix
+    // sealing (top-level givens over opaque types), on diagnostic givens, and on
+    // JSR-45 source maps (formerly `-Xjsr45`; hyperbole's stack-trace resolver).
+    // Not enabled: `-Zliterate-literals` (the literal-conversion trial, which needs
+    // `scala.Literate` instances that main does not define) and
+    // `-Zsemantic-diagnostics` (anthology passes it per-invocation when a tool wants
+    // markup diagnostics).
+    "-Zalias-captures",
+    "-Zdiagnostic-givens",
+    "-Zgiven-prefixes",
+    "-Zinline-source-maps",
+    "-Zopaque-mutability",
+    "-Zpure-iarrays",
+    "-Zretains-bounds",
+    "-Zretains-skolems",
+    "-Zspreadable-varargs",
+    "-Zunboxed-pure-types",
+    "-Zunion-captures",
     "-experimental",
     "-new-syntax",
     "-feature",
@@ -127,9 +147,6 @@ object settings:
     "-Wconf:src=.*synesthesia.McpServer.*&msg=match may not be exhaustive:s",
     // "-Wsafe-init",
     "-Xmax-inlines", "32",
-    // Emit JSR-45 SMAPs (SourceDebugExtension) mapping inlined code back to its source, so
-    // hyperbole's stack-trace resolver can expand and name each frame's inline chain.
-    "-Xjsr45",
     //"-Ycc-new",
     "-Yno-flexible-types",
     "-Yexplicit-nulls",
@@ -243,8 +260,16 @@ object toolchain extends Module:
     // Scala.js runtime jars — which the fork builds against a custom (non-Central) Scala.js and
     // ships under their own `-<jsVersion>` filenames — keep the Scala.js coordinate `js`.
     val artifacts = Seq(
-      (sl, "scala-library", "scala-library.jar", v, Seq()),
-      (sl, "scala3-library_3", "scala3-library.jar", v, Seq((sl, "scala-library", v))),
+      // The fork's standard-library additions (`scala.Literate`, `scala.Spreadable`),
+      // shipped as a supplementary jar so `scala-library` stays byte-identical to
+      // upstream's build. Declared as a dependency of the unified `scala-library` —
+      // the artifact every module actually resolves — so the whole build carries it
+      // without per-module wiring; its own deps stay empty to avoid a cycle.
+      (sl, "proscala-library_3", "proscala-library.jar", v, Seq()),
+      (sl, "scala-library", "scala-library.jar", v, Seq(
+        (sl, "proscala-library_3", v))),
+      (sl, "scala3-library_3", "scala3-library.jar", v, Seq(
+        (sl, "scala-library", v))),
       (sl, "scala3-interfaces", "scala3-interfaces.jar", v, Seq()),
       (sl, "tasty-core_3", "tasty-core.jar", v, Seq((sl, "scala-library", v))),
       (sl, "scala3-compiler_3", "scala3-compiler.jar", v, Seq(
@@ -283,8 +308,10 @@ object toolchain extends Module:
         (sjs, "scalajs-javalib", js))),
       (sjs, "scalajs-scalalib_2.13", "scalajs-scalalib_2.13.jar", v, Seq(
         (sjs, "scalajs-javalib", js))),
+      (sl, "proscala-library_sjs1_3", "proscala-library_sjs1.jar", v, Seq()),
       (sl, "scala3-library_sjs1_3", "scala3-library_sjs1.jar", v, Seq(
         (sl, "scala-library", v),
+        (sl, "proscala-library_sjs1_3", v),
         (sjs, "scalajs-library_2.13", js),
         (sjs, "scalajs-scalalib_2.13", v))))
 

--- a/lib/anthology/src/scala/anthology_scala.scala
+++ b/lib/anthology/src/scala/anthology_scala.scala
@@ -53,7 +53,7 @@ object scalacOptions:
 
   val experimental = Scalac.Option[3.4 | 3.5 | 3.6 | 3.7 | 3.8](t"-experimental")
 
-  val semanticDiagnostics = Scalac.Option[3.9](t"-Xsemantic-diagnostics")
+  val semanticDiagnostics = Scalac.Option[3.9](t"-Zsemantic-diagnostics")
 
   object warnings:
     val feature = Scalac.Option[Scalac.Versions](t"-feature")
@@ -138,7 +138,7 @@ private[anthology] def notice(diagnostic: Diagnostic): Notice =
   val file: Text = diagnostic.position.map(_.nn.source.nn.name.nn.tt).nn.orElse(t"unknown").nn
   val message: Text = diagnostic.message.tt
 
-  // Under `-Xsemantic-diagnostics`, the raw message carries in-band semantic
+  // Under `-Zsemantic-diagnostics`, the raw message carries in-band semantic
   // markers (stripped from the `message` accessor above); preserve it so
   // consumers can interpret them, e.g. with the `delicious` module.
   val markup: Optional[Text] =

--- a/lib/delicious/src/scala/delicious_scala.scala
+++ b/lib/delicious/src/scala/delicious_scala.scala
@@ -40,7 +40,7 @@ import vacuous.*
 
 extension (notice: anthology.Notice)
   /** The message's semantic structure, when it was compiled under
-   *  `-Xsemantic-diagnostics`. */
+   *  `-Zsemantic-diagnostics`. */
   def semantic: Optional[SemanticMessage] = notice.markup.let(SemanticMessage.parse(_))
 
 extension (message: SemanticMessage)

--- a/lib/delicious/src/test/delicious_test.scala
+++ b/lib/delicious/src/test/delicious_test.scala
@@ -225,12 +225,13 @@ object Tests extends Suite(m"Delicious Tests"):
     //     class Local
     //     val xs: List[String] = List(1.5)
     //     def f: Option[Int] = List(new Local)
-    // TASTy is version-locked (28.9-1), so these decode under any 3.9-stream compiler.
+    // TASTy is version-locked (28.9-0, the stable 3.9.0 release), so these decode under any
+    // compiler built from the 3.9.0-final-based stream.
     val stringPayload: Text =
-      t"XKGrH5yJgZpTY2FsYSAzLjkuMC1SQzEtcHJvcGVuc2l2ZQAadmNlJOIHAAAAAAAAAACeAYRBU1RzAYZTdHJpbmcBhGphdmEBhGxhbmcCgoKDgIR1gUCE"
+      t"XKGrH5yJgJpTY2FsYSAzLjkuMC1SQzYtcHJvcGVuc2l2ZQAadmNlJOIHAAAAAAAAAACeAYRBU1RzAYZTdHJpbmcBhGphdmEBhGxhbmcCgoKDgIR1gUCE"
 
     val placeholderPayload: Text =
-      t"XKGrH5yJgZpTY2FsYSAzLjkuMC1SQzEtcHJvcGVuc2l2ZQDQKNr7HmsuAAAAAAAAAADGAYRBU1RzAYRMaXN0AYVzY2FsYQGKY29sbGVjdGlvbgKCgoMBiWltbXV0YWJsZQKChIUBkuKfqHNjYWxhLWRpYWc6MOKfqYCIoYZ1gUCGSoc="
+      t"XKGrH5yJgJpTY2FsYSAzLjkuMC1SQzYtcHJvcGVuc2l2ZQDQKNr7HmsuAAAAAAAAAADGAYRBU1RzAYRMaXN0AYVzY2FsYQGKY29sbGVjdGlvbgKCgoMBiWltbXV0YWJsZQKChIUBkuKfqHNjYWxhLWRpYWc6MOKfqYCIoYZ1gUCGSoc="
 
     proscalaLibrary().let: lib =>
       val jars = List("scala-library.jar", "scala3-library.jar").map(lib.resolve(_).nn)

--- a/lib/larceny/src/plugin/larceny.LarcenyTransformer.scala
+++ b/lib/larceny/src/plugin/larceny.LarcenyTransformer.scala
@@ -130,6 +130,13 @@ class LarcenyTransformer() extends PluginPhase:
     val yimports = ctx.settings.Yimports.value
     val noPredef = ctx.settings.YnoPredef.value
 
+    // The fork's opt-in behaviours (`-Z<name>`) are part of the language environment too:
+    // a patch that is off in the sub-compilation but on in the parent makes the two
+    // disagree, and a capture-checking repair the parent relies on (skolems in `@retains`
+    // sets, say) is a crash rather than a diagnostic when it is missing.
+    val zflags = config.Proscala.features.filter(config.Proscala.enabled(_)).map: feature =>
+      s"-Z${feature.name}"
+
     // Warnings used to be invisible to `demilitarize` in all but one case. The sub-compilation
     // starts from `initCtx.fresh` -- a compiler-default context, not the parent's -- so none of
     // the parent's warning flags applied, and every flag-gated warning (deprecation and unused
@@ -194,7 +201,8 @@ class LarcenyTransformer() extends PluginPhase:
 
     val errors: List[CompileError] =
       Subcompiler.compile
-        ( language, classpath, source, regions, plugins, ccNew, yimports, noPredef, warnings )
+        ( language, classpath, source, regions, plugins, ccNew, yimports, noPredef, warnings,
+          zflags )
 
     object transformer extends UntypedTreeMap:
       override def transform(tree: Tree)(using Context): Tree = tree match

--- a/lib/larceny/src/plugin/larceny.Subcompiler.scala
+++ b/lib/larceny/src/plugin/larceny.Subcompiler.scala
@@ -138,7 +138,8 @@ object Subcompiler:
   // production code would see — except for larceny, whose recursion would
   // re-fire on any `demilitarize(...)` calls in the sub-source. `ccNew`
   // propagates the parent's `-Ycc-new`, which selects the capture-checking
-  // scheme but is not part of the `-language` settings.
+  // scheme but is not part of the `-language` settings. `zflags` carries the parent's
+  // enabled `-Z<name>` behaviours, which are likewise outside `-language`.
   def compile
     ( language:  List[Settings.Setting.ChoiceWithHelp[String]],
       classpath: String,
@@ -148,7 +149,8 @@ object Subcompiler:
       ccNew:     Boolean = false,
       yimports:  List[String] = Nil,
       noPredef:  Boolean = false,
-      warnings:  List[String] = Nil )
+      warnings:  List[String] = Nil,
+      zflags:    List[String] = Nil )
   :   List[CompileError] =
 
     object driver extends Driver:
@@ -164,7 +166,8 @@ object Subcompiler:
         val pluginOptions = plugins.map: plugin => s"-Xplugin:$plugin"
 
         val args =
-          scala.Array[String]("") ++ ccOptions ++ importOptions ++ warnings ++ pluginOptions
+          scala.Array[String]("") ++ ccOptions ++ importOptions ++ zflags ++ warnings
+            ++ pluginOptions
 
         setup(args, context2).map(_(1)).get
 


### PR DESCRIPTION
Proscala 3.9.0-p16 — the first release from the 3.9.0 final tree — enables each of its behaviour-changing patches by name (`-Z<name>`; a bare `-Z` lists them) and ships its standard-library additions (`scala.Spreadable`, `scala.Literate`) as a separate `proscala-library` jar, so `scala-library` is byte-identical to upstream's. This PR moves Soundness onto it: the eleven `-Z` behaviours the build relies on are enabled globally (`-Xjsr45` becomes `-Zinline-source-maps`, and anthology's option constant follows `-Xsemantic-diagnostics` to `-Zsemantic-diagnostics`); the toolchain repository serves `proscala-library` as a dependency of the unified `scala-library` — the only standard-library artifact on module classpaths — and its Scala.js twin under `scala3-library_sjs1_3`; larceny forwards the parent compilation's `-Z` flags into its sub-compilations, which otherwise ran without the retains-skolems repair and crashed with `IllegalCaptureRef`; delicious's stenography fixtures are regenerated for p16's stable-28.9 TASTy; and the toolchain defaults move to the `3.9.0-p16` tag.

## Release notes

- Soundness now builds with **Proscala 3.9.0-p16**, downloaded automatically into `~/.cache/soundness/proscala/3.9.0-p16` on first use; `SOUNDNESS_SCALA_RELEASE`/`SOUNDNESS_SCALA_VERSION` override it as before, and `SOUNDNESS_SCALA_HOME` still selects a locally built `release` directory.
- p16 is built from the 3.9.0 final tree, so its TASTy is the stable 28.9 era: artifacts compiled by p16 are not interchangeable with those of the RC-era releases (`3.9.0-RC6-p15` and earlier) in either direction.
- The fork's opt-in behaviours are enabled by name. `-Xjsr45` is now `-Zinline-source-maps`; `-Xsemantic-diagnostics` is now `-Zsemantic-diagnostics` (`Scalac.Option.semanticDiagnostics` in anthology follows).
- Tools that compile code at runtime through anthology's `Scalac` driver see the fork's behaviours only for the `-Z` flags they pass; code that depends on, say, given-prefix sealing or the capture-checking repairs must enable them explicitly.
- `demilitarize` sub-compilations (larceny) now inherit the parent compilation's enabled `-Z` flags automatically.
