### PR TITLE
Sync GitHub releases into the local ivy repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 tests/JSONTestSuite
 lib/ethereal/target
 rep/_probe
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ release:
 	@if [ -z "$(VERSION)" ]; then echo "Usage: make release VERSION=X.Y.Z" >&2; exit 1; fi
 	./etc/ci/release.sh "$(VERSION)"
 
+sync-releases:
+	./etc/ci/sync-releases.sh $(VERSION)
+
 xeq-build:
 	@if [ -z "$(RUNNERS_VERSION)" ]; then echo "Usage: make xeq-build RUNNERS_VERSION=X" >&2; exit 1; fi
 	./etc/ci/xeq-build.sh "$(RUNNERS_VERSION)"

--- a/build.mill
+++ b/build.mill
@@ -3662,7 +3662,35 @@ val releasableModules: Seq[PublishModule] =
 // jars of `releasableModules`, each named `<artifactId>-<version>.jar` — no bundles, no source or
 // javadoc jars, and no checksum files (GitHub records a SHA-256 digest per asset, which is what
 // downstream tools such as burdock match against).
+//
+// Each released jar is self-describing: it carries its own POM and ivy.xml under
+// `META-INF/maven/<group>/<artifactId>/`, the Maven convention for an embedded descriptor. That
+// is what lets `etc/ci/sync-releases.sh` reconstruct a resolvable local repository from the jars
+// alone, with no separate metadata assets.
 object release extends Module:
+  // Copies `source` to `target`, appending the descriptor entries. Written with `java.util.zip`
+  // rather than re-created from the classfiles so that every existing entry is carried over
+  // byte-for-byte.
+  private def withDescriptors(source: os.Path, target: os.Path, entries: Seq[(String, os.Path)])
+  :   Unit =
+    val input = new java.util.zip.ZipFile(source.toIO)
+    val output = new java.util.zip.ZipOutputStream(new java.io.FileOutputStream(target.toIO))
+    try
+      val existing = input.entries()
+      while existing.hasMoreElements do
+        val entry = existing.nextElement()
+        output.putNextEntry(new java.util.zip.ZipEntry(entry.getName))
+        if !entry.isDirectory then input.getInputStream(entry).transferTo(output)
+        output.closeEntry()
+
+      for (name, file) <- entries do
+        output.putNextEntry(new java.util.zip.ZipEntry(name))
+        output.write(os.read.bytes(file))
+        output.closeEntry()
+    finally
+      output.close()
+      input.close()
+
   // The module paths of everything released, for `publishLocal` and for the release script's
   // reporting.
   def modules: T[Seq[String]] = Task(releasableModules.map(_.moduleSegments.render).sorted)
@@ -3671,17 +3699,20 @@ object release extends Module:
   // run a task on every released module: `./mill "$(./mill show release.selector).publishLocal"`.
   def selector: T[String] = Task(modules().mkString("{", ",", "}"))
 
-  // Builds every released jar and copies it into one directory under its release asset name.
-  // The version is `publishVersion`, which the release script pins with
-  // `SOUNDNESS_RELEASE_VERSION` so every asset carries exactly the tagged version.
+  // Builds every released jar and copies it into one directory under its release asset name,
+  // with its POM and ivy.xml embedded. The version is `publishVersion`, which the release script
+  // pins with `SOUNDNESS_RELEASE_VERSION` so every asset carries exactly the tagged version.
   def stage: T[Seq[PathRef]] = Task:
-    val jars: Seq[(PathRef, String, String)] =
+    val jars: Seq[(PathRef, String, String, String, PathRef, PathRef)] =
       Task.traverse(releasableModules)(module =>
-        Task.Anon((module.jar(), module.artifactId(), module.publishVersion())))()
+        Task.Anon((module.jar(), module.pomSettings().organization, module.artifactId(),
+                   module.publishVersion(), module.pom(), module.ivy())))()
 
-    jars.map: (jar, artifactId, version) =>
+    jars.map: (jar, group, artifactId, version, pom, ivy) =>
       val target = Task.dest / s"$artifactId-$version.jar"
-      os.copy(jar.path, target)
+      val prefix = s"META-INF/maven/$group/$artifactId"
+      val descriptors = Seq(s"$prefix/pom.xml" -> pom.path, s"$prefix/ivy.xml" -> ivy.path)
+      withDescriptors(jar.path, target, descriptors)
       PathRef(target)
 
 // A tiny Scala.js app whose `fastLinkJS` actually LINKS a representative slice of

