### PR TITLE
Build the JVM and Scala.js surfaces before staging a release

### DIFF
--- a/etc/ci/release.sh
+++ b/etc/ci/release.sh
@@ -105,6 +105,20 @@ for module in $probes; do
 done
 
 # Build every released jar into one directory, named as its release asset.
+# Build the JVM surface first, then the Scala.js surface, before staging — the shape attest
+# verifies. `release.stage` alone starts the JVM, Scala.js and Native compilers of the root
+# module (`proscenium.core`) simultaneously on a cold daemon JVM, and those three instances race
+# on dotty's JVM-global jar-lookup cache: one of them can see a partial view of the standard
+# library and fail capture checking (`any.rd cannot be tracked since its capture set is empty`
+# in `proscenium.Array`) although the very same module compiles cleanly a moment later. The
+# aggregates compile the root alone before anything runs concurrently, so the caches are warm by
+# the time the platform crosses compile side by side.
+if ! ./mill soundness.all.compile; then
+  fail "building the JVM surface failed"
+fi
+if ! ./mill soundness.js.compile; then
+  fail "building the Scala.js surface failed"
+fi
 if ! ./mill release.stage; then
   fail "building the release jars failed"
 fi


### PR DESCRIPTION
`release.stage` on its own starts the JVM, Scala.js and Native compilers of the root module (`proscenium.core`) simultaneously on a cold daemon JVM, and those three instances race on dotty's JVM-global jar-lookup cache (`ZipAndJarFileLookupFactory.FileBasedCache`, shared across compiler instances): one of them sees a partial view of the standard library and fails capture checking with `any.rd cannot be tracked since its capture set is empty` in `proscenium.Array` — reproducibly 3 out of 3 on a fresh daemon (a different platform losing each time), never once the JVM is warm, and never under attest, whose aggregates compile the single root alone before anything runs concurrently. That is why `make release VERSION=0.64.0` failed twice on a tree whose attestation was green, and why a clean build did not help. The script now builds `soundness.all.compile`, then `soundness.js.compile`, and only then stages, so a release comes from the same build shape attest verified; validated end to end by clean → warm-up → `release.stage`, which staged all 627 jars.

## Release notes

Release process only; no library changes.
