### PR TITLE
Record every material change in doc/migration/pending.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -93,6 +93,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Open as **ready for review** (not draft). Enable auto-merge so the PR merges as soon as the `Build` check passes.
 - Immediately before opening the PR, make sure the branch is based upon the current `origin/main`, and rebase if necessary.
 - When several PRs are in flight, stack them: base each new PR branch on the previous open PR's branch and merge bottom-up, so each is attested once. `AGENTS.md` explains why and the rules.
+- Every PR that changes what a consumer of a Soundness library could observe (renames, moves, signatures, removals, behaviour) adds an entry to `doc/migration/pending.md`, written for an LLM to apply. `AGENTS.md` specifies the format; `doc/migration.md` explains the scheme.
 - Title is a clear one-line description of the work.
 - Body follows `.github/pull_request_template.md`: a single summary paragraph, a blank line, then Markdown release notes for users (with code examples if useful).
 - Whenever a new commit is added to a PR, re-read the PR description and update it if it no longer accurately describes the full set of commits. Each new commit also requires a fresh `make attest && make push` before the `Build` check can pass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Read `.claude/CLAUDE.md` first: it covers the build, code style, the commit and PR workflow,
 and the local-CI attestation scheme. This file adds the rules for developing several PRs at
-once.
+once, and for recording every material change in the migration notes.
 
 ## Stack concurrent PRs; never develop them side by side
 
@@ -49,3 +49,71 @@ attestation.
    genuinely required.
 5. Keep each PR's own diff reviewable: the PR base is the branch beneath it, so the diff shows
    only that PR's changes.