--- a/doc/roadmap/distribution.md
+++ b/doc/roadmap/distribution.md
@@ -15,7 +15,10 @@ itself: LIRA — one file per library release carrying every compiled representa
 manifest, API-derived versioning and verifiable signatures — is specified but unimplemented,
 and replaces Maven Central. Maven Central publishing has already been switched off: each tagged
 version is published as a GitHub release whose assets are the individual component jars, an
-interim channel until LIRA is live. The gate requires attested LIRA publishing to be live.
+interim channel until LIRA is live. Each released jar embeds its POM and ivy.xml, and
+`make sync-releases` installs a release into `~/.ivy2/local`, from which Mill resolves the
+components by version with no repository configuration. The gate requires attested LIRA
+publishing to be live.
 
 ## dist-1: releases are changelogged
 

--- a/etc/ci/release.sh
+++ b/etc/ci/release.sh
@@ -8,7 +8,8 @@
 # ruled out publishing every component): the tagged version becomes one release whose assets are
 # the jars of every component and every platform cross — `release.stage` in build.mill — each
 # named `<artifactId>-<version>.jar`. No bundles, source or javadoc jars, or checksum files are
-# published; GitHub records a SHA-256 digest per asset.
+# published; GitHub records a SHA-256 digest per asset, and each jar embeds its own POM and
+# ivy.xml, from which `etc/ci/sync-releases.sh` rebuilds a resolvable local repository.
 #
 # Usage: ./etc/ci/release.sh X.Y.Z   (or `make release VERSION=X.Y.Z`)
 #
