### PR TITLE
Stack concurrent PRs so each is attested once

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -92,6 +92,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Let the user approve the title and body text before the PR is opened.
 - Open as **ready for review** (not draft). Enable auto-merge so the PR merges as soon as the `Build` check passes.
 - Immediately before opening the PR, make sure the branch is based upon the current `origin/main`, and rebase if necessary.
+- When several PRs are in flight, stack them: base each new PR branch on the previous open PR's branch and merge bottom-up, so each is attested once. `AGENTS.md` explains why and the rules.
 - Title is a clear one-line description of the work.
 - Body follows `.github/pull_request_template.md`: a single summary paragraph, a blank line, then Markdown release notes for users (with code examples if useful).
 - Whenever a new commit is added to a PR, re-read the PR description and update it if it no longer accurately describes the full set of commits. Each new commit also requires a fresh `make attest && make push` before the `Build` check can pass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# Agent instructions for Soundness
+
+Read `.claude/CLAUDE.md` first: it covers the build, code style, the commit and PR workflow,
+and the local-CI attestation scheme. This file adds the rules for developing several PRs at
+once.
+
+## Stack concurrent PRs; never develop them side by side
+
+When more than one PR is in flight, each new PR branch must be **based on the branch of the
+previous open PR**, not on `main`, forming a single linear stack:
+
+```
+main ── A ── B ── C
+```
+
+Open the PR for `B` against `A`'s branch, `C` against `B`'s, and so on. GitHub retargets each
+PR to `main` automatically when the branch beneath it merges and is deleted.
+
+### Why: attestations are keyed by content
+
+The `Build` check verifies a signed attestation that `make attest` attaches to the **filtered
+git tree** of the commit (the tree with `.dockerignore`-excluded paths removed). A commit is
+attested if some attested build produced exactly that tree.
+
+- In a **stack**, attesting `B` builds `main + A + B`. When `A` is squash-merged from an
+  up-to-date branch, `main`'s tree becomes `A`'s tree, so rebasing `B` onto the new `main` yields
+  the *same* tree `B` already had. `B` merges on its existing attestation. Each PR in the stack
+  is attested exactly once, and they merge bottom-up with no rebuilds.
+- Developed **side by side** from `main`, `A` and `B` are each attested against `main` alone.
+  Once `A` merges, `B` must be rebased, which produces a tree nobody has built, so `B` needs a
+  full `make attest` again before it can merge. With `n` concurrent PRs that is up to `n - 1`
+  extra attestations, each a from-scratch build and test run.
+
+The same reasoning is why a branch must be rebased onto the current `origin/main` immediately
+before merging: a squash of a stale branch produces a tree that was never built and has no
+attestation.
+
+### Rules for working in a stack
+
+1. Start every new branch from the top of the stack (the newest open PR branch), after
+   confirming that branch is itself based on the current `origin/main`.
+2. Merge from the bottom up. Do not merge `B` before `A`.
+3. Amending a lower PR invalidates everything above it: rebase each higher branch onto the
+   amended one, in order, and re-attest each. Prefer finishing and merging lower PRs over
+   revising them.
+4. After a lower PR merges, rebase the next branch onto `origin/main`. Its filtered tree should
+   be unchanged; `make attest` will report an existing attestation and exit without building.
+   If it starts a build instead, something in between changed the content, and the rebuild is
+   genuinely required.
+5. Keep each PR's own diff reviewable: the PR base is the branch beneath it, so the diff shows
+   only that PR's changes.


### PR DESCRIPTION
When several PRs are in flight, each new PR branch should be stacked on the previous open PR's branch rather than started from main, and the stack merged bottom-up. Because attestations are keyed by the filtered tree, attesting the top of a stack builds main plus every PR beneath it, so once a lower PR squash-merges, rebasing the next one onto main reproduces a tree that is already attested. Side-by-side branches each need a fresh from-scratch build after every merge beneath them.

This adds `AGENTS.md` at the repository root with the rule and its reasoning, and points to it from the PR workflow section of `.claude/CLAUDE.md`. The rules in brief:

- Start every new branch from the top of the stack, having checked that branch is itself on the current `origin/main`.
- Merge from the bottom up.
- Amending a lower PR invalidates everything above it: rebase and re-attest each higher branch in order.
- After a lower PR merges, rebase the next branch onto `origin/main`. Its filtered tree is unchanged, so `make attest` exits without building.
- Base each PR on the branch beneath it so its diff shows only its own changes.

Both files are outside the CI input set, so this PR reuses main's existing attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