+
+## Record every material change in `doc/migration/pending.md`
+
+Downstream code is upgraded across Soundness releases by an LLM agent that reads one file per
+release, `doc/migration/<version>.md`, and applies what it describes. `doc/migration.md`
+explains the scheme. Since the 0.64.0 release, every PR contributes to the next file.
+
+### When an entry is required
+
+A PR must add an entry for every change a consumer of a Soundness library could observe:
+
+- renames of packages, modules, types, members, givens, extension methods or annotations;
+- moves between packages or modules, including changes to which module or import provides
+  something, and changes to artifact or module names;
+- signature changes: parameters added, removed, reordered or retyped; result types; type
+  parameters; changed `inline`/`transparent`/`erased`/`using` status; new required givens;
+- removals and deprecations, with their replacement if one exists;
+- changed defaults, changed semantics, changed error types, changed ordering, changed
+  formatting of output, changed thread-safety or laziness, and any other behaviour change that
+  could alter what existing downstream code does;
+- changes to compiler flags, Scala version, or build requirements that consumers must match.
+
+No entry is needed for changes with no observable effect on consumers: formatting, comments,
+performance work that preserves behaviour, tests, benchmarks, internal refactoring, and CI or
+documentation changes. Purely additive API is optional; record it only when it supersedes an
+existing way of doing something.
+
+### How to write an entry
+
+The reader is an intelligent LLM capable of complex refactoring, not a person. Optimise for
+precision and density, not readability:
+
+- State **what** changed, exactly. Give fully-qualified old and new names, complete old and
+  new signatures, and exact old and new semantics. Do not describe motivation.
+- Leave **how** to adapt to the reader, unless the adaptation is not deducible from the change
+  itself (for example, a semantic change that requires call sites to be audited for a
+  particular pattern). Then state the condition under which code must change.
+- One entry per change; never merge distinct changes into one entry. Group entries under a
+  `## <module>` heading per library, appending within the group. Reference the PR number.
+- Be exhaustive within the change: if a rename applies to a family of members, list every
+  member, not "and similar".
+- If a change is reverted before release, delete its entry rather than adding a counter-entry.
+
+A representative entry:
+
+```
+## gossamer
+
+- `gossamer.Text#sub(from: Text, to: Text): Text` renamed to `replace`; `sub` removed.
+  Behaviour unchanged. (#1900)
+- `gossamer.Text#cut(separator: Text)` now returns `proscenium.List[Text]` instead of
+  `scala.collection.immutable.List[Text]`; it also no longer drops a trailing empty
+  element, so `t"a,b,".cut(t",")` yields three elements where it previously yielded two.
+  (#1904)
+```
+
+### Rules
+
+1. Write only to `doc/migration/pending.md`. Never edit a released `doc/migration/<version>.md`
+   except to correct an error in it.
+2. Add the entry in the same PR as the change, in the same commit as the change or a later one.
+   `doc/migration/**` is outside the CI input set, so adding or amending an entry does not
+   invalidate the PR's attestation.
+3. On release, the release PR renames `doc/migration/pending.md` to
+   `doc/migration/<version>.md` (`git mv`) and creates a fresh `pending.md` containing only its
+   header. The release process is not complete until this has merged.
+4. Reviewing a PR includes checking that `pending.md` covers every observable change the diff
+   makes.

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -1,0 +1,33 @@
+# Migration notes
+
+Soundness moves quickly and renames, moves and reshapes its API between releases. Downstream
+code is expected to be upgraded by an LLM agent rather than by hand, so from the 0.64.0
+release onwards every release ships a machine-oriented record of what changed.
+
+## How it works
+
+- `doc/migration/pending.md` accumulates the changes since the last release. Every PR that
+  makes a material change to the public API or observable behaviour adds an entry to it.
+- When a release is cut, `pending.md` is renamed to `doc/migration/<version>.md`
+  (for example `doc/migration/0.65.0.md` for Soundness 0.65.0) and a fresh, empty
+  `pending.md` is started. Released files are not edited afterwards except to correct
+  mistakes.
+- The result is one file per release, each describing exactly the changes between the
+  previous release and that one.
+
+## Upgrading downstream code
+
+To upgrade a project from version `A` to version `B`, instruct an LLM agent to read every file
+`doc/migration/<v>.md` with `A < v <= B`, in ascending version order, and to apply the changes
+each one describes to the project's code. For example, moving from 0.64.0 to 0.67.0 means
+reading `0.65.0.md`, `0.66.0.md` and `0.67.0.md`, in that order.
+
+## What the files contain
+
+The files are written for an intelligent LLM, not for people. They are precise, dense and
+complete: every rename, move, signature change, removal, changed default and changed
+behaviour that a consumer of a Soundness library could observe. They say *what* changed,
+with fully-qualified old and new names and exact semantics, and leave working out *how* to
+adapt a particular codebase to the agent reading them, except where the adaptation is not
+deducible from the change itself. `AGENTS.md` at the repository root specifies the format
+and the rules for maintaining them.

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -1,0 +1,8 @@
+# Changes since 0.64.0 (pending release)
+
+This file is read by an LLM agent to upgrade code that consumes Soundness libraries. Each
+entry states precisely what changed; see `AGENTS.md` for the format. Entries are grouped
+by module, most-recently-added last within a module.
+
+Entries for changes merged between the 0.64.0 release and the introduction of this file have
+not yet been recorded here.


### PR DESCRIPTION
Downstream code is upgraded across Soundness releases by an LLM agent reading one migration file per release, so every PR that changes what a consumer of a Soundness library could observe now adds an entry to `doc/migration/pending.md`. When a release is cut, that file is renamed to `doc/migration/<version>.md` and a fresh pending file is started. To upgrade from 0.64.0 to 0.67.0, an agent reads `0.65.0.md`, `0.66.0.md` and `0.67.0.md` in order and applies what they describe.

`AGENTS.md` now specifies the scheme for contributors: which changes require an entry (renames, moves, signature changes, removals, changed defaults and semantics, build requirements), which do not (formatting, behaviour-preserving performance work, tests, internal refactoring, CI and docs), and how to write entries for an LLM rather than a person: exact fully-qualified old and new names, complete signatures and semantics, one entry per change grouped by module with the PR number, stating what changed and leaving how to adapt to the reader unless it is not deducible. `doc/migration.md` gives the short explanation of the scheme, and `doc/migration/pending.md` is created with its header, noting that changes merged between 0.64.0 and now are not yet recorded.

All files are outside the CI input set, so this PR reuses main's existing attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