@@ -130,8 +131,10 @@ notes="Soundness $VERSION.
 
 Every component of every library is attached as its own jar, \`<artifactId>-$VERSION.jar\`, \
 alongside the Scala.js (\`_sjs1_3\`) and Scala Native (\`_native0.5_3\`) cross-builds of the \
-platform-capable components. The build and test run behind this release are attested by the \
-signed note on \`refs/notes/ci-attestation\` for commit $HEAD_SHA."
+platform-capable components. Each jar embeds its POM and ivy.xml under \`META-INF/maven/\`; \
+\`make sync-releases VERSION=$VERSION\` installs the set into a local ivy repository for Mill to \
+resolve by version. The build and test run behind this release are attested by the signed note \
+on \`refs/notes/ci-attestation\` for commit $HEAD_SHA."
 
 if ! gh release create "$VERSION" --repo "$REPO" --draft --target "$HEAD_SHA" \
        --title "Soundness $VERSION" --notes "$notes" >/dev/null; then

--- a/etc/ci/sync-releases.sh
+++ b/etc/ci/sync-releases.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Synchronize the local ivy2 repository (`~/.ivy2/local`, which coursier — and so Mill —
+# consults by default) with the Soundness jars published to GitHub Releases, so any Mill build can
+# resolve `mvn"dev.propensive:<artifactId>:<version>"` without a repository configuration.
+#
+# Every released jar carries its own POM and ivy.xml under `META-INF/maven/…` (see `release.stage`
+# in build.mill), so the jar is all that needs downloading: the descriptors are extracted from it
+# into the `poms/` and `ivys/` directories of the ivy2 layout. Jars already present with the
+# SHA-256 digest GitHub reports are left alone, so re-running is cheap and idempotent.
+#
+# Usage: ./etc/ci/sync-releases.sh [X.Y.Z]          one release, or every X.Y.Z release if omitted
+#        ./etc/ci/sync-releases.sh --staged          the jars of a local `./mill release.stage`
+#         (or `make sync-releases [VERSION=X.Y.Z]`)
+#
+# Environment: SOUNDNESS_RELEASE_REPO=owner/repo (default propensive/soundness); GITHUB_TOKEN,
+# if set, is sent with API requests to lift the unauthenticated rate limit; IVY_LOCAL overrides
+# the destination (default ~/.ivy2/local).
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+exec python3 ./etc/ci/sync_releases.py "$@"

--- a/etc/ci/sync_releases.py
+++ b/etc/ci/sync_releases.py
@@ -1,0 +1,209 @@
+"""Synchronize ~/.ivy2/local with the Soundness jars on GitHub Releases.
+
+Invoked by `etc/ci/sync-releases.sh`; see its header for usage. Each released jar embeds its
+POM and ivy.xml under `META-INF/maven/<group>/<artifactId>/`, so the jar alone reconstructs
+the ivy2 layout coursier expects:
+
+    <ivy-local>/<group>/<artifactId>/<version>/jars/<artifactId>.jar
+                                             /poms/<artifactId>.pom
+                                             /ivys/ivy.xml
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import urllib.request
+import zipfile
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+
+GROUP = "dev.propensive"
+VERSION_TAG = re.compile(r"^\d+\.\d+\.\d+$")
+DIGEST_PREFIX = "sha256:"
+WORKERS = 8
+
+
+@dataclass
+class Asset:
+    artifact: str
+    version: str
+    source: str            # URL, or a local path when syncing a staged directory
+    digest: str | None     # lowercase SHA-256 hex, when known in advance
+
+
+def log(message: str) -> None:
+    print(f"sync-releases: {message}", flush=True)
+
+
+def fail(message: str) -> None:
+    print(f"sync-releases: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+# ---- GitHub ------------------------------------------------------------------
+
+def api(url: str) -> object:
+    request = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(request) as response:
+        return json.load(response)
+
+
+def releases(repo: str) -> list[dict]:
+    """Every release of `repo`, paging until the API returns an empty page."""
+    found: list[dict] = []
+    page = 1
+    while True:
+        batch = api(f"https://api.github.com/repos/{repo}/releases?per_page=100&page={page}")
+        if not batch:
+            return found
+        found.extend(batch)
+        page += 1
+
+
+def release_assets(release: dict) -> list[Asset]:
+    version = release["tag_name"]
+    suffix = f"-{version}.jar"
+    assets: list[Asset] = []
+    for asset in release.get("assets", []):
+        name = asset["name"]
+        if not name.endswith(suffix):
+            continue
+        digest = asset.get("digest") or ""
+        digest = digest[len(DIGEST_PREFIX):].lower() if digest.startswith(DIGEST_PREFIX) else None
+        assets.append(Asset(name[: -len(suffix)], version, asset["browser_download_url"], digest))
+    return assets
+
+
+def staged_assets(directory: Path) -> list[Asset]:
+    """The jars of a local `./mill release.stage`, named `<artifactId>-<version>.jar`."""
+    assets: list[Asset] = []
+    for jar in sorted(directory.glob("*.jar")):
+        match = re.match(r"^(.+)-(\d+\.\d+\.\d+(?:-[\w.]+)?)\.jar$", jar.name)
+        if match is None:
+            fail(f"staged jar {jar.name} is not named <artifactId>-<version>.jar")
+        assets.append(Asset(match.group(1), match.group(2), str(jar), None))
+    return assets
+
+
+# ---- ivy2 layout -------------------------------------------------------------
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def fetch(asset: Asset, destination: Path) -> None:
+    if asset.source.startswith("http"):
+        with urllib.request.urlopen(asset.source) as response, destination.open("wb") as file:
+            shutil.copyfileobj(response, file)
+    else:
+        shutil.copy(asset.source, destination)
+
+
+def install(asset: Asset, ivy_local: Path) -> str:
+    """Installs one asset into the ivy2 layout; returns `fresh`, `current` or `repaired`."""
+    home = ivy_local / GROUP / asset.artifact / asset.version
+    jar = home / "jars" / f"{asset.artifact}.jar"
+    pom = home / "poms" / f"{asset.artifact}.pom"
+    ivy = home / "ivys" / "ivy.xml"
+
+    if jar.exists() and pom.exists() and ivy.exists():
+        if asset.digest is None or sha256(jar) == asset.digest:
+            return "current"
+        outcome = "repaired"
+    else:
+        outcome = "fresh"
+
+    with tempfile.TemporaryDirectory() as scratch:
+        downloaded = Path(scratch) / jar.name
+        fetch(asset, downloaded)
+        actual = sha256(downloaded)
+        if asset.digest is not None and actual != asset.digest:
+            raise RuntimeError(f"{asset.artifact}-{asset.version}.jar: SHA-256 mismatch "
+                               f"(expected {asset.digest}, got {actual})")
+
+        prefix = f"META-INF/maven/{GROUP}/{asset.artifact}/"
+        with zipfile.ZipFile(downloaded) as archive:
+            names = set(archive.namelist())
+            for entry in (prefix + "pom.xml", prefix + "ivy.xml"):
+                if entry not in names:
+                    raise RuntimeError(f"{asset.artifact}-{asset.version}.jar has no embedded "
+                                       f"{entry}; it predates self-describing releases")
+            pom_bytes = archive.read(prefix + "pom.xml")
+            ivy_bytes = archive.read(prefix + "ivy.xml")
+
+        for path in (jar, pom, ivy):
+            path.parent.mkdir(parents=True, exist_ok=True)
+        pom.write_bytes(pom_bytes)
+        ivy.write_bytes(ivy_bytes)
+        shutil.move(str(downloaded), str(jar))
+
+    return outcome
+
+
+# ---- entry point -------------------------------------------------------------
+
+def main(arguments: list[str]) -> None:
+    repo = os.environ.get("SOUNDNESS_RELEASE_REPO", "propensive/soundness")
+    ivy_local = Path(os.environ.get("IVY_LOCAL", str(Path.home() / ".ivy2" / "local")))
+
+    if arguments and arguments[0] == "--staged":
+        staged = Path(arguments[1]) if len(arguments) > 1 else Path("out/release/stage.dest")
+        if not staged.is_dir():
+            fail(f"{staged} does not exist; run `./mill release.stage` first")
+        assets = staged_assets(staged)
+        log(f"syncing {len(assets)} staged jars from {staged}")
+    else:
+        wanted = arguments[0] if arguments else None
+        if wanted is not None and not VERSION_TAG.match(wanted):
+            fail(f"version must be X.Y.Z (got '{wanted}')")
+        selected = [release for release in releases(repo)
+                    if VERSION_TAG.match(release["tag_name"])
+                    and (wanted is None or release["tag_name"] == wanted)]
+        if wanted is not None and not selected:
+            fail(f"{repo} has no release {wanted}")
+        assets = [asset for release in selected for asset in release_assets(release)]
+        versions = ", ".join(release["tag_name"] for release in selected)
+        log(f"syncing {len(assets)} jars from {repo} ({versions})")
+
+    if not assets:
+        fail("nothing to sync")
+
+    outcomes: dict[str, int] = {"fresh": 0, "current": 0, "repaired": 0}
+    failures: list[str] = []
+
+    def work(asset: Asset) -> None:
+        try:
+            outcome = install(asset, ivy_local)
+            outcomes[outcome] += 1
+            if outcome != "current":
+                log(f"{outcome}: {asset.artifact} {asset.version}")
+        except Exception as error:  # report every failure, then exit non-zero below
+            failures.append(str(error))
+
+    with ThreadPoolExecutor(max_workers=WORKERS) as pool:
+        list(pool.map(work, assets))
+
+    log(f"{outcomes['fresh']} installed, {outcomes['repaired']} repaired, "
+        f"{outcomes['current']} already current, in {ivy_local}")
+    if failures:
+        for failure in failures:
+            print(f"sync-releases: {failure}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Soundness jars published to GitHub Releases can now be used from any Mill build by version number: each released jar embeds its own POM and ivy.xml, and `make sync-releases` installs a release into the local ivy repository that Mill consults by default, so a build can depend on `mvn"dev.propensive:<artifactId>:<version>"` with no repository configuration.

Every jar that `release.stage` produces now carries its descriptors under `META-INF/maven/dev.propensive/<artifactId>/`, the Maven convention for a self-describing jar, so a release still consists of nothing but jars. The new sync command reconstructs a resolvable repository from them:

    make sync-releases VERSION=0.65.0     # one release
    make sync-releases                    # every X.Y.Z release
    ./etc/ci/sync-releases.sh --staged    # a local `./mill release.stage` output

It lists the release through the GitHub API, downloads each `<artifactId>-<version>.jar`, verifies it against the SHA-256 digest GitHub reports, and lays the jar, POM and ivy.xml out under `~/.ivy2/local/dev.propensive/<artifactId>/<version>/`. Jars already present with the right digest are skipped, so re-running is cheap and idempotent. `GITHUB_TOKEN` is honoured to lift the unauthenticated rate limit, and `IVY_LOCAL` and `SOUNDNESS_RELEASE_REPO` override the destination and source repository.

Only the `dev.propensive` coordinates come from the synced repository; the proscala standard library and third-party dependencies resolve from the toolchain repository and Maven Central as they do today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
