### PR TITLE
Name importable givens for what they select, and write the standard down

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,6 +67,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   givens, as `soundness_scintillate_server.scala` does); and a lexically-scoped given
   (imported or same-package toplevel) outranks any companion given, which is what makes the
   choice-package pattern override defaults.
+- How an importable given is *named* (family as role, choice-then-role, uniqueness with the
+  package removed, provenance words such as `javaBase…`/`wasi…`/`scalaNative…`/`soundness…`)
+  is `doc/standards/given-naming.md`.
 
 ## Workflow
 

--- a/build.mill
+++ b/build.mill
@@ -125,17 +125,17 @@ object settings:
     // compilation), so it is silenced narrowly by `origin` (the imported symbol's path).
     "-Wconf:origin=.*unsafeExceptions.canThrowAny:s",
     "-Wconf:origin=.*strategies.throwUnsafely:s",
-    "-Wconf:origin=.*hashProviders.soundnessHashing:s",
-    "-Wconf:origin=.*charEncoders.ascii:s",
-    "-Wconf:origin=.*textMetrics.uniform:s",
+    "-Wconf:origin=.*providers.soundnessProvider:s",
+    "-Wconf:origin=.*charEncoders.asciiEncoder:s",
+    "-Wconf:origin=.*textMetrics.uniformMetric:s",
     "-Wconf:origin=.*arithmeticOptions.uncheckedOverflow:s",
-    "-Wconf:origin=.*errorDiagnostics.empty:s",
-    "-Wconf:origin=.*logging.silent:s",
+    "-Wconf:origin=.*errorDiagnostics.emptyDiagnostics:s",
+    "-Wconf:origin=.*logging.silentLogging:s",
     "-Wconf:origin=.*pathOnLinux:s",
-    "-Wconf:origin=.*systems.java:s",
-    "-Wconf:origin=.*overwritePreexisting.enabled:s",
-    "-Wconf:origin=.*dynamicJsonAccess.enabled:s",
-    "-Wconf:origin=.*dynamicTelAccess.enabled:s",
+    "-Wconf:origin=.*systems.javaBaseSystem:s",
+    "-Wconf:origin=.*filesystemOptions.overwritePreexisting:s",
+    "-Wconf:origin=.*dynamicAccess.dynamicJson:s",
+    "-Wconf:origin=.*dynamicAccess.dynamicTel:s",
     "-Wconf:origin=.*queryParameters.arbitraryQueryParameter:s",
     "-Wconf:origin=.*CssClass.nominative:s",
     "-Wconf:origin=.*Async.nominative:s",
@@ -1544,13 +1544,13 @@ object chiaroscuro extends Library:
 object coaxial extends Library:
   object core extends Component(anticipation.path, urticose.core, turbulence.core,
     aperture.core):
-    // The native `SocketBackend` (`socketBackends.native`) is folded into the native cross via
+    // The native `SocketBackend` (`socketBackends.scalaNativeSockets`) is folded into the native cross via
     // `nativeSources` (as galilei's filesystem backend is): TCP and UDP over Scala Native's
     // `java.net` sockets, with Unix-domain sockets and TLS unsupported for now.
     override def nativeSources = Task.Sources(moduleDir, moduleDir / os.up / "native")
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
-  // The `java.net`/`java.nio.channels` `SocketBackend` (`socketBackends.virtualMachine`), split out
+  // The `java.net`/`java.nio.channels` `SocketBackend` (`socketBackends.javaBaseSockets`), split out
   // of `core` so the platform-neutral socket API can cross-compile; other platforms (e.g. WASI)
   // supply their own backend.
   object jvm extends Component(core, gastronomy.core):
@@ -1763,7 +1763,7 @@ object enigmatic extends Library:
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // The platform split mirrors gastronomy's: the cipher/key/PEM model is platform-neutral, while
-  // the `JavaStdlibCrypto` provider and PKCS#12 keystores compile against `javax.crypto`/
+  // the `JavaBaseCrypto` provider and PKCS#12 keystores compile against `javax.crypto`/
   // `java.security` on the JVM (`core-jvm`) and against panicking stubs on native (`core-native`,
   // where the OpenSSL provider is the real implementation).
   object core extends Component(anticipation.path, aperture.core, gastronomy.core, asn1):
@@ -2071,13 +2071,13 @@ object fulminate extends Library:
 object galilei extends Library:
   object core extends Component(aperture.core, serpentine.core, ambience.core, turbulence.core,
       kaleidoscope.core):
-    // The native `FilesystemBackend` (`filesystemBackends.native`) is folded into the native cross
+    // The native `FilesystemBackend` (`filesystemBackends.scalaNativeFilesystem`) is folded into the native cross
     // via `nativeSources` — native has a single OS filesystem, so (unlike the JVM/WASI backends,
     // which are separate modules) it need not be an opt-in dependency.
     override def nativeSources = Task.Sources(moduleDir, moduleDir / os.up / "native")
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
-  // The `java.nio` `FilesystemBackend` (`filesystemBackends.virtualMachine`), split out of `core`
+  // The `java.nio` `FilesystemBackend` (`filesystemBackends.javaBaseFilesystem`), split out of `core`
   // so the platform-neutral filesystem API can cross-compile; other platforms (e.g. WASI) supply
   // their own backend.
   object jvm extends Component(core, guillotine.core):
@@ -2097,7 +2097,7 @@ object galilei extends Library:
 
 object gastronomy extends Library:
   // Hashing works on every platform: the pure-Scala MD5/SHA/CRC-32 implementations (and BLAKE3)
-  // are shared, while the `JavaStdlibHashing` provider is compiled against `java.security` on the
+  // are shared, while the `JavaBaseHashing` provider is compiled against `java.security` on the
   // JVM (`core-jvm`, native `MessageDigest`) and against the pure implementations elsewhere
   // (`core-native`), selected by the `jsSources` platform split.
   // `corpuscular.core` supplies `Algorithm` and `Digestion` (the marker and the incremental
@@ -3137,7 +3137,7 @@ object telekinesis extends Library:
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   // JVM-only transports split out of `core` so the platform-agnostic HTTP model and client can
-  // cross-compile to Scala.js: the `java.net.http` `Http.Backend` (`httpBackends.virtualMachine`)
+  // cross-compile to Scala.js: the `java.net.http` `Http.Backend` (`httpBackends.javaNetHttp`)
   // and the `coaxial` domain-socket client.
   object jvm extends Component(core, http2, coaxial.jvm):
     override def scalaJs = false

--- a/build.mill
+++ b/build.mill
@@ -128,7 +128,7 @@ object settings:
     "-Wconf:origin=.*hashProviders.soundnessHashing:s",
     "-Wconf:origin=.*charEncoders.ascii:s",
     "-Wconf:origin=.*textMetrics.uniform:s",
-    "-Wconf:origin=.*arithmeticOptions.overflow.unchecked:s",
+    "-Wconf:origin=.*arithmeticOptions.uncheckedOverflow:s",
     "-Wconf:origin=.*errorDiagnostics.empty:s",
     "-Wconf:origin=.*logging.silent:s",
     "-Wconf:origin=.*pathOnLinux:s",

--- a/doc/api-nesting-proposal.md
+++ b/doc/api-nesting-proposal.md
@@ -388,7 +388,7 @@ now exhausted. Six new rules, and one revert overturned.
   missing *extension methods* long before they show up as missing types, so diff the two
   import lists rather than adding only what the type errors demand.
 - **Never re-sort a receiving file's imports.** `obligatory.JsonRpc.scala` ends with
-  `import httpBackends.virtualMachineHttp`, a choice import that must follow `telekinesis.*`;
+  `import httpBackends.javaNetHttp`, a choice import that must follow `telekinesis.*`;
   alphabetising the block moved it above and it stopped resolving. Insert new imports into
   the alphabetical run and leave the trailing choice imports alone. Relatedly, scope a
   donor's `scala.collection.immutable.{::, Nil}` imports to the member that needs them — at

--- a/doc/api-nesting-proposal.md
+++ b/doc/api-nesting-proposal.md
@@ -557,7 +557,7 @@ them about not breaking something while moving something else.
   away, as `Not found: type rpc` inside a macro in a different component, and survives
   incremental rebuilds until `mill clean`. `obligatory`'s `@rpc` annotation hit this; moving
   it into `object annotations` and exporting it frees the name. Nested lowercase objects are
-  safe — hypotenuse's `arithmeticOptions.division` does not block `Division`.
+  safe — hypotenuse's `arithmeticOptions.checkedDivision` does not block `Division`.
 - **An inner wildcard import shadows the outer ones.** Gathering files into one object means
   merging their imports, and a nested object that re-imports only its *distinctive* imports
   loses the rest: `object Dialect` with `import proscenium.compat.*` inside it stopped seeing

--- a/doc/api-reduction-candidates.md
+++ b/doc/api-reduction-candidates.md
@@ -183,8 +183,8 @@ scintillate depends on — rather than a listener that could not bind. It is
 `Httpd.Error`, beside the `Httpd.Event` that both server backends already share. `HttpServer`
 itself has since become `Httpd` — a single word for the same thing, which also takes it out of
 the R2 exclusion table, since there is no longer a compound name to justify. Its family went
-with it: `HttpServerFor`, `stdlibHttpServer` and `stdlibPublicHttpServer` are `HttpdFor`,
-`stdlibHttpd` and `stdlibPublicHttpd`.
+with it: `HttpServerFor`, `stdlibHttpServer` and `jdkHttpserverPublic` are `HttpdFor`,
+`jdkHttpserver` and `jdkHttpserverPublic`.
 
 `BoundsError` was **deleted** rather than renamed. It duplicated
 `JsonBlueprint.Error`'s `IntOutOfRange` reason — the same failure, the same three fields,
@@ -290,7 +290,7 @@ ultimatum's is the likelier one to rename.
 | `Http*` | anticipation, honeycomb, urticose | 4 | `HttpEquiv`, `HttpRequests`, `HttpStreams`, `HttpUrl` |
 | `Image*` | embarcadero | 2 | `ImageOpenable`, `ImageRecord` |
 | `Inline*` | profanity, ultimatum | 5 | `InlineAnchoring`, `InlineBoard`, `InlineGrowth`, `InlineRoot`, `InlineShrink` |
-| `Java*` | anthology, diuretic, enigmatic, gastronomy, scintillate | 11 | `JavaIoFile`, `JavaLongDuration`, `JavaLongInstant`, `JavaNetUrl`, `JavaNioPath`, `JavaServlet`, `JavaStdlibCrypto`, `JavaStdlibHashing`, `JavaTimeInstant`, `JavaUtilDate`, `JavaVersion` |
+| `Java*` | anthology, diuretic, enigmatic, gastronomy, scintillate | 11 | `JavaIoFile`, `JavaLongDuration`, `JavaLongInstant`, `JavaNetUrl`, `JavaNioPath`, `JavaServlet`, `JavaBaseCrypto`, `JavaBaseHashing`, `JavaTimeInstant`, `JavaUtilDate`, `JavaVersion` |
 | `Json*` | jacinta, obligatory | 4 | `JsonBlueprint`, `JsonPointer`, `JsonRpc`, `JsonSchema` |
 | `Kotlin*` | xenophile | 5 | `KotlinDialect`, `KotlinFacade`, `KotlinInvoke`, `KotlinMetadataAtomizer`, `KotlinMetadataDiscipline` |
 | `Lane*` | dendrology | 2 | `LaneDagDiagram`, `LaneDagStyle` |
@@ -301,7 +301,7 @@ ultimatum's is the likelier one to rename.
 | `List*` | embarcadero, proscenium | 9 | `ListContainersRequest`, `ListContainersResponse`, `ListHasAsScala`, `ListImagesRequest`, `ListImagesResponse`, `ListNamespacesRequest`, `ListNamespacesResponse`, `ListTasksRequest`, `ListTasksResponse` |
 | `Local*` | hellenism, urticose | 2 | `LocalClasspath`, `LocalPart` |
 | `Log*` | anticipation, eucalyptus | 2 | `LogPalette`, `LogSink` |
-| `Native*` | surveillance, xenophile | 2 | `NativeInvoke`, `NativeWatcher` |
+| `Native*` | surveillance, xenophile | 2 | `NativeInvoke`, `JavaBaseWatcher` |
 | `Network*` | sedentary, urticose | 3 | `NetworkDevice`, `NetworkDeviceSessional`, `NetworkInterface` |
 | `Oci*` | anthology | 2 | `OciConfiguration`, `OciImage` |
 | `Open*` | apoplexy, galilei | 2 | `OpenApi`, `OpenFlag` |

--- a/doc/errors/868.md
+++ b/doc/errors/868.md
@@ -26,13 +26,13 @@ the dividend before dividing.
 
 ### `SN-868.1` — `DivisionByZero`
 
-The divisor was zero. Raised only under `import arithmeticOptions.division.checked`;
+The divisor was zero. Raised only under `import arithmeticOptions.checkedDivision`;
 the unchecked default lets the platform's own division semantics apply.
 
 ### `SN-868.2` — `Overflow`
 
 The result exceeded the range of its type. Raised only under
-`import arithmeticOptions.overflow.checked`. This was `SN-331` (`OverflowError`)
+`import arithmeticOptions.checkedOverflow`. This was `SN-331` (`OverflowError`)
 until the two were unified.
 
 ## See also

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -6,3 +6,280 @@ by module, most-recently-added last within a module.
 
 Entries for changes merged between the 0.64.0 release and the introduction of this file have
 not yet been recorded here.
+
+## ambience
+
+- `ambience.systems.javaSystem` renamed to `javaBaseSystem`. (#PR)
+- `ambience.environments.javaEnvironment` renamed to `javaBaseEnvironment`. (#PR)
+- `ambience.workingDirectories.javaWorkingDirectory` renamed to `javaBaseWorkingDirectory`. (#PR)
+- `ambience.workingDirectories.defaultWorkingDirectory` removed; use `javaBaseWorkingDirectory`,
+  which reads the `user.dir` property (the removed given read `java.nio.file.Paths.get("")`,
+  which resolves to the same directory). (#PR)
+- `ambience.temporaryDirectories.javaTemporaryDirectory` renamed to `javaBaseTemporaryDirectory`. (#PR)
+
+## turbulence
+
+- `turbulence.stdios.virtualMachineStdio` (wrapping `java.io.FileDescriptor.{in,out,err}`) renamed
+  to `fileDescriptorStdio`. (#PR)
+- `turbulence.stdios.systemStdio` (wrapping `java.lang.System.{in,out,err}`) renamed to
+  `javaLangSystemStdio`. (#PR)
+- `turbulence.lineSeparation.virtualMachineLineSeparation` renamed to `javaBaseLineSeparation`. (#PR)
+
+## coaxial
+
+- `coaxial.socketBackends.virtualMachineSockets` renamed to `javaBaseSockets`. (#PR)
+- `coaxial.socketBackends.native` (Scala Native module) renamed to `scalaNativeSockets`, and now
+  re-exported as `soundness.socketBackends.scalaNativeSockets`. (#PR)
+
+## galilei
+
+- `galilei.filesystemBackends.virtualMachineFilesystem` renamed to `javaBaseFilesystem`. (#PR)
+- `galilei.filesystemBackends.native` (Scala Native module) renamed to `scalaNativeFilesystem`,
+  and now re-exported as `soundness.filesystemBackends.scalaNativeFilesystem`. (#PR)
+- The nested objects under `galilei.filesystemOptions` are flattened into givens of the same
+  types: `dereferenceSymlinks.enabled` → `dereferenceSymlinks`, `dereferenceSymlinks.disabled` →
+  `preserveSymlinks`, `moveAtomically.enabled` → `moveAtomically`, `moveAtomically.disabled` →
+  `moveNonAtomically`, `copyAttributes.enabled` → `copyAttributes`, `copyAttributes.disabled` →
+  `discardAttributes`, `deleteRecursively.enabled` → `deleteRecursively`,
+  `deleteRecursively.disabled` → `deleteOnlyEmpty`, `overwritePreexisting.enabled` →
+  `overwritePreexisting`, `overwritePreexisting.disabled` → `failOnPreexisting`,
+  `createNonexistentParents.enabled` → `createNonexistentParents`,
+  `createNonexistentParents.disabled` → `requireParents`. The objects no longer exist. (#PR)
+
+## telekinesis
+
+- `telekinesis.httpBackends.virtualMachineHttp` renamed to `javaNetHttp`. (#PR)
+- `telekinesis.httpBackends.nativeHttp` renamed to `soundnessHttp`. (#PR)
+
+## scintillate
+
+- `scintillate.httpServers.stdlibHttpd` renamed to `jdkHttpserver`; `stdlibPublicHttpd` renamed
+  to `jdkHttpserverPublic`. (#PR)
+- `scintillate.httpServers.nativeHttpServer` renamed to `soundnessHttpd`; `nativePublicHttpServer`
+  renamed to `soundnessHttpdPublic`; both are now also re-exported as
+  `soundness.httpServers.{soundnessHttpd, soundnessHttpdPublic}`. (#PR)
+- `scintillate.frontends.threadPerConnection` renamed to `threadPerConnectionFrontend`;
+  `frontends.reactive` renamed to `reactiveFrontend`. (#PR)
+- `scintillate.webserverErrorPages.standardErrorPage` renamed to `styledErrorPage`. (#PR)
+
+## surveillance
+
+- `surveillance.watchers.nativeWatcher` renamed to `javaBaseWatcher`; `surveillance.NativeWatcher`
+  (object) renamed to `JavaBaseWatcher`. (#PR)
+
+## gastronomy
+
+- `gastronomy.Provider.JavaStdlib` renamed to `Provider.JavaBase`; `gastronomy.JavaStdlibHashing`
+  renamed to `JavaBaseHashing`; `gastronomy.Hashing.javaStdlibHashing` renamed to
+  `javaBaseHashing`; `gastronomy.providers.javaStdlibProvider` renamed to `javaBaseProvider`. (#PR)
+- Choice package `gastronomy.crypto` renamed to `gastronomy.cryptoPermits` (members
+  `permitUnauthenticatedCrypto`, `permitDeprecatedCrypto`, `permitLegacyCrypto`,
+  `permitDisallowedCrypto`, `permitCryptoThrough2014`, `permitCryptoThrough2024`,
+  `permitCryptoThrough2030`, `permitLegacyTls`, `permitUntrustedCertificates`,
+  `permitUncheckedRevocation`, `permitNonCryptographicHashes` unchanged). (#PR)
+
+## enigmatic
+
+- `enigmatic.JavaStdlibCrypto` renamed to `JavaBaseCrypto`; `enigmatic.Crypto.javaStdlibCrypto`
+  renamed to `javaBaseCrypto`. (#PR)
+- `enigmatic.cloaks.{cloakHeap, cloakOffHeap, cloakVeiledHeap, cloakVeiledOffHeap}` renamed to
+  `{heapCloak, offHeapCloak, veiledHeapCloak, veiledOffHeapCloak}`. (#PR)
+- Choice packages `enigmatic.blockCipherMode` and `enigmatic.blockCipherPadding` renamed to
+  `blockCipherModes` and `blockCipherPaddings` (members `cbc`, `ctr`, `cfb`, `ofb`, `pkcs7`,
+  `iso10126` unchanged). (#PR)
+
+## kaleidoscope
+
+- `kaleidoscope.Jur` (type and companion) renamed to `JavaBaseRegex`;
+  `kaleidoscope.regexBackends.jur` renamed to `javaBaseRegex`. (#PR)
+
+## diuretic
+
+- Top-level `diuretic.javaNioFilePath` renamed to `javaNioPathRepresentative` and top-level
+  `diuretic.javaIoFile` renamed to `javaIoFileRepresentative` (the `Representative of Paths`
+  markers; `anticipation.interfaces.paths.{javaNioPath, javaIoFile}` are unchanged). (#PR)
+
+## harlequin
+
+- `punctuation.formattables.{scala, java}` (the `CommonFormattable` givens in `harlequin.md`)
+  renamed to `{scalaFormattable, javaFormattable}`. (#PR)
+
+## aviation
+
+- `aviation.chronometries.unix` renamed to `unixChronometry`; `chronometries.atomic` renamed to
+  `taiChronometry`. (#PR)
+- `aviation.leapModes.exact` renamed to `exactLeapMode`. (#PR)
+- `aviation.gapPolicies.pushBackward` renamed to `pushBackwardGapPolicy`; `gapPolicies.rejectGap`
+  renamed to `rejectGapPolicy`. (#PR)
+- `aviation.timespanFormats.{englishRelative, frenchRelative, germanRelative, spanishRelative}`
+  renamed to `{englishRelativeTimespan, frenchRelativeTimespan, germanRelativeTimespan,
+  spanishRelativeTimespan}`. (#PR)
+- Newly re-exported into `soundness`: `hourFormats.{twelveHourSecondsClock,
+  twentyFourHourSecondsClock}`, new family `timeSpecificities.{minutesSpecificity,
+  secondsSpecificity}` (library package `aviation.timeFormats.specificity`), and
+  `interfaces.instants.aviationInstant` / `interfaces.durations.aviationDuration`. (#PR)
+
+## probably
+
+- `probably.harnesses.threadLocal` renamed to `threadLocalHarness`. (#PR)
+- `probably.autopsies.none` renamed to `noAutopsy`; `autopsies.contrastExpectations` renamed to
+  `contrastAutopsy`. (#PR)
+
+## iridescence
+
+- Every member of `iridescence.mixing` gains the suffix `Mixing`: `proportional` →
+  `proportionalMixing`, `multiply` → `multiplyMixing`, `screen` → `screenMixing`, `darken` →
+  `darkenMixing`, `lighten` → `lightenMixing`, `difference` → `differenceMixing`, `exclusion` →
+  `exclusionMixing`, `linearDodge` → `linearDodgeMixing`, `linearBurn` → `linearBurnMixing`,
+  `hardLight` → `hardLightMixing`, `overlay` → `overlayMixing`, `softLight` → `softLightMixing`,
+  `colorDodge` → `colorDodgeMixing`, `colorBurn` → `colorBurnMixing`. (#PR)
+- Every member of `iridescence.colorimetry` gains the suffix `Colorimetry`: `incandescentTungsten`,
+  `oldDirectSunlightAtNoon`, `oldDaylight`, `iccProfilePcs`, `midMorningDaylight`, `daylight`,
+  `srgb`, `adobeRgb`, `northSkyDaylight`, `equalEnergy`, `daylightFluorescentF1`,
+  `coolFluorescent`, `whiteFluorescent`, `warmWhiteFluorescent`, `daylightFluorescentF5`,
+  `liteWhiteFluorescent`, `daylightFluorescentF7`, `d65Simulator`, `sylvaniaF40`, `d50Simulator`,
+  `coolWhiteFluorescent`, `philipsTl85`, `ultralume50`, `philipsTl84`, `ultralume40`,
+  `philipsTl83`, `ultralume30` become `incandescentTungstenColorimetry`, …,
+  `ultralume30Colorimetry`. (#PR)
+
+## gossamer
+
+- `gossamer.collations.unicode` renamed to `unicodeCollation`; `collations.codepoints` renamed to
+  `codepointCollation`. (#PR)
+
+## rudiments
+
+- Top-level `rudiments.populatedEquality2` renamed to `populatedEqualityReversed`. (#PR)
+
+## zephyrine
+
+- `zephyrine.lineation.linefeedChars` renamed to `linefeedChar`. The `lineation` family
+  (`linefeedChar`, `carriageReturnChar`, `linefeedByte`, `carriageReturnByte`) is now re-exported
+  as `soundness.lineation`. (#PR)
+
+## hypotenuse
+
+- The nested objects under `hypotenuse.arithmeticOptions` are flattened into givens of the same
+  types: `division.checked` → `checkedDivision`, `division.unchecked` → `uncheckedDivision`,
+  `overflow.checked` → `checkedOverflow`, `overflow.unchecked` → `uncheckedOverflow`,
+  `rationalDivision.q64` → `q64RationalDivision`, `rationalDivision.q32` → `q32RationalDivision`.
+  The objects no longer exist. (#PR)
+
+## honeycomb
+
+- `honeycomb.formatting.flatHtmlFormatting` renamed to `compactHtmlFormatting`. (#PR)
+- `honeycomb.recoveries.permissiveRecovery` is now re-exported as `soundness.recoveries`. (#PR)
+
+## cataclysm
+
+- `cataclysm.formatting.standardCssFormatting` renamed to `indentedCssFormatting`. (#PR)
+
+## dendrology
+
+- `dendrology.treeStyles.defaultTreeStyle` renamed to `squareTreeStyle`;
+  `dagStyles.defaultDagStyle` renamed to `boxDrawingDagStyle`; `laneDagStyles.defaultLaneDagStyle`
+  renamed to `boxDrawingLaneDagStyle`. (#PR)
+
+## escritoire
+
+- `escritoire.tableStyles.defaultTableStyle` renamed to `thickTableStyle`. (#PR)
+
+## eucalyptus
+
+- `eucalyptus.logFormats.standardLogFormat` renamed to `timestampedLogFormat`;
+  `logFormats.ansiStandardLogFormat` renamed to `ansiTimestampedLogFormat`. (#PR)
+- `eucalyptus.logFormats.lightweightLogFormat` removed; it was identical to
+  `untimestampedLogFormat`. (#PR)
+
+## legerdemain
+
+- `legerdemain.formulations.defaultFormulation` renamed to `postFormulation`. (#PR)
+
+## octogenarian
+
+- `octogenarian.gitCommands.environmentDefaultGitCommand` renamed to `searchpathGitCommand`. (#PR)
+
+## caesura
+
+- `caesura.optics.{cellLens, rowOptical, rowEach, rowFilter}` renamed to `{dsvCellLens,
+  dsvRowOptical, dsvRowEachOptical, dsvRowFilterOptical}`. (#PR)
+- `caesura.dynamicDsvAccess.enabled` (object member) replaced by
+  `caesura.dynamicAccess.dynamicDsv` (choice package); the object `dynamicDsvAccess` no longer
+  exists. (#PR)
+
+## capricious
+
+- `capricious.randomization.sizes.{uniformUpto10, uniformUpto100, uniformUpto1000,
+  uniformUpto10000, uniformUpto100000}` renamed to `{uniformSizeUpto10, uniformSizeUpto100,
+  uniformSizeUpto1000, uniformSizeUpto10000, uniformSizeUpto100000}`. (#PR)
+- `capricious.randomization.text.bigListOfNaughtyStrings` renamed to `naughtyStringsText`, and
+  now re-exported as `soundness.randomization.text.naughtyStringsText`. (#PR)
+
+## exoskeleton
+
+- `exoskeleton.executives.completions` renamed to `completionsExecutive`. (#PR)
+
+## caduceus
+
+- `caduceus.couriers.resend` renamed to `resendCourier`. (#PR)
+
+## ultimatum
+
+- `ultimatum.inlineAnchoring.{bottomDocked, topAnchored, topAfterResize, fullscreen, inline}`
+  renamed to `{bottomDockedAnchoring, topAnchoring, topAfterResizeAnchoring, fullscreenAnchoring,
+  flowAnchoring}`; enum case `ultimatum.InlineAnchoring.Inline` renamed to `Flow`. (#PR)
+- `ultimatum.inlineGrowth.{scrollIntoScrollback, clampToScreen}` renamed to `{scrollbackGrowth,
+  clampedGrowth}`. (#PR)
+- `ultimatum.inlineShrink.{redockBottom, keepTop}` renamed to `{redockBottomShrink,
+  keepTopShrink}`. (#PR)
+
+## jacinta
+
+- `jacinta.dynamicJsonAccess.enabled` (object member) replaced by `jacinta.dynamicAccess.dynamicJson`
+  (choice package); the object `dynamicJsonAccess` no longer exists. (#PR)
+- `jacinta.jsonConversion.encodable` (object member) replaced by
+  `jacinta.conversions.encodableToJson` (choice package); the object `jsonConversion` no longer
+  exists. (#PR)
+
+## xylophone
+
+- `xylophone.dynamicXmlAccess.enabled` replaced by `xylophone.dynamicAccess.dynamicXml`; the
+  object `dynamicXmlAccess` no longer exists. (#PR)
+
+## ypsiloid
+
+- `ypsiloid.dynamicYamlAccess.enabled` replaced by `ypsiloid.dynamicAccess.dynamicYaml`; the
+  object `dynamicYamlAccess` no longer exists. (#PR)
+- `ypsiloid.yamlConversion.encodable` replaced by `ypsiloid.conversions.encodableToYaml`; the
+  object `yamlConversion` no longer exists. (#PR)
+
+## stratiform
+
+- `stratiform.dynamicTelAccess.enabled` replaced by `stratiform.dynamicAccess.dynamicTel`; the
+  object `dynamicTelAccess` no longer exists. (#PR)
+- `stratiform.telConversion.encodable` replaced by `stratiform.conversions.encodableToTel`; the
+  object `telConversion` no longer exists. (#PR)
+
+## breviloquence
+
+- `breviloquence.dynamicCborAccess.enabled` replaced by `breviloquence.dynamicAccess.dynamicCbor`;
+  the object `dynamicCborAccess` no longer exists. (#PR)
+- `breviloquence.cborConversion.encodable` replaced by `breviloquence.conversions.encodableToCbor`;
+  the object `cborConversion` no longer exists. (#PR)
+
+## locomotion
+
+- `locomotion.protobufConversion.encodable` replaced by
+  `locomotion.conversions.encodableToProtobuf`; the object `protobufConversion` no longer
+  exists. (#PR)
+
+## superlunary
+
+- `superlunary.embeddings.automatic` (object member) replaced by
+  `superlunary.embeddings.automaticEmbedding` (choice package); `embeddings` is no longer an
+  object. (#PR)
+
+## escapade
+
+- `escapade.writables.{out, err}` renamed to `{outTeletypeWritable, errTeletypeWritable}`. (#PR)
+- `escapade.teletypeables.graphical` renamed to `graphicalTeletype`. (#PR)

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -9,33 +9,33 @@ not yet been recorded here.
 
 ## ambience
 
-- `ambience.systems.javaSystem` renamed to `javaBaseSystem`. (#PR)
-- `ambience.environments.javaEnvironment` renamed to `javaBaseEnvironment`. (#PR)
-- `ambience.workingDirectories.javaWorkingDirectory` renamed to `javaBaseWorkingDirectory`. (#PR)
+- `ambience.systems.javaSystem` renamed to `javaBaseSystem`. (#1939)
+- `ambience.environments.javaEnvironment` renamed to `javaBaseEnvironment`. (#1939)
+- `ambience.workingDirectories.javaWorkingDirectory` renamed to `javaBaseWorkingDirectory`. (#1939)
 - `ambience.workingDirectories.defaultWorkingDirectory` removed; use `javaBaseWorkingDirectory`,
   which reads the `user.dir` property (the removed given read `java.nio.file.Paths.get("")`,
-  which resolves to the same directory). (#PR)
-- `ambience.temporaryDirectories.javaTemporaryDirectory` renamed to `javaBaseTemporaryDirectory`. (#PR)
+  which resolves to the same directory). (#1939)
+- `ambience.temporaryDirectories.javaTemporaryDirectory` renamed to `javaBaseTemporaryDirectory`. (#1939)
 
 ## turbulence
 
 - `turbulence.stdios.virtualMachineStdio` (wrapping `java.io.FileDescriptor.{in,out,err}`) renamed
-  to `fileDescriptorStdio`. (#PR)
+  to `fileDescriptorStdio`. (#1939)
 - `turbulence.stdios.systemStdio` (wrapping `java.lang.System.{in,out,err}`) renamed to
-  `javaLangSystemStdio`. (#PR)
-- `turbulence.lineSeparation.virtualMachineLineSeparation` renamed to `javaBaseLineSeparation`. (#PR)
+  `javaLangSystemStdio`. (#1939)
+- `turbulence.lineSeparation.virtualMachineLineSeparation` renamed to `javaBaseLineSeparation`. (#1939)
 
 ## coaxial
 
-- `coaxial.socketBackends.virtualMachineSockets` renamed to `javaBaseSockets`. (#PR)
+- `coaxial.socketBackends.virtualMachineSockets` renamed to `javaBaseSockets`. (#1939)
 - `coaxial.socketBackends.native` (Scala Native module) renamed to `scalaNativeSockets`, and now
-  re-exported as `soundness.socketBackends.scalaNativeSockets`. (#PR)
+  re-exported as `soundness.socketBackends.scalaNativeSockets`. (#1939)
 
 ## galilei
 
-- `galilei.filesystemBackends.virtualMachineFilesystem` renamed to `javaBaseFilesystem`. (#PR)
+- `galilei.filesystemBackends.virtualMachineFilesystem` renamed to `javaBaseFilesystem`. (#1939)
 - `galilei.filesystemBackends.native` (Scala Native module) renamed to `scalaNativeFilesystem`,
-  and now re-exported as `soundness.filesystemBackends.scalaNativeFilesystem`. (#PR)
+  and now re-exported as `soundness.filesystemBackends.scalaNativeFilesystem`. (#1939)
 - The nested objects under `galilei.filesystemOptions` are flattened into givens of the same
   types: `dereferenceSymlinks.enabled` → `dereferenceSymlinks`, `dereferenceSymlinks.disabled` →
   `preserveSymlinks`, `moveAtomically.enabled` → `moveAtomically`, `moveAtomically.disabled` →
@@ -44,86 +44,86 @@ not yet been recorded here.
   `deleteRecursively.disabled` → `deleteOnlyEmpty`, `overwritePreexisting.enabled` →
   `overwritePreexisting`, `overwritePreexisting.disabled` → `failOnPreexisting`,
   `createNonexistentParents.enabled` → `createNonexistentParents`,
-  `createNonexistentParents.disabled` → `requireParents`. The objects no longer exist. (#PR)
+  `createNonexistentParents.disabled` → `requireParents`. The objects no longer exist. (#1939)
 
 ## telekinesis
 
-- `telekinesis.httpBackends.virtualMachineHttp` renamed to `javaNetHttp`. (#PR)
-- `telekinesis.httpBackends.nativeHttp` renamed to `soundnessHttp`. (#PR)
+- `telekinesis.httpBackends.virtualMachineHttp` renamed to `javaNetHttp`. (#1939)
+- `telekinesis.httpBackends.nativeHttp` renamed to `soundnessHttp`. (#1939)
 
 ## scintillate
 
 - `scintillate.httpServers.stdlibHttpd` renamed to `jdkHttpserver`; `stdlibPublicHttpd` renamed
-  to `jdkHttpserverPublic`. (#PR)
+  to `jdkHttpserverPublic`. (#1939)
 - `scintillate.httpServers.nativeHttpServer` renamed to `soundnessHttpd`; `nativePublicHttpServer`
   renamed to `soundnessHttpdPublic`; both are now also re-exported as
-  `soundness.httpServers.{soundnessHttpd, soundnessHttpdPublic}`. (#PR)
+  `soundness.httpServers.{soundnessHttpd, soundnessHttpdPublic}`. (#1939)
 - `scintillate.frontends.threadPerConnection` renamed to `threadPerConnectionFrontend`;
-  `frontends.reactive` renamed to `reactiveFrontend`. (#PR)
-- `scintillate.webserverErrorPages.standardErrorPage` renamed to `styledErrorPage`. (#PR)
+  `frontends.reactive` renamed to `reactiveFrontend`. (#1939)
+- `scintillate.webserverErrorPages.standardErrorPage` renamed to `styledErrorPage`. (#1939)
 
 ## surveillance
 
 - `surveillance.watchers.nativeWatcher` renamed to `javaBaseWatcher`; `surveillance.NativeWatcher`
-  (object) renamed to `JavaBaseWatcher`. (#PR)
+  (object) renamed to `JavaBaseWatcher`. (#1939)
 
 ## gastronomy
 
 - `gastronomy.Provider.JavaStdlib` renamed to `Provider.JavaBase`; `gastronomy.JavaStdlibHashing`
   renamed to `JavaBaseHashing`; `gastronomy.Hashing.javaStdlibHashing` renamed to
-  `javaBaseHashing`; `gastronomy.providers.javaStdlibProvider` renamed to `javaBaseProvider`. (#PR)
+  `javaBaseHashing`; `gastronomy.providers.javaStdlibProvider` renamed to `javaBaseProvider`. (#1939)
 - Choice package `gastronomy.crypto` renamed to `gastronomy.cryptoPermits` (members
   `permitUnauthenticatedCrypto`, `permitDeprecatedCrypto`, `permitLegacyCrypto`,
   `permitDisallowedCrypto`, `permitCryptoThrough2014`, `permitCryptoThrough2024`,
   `permitCryptoThrough2030`, `permitLegacyTls`, `permitUntrustedCertificates`,
-  `permitUncheckedRevocation`, `permitNonCryptographicHashes` unchanged). (#PR)
+  `permitUncheckedRevocation`, `permitNonCryptographicHashes` unchanged). (#1939)
 
 ## enigmatic
 
 - `enigmatic.JavaStdlibCrypto` renamed to `JavaBaseCrypto`; `enigmatic.Crypto.javaStdlibCrypto`
-  renamed to `javaBaseCrypto`. (#PR)
+  renamed to `javaBaseCrypto`. (#1939)
 - `enigmatic.cloaks.{cloakHeap, cloakOffHeap, cloakVeiledHeap, cloakVeiledOffHeap}` renamed to
-  `{heapCloak, offHeapCloak, veiledHeapCloak, veiledOffHeapCloak}`. (#PR)
+  `{heapCloak, offHeapCloak, veiledHeapCloak, veiledOffHeapCloak}`. (#1939)
 - Choice packages `enigmatic.blockCipherMode` and `enigmatic.blockCipherPadding` renamed to
   `blockCipherModes` and `blockCipherPaddings` (members `cbc`, `ctr`, `cfb`, `ofb`, `pkcs7`,
-  `iso10126` unchanged). (#PR)
+  `iso10126` unchanged). (#1939)
 
 ## kaleidoscope
 
 - `kaleidoscope.Jur` (type and companion) renamed to `JavaBaseRegex`;
-  `kaleidoscope.regexBackends.jur` renamed to `javaBaseRegex`. (#PR)
+  `kaleidoscope.regexBackends.jur` renamed to `javaBaseRegex`. (#1939)
 
 ## diuretic
 
 - Top-level `diuretic.javaNioFilePath` renamed to `javaNioPathRepresentative` and top-level
   `diuretic.javaIoFile` renamed to `javaIoFileRepresentative` (the `Representative of Paths`
-  markers; `anticipation.interfaces.paths.{javaNioPath, javaIoFile}` are unchanged). (#PR)
+  markers; `anticipation.interfaces.paths.{javaNioPath, javaIoFile}` are unchanged). (#1939)
 
 ## harlequin
 
 - `punctuation.formattables.{scala, java}` (the `CommonFormattable` givens in `harlequin.md`)
-  renamed to `{scalaFormattable, javaFormattable}`. (#PR)
+  renamed to `{scalaFormattable, javaFormattable}`. (#1939)
 
 ## aviation
 
 - `aviation.chronometries.unix` renamed to `unixChronometry`; `chronometries.atomic` renamed to
-  `taiChronometry`. (#PR)
-- `aviation.leapModes.exact` renamed to `exactLeapMode`. (#PR)
+  `taiChronometry`. (#1939)
+- `aviation.leapModes.exact` renamed to `exactLeapMode`. (#1939)
 - `aviation.gapPolicies.pushBackward` renamed to `pushBackwardGapPolicy`; `gapPolicies.rejectGap`
-  renamed to `rejectGapPolicy`. (#PR)
+  renamed to `rejectGapPolicy`. (#1939)
 - `aviation.timespanFormats.{englishRelative, frenchRelative, germanRelative, spanishRelative}`
   renamed to `{englishRelativeTimespan, frenchRelativeTimespan, germanRelativeTimespan,
-  spanishRelativeTimespan}`. (#PR)
+  spanishRelativeTimespan}`. (#1939)
 - Newly re-exported into `soundness`: `hourFormats.{twelveHourSecondsClock,
   twentyFourHourSecondsClock}`, new family `timeSpecificities.{minutesSpecificity,
   secondsSpecificity}` (library package `aviation.timeFormats.specificity`), and
-  `interfaces.instants.aviationInstant` / `interfaces.durations.aviationDuration`. (#PR)
+  `interfaces.instants.aviationInstant` / `interfaces.durations.aviationDuration`. (#1939)
 
 ## probably
 
-- `probably.harnesses.threadLocal` renamed to `threadLocalHarness`. (#PR)
+- `probably.harnesses.threadLocal` renamed to `threadLocalHarness`. (#1939)
 - `probably.autopsies.none` renamed to `noAutopsy`; `autopsies.contrastExpectations` renamed to
-  `contrastAutopsy`. (#PR)
+  `contrastAutopsy`. (#1939)
 
 ## iridescence
 
@@ -132,7 +132,7 @@ not yet been recorded here.
   `darkenMixing`, `lighten` → `lightenMixing`, `difference` → `differenceMixing`, `exclusion` →
   `exclusionMixing`, `linearDodge` → `linearDodgeMixing`, `linearBurn` → `linearBurnMixing`,
   `hardLight` → `hardLightMixing`, `overlay` → `overlayMixing`, `softLight` → `softLightMixing`,
-  `colorDodge` → `colorDodgeMixing`, `colorBurn` → `colorBurnMixing`. (#PR)
+  `colorDodge` → `colorDodgeMixing`, `colorBurn` → `colorBurnMixing`. (#1939)
 - Every member of `iridescence.colorimetry` gains the suffix `Colorimetry`: `incandescentTungsten`,
   `oldDirectSunlightAtNoon`, `oldDaylight`, `iccProfilePcs`, `midMorningDaylight`, `daylight`,
   `srgb`, `adobeRgb`, `northSkyDaylight`, `equalEnergy`, `daylightFluorescentF1`,
@@ -140,22 +140,22 @@ not yet been recorded here.
   `liteWhiteFluorescent`, `daylightFluorescentF7`, `d65Simulator`, `sylvaniaF40`, `d50Simulator`,
   `coolWhiteFluorescent`, `philipsTl85`, `ultralume50`, `philipsTl84`, `ultralume40`,
   `philipsTl83`, `ultralume30` become `incandescentTungstenColorimetry`, …,
-  `ultralume30Colorimetry`. (#PR)
+  `ultralume30Colorimetry`. (#1939)
 
 ## gossamer
 
 - `gossamer.collations.unicode` renamed to `unicodeCollation`; `collations.codepoints` renamed to
-  `codepointCollation`. (#PR)
+  `codepointCollation`. (#1939)
 
 ## rudiments
 
-- Top-level `rudiments.populatedEquality2` renamed to `populatedEqualityReversed`. (#PR)
+- Top-level `rudiments.populatedEquality2` renamed to `populatedEqualityReversed`. (#1939)
 
 ## zephyrine
 
 - `zephyrine.lineation.linefeedChars` renamed to `linefeedChar`. The `lineation` family
   (`linefeedChar`, `carriageReturnChar`, `linefeedByte`, `carriageReturnByte`) is now re-exported
-  as `soundness.lineation`. (#PR)
+  as `soundness.lineation`. (#1939)
 
 ## hypotenuse
 
@@ -163,123 +163,123 @@ not yet been recorded here.
   types: `division.checked` → `checkedDivision`, `division.unchecked` → `uncheckedDivision`,
   `overflow.checked` → `checkedOverflow`, `overflow.unchecked` → `uncheckedOverflow`,
   `rationalDivision.q64` → `q64RationalDivision`, `rationalDivision.q32` → `q32RationalDivision`.
-  The objects no longer exist. (#PR)
+  The objects no longer exist. (#1939)
 
 ## honeycomb
 
-- `honeycomb.formatting.flatHtmlFormatting` renamed to `compactHtmlFormatting`. (#PR)
-- `honeycomb.recoveries.permissiveRecovery` is now re-exported as `soundness.recoveries`. (#PR)
+- `honeycomb.formatting.flatHtmlFormatting` renamed to `compactHtmlFormatting`. (#1939)
+- `honeycomb.recoveries.permissiveRecovery` is now re-exported as `soundness.recoveries`. (#1939)
 
 ## cataclysm
 
-- `cataclysm.formatting.standardCssFormatting` renamed to `indentedCssFormatting`. (#PR)
+- `cataclysm.formatting.standardCssFormatting` renamed to `indentedCssFormatting`. (#1939)
 
 ## dendrology
 
 - `dendrology.treeStyles.defaultTreeStyle` renamed to `squareTreeStyle`;
   `dagStyles.defaultDagStyle` renamed to `boxDrawingDagStyle`; `laneDagStyles.defaultLaneDagStyle`
-  renamed to `boxDrawingLaneDagStyle`. (#PR)
+  renamed to `boxDrawingLaneDagStyle`. (#1939)
 
 ## escritoire
 
-- `escritoire.tableStyles.defaultTableStyle` renamed to `thickTableStyle`. (#PR)
+- `escritoire.tableStyles.defaultTableStyle` renamed to `thickTableStyle`. (#1939)
 
 ## eucalyptus
 
 - `eucalyptus.logFormats.standardLogFormat` renamed to `timestampedLogFormat`;
-  `logFormats.ansiStandardLogFormat` renamed to `ansiTimestampedLogFormat`. (#PR)
+  `logFormats.ansiStandardLogFormat` renamed to `ansiTimestampedLogFormat`. (#1939)
 - `eucalyptus.logFormats.lightweightLogFormat` removed; it was identical to
-  `untimestampedLogFormat`. (#PR)
+  `untimestampedLogFormat`. (#1939)
 
 ## legerdemain
 
-- `legerdemain.formulations.defaultFormulation` renamed to `postFormulation`. (#PR)
+- `legerdemain.formulations.defaultFormulation` renamed to `postFormulation`. (#1939)
 
 ## octogenarian
 
-- `octogenarian.gitCommands.environmentDefaultGitCommand` renamed to `searchpathGitCommand`. (#PR)
+- `octogenarian.gitCommands.environmentDefaultGitCommand` renamed to `searchpathGitCommand`. (#1939)
 
 ## caesura
 
 - `caesura.optics.{cellLens, rowOptical, rowEach, rowFilter}` renamed to `{dsvCellLens,
-  dsvRowOptical, dsvRowEachOptical, dsvRowFilterOptical}`. (#PR)
+  dsvRowOptical, dsvRowEachOptical, dsvRowFilterOptical}`. (#1939)
 - `caesura.dynamicDsvAccess.enabled` (object member) replaced by
   `caesura.dynamicAccess.dynamicDsv` (choice package); the object `dynamicDsvAccess` no longer
-  exists. (#PR)
+  exists. (#1939)
 
 ## capricious
 
 - `capricious.randomization.sizes.{uniformUpto10, uniformUpto100, uniformUpto1000,
   uniformUpto10000, uniformUpto100000}` renamed to `{uniformSizeUpto10, uniformSizeUpto100,
-  uniformSizeUpto1000, uniformSizeUpto10000, uniformSizeUpto100000}`. (#PR)
+  uniformSizeUpto1000, uniformSizeUpto10000, uniformSizeUpto100000}`. (#1939)
 - `capricious.randomization.text.bigListOfNaughtyStrings` renamed to `naughtyStringsText`, and
-  now re-exported as `soundness.randomization.text.naughtyStringsText`. (#PR)
+  now re-exported as `soundness.randomization.text.naughtyStringsText`. (#1939)
 
 ## exoskeleton
 
-- `exoskeleton.executives.completions` renamed to `completionsExecutive`. (#PR)
+- `exoskeleton.executives.completions` renamed to `completionsExecutive`. (#1939)
 
 ## caduceus
 
-- `caduceus.couriers.resend` renamed to `resendCourier`. (#PR)
+- `caduceus.couriers.resend` renamed to `resendCourier`. (#1939)
 
 ## ultimatum
 
 - `ultimatum.inlineAnchoring.{bottomDocked, topAnchored, topAfterResize, fullscreen, inline}`
   renamed to `{bottomDockedAnchoring, topAnchoring, topAfterResizeAnchoring, fullscreenAnchoring,
-  flowAnchoring}`; enum case `ultimatum.InlineAnchoring.Inline` renamed to `Flow`. (#PR)
+  flowAnchoring}`; enum case `ultimatum.InlineAnchoring.Inline` renamed to `Flow`. (#1939)
 - `ultimatum.inlineGrowth.{scrollIntoScrollback, clampToScreen}` renamed to `{scrollbackGrowth,
-  clampedGrowth}`. (#PR)
+  clampedGrowth}`. (#1939)
 - `ultimatum.inlineShrink.{redockBottom, keepTop}` renamed to `{redockBottomShrink,
-  keepTopShrink}`. (#PR)
+  keepTopShrink}`. (#1939)
 
 ## jacinta
 
 - `jacinta.dynamicJsonAccess.enabled` (object member) replaced by `jacinta.dynamicAccess.dynamicJson`
-  (choice package); the object `dynamicJsonAccess` no longer exists. (#PR)
+  (choice package); the object `dynamicJsonAccess` no longer exists. (#1939)
 - `jacinta.jsonConversion.encodable` (object member) replaced by
   `jacinta.conversions.encodableToJson` (choice package); the object `jsonConversion` no longer
-  exists. (#PR)
+  exists. (#1939)
 
 ## xylophone
 
 - `xylophone.dynamicXmlAccess.enabled` replaced by `xylophone.dynamicAccess.dynamicXml`; the
-  object `dynamicXmlAccess` no longer exists. (#PR)
+  object `dynamicXmlAccess` no longer exists. (#1939)
 
 ## ypsiloid
 
 - `ypsiloid.dynamicYamlAccess.enabled` replaced by `ypsiloid.dynamicAccess.dynamicYaml`; the
-  object `dynamicYamlAccess` no longer exists. (#PR)
+  object `dynamicYamlAccess` no longer exists. (#1939)
 - `ypsiloid.yamlConversion.encodable` replaced by `ypsiloid.conversions.encodableToYaml`; the
-  object `yamlConversion` no longer exists. (#PR)
+  object `yamlConversion` no longer exists. (#1939)
 
 ## stratiform
 
 - `stratiform.dynamicTelAccess.enabled` replaced by `stratiform.dynamicAccess.dynamicTel`; the
-  object `dynamicTelAccess` no longer exists. (#PR)
+  object `dynamicTelAccess` no longer exists. (#1939)
 - `stratiform.telConversion.encodable` replaced by `stratiform.conversions.encodableToTel`; the
-  object `telConversion` no longer exists. (#PR)
+  object `telConversion` no longer exists. (#1939)
 
 ## breviloquence
 
 - `breviloquence.dynamicCborAccess.enabled` replaced by `breviloquence.dynamicAccess.dynamicCbor`;
-  the object `dynamicCborAccess` no longer exists. (#PR)
+  the object `dynamicCborAccess` no longer exists. (#1939)
 - `breviloquence.cborConversion.encodable` replaced by `breviloquence.conversions.encodableToCbor`;
-  the object `cborConversion` no longer exists. (#PR)
+  the object `cborConversion` no longer exists. (#1939)
 
 ## locomotion
 
 - `locomotion.protobufConversion.encodable` replaced by
   `locomotion.conversions.encodableToProtobuf`; the object `protobufConversion` no longer
-  exists. (#PR)
+  exists. (#1939)
 
 ## superlunary
 
 - `superlunary.embeddings.automatic` (object member) replaced by
   `superlunary.embeddings.automaticEmbedding` (choice package); `embeddings` is no longer an
-  object. (#PR)
+  object. (#1939)
 
 ## escapade
 
-- `escapade.writables.{out, err}` renamed to `{outTeletypeWritable, errTeletypeWritable}`. (#PR)
-- `escapade.teletypeables.graphical` renamed to `graphicalTeletype`. (#PR)
+- `escapade.writables.{out, err}` renamed to `{outTeletypeWritable, errTeletypeWritable}`. (#1939)
+- `escapade.teletypeables.graphical` renamed to `graphicalTeletype`. (#1939)

--- a/doc/modules/cbor.md
+++ b/doc/modules/cbor.md
@@ -100,7 +100,7 @@ With dynamic access enabled, a map's fields read as members, an array indexes, a
 including removal, by assigning `Unset` — produce new values:
 
 ```scala
-import dynamicCborAccess.enabled
+import dynamicAccess.dynamicCbor
 
 val person = Person(t"Ada", 36).in[Cbor]
 person.name.as[Text]                 // t"Ada"

--- a/doc/modules/cli.md
+++ b/doc/modules/cli.md
@@ -188,7 +188,7 @@ the shell's name, and hand them to the application in completions mode.
 Turning completions on replaces the default executive with the completions executive:
 
 ```scala
-import executives.completions
+import executives.completionsExecutive
 ```
 
 Under this executive the body returns an `Execution`, and the only way to build one is an

--- a/doc/modules/cli.md
+++ b/doc/modules/cli.md
@@ -32,7 +32,7 @@ import soundness.*
 import executives.directExecutive
 import interpreters.posixInterpreter
 import backstops.genericErrorMessageBackstop
-import systems.javaSystem
+import systems.javaBaseSystem
 ```
 
 ### An entry point

--- a/doc/modules/colors.md
+++ b/doc/modules/colors.md
@@ -37,7 +37,7 @@ the `soundness` package, with a color profile chosen in scope:
 ```scala
 import soundness.*
 
-given Colorimetry = colorimetry.daylight
+given Colorimetry = colorimetry.daylightColorimetry
 ```
 
 ### Color spaces
@@ -99,7 +99,7 @@ parts of it going into the mixture and add them up, the way a painter measures p
 onto a palette. A mixing mode is chosen by importing one:
 
 ```scala
-import mixing.proportional
+import mixing.proportionalMixing
 
 5*WebColors.Red + 3*WebColors.Yellow   // Srgb(1, 0.375, 0) — an orange
 ```
@@ -129,7 +129,7 @@ blend modes of Photoshop and GIMP — `multiply`, `screen`, `overlay`, `hardLigh
 `linearDodge` and `linearBurn` — and each is imported the same way:
 
 ```scala
-import mixing.multiply
+import mixing.multiplyMixing
 
 1*WebColors.Yellow + 1*WebColors.Cyan   // Srgb(0.5, 1, 0) — a green, as paint mixes
 ```
@@ -200,12 +200,12 @@ output once converted.
 ### Color profiles
 
 A `Colorimetry` describes the illuminant and observer that a profile-dependent conversion
-assumes. `colorimetry.daylight` suits most screen work; others model incandescent,
+assumes. `colorimetry.daylightColorimetry` suits most screen work; others model incandescent,
 fluorescent and standard-illuminant conditions. The profile is a given, so every
 conversion within its scope uses it, and none has to name it:
 
 ```scala
-given Colorimetry = colorimetry.incandescentTungsten
+given Colorimetry = colorimetry.incandescentTungstenColorimetry
 
 WebColors.Ivory.to[Cielab]   // computed for tungsten light
 ```

--- a/doc/modules/cryptography.md
+++ b/doc/modules/cryptography.md
@@ -30,14 +30,14 @@ a provider in scope:
 ```scala
 import soundness.*
 import strategies.throwUnsafely
-import providers.javaStdlibProvider
-import cloaks.cloakHeap
+import providers.javaBaseProvider
+import cloaks.heapCloak
 ```
 
 There is deliberately no default `Cloak`: constructing any secret value — a password, a
 symmetric key, a private key — needs one in scope, so the storage decision is always written
-down. `cloakHeap` keeps the material in a private byte array; `cloakOffHeap` moves it out of
-the Java heap, so it does not appear in a heap dump; `cloakVeiledHeap` and `cloakVeiledOffHeap`
+down. `heapCloak` keeps the material in a private byte array; `offHeapCloak` moves it out of
+the Java heap, so it does not appear in a heap dump; `veiledHeapCloak` and `veiledOffHeapCloak`
 additionally keep it encrypted under an ephemeral key between uses. No cloak defends against a
 debugger in the same process; what the stronger ones shrink is the window during which
 cleartext is reachable from a heap dump or core file.
@@ -49,8 +49,8 @@ padding, all in the type — and encryption happens inside the key's `uncloak` b
 [initialization vector](https://en.wikipedia.org/wiki/Initialization_vector) supplied explicitly:
 
 ```scala
-import blockCipherMode.cbc
-import blockCipherPadding.pkcs7
+import blockCipherModes.cbc
+import blockCipherPaddings.pkcs7
 
 val key = SymmetricKey.generate[Aes[256]]()
 

--- a/doc/modules/css.md
+++ b/doc/modules/css.md
@@ -27,7 +27,7 @@ the `soundness` package, with a formatting choice in scope for rendering:
 ```scala
 import soundness.*
 import strategies.throwUnsafely
-import formatting.standardCssFormatting
+import formatting.indentedCssFormatting
 ```
 
 ### Writing CSS

--- a/doc/modules/csv.md
+++ b/doc/modules/csv.md
@@ -182,7 +182,7 @@ With dynamic access enabled, a cell of a header-bearing row reads as a named mem
 the type asked for:
 
 ```scala
-import dynamicDsvAccess.enabled
+import dynamicAccess.dynamicDsv
 
 val row = t"greeting,number\nhello,23".read[Sheet].rows.head
 row.number[Int]   // 23

--- a/doc/modules/daemons.md
+++ b/doc/modules/daemons.md
@@ -28,7 +28,7 @@ own faithful context. Everything comes from the `soundness` package, alongside t
 
 ```scala
 import soundness.*
-import executives.completions
+import executives.completionsExecutive
 import interpreters.posixInterpreter
 import backstops.stackTraceBackstop
 import threading.virtualThreading

--- a/doc/modules/docker.md
+++ b/doc/modules/docker.md
@@ -31,7 +31,7 @@ tar layers; both halves come from the `soundness` package:
 
 ```scala
 import soundness.*
-import providers.javaStdlibProvider
+import providers.javaBaseProvider
 import alphabets.hexLowerCase
 import charEncoders.utf8Encoder
 import formatting.compactJsonFormatting

--- a/doc/modules/email.md
+++ b/doc/modules/email.md
@@ -24,7 +24,7 @@ package, with a courier and a sender in scope:
 
 ```scala
 import soundness.*
-import couriers.resend
+import couriers.resendCourier
 
 given Sender = Sender(email"noreply@example.com")
 given Resend.ApiKey = Resend.ApiKey(apiKeyText)

--- a/doc/modules/environment.md
+++ b/doc/modules/environment.md
@@ -30,8 +30,8 @@ supplied:
 
 ```scala
 import soundness.*
-import environments.javaEnvironment
-import systems.javaSystem
+import environments.javaBaseEnvironment
+import systems.javaBaseSystem
 import strategies.throwUnsafely
 ```
 
@@ -73,7 +73,7 @@ An undefined property raises a `PropertyError`, handled like any other.
 ### The working directory
 
 The directory a program was launched in is a `WorkingDirectory` capability, requested where it
-is needed rather than read from a global. With `workingDirectories.javaWorkingDirectory` in
+is needed rather than read from a global. With `workingDirectories.javaBaseWorkingDirectory` in
 scope, a method that resolves a relative path against the working directory declares that need
 in its signature.
 

--- a/doc/modules/filesystem.md
+++ b/doc/modules/filesystem.md
@@ -31,7 +31,7 @@ operations need brought into scope:
 ```scala
 import soundness.*
 import strategies.throwUnsafely
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 import filesystemOptions.overwritePreexisting.enabled
 import filesystemOptions.deleteRecursively.enabled

--- a/doc/modules/filesystem.md
+++ b/doc/modules/filesystem.md
@@ -33,8 +33,8 @@ import soundness.*
 import strategies.throwUnsafely
 import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
-import filesystemOptions.overwritePreexisting.enabled
-import filesystemOptions.deleteRecursively.enabled
+import filesystemOptions.overwritePreexisting
+import filesystemOptions.deleteRecursively
 ```
 
 ### Files and directories
@@ -266,7 +266,7 @@ unavailable, `watchers.polling` checks at an interval instead.
 Nothing above names a platform API. The primitive operations a filesystem must offer — stat,
 open, read, write, list, link, delete — are gathered into a `FilesystemBackend` for a plane,
 and everything else is defined in terms of them. The `java.nio` implementation is
-`filesystemBackends.virtualMachineFilesystem`, and a WASI implementation over `wasi:filesystem` is
+`filesystemBackends.javaBaseFilesystem`, and a WASI implementation over `wasi:filesystem` is
 supplied by `galilei.wasi`, so the same code reads and writes files on the JVM and inside a
 WebAssembly component. An operation a backend cannot support raises an `Io.Error` whose reason
 is `Unsupported`, rather than approximating it. Narrowing the platform's surface to a seam

--- a/doc/modules/forms.md
+++ b/doc/modules/forms.md
@@ -23,7 +23,7 @@ a message pointing at the email field. Everything comes from the `soundness` pac
 
 ```scala
 import soundness.*
-import formulations.defaultFormulation
+import formulations.postFormulation
 ```
 
 ### Rendering a form
@@ -65,5 +65,5 @@ so a handler deals in values, not requests.
 ### Customising appearance
 
 How a form and its rows render is a `Formulation` — the frame around the widgets, the placement of
-labels and error messages. `defaultFormulation` gives a plain, unstyled rendering; an application
+labels and error messages. `postFormulation` gives a plain, unstyled rendering; an application
 supplies its own to match its design, without touching how fields are derived.

--- a/doc/modules/git.md
+++ b/doc/modules/git.md
@@ -27,7 +27,7 @@ capabilities the operations need in scope:
 ```scala
 import soundness.*
 import gitCommands.environmentDefaultGitCommand
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 import internetAccess.online
 import logging.silentLogging
 import strategies.throwUnsafely

--- a/doc/modules/git.md
+++ b/doc/modules/git.md
@@ -26,7 +26,7 @@ capabilities the operations need in scope:
 
 ```scala
 import soundness.*
-import gitCommands.environmentDefaultGitCommand
+import gitCommands.searchpathGitCommand
 import workingDirectories.javaBaseWorkingDirectory
 import internetAccess.online
 import logging.silentLogging

--- a/doc/modules/hashing.md
+++ b/doc/modules/hashing.md
@@ -32,7 +32,7 @@ hashing provider and an alphabet in scope:
 
 ```scala
 import soundness.*
-import providers.javaStdlibProvider
+import providers.javaBaseProvider
 import alphabets.hexLowerCase
 ```
 
@@ -45,7 +45,7 @@ t"Hello world".digest[Sha2[256]].serialize[Hex]
 // the 64-character hexadecimal SHA-256 digest
 ```
 
-The provider in scope supplies the algorithms — `javaStdlibProvider` for the SHA and MD5 family and
+The provider in scope supplies the algorithms — `javaBaseProvider` for the SHA and MD5 family and
 CRC-32, and `soundnessProvider` for the pure-Scala BLAKE3.
 
 The algorithm need not be named where the expected type already says it. A digest carries its
@@ -62,7 +62,7 @@ That is the pattern throughout: digests, HMACs, keys and signatures are all byte
 the algorithm that produced them, so a value from one algorithm cannot be passed where another is
 expected, and the algorithm rarely has to be written twice.
 
-`javaStdlibProvider` names the JDK's `MessageDigest` where there is one. Off the JVM there is
+`javaBaseProvider` names the JDK's `MessageDigest` where there is one. Off the JVM there is
 not, so the same import selects pure-Scala implementations of MD5, SHA-1, SHA-2 and CRC-32,
 validated byte for byte against the JDK's. Code that hashes therefore reads the same, and
 produces the same digests, on the JVM, in a browser and inside a WebAssembly component.
@@ -122,7 +122,7 @@ MD5 and SHA-1 are broken for security purposes, and remain only for compatibilit
 one requires a permission in scope, so the choice is visible and deliberate:
 
 ```scala
-import crypto.permitDisallowedCrypto
+import cryptoPermits.permitDisallowedCrypto
 
 t"Hello world".digest[Md5].serialize[Hex]
 ```

--- a/doc/modules/http-client.md
+++ b/doc/modules/http-client.md
@@ -98,12 +98,12 @@ session: the next fetch drains what remains of the previous body to reach the re
 
 ### Choosing a transport
 
-The transport is a given. `httpBackends.virtualMachineHttp` uses the JVM's own `java.net.http`;
-`httpBackends.native` speaks Soundness's wire codecs directly over a socket, with no
+The transport is a given. `httpBackends.javaNetHttp` uses the JVM's own `java.net.http`;
+`httpBackends.soundnessHttp` speaks Soundness's wire codecs directly over a socket, with no
 `java.net.http` involved:
 
 ```scala
-import httpBackends.native
+import httpBackends.soundnessHttp
 ```
 
 The native backend pools kept-alive HTTP/1.1 connections per origin, and negotiates by ALPN over

--- a/doc/modules/json.md
+++ b/doc/modules/json.md
@@ -269,7 +269,7 @@ field reads as though it were a member, and a nonexistent one is discovered at r
 where it is written.
 
 ```scala
-import dynamicJsonAccess.enabled
+import dynamicAccess.dynamicJson
 
 val person = t"""{"name": "Bob"}""".read[Json]
 person.name.as[Text]   // t"Bob"
@@ -289,7 +289,7 @@ immutable, so an update returns a copy. Assigning a value adds or replaces a fie
 and assigning `Unset` removes one:
 
 ```scala
-import dynamicJsonAccess.enabled
+import dynamicAccess.dynamicJson
 
 val base = t"""{"x": 1}""".read[Json]
 (base.y = 2).show        // t"""{"x":1,"y":2}"""
@@ -300,7 +300,7 @@ Deeper updates are written with a lens, which reaches through several levels and
 carry optics such as `Each` or `Filter` to touch many elements at once:
 
 ```scala
-import dynamicJsonAccess.enabled, jsonConversion.encodable
+import dynamicAccess.dynamicJson, conversions.encodableToJson
 
 case class Role(name: Text)
 case class Entity(name: Text, age: Int, roles: List[Role])

--- a/doc/modules/json.md
+++ b/doc/modules/json.md
@@ -577,7 +577,7 @@ types of its date-and-time library. An `Instant` and a `Duration` travel as a wh
 number of milliseconds:
 
 ```scala
-import chronometries.unix
+import chronometries.unixChronometry
 
 Instant(1700000000000L).in[Json].show                       // t"1700000000000"
 t"5000".read[Json].as[Duration].value                   // 5.0

--- a/doc/modules/logging.md
+++ b/doc/modules/logging.md
@@ -39,7 +39,7 @@ format and the concurrency context a logger writes under:
 
 ```scala
 import soundness.*
-import logFormats.standardLogFormat
+import logFormats.timestampedLogFormat
 import probates.cancelProbate
 import threading.virtualThreading
 ```
@@ -62,7 +62,7 @@ HTTP events and nothing else, so the events of one library can be routed or sile
 independently of the rest.
 
 `Logger` runs its writes on a background thread, so it needs the ambient concurrency
-context that `supervise` provides. The format in scope — here `standardLogFormat`,
+context that `supervise` provides. The format in scope — here `timestampedLogFormat`,
 which prefixes each line with a timestamp and level — decides how an event renders to
 text; `untimestampedLogFormat` omits the timestamp.
 

--- a/doc/modules/numbers.md
+++ b/doc/modules/numbers.md
@@ -56,14 +56,14 @@ checked given changes the result type of `+`, `-` and `*` to one that can raise
 `OverflowError`, so an overflow becomes a handled failure rather than a silent wrap:
 
 ```scala
-import arithmeticOptions.overflow.checked
+import arithmeticOptions.checkedOverflow
 import strategies.throwUnsafely
 
 val big: S32 = 2000000000
 big + big   // raises OverflowError rather than wrapping negative
 ```
 
-Division by zero is checked the same way, by importing `arithmeticOptions.division.checked`,
+Division by zero is checked the same way, by importing `arithmeticOptions.checkedDivision`,
 after which `/` may raise a `DivisionError`. Where the check is not imported, the operations
 keep their bare machine behaviour and cost nothing.
 

--- a/doc/modules/optics.md
+++ b/doc/modules/optics.md
@@ -78,7 +78,7 @@ The dynamic formats define the same optics over their own structures, so a parse
 with the identical syntax — one skill, both worlds:
 
 ```scala
-import dynamicJsonAccess.enabled, jsonConversion.encodable
+import dynamicAccess.dynamicJson, conversions.encodableToJson
 
 json.lens(_.leader.age = 41)
 json.lens(_.leader.roles(Each).name = t"member")

--- a/doc/modules/processes.md
+++ b/doc/modules/processes.md
@@ -25,7 +25,7 @@ strategy in scope:
 
 ```scala
 import soundness.*
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 import logging.silentLogging
 import strategies.throwUnsafely
 ```

--- a/doc/modules/protobuf.md
+++ b/doc/modules/protobuf.md
@@ -88,7 +88,7 @@ is field 1, `Sec` field 2, and so on. A lens reaches through nested messages and
 without disturbing the rest:
 
 ```scala
-import protobufConversion.encodable
+import conversions.encodableToProtobuf
 
 wrapper.lens(_(Prim) = Point(7, 8).in[Protobuf]).as[Wrapper]
 ```

--- a/doc/modules/randomness.md
+++ b/doc/modules/randomness.md
@@ -70,7 +70,7 @@ be confused: the difference is written at the import.
 
 ### Collections and custom types
 
-A random collection needs a size, chosen as a `RandomSize` given — `randomization.sizes.uniformUpto100`
+A random collection needs a size, chosen as a `RandomSize` given — `randomization.sizes.uniformSizeUpto100`
 bounds it at a hundred elements. A type whose values need more care than field-by-field generation
 defines its own instance, or maps an existing one:
 

--- a/doc/modules/sockets.md
+++ b/doc/modules/sockets.md
@@ -107,7 +107,7 @@ one socket. Offering nothing preserves the plain-TLS handshake that `wss` peers 
 Nothing above names a platform API. The primitive operations each role needs — bind and accept,
 connect and converse, receive and reply, dispatch a datagram — are gathered into a
 `SocketBackend`, and the loops that compose them stay platform-neutral. The
-`java.nio.channels` implementation is `socketBackends.virtualMachineSockets`, and backends over
+`java.nio.channels` implementation is `socketBackends.javaBaseSockets`, and backends over
 `wasi:sockets` and over Scala Native's sockets supply the same operations, so the same protocol
 code runs on the JVM, inside a WebAssembly component, and in a native binary. An operation a
 backend cannot support — Unix-domain sockets or TLS on WASI — raises the appropriate error rather

--- a/doc/modules/staging.md
+++ b/doc/modules/staging.md
@@ -58,7 +58,7 @@ out. Everything comes from the `soundness` package:
 ```scala
 import scala.quoted.*
 import soundness.*
-import embeddings.automatic
+import embeddings.automaticEmbedding
 import strategies.throwUnsafely
 import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory

--- a/doc/modules/staging.md
+++ b/doc/modules/staging.md
@@ -60,7 +60,7 @@ import scala.quoted.*
 import soundness.*
 import embeddings.automatic
 import strategies.throwUnsafely
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 ```
 

--- a/doc/modules/tables.md
+++ b/doc/modules/tables.md
@@ -24,7 +24,7 @@ policy in scope:
 
 ```scala
 import soundness.*
-import tableStyles.defaultTableStyle
+import tableStyles.thickTableStyle
 import textMetrics.uniformMetric
 import columnAttenuation.ignoreAttenuation
 import hyphenations.englishHyphenation

--- a/doc/modules/tel.md
+++ b/doc/modules/tel.md
@@ -89,7 +89,7 @@ doc.verify[Assignment].office.city.as[Text]   // t"Town"
 ```
 
 Unverified dynamic access — reaching into a document whose shape is only informally known — is
-available too, enabled by `import dynamicTelAccess.enabled`, keeping the checked and unchecked
+available too, enabled by `import dynamicAccess.dynamicTel`, keeping the checked and unchecked
 styles visibly distinct. A keyword may legitimately repeat, which a single-valued accessor cannot
 express, so `fields` returns every matching child in document order:
 
@@ -106,7 +106,7 @@ change one value and write the file back without reformatting everything a perso
 `modify` replaces a field's compound, or appends it where the field is absent:
 
 ```scala
-import dynamicTelAccess.enabled
+import dynamicAccess.dynamicTel
 
 document.modify("name", Tel.scalar(t"Bob"))
 ```

--- a/doc/modules/time.md
+++ b/doc/modules/time.md
@@ -359,7 +359,7 @@ type. The `Unix` timeline — POSIX time — counts milliseconds from the
 [Unix epoch](https://en.wikipedia.org/wiki/Unix_time):
 
 ```scala
-import chronometries.unix
+import chronometries.unixChronometry
 
 val epoch = Instant(0L)   // 1970-01-01T00:00:00Z
 ```
@@ -449,7 +449,7 @@ spring.instant   // pushed forward to 01:30 UTC by default
 ```
 
 ```scala
-import gapPolicies.rejectGap
+import gapPolicies.rejectGapPolicy
 Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant
 // raises a TimeError: the local time never happens
 ```
@@ -698,7 +698,7 @@ A timespan describes itself relative to now, reading forward or backward dependi
 on its sign:
 
 ```scala
-import timespanFormats.englishRelative
+import timespanFormats.englishRelativeTimespan
 given Locale[en] = Locale(en)
 
 Timespan(minutes = 18).show    // "in 18 minutes"
@@ -799,7 +799,7 @@ adding two hours across the leap second at the end of 2016 lands one second shor
 of the lenient answer:
 
 ```scala
-import leapModes.exact
+import leapModes.exactLeapMode
 val start = Moment(2016-Dec-31, Clockface(23, 0, 0), tz"UTC")
 (start + 2*Hour).instant
 // 2017-01-01T00:59:59Z — one second behind the lenient result

--- a/doc/modules/trees.md
+++ b/doc/modules/trees.md
@@ -21,7 +21,7 @@ Everything comes from the `soundness` package:
 
 ```scala
 import soundness.*
-import treeStyles.defaultTreeStyle
+import treeStyles.squareTreeStyle
 ```
 
 ### Trees
@@ -51,7 +51,7 @@ grid of connecting tiles; `LaneDagDiagram` is the lane form — nodes as bullets
 edges flowing between them — the shape version-control history is drawn in:
 
 ```scala
-import laneDagStyles.defaultLaneDagStyle
+import laneDagStyles.boxDrawingLaneDagStyle
 import strategies.throwUnsafely
 
 val history = Dag(t"C" -> Set(t"B"), t"B" -> Set(t"A"), t"A" -> Set())

--- a/doc/modules/xml.md
+++ b/doc/modules/xml.md
@@ -174,7 +174,7 @@ With dynamic access enabled, a child element is reached as though it were a memb
 chain; an index picks among repeated elements:
 
 ```scala
-import dynamicXmlAccess.enabled
+import dynamicAccess.dynamicXml
 
 val data = t"<a><b><c>42</c></b></a>".read[Xml]
 data.b().c().as[Int]   // 42
@@ -190,7 +190,7 @@ as `Each` to touch every matching element at once. Because XML values are immuta
 returns a new document:
 
 ```scala
-import dynamicXmlAccess.enabled
+import dynamicAccess.dynamicXml
 
 val document = t"<doc><x>1</x><x>2</x><x>3</x></doc>".read[Xml]
 document.lens(_.x = x"<x>9</x>").show   // the first <x> replaced

--- a/doc/modules/yaml.md
+++ b/doc/modules/yaml.md
@@ -150,7 +150,7 @@ With dynamic access enabled, fields read as members and updates produce new docu
 reaching many elements at once:
 
 ```scala
-import dynamicYamlAccess.enabled
+import dynamicAccess.dynamicYaml
 
 val doc = t"{name: Alice, age: 30}".read[Yaml]
 doc.name.as[Text]      // t"Alice"

--- a/doc/philosophy/declarative-context.md
+++ b/doc/philosophy/declarative-context.md
@@ -53,8 +53,8 @@ import dateFormats.iso8601DateFormat       // how dates are shown
 import affirmations.yesNoAffirmation       // how a boolean is shown
 import threading.virtualThreading          // what a task runs on
 import probates.cancelProbate              // what happens to unfinished tasks
-import httpBackends.native                 // which HTTP transport is used
-import filesystemBackends.virtualMachineFilesystem   // which filesystem implementation
+import httpBackends.soundnessHttp              // which HTTP transport is used
+import filesystemBackends.javaBaseFilesystem   // which filesystem implementation
 import calendars.gregorianCalendar         // which calendar a date literal means
 ```
 
@@ -64,7 +64,7 @@ applies to all of them.
 ## Naming makes the choice legible
 
 A given is named for what it *selects*, not for its type, because the import line is what
-a reader sees. `import strategies.accrue` says something about the code below it;
+a reader sees. `import strategies.throwUnsafely` says something about the code below it;
 `import strategies.given` would not.
 
 This is why the convention matters more here than elsewhere: a contextual value is

--- a/doc/philosophy/naming.md
+++ b/doc/philosophy/naming.md
@@ -50,7 +50,7 @@ import dateFormats.iso8601DateFormat
 import probates.cancelProbate
 ```
 
-Someone encountering `import strategies.accrue` in unfamiliar code learns something about
+Someone encountering `import strategies.throwUnsafely` in unfamiliar code learns something about
 that code from the import line alone.
 
 ## Type parameters as words

--- a/doc/philosophy/zero-cost.md
+++ b/doc/philosophy/zero-cost.md
@@ -72,7 +72,7 @@ checking on every build.
 
 Being honest about this matters more than the claim itself.
 
-**Checked arithmetic costs what it checks.** Importing `arithmeticOptions.overflow.checked`
+**Checked arithmetic costs what it checks.** Importing `arithmeticOptions.checkedOverflow`
 adds a real test to every addition. The default is unchecked, so the cost is paid only
 where it is asked for — but where it is asked for, it is paid.
 

--- a/doc/roadmap/modularity.md
+++ b/doc/roadmap/modularity.md
@@ -458,7 +458,7 @@ Horizon: mid — after mod-4, so nothing moves twice.
   ports), pneumatic's `Crc64` in the XZ layer, hallucination's one-shot `Crc32`, and zeppelin's
   `crc32` — but **two of them should not be deduplicated at all**: zeppelin's delegates to
   `java.util.zip.CRC32`, and gastronomy's `Digestion` CRC-32 likewise goes through
-  `JavaStdlibHashing`. Both are JVM intrinsics; replacing them with a table-driven Scala loop
+  `JavaBaseHashing`. Both are JVM intrinsics; replacing them with a table-driven Scala loop
   would be a performance regression for no benefit. The same is true of pneumatic on the JVM,
   whose `FlateBackend` uses `JavaCrc32`; its pure `Crc32` is the JS/native path only.
 
@@ -723,7 +723,7 @@ stack from the compiler stack entirely.
 
 - **obligatory.json** drops scintillate.server, hyperbole.core and revolution.core — all
   three dead. obligatory.json is a JSON-RPC peer plus SSE codec: it never serves HTTP
-  (its `Servable` is telekinesis's, reached via jacinta.http; `httpBackends.virtualMachineHttp`
+  (its `Servable` is telekinesis's, reached via jacinta.http; `httpBackends.javaNetHttp`
   comes from telekinesis.jvm via jacinta.schema), never introspects TASTy, and never touches
   a manifest. The hyperbole edge is what put the whole harlequin/anthology stack under
   exegesis; deleting it collapses the measured deepest path. (eucalyptus.core is genuinely

--- a/doc/standards/given-naming.md
+++ b/doc/standards/given-naming.md
@@ -1,14 +1,143 @@
-# Soundness Contextual-Value Naming Standards
+# Contextual-Value Naming Standards
 
-_(Stub — scope for review; full content to follow. May instead be folded into
-`naming.md`.)_
+This standard defines how importable `given` values are named and grouped. It covers
+the *orphan* contextual values: those a user brings into scope by name, either from a
+choice package (`import strategies.throwUnsafely`) or, for the few that cannot be
+anchored to a companion, from a library's top level (`import bitumen.tarPathOpenable`).
+Where a given *lives* is decided by the placement rules in `.claude/CLAUDE.md`; this
+document decides what it is *called*. For why the name matters at all, see
+[declarative context](../philosophy/declarative-context.md) and
+[naming](../philosophy/naming.md).
 
-This standard will define how importable `given` values are named and grouped, so
-that bringing one into scope reads clearly at the import site. It will document the
-`<component>.<family>.<name>` scheme — a contextual value lives in a package object
-named for its family (the plural role it fills) and has a descriptive name for the
-particular choice it represents, as in `strategies.throwUnsafely`,
-`charEncoders.utf8Encoder`, `formatting.compactJsonFormatting`, and
-`logFormats.standardLogFormat`. It will set out how to choose the family name, how
-the name should read as the object of an `import`, and the conventions for the
-package objects that collect related givens for à-la-carte import.
+Givens in companion objects (`InlineAnchoring.default`, `Buffering.standard`) are outside
+this standard: they resolve by type and are never written at an import site.
+
+## The test
+
+A reader who knows everything Soundness can do, but nothing about what it calls things,
+should be able to say what a given does from its name alone, with the package stripped
+off. `throwUnsafely` passes: it is a strategy, and it throws. `enabled` and `native` fail:
+enabled *what*, and native *to what*? The name is the only thing visible at the import
+line, and often the only thing visible anywhere, so it carries the whole meaning.
+
+## Rules
+
+### 1. The family is the role, as a package
+
+A choice package is named for the role its members fill: a plural count noun
+(`strategies`, `stdios`, `filesystemBackends`, `probates`) or a mass noun
+(`formatting`, `threading`, `logging`). Never a singular count noun: `blockCipherModes`,
+not `blockCipherMode`. Family names are global — same-named blocks from different
+libraries merge in the `soundness` umbrella — so a family must mean one role
+everywhere.
+
+A library may nest families for its own organisation (aviation keeps `dateFormats.months`),
+but the flat name in its `soundness_*` export file (`monthFormats`) is the canonical one,
+and documentation cites that.
+
+### 2. The name is the choice, then the role
+
+The choice word comes first, and the role's singular is appended unless the choice
+already implies it:
+
+```scala
+import probates.cancelProbate           // cancel + Probate
+import textSanitizers.strictSanitizer   // strict + Sanitizer
+import sortingAlgorithms.quicksort      // "quicksort" is already a sorting algorithm
+import charEncoders.utf8Encoder         // UTF-8 could be a decoder; say which
+import regexBackends.re2                // RE2 is a regex engine; nothing to add
+```
+
+The suffix is the role's own word (`…Probate`, `…Stdio`, `…Formatting`), not a synonym
+for it, so that every member of a family ends the same way.
+
+### 3. Unique with the package removed
+
+Every orphan given is unique across the whole of Soundness, judged as if the package
+were not there. All of them are exported into `soundness`, and any two may have to
+coexist in one scope, so `import x.enabled` and `import y.enabled` cannot both exist.
+
+The corollary is that there are no toggle members. A switch is named for the behaviour
+it selects, on both sides:
+
+```scala
+import filesystemOptions.deleteRecursively     // not deleteRecursively.enabled
+import filesystemOptions.deleteOnlyEmpty       // not deleteRecursively.disabled
+import arithmeticOptions.checkedOverflow       // not overflow.checked
+import dynamicAccess.dynamicJson               // not dynamicJsonAccess.enabled
+```
+
+### 4. Existing vocabulary only
+
+A name reuses the type or term it selects, so that the import and the declaration it
+enables read with the same words: `cancelProbate` selects a `Probate`; `taiChronometry`
+selects the `Tai` timeline; `offHeapCloak` is the `OffHeapCloak`. A name never coins a
+term that appears nowhere else in Soundness.
+
+`default`, `standard`, `basic` and `simple` are not choice words: they say that a
+choice is common, not what it is. `indentedCssFormatting`, `thickTableStyle` and
+`timestampedLogFormat` each say what they do; `standardCssFormatting` said only that
+somebody preferred it. The exception is when such a word *is* the type's own name
+(`standardKeyboard` selects `Keyboard.Standard`; the RFC 4648 alphabets are called
+"standard" by their specification).
+
+Numerals belong in a name only when they are part of the choice (`sha256Signature`,
+`xterm256Termcap`, `iso8601DateFormat`), never to tell two givens apart
+(`populatedEquality2`).
+
+### 5. Provenance words for backends
+
+When the choice is *which implementation*, the choice word names where the
+implementation comes from. One word per source, used the same way everywhere:
+
+| Source | Word | Examples |
+|---|---|---|
+| A Java module | the module's name | `javaBaseFilesystem`, `javaBaseSockets`, `javaNetHttp`, `jdkHttpserver` |
+| A WASI interface | `wasi` + the interface | `wasiFilesystem` (`wasi:filesystem`), `wasiHttp`, `wasiSockets` |
+| Scala Native, over libc/POSIX | `scalaNative` | `scalaNativeFilesystem`, `scalaNativeSockets` |
+| Scala.js | `javascript` | `javascriptThreading` |
+| Soundness's own pure-Scala code | `soundness` | `soundnessHttp`, `soundnessHttpd`, `soundnessProvider` |
+| A third party | its own name | `opensslProvider`, `re2`, `resendCourier` |
+
+Java modules are named because that is what a `requires` clause names: Soundness
+intends to declare, per module, which Java modules it depends on, and the given that
+selects a Java-backed implementation should say which module it is drawing on.
+`java.base` supplies most of them, so `javaBase…` is the common case; where two
+`java.base` choices differ, the name says how (`fileDescriptorStdio` wraps the process
+file descriptors; `javaLangSystemStdio` wraps `java.lang.System`'s redirectable
+streams).
+
+Two things look like provenance and are not. A Java *type* adopted as a representative
+keeps the type-path name it already has elsewhere in Soundness (`javaNioPath`,
+`javaUtilDate`, `javaNetUrl`): the choice there is the type, not the module. And Java's
+own concept words stay Java's where they name the concept rather than the source:
+`platformThreading` and `virtualThreading` are platform and virtual threads;
+`systemClassloader` and `platformClassloader` are the JDK's names for those loaders.
+
+`native` never appears alone. It has meant Scala Native, the JDK's `WatchService` and
+Soundness's own HTTP stack at different times, which is three meanings too many.
+
+### 6. Top-level orphans are named for their library
+
+A given that cannot live in a companion (its subject is owned elsewhere, or is a union
+or alias, or the library is a platform component of a platform-neutral type) stays at
+the library's top level with a name qualified by what it is for: `tarPathOpenable`,
+`terminalStdio`, `collationComparable`. It is never anonymous, since an unnameable
+given cannot be imported selectively or disambiguated, and never a bare generic word.
+
+## Sanctioned without a suffix
+
+These pass rule 2 because the choice already names the role, and are listed so that
+nobody re-litigates them: `sortingAlgorithms.*`, `alphabets.*`,
+`blockCipherModes.{cbc, ctr, cfb, ofb}`, `blockCipherPaddings.{pkcs7, iso10126}`,
+`regexBackends.re2`, `internetAccess.{online, offline}`, `endianness.*`,
+`doms.html.{whatwg, html4Transitional}`, `currencies.Usd…` (ISO codes, used as terms),
+`strategies.*`, `calendars.*`, `highlighting.*`, `caseSensitivity.*`,
+`dysasymptotics.*`, and `context.explainMissingContext`.
+
+## Checking
+
+`make build` runs `etc/check-given-uniqueness.py`, which reads every choice package in
+the libraries and their `soundness_*` export mirrors and fails on a duplicate name or an
+unmirrored family. A new orphan given is checked against the whole namespace when it is
+added, not when a user meets the clash.

--- a/etc/check-given-uniqueness.py
+++ b/etc/check-given-uniqueness.py
@@ -1,36 +1,121 @@
 #!/usr/bin/env python3
-"""Verify that every importable `given` re-exported into the `soundness` package
-has a globally-unique leaf name.
+"""Check the importable (orphan) contextual values against the naming standard
+in doc/standards/given-naming.md.
 
-Soundness exposes selection/default `given`s through lowercase family packages
-(e.g. `soundness.watchers.nativeWatcher`) that are re-exported from each
-component's `soundness_<component>_<module>.scala` files. The naming convention
-requires each exported leaf name to be unique across *all* families, so that the
-name alone identifies the given and re-exports can never collide. This script
-enforces that invariant; run it with `make check-givens`.
+Soundness exposes selection givens through lowercase family packages
+(`package watchers:` holding `given javaBaseWatcher`) that each component's
+`soundness_<component>_<module>.scala` file mirrors as a `package watchers:`
+block. The standard requires every family-given name to be unique across *all*
+families, judged with the package removed, so that the name alone identifies the
+given and re-exports can never collide. This script enforces that, and also
+reports any family declared in a library that no export file mirrors, since an
+unmirrored family is invisible to `import soundness.*` users. Run it with
+`make check-givens`.
 """
 import re, glob, collections, sys
 
-leaves = collections.defaultdict(set)
+GIVEN = re.compile(r'^(?P<indent>[ ]*)(?:transparent\s+)?(?:inline\s+)?given\s+(?P<name>[a-z]\w*)\b', re.M)
+PACKAGE = re.compile(r'^(?P<indent>[ ]*)package\s+(?P<name>[a-z][\w.]*):\s*$', re.M)
+ITEM = re.compile(r'^(?P<indent>[ ]*)(?:package|object|class|trait|enum|def|val|given|export|extension|case)\b', re.M)
+
+# Families sanctioned to have no umbrella mirror (fixture objects, or deliberately internal).
+UNMIRRORED_OK = {'internal', 'stagedInternal', 'bintelInternal', 'inlinables',
+                 'context'}   # frontier's `context.explainMissingContext` is an `implicit def` in the umbrella
+
+declared = collections.defaultdict(set)       # leaf -> {path}
+families = collections.defaultdict(set)       # family -> {path}
+family_leaves = collections.defaultdict(set)  # family -> {leaf}
+
+for path in glob.glob('lib/*/src/*/*.scala'):
+    if '/src/test' in path or '/src/bench' in path or '/src/demo' in path or '/src/example' in path:
+        continue
+    if '/soundness_' in path:   # the umbrella mirrors are checked separately below
+        continue
+    text = open(path, encoding='utf-8', errors='replace').read()
+    lines = text.split('\n')
+    # Walk the file tracking the innermost enclosing family package (Scala 3 braceless blocks).
+    stack = []   # (indent, family-name)
+    for line in lines:
+        if not line.strip() or line.lstrip().startswith('//'):
+            continue
+        indent = len(line) - len(line.lstrip(' '))
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+        pkg = PACKAGE.match(line)
+        if pkg:
+            name = pkg.group('name')
+            # A top-level `package foo:` block (indent 0, name lowercase) is a family; the
+            # file's own `package lib` header has no trailing colon and is not matched.
+            stack.append((indent, name))
+            if not any(seg in UNMIRRORED_OK for seg in name.split('.')):
+                families['.'.join(n for _, n in stack)].add(path)
+            continue
+        item = ITEM.match(line)
+        if item and item.group(0).strip().split()[0] in ('object', 'class', 'trait', 'enum'):
+            stack.append((indent, None))   # non-family scope: givens inside are companion-scoped
+            continue
+        g = GIVEN.match(line)
+        if g and stack and all(n is not None for _, n in stack):
+            declared[g.group('name')].add(path)
+            family_leaves['.'.join(n for _, n in stack)].add(g.group('name'))
+    del stack
+
+exported_families = set()
+export_leaves = collections.defaultdict(set)
 for path in glob.glob('lib/*/src/*/soundness_*.scala'):
     text = open(path, encoding='utf-8', errors='replace').read()
-    # `export a.b.c.{leaf1, leaf2, ...}` — collect lowercase-initial leaves
-    for match in re.finditer(r'export\s+[\w.]+\.\{([^}]*)\}', text, re.S):
-        for leaf in match.group(1).split(','):
-            leaf = leaf.strip().strip('`')
-            if leaf and leaf[0].islower():
-                leaves[leaf].add(path)
-    # `export a.b.c.leaf` — single lowercase-initial leaf
-    for match in re.finditer(r'export\s+[\w.]+\.([a-z]\w*)\s*$', text, re.M):
-        leaves[match.group(1)].add(path)
+    # Only exports inside a `package <family>:` block are family givens; the top-level
+    # `export lib.{...}` term lists may legitimately repeat names (extension methods).
+    blocks = re.split(r'^(?=package\s+[a-z][\w.]*:\s*$)', text, flags=re.M)
+    for block in blocks:
+        m = PACKAGE.match(block)
+        if not m:
+            continue
+        exported_families.add(m.group('name'))
+        for match in re.finditer(r'export\s+[\w.]+\s*\.\s*\{([^}]*)\}', block, re.S):
+            for leaf in match.group(1).split(','):
+                leaf = leaf.strip().strip('`')
+                if leaf and leaf[0].islower():
+                    export_leaves[leaf].add(path)
+        for match in re.finditer(r'export\s+[\w.]+\.([a-z]\w*)\s*$', block, re.M):
+            export_leaves[match.group(1)].add(path)
+        for match in GIVEN.finditer(block):   # hand-written delegating givens
+            export_leaves[match.group('name')].add(path)
 
-duplicates = {leaf: paths for leaf, paths in leaves.items() if len(paths) > 1}
-
-print(f'{len(leaves)} distinct exported family-given leaves checked')
-if duplicates:
-    print(f'ERROR: {len(duplicates)} leaf name(s) exported from more than one place:')
-    for leaf in sorted(duplicates):
-        for path in sorted(duplicates[leaf]):
+failed = False
+dups = {leaf: paths for leaf, paths in declared.items() if len(paths) > 1}
+print(f'{len(declared)} distinct family-given names declared in {len(families)} families')
+if dups:
+    failed = True
+    print(f'ERROR: {len(dups)} family-given name(s) declared in more than one place:')
+    for leaf in sorted(dups):
+        for path in sorted(dups[leaf]):
             print(f'  {leaf}  <-  {path}')
+
+exp_dups = {leaf: paths for leaf, paths in export_leaves.items() if len(paths) > 1}
+if exp_dups:
+    failed = True
+    print(f'ERROR: {len(exp_dups)} leaf name(s) exported from more than one place:')
+    for leaf in sorted(exp_dups):
+        for path in sorted(exp_dups[leaf]):
+            print(f'  {leaf}  <-  {path}')
+
+# A nested library family (`dateFormats.months`) may be mirrored under a flat umbrella name
+# (`monthFormats`); accept any family whose leaf givens are all exported somewhere.
+unmirrored = []
+for fam, paths in sorted(families.items()):
+    if fam in exported_families or fam.split('.')[-1] in exported_families:
+        continue
+    fam_leaves = family_leaves.get(fam, set())
+    if fam_leaves and fam_leaves <= set(export_leaves):
+        continue
+    unmirrored.append((fam, sorted(paths)))
+if unmirrored:
+    failed = True
+    print(f'ERROR: {len(unmirrored)} family package(s) not mirrored by any soundness_*.scala export file:')
+    for fam, paths in unmirrored:
+        print(f'  {fam}  <-  {", ".join(paths)}')
+
+if failed:
     sys.exit(1)
-print('All exported given leaf names are globally unique.')
+print('All family-given names are globally unique and every family is mirrored.')

--- a/lib/ambience/src/core/ambience_core.scala
+++ b/lib/ambience/src/core/ambience_core.scala
@@ -35,7 +35,6 @@ package ambience
 import scala.language.experimental.pureFunctions
 
 import java.lang as jl
-import java.nio.file as jnf
 
 import anticipation.*
 import contingency.*
@@ -49,7 +48,7 @@ package systems:
   given emptySystem: System:
     def apply(name: Text): Unset.type = Unset
 
-  given javaSystem: System:
+  given javaBaseSystem: System:
     def apply(name: Text): Optional[Text] = Optional(jl.System.getProperty(name.s)).let(_.tt)
 
 package workingDirectories:
@@ -57,23 +56,20 @@ package workingDirectories:
   given systemWorkingDirectory: (properties: System) => WorkingDirectory =
     () => properties(t"user.dir").or(panic(m"the property `user.dir` should be present"))
 
-  // The JDK's working directory: `systemWorkingDirectory` specialised to the JVM
+  // The `java.base` working directory: `systemWorkingDirectory` specialised to the JVM
   // `System`, equivalent to reading `user.dir` directly.
-  given javaWorkingDirectory: WorkingDirectory =
-    systemWorkingDirectory(using ambience.systems.javaSystem)
-
-  given defaultWorkingDirectory: WorkingDirectory =
-    () => jnf.Paths.get("").nn.toAbsolutePath.toString
+  given javaBaseWorkingDirectory: WorkingDirectory =
+    systemWorkingDirectory(using ambience.systems.javaBaseSystem)
 
 package environments:
   given emptyEnvironment: Environment:
     def variable(name: Text): Unset.type = Unset
 
-  given javaEnvironment: Environment:
+  given javaBaseEnvironment: Environment:
     def variable(name: Text): Optional[Text] = Optional(jl.System.getenv(name.s)).let(_.tt)
 
 package temporaryDirectories:
-  given javaTemporaryDirectory: TemporaryDirectory = () =>
+  given javaBaseTemporaryDirectory: TemporaryDirectory = () =>
     Optional(jl.System.getProperty("java.io.tmpdir")).let(_.tt).or:
       panic(m"the `java.io.tmpdir` system property is not set")
 

--- a/lib/ambience/src/core/soundness_ambience_core.scala
+++ b/lib/ambience/src/core/soundness_ambience_core.scala
@@ -39,17 +39,16 @@ export
       WorkingDirectory, workingDirectory, Xdg }
 
 package systems:
-  export ambience.systems.{emptySystem, javaSystem}
+  export ambience.systems.{emptySystem, javaBaseSystem}
 
 package environments:
-  export ambience.environments.{emptyEnvironment, javaEnvironment}
+  export ambience.environments.{emptyEnvironment, javaBaseEnvironment}
 
 package workingDirectories:
-  export ambience.workingDirectories.{defaultWorkingDirectory, systemWorkingDirectory,
-      javaWorkingDirectory}
+  export ambience.workingDirectories.{javaBaseWorkingDirectory, systemWorkingDirectory}
 
 package temporaryDirectories:
-  export ambience.temporaryDirectories.{environmentTemporaryDirectory, javaTemporaryDirectory,
+  export ambience.temporaryDirectories.{environmentTemporaryDirectory, javaBaseTemporaryDirectory,
       systemTemporaryDirectory}
 
 package termcaps:

--- a/lib/ambience/src/test/ambience_test.scala
+++ b/lib/ambience/src/test/ambience_test.scala
@@ -191,7 +191,7 @@ object Tests extends Suite(m"Ambience Tests"):
       . assert(_ == Unset)
 
       test(m"The Java system reads a real property"):
-        systems.javaSystem(t"java.version") == Unset
+        systems.javaBaseSystem(t"java.version") == Unset
       . assert(_ == false)
 
     suite(m"Configurator tests"):
@@ -303,7 +303,7 @@ object Tests extends Suite(m"Ambience Tests"):
       . assert(_ == t"/tmp/work")
 
       test(m"The default working directory is absolute"):
-        workingDirectories.defaultWorkingDirectory.directory().starts(t"/")
+        workingDirectories.javaBaseWorkingDirectory.directory().starts(t"/")
       . assert(_ == true)
 
     suite(m"Error message tests"):

--- a/lib/anthology/src/apk/anthology.Apk.scala
+++ b/lib/anthology/src/apk/anthology.Apk.scala
@@ -44,7 +44,7 @@ import gossamer.*
 import rudiments.*
 import vacuous.*
 
-import gastronomy.providers.javaStdlibProvider
+import gastronomy.providers.javaBaseProvider
 import denominative.*
 import symbolism.*
 import denominative.dysasymptotics.linearSize

--- a/lib/anthology/src/linker/anthology.Bundler.scala
+++ b/lib/anthology/src/linker/anthology.Bundler.scala
@@ -55,8 +55,8 @@ import filesystemOptions.dereferenceSymlinks.enabled
 import filesystemTraversal.preOrderTraversal
 import logging.silentLogging
 import manifestAttributes.*
-import systems.javaSystem
-import workingDirectories.javaWorkingDirectory
+import systems.javaBaseSystem
+import workingDirectories.javaBaseWorkingDirectory
 
 object Bundler:
   // The classpath of the running application, as introspected from the thread-context

--- a/lib/anthology/src/linker/anthology.Bundler.scala
+++ b/lib/anthology/src/linker/anthology.Bundler.scala
@@ -50,8 +50,8 @@ import turbulence.*
 import vacuous.*
 import zeppelin.*
 
-import filesystemBackends.virtualMachineFilesystem
-import filesystemOptions.dereferenceSymlinks.enabled
+import filesystemBackends.javaBaseFilesystem
+import filesystemOptions.dereferenceSymlinks
 import filesystemTraversal.preOrderTraversal
 import logging.silentLogging
 import manifestAttributes.*

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -43,10 +43,10 @@ import galilei.Linux.pathOnLinux
 import logging.silentLogging
 import probates.cancelProbate
 import strategies.throwUnsafely
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 import threading.platformThreading
-import workingDirectories.javaWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 private type JnfPath = java.nio.file.Path
 

--- a/lib/aviation/src/core/aviation.Chronometry.scala
+++ b/lib/aviation/src/core/aviation.Chronometry.scala
@@ -45,7 +45,7 @@ import prepositional.*
 // a later extension, where the conversion's working unit becomes part of the chronometry.)
 object Chronometry:
   // The default chronometry for instants that don't state one — selected by importing one of the
-  // `chronometries.*` givens (e.g. `import chronometries.unix`). It names the marker type so a
+  // `chronometries.*` givens (e.g. `import chronometries.unixChronometry`). It names the marker type so a
   // constructed `Instant` takes that chronometry at the type level.
   trait Ambient:
     type Transport

--- a/lib/aviation/src/core/aviation.GapPolicy.scala
+++ b/lib/aviation/src/core/aviation.GapPolicy.scala
@@ -40,8 +40,8 @@ import prepositional.*
 // by keeping the pre-transition offset on the same wall-clock, which lands just after the gap) or
 // held in the old offset (`backward`, just before the gap), or rejected. The policy is supplied
 // contextually; unlike `Disambiguation` there is a default (`pushForward`, matching `java.time`),
-// so grounding stays total and non-breaking. Import `gapPolicies.pushBackward` /
-// `gapPolicies.rejectGap` to override it.
+// so grounding stays total and non-breaking. Import `gapPolicies.pushBackwardGapPolicy` /
+// `gapPolicies.rejectGapPolicy` to override it.
 //
 // `resolve` receives the two candidate instants and returns one (or aborts). The rejecting policy
 // captures a `Tactic[Moment.Error]` when constructed, so it doesn't widen grounding's effect type.

--- a/lib/aviation/src/core/aviation.LeapMode.scala
+++ b/lib/aviation/src/core/aviation.LeapMode.scala
@@ -37,7 +37,7 @@ package aviation
 // and a leap second crossed in between is invisible. `Exact` adds the same duration as real SI
 // seconds (routing through the TAI timeline), so crossing an inserted leap second shifts the
 // wall-clock result back by that second. The two agree except across one of the ~27 historical leap
-// instants. Import `leapModes.exact` to switch from `Lenient`.
+// instants. Import `leapModes.exactLeapMode` to switch from `Lenient`.
 object LeapMode:
   given lenient: LeapMode = LeapMode.Lenient
 

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -399,13 +399,13 @@ package timeFormats:
 // A human-readable, relative rendering of a `Timespan`, in place of the default ISO-8601 duration:
 // "in 18 minutes", "8 minutes ago", "just now", and their French/German/Spanish equivalents. Only
 // the non-zero components are shown (coarsest first); the sign chooses the future/past form. Import
-// the variant for the language(s) you want (e.g. `timespanFormats.frenchRelative`); the in-scope
+// the variant for the language(s) you want (e.g. `timespanFormats.frenchRelativeTimespan`); the in-scope
 // `Locale` selects which applies.
 package timespanFormats:
-  given englishRelative: Locale[en] => Timespan is Showable = Vernacular.english.relativeTimespan(_)
-  given frenchRelative: Locale[fr] => Timespan is Showable = Vernacular.french.relativeTimespan(_)
-  given germanRelative: Locale[de] => Timespan is Showable = Vernacular.german.relativeTimespan(_)
-  given spanishRelative: Locale[es] => Timespan is Showable = Vernacular.spanish.relativeTimespan(_)
+  given englishRelativeTimespan: Locale[en] => Timespan is Showable = Vernacular.english.relativeTimespan(_)
+  given frenchRelativeTimespan: Locale[fr] => Timespan is Showable = Vernacular.french.relativeTimespan(_)
+  given germanRelativeTimespan: Locale[de] => Timespan is Showable = Vernacular.german.relativeTimespan(_)
+  given spanishRelativeTimespan: Locale[es] => Timespan is Showable = Vernacular.spanish.relativeTimespan(_)
 
 package calendars:
   given julianCalendar: RomanCalendar(t"Julian"):
@@ -461,12 +461,12 @@ package calendars:
 // The default interpretation of an `Instant`'s `Long` (used by `Instant(…)`, decoding, etc.).
 // Import one of these to choose the timeline bare instants count on; convert with `.over[…]`.
 package chronometries:
-  given unix: (Chronometry.Ambient { type Transport = Unix }) =
+  given unixChronometry: (Chronometry.Ambient { type Transport = Unix }) =
     new Chronometry.Ambient:
       type Transport = Unix
       def chronometry: Unix is Chronometry = Chronometry.unix
 
-  given atomic: (Chronometry.Ambient { type Transport = Tai }) =
+  given taiChronometry: (Chronometry.Ambient { type Transport = Tai }) =
     new Chronometry.Ambient:
       type Transport = Tai
       def chronometry: Tai is Chronometry = Chronometry.tai
@@ -475,16 +475,16 @@ package chronometries:
 // exist. The ambient default is `GapPolicy.pushForward` (matching `java.time`); import one of these
 // to push the other way or to reject the gap.
 package gapPolicies:
-  given pushBackward: GapPolicy = (_, backward) => backward
+  given pushBackwardGapPolicy: GapPolicy = (_, backward) => backward
 
-  given rejectGap: Tactic[Moment.Error] => GapPolicy =
+  given rejectGapPolicy: Tactic[Moment.Error] => GapPolicy =
     (_, _) => abort(Moment.Error(_.Gap))
 
 // Switch sub-day `Moment` arithmetic to count leap seconds (the default `LeapMode.Lenient` works on
-// the leap-free POSIX line). Import `leapModes.exact` so adding a duration that crosses an inserted
+// the leap-free POSIX line). Import `leapModes.exactLeapMode` so adding a duration that crosses an inserted
 // leap second advances by that many real SI seconds.
 package leapModes:
-  given exact: LeapMode = LeapMode.Exact
+  given exactLeapMode: LeapMode = LeapMode.Exact
 
 // Month-end overflow policies for adding months/years to a date (e.g. Jan 31 + 1 month). No default
 // is provided, so such arithmetic requires one of these to be imported.

--- a/lib/aviation/src/core/soundness_aviation_core.scala
+++ b/lib/aviation/src/core/soundness_aviation_core.scala
@@ -135,3 +135,10 @@ package hebdomads:
 
 package instantDecodables:
   export aviation.instantDecodables.{iso8601InstantDecodable, rfc1123InstantDecodable}
+
+package interfaces:
+  package instants:
+    export anticipation.interfaces.instants.aviationInstant
+
+  package durations:
+    export anticipation.interfaces.durations.aviationDuration

--- a/lib/aviation/src/core/soundness_aviation_core.scala
+++ b/lib/aviation/src/core/soundness_aviation_core.scala
@@ -65,13 +65,13 @@ package monthEnds:
   export aviation.monthEnds.{clampMonthEnd, overflowMonthEnd, raiseMonthEnd}
 
 package gapPolicies:
-  export aviation.gapPolicies.{pushBackward, rejectGap}
+  export aviation.gapPolicies.{pushBackwardGapPolicy, rejectGapPolicy}
 
 package leapModes:
-  export aviation.leapModes.exact
+  export aviation.leapModes.exactLeapMode
 
 package chronometries:
-  export aviation.chronometries.{unix, atomic}
+  export aviation.chronometries.{unixChronometry, taiChronometry}
 
 package dateFormats:
   export aviation.dateFormats.{americanDateFormat, europeanDateFormat, iso8601DateFormat,
@@ -110,10 +110,14 @@ package timeFormats:
         ledgerTimeFormat, militaryTimeFormat, railwayTimeFormat }
 
 package timespanFormats:
-  export aviation.timespanFormats.{englishRelative, frenchRelative, germanRelative, spanishRelative}
+  export aviation.timespanFormats.{englishRelativeTimespan, frenchRelativeTimespan, germanRelativeTimespan, spanishRelativeTimespan}
 
 package hourFormats:
-  export aviation.timeFormats.hours.{twelveHourClock, twentyFourHourClock}
+  export aviation.timeFormats.hours.{twelveHourClock, twelveHourSecondsClock, twentyFourHourClock,
+      twentyFourHourSecondsClock}
+
+package timeSpecificities:
+  export aviation.timeFormats.specificity.{minutesSpecificity, secondsSpecificity}
 
 package meridiems:
   export aviation.timeFormats.meridiems.{lowerMeridiem, lowerPunctuatedMeridiem, upperMeridiem,

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -39,7 +39,7 @@ import soundness.sortingAlgorithms.timsort
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import abstractables.epochMillisecondsAbstractable
-import chronometries.unix
+import chronometries.unixChronometry
 import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Aviation Tests"):
@@ -2251,7 +2251,7 @@ object Tests extends Suite(m"Aviation Tests"):
       given Locale[fr] = Locale(fr)
       import monthFormats.frenchMonths
       import weekdays.frenchWeekdays
-      import timespanFormats.frenchRelative
+      import timespanFormats.frenchRelativeTimespan
 
       test(m"The 3rd Monday of each month, in French"):
         Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3))).show
@@ -2275,7 +2275,7 @@ object Tests extends Suite(m"Aviation Tests"):
       given Locale[de] = Locale(de)
       import monthFormats.germanMonths
       import weekdays.germanWeekdays
-      import timespanFormats.germanRelative
+      import timespanFormats.germanRelativeTimespan
 
       test(m"The 3rd Monday of each month, in German"):
         Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3))).show
@@ -2294,7 +2294,7 @@ object Tests extends Suite(m"Aviation Tests"):
       given Locale[es] = Locale(es)
       import monthFormats.spanishMonths
       import weekdays.spanishWeekdays
-      import timespanFormats.spanishRelative
+      import timespanFormats.spanishRelativeTimespan
 
       test(m"The 3rd Monday of each month, in Spanish"):
         Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3))).show
@@ -2345,13 +2345,13 @@ object Tests extends Suite(m"Aviation Tests"):
       . assert(_ == Moment(2017-Jan-1, Clockface(1, 0, 0), tz"UTC").instant)
 
       test(m"Exact addition counts a crossed leap second"):
-        import leapModes.exact
+        import leapModes.exactLeapMode
         val start = Moment(2016-Dec-31, Clockface(23, 0, 0), tz"UTC")
         (start + 2*Hour).instant
       . assert(_ == Moment(2017-Jan-1, Clockface(0, 59, 59), tz"UTC").instant)
 
       test(m"Exact and lenient agree when no leap second is crossed"):
-        import leapModes.exact
+        import leapModes.exactLeapMode
         val start = Moment(2024-Jun-1, Clockface(12, 0, 0), tz"UTC")
         (start + 2*Hour).instant
       . assert(_ == Moment(2024-Jun-1, Clockface(14, 0, 0), tz"UTC").instant)
@@ -2409,7 +2409,7 @@ object Tests extends Suite(m"Aviation Tests"):
 
       test(m"Timestamp.instant honours a non-default GapPolicy"):
         import instantDecodables.iso8601InstantDecodable
-        import gapPolicies.pushBackward
+        import gapPolicies.pushBackwardGapPolicy
         given Timezone = tz"Europe/London"
         val grounded = Timestamp(2024-Mar-31, Clockface(1, 30, 0)).instant
         grounded == t"2024-03-31T00:30:00Z".as[Instant over Unix]
@@ -2456,13 +2456,13 @@ object Tests extends Suite(m"Aviation Tests"):
 
       test(m"Spring-forward gap can push backward"):
         import instantDecodables.iso8601InstantDecodable
-        import gapPolicies.pushBackward
+        import gapPolicies.pushBackwardGapPolicy
         val grounded = Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant
         grounded == t"2024-03-31T00:30:00Z".as[Instant over Unix]
       . assert(_ == true)
 
       test(m"Spring-forward gap can be rejected"):
-        import gapPolicies.rejectGap
+        import gapPolicies.rejectGapPolicy
         capture(Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant)
       . assert(_ == Moment.Error(_.Gap))
 
@@ -2689,7 +2689,7 @@ object Tests extends Suite(m"Aviation Tests"):
       . assert(_.nonEmpty)
 
     suite(m"Relative timespan formatting"):
-      import timespanFormats.englishRelative
+      import timespanFormats.englishRelativeTimespan
       given Locale[en] = Locale(en)
 
       test(m"A future single component reads as \"in …\""):

--- a/lib/bitumen/src/core/bitumen.Tar.scala
+++ b/lib/bitumen/src/core/bitumen.Tar.scala
@@ -40,7 +40,7 @@ import distillate.*
 import galilei.*
 import gossamer.*
 import hieroglyph.*, charEncoders.asciiEncoder, textMetrics.uniformMetric
-import hypotenuse.*, arithmeticOptions.overflow.unchecked
+import hypotenuse.*, arithmeticOptions.uncheckedOverflow
 import nomenclature.*
 import prepositional.*
 import rudiments.*

--- a/lib/bitumen/src/core/bitumen.TarDataOpenable.scala
+++ b/lib/bitumen/src/core/bitumen.TarDataOpenable.scala
@@ -39,7 +39,7 @@ import distillate.*
 import galilei.*
 import gossamer.*
 import hieroglyph.*, charEncoders.asciiEncoder, textMetrics.uniformMetric
-import hypotenuse.*, arithmeticOptions.overflow.unchecked
+import hypotenuse.*, arithmeticOptions.uncheckedOverflow
 import nomenclature.*
 import prepositional.*
 import rudiments.*

--- a/lib/bitumen/src/core/bitumen.TypeFlag.scala
+++ b/lib/bitumen/src/core/bitumen.TypeFlag.scala
@@ -34,7 +34,7 @@ package bitumen
 
 
 import hieroglyph.*, charEncoders.asciiEncoder, textMetrics.uniformMetric
-import hypotenuse.*, arithmeticOptions.overflow.unchecked
+import hypotenuse.*, arithmeticOptions.uncheckedOverflow
 
 enum TypeFlag:
   case File

--- a/lib/bitumen/src/core/bitumen.UnixGroup.scala
+++ b/lib/bitumen/src/core/bitumen.UnixGroup.scala
@@ -36,7 +36,7 @@ package bitumen
 import anticipation.*
 import gossamer.*
 import hieroglyph.*, charEncoders.asciiEncoder, textMetrics.uniformMetric
-import hypotenuse.*, arithmeticOptions.overflow.unchecked
+import hypotenuse.*, arithmeticOptions.uncheckedOverflow
 import vacuous.*
 
 case class UnixGroup(value: Int, name: Optional[Text] = Unset):

--- a/lib/bitumen/src/core/bitumen.UnixMode.scala
+++ b/lib/bitumen/src/core/bitumen.UnixMode.scala
@@ -36,7 +36,7 @@ package bitumen
 import anticipation.*
 import gossamer.*
 import hieroglyph.*, charEncoders.asciiEncoder, textMetrics.uniformMetric
-import hypotenuse.*, arithmeticOptions.overflow.unchecked
+import hypotenuse.*, arithmeticOptions.uncheckedOverflow
 
 object UnixMode:
   def from(int: Int): UnixMode =

--- a/lib/bitumen/src/core/bitumen.UnixUser.scala
+++ b/lib/bitumen/src/core/bitumen.UnixUser.scala
@@ -36,7 +36,7 @@ package bitumen
 import anticipation.*
 import gossamer.*
 import hieroglyph.*, charEncoders.asciiEncoder, textMetrics.uniformMetric
-import hypotenuse.*, arithmeticOptions.overflow.unchecked
+import hypotenuse.*, arithmeticOptions.uncheckedOverflow
 import vacuous.*
 
 case class UnixUser(value: Int, name: Optional[Text] = Unset):

--- a/lib/bitumen/src/jvm/bitumen.TarFilesystem.scala
+++ b/lib/bitumen/src/jvm/bitumen.TarFilesystem.scala
@@ -41,7 +41,7 @@ import distillate.*
 import fulminate.*
 import galilei.*
 import hieroglyph.*, charEncoders.asciiEncoder
-import hypotenuse.*, arithmeticOptions.overflow.unchecked
+import hypotenuse.*, arithmeticOptions.uncheckedOverflow
 import prepositional.*
 import rudiments.*
 import serpentine.*

--- a/lib/bitumen/src/jvm/bitumen.TarFilesystem.scala
+++ b/lib/bitumen/src/jvm/bitumen.TarFilesystem.scala
@@ -48,7 +48,7 @@ import serpentine.*
 import spectacular.*
 import vacuous.*
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 private[bitumen] object TarFilesystem:
   def entryFor[plane <: Posix: Filesystem]

--- a/lib/bitumen/src/jvm/bitumen_jvm.scala
+++ b/lib/bitumen/src/jvm/bitumen_jvm.scala
@@ -43,7 +43,7 @@ import turbulence.*
 import vacuous.*
 import zephyrine.*
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 // Opening a filesystem path or building an archive from disk needs `bitumen.jvm`; re-exported
 // through `soundness.*`, so `path.open[Tar]` and `Tar.Entry(...)` resolve as before on the JVM.

--- a/lib/bitumen/src/test/bitumen_test.scala
+++ b/lib/bitumen/src/test/bitumen_test.scala
@@ -541,9 +541,9 @@ object Tests extends Suite(m"Bitumen Tests"):
       . assert(_ == t"a test file")
 
     suite(m"External tar reads archives produced by Bitumen"):
-      import systems.javaSystem
+      import systems.javaBaseSystem
       import temporaryDirectories.systemTemporaryDirectory
-      import workingDirectories.defaultWorkingDirectory
+      import workingDirectories.javaBaseWorkingDirectory
       import logging.silentLogging
       import filesystemOptions.dereferenceSymlinks.enabled
       import filesystemOptions.overwritePreexisting.enabled
@@ -621,7 +621,7 @@ object Tests extends Suite(m"Bitumen Tests"):
       . assert(_ == List(t"link"))
 
     suite(m"Filesystem integration: Tarfile.from / extractTo"):
-      import systems.javaSystem
+      import systems.javaBaseSystem
       import temporaryDirectories.systemTemporaryDirectory
       import filesystemTraversal.preOrderTraversal
       import filesystemOptions.dereferenceSymlinks.disabled
@@ -707,7 +707,7 @@ object Tests extends Suite(m"Bitumen Tests"):
       . assert(_ == true)
 
     suite(m"Scoped opening"):
-      import systems.javaSystem
+      import systems.javaBaseSystem
       import temporaryDirectories.systemTemporaryDirectory
       import filesystemOptions.createNonexistentParents.enabled
       import filesystemOptions.overwritePreexisting.enabled
@@ -742,7 +742,7 @@ object Tests extends Suite(m"Bitumen Tests"):
       . assert(_ == Tar.Error.Reason.WriteUnsupported)
 
     suite(m"Creating archives"):
-      import systems.javaSystem
+      import systems.javaBaseSystem
       import temporaryDirectories.systemTemporaryDirectory
       import filesystemOptions.createNonexistentParents.enabled
       import filesystemOptions.overwritePreexisting.enabled

--- a/lib/bitumen/src/test/bitumen_test.scala
+++ b/lib/bitumen/src/test/bitumen_test.scala
@@ -34,7 +34,7 @@ package bitumen
 
 
 import soundness.*
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 import java.nio.file as jnf
 
@@ -545,10 +545,10 @@ object Tests extends Suite(m"Bitumen Tests"):
       import temporaryDirectories.systemTemporaryDirectory
       import workingDirectories.javaBaseWorkingDirectory
       import logging.silentLogging
-      import filesystemOptions.dereferenceSymlinks.enabled
-      import filesystemOptions.overwritePreexisting.enabled
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.deleteRecursively.enabled
+      import filesystemOptions.dereferenceSymlinks
+      import filesystemOptions.overwritePreexisting
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.deleteRecursively
 
       val workDir: Path on Linux = temporaryDirectory[Path on Linux] / Uuid().show
       workDir.create[Directory]()
@@ -624,10 +624,10 @@ object Tests extends Suite(m"Bitumen Tests"):
       import systems.javaBaseSystem
       import temporaryDirectories.systemTemporaryDirectory
       import filesystemTraversal.preOrderTraversal
-      import filesystemOptions.dereferenceSymlinks.disabled
-      import filesystemOptions.overwritePreexisting.enabled
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.deleteRecursively.enabled
+      import filesystemOptions.preserveSymlinks
+      import filesystemOptions.overwritePreexisting
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.deleteRecursively
 
       def freshDir(): Path on Linux =
         val d = temporaryDirectory[Path on Linux] / Uuid().show
@@ -709,9 +709,9 @@ object Tests extends Suite(m"Bitumen Tests"):
     suite(m"Scoped opening"):
       import systems.javaBaseSystem
       import temporaryDirectories.systemTemporaryDirectory
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
-      import filesystemOptions.deleteRecursively.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
+      import filesystemOptions.deleteRecursively
 
       val tar = Tarfile(List(helloFile, emptyDir))
 
@@ -744,9 +744,9 @@ object Tests extends Suite(m"Bitumen Tests"):
     suite(m"Creating archives"):
       import systems.javaBaseSystem
       import temporaryDirectories.systemTemporaryDirectory
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
-      import filesystemOptions.deleteRecursively.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
+      import filesystemOptions.deleteRecursively
 
       val createDir: Path on Linux = temporaryDirectory[Path on Linux] / Uuid().show
       createDir.create[Directory]()

--- a/lib/breviloquence/src/bench/breviloquence.Benchmarks.scala
+++ b/lib/breviloquence/src/bench/breviloquence.Benchmarks.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package breviloquence
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -929,7 +929,7 @@ object Cbor extends Cbor2, Dynamic:
     type Form = Cbor
     type Self = derivation
 
-    import dynamicCborAccess.enabled
+    import dynamicAccess.dynamicCbor
 
     def rewrite(kind: Text, cbor: Cbor): Cbor = unsafely(cbor.updateDynamic(key.s)(kind))
     def discriminate(cbor: Cbor): Optional[Text] =

--- a/lib/breviloquence/src/core/breviloquence.conversions.scala
+++ b/lib/breviloquence/src/core/breviloquence.conversions.scala
@@ -30,19 +30,13 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package gastronomy
+package breviloquence
 
-// Off the JVM (Scala.js and WASI) there is no `java.security.MessageDigest`, so the
-// "JavaStdlib" provider forwards to the pure-Scala implementations in `SoundnessHashing`. This
-// keeps `import providers.javaStdlibProvider` working identically on every platform — code that
-// selects it gets native hashing on the JVM and the pure port elsewhere, with no source change.
-object JavaStdlibHashing extends Hashing:
-  def md5:  Hashing.Function = SoundnessHashing.md5
-  def sha1: Hashing.Function = SoundnessHashing.sha1
-  def sha2(bits: Int): Hashing.Function = SoundnessHashing.sha2(bits)
-  def crc32: Hashing.Function = SoundnessHashing.crc32
+import anticipation.*
+import prepositional.*
 
-  // The checksums forward too, so `.digest[Crc32]`/`.digest[Adler32]` resolve under this
-  // provider on every platform. CRC-64 is deliberately absent here as it is on the JVM: no
-  // `java.util.zip` equivalent exists, so it is reached through the Soundness provider only.
-  def adler32: Hashing.Function = SoundnessHashing.adler32
+// Importing `conversions.encodableToCbor` brings a scoped `Conversion` into lexical scope that lets
+// any `Encodable in Cbor` value be supplied directly at lens-assignment positions, such as
+// `cbor.lens(_.field = value)`, without an explicit `.cbor`.
+package conversions:
+  given encodableToCbor: [entity: Encodable in Cbor] => Conversion[entity, Cbor] = _.encode

--- a/lib/breviloquence/src/core/breviloquence.dynamicAccess.scala
+++ b/lib/breviloquence/src/core/breviloquence.dynamicAccess.scala
@@ -32,11 +32,7 @@
                                                                                                   */
 package breviloquence
 
-import anticipation.*
-import prepositional.*
+import rudiments.*
 
-// Importing `cborConversion.encodable` brings a scoped `Conversion` into lexical scope that lets
-// any `Encodable in Cbor` value be supplied directly at lens-assignment positions, such as
-// `cbor.lens(_.field = value)`, without an explicit `.cbor`.
-object cborConversion:
-  given encodable: [entity: Encodable in Cbor] => Conversion[entity, Cbor] = _.encode
+package dynamicAccess:
+  inline given dynamicCbor: DynamicCborEnabler = !!

--- a/lib/breviloquence/src/core/soundness_breviloquence_core.scala
+++ b/lib/breviloquence/src/core/soundness_breviloquence_core.scala
@@ -32,4 +32,10 @@
                                                                                                   */
 package soundness
 
-export breviloquence.{Cbor, Cbor2, cborConversion, DynamicCborEnabler, dynamicCborAccess}
+export breviloquence.{Cbor, Cbor2, DynamicCborEnabler}
+
+package dynamicAccess:
+  export breviloquence.dynamicAccess.dynamicCbor
+
+package conversions:
+  export breviloquence.conversions.encodableToCbor

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -367,7 +367,7 @@ object Tests extends Suite(m"Breviloquence Tests"):
       . assert(_ == Person(t"Alice", 30))
 
     suite(m"Optics"):
-      import dynamicCborAccess.enabled, cborConversion.encodable
+      import dynamicAccess.dynamicCbor, conversions.encodableToCbor
 
       val team = Team(Person(t"John", 40), 3).in[Cbor]
       val list = Wrapper(List(1, 2, 3), t"hi").in[Cbor]
@@ -425,7 +425,7 @@ object Tests extends Suite(m"Breviloquence Tests"):
       . assert(_ == (0L, 28))
 
     suite(m"Dynamic access"):
-      import dynamicCborAccess.enabled
+      import dynamicAccess.dynamicCbor
 
       test(m"selectDynamic reads a map field by name"):
         Person(t"Ada", 36).in[Cbor].selectDynamic("name").as[Text]

--- a/lib/burdock/src/core/burdock.DepsDev.scala
+++ b/lib/burdock/src/core/burdock.DepsDev.scala
@@ -46,7 +46,7 @@ import telekinesis.*
 import urticose.*
 import vacuous.*
 
-import httpBackends.virtualMachineHttp
+import httpBackends.javaNetHttp
 import internetAccess.online
 
 // Resolves a dependency's content hash to its public download URL using Google's

--- a/lib/burdock/src/core/burdock.GitHub.scala
+++ b/lib/burdock/src/core/burdock.GitHub.scala
@@ -53,7 +53,7 @@ import Repackager.UserError
 import denominative.nil
 import denominative.size
 import errorDiagnostics.emptyDiagnostics
-import httpBackends.virtualMachineHttp
+import httpBackends.javaNetHttp
 import internetAccess.online
 
 // Resolves dependency content hashes against the release assets of GitHub repositories the

--- a/lib/burdock/src/core/burdock_repackage.scala
+++ b/lib/burdock/src/core/burdock_repackage.scala
@@ -60,12 +60,12 @@ import zeppelin.*
 
 import Repackager.UserError
 import backstops.stackTraceBackstop
-import environments.javaEnvironment
+import environments.javaBaseEnvironment
 import executives.directExecutive
 import filesystemOptions.dereferenceSymlinks.enabled
 import interpreters.posixInterpreter
-import stdios.virtualMachineStdio
-import systems.javaSystem
+import stdios.fileDescriptorStdio
+import systems.javaBaseSystem
 import termcaps.environmentTermcap
 
 import filesystemBackends.virtualMachineFilesystem

--- a/lib/burdock/src/core/burdock_repackage.scala
+++ b/lib/burdock/src/core/burdock_repackage.scala
@@ -62,13 +62,13 @@ import Repackager.UserError
 import backstops.stackTraceBackstop
 import environments.javaBaseEnvironment
 import executives.directExecutive
-import filesystemOptions.dereferenceSymlinks.enabled
+import filesystemOptions.dereferenceSymlinks
 import interpreters.posixInterpreter
 import stdios.fileDescriptorStdio
 import systems.javaBaseSystem
 import termcaps.environmentTermcap
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 // `linearSize`: the externalized-dependency count is reported once, at the end of a repackage
 // that has already walked every entry in the JAR.
@@ -168,10 +168,10 @@ def repackage(arguments: List[Text]): Unit = application(arguments):
         Out.print(csi.dectcem(true))
         Out.println()
 
-      import filesystemOptions.overwritePreexisting.enabled
-      import filesystemOptions.deleteRecursively.disabled
-      import filesystemOptions.moveAtomically.enabled
-      import filesystemOptions.createNonexistentParents.disabled
+      import filesystemOptions.overwritePreexisting
+      import filesystemOptions.deleteOnlyEmpty
+      import filesystemOptions.moveAtomically
+      import filesystemOptions.requireParents
 
       tmpFile.moveTo(inputJar)
 

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -40,7 +40,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import charEncoders.utf8Encoder
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 
 object Tests extends Suite(m"Burdock Tests"):

--- a/lib/caduceus/src/resend/caduceus_core.scala
+++ b/lib/caduceus/src/resend/caduceus_core.scala
@@ -56,12 +56,12 @@ import charEncoders.utf8Encoder
 import environments.javaBaseEnvironment
 import errorDiagnostics.stackTracesDiagnostics
 import formatting.compactJsonFormatting
-import httpBackends.virtualMachineHttp
+import httpBackends.javaNetHttp
 import stdios.fileDescriptorStdio
 import termcaps.environmentTermcap
 
 package couriers:
-  given resend
+  given resendCourier
   :   ( courierTactic: Tactic[Courier.Error], online: Online, loggable: Http.Event is Loggable,
         client: Http.Client )
   =>  ( apiKey: Resend.ApiKey )

--- a/lib/caduceus/src/resend/caduceus_core.scala
+++ b/lib/caduceus/src/resend/caduceus_core.scala
@@ -53,11 +53,11 @@ import zephyrine.*
 
 import alphabets.base64Standard
 import charEncoders.utf8Encoder
-import environments.javaEnvironment
+import environments.javaBaseEnvironment
 import errorDiagnostics.stackTracesDiagnostics
 import formatting.compactJsonFormatting
 import httpBackends.virtualMachineHttp
-import stdios.virtualMachineStdio
+import stdios.fileDescriptorStdio
 import termcaps.environmentTermcap
 
 package couriers:

--- a/lib/caduceus/src/resend/soundness_caduceus_resend.scala
+++ b/lib/caduceus/src/resend/soundness_caduceus_resend.scala
@@ -35,4 +35,4 @@ package soundness
 export caduceus.{Resend}
 
 package couriers:
-  export caduceus.couriers.resend
+  export caduceus.couriers.resendCourier

--- a/lib/caesura/src/bench/caesura.Benchmarks.scala
+++ b/lib/caesura/src/bench/caesura.Benchmarks.scala
@@ -46,7 +46,7 @@ import proscenium.*
 import rudiments.*
 import quantitative.*
 import sedentary.*
-import superlunary.embeddings.automatic
+import superlunary.embeddings.automaticEmbedding
 import symbolism.*
 import temporaryDirectories.systemTemporaryDirectory
 import turbulence.*

--- a/lib/caesura/src/bench/caesura.Benchmarks.scala
+++ b/lib/caesura/src/bench/caesura.Benchmarks.scala
@@ -35,7 +35,7 @@ package caesura
 import scala.language.unsafeNulls
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*

--- a/lib/caesura/src/core/caesura.dynamicAccess.scala
+++ b/lib/caesura/src/core/caesura.dynamicAccess.scala
@@ -30,13 +30,9 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package locomotion
+package caesura
 
-import anticipation.*
-import prepositional.*
+import rudiments.*
 
-// Importing `protobufConversion.encodable` brings a scoped `Conversion` into lexical scope that
-// lets any `Encodable in Protobuf` value be supplied directly at lens-assignment positions, such
-// as `protobuf.lens(_.field = value)`, without an explicit `.protobuf`.
-object protobufConversion:
-  given encodable: [entity: Encodable in Protobuf] => Conversion[entity, Protobuf] = _.encode
+package dynamicAccess:
+  inline given dynamicDsv: DynamicDsvEnabler = !!

--- a/lib/caesura/src/core/caesura_core.scala
+++ b/lib/caesura/src/core/caesura_core.scala
@@ -107,7 +107,7 @@ private def parsedIterator[value](consume reader: DsvReader^, parsable: value is
       row
 
 // Panopticon optics for tabular data (no nesting, so they mirror the row/cell
-// structure rather than JSON's map/array). `cellLens` reads/writes a cell by column
+// structure rather than JSON's map/array). `dsvCellLens` reads/writes a cell by column
 // name within a row; the `Sheet` opticals address the n-th row (`Ordinal`), every
 // row (`Each`), or rows matching a predicate (`Filter`). So
 // `sheet.lens(_(Sec).name = t"…")` updates the "name" column of the second row.
@@ -119,22 +119,22 @@ package optics:
   private def withCell(row: Dsv, name: String, value: Text): Dsv =
     row.columns.let(_(name.tt)).lay(row): index => row.copy(data = Array.frozen(row.data.readable.updated(index, value)))
 
-  given cellLens: [name <: Label: ValueOf] => (erased dynamicDsvEnabler: DynamicDsvEnabler)
+  given dsvCellLens: [name <: Label: ValueOf] => (erased dynamicDsvEnabler: DynamicDsvEnabler)
   =>  name is Lens from Dsv onto Text =
     Lens(cell(_, valueOf[name]), withCell(_, valueOf[name], _))
 
-  given rowOptical: [element] => Ordinal is Optical from Sheet onto Dsv = ordinal =>
+  given dsvRowOptical: [element] => Ordinal is Optical from Sheet onto Dsv = ordinal =>
     Optic: (origin, lambda) =>
       origin.copy(rows = origin.rows.indexed.remap: (row, index) =>
         if index == ordinal then lambda(row) else row)
 
-  given rowEach: Each.type is Optical from Sheet onto Dsv = _ =>
+  given dsvRowEachOptical: Each.type is Optical from Sheet onto Dsv = _ =>
     Optic: (origin, lambda) => origin.copy(rows = origin.rows.remap(lambda))
 
   // The `predicate` laundering is for the Scala.js pipeline, which — unlike the JVM pipeline —
   // rejects the `Optic`'s capture of `filter.predicate` against the required pure `Optic` type.
   // (Compiler divergence; see #1520 and the identical laundering in `panopticon.Optical.filter`.)
-  given rowFilter: Filter[Dsv] is Optical from Sheet onto Dsv = filter =>
+  given dsvRowFilterOptical: Filter[Dsv] is Optical from Sheet onto Dsv = filter =>
     val predicate: Dsv -> Boolean = caps.unsafe.unsafeAssumePure(filter.predicate)
 
     Optic: (origin, lambda) =>

--- a/lib/caesura/src/core/soundness_caesura_core.scala
+++ b/lib/caesura/src/core/soundness_caesura_core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export
   caesura
-  . { CellRef, Dsv, dsv, dynamicDsvAccess, DynamicDsvEnabler,
+  . { CellRef, Dsv, dsv, DynamicDsvEnabler,
       rows, rowsOf, Sheet, Spannable }
 
 package dsvFormats:
@@ -48,4 +48,7 @@ package dsvRedesignations:
         lowerWordsRedesignation, unchangedRedesignation }
 
 package optics:
-  export caesura.optics.{cellLens, rowEach, rowFilter, rowOptical}
+  export caesura.optics.{dsvCellLens, dsvRowEachOptical, dsvRowFilterOptical, dsvRowOptical}
+
+package dynamicAccess:
+  export caesura.dynamicAccess.dynamicDsv

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -36,7 +36,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
-import caesura.optics.{cellLens, rowEach, rowFilter, rowOptical}
+import caesura.optics.{dsvCellLens, dsvRowEachOptical, dsvRowFilterOptical, dsvRowOptical}
 
 given decimalizer: Decimalizer = Decimalizer(1)
 

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -193,7 +193,7 @@ object Tests extends Suite(m"Caesura tests"):
 
 
     suite(m"Dynamic JSON access"):
-      import dynamicDsvAccess.enabled
+      import dynamicAccess.dynamicDsv
 
       test(m"Access field by name"):
         import dsvFormats.tsvWithHeaderFormat
@@ -311,7 +311,7 @@ object Tests extends Suite(m"Caesura tests"):
 
     suite(m"Optics"):
       import dsvFormats.csvWithHeaderFormat
-      import dynamicDsvAccess.enabled
+      import dynamicAccess.dynamicDsv
       def sheet: Sheet = t"name,age\nAlice,30\nBob,25".read[Sheet]
 
       test(m"cell lens reads a cell by column name"):

--- a/lib/capricious/src/core/capricious_core.scala
+++ b/lib/capricious/src/core/capricious_core.scala
@@ -46,18 +46,18 @@ import hypotenuse.*
 
 package randomization:
   package text:
-    given bigListOfNaughtyStrings: Text is Randomizable:
+    given naughtyStringsText: Text is Randomizable:
       val resource = getClass.getResourceAsStream("/capricious/blns.txt").nn
       val blns = Array.from(scala.io.Source.fromInputStream(resource).getLines().map(_.tt))
 
       def randomize(random: Random) = blns.readable(random.long().toInt.abs%blns.length)
 
   package sizes:
-    given uniformUpto10: Random.Size = _.long().toInt.abs%10
-    given uniformUpto100: Random.Size = _.long().toInt.abs%100
-    given uniformUpto1000: Random.Size = _.long().toInt.abs%1000
-    given uniformUpto10000: Random.Size = _.long().toInt.abs%10000
-    given uniformUpto100000: Random.Size = _.long().toInt.abs%100000
+    given uniformSizeUpto10: Random.Size = _.long().toInt.abs%10
+    given uniformSizeUpto100: Random.Size = _.long().toInt.abs%100
+    given uniformSizeUpto1000: Random.Size = _.long().toInt.abs%1000
+    given uniformSizeUpto10000: Random.Size = _.long().toInt.abs%10000
+    given uniformSizeUpto100000: Random.Size = _.long().toInt.abs%100000
 
   given unseededRandomization: Randomization = () => su.Random(java.util.Random())
   given secureUnseededRandomization: Randomization = () => su.Random(js.SecureRandom())

--- a/lib/capricious/src/core/soundness_capricious_core.scala
+++ b/lib/capricious/src/core/soundness_capricious_core.scala
@@ -44,7 +44,10 @@ package randomization:
   package sizes:
     export
       capricious.randomization.sizes
-      . { uniformUpto10, uniformUpto100, uniformUpto1000, uniformUpto10000, uniformUpto100000 }
+      . { uniformSizeUpto10, uniformSizeUpto100, uniformSizeUpto1000, uniformSizeUpto10000, uniformSizeUpto100000 }
+
+  package text:
+    export capricious.randomization.text.naughtyStringsText
 
 package randomDistributions:
   export

--- a/lib/cataclysm/src/core/cataclysm.Css.scala
+++ b/lib/cataclysm/src/core/cataclysm.Css.scala
@@ -71,7 +71,7 @@ object Css:
 
   // Controls how a `Css` tree is serialized. `newlines` puts each rule and declaration on its own
   // indented line; `spaces` adds the cosmetic spaces (after `:` and before `{`). Bundled as
-  // `formatting.standardCssFormatting` and `formatting.compactCssFormatting`.
+  // `formatting.indentedCssFormatting` and `formatting.compactCssFormatting`.
   object Formatting:
     def apply(newlines: Boolean, spaces: Boolean): Formatting = Basic(newlines, spaces)
     private case class Basic(newlines: Boolean, spaces: Boolean) extends Formatting

--- a/lib/cataclysm/src/core/cataclysm.CssParser.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssParser.scala
@@ -50,13 +50,13 @@ private[cataclysm] object CssParser:
   // construction, no stdlib hop. No default for `validating`: only one
   // overloaded alternative may define default arguments.
   def parse(input: Chain[Text], validating: Boolean)(using Tactic[Css.Error]): Css =
-    import zephyrine.lineation.linefeedChars
+    import zephyrine.lineation.linefeedChar
 
     Parser(Cursor[Text](input), validating).document()
 
   // The legacy interoperation shape: a stdlib `Iterator` of chunks.
   def parse(input: Iterator[Text], validating: Boolean = true)(using Tactic[Css.Error]): Css =
-    import zephyrine.lineation.linefeedChars
+    import zephyrine.lineation.linefeedChar
 
     Parser(Cursor[Text](input), validating).document()
 

--- a/lib/cataclysm/src/core/cataclysm.SelectorParser.scala
+++ b/lib/cataclysm/src/core/cataclysm.SelectorParser.scala
@@ -46,7 +46,7 @@ import zephyrine.*
 // and any other function keeps its argument as raw text.
 private[cataclysm] object SelectorParser:
   def parse(text: Text)(using Tactic[Css.Error]): SelectorList =
-    import zephyrine.lineation.linefeedChars
+    import zephyrine.lineation.linefeedChar
 
     Parser(Cursor[Text](text)).document()
 

--- a/lib/cataclysm/src/core/cataclysm.SyntaxParser.scala
+++ b/lib/cataclysm/src/core/cataclysm.SyntaxParser.scala
@@ -44,7 +44,7 @@ import zephyrine.*
 // (`?`, `*`, `+`, `{m,n}`, `#`, `!`) which bind to the preceding term.
 private[cataclysm] object SyntaxParser:
   def parse(text: Text)(using Tactic[Css.Error]): Css.Syntax =
-    import zephyrine.lineation.linefeedChars
+    import zephyrine.lineation.linefeedChar
 
     Parser(Cursor[Text](text)).document()
 

--- a/lib/cataclysm/src/core/cataclysm.ValueTokenizer.scala
+++ b/lib/cataclysm/src/core/cataclysm.ValueTokenizer.scala
@@ -43,7 +43,7 @@ import zephyrine.*
 // only for an unterminated string.
 private[cataclysm] object ValueTokenizer:
   def tokens(text: Text)(using Tactic[Css.Error]): List[ValueToken] =
-    import zephyrine.lineation.linefeedChars
+    import zephyrine.lineation.linefeedChar
 
     Tokenizer(Cursor[Text](text)).all()
 

--- a/lib/cataclysm/src/core/soundness_cataclysm_core.scala
+++ b/lib/cataclysm/src/core/soundness_cataclysm_core.scala
@@ -41,4 +41,4 @@ export cataclysm.{Css, SelectorList, Selector, Compound,
     ids}
 
 package formatting:
-  export cataclysm.formatting.{standardCssFormatting, compactCssFormatting}
+  export cataclysm.formatting.{indentedCssFormatting, compactCssFormatting}

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -625,7 +625,7 @@ object Tests extends Suite(m"Cataclysm Tests"):
       . assert(_ == t"a{color:red;}")
 
       test(m"standard serialization indents declarations"):
-        import formatting.standardCssFormatting
+        import formatting.indentedCssFormatting
         t"a { color: red }".read[Css].show
       . assert(_ == t"a {\n  color: red;\n}\n")
 

--- a/lib/charisma/src/core/charisma.Molecule.scala
+++ b/lib/charisma/src/core/charisma.Molecule.scala
@@ -35,7 +35,7 @@ package charisma
 import anticipation.*
 import gossamer.*
 import gossamer.collationComparable
-import gossamer.collations.codepoints
+import gossamer.collations.codepointCollation
 import hieroglyph.*
 import hypotenuse.*
 import rudiments.*

--- a/lib/chiaroscuro/src/render/chiaroscuro_render.scala
+++ b/lib/chiaroscuro/src/render/chiaroscuro_render.scala
@@ -82,7 +82,7 @@ package teletypeables:
 
       value match
         case Juxtaposition.Collation(name, comparison, _, _) =>
-          import tableStyles.defaultTableStyle
+          import tableStyles.thickTableStyle
           val columns = 110
           val length = comparison.size
           val topRule = e"\n$subdued(────┬${(t"─"*(length.min(columns)))}┬────)\n"
@@ -160,7 +160,7 @@ package teletypeables:
             case class Row(treeLine: Text, left: Teletype, right: Teletype, memo: Teletype)
 
             given treeStyle: (Text is Textual) => TreeStyle[Row] = (tiles, row) =>
-              row.copy(treeLine = tiles.map(treeStyles.defaultTreeStyle.text(_)).join+row.treeLine)
+              row.copy(treeLine = tiles.map(treeStyles.squareTreeStyle.text(_)).join+row.treeLine)
 
             def line(data: (Text, Juxtaposition)): Row =
               def line(bullet: Text): Text = t"$bullet ${data(0)}"

--- a/lib/coaxial/src/core/coaxial.Socket.scala
+++ b/lib/coaxial/src/core/coaxial.Socket.scala
@@ -52,7 +52,7 @@ object Socket:
   // The pluggable low-level socket backend: the complete set of platform-specific operations that
   // coaxial's `Bindable`/`Connectable`/`Serviceable`/`Routable` typeclasses are defined in terms
   // of, expressed without reference to any platform API. `coaxial.jvm` provides the
-  // `java.nio.channels`/`java.net` implementation (`socketBackends.virtualMachineSockets`); other
+  // `java.nio.channels`/`java.net` implementation (`socketBackends.javaBaseSockets`); other
   // platforms (e.g. WASI's `wasi:sockets`) supply their own.
   //
   // The seam is structured by the four *roles* coaxial's typeclasses play, because each has its

--- a/lib/coaxial/src/jvm/coaxial_jvm.scala
+++ b/lib/coaxial/src/jvm/coaxial_jvm.scala
@@ -74,7 +74,7 @@ private enum ClientExchange:
 private case class UdpCourier(address: jn.InetAddress, port: Int, socket: jn.DatagramSocket)
 
 package socketBackends:
-  given virtualMachineSockets: Socket.Backend = new Socket.Backend:
+  given javaBaseSockets: Socket.Backend = new Socket.Backend:
     type ServerSocket = ServerBinding
     type DatagramSocket = jn.DatagramSocket
     type Exchange = ClientExchange

--- a/lib/coaxial/src/jvm/soundness_coaxial_jvm.scala
+++ b/lib/coaxial/src/jvm/soundness_coaxial_jvm.scala
@@ -35,4 +35,4 @@ package soundness
 export coaxial.{Connection, SecureEndpoint, Tls, TlsAcceptance, Trust}
 
 package socketBackends:
-  export coaxial.socketBackends.virtualMachineSockets
+  export coaxial.socketBackends.javaBaseSockets

--- a/lib/coaxial/src/native/coaxial_native.scala
+++ b/lib/coaxial/src/native/coaxial_native.scala
@@ -73,7 +73,7 @@ private enum ClientExchange:
 private case class UdpCourier(address: jn.InetAddress, port: Int, socket: jn.DatagramSocket)
 
 package socketBackends:
-  given native: Socket.Backend = new Socket.Backend:
+  given scalaNativeSockets: Socket.Backend = new Socket.Backend:
     type ServerSocket = ServerBinding
     type DatagramSocket = jn.DatagramSocket
     type Exchange = ClientExchange

--- a/lib/coaxial/src/native/soundness_coaxial_native.scala
+++ b/lib/coaxial/src/native/soundness_coaxial_native.scala
@@ -30,9 +30,7 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package ypsiloid
+package soundness
 
-import rudiments.*
-
-object dynamicYamlAccess:
-  inline given enabled: DynamicYamlEnabler = !!
+package socketBackends:
+  export coaxial.socketBackends.scalaNativeSockets

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -52,7 +52,7 @@ import probates.awaitProbate
 
 import Control.*
 
-import socketBackends.virtualMachineSockets
+import socketBackends.javaBaseSockets
 
 object Tests extends Suite(m"Coaxial tests"):
   def run(): Unit = unsafely:

--- a/lib/cosmopolite/src/core/cosmopolite_core.scala
+++ b/lib/cosmopolite/src/core/cosmopolite_core.scala
@@ -40,7 +40,7 @@ object en extends Language(t"en"):
   type Code = en
 
   given collatable: en is Collatable:
-    def collation: Collation = collations.unicode
+    def collation: Collation = collations.unicodeCollation
 
 trait en
 
@@ -82,7 +82,7 @@ object fr extends Language(t"fr"):
   // CLDR root French is untailored (backward secondary accents are a Canadian French
   // convention, not used by `fr` since CLDR 1.9).
   given collatable: fr is Collatable:
-    def collation: Collation = collations.unicode
+    def collation: Collation = collations.unicodeCollation
 
 trait fr
 
@@ -92,7 +92,7 @@ object de extends Language(t"de"):
   // CLDR standard German is untailored (umlauts differ at the secondary level, which is
   // already the root table's behaviour; DIN phonebook order is a different collation type).
   given collatable: de is Collatable:
-    def collation: Collation = collations.unicode
+    def collation: Collation = collations.unicodeCollation
 
 trait de
 

--- a/lib/degustation/src/test/degustation_test.scala
+++ b/lib/degustation/src/test/degustation_test.scala
@@ -43,7 +43,7 @@ import alphabets.hexLowerCase
 import logging.silentLogging
 import probates.cancelProbate
 import strategies.throwUnsafely
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 import threading.platformThreading
 

--- a/lib/delicious/src/test/delicious_test.scala
+++ b/lib/delicious/src/test/delicious_test.scala
@@ -42,10 +42,10 @@ import galilei.Linux.pathOnLinux
 import logging.silentLogging
 import probates.cancelProbate
 import strategies.throwUnsafely
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 import threading.platformThreading
-import workingDirectories.javaWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 object Tests extends Suite(m"Delicious Tests"):
   given palette: ScalaSyntaxPalette = new Palette:

--- a/lib/dendrology/src/dag/dendrology_dag.scala
+++ b/lib/dendrology/src/dag/dendrology_dag.scala
@@ -37,14 +37,14 @@ import gossamer.*
 import hieroglyph.*
 
 package dagStyles:
-  given defaultDagStyle: [text: Textual] => TextualDagStyle[text] =
+  given boxDrawingDagStyle: [text: Textual] => TextualDagStyle[text] =
     TextualDagStyle("  ".tt, "└─".tt, "│ ".tt, "├─".tt, "──".tt, "┴─".tt, "│─".tt, "┼─".tt)
 
   given asciiDagStyle: [text: Textual] => TextualDagStyle[text] =
     TextualDagStyle("  ".tt, "+-".tt, "| ".tt, "+-".tt, "--".tt, "+-".tt, "|-".tt, "+-".tt)
 
 package laneDagStyles:
-  given defaultLaneDagStyle: [text: Textual] => (Text is Measurable)
+  given boxDrawingLaneDagStyle: [text: Textual] => (Text is Measurable)
   =>  TextualLaneDagStyle[text] =
     TextualLaneDagStyle
       ( "  ".tt, "│ ".tt, "──".tt, "╰─".tt, "╯ ".tt, "╭─".tt, "╮ ".tt,

--- a/lib/dendrology/src/dag/soundness_dendrology_dag.scala
+++ b/lib/dendrology/src/dag/soundness_dendrology_dag.scala
@@ -36,7 +36,7 @@ export dendrology.{DagDiagram, DagStyle, DagTile, LaneDagDiagram, LaneDagStyle,
         LayeredDagDiagram, TextualDagStyle, TextualLaneDagStyle}
 
 package dagStyles:
-  export dendrology.dagStyles.{asciiDagStyle, defaultDagStyle}
+  export dendrology.dagStyles.{asciiDagStyle, boxDrawingDagStyle}
 
 package laneDagStyles:
-  export dendrology.laneDagStyles.{asciiLaneDagStyle, defaultLaneDagStyle}
+  export dendrology.laneDagStyles.{asciiLaneDagStyle, boxDrawingLaneDagStyle}

--- a/lib/dendrology/src/demo/dendrology_demo.scala
+++ b/lib/dendrology/src/demo/dendrology_demo.scala
@@ -34,7 +34,7 @@ package dendrology
 
 import soundness.*
 
-import dendrology.laneDagStyles.defaultLaneDagStyle
+import dendrology.laneDagStyles.boxDrawingLaneDagStyle
 import environments.javaBaseEnvironment
 import stdios.fileDescriptorStdio
 import strategies.throwUnsafely

--- a/lib/dendrology/src/demo/dendrology_demo.scala
+++ b/lib/dendrology/src/demo/dendrology_demo.scala
@@ -35,8 +35,8 @@ package dendrology
 import soundness.*
 
 import dendrology.laneDagStyles.defaultLaneDagStyle
-import environments.javaEnvironment
-import stdios.virtualMachineStdio
+import environments.javaBaseEnvironment
+import stdios.fileDescriptorStdio
 import strategies.throwUnsafely
 import termcaps.environmentTermcap
 

--- a/lib/dendrology/src/test/dendrology_test.scala
+++ b/lib/dendrology/src/test/dendrology_test.scala
@@ -80,18 +80,18 @@ object Tests extends Suite(m"Dendrology tests"):
   )
 
   def run(): Unit =
-    import dagStyles.defaultDagStyle
+    import dagStyles.boxDrawingDagStyle
     DagDiagram(types).render { node => t"▪ $node" }
 
     test(m"Tree flow: node content wraps into follow-on rows"):
-      import treeStyles.defaultTreeStyle
+      import treeStyles.squareTreeStyle
       TreeDiagram.by[Tree](_.children)
         ( Tree(t"the quick brown fox"), Tree(t"leaf") )
       . flow(11)(_.value).stdlib.to(List)
     . assert(_ == List(t"├─the quick", t"│ brown fox", t"└─leaf"))
 
     test(m"Tree flow: follow-on rows under a last child use space, not an extender"):
-      import treeStyles.defaultTreeStyle
+      import treeStyles.squareTreeStyle
       TreeDiagram.by[Tree](_.children)
         ( Tree(t"parent", List(Tree(t"the quick brown fox"))) )
       . flow(13)(_.value).stdlib.to(List)
@@ -109,7 +109,7 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == List(t"└parent", t"  └ab abcdef", t"    ghi", t"    jklmno"))
 
     test(m"Lane DAG: a wide glyph's column measures display cells, not chars"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       import hieroglyph.textMetrics.wideCharacterWidthMetric
       val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"))
       val glyph = (n: Text) => if n == t"A" then t"日" else t"● "
@@ -117,14 +117,14 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == List(t"日 A", t"│ ", t"●  B"))
 
     test(m"Lane DAG: linear chain"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"), t"C" -> Set(t"B"))
       LaneDagDiagram(dag).render(node => t" $node").join(t"\n")
 
     . assert(_ == t"●  A\n│ \n●  B\n│ \n●  C")
 
     test(m"Lane DAG: diamond"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       val dag = Dag
         ( t"A" -> Set(),
           t"B" -> Set(t"A"),
@@ -135,7 +135,7 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == 7)
 
     test(m"Lane DAG: diamond layout shapes"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       val dag = Dag
         ( t"A" -> Set(),
           t"B" -> Set(t"A"),
@@ -151,14 +151,14 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == (true, true, false, false))
 
     test(m"Lane DAG: single node"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       val dag = Dag(t"A" -> Set())
       LaneDagDiagram(dag).render(node => t" $node").join(t"\n")
 
     . assert(_ == t"●  A")
 
     test(m"Lane DAG: high fan-out"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       val dag = Dag
         ( t"root" -> Set(),
           t"a"    -> Set(t"root"),
@@ -170,7 +170,7 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == 9)
 
     test(m"Lane DAG: high fan-in"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       val dag = Dag
         ( t"a"    -> Set(),
           t"b"    -> Set(),
@@ -182,14 +182,14 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == 9)
 
     test(m"Lane DAG: linear chain detail"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"), t"C" -> Set(t"B"))
       LaneDagDiagram(dag).render(node => t" $node")
 
     . assert(_ == List(t"●  A", t"│ ", t"●  B", t"│ ", t"●  C"))
 
     test(m"Lane DAG: crossing renders as horizontal not junction"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       val dag = Dag
         ( t"A" -> Set(),
           t"B" -> Set(t"A"),
@@ -200,7 +200,7 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == 7)
 
     test(m"Lane DAG: per-vertex glyph"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"))
       val glyph = (n: Text) => if n == t"A" then t"★ " else t"● "
       LaneDagDiagram(dag).render(glyph, n => t" $n")
@@ -208,7 +208,7 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == List(t"★  A", t"│ ", t"●  B"))
 
     test(m"Lane DAG: compact preserves single-vertical row"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       // A→B is a direct edge: connector has exactly one Vertical, must stay.
       val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"))
       LaneDagDiagram(dag).compact.render(n => t" $n").size
@@ -216,7 +216,7 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == 3)
 
     test(m"Lane DAG: compact removes multi-vertical pass-through row"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       // A→D is long, B and C are between. After A's row a connector row of
       // pure pass-throughs (multi-vertical) appears; compact should drop it.
       val dag = Dag
@@ -253,7 +253,7 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == (3, 1, 2, 1))
 
     test(m"Layered DAG: per-vertex glyph"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"))
       val glyph = (n: Text) => if n == t"A" then t"★ " else t"● "
       LayeredDagDiagram(dag).render(glyph)
@@ -261,7 +261,7 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == List(t"★ ", t"│ ", t"● "))
 
     test(m"Layered DAG: variable column widths"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       // The B node has a wide glyph; column 0 should expand to fit it.
       val dag = Dag(t"A" -> Set(), t"B" -> Set(t"A"))
       val glyph = (n: Text) => if n == t"B" then t"[long]" else t"●     "
@@ -270,7 +270,7 @@ object Tests extends Suite(m"Dendrology tests"):
     . assert(_ == List(t"●     ", t"│     ", t"[long]"))
 
     test(m"Lane DAG: variable column widths in connectors"):
-      import laneDagStyles.defaultLaneDagStyle
+      import laneDagStyles.boxDrawingLaneDagStyle
       val dag = Dag
         ( t"A" -> Set(),
           t"B" -> Set(t"A"),

--- a/lib/dendrology/src/tree/dendrology_tree.scala
+++ b/lib/dendrology/src/tree/dendrology_tree.scala
@@ -36,7 +36,7 @@ import anticipation.*
 import gossamer.*
 
 package treeStyles:
-  given defaultTreeStyle: [text: Textual] => TextualTreeStyle[text] =
+  given squareTreeStyle: [text: Textual] => TextualTreeStyle[text] =
     TextualTreeStyle(t"  ", t"└─", t"├─", t"│ ")
 
   given roundedTreeStyle: [text: Textual] => TextualTreeStyle[text] =

--- a/lib/dendrology/src/tree/soundness_dendrology_tree.scala
+++ b/lib/dendrology/src/tree/soundness_dendrology_tree.scala
@@ -35,4 +35,4 @@ package soundness
 export dendrology.{Expandable, TextualTreeStyle, TreeDiagram, TreeStyle, TreeTile}
 
 package treeStyles:
-  export dendrology.treeStyles.{asciiTreeStyle, defaultTreeStyle, roundedTreeStyle}
+  export dendrology.treeStyles.{asciiTreeStyle, squareTreeStyle, roundedTreeStyle}

--- a/lib/diuretic/src/core/diuretic.JavaIoFile.scala
+++ b/lib/diuretic/src/core/diuretic.JavaIoFile.scala
@@ -50,4 +50,4 @@ object JavaIoFile extends Abstractable, Instantiable:
 
 // `java.io.File` can stand in for a soundness path abstraction (moved here from `anticipation.path`
 // to keep that module Scala.js-portable).
-inline given javaIoFile: ji.File is Representative of Paths = caps.unsafe.unsafeErasedValue
+inline given javaIoFileRepresentative: ji.File is Representative of Paths = caps.unsafe.unsafeErasedValue

--- a/lib/diuretic/src/core/diuretic.JavaNioPath.scala
+++ b/lib/diuretic/src/core/diuretic.JavaNioPath.scala
@@ -50,4 +50,4 @@ object JavaNioPath extends Instantiable, Abstractable:
 
 // `java.nio.file.Path` can stand in for a soundness path abstraction (moved here from
 // `anticipation.path` to keep that module Scala.js-portable).
-inline given javaNioFilePath: jnf.Path is Representative of Paths = caps.unsafe.unsafeErasedValue
+inline given javaNioPathRepresentative: jnf.Path is Representative of Paths = caps.unsafe.unsafeErasedValue

--- a/lib/embarcadero/src/oci/embarcadero_oci.scala
+++ b/lib/embarcadero/src/oci/embarcadero_oci.scala
@@ -33,7 +33,7 @@
 package embarcadero
 
 import anticipation.*
-import gastronomy.*, providers.javaStdlibProvider
+import gastronomy.*, providers.javaBaseProvider
 import gesticulate.*
 import gossamer.*
 import hieroglyph.*, charEncoders.utf8Encoder

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -726,7 +726,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
       // millis; Aviation's own `Instant` abstractable/instantiable instances are found
       // via its companion, so `embarcadero` needs no dependency on Aviation.
       import abstractables.epochMillisecondsAbstractable
-      import chronometries.unix
+      import chronometries.unixChronometry
       val moment = Instant(1_700_000_001_000L)
 
       test(m"a Container timestamp round-trips and converts to an Aviation Instant"):

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -34,7 +34,7 @@ package embarcadero
 
 import soundness.*
 
-import providers.javaStdlibProvider
+import providers.javaBaseProvider
 import alphabets.hexLowerCase
 import charEncoders.utf8Encoder
 import formatting.compactJsonFormatting

--- a/lib/enigmatic/src/core-jvm/enigmatic.JavaBaseCrypto.scala
+++ b/lib/enigmatic/src/core-jvm/enigmatic.JavaBaseCrypto.scala
@@ -49,7 +49,7 @@ import denominative.dysasymptotics.linearSize
 // `java.security`). This is the single home of all `javax.crypto.*` and
 // `java.security.*` usage in enigmatic; every other module reaches these
 // algorithms only through the `Crypto` contract.
-object JavaStdlibCrypto extends Crypto:
+object JavaBaseCrypto extends Crypto:
   def random: Crypto.Random = new Crypto.Random:
     def bytes(size: Int): Data =
       val output = Array.allocate[Byte](size)
@@ -113,7 +113,7 @@ object JavaStdlibCrypto extends Crypto:
 
         generator.generateKeyPair().nn.getPrivate.nn.getEncoded.nn.immutable(using Unsafe)
 
-      def privateToPublic(privateKey: Data): Data = JavaStdlibCrypto.rsa.privateToPublic(privateKey)
+      def privateToPublic(privateKey: Data): Data = JavaBaseCrypto.rsa.privateToPublic(privateKey)
 
   // ECDSA over a NIST prime curve. The curve is chosen by key size, since `KeyPairGenerator` needs
   // a curve name rather than a bit count for EC; P-521 really is 521 bits, not 512.

--- a/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
+++ b/lib/enigmatic/src/core-jvm/enigmatic.cloaks.scala
@@ -39,7 +39,7 @@ import java.security as js
 import java.util as ju
 import javax.crypto as jc, jc.spec as jcs
 
-// The available cloaks, selected by named import (e.g. `import enigmatic.cloaks.cloakOffHeap`).
+// The available cloaks, selected by named import (e.g. `import enigmatic.cloaks.offHeapCloak`).
 // All but `heap` keep secret material out of (or encrypted on) the Java heap, so that a
 // heap dump or core file taken while a secret is at rest reveals nothing directly. Off-heap
 // segments are allocated from `java.lang.foreign` arenas, zeroed and released by
@@ -48,7 +48,7 @@ import javax.crypto as jc, jc.spec as jcs
 // these can protect against.
 package cloaks:
   // Cleartext on the heap: portable and pure, so heap-cloaked secrets are untracked.
-  given cloakHeap: Cloak = HeapCloak
+  given heapCloak: Cloak = HeapCloak
 
   // The three JVM strategies are capabilities, and a capability cannot sit in a top-level
   // given field, so their givens are `transparent inline`: each summon site instantiates a
@@ -56,16 +56,16 @@ package cloaks:
   // key — captured by the secrets built with it.
 
   // Cleartext in off-heap memory: nothing at rest on the heap at all.
-  transparent inline given cloakOffHeap: (OffHeapCloak^) = OffHeapCloak()
+  transparent inline given offHeapCloak: (OffHeapCloak^) = OffHeapCloak()
 
   // Ciphertext on the heap, encrypted with an ephemeral key held in off-heap memory: at
   // rest, the heap holds only ciphertext, and the key needed to read it is off-heap.
-  transparent inline given cloakVeiledHeap: (VeiledHeapCloak^) = VeiledHeapCloak()
+  transparent inline given veiledHeapCloak: (VeiledHeapCloak^) = VeiledHeapCloak()
 
   // Ciphertext in off-heap memory, encrypted with an ephemeral key held on the heap: the
   // mirror image, for when bulk secret material should stay out of the heap but a 32-byte
   // heap-resident key is acceptable.
-  transparent inline given cloakVeiledOffHeap: (VeiledOffHeapCloak^) = VeiledOffHeapCloak()
+  transparent inline given veiledOffHeapCloak: (VeiledOffHeapCloak^) = VeiledOffHeapCloak()
 
 // Copies `bytes` into fresh off-heap memory in `arena`, zeroing the input.
 private def offload(bytes: scala.Array[Byte], arena: jlf.Arena): jlf.MemorySegment =

--- a/lib/enigmatic/src/core-jvm/soundness_enigmatic_jvm.scala
+++ b/lib/enigmatic/src/core-jvm/soundness_enigmatic_jvm.scala
@@ -37,4 +37,4 @@ package soundness
 export enigmatic.{keystore, Keystore}
 
 package cloaks:
-  export enigmatic.cloaks.{cloakHeap, cloakOffHeap, cloakVeiledHeap, cloakVeiledOffHeap}
+  export enigmatic.cloaks.{heapCloak, offHeapCloak, veiledHeapCloak, veiledOffHeapCloak}

--- a/lib/enigmatic/src/core-native/enigmatic.JavaBaseCrypto.scala
+++ b/lib/enigmatic/src/core-native/enigmatic.JavaBaseCrypto.scala
@@ -35,11 +35,11 @@ package enigmatic
 import anticipation.*
 import fulminate.*
 
-// The Scala Native twin of the JVM `JavaStdlibCrypto` provider. `javax.crypto` does not exist on
+// The Scala Native twin of the JVM `JavaBaseCrypto` provider. `javax.crypto` does not exist on
 // Scala Native, so every operation panics: the object exists only so the platform-neutral
-// `Crypto.javaStdlibCrypto` given (and code mentioning the provider, like `OpensslCrypto.rsa`'s
+// `Crypto.javaBaseCrypto` given (and code mentioning the provider, like `OpensslCrypto.rsa`'s
 // delegation) compiles unchanged — selecting it *and using it* on native is the error.
-object JavaStdlibCrypto extends Crypto:
+object JavaBaseCrypto extends Crypto:
   private def unavailable: Nothing =
     panic(m"the Java standard library's cryptography is unavailable on Scala Native")
 

--- a/lib/enigmatic/src/core/enigmatic.Cloak.scala
+++ b/lib/enigmatic/src/core/enigmatic.Cloak.scala
@@ -38,7 +38,7 @@ import java.util as ju
 // Where secret material — passwords, private and symmetric keys — is stored. A `Cloak` must
 // be in scope to construct any secret value, and the secret captures the cloak that stores
 // it, so a secret can never outlive its storage. There is deliberately no default given:
-// end-users import a cloak by name (e.g. `import enigmatic.cloaks.cloakHeap`) so the storage
+// end-users import a cloak by name (e.g. `import enigmatic.cloaks.heapCloak`) so the storage
 // decision is always explicit in user code.
 //
 // No cloak offers complete protection: a debugger or same-process attacker sees everything,
@@ -58,7 +58,7 @@ trait Cloak:
 // Cleartext on the heap, as a private byte array. The weakest strategy — the material is
 // visible in a heap dump for the secret's lifetime — but portable and pure: heap-cloaked
 // secrets have empty capture sets, so they can be stored and returned without tracking.
-// Selected as `cloaks.cloakHeap`.
+// Selected as `cloaks.heapCloak`.
 private[enigmatic] object HeapCloak extends Cloak:
   def cloak(bytes: scala.Array[Byte]): Secret =
     val copy = bytes.clone

--- a/lib/enigmatic/src/core/enigmatic.Crypto.scala
+++ b/lib/enigmatic/src/core/enigmatic.Crypto.scala
@@ -40,7 +40,7 @@ import fulminate.*
 // A pluggable cryptographic provider: it supplies the raw algorithmic
 // implementations (the JDK's JCE, BouncyCastle, OpenSSL, …) that the typed
 // enigmatic API delegates to. Pick one with an explicit import, e.g.
-// `import providers.javaStdlibProvider`.
+// `import providers.javaBaseProvider`.
 //
 // Every provider must implement the mandatory baseline below — the modern,
 // universally-supported primitives. Legacy or provider-specific algorithms (DES,
@@ -89,10 +89,10 @@ object Crypto:
     def bytes(size: Int): Data
 
   // The JDK provider supplies cryptography whenever it has been selected with
-  // `import providers.javaStdlibProvider`. The marker lives in gastronomy, so the
+  // `import providers.javaBaseProvider`. The marker lives in gastronomy, so the
   // single provider import enables both hashing (in gastronomy) and cryptography.
-  given javaStdlibCrypto(using gastronomy.Provider.JavaStdlib.type): JavaStdlibCrypto.type =
-    JavaStdlibCrypto
+  given javaBaseCrypto(using gastronomy.Provider.JavaBase.type): JavaBaseCrypto.type =
+    JavaBaseCrypto
 
   // CryptoError → Crypto.Error
   object Error:

--- a/lib/enigmatic/src/core/enigmatic.PrivateKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.PrivateKey.scala
@@ -33,7 +33,7 @@
 package enigmatic
 
 import anticipation.*
-import gastronomy.*, providers.javaStdlibProvider
+import gastronomy.*, providers.javaBaseProvider
 import gossamer.*
 import monotonous.*
 import prepositional.*

--- a/lib/enigmatic/src/core/enigmatic_core.scala
+++ b/lib/enigmatic/src/core/enigmatic_core.scala
@@ -55,7 +55,7 @@ package signatureDigests:
   given sha384Signature: Signature.Digest = Signature.Digest(t"SHA384")
   given sha512Signature: Signature.Digest = Signature.Digest(t"SHA512")
 
-package blockCipherMode:
+package blockCipherModes:
   export Cbc.mode as cbc
   export Ctr.mode as ctr
   export Cfb.mode as cfb
@@ -64,7 +64,7 @@ package blockCipherMode:
   // an erased `Permit[Concession.Ecb]`), and re-exporting such a given trips a
   // compiler assertion. ECB is summoned from its own companion; use `over Ecb`.
 
-package blockCipherPadding:
+package blockCipherPaddings:
   export Pkcs7.padding as pkcs7
   export Iso10126.padding as iso10126
   // `NoPadding` is not re-exported for import-based inference: its `given` takes a
@@ -75,17 +75,17 @@ package blockCipherPadding:
 // `InitializationVector.random` / `.fixed(…)` / `.zero` — so there is no
 // `initializationVector` given namespace.
 
-// The JDK crypto provider is derived from the shared `Provider.JavaStdlib` marker
-// in `Crypto`'s companion, so `import providers.javaStdlibProvider` (from
+// The JDK crypto provider is derived from the shared `Provider.JavaBase` marker
+// in `Crypto`'s companion, so `import providers.javaBaseProvider` (from
 // gastronomy) enables both hashing and cryptography. OpenSSL (crypto-only) is
 // selected directly via `import providers.opensslProvider` in the openssl module.
 
-// The `Permit`/`Concession` machinery and the `crypto.permit…Crypto` aggregates
+// The `Permit`/`Concession` machinery and the `cryptoPermits.permit…Crypto` aggregates
 // live in gastronomy (shared with hashing); the cipher concessions they cover are
 // mapped from cipher types by `Weakness`/`Authentication` in `enigmatic.Weakness`.
 
 // The cipher-side concession match types. The shared `Concession` markers, `Permit`
-// and the `crypto.permit…Crypto` aggregates live in gastronomy; these map a cipher
+// and the `cryptoPermits.permit…Crypto` aggregates live in gastronomy; these map a cipher
 // type to its concession.
 
 // The algorithm/key-length concession of a cipher type, extracted by matching the

--- a/lib/enigmatic/src/core/soundness_enigmatic_core.scala
+++ b/lib/enigmatic/src/core/soundness_enigmatic_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-// `Concession`, `Permit`, `ProcessingPermit` and the `crypto.permit…Crypto`
+// `Concession`, `Permit`, `ProcessingPermit` and the `cryptoPermits.permit…Crypto`
 // aggregates are re-exported by gastronomy (where they now live).
 export
   enigmatic
@@ -40,7 +40,7 @@ export
       Cleartext, cleartext, Cloak, Crypto, Ctr, decrypt, Decryptor,
       Des, Divulgence,
       Dsa, Ecb, Ecdsa, encrypt, Encryptor, Encryption,
-      Hmac, hmac, InitializationVector, Iso10126, JavaStdlibCrypto,
+      Hmac, hmac, InitializationVector, Iso10126, JavaBaseCrypto,
       MlDsa, NoPadding, Ofb, Pem, Password,
       Permits, Pkcs7, PrivateKey, PublicKey, Rc2, Rsa, Signature, Signing,
       Symmetric, SymmetricKey, TripleDes, uncloak }
@@ -48,8 +48,8 @@ export
 package signatureDigests:
   export enigmatic.signatureDigests.{sha256Signature, sha384Signature, sha512Signature}
 
-package blockCipherMode:
-  export enigmatic.blockCipherMode.{cbc, cfb, ctr, ofb}
+package blockCipherModes:
+  export enigmatic.blockCipherModes.{cbc, cfb, ctr, ofb}
 
-package blockCipherPadding:
-  export enigmatic.blockCipherPadding.{iso10126, pkcs7}
+package blockCipherPaddings:
+  export enigmatic.blockCipherPaddings.{iso10126, pkcs7}

--- a/lib/enigmatic/src/openssl/enigmatic.OpensslCrypto.scala
+++ b/lib/enigmatic/src/openssl/enigmatic.OpensslCrypto.scala
@@ -102,12 +102,12 @@ object OpensslCrypto extends Crypto:
   // RSA is not yet implemented natively (it needs EVP_PKEY DER parsing and keygen); delegate to
   // the JDK provider so this remains a complete `Crypto` (on Scala Native, where that provider
   // is a panicking stub, `rsa` is simply unavailable).
-  def rsa: Crypto.PublicKeyCipher = JavaStdlibCrypto.rsa
+  def rsa: Crypto.PublicKeyCipher = JavaBaseCrypto.rsa
 
   def rsaSignature(digest: Text): Crypto.SignatureScheme =
-    JavaStdlibCrypto.rsaSignature(digest)
+    JavaBaseCrypto.rsaSignature(digest)
 
-  def ecdsa(digest: Text): Crypto.SignatureScheme = JavaStdlibCrypto.ecdsa(digest)
+  def ecdsa(digest: Text): Crypto.SignatureScheme = JavaBaseCrypto.ecdsa(digest)
 
   private def digest(algorithm: Text): Address = algorithm match
     case t"HmacSHA256" => Foreign["library", Native].EVP_sha256().call[Address]()

--- a/lib/enigmatic/src/test/enigmatic.CaptureTests.scala
+++ b/lib/enigmatic/src/test/enigmatic.CaptureTests.scala
@@ -43,9 +43,9 @@ import soundness.*
 import strategies.throwUnsafely
 import charDecoders.utf8Decoder, charEncoders.utf8Encoder, textSanitizers.skipSanitizer
 import gossamer.textDecodable
-import providers.javaStdlibProvider
-import crypto.permitDisallowedCrypto   // RSA-1024 below is weak; AES-CBC is unauthenticated
-import cloaks.cloakHeap
+import providers.javaBaseProvider
+import cryptoPermits.permitDisallowedCrypto   // RSA-1024 below is weak; AES-CBC is unauthenticated
+import cloaks.heapCloak
 
 // `uncloak` lends a key to its block as an `Encryptor`/`Decryptor` capability, and
 // capture checking confines the capability to that block: these tests demonstrate
@@ -136,7 +136,7 @@ object CaptureTests extends Suite(m"Capability confinement tests"):
     . assert(_ == t"Password(•••)")
 
     test(m"an off-heap-cloaked key round-trips under capture checking"):
-      import cloaks.cloakOffHeap
+      import cloaks.offHeapCloak
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.uncloak:
         t"Hello world".encrypt(InitializationVector.random).decrypt.as[Text]
@@ -144,7 +144,7 @@ object CaptureTests extends Suite(m"Capability confinement tests"):
 
     test(m"an off-heap-cloaked key cannot be ascribed a pure type"):
       demilitarize:
-        import cloaks.cloakOffHeap
+        import cloaks.offHeapCloak
         val key: SymmetricKey[Aes[256] over Cbc against Pkcs7] =
           SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
     . assert(_.nonEmpty)

--- a/lib/enigmatic/src/test/enigmatic_compile_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_compile_test.scala
@@ -35,10 +35,10 @@ package enigmatic
 import soundness.*
 
 import charEncoders.utf8Encoder
-import blockCipherMode.cbc, blockCipherPadding.pkcs7
-import providers.javaStdlibProvider
-import crypto.permitUnauthenticatedCrypto   // AES-CBC is unauthenticated
-import cloaks.cloakHeap
+import blockCipherModes.cbc, blockCipherPaddings.pkcs7
+import providers.javaBaseProvider
+import cryptoPermits.permitUnauthenticatedCrypto   // AES-CBC is unauthenticated
+import cloaks.heapCloak
 
 // Compile-time regressions for the cipher API. (Capture-checking confinement of
 // the lent `Encryptor`/`Decryptor` capability is enforced and regression-tested
@@ -64,9 +64,9 @@ object CompileChecks:
   //
   //   val noTactic = SymmetricKey.generate[Aes[256] over Cbc against NoPadding]()
 
-  // Permission regression: only `crypto.permitUnauthenticatedCrypto` is imported
+  // Permission regression: only `cryptoPermits.permitUnauthenticatedCrypto` is imported
   // here, so AES (above) compiles, but reaching a "disallowed" algorithm without
-  // `crypto.permitDisallowedCrypto` does not — encrypting with DES fails with the
+  // `cryptoPermits.permitDisallowedCrypto` does not — encrypting with DES fails with the
   // `Permit` "no given instance" diagnostic (verified manually — uncomment). Note
   // that key generation is *not* gated; only the encryption operation is.
   //

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -38,9 +38,9 @@ import strategies.throwUnsafely
 import charDecoders.utf8Decoder, charEncoders.utf8Encoder, textSanitizers.skipSanitizer
 import gossamer.textDecodable
 import errorDiagnostics.stackTracesDiagnostics
-import providers.javaStdlibProvider
-import crypto.permitDisallowedCrypto   // the suite deliberately exercises weak crypto
-import cloaks.cloakHeap
+import providers.javaBaseProvider
+import cryptoPermits.permitDisallowedCrypto   // the suite deliberately exercises weak crypto
+import cloaks.heapCloak
 import dysasymptotics.linearSize
 
 import alphabets.hexUpperCase
@@ -177,7 +177,7 @@ object Tests extends Suite(m"Enigmatic tests"):
     . assert(_ == t"Hello world")
 
     test(m"AES roundtrip"):
-      import blockCipherMode.cbc, blockCipherPadding.pkcs7
+      import blockCipherModes.cbc, blockCipherPaddings.pkcs7
       val key: SymmetricKey[Aes[256]] = SymmetricKey.generate[Aes[256]]()
       key.uncloak:
         t"Hello world".encrypt(InitializationVector.random).decrypt.as[Text]
@@ -202,21 +202,21 @@ object Tests extends Suite(m"Enigmatic tests"):
     . assert(_ == t"Hello world")
 
     test(m"AES/CBC with padding inferred as PKCS7 from import"):
-      import blockCipherPadding.pkcs7
+      import blockCipherPaddings.pkcs7
       val key = SymmetricKey.generate[Aes[256] over Cbc]()
       key.uncloak:
         t"Hello world".encrypt(InitializationVector.random).decrypt.as[Text]
     . assert(_ == t"Hello world")
 
     test(m"AES with mode and padding inferred as CBC/PKCS7 from imports"):
-      import blockCipherMode.cbc, blockCipherPadding.pkcs7
+      import blockCipherModes.cbc, blockCipherPaddings.pkcs7
       val key = SymmetricKey.generate[Aes[256]]()
       key.uncloak:
         t"Hello world".encrypt(InitializationVector.random).decrypt.as[Text]
     . assert(_ == t"Hello world")
 
     test(m"stream-encrypted data decrypts through the whole-value path"):
-      import blockCipherMode.cbc, blockCipherPadding.pkcs7
+      import blockCipherModes.cbc, blockCipherPaddings.pkcs7
       import charEncoders.utf8Encoder
       val key = SymmetricKey.generate[Aes[256]]()
       key.uncloak:
@@ -225,7 +225,7 @@ object Tests extends Suite(m"Enigmatic tests"):
     . assert(_ == t"Hello world")
 
     test(m"whole-value-encrypted data decrypts through a stream"):
-      import blockCipherMode.cbc, blockCipherPadding.pkcs7
+      import blockCipherModes.cbc, blockCipherPaddings.pkcs7
       import charEncoders.utf8Encoder
       val key = SymmetricKey.generate[Aes[256]]()
       key.uncloak:
@@ -233,7 +233,7 @@ object Tests extends Suite(m"Enigmatic tests"):
     . assert(_ == t"Hello world".in[Data].to[List])
 
     test(m"one-byte-chunk streams roundtrip through stream encrypt and decrypt"):
-      import blockCipherMode.cbc, blockCipherPadding.pkcs7
+      import blockCipherModes.cbc, blockCipherPaddings.pkcs7
       import charEncoders.utf8Encoder
       val key = SymmetricKey.generate[Aes[256]]()
       key.uncloak:
@@ -251,7 +251,7 @@ object Tests extends Suite(m"Enigmatic tests"):
     . assert(_ == t"Hello world".in[Data].to[List])
 
     test(m"legacy Chain encryption survives one-byte chunks"):
-      import blockCipherMode.cbc, blockCipherPadding.pkcs7
+      import blockCipherModes.cbc, blockCipherPaddings.pkcs7
       import charEncoders.utf8Encoder
       val key = SymmetricKey.generate[Aes[256]]()
       key.uncloak:
@@ -296,12 +296,12 @@ object Tests extends Suite(m"Enigmatic tests"):
       // the provider seam (and its random source) is injectable.
       given Crypto:
         def random: Crypto.Random = size => Array.fill[Byte](size)(0.toByte)
-        def aes: Crypto.SymmetricCipher = JavaStdlibCrypto.aes
-        def rsa: Crypto.PublicKeyCipher = JavaStdlibCrypto.rsa
-        def hmac(algorithm: Text): Crypto.Mac = JavaStdlibCrypto.hmac(algorithm)
+        def aes: Crypto.SymmetricCipher = JavaBaseCrypto.aes
+        def rsa: Crypto.PublicKeyCipher = JavaBaseCrypto.rsa
+        def hmac(algorithm: Text): Crypto.Mac = JavaBaseCrypto.hmac(algorithm)
 
         def rsaSignature(digest: Text): Crypto.SignatureScheme =
-          JavaStdlibCrypto.rsaSignature(digest)
+          JavaBaseCrypto.rsaSignature(digest)
 
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.uncloak:
@@ -485,7 +485,7 @@ object Tests extends Suite(m"Enigmatic tests"):
       . assert(!_)
 
     suite(m"OpenSSL provider (libcrypto via xenophile FFM)"):
-      // A local `given Crypto` outranks the file-level `javaStdlibCrypto` import,
+      // A local `given Crypto` outranks the file-level `javaBaseCrypto` import,
       // so each block unambiguously selects its provider; cross-validating the two
       // proves the OpenSSL path agrees with the JDK on the wire.
       val key32: Data = t"a-32-byte-key-for-aes-256-cbc!!!".in[Data]
@@ -582,7 +582,7 @@ object Tests extends Suite(m"Enigmatic tests"):
       . assert(_ == Unset)
 
       test(m"A keystore opens with a password held by the veiled-heap cloak"):
-        import soundness.cloaks.cloakVeiledHeap
+        import soundness.cloaks.veiledHeapCloak
         guarded.open[Keystore](Password(t"sesame")):
           keystore.aliases
       . assert(_ == Nil)
@@ -598,37 +598,37 @@ object Tests extends Suite(m"Enigmatic tests"):
       // Each strategy is imported through the `soundness` bundle, exercising the re-export
       // of the (inline, capability-yielding) givens as well as the strategies themselves.
       test(m"AES round-trips through the heap cloak"):
-        import soundness.cloaks.cloakHeap
+        import soundness.cloaks.heapCloak
         roundtrip()
       . assert(_ == t"Hello world")
 
       test(m"AES round-trips through the off-heap cloak"):
-        import soundness.cloaks.cloakOffHeap
+        import soundness.cloaks.offHeapCloak
         roundtrip()
       . assert(_ == t"Hello world")
 
       test(m"AES round-trips through the veiled-heap cloak"):
-        import soundness.cloaks.cloakVeiledHeap
+        import soundness.cloaks.veiledHeapCloak
         roundtrip()
       . assert(_ == t"Hello world")
 
       test(m"AES round-trips through the veiled-off-heap cloak"):
-        import soundness.cloaks.cloakVeiledOffHeap
+        import soundness.cloaks.veiledOffHeapCloak
         roundtrip()
       . assert(_ == t"Hello world")
 
       test(m"a password round-trips through the off-heap cloak"):
-        import soundness.cloaks.cloakOffHeap
+        import soundness.cloaks.offHeapCloak
         passwordTrip()
       . assert(_ == t"hunter2")
 
       test(m"a password round-trips through the veiled-heap cloak"):
-        import soundness.cloaks.cloakVeiledHeap
+        import soundness.cloaks.veiledHeapCloak
         passwordTrip()
       . assert(_ == t"hunter2")
 
       test(m"a password round-trips through the veiled-off-heap cloak"):
-        import soundness.cloaks.cloakVeiledOffHeap
+        import soundness.cloaks.veiledOffHeapCloak
         passwordTrip()
       . assert(_ == t"hunter2")
 
@@ -639,14 +639,14 @@ object Tests extends Suite(m"Enigmatic tests"):
       . assert(_ == (true, t"hunter2"))
 
       test(m"DSA signing works through an off-heap cloak"):
-        import soundness.cloaks.cloakOffHeap
+        import soundness.cloaks.offHeapCloak
         val key = PrivateKey.generate[Dsa[1024]]()
         val signature = key.sign(t"attested")
         key.public.verify(t"attested", signature)
       . assert(_ == true)
 
       test(m"a symmetric key's material survives multiple uncloaks intact"):
-        import soundness.cloaks.cloakVeiledOffHeap
+        import soundness.cloaks.veiledOffHeapCloak
         val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
         val first = key.data(Divulgence)
         val second = key.data(Divulgence)

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -797,7 +797,7 @@ object Tests extends Suite(m"Enigmatic tests"):
       import java.io as ji
       import java.security as js, js.cert as jsc
 
-      import chronometries.unix
+      import chronometries.unixChronometry
 
       val subject = Distinguished
                      ( commonName = t"asn1.example.com",

--- a/lib/escapade/src/bench/escapade.Benchmarks.scala
+++ b/lib/escapade/src/bench/escapade.Benchmarks.scala
@@ -34,7 +34,7 @@ package escapade
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -40,7 +40,7 @@ import anticipation.*
 import denominative.*
 import gossamer.*
 import gossamer.collationComparable
-import gossamer.collations.codepoints
+import gossamer.collations.codepointCollation
 import hieroglyph.*
 import mercator.*
 import prepositional.*

--- a/lib/escapade/src/graphics/escapade_graphics.scala
+++ b/lib/escapade/src/graphics/escapade_graphics.scala
@@ -43,7 +43,7 @@ import spectacular.*
 import vacuous.*
 
 package teletypeables:
-  given graphical: [graphical: Graphical] => graphical is Teletypeable = graphic =>
+  given graphicalTeletype: [graphical: Graphical] => graphical is Teletypeable = graphic =>
     Teletype.Builder().build:
       for y <- 0 until (graphical.height(graphic) - 1) by 2 do
         for x <- 0 until graphical.width(graphic)

--- a/lib/escapade/src/graphics/soundness_escapade_graphics.scala
+++ b/lib/escapade/src/graphics/soundness_escapade_graphics.scala
@@ -33,4 +33,4 @@
 package soundness
 
 package teletypeables:
-  export escapade.teletypeables.{graphical}
+  export escapade.teletypeables.{graphicalTeletype}

--- a/lib/escapade/src/io/escapade_io.scala
+++ b/lib/escapade/src/io/escapade_io.scala
@@ -43,7 +43,7 @@ import zephyrine.*
 // Teletype values are records, so their streams travel on the boxed medium
 // (windows of `Array[Teletype]^{}`); each record prints as it arrives.
 package writables:
-  given out: Stdio => Out.type is Writable by (Array[Teletype]^{}) = new Writable:
+  given outTeletypeWritable: Stdio => Out.type is Writable by (Array[Teletype]^{}) = new Writable:
     type Self = Out.type
     type Operand = Array[Teletype]^{}
 
@@ -51,7 +51,7 @@ package writables:
       stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Array[Teletype]^{}] over Credit)^]
       . records.each(Out.print(_))
 
-  given err: Stdio => Err.type is Writable by (Array[Teletype]^{}) = new Writable:
+  given errTeletypeWritable: Stdio => Err.type is Writable by (Array[Teletype]^{}) = new Writable:
     type Self = Err.type
     type Operand = Array[Teletype]^{}
 

--- a/lib/escapade/src/io/soundness_escapade_io.scala
+++ b/lib/escapade/src/io/soundness_escapade_io.scala
@@ -34,4 +34,4 @@ package soundness
 
 
 package writables:
-  export escapade.writables.{err, out}
+  export escapade.writables.{errTeletypeWritable, outTeletypeWritable}

--- a/lib/escritoire/src/core/escritoire_core.scala
+++ b/lib/escritoire/src/core/escritoire_core.scala
@@ -70,7 +70,7 @@ package tableStyles:
   import tessellate.BoxLine.*
   import tessellate.LineCharset.{Default, Rounded}
 
-  given defaultTableStyle: TableStyle = TableStyle(1, Thick, Thick, Thin, Thick, Thin, Default)
+  given thickTableStyle: TableStyle = TableStyle(1, Thick, Thick, Thin, Thick, Thin, Default)
   given thinRoundedTableStyle: TableStyle = TableStyle(1, Thin, Thin, Thin, Thin, Thin, Rounded)
   given horizontalTableStyle: TableStyle = TableStyle(1, Thin, Thin, Thin, Blank, Blank, Default)
   given midOnlyTableStyle: TableStyle = TableStyle(1, Blank, Blank, Thin, Blank, Blank, Default)

--- a/lib/escritoire/src/core/soundness_escritoire_core.scala
+++ b/lib/escritoire/src/core/soundness_escritoire_core.scala
@@ -42,7 +42,7 @@ package columnAttenuation:
   export escritoire.columnAttenuation.{failAttenuation, ignoreAttenuation}
 
 package tableStyles:
-  export escritoire.tableStyles.{defaultTableStyle, horizontalTableStyle, midOnlyTableStyle,
+  export escritoire.tableStyles.{thickTableStyle, horizontalTableStyle, midOnlyTableStyle,
       minimalTableStyle, thinRoundedTableStyle, verticalTableStyle}
 
 package columnar:

--- a/lib/escritoire/src/example/example.scala
+++ b/lib/escritoire/src/example/example.scala
@@ -119,7 +119,7 @@ def run(): Unit =
     Out.println(pinkFloyd.table)
 
   // for style <- List
-  //               (tableStyles.defaultTableStyle,
+  //               (tableStyles.thickTableStyle,
   //                tableStyles.thinRoundedTableStyle,
   //                tableStyles.horizontalTableStyle,
   //                tableStyles.midOnlyTableStyle,

--- a/lib/escritoire/src/example/example.scala
+++ b/lib/escritoire/src/example/example.scala
@@ -42,8 +42,8 @@ import rudiments.*
 import spectacular.*
 import turbulence.*
 
-import environments.javaEnvironment
-import stdios.virtualMachineStdio
+import environments.javaBaseEnvironment
+import stdios.fileDescriptorStdio
 import termcaps.environmentTermcap
 
 given decimalizer: Decimalizer = Decimalizer(3)

--- a/lib/escritoire/src/test/escritoire_test.scala
+++ b/lib/escritoire/src/test/escritoire_test.scala
@@ -113,7 +113,7 @@ object Tests extends Suite(m"Escritoire tests"):
             t"╰───────┴─────╯" )
 
     test(m"Render a simple table with the default thick border style"):
-      import tableStyles.defaultTableStyle
+      import tableStyles.thickTableStyle
       import columnAttenuation.ignoreAttenuation
       render(scaffold, people, 40)
     . assert:

--- a/lib/espionage/src/core/espionage.Acp.scala
+++ b/lib/espionage/src/core/espionage.Acp.scala
@@ -251,7 +251,7 @@ object Acp:
   case class ToolCallLocation(path: Text, line: Optional[Int] = Unset)
 
   object ToolCallContent:
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
 
     private val typeTag = Json.discriminatedUnion[ToolCallContent](t"type")
 
@@ -397,7 +397,7 @@ object Acp:
   // Session updates
 
   object SessionUpdate:
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
 
     private val typeTag = Json.discriminatedUnion[SessionUpdate](t"sessionUpdate")
 
@@ -534,7 +534,7 @@ object Acp:
   case class PermissionOption(optionId: Text, name: Text, kind: PermissionOptionKind)
 
   object RequestPermissionOutcome:
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
 
     private val typeTag = Json.discriminatedUnion[RequestPermissionOutcome](t"outcome")
 

--- a/lib/espionage/src/demo/espionage_demo.scala
+++ b/lib/espionage/src/demo/espionage_demo.scala
@@ -35,7 +35,7 @@ package espionage
 import soundness.*
 
 import backstops.stackTraceBackstop
-import executives.completions
+import executives.completionsExecutive
 import interpreters.posixInterpreter
 import probates.awaitProbate
 import errorDiagnostics.stackTracesDiagnostics

--- a/lib/espionage/src/demo/espionage_demo.scala
+++ b/lib/espionage/src/demo/espionage_demo.scala
@@ -41,7 +41,7 @@ import probates.awaitProbate
 import errorDiagnostics.stackTracesDiagnostics
 import strategies.throwUnsafely
 import threading.virtualThreading
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 // A minimal ACP client: spawns `claude-code-acp` (which must be on the path), opens a session in
 // the current working directory, sends the command-line arguments as one prompt, and prints the

--- a/lib/espionage/src/test/espionage_test.scala
+++ b/lib/espionage/src/test/espionage_test.scala
@@ -119,7 +119,7 @@ object TestClient:
 // is made only after `session/cancel` arrives, exercising the mandatory `cancelled` answer.
 object AgentFixture:
   import Acp.*
-  import dynamicJsonAccess.enabled
+  import dynamicAccess.dynamicJson
 
   // What the fake agent observed, for the assertions.
   val received: scm.ArrayBuffer[Text] = scm.ArrayBuffer()
@@ -336,13 +336,13 @@ object Tests extends Suite(m"Espionage Tests"):
 
     suite(m"Permission outcome codecs"):
       test(m"a selection encodes with its discriminator"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val json = Selected(t"allow").asInstanceOf[RequestPermissionOutcome].in[Json]
         (json.outcome.as[Text], json.optionId.as[Text])
       . assert(_ == (t"selected", t"allow"))
 
       test(m"a cancellation encodes with its discriminator"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         Cancelled.asInstanceOf[RequestPermissionOutcome].in[Json].outcome.as[Text]
       . assert(_ == t"cancelled")
 
@@ -416,7 +416,7 @@ object Tests extends Suite(m"Espionage Tests"):
               "sessionId":"s1","toolCall":{"toolCallId":"c1"},
               "options":[{"optionId":"go","name":"Go","kind":"allow_once"}]}}"""
 
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         TestClient.roundtrip(message.as[Json]).let(_.result.outcome.optionId.as[Text])
       . assert(_ == t"go")
 
@@ -426,7 +426,7 @@ object Tests extends Suite(m"Espionage Tests"):
               "sessionId":"s1","toolCall":{"toolCallId":"c1"},
               "options":[{"optionId":"no","name":"No","kind":"reject_once"}]}}"""
 
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         TestClient.roundtrip(message.as[Json]).let(_.result.outcome.outcome.as[Text])
       . assert(_ == t"cancelled")
 
@@ -438,7 +438,7 @@ object Tests extends Suite(m"Espionage Tests"):
               "sessionId":"s2","toolCall":{"toolCallId":"c1"},
               "options":[{"optionId":"go","name":"Go","kind":"allow_once"}]}}"""
 
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         TestClient.roundtrip(message.as[Json]).let(_.result.outcome.outcome.as[Text])
       . assert(_ == t"cancelled")
 
@@ -456,7 +456,7 @@ object Tests extends Suite(m"Espionage Tests"):
           t"""{"jsonrpc":"2.0","id":13,"method":"fs/write_text_file","params":{
               "sessionId":"s1","path":"/tmp/a.txt","content":"x"}}"""
 
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         TestClient.roundtrip(message.as[Json]).let(_.error.code.as[Int])
       . assert(_ == -32601)
 

--- a/lib/espionage/src/test/espionage_test.scala
+++ b/lib/espionage/src/test/espionage_test.scala
@@ -44,7 +44,7 @@ import errorDiagnostics.stackTracesDiagnostics
 import probates.awaitProbate
 import strategies.throwUnsafely
 import threading.virtualThreading
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 // Kept as a top-level object (its own class) rather than nested in `Tests` so the ACP codecs the
 // dispatchers inline do not add to the `Tests` class, which would otherwise exceed the JVM

--- a/lib/ethereal/src/core/ethereal.Assembler.scala
+++ b/lib/ethereal/src/core/ethereal.Assembler.scala
@@ -54,11 +54,11 @@ import zeppelin.*
 
 import errorDiagnostics.emptyDiagnostics
 
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.dereferenceSymlinks.enabled
-import filesystemOptions.overwritePreexisting.enabled
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.dereferenceSymlinks
+import filesystemOptions.overwritePreexisting
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 // Produces a self-contained per-platform executable by patching a bare ethereal
 // runner binary's ETHRCFG block (build id, Java version policy, ML-DSA-44 public
@@ -195,8 +195,8 @@ object Assembler:
 
     if !isWindows then temporary.executable() = true
 
-    import filesystemOptions.moveAtomically.enabled
-    import filesystemOptions.deleteRecursively.disabled
+    import filesystemOptions.moveAtomically
+    import filesystemOptions.deleteOnlyEmpty
     temporary.moveTo(output)
     ()
 

--- a/lib/ethereal/src/core/ethereal.Installer.scala
+++ b/lib/ethereal/src/core/ethereal.Installer.scala
@@ -114,8 +114,8 @@ object Installer:
     ( using Tactic[Install.Error], (DaemonLogEvent is Loggable)^ )
   :   Result =
 
-    import workingDirectories.javaWorkingDirectory
-    import systems.javaSystem
+    import workingDirectories.javaBaseWorkingDirectory
+    import systems.javaBaseSystem
 
     mitigate:
       case Path.Error(_, _)      => Install.Error(Install.Error.Reason.Environment)

--- a/lib/ethereal/src/core/ethereal.Installer.scala
+++ b/lib/ethereal/src/core/ethereal.Installer.scala
@@ -55,12 +55,12 @@ import turbulence.*
 import vacuous.*
 import zeppelin.*
 
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.deleteRecursively.enabled
-import filesystemOptions.dereferenceSymlinks.enabled
-import filesystemOptions.overwritePreexisting.enabled
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.deleteRecursively
+import filesystemOptions.dereferenceSymlinks
+import filesystemOptions.overwritePreexisting
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 import rudiments.sortingAlgorithms.timsort
 
 object Installer:
@@ -177,7 +177,7 @@ object Installer:
 
             tempFile.executable() = true
 
-            import filesystemOptions.moveAtomically.enabled
+            import filesystemOptions.moveAtomically
             tempFile.moveTo(file)
             Result.Installed(command, file.encode)
 

--- a/lib/ethereal/src/core/ethereal.Runners.scala
+++ b/lib/ethereal/src/core/ethereal.Runners.scala
@@ -45,8 +45,8 @@ import urticose.*
 import vacuous.*
 
 import errorDiagnostics.emptyDiagnostics
-import gastronomy.*, providers.javaStdlibProvider
-import httpBackends.virtualMachineHttp
+import gastronomy.*, providers.javaBaseProvider
+import httpBackends.javaNetHttp
 import internetAccess.online
 import monotonous.*, alphabets.hexLowerCase
 

--- a/lib/ethereal/src/core/ethereal.Upgrade.scala
+++ b/lib/ethereal/src/core/ethereal.Upgrade.scala
@@ -34,7 +34,7 @@ package ethereal
 
 import java.lang as jl
 
-import ambience.*, systems.javaSystem
+import ambience.*, systems.javaBaseSystem
 import anticipation.*
 import contingency.*
 import aperture.*

--- a/lib/ethereal/src/core/ethereal.Upgrade.scala
+++ b/lib/ethereal/src/core/ethereal.Upgrade.scala
@@ -47,12 +47,12 @@ import serpentine.*
 import turbulence.*
 import vacuous.*
 
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.deleteRecursively.disabled
-import filesystemOptions.dereferenceSymlinks.enabled
-import filesystemOptions.overwritePreexisting.enabled
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.deleteOnlyEmpty
+import filesystemOptions.dereferenceSymlinks
+import filesystemOptions.overwritePreexisting
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 // Apply an upgrade to the running ethereal application. The given `source`
 // must yield the bytes of a complete signed runner+JAR binary — exactly

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic as juca
 
 import scala.collection.concurrent as scc
 
-import ambience.*, systems.javaSystem
+import ambience.*, systems.javaBaseSystem
 import anticipation.*
 import aperture.*
 import coaxial.*
@@ -91,9 +91,9 @@ def cli[bus <: Matchable](using executive: Executive)
 
   import strategies.throwUnsafely
   import workingDirectories.systemWorkingDirectory
-  import environments.javaEnvironment
+  import environments.javaBaseEnvironment
   import termcaps.environmentTermcap
-  import stdios.virtualMachineStdio
+  import stdios.fileDescriptorStdio
 
   val name: Text =
     recover:
@@ -609,9 +609,9 @@ def cli[bus <: Matchable](using executive: Executive)
 
   // `application` takes a stdlib `Iterable` of arguments, which the opaque `Nil` is not.
   application(using executives.directExecutive(using backstops.silentBackstop))(Nil):
-    import environments.javaEnvironment
+    import environments.javaBaseEnvironment
     import termcaps.environmentTermcap
-    import stdios.virtualMachineStdio
+    import stdios.fileDescriptorStdio
     import probates.awaitProbate
 
     Os.intercept[Shutdown]:

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -73,11 +73,11 @@ import symbolism.*
 import turbulence.*
 import vacuous.*
 
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.deleteRecursively.enabled
-import filesystemOptions.dereferenceSymlinks.enabled
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.deleteRecursively
+import filesystemOptions.dereferenceSymlinks
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 def service[bus <: Matchable](using service: DaemonService[bus]): DaemonService[bus]^{service} =
   service
@@ -193,7 +193,7 @@ def cli[bus <: Matchable](using executive: Executive)
                     Exit.Fail(1).terminate()
 
                 . protect:
-                    import filesystemOptions.overwritePreexisting.disabled
+                    import filesystemOptions.failOnPreexisting
                     Out.println(e"Downloading $runnerName from runners-${Runners.version}")
                     val bytes: Data = Runners.download(platformLabel)
                     if !cacheDir.existent() then cacheDir.create[Directory](CreateFlag.Parents)
@@ -295,7 +295,7 @@ def cli[bus <: Matchable](using executive: Executive)
   case class ScriptIdentity(size: Long, mtime: Long, hash: Text)
 
   def hashScript(script: Path on Local): Optional[Text] = safely:
-    import gastronomy.*, providers.javaStdlibProvider
+    import gastronomy.*, providers.javaBaseProvider
     import monotonous.*, alphabets.hexLowerCase
     script.open[File](Read)(file.checksum[Sha2[256]].serialize[Hex])
 
@@ -618,7 +618,7 @@ def cli[bus <: Matchable](using executive: Executive)
       wipeState()
 
     supervise:
-      import logFormats.standardLogFormat
+      import logFormats.timestampedLogFormat
       given syslog: Logger[DaemonLogEvent, Message] = Logger(Syslog(t"ethereal"))
 
       safely(socketFile.wipe())

--- a/lib/ethereal/src/example/ethereal_hello.scala
+++ b/lib/ethereal/src/example/ethereal_hello.scala
@@ -35,7 +35,7 @@ package ethereal
 import soundness.*
 
 import backstops.stackTraceBackstop
-import executives.completions
+import executives.completionsExecutive
 import interpreters.posixInterpreter
 import threading.virtualThreading
 

--- a/lib/ethereal/src/example/ethereal_testfixture.scala
+++ b/lib/ethereal/src/example/ethereal_testfixture.scala
@@ -42,7 +42,7 @@ import backstops.silentBackstop
 import charDecoders.utf8Decoder
 import classloaders.threadContextClassloader
 import environments.daemonClientEnvironment
-import executives.completions
+import executives.completionsExecutive
 import interpreters.posixInterpreter
 import systems.javaBaseSystem
 import textSanitizers.strictSanitizer

--- a/lib/ethereal/src/example/ethereal_testfixture.scala
+++ b/lib/ethereal/src/example/ethereal_testfixture.scala
@@ -44,7 +44,7 @@ import classloaders.threadContextClassloader
 import environments.daemonClientEnvironment
 import executives.completions
 import interpreters.posixInterpreter
-import systems.javaSystem
+import systems.javaBaseSystem
 import textSanitizers.strictSanitizer
 import threading.platformThreading
 import workingDirectories.systemWorkingDirectory

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -77,7 +77,7 @@ object Tests extends Suite(m"Ethereal Tests"):
 
       val launcher = Enclave(name).dispatch:
         ' {
-            import executives.completions
+            import executives.completionsExecutive
             import interpreters.posixInterpreter
             import systems.javaBaseSystem
 
@@ -661,7 +661,7 @@ object Tests extends Suite(m"Ethereal Tests"):
 
       val launcherV1 = Enclave(upgradeName, buildId = 1).dispatch:
         ' {
-            import executives.completions
+            import executives.completionsExecutive
             import interpreters.posixInterpreter
 
             cli:
@@ -679,7 +679,7 @@ object Tests extends Suite(m"Ethereal Tests"):
 
       val launcherV2 = Enclave(upgradeName, buildId = 2).dispatch:
         ' {
-            import executives.completions
+            import executives.completionsExecutive
             import interpreters.posixInterpreter
 
             cli:
@@ -743,7 +743,7 @@ object Tests extends Suite(m"Ethereal Tests"):
 
       val dispV1 = Enclave(dispName, buildId = 1).dispatch:
         ' {
-            import executives.completions
+            import executives.completionsExecutive
             import interpreters.posixInterpreter
 
             cli:
@@ -759,7 +759,7 @@ object Tests extends Suite(m"Ethereal Tests"):
 
       val dispV2 = Enclave(dispName, buildId = 1).dispatch:
         ' {
-            import executives.completions
+            import executives.completionsExecutive
             import interpreters.posixInterpreter
 
             cli:
@@ -796,7 +796,7 @@ object Tests extends Suite(m"Ethereal Tests"):
 
       val selfuV1 = Enclave(selfuName, buildId = 1).dispatch:
         ' {
-            import executives.completions
+            import executives.completionsExecutive
             import interpreters.posixInterpreter
 
             cli:
@@ -812,7 +812,7 @@ object Tests extends Suite(m"Ethereal Tests"):
 
       val selfuV2 = Enclave(selfuName, buildId = 2).dispatch:
         ' {
-            import executives.completions
+            import executives.completionsExecutive
             import interpreters.posixInterpreter
 
             cli:
@@ -904,7 +904,7 @@ object Tests extends Suite(m"Ethereal Tests"):
 
       val brokenExe: Path on Linux = Enclave("brokn").dispatch:
         ' {
-            import executives.completions
+            import executives.completionsExecutive
             import interpreters.posixInterpreter
 
             if jl.System.getProperty("ethereal.name") != null then jl.System.exit(1)

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -685,7 +685,7 @@ object Tests extends Suite(m"Ethereal Tests"):
             cli:
               arguments match
                 case Argument("version") :: Nil =>
-                  execute(Out.print(t"v2") yet Exit.Ok)
+                  execute(Out.print(t"v2 (upgraded build)") yet Exit.Ok)
 
                 case _ =>
                   execute(Exit.Fail(1))
@@ -695,6 +695,14 @@ object Tests extends Suite(m"Ethereal Tests"):
 
       val toolV2 = launcherV2.path
 
+      // The v2 output is deliberately longer than v1's: the launcher decides whether a
+      // running daemon is stale by comparing its own file size against the size the
+      // daemon recorded, and only falls back to asking the daemon to re-hash *its own*
+      // launcher when the sizes match. Two launchers built at different paths with
+      // identical sizes therefore look like a mere mtime change to the v1 daemon, which
+      // finds its own file unchanged and stays. In practice an upgrade replaces the
+      // launcher in place, so that path is sound; the test just has to make the jars
+      // differ by more than a byte of deflate output.
       // A daemon's first invocation can momentarily return no output while it
       // cold-starts — or while the old daemon is being swapped out — under load, so
       // retry the `version` call until it serves the expected build (or a deadline
@@ -717,11 +725,11 @@ object Tests extends Suite(m"Ethereal Tests"):
         .assert(_ == t"v1")
 
         test(m"v2 launcher replaces v1 daemon and returns v2 output"):
-          serves(toolV2, t"v2")
-        .assert(_ == t"v2")
+          serves(toolV2, t"v2 (upgraded build)")
+        .assert(_ == t"v2 (upgraded build)")
 
         test(m"v1 daemon is no longer running after upgrade"):
-          serves(toolV2, t"v2") == t"v2"
+          serves(toolV2, t"v2 (upgraded build)") == t"v2 (upgraded build)"
         .assert(_ == true)
 
       safely(sh"$toolV2 '{admin}' kill".exec[Exit]())

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -40,10 +40,10 @@ import java.util.zip as juz
 import soundness.*
 
 import classloaders.systemClassloader
-import environments.javaEnvironment
-import systems.javaSystem
+import environments.javaBaseEnvironment
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 import logging.silentLogging
 import threading.platformThreading
 
@@ -79,7 +79,7 @@ object Tests extends Suite(m"Ethereal Tests"):
         ' {
             import executives.completions
             import interpreters.posixInterpreter
-            import systems.javaSystem
+            import systems.javaBaseSystem
 
             cli:
               arguments match

--- a/lib/eucalyptus/src/ansi/eucalyptus_ansi.scala
+++ b/lib/eucalyptus/src/ansi/eucalyptus_ansi.scala
@@ -55,7 +55,7 @@ package logFormats:
 
   private val indent = e" "*46
 
-  given ansiStandardLogFormat: (palette: LogPalette) => Message is Inscribable in Teletype =
+  given ansiTimestampedLogFormat: (palette: LogPalette) => Message is Inscribable in Teletype =
     (event, level, timestamp) =>
       try
         event.teletype.cut(t"\n").bind(_.slices(76)) match

--- a/lib/eucalyptus/src/ansi/soundness_eucalyptus_ansi.scala
+++ b/lib/eucalyptus/src/ansi/soundness_eucalyptus_ansi.scala
@@ -35,4 +35,4 @@ package soundness
 export eucalyptus.{LogPalette}
 
 package logFormats:
-  export eucalyptus.logFormats.ansiStandardLogFormat
+  export eucalyptus.logFormats.ansiTimestampedLogFormat

--- a/lib/eucalyptus/src/core/eucalyptus_core.scala
+++ b/lib/eucalyptus/src/core/eucalyptus_core.scala
@@ -49,14 +49,11 @@ package logFormats:
     case Level.Warn => t"WARN"
     case Level.Fail => t"FAIL"
 
-  given standardLogFormat: [event: Communicable] => event is Inscribable in Text =
+  given timestampedLogFormat: [event: Communicable] => event is Inscribable in Text =
     (event, level, timestamp) =>
       t"${dateFormat.format(timestamp).nn} [$level] ${event.communicate}\n"
 
   given untimestampedLogFormat: [event: Communicable] => event is Inscribable in Text =
-    (event, level, timestamp) => t"[$level] ${event.communicate}\n"
-
-  given lightweightLogFormat: [event: Communicable] => event is Inscribable in Text =
     (event, level, timestamp) => t"[$level] ${event.communicate}\n"
 
 val dateFormat = jt.SimpleDateFormat(t"yyyy-MMM-dd HH:mm:ss.SSS".s)

--- a/lib/eucalyptus/src/core/soundness_eucalyptus_core.scala
+++ b/lib/eucalyptus/src/core/soundness_eucalyptus_core.scala
@@ -35,7 +35,7 @@ package soundness
 export eucalyptus.{dateFormat, Inscribable, Logger, mute, Taggable}
 
 package logFormats:
-  export eucalyptus.logFormats.{lightweightLogFormat, standardLogFormat, untimestampedLogFormat}
+  export eucalyptus.logFormats.{timestampedLogFormat, untimestampedLogFormat}
 
 package logging:
   export eucalyptus.logging.silentLogging

--- a/lib/eucalyptus/src/syslog/eucalyptus.Syslog.scala
+++ b/lib/eucalyptus/src/syslog/eucalyptus.Syslog.scala
@@ -44,7 +44,7 @@ import vacuous.*
 
 object Syslog:
   given writable: Monitor => Syslog is Writable by Text = (syslog, stream) =>
-    import workingDirectories.javaWorkingDirectory
+    import workingDirectories.javaBaseWorkingDirectory
     // The system charset, as the pre-migration `sysData` encoding used.
     given hieroglyph.CharEncoder = hieroglyph.CharEncoder.system
 

--- a/lib/exegesis/src/core/exegesis.Lsp.scala
+++ b/lib/exegesis/src/core/exegesis.Lsp.scala
@@ -1514,7 +1514,7 @@ object Lsp:
 
   // The `params` of a message, or the whole message if it has none.
   private[exegesis] def params(json: Json): Json =
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
     try json.params catch case _: Exception => json
 
   private[exegesis] def requestId(json: Json): Optional[Json] =
@@ -1995,7 +1995,7 @@ object Lsp:
         scala.caps.unsafe.unsafeAssumeSeparate(JsonRpc.serve[LspResolve](server))
 
     def apply(server: Lsp): Json => Optional[Json] =
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       import strategies.throwUnsafely
 
       // Each expansion is bound to a bare local, and the routing is an if-chain over locals
@@ -2513,7 +2513,7 @@ object Lsp:
     // The `result` member of a response, rewritten in place. A response carrying an `error` is left
     // alone: a fault is not a payload, and a rewriter typed for the payload could not read it.
     private def rewriteResult(json: Json, rewrite: Json => Json): Json =
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       import strategies.throwUnsafely
 
       try
@@ -2524,7 +2524,7 @@ object Lsp:
 
     // The `params` of a notification or of a request the server made of its client, rewritten.
     private def rewriteParams(json: Json, rewrite: Json => Json): Json =
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       import strategies.throwUnsafely
 
       try

--- a/lib/exegesis/src/core/exegesis.rewrite.scala
+++ b/lib/exegesis/src/core/exegesis.rewrite.scala
@@ -132,7 +132,7 @@ object rewrite:
   :   Unit =
 
     proxy.notices(t"textDocument/publishDiagnostics") = Lsp.Registry.Slot[Json => Json]: params =>
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       import strategies.throwUnsafely
 
       Map

--- a/lib/exegesis/src/demo/exegesis_demoproxy.scala
+++ b/lib/exegesis/src/demo/exegesis_demoproxy.scala
@@ -42,7 +42,7 @@ import logging.silentLogging
 import probates.awaitProbate
 import strategies.throwUnsafely
 import threading.virtualThreading
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 // An example proxy: it launches the language server named by its own arguments, forwards
 // everything an editor sends it, and amends two of the answers on the way back — every hover is

--- a/lib/exegesis/src/demo/exegesis_demoproxy.scala
+++ b/lib/exegesis/src/demo/exegesis_demoproxy.scala
@@ -36,7 +36,7 @@ import soundness.*
 
 import backstops.stackTraceBackstop
 import errorDiagnostics.stackTracesDiagnostics
-import executives.completions
+import executives.completionsExecutive
 import interpreters.posixInterpreter
 import logging.silentLogging
 import probates.awaitProbate

--- a/lib/exegesis/src/demo/exegesis_demoserver.scala
+++ b/lib/exegesis/src/demo/exegesis_demoserver.scala
@@ -35,7 +35,7 @@ package exegesis
 import soundness.*
 
 import backstops.stackTraceBackstop
-import executives.completions
+import executives.completionsExecutive
 import interpreters.posixInterpreter
 import probates.awaitProbate
 import strategies.throwUnsafely

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -213,7 +213,7 @@ object ProxyFixture:
   // Decoded in a `try` rather than with `safely`, here and below: a decodable cannot thread the
   // boundary tactic under separation checking.
   def commandName(message: Json): Text =
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
     try Lsp.params(message).command.as[Text] catch case _: Exception => t""
 
   def connect[result](using listener: Lsp.Listener^)
@@ -456,7 +456,7 @@ object Tests extends Suite(m"Exegesis Tests"):
       . assert(_ == t"resolved")
 
     suite(m"Error responses"):
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
 
       test(m"a handler fault becomes an error response with its wire code and the request id"):
         val request: Json =

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -46,7 +46,7 @@ import logging.silentLogging
 import probates.awaitProbate
 import strategies.throwUnsafely
 import threading.virtualThreading
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 // Kept as a top-level object (its own class) rather than nested in `Tests` so the LSP codecs the
 // dispatcher inlines do not add to the `Tests` class, which would otherwise exceed the JVM

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -40,7 +40,7 @@ import denominative.*
 import escapade.*
 import gossamer.*
 import gossamer.collationComparable
-import gossamer.collations.codepoints
+import gossamer.collations.codepointCollation
 import guillotine.*
 import hieroglyph.*, textMetrics.uniformMetric
 import hypotenuse.*

--- a/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
@@ -34,7 +34,7 @@ package exoskeleton
 
 import scala.collection.mutable as scm
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import aperture.*
 import contingency.*

--- a/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
@@ -58,7 +58,7 @@ import vacuous.*
 import charDecoders.utf8Decoder
 import textSanitizers.skipSanitizer
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 object Completions:
   case class Tab(arguments: List[Text], focus: Int, cursor: Int, count: Int = 0):

--- a/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
@@ -45,10 +45,10 @@ import serpentine.*
 import symbolism.*
 import vacuous.*
 
-import filesystemOptions.dereferenceSymlinks.enabled
+import filesystemOptions.dereferenceSymlinks
 import interfaces.paths.pathOnLocal
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 object Pathname:
   // The property is read straight off the `System` capability rather than through

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -234,7 +234,7 @@ def helpTree
   build(Nil, command, Unset, Unset, Set(), Set())
 
 package executives:
-  given completions: (backstop: Backstop) => Executive:
+  given completionsExecutive: (backstop: Backstop) => Executive:
     type Interface = Cli
     type Return = Execution
 

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -44,7 +44,7 @@ import eucalyptus.*
 import fulminate.*
 import gossamer.*
 import gossamer.collationComparable
-import gossamer.collations.codepoints
+import gossamer.collations.codepointCollation
 import guillotine.*
 import prepositional.*
 import rudiments.*

--- a/lib/exoskeleton/src/completions/soundness_exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/soundness_exoskeleton_completions.scala
@@ -36,4 +36,4 @@ export exoskeleton.{CliEvent, Completion, Completions, execute, Execution, expla
     pathnameDiscoverable}
 
 package executives:
-  export exoskeleton.executives.completions
+  export exoskeleton.executives.completionsExecutive

--- a/lib/exoskeleton/src/core/exoskeleton.Application.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Application.scala
@@ -39,7 +39,7 @@ abstract class Application:
   import executives.directExecutive
   import backstops.genericErrorMessageBackstop
   import interpreters.posixInterpreter
-  import ambience.systems.javaSystem
+  import ambience.systems.javaBaseSystem
 
   def invoke(using Cli): Exit
   def main(textArguments: Array[Text]^{}): Unit = application(List.from(textArguments.readable))(invoke)

--- a/lib/exoskeleton/src/core/exoskeleton_core.scala
+++ b/lib/exoskeleton/src/core/exoskeleton_core.scala
@@ -57,7 +57,7 @@ import serpentine.*
 import turbulence.*
 import vacuous.*
 
-import environments.javaEnvironment
+import environments.javaBaseEnvironment
 import termcaps.environmentTermcap
 
 package backstops:
@@ -114,8 +114,8 @@ package executives:
 
       Invocation
         ( Cli.arguments(arguments, Unset, Unset, Unset),
-          environments.javaEnvironment,
-          workingDirectories.javaWorkingDirectory,
+          environments.javaBaseEnvironment,
+          workingDirectories.javaBaseWorkingDirectory,
           stdio,
           arguments.prim.let(_ != t"{admin}").or(true),
           login )
@@ -148,9 +148,9 @@ def application(using executive: Executive, interpreter: Interpreter, system: Sy
   val cli =
     executive.invocation
       ( arguments,
-        environments.javaEnvironment,
-        workingDirectories.javaWorkingDirectory,
-        stdios.virtualMachineStdio,
+        environments.javaBaseEnvironment,
+        workingDirectories.javaBaseWorkingDirectory,
+        stdios.fileDescriptorStdio,
         entrypoint,
         Login(ProcessHandle.current().nn.info().nn.user().nn.get().nn.tt, Unset) )
 

--- a/lib/exoskeleton/src/manpage/exoskeleton.Manpages.scala
+++ b/lib/exoskeleton/src/manpage/exoskeleton.Manpages.scala
@@ -47,7 +47,7 @@ import turbulence.*
 import vacuous.*
 import virility.*
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 // Installs a rendered manpage into the XDG man hierarchy, mirroring how `Completions.install`
 // places shell-completion scripts. `$XDG_DATA_HOME/man` is on the default manpath of modern

--- a/lib/exoskeleton/src/manpage/exoskeleton.Manpages.scala
+++ b/lib/exoskeleton/src/manpage/exoskeleton.Manpages.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package exoskeleton
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import aperture.*
 import contingency.*

--- a/lib/exoskeleton/src/manpage/exoskeleton_manpage.scala
+++ b/lib/exoskeleton/src/manpage/exoskeleton_manpage.scala
@@ -38,7 +38,7 @@ import aviation.*, dateFormats.iso8601DateFormat
 import escapade.*
 import gossamer.*
 import gossamer.collationComparable
-import gossamer.collations.codepoints
+import gossamer.collations.codepointCollation
 import rudiments.*
 import spectacular.*
 import symbolism.*

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -59,9 +59,9 @@ import vacuous.*
 import filesystemOptions.deleteRecursively.disabled
 import logging.silentLogging
 import probates.cancelProbate
-import systems.javaSystem
+import systems.javaBaseSystem
 import threading.platformThreading
-import workingDirectories.javaWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 import filesystemBackends.virtualMachineFilesystem
 

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -56,14 +56,14 @@ import superlunary.*
 import symbolism.*
 import vacuous.*
 
-import filesystemOptions.deleteRecursively.disabled
+import filesystemOptions.deleteOnlyEmpty
 import logging.silentLogging
 import probates.cancelProbate
 import systems.javaBaseSystem
 import threading.platformThreading
 import workingDirectories.javaBaseWorkingDirectory
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 object Enclave:
   // A `Tool` is a *capability*: it references a live installed daemon process whose lifetime

--- a/lib/exoskeleton/src/rig/exoskeleton_rig.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton_rig.scala
@@ -37,7 +37,7 @@ import soundness.*
 import errorDiagnostics.stackTracesDiagnostics
 import interfaces.paths.pathOnLinux
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 extension (shell: Shell)
   // Explicit `using` evidence instead of `raises`/`logs` sugar: a context-function result
@@ -131,8 +131,8 @@ extension (shell: Shell)
                  |}
                  |""".stripMargin
 
-            import filesystemOptions.createNonexistentParents.disabled
-            import filesystemOptions.dereferenceSymlinks.enabled
+            import filesystemOptions.requireParents
+            import filesystemOptions.dereferenceSymlinks
             import charEncoders.utf8Encoder
 
             val tmpDir: Path on Linux = temporaryDirectory[Path on Linux]
@@ -272,7 +272,7 @@ extension (shell: Shell)
         sh"tmux kill-session -t ${tmux.id}".exec[Exit]()
 
         psFile.let: file =>
-          import filesystemOptions.deleteRecursively.disabled
+          import filesystemOptions.deleteOnlyEmpty
           safely(file.delete())
 
         result

--- a/lib/exoskeleton/src/test/exoskeleton.SettingTests.scala
+++ b/lib/exoskeleton/src/test/exoskeleton.SettingTests.scala
@@ -35,7 +35,7 @@ package exoskeleton
 import soundness.*
 
 import strategies.throwUnsafely
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 object SettingTests extends Suite(m"Setting tests"):
   import interpreters.posixInterpreter

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -34,14 +34,14 @@ package exoskeleton
 
 import soundness.*
 import soundness.collationComparable
-import soundness.collations.codepoints
+import soundness.collations.codepointCollation
 import soundness.sortingAlgorithms.timsort
 
 import classloaders.systemClassloader
-import environments.javaEnvironment
-import systems.javaSystem
+import environments.javaBaseEnvironment
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 import logging.silentLogging
 import threading.platformThreading
 
@@ -137,7 +137,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
                   execute(Exit.Ok)
 
                 case Files() :: rest =>
-                  import systems.javaSystem
+                  import systems.javaBaseSystem
                   given WorkingDirectory = summon[Cli].workingDirectory
 
                   rest match

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -50,7 +50,7 @@ import backstops.silentBackstop
 
 import Shell.*
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 // Statuses must be declared at the top level: capture checking rejects
 // `value.type <: value.type | other.type` for singletons of method-local definitions
@@ -68,7 +68,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
       val foo: Text = "hello"
       Enclave(t"abcd").dispatch:
         ' {
-            import executives.completions
+            import executives.completionsExecutive
             import interpreters.posixInterpreter
 
             val Alpha = Subcommand("alpha", e"a command to run")
@@ -857,7 +857,7 @@ object Tests extends Suite(m"Exoskeleton Tests"):
       // `-c` to offer.
       Enclave(t"clstr").dispatch:
         ' {
-            import executives.completions
+            import executives.completionsExecutive
             import interpreters.posixClusteringInterpreter
 
             cli:

--- a/lib/facsimile/src/core/facsimile.FontEmbedder.scala
+++ b/lib/facsimile/src/core/facsimile.FontEmbedder.scala
@@ -41,8 +41,8 @@ import phoenicia.*
 import rudiments.*
 import vacuous.*
 
-import gastronomy.crypto.permitDisallowedCrypto
-import gastronomy.providers.javaStdlibProvider
+import gastronomy.cryptoPermits.permitDisallowedCrypto
+import gastronomy.providers.javaBaseProvider
 
 // Embeds a TrueType (or OpenType) font program as a simple, single-byte PDF font with WinAnsi
 // encoding: the program becomes a `FontFile2` stream, referenced by a `FontDescriptor` built

--- a/lib/facsimile/src/core/facsimile.Guard.scala
+++ b/lib/facsimile/src/core/facsimile.Guard.scala
@@ -49,9 +49,9 @@ import prepositional.*
 import rudiments.*
 import vacuous.*
 
-import enigmatic.cloaks.cloakHeap
-import gastronomy.crypto.permitDisallowedCrypto
-import gastronomy.providers.javaStdlibProvider
+import enigmatic.cloaks.heapCloak
+import gastronomy.cryptoPermits.permitDisallowedCrypto
+import gastronomy.providers.javaBaseProvider
 
 // The standard security handler (ISO 32000-2 §7.6.4), revisions 2–6. The file key is derived
 // from the user password and the `/Encrypt` dictionary and validated against `/U` at open;

--- a/lib/facsimile/src/file/facsimile.PdfFile.scala
+++ b/lib/facsimile/src/file/facsimile.PdfFile.scala
@@ -57,8 +57,8 @@ import filesystemOptions.dereferenceSymlinks.enabled
 import filesystemOptions.moveAtomically.enabled
 import filesystemOptions.overwritePreexisting.enabled
 import logging.silentLogging
-import systems.javaSystem
-import workingDirectories.javaWorkingDirectory
+import systems.javaBaseSystem
+import workingDirectories.javaBaseWorkingDirectory
 
 object PdfFile:
   def apply[path: Abstractable across Paths to Text](path: path): PdfFile =

--- a/lib/facsimile/src/file/facsimile.PdfFile.scala
+++ b/lib/facsimile/src/file/facsimile.PdfFile.scala
@@ -50,12 +50,12 @@ import turbulence.*
 import vacuous.*
 
 import fulminate.errorDiagnostics.stackTracesDiagnostics
-import filesystemBackends.virtualMachineFilesystem
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.deleteRecursively.enabled
-import filesystemOptions.dereferenceSymlinks.enabled
-import filesystemOptions.moveAtomically.enabled
-import filesystemOptions.overwritePreexisting.enabled
+import filesystemBackends.javaBaseFilesystem
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.deleteRecursively
+import filesystemOptions.dereferenceSymlinks
+import filesystemOptions.moveAtomically
+import filesystemOptions.overwritePreexisting
 import logging.silentLogging
 import systems.javaBaseSystem
 import workingDirectories.javaBaseWorkingDirectory

--- a/lib/facsimile/src/test/facsimile_test.scala
+++ b/lib/facsimile/src/test/facsimile_test.scala
@@ -47,7 +47,7 @@ import facsimile.Filter
 import charEncoders.utf8Encoder
 import errorDiagnostics.stackTracesDiagnostics
 import strategies.throwUnsafely
-import cloaks.cloakHeap
+import cloaks.heapCloak
 
 import _root_.java.io as ji
 import _root_.java.nio.file as jnf

--- a/lib/galilei/src/core/galilei.FilesystemBackend.scala
+++ b/lib/galilei/src/core/galilei.FilesystemBackend.scala
@@ -41,7 +41,7 @@ import vacuous.*
 // The pluggable low-level filesystem backend for a plane: the complete set of primitive
 // operations that galilei's user-facing API is defined in terms of, expressed without reference
 // to any platform API. `galilei.jvm` provides the `java.nio` implementation
-// (`filesystemBackends.virtualMachineFilesystem`); other platforms (e.g. WASI's `wasi:filesystem`) supply
+// (`filesystemBackends.javaBaseFilesystem`); other platforms (e.g. WASI's `wasi:filesystem`) supply
 // their own.
 //
 // Operations that compose several primitives (recursive deletion, copy-into, creating parents)

--- a/lib/galilei/src/core/galilei.Subtree.scala
+++ b/lib/galilei/src/core/galilei.Subtree.scala
@@ -133,5 +133,5 @@ object Subtree:
     ( using filesystem: under is Filesystem )
     ( using backend: FilesystemBackend on under, tactic: Tactic[Io.Error] )
   :   Unit =
-    import filesystemOptions.deleteRecursively.disabled
+    import filesystemOptions.deleteOnlyEmpty
     path.delete()

--- a/lib/galilei/src/core/galilei_core.scala
+++ b/lib/galilei/src/core/galilei_core.scala
@@ -188,7 +188,7 @@ extension [plane: Filesystem](path: Path on plane)
   // Named `filesize` (not `size`): a same-named export beside the collections' `size` at the
   // `soundness` umbrella makes extension resolution commit to the wrong candidate.
   def filesize()(using plane is Explorable, FilesystemBackend on plane): Bytes raises Io.Error =
-    import filesystemOptions.dereferenceSymlinks.disabled
+    import filesystemOptions.preserveSymlinks
     given TraversalOrder = TraversalOrder.PreOrder
 
     descendants.fold(summon[FilesystemBackend on plane].stat(path, false).size.b):
@@ -280,7 +280,7 @@ extension [plane: Filesystem](path: Path on plane)
   :   Path on plane raises Io.Error =
 
     given CreateNonexistentParents on plane =
-      filesystemOptions.createNonexistentParents.enabled[plane]
+      filesystemOptions.createNonexistentParents[plane]
 
     val file2: Path on plane = unsafely(destination.child(path.descent.head))
     copyTo(file2)
@@ -314,7 +314,7 @@ extension [plane: Filesystem](path: Path on plane)
     ( using FilesystemBackend on plane )
   :   Path on plane raises Io.Error =
 
-    import filesystemOptions.createNonexistentParents.enabled
+    import filesystemOptions.createNonexistentParents
     moveTo(unsafely(destination.child(path.descent.head)))
 
 
@@ -344,7 +344,7 @@ extension [plane: Filesystem](path: Path on plane)
     ( using FilesystemBackend on plane )
   :   Path on plane raises Io.Error =
 
-    import filesystemOptions.createNonexistentParents.enabled
+    import filesystemOptions.createNonexistentParents
     symlinkTo(unsafely(destination.child(path.descent.head)))
 
 
@@ -395,95 +395,89 @@ extension [plane <: Posix: Filesystem](path: Path on plane)
     backend.hardLinkCount(path, dereferenceSymlinks.dereference)
 
 package filesystemOptions:
-  object dereferenceSymlinks:
-    given enabled: DereferenceSymlinks:
-      def dereference = true
+  given dereferenceSymlinks: DereferenceSymlinks:
+    def dereference = true
 
-    given disabled: DereferenceSymlinks:
-      def dereference = false
+  given preserveSymlinks: DereferenceSymlinks:
+    def dereference = false
 
-  object moveAtomically:
-    given enabled: MoveAtomically:
-      def atomic = true
+  given moveAtomically: MoveAtomically:
+    def atomic = true
 
-    given disabled: MoveAtomically:
-      def atomic = false
+  given moveNonAtomically: MoveAtomically:
+    def atomic = false
 
-  object copyAttributes:
-    given enabled: CopyAttributes:
-      def attributes = true
+  given copyAttributes: CopyAttributes:
+    def attributes = true
 
-    given disabled: CopyAttributes:
-      def attributes = false
+  given discardAttributes: CopyAttributes:
+    def attributes = false
 
-  object deleteRecursively:
-    given enabled: [plane: Filesystem]
-    =>  ( explorable: plane is Explorable, backend: FilesystemBackend on plane )
-    =>  DeleteRecursively on plane:
+  given deleteRecursively: [plane: Filesystem]
+  =>  ( explorable: plane is Explorable, backend: FilesystemBackend on plane )
+  =>  DeleteRecursively on plane:
 
-      type Plane = plane
+    type Plane = plane
 
-      def recur(path: Path on plane): Unit raises Io.Error =
-        path.children.each(recur(_))
-        backend.delete(path)
+    def recur(path: Path on plane): Unit raises Io.Error =
+      path.children.each(recur(_))
+      backend.delete(path)
 
-      def conditionally[result](path: Path on Plane)(operation: => result)
-      :   (Tactic[Io.Error]^) ?->{operation} result =
-        path.children.each(recur(_)) yet operation
+    def conditionally[result](path: Path on Plane)(operation: => result)
+    :   (Tactic[Io.Error]^) ?->{operation} result =
+      path.children.each(recur(_)) yet operation
 
-    given disabled: [plane: {Filesystem, Explorable}] => DeleteRecursively on plane:
+  given deleteOnlyEmpty: [plane: {Filesystem, Explorable}] => DeleteRecursively on plane:
 
-      type Plane = plane
+    type Plane = plane
 
-      def conditionally[result](path: Path on Plane)(operation: => result)
-      :   (Tactic[Io.Error]^) ?->{operation} result =
-        if !path.children.nil
-        then abort(Io.Error(path, Io.Error.Operation.Delete, Reason.DirectoryNotEmpty))
-        else operation
+    def conditionally[result](path: Path on Plane)(operation: => result)
+    :   (Tactic[Io.Error]^) ?->{operation} result =
+      if !path.children.nil
+      then abort(Io.Error(path, Io.Error.Operation.Delete, Reason.DirectoryNotEmpty))
+      else operation
 
-  object overwritePreexisting:
-    given enabled: [plane: Filesystem]
-    =>  ( deleteRecursively: DeleteRecursively on plane )
-    =>  OverwritePreexisting on plane:
+  given overwritePreexisting: [plane: Filesystem]
+  =>  ( deleteRecursively: DeleteRecursively on plane )
+  =>  OverwritePreexisting on plane:
 
-      type Plane = plane
+    type Plane = plane
 
-      def apply[result](path: Path on Plane)(operation: => result)
-      :   (Tactic[Io.Error]^) ?->{operation} result =
-        deleteRecursively.conditionally(path)(operation)
+    def apply[result](path: Path on Plane)(operation: => result)
+    :   (Tactic[Io.Error]^) ?->{operation} result =
+      deleteRecursively.conditionally(path)(operation)
 
-    // The backend raises `AlreadyExists` itself when the operation collides with an existing
-    // entry, so nothing needs intercepting here.
-    given disabled: [plane: Filesystem] => OverwritePreexisting on plane:
+  // The backend raises `AlreadyExists` itself when the operation collides with an existing
+  // entry, so nothing needs intercepting here.
+  given failOnPreexisting: [plane: Filesystem] => OverwritePreexisting on plane:
 
-      type Plane = plane
+    type Plane = plane
 
-      def apply[result](path: Path on Plane)(operation: => result)
-      :   (Tactic[Io.Error]^) ?->{operation} result =
-        operation
+    def apply[result](path: Path on Plane)(operation: => result)
+    :   (Tactic[Io.Error]^) ?->{operation} result =
+      operation
 
-  object createNonexistentParents:
-    given enabled: [plane: Filesystem]
-    =>  ( backend: FilesystemBackend on plane )
-    =>  CreateNonexistentParents on plane:
+  given createNonexistentParents: [plane: Filesystem]
+  =>  ( backend: FilesystemBackend on plane )
+  =>  CreateNonexistentParents on plane:
 
-      def apply[result](path: Path on plane)(operation: => result)
-      :   (Tactic[Io.Error]^) ?->{operation} result =
-        def ensure(directory: Path on plane): Unit =
-          if !backend.exists(directory, true) then
-            safely(directory.parent).let(ensure(_))
-            backend.createDirectory(directory)
+    def apply[result](path: Path on plane)(operation: => result)
+    :   (Tactic[Io.Error]^) ?->{operation} result =
+      def ensure(directory: Path on plane): Unit =
+        if !backend.exists(directory, true) then
+          safely(directory.parent).let(ensure(_))
+          backend.createDirectory(directory)
 
-        safely(path.parent).let(ensure(_))
-        operation
+      safely(path.parent).let(ensure(_))
+      operation
 
-    given disabled: [plane: Filesystem] => CreateNonexistentParents on plane:
+  given requireParents: [plane: Filesystem] => CreateNonexistentParents on plane:
 
-      type Plane = plane
+    type Plane = plane
 
-      def apply[result](path: Path on plane)(block: => result)
-      :   (Tactic[Io.Error]^) ?->{block} result =
-        block
+    def apply[result](path: Path on plane)(block: => result)
+    :   (Tactic[Io.Error]^) ?->{block} result =
+      block
 
 
 // Extended attributes, gated by the storage-filesystem axis (issue #567): available only on a

--- a/lib/galilei/src/core/soundness_galilei_core.scala
+++ b/lib/galilei/src/core/soundness_galilei_core.scala
@@ -58,8 +58,9 @@ package interfaces.paths:
 package filesystemOptions:
   export
     galilei.filesystemOptions
-    . { copyAttributes, createNonexistentParents, deleteRecursively,
-        dereferenceSymlinks, moveAtomically, overwritePreexisting }
+    . { copyAttributes, createNonexistentParents, deleteOnlyEmpty, deleteRecursively,
+        dereferenceSymlinks, discardAttributes, failOnPreexisting, moveAtomically, moveNonAtomically,
+        overwritePreexisting, preserveSymlinks, requireParents }
 
 package filesystemTraversal:
   export galilei.filesystemTraversal.{postOrderTraversal, preOrderTraversal}

--- a/lib/galilei/src/jvm/galilei_jvm.scala
+++ b/lib/galilei/src/jvm/galilei_jvm.scala
@@ -51,7 +51,7 @@ import vacuous.*
 import Io.Error.{Operation, Reason}
 
 package filesystemBackends:
-  given virtualMachineFilesystem: [plane: Filesystem] => FilesystemBackend on plane =
+  given javaBaseFilesystem: [plane: Filesystem] => FilesystemBackend on plane =
     new FilesystemBackend:
       type Plane = plane
 

--- a/lib/galilei/src/jvm/soundness_galilei_jvm.scala
+++ b/lib/galilei/src/jvm/soundness_galilei_jvm.scala
@@ -35,4 +35,4 @@ package soundness
 export galilei.{socketCreatable, Device, Ram, RamFlag}
 
 package filesystemBackends:
-  export galilei.filesystemBackends.virtualMachineFilesystem
+  export galilei.filesystemBackends.javaBaseFilesystem

--- a/lib/galilei/src/native/galilei_native.scala
+++ b/lib/galilei/src/native/galilei_native.scala
@@ -52,7 +52,7 @@ import vacuous.*
 import Io.Error.{Operation, Reason}
 
 package filesystemBackends:
-  given native: [plane: Filesystem] => FilesystemBackend on plane =
+  given scalaNativeFilesystem: [plane: Filesystem] => FilesystemBackend on plane =
     new FilesystemBackend:
       type Plane = plane
 

--- a/lib/galilei/src/native/soundness_galilei_native.scala
+++ b/lib/galilei/src/native/soundness_galilei_native.scala
@@ -30,13 +30,7 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package ypsiloid
+package soundness
 
-import anticipation.*
-import prepositional.*
-
-// Importing `yamlConversion.encodable` brings a scoped `Conversion` into lexical scope that lets
-// any `Encodable in Yaml` value be supplied directly at lens-assignment positions, such as
-// `yaml.lens(_.field = value)`, without an explicit `.yaml`.
-object yamlConversion:
-  given encodable: [entity: Encodable in Yaml] => Conversion[entity, Yaml] = _.encode
+package filesystemBackends:
+  export galilei.filesystemBackends.scalaNativeFilesystem

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -34,7 +34,7 @@ package galilei
 
 import soundness.*
 import soundness.collationComparable
-import soundness.collations.codepoints
+import soundness.collations.codepointCollation
 import soundness.sortingAlgorithms.timsort
 
 import filesystemBackends.virtualMachineFilesystem
@@ -827,7 +827,7 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == unsafely(stemA / "themes" / "new.css"))
 
       test(m"the Xdg constructor reads the variables in spec order"):
-        import systems.javaSystem
+        import systems.javaBaseSystem
         given Environment = name =>
           if name == t"XDG_DATA_HOME" then stemA.encode
           else if name == t"XDG_DATA_DIRS" then stemB.encode

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -37,7 +37,7 @@ import soundness.collationComparable
 import soundness.collations.codepointCollation
 import soundness.sortingAlgorithms.timsort
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 object Tests extends Suite(m"Galilei tests"):
   def run(): Unit =
@@ -89,9 +89,9 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == t"Hello world!")
 
     suite(m"Opening directories"):
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
-      import filesystemOptions.deleteRecursively.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
+      import filesystemOptions.deleteRecursively
 
       val dirLeaf: Text = Uuid().show
       val root: Path on Linux = unsafely((% / "tmp" / dirLeaf).on[Linux])
@@ -246,9 +246,9 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == false)
 
     suite(m"Scratch directories"):
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
-      import filesystemOptions.deleteRecursively.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
+      import filesystemOptions.deleteRecursively
 
       val scratchLeaf: Text = Uuid().show
       val base: Path on Linux = unsafely((% / "tmp" / scratchLeaf).on[Linux])
@@ -363,9 +363,9 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == Io.Error.Reason.Unsupported)
 
     suite(m"The access register"):
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
-      import filesystemOptions.deleteRecursively.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
+      import filesystemOptions.deleteRecursively
 
       val registerLeaf: Text = Uuid().show
       val outer: Path on Linux = unsafely((% / "tmp" / registerLeaf).on[Linux])
@@ -418,9 +418,9 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == true)
 
     suite(m"Glob expansion"):
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
-      import filesystemOptions.dereferenceSymlinks.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
+      import filesystemOptions.dereferenceSymlinks
 
       val globLeaf: Text = Uuid().show
       val root: Path on Linux = unsafely((% / "tmp" / globLeaf).on[Linux])
@@ -468,9 +468,9 @@ object Tests extends Suite(m"Galilei tests"):
 
     suite(m"File locking"):
       import errorDiagnostics.stackTracesDiagnostics
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
-      import filesystemOptions.deleteRecursively.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
+      import filesystemOptions.deleteRecursively
 
       val lockDirLeaf: Text = Uuid().show
       val lockDir: Path on Linux = unsafely((% / "tmp" / lockDirLeaf).on[Linux])
@@ -518,8 +518,8 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == true)
 
     suite(m"Positional reading"):
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
 
       val expanseLeaf: Text = Uuid().show
       val source: Path on Linux = unsafely((% / "tmp" / expanseLeaf).on[Linux])
@@ -579,9 +579,9 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == true)
 
     suite(m"Entry identity"):
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.deleteRecursively.enabled
-      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.deleteRecursively
+      import filesystemOptions.overwritePreexisting
 
       val identifiedLeaf: Text = Uuid().show
       val linkedLeaf: Text = Uuid().show
@@ -607,8 +607,8 @@ object Tests extends Suite(m"Galilei tests"):
 
     suite(m"Shared locking"):
       import errorDiagnostics.stackTracesDiagnostics
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
 
       val sharedLeaf: Text = Uuid().show
       val shared: Path on Linux = unsafely((% / "tmp" / sharedLeaf).on[Linux])
@@ -640,8 +640,8 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == Io.Error.Reason.Busy)
 
     suite(m"Awaited locking"):
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
       import threading.platformThreading
 
       val awaitLeaf: Text = Uuid().show
@@ -673,8 +673,8 @@ object Tests extends Suite(m"Galilei tests"):
 
     suite(m"Slice locking"):
       import errorDiagnostics.stackTracesDiagnostics
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
 
       val sliceLeaf: Text = Uuid().show
       val sliced: Path on Linux = unsafely((% / "tmp" / sliceLeaf).on[Linux])
@@ -712,8 +712,8 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == Io.Error.Reason.Busy)
 
     suite(m"Extended attributes"):
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
 
       val xattrLeaf: Text = Uuid().show
       val xattred: Path on Linux = unsafely((% / "tmp" / xattrLeaf).on[Linux])
@@ -740,8 +740,8 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == true)
 
     suite(m"Slice windows write"):
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
       import charDecoders.utf8Decoder
       import textSanitizers.skipSanitizer
 
@@ -774,8 +774,8 @@ object Tests extends Suite(m"Galilei tests"):
       . assert(_ == 0)
 
     suite(m"Searchpaths"):
-      import filesystemOptions.createNonexistentParents.enabled
-      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.createNonexistentParents
+      import filesystemOptions.overwritePreexisting
       import interfaces.paths.pathOnLinux
 
       val spLeafA: Text = t"sp-a-${Uuid().show}"

--- a/lib/gastronomy/src/core-jvm/gastronomy.JavaBaseHashing.scala
+++ b/lib/gastronomy/src/core-jvm/gastronomy.JavaBaseHashing.scala
@@ -30,9 +30,60 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package caesura
+package gastronomy
 
-import rudiments.*
+import scala.caps
 
-object dynamicDsvAccess:
-  inline given enabled: DynamicDsvEnabler = !!
+import java.security as js
+import java.util.zip as juz
+
+import anticipation.*
+import corpuscular.*
+import gossamer.*
+
+// The default hashing provider, backed by the JDK: `MessageDigest` for the
+// cryptographic hashes and `java.util.zip.CRC32` for the checksum. This is the
+// single home of `java.security`/`java.util.zip` usage in gastronomy. It does not
+// offer BLAKE3 (the JDK has no implementation) — use the Soundness provider.
+object JavaBaseHashing extends Hashing:
+  def md5:  Hashing.Function = messageDigest(t"MD5")
+  def sha1: Hashing.Function = messageDigest(t"SHA1")
+  def sha2(bits: Int): Hashing.Function = messageDigest(t"SHA-$bits")
+
+  // The JDK has `java.util.zip` CRC-32 and Adler-32 (both intrinsified) but no CRC-64, so this
+  // provider simply does not offer `crc64`; the structural refinement means a CRC-64 digest
+  // resolves only under the Soundness provider, exactly as BLAKE3 does.
+  def adler32: Hashing.Function = new Hashing.Function:
+    def digestion(): Digestion^ = new Digestion:
+      private val state: juz.Adler32 = juz.Adler32()
+      update def append(bytes: Data): Unit = state.update(Array.unsafeJvm(bytes))
+
+      override update def append(array: Array[Byte]^{caps.any.rd}, start: Int, count: Int): Unit =
+        state.update(Array.unsafeJvm(array), start, count)
+
+      update def digest(): Data =
+        val v = state.getValue
+        Array(((v >>> 24) & 0xff).toByte, ((v >>> 16) & 0xff).toByte, ((v >>> 8) & 0xff).toByte,
+              (v & 0xff).toByte)
+
+  def crc32: Hashing.Function = new Hashing.Function:
+    def digestion(): Digestion^ = new Digestion:
+      private val state: juz.CRC32 = juz.CRC32()
+      update def append(bytes: Data): Unit = state.update(Array.unsafeJvm(bytes))
+
+      override update def append(array: Array[Byte]^{caps.any.rd}, start: Int, count: Int): Unit =
+        state.update(Array.unsafeJvm(array), start, count)
+
+      update def digest(): Data =
+        val value = state.getValue()
+        Array[Byte]((value >> 24).toByte, (value >> 16).toByte, (value >> 8).toByte, value.toByte)
+
+  private def messageDigest(name: Text): Hashing.Function = new Hashing.Function:
+    def digestion(): Digestion^ = new Digestion:
+      private val md: js.MessageDigest = js.MessageDigest.getInstance(name.s).nn
+      update def append(bytes: Data): Unit = md.update(Array.unsafeJvm(bytes))
+
+      override update def append(array: Array[Byte]^{caps.any.rd}, start: Int, count: Int): Unit =
+        md.update(Array.unsafeJvm(array), start, count)
+
+      update def digest(): Data = Array.unsafeFrozen(md.digest.nn)

--- a/lib/gastronomy/src/core-native/gastronomy.JavaBaseHashing.scala
+++ b/lib/gastronomy/src/core-native/gastronomy.JavaBaseHashing.scala
@@ -30,9 +30,19 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package jacinta
+package gastronomy
 
-import rudiments.*
+// Off the JVM (Scala.js and WASI) there is no `java.security.MessageDigest`, so the
+// "JavaBase" provider forwards to the pure-Scala implementations in `SoundnessHashing`. This
+// keeps `import providers.javaBaseProvider` working identically on every platform — code that
+// selects it gets native hashing on the JVM and the pure port elsewhere, with no source change.
+object JavaBaseHashing extends Hashing:
+  def md5:  Hashing.Function = SoundnessHashing.md5
+  def sha1: Hashing.Function = SoundnessHashing.sha1
+  def sha2(bits: Int): Hashing.Function = SoundnessHashing.sha2(bits)
+  def crc32: Hashing.Function = SoundnessHashing.crc32
 
-object dynamicJsonAccess:
-  inline given enabled: DynamicJsonEnabler = !!
+  // The checksums forward too, so `.digest[Crc32]`/`.digest[Adler32]` resolve under this
+  // provider on every platform. CRC-64 is deliberately absent here as it is on the JVM: no
+  // `java.util.zip` equivalent exists, so it is reached through the Soundness provider only.
+  def adler32: Hashing.Function = SoundnessHashing.adler32

--- a/lib/gastronomy/src/core/gastronomy.Concession.scala
+++ b/lib/gastronomy/src/core/gastronomy.Concession.scala
@@ -33,7 +33,7 @@
 package gastronomy
 
 // A "concession" is a specific cryptographic weakness a caller must explicitly
-// accept (via a `crypto.permit…Crypto` import) before the corresponding algorithm,
+// accept (via a `cryptoPermits.permit…Crypto` import) before the corresponding algorithm,
 // key length or mode can be used. `Acceptable` is the absence of any weakness.
 //
 // All concession markers live here in gastronomy (the lowest crypto module) so the

--- a/lib/gastronomy/src/core/gastronomy.Hashing.scala
+++ b/lib/gastronomy/src/core/gastronomy.Hashing.scala
@@ -41,10 +41,10 @@ object Hashing:
     def digestion(): Digestion^
 
   // The JDK provider supplies hashing whenever it has been selected with
-  // `import providers.javaStdlibProvider`. Ambient here (in `Hashing`'s implicit
+  // `import providers.javaBaseProvider`. Ambient here (in `Hashing`'s implicit
   // scope) so the single provider import enables both hashing and cryptography.
-  given javaStdlibHashing(using Provider.JavaStdlib.type): JavaStdlibHashing.type =
-    JavaStdlibHashing
+  given javaBaseHashing(using Provider.JavaBase.type): JavaBaseHashing.type =
+    JavaBaseHashing
 
 // A pluggable hashing provider: it supplies the implementation of each hash
 // function as a `Hashing.Function` (a factory for fresh `Digestion`s). Providers
@@ -52,5 +52,5 @@ object Hashing:
 // (with no JDK implementation) is supplied by the pure-Scala Soundness provider —
 // so each algorithm is reached through a structural refinement rather than a
 // mandatory baseline. Select providers with explicit imports, e.g.
-// `import providers.javaStdlibProvider, providers.soundnessProvider`.
+// `import providers.javaBaseProvider, providers.soundnessProvider`.
 trait Hashing

--- a/lib/gastronomy/src/core/gastronomy.Permit.scala
+++ b/lib/gastronomy/src/core/gastronomy.Permit.scala
@@ -41,13 +41,13 @@ import scala.annotation.implicitNotFound
 // `ProcessingPermit` allows *processing already-protected* data (decrypt/verify),
 // while `Permit` (a subtype) additionally allows *applying new protection*
 // (encrypt/sign/hash). Both are erased — purely compile-time gates with no runtime
-// cost. Bring them into scope with a `crypto.permit…Crypto` import. Defined here in
+// cost. Bring them into scope with a `cryptoPermits.permit…Crypto` import. Defined here in
 // gastronomy so both gastronomy (weak hashes) and enigmatic (weak ciphers) share
 // one permit vocabulary.
 
 @implicitNotFound("this operation uses an algorithm whose status is \"legacy use\" or worse; "+
-    "import a permit (e.g. `crypto.permitLegacyCrypto` to process existing data, or "+
-    "`crypto.permitDisallowedCrypto`) to allow it")
+    "import a permit (e.g. `cryptoPermits.permitLegacyCrypto` to process existing data, or "+
+    "`cryptoPermits.permitDisallowedCrypto`) to allow it")
 object ProcessingPermit:
   erased given acceptable: ProcessingPermit[Concession.Acceptable] = caps.unsafe.unsafeErasedValue
 
@@ -55,9 +55,9 @@ trait ProcessingPermit[concession]
 
 @implicitNotFound("this operation uses a sub-optimal algorithm, key length or mode — or a "+
     "checksum in place of a hash; import the matching permit "+
-    "(`crypto.permitNonCryptographicHashes` for CRC-32/CRC-64/Adler-32, or "+
-    "`crypto.permitUnauthenticatedCrypto`, `crypto.permitDeprecatedCrypto` or "+
-    "`crypto.permitDisallowedCrypto`) to allow it")
+    "(`cryptoPermits.permitNonCryptographicHashes` for CRC-32/CRC-64/Adler-32, or "+
+    "`cryptoPermits.permitUnauthenticatedCrypto`, `cryptoPermits.permitDeprecatedCrypto` or "+
+    "`cryptoPermits.permitDisallowedCrypto`) to allow it")
 object Permit:
   // `Acceptable` crypto needs no permission, so this permit is always available.
   erased given acceptable: Permit[Concession.Acceptable] = caps.unsafe.unsafeErasedValue

--- a/lib/gastronomy/src/core/gastronomy.Provider.scala
+++ b/lib/gastronomy/src/core/gastronomy.Provider.scala
@@ -40,4 +40,4 @@ package gastronomy
 // have no marker: their `providers` given supplies the capability directly.
 object Provider:
   // The JDK provider: `MessageDigest`/`CRC32` hashing and JCE cryptography.
-  object JavaStdlib
+  object JavaBase

--- a/lib/gastronomy/src/core/gastronomy.SoundnessHashing.scala
+++ b/lib/gastronomy/src/core/gastronomy.SoundnessHashing.scala
@@ -37,8 +37,8 @@ import corpuscular.*
 // A complete pure-Scala hashing provider: BLAKE3 (which the JDK does not implement) plus MD5,
 // SHA-1 and the SHA-2 family (implemented in `PureHashes`), plus the corpuscular checksums, so
 // hashing is available on
-// every platform. On the JVM the JDK-backed `JavaStdlibHashing` remains the default, delegating
-// to native `MessageDigest`; off the JVM (`JavaStdlibHashing`'s native variant) it forwards here.
+// every platform. On the JVM the JDK-backed `JavaBaseHashing` remains the default, delegating
+// to native `MessageDigest`; off the JVM (`JavaBaseHashing`'s native variant) it forwards here.
 // Select it explicitly with `import providers.soundnessProvider`.
 object SoundnessHashing extends Hashing:
   def blake3: Hashing.Function = new Hashing.Function:

--- a/lib/gastronomy/src/core/gastronomy_core.scala
+++ b/lib/gastronomy/src/core/gastronomy_core.scala
@@ -44,14 +44,14 @@ import turbulence.*
 import zephyrine.*
 
 // Capability providers. Pick one (or more) with an explicit import, e.g.
-// `import providers.javaStdlibProvider` for the JDK (which enables both hashing
+// `import providers.javaBaseProvider` for the JDK (which enables both hashing
 // and, in enigmatic, cryptography) and `import providers.soundnessProvider` for
 // BLAKE3 hashing. The JDK provider is a marker that the `Hashing` and `Crypto`
 // companions derive their implementations from; single-capability providers
 // supply their capability object's singleton type directly, so the
 // structurally-typed algorithms it offers stay visible to the per-algorithm givens.
 package providers:
-  given javaStdlibProvider: Provider.JavaStdlib.type = Provider.JavaStdlib
+  given javaBaseProvider: Provider.JavaBase.type = Provider.JavaBase
   given soundnessProvider: SoundnessHashing.type = SoundnessHashing
 
 // Opt-in permits for sub-optimal cryptography, named after NIST SP 800-131A's
@@ -59,7 +59,7 @@ package providers:
 // covering both hashes (here) and ciphers (added downstream by enigmatic). The
 // levels nest by inclusion: `permitDisallowedCrypto` contains every other permit,
 // and since `Permit <: ProcessingPermit` it also covers "legacy use".
-package crypto:
+package cryptoPermits:
   // Unauthenticated (non-AEAD) encryption — every block-cipher mode (enigmatic).
   erased given permitUnauthenticatedCrypto: Permit[Concession.Unauthenticated] =
     caps.unsafe.unsafeErasedValue

--- a/lib/gastronomy/src/core/soundness_gastronomy_core.scala
+++ b/lib/gastronomy/src/core/soundness_gastronomy_core.scala
@@ -35,14 +35,14 @@ package soundness
 export
   gastronomy
   . { Blake3, checksum, Concession, Digest, digest, Digester, Digestible,
-      Feistel, Hash, Hashing, JavaStdlibHashing, Md5, Permit, ProcessingPermit, Provider,
+      Feistel, Hash, Hashing, JavaBaseHashing, Md5, Permit, ProcessingPermit, Provider,
       Sha1, Sha2, Sha384, Sha512, SoundnessHashing }
 
 package providers:
-  export gastronomy.providers.{javaStdlibProvider, soundnessProvider}
+  export gastronomy.providers.{javaBaseProvider, soundnessProvider}
 
-package crypto:
-  export gastronomy.crypto.{permitUnauthenticatedCrypto, permitDeprecatedCrypto, permitLegacyCrypto,
+package cryptoPermits:
+  export gastronomy.cryptoPermits.{permitUnauthenticatedCrypto, permitDeprecatedCrypto, permitLegacyCrypto,
       permitDisallowedCrypto, permitCryptoThrough2014, permitCryptoThrough2024,
       permitCryptoThrough2030, permitLegacyTls, permitUntrustedCertificates,
       permitUncheckedRevocation, permitNonCryptographicHashes}

--- a/lib/gastronomy/src/test/gastronomy_test.scala
+++ b/lib/gastronomy/src/test/gastronomy_test.scala
@@ -34,8 +34,8 @@ package gastronomy
 
 import soundness.*
 
-import providers.javaStdlibProvider, providers.soundnessProvider
-import crypto.permitDisallowedCrypto   // the suite exercises MD5 and SHA-1
+import providers.javaBaseProvider, providers.soundnessProvider
+import cryptoPermits.permitDisallowedCrypto   // the suite exercises MD5 and SHA-1
 
 import alphabets.hexUpperCase
 
@@ -246,20 +246,20 @@ object Tests extends Suite(m"Gastronomy tests"):
       . assert(_ == whole(SoundnessHashing.adler32.digestion()))
 
       test(m"windowed JDK Adler-32 matches whole-value append"):
-        windowed(JavaStdlibHashing.adler32.digestion())
-      . assert(_ == whole(JavaStdlibHashing.adler32.digestion()))
+        windowed(JavaBaseHashing.adler32.digestion())
+      . assert(_ == whole(JavaBaseHashing.adler32.digestion()))
 
       test(m"windowed BLAKE3 matches whole-value append"):
         windowed(Blake3.digestion())
       . assert(_ == whole(Blake3.digestion()))
 
       test(m"windowed JDK SHA-256 matches whole-value append"):
-        windowed(JavaStdlibHashing.sha2(256).digestion())
-      . assert(_ == whole(JavaStdlibHashing.sha2(256).digestion()))
+        windowed(JavaBaseHashing.sha2(256).digestion())
+      . assert(_ == whole(JavaBaseHashing.sha2(256).digestion()))
 
       test(m"windowed JDK CRC-32 matches whole-value append"):
-        windowed(JavaStdlibHashing.crc32.digestion())
-      . assert(_ == whole(JavaStdlibHashing.crc32.digestion()))
+        windowed(JavaBaseHashing.crc32.digestion())
+      . assert(_ == whole(JavaBaseHashing.crc32.digestion()))
 
       val chunked: Chain[Data] = payload.readable.grouped(7777).map(Array.frozen(_)).to(Chain)
 
@@ -276,17 +276,17 @@ object Tests extends Suite(m"Gastronomy tests"):
     // the same single import. `123456789` has the published CRC-32 check value 0xcbf43926.
     // Each digest additionally concedes that a checksum is not a hash.
     suite(m"Checksums through the digest API"):
-      import crypto.permitNonCryptographicHashes
+      import cryptoPermits.permitNonCryptographicHashes
 
       test(m"CRC-32 of the standard check vector, via the JDK provider"):
-        import providers.javaStdlibProvider
+        import providers.javaBaseProvider
         t"123456789".digest[Crc32].serialize[Hex].lower
       . assert(_ == t"cbf43926")
 
       test(m"CRC-32 agrees between the JDK and Soundness providers"):
         val jdk =
           locally:
-            import providers.javaStdlibProvider
+            import providers.javaBaseProvider
             t"123456789".digest[Crc32].serialize[Hex]
 
         val pure =
@@ -300,7 +300,7 @@ object Tests extends Suite(m"Gastronomy tests"):
       test(m"Adler-32 agrees between the JDK and Soundness providers"):
         val jdk =
           locally:
-            import providers.javaStdlibProvider
+            import providers.javaBaseProvider
             t"123456789".digest[Adler32].serialize[Hex]
 
         val pure =
@@ -321,14 +321,14 @@ object Tests extends Suite(m"Gastronomy tests"):
     suite(m"The non-cryptographic concession"):
       test(m"digesting with a checksum needs the permit"):
         demilitarize:
-          import providers.javaStdlibProvider
+          import providers.javaBaseProvider
           t"123456789".digest[Crc32]
         . map(_.message)
       . assert(_.nonEmpty)
 
       test(m"digesting with SHA-2 needs no permit"):
         demilitarize:
-          import providers.javaStdlibProvider
+          import providers.javaBaseProvider
           t"123456789".digest[Sha2[256]]
       . assert(_ == Nil)
 
@@ -336,7 +336,7 @@ object Tests extends Suite(m"Gastronomy tests"):
     // vectors (multiformats/multihash `tests/values/test_cases.csv`): the input bytes are hashed,
     // enveloped, and the result compared to the multihash the vector gives.
     suite(m"Multihash"):
-      import providers.javaStdlibProvider
+      import providers.javaBaseProvider
       import strategies.throwUnsafely
       import errorDiagnostics.stackTracesDiagnostics
 

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -606,7 +606,7 @@ given collationComparable: (collation: Collation) => Text is Comparable =
 package collations:
   // Dictionary order: the root table of the Unicode Collation Algorithm (UTS #10),
   // non-ignorable, with three levels. Language-specific orderings tailor this table.
-  given unicode: Collation:
+  given unicodeCollation: Collation:
     def compare(left: Text, right: Text): Comparison =
       Comparison(hieroglyph.CollationTable.root.compare(left, right))
 
@@ -615,7 +615,7 @@ package collations:
   // Raw codepoint order: deterministic and table-free, for machine-facing sorting such as
   // stable file listings. Not `String` order, which compares UTF-16 code units and so places
   // supplementary characters before U+E000..U+FFFF.
-  given codepoints: Collation:
+  given codepointCollation: Collation:
     def compare(left: Text, right: Text): Comparison =
       val leftString = left.s
       val rightString = right.s

--- a/lib/gossamer/src/core/soundness_gossamer_core.scala
+++ b/lib/gossamer/src/core/soundness_gossamer_core.scala
@@ -60,4 +60,4 @@ package caseSensitivity:
   export gossamer.caseSensitivity.{caseInsensitive, caseSensitive, smartCase}
 
 package collations:
-  export gossamer.collations.{codepoints, unicode}
+  export gossamer.collations.{codepointCollation, unicodeCollation}

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -1378,27 +1378,27 @@ object Tests extends Suite(m"Gossamer Tests"):
       . assert(_.exists(_.contains("is symbolism.Comparable")))
 
       test(m"dictionary order ranks accents before case: cafe < café < caff"):
-        import collations.unicode
+        import collations.unicodeCollation
         proscenium.List(t"caff", t"café", t"cafe").sort
       . assert(_ == proscenium.List(t"cafe", t"café", t"caff"))
 
       test(m"comparison operators work once a collation is chosen"):
-        import collations.unicode
+        import collations.unicodeCollation
         t"apple" < t"banana"
       . assert(_ == true)
 
       test(m"codepoint order sorts supplementary characters after the BMP"):
-        import collations.codepoints
+        import collations.codepointCollation
         proscenium.List(t"𝓐", t"�").sort
       . assert(_ == proscenium.List(t"�", t"𝓐"))
 
       test(m"codepoint and dictionary orders differ on case"):
         val upper = proscenium.List(t"a", t"B")
-        import collations.unicode
+        import collations.unicodeCollation
         val dictionary = upper.sort
 
         val codepoint =
-          import collations.codepoints
+          import collations.codepointCollation
           upper.sort
 
         (dictionary, codepoint)

--- a/lib/graffiti/src/core/graffiti.Archetype.scala
+++ b/lib/graffiti/src/core/graffiti.Archetype.scala
@@ -36,7 +36,7 @@ import scala.caps
 
 import anticipation.*
 import cataclysm.*
-import cataclysm.formatting.standardCssFormatting
+import cataclysm.formatting.indentedCssFormatting
 import gesticulate.*
 import gossamer.*
 import honeycomb.*

--- a/lib/graffiti/src/test/graffiti_test.scala
+++ b/lib/graffiti/src/test/graffiti_test.scala
@@ -35,7 +35,7 @@ package graffiti
 import soundness.*
 
 import doms.html.whatwg.*
-import formatting.standardCssFormatting
+import formatting.indentedCssFormatting
 import strategies.throwUnsafely
 import parasite.probates.awaitProbate
 import parasite.threading.virtualThreading

--- a/lib/guillotine/src/test/guillotine_test.scala
+++ b/lib/guillotine/src/test/guillotine_test.scala
@@ -34,7 +34,7 @@ package guillotine
 
 import soundness.*
 
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 import abstractables.millisecondsAbstractable
 import strategies.throwUnsafely
 import errorDiagnostics.emptyDiagnostics

--- a/lib/harlequin/src/md/punctuation_harlequin_md.scala
+++ b/lib/harlequin/src/md/punctuation_harlequin_md.scala
@@ -43,13 +43,13 @@ import vacuous.*
 import doms.html.whatwg, whatwg.*
 
 package formattables:
-  given scala: ("scala" is CommonFormattable) = new CommonFormattable:
+  given scalaFormattable: ("scala" is CommonFormattable) = new CommonFormattable:
     type Self = "scala"
 
     def format(meta: List[Text], content: Text): Optional[Html of Flow] =
       postprocess(Scala.highlight(content)).unless(_ => meta.prim != t"scala")
 
-  given java: ("java" is CommonFormattable) = new CommonFormattable:
+  given javaFormattable: ("java" is CommonFormattable) = new CommonFormattable:
     type Self = "java"
 
     def format(meta: List[Text], content: Text): Optional[Html of Flow] =

--- a/lib/harlequin/src/md/soundness_harlequin_md.scala
+++ b/lib/harlequin/src/md/soundness_harlequin_md.scala
@@ -35,4 +35,4 @@ package soundness
 export harlequin.{CommonFormattable}
 
 package formattables:
-  export punctuation.formattables.{java, scala}
+  export punctuation.formattables.{javaFormattable, scalaFormattable}

--- a/lib/harlequin/src/test/harlequin_test.scala
+++ b/lib/harlequin/src/test/harlequin_test.scala
@@ -40,7 +40,7 @@ import soundness.*
 // `Fragment` from another file; the by-name import restores it.
 import harlequin.Fragment
 
-import ambience.systems.javaSystem
+import ambience.systems.javaBaseSystem
 import denominative.dysasymptotics.linearSize
 
 // A `Dynamic` type with a `Completable` companion, exercising the dynamic-completions route: its

--- a/lib/hellenism/src/jvm/hellenism.LocalClasspath.scala
+++ b/lib/hellenism/src/jvm/hellenism.LocalClasspath.scala
@@ -44,7 +44,7 @@ import serpentine.*
 import spectacular.*
 import symbolism.*
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 object LocalClasspath:
   given encodable: System => LocalClasspath is Encodable in Text = _()

--- a/lib/hellenism/src/test/hellenism_test.scala
+++ b/lib/hellenism/src/test/hellenism_test.scala
@@ -69,7 +69,7 @@ object Tests extends Suite(m"Hellenism Tests"):
     . assert(_ == List(t"hellenism: the path foobar is not a valid classpath path"))
 
     test(m"load services from META-INF/services"):
-      import systems.javaSystem
+      import systems.javaBaseSystem
       val classpath = unsafely(System.properties.java.`class`.path().as[LocalClasspath])
       classpath.services[TestService].stdlib.map(_.name).to(Set)
     . assert(_ == Set(t"A", t"B"))

--- a/lib/honeycomb/src/bench/honeycomb.Benchmarks.scala
+++ b/lib/honeycomb/src/bench/honeycomb.Benchmarks.scala
@@ -34,7 +34,7 @@ package honeycomb
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import doms.html.whatwg

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -584,7 +584,7 @@ object Html extends Tag.Container
   // `Iterator[Text]` (pulls chunks via the loader). Slicing is uniform
   // (one buffer; one `arraycopy`) so there's no separate same-block fast
   // path versus cross-block grab path. Line/column tracking is delegated
-  // to Cursor via `linefeedChars` lineation, so `computePosition` is
+  // to Cursor via `linefeedChar` lineation, so `computePosition` is
   // O(1) — the per-byte tracking cost is small and avoids re-walking the
   // source on each error (which used to be O(n)).
 

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -73,9 +73,9 @@ object Html extends Tag.Container
     foreign     = false,
     boundary    = true ), Format:
   // Controls how an `Html` document is serialized by `emit`. `indented` lays whitespace-mode
-  // elements out one per indented line (the default); `flatHtmlFormatting` keeps it on one line.
+  // elements out one per indented line (the default); `compactHtmlFormatting` keeps it on one line.
   // (`.show` of a bare node is always compact.) Bundled as `formatting.indentedHtmlFormatting`
-  // and `formatting.flatHtmlFormatting`.
+  // and `formatting.compactHtmlFormatting`.
   object Formatting:
     def apply(indented: Boolean): Formatting = Basic(indented)
     private case class Basic(indented: Boolean) extends Formatting

--- a/lib/honeycomb/src/core/honeycomb_core.scala
+++ b/lib/honeycomb/src/core/honeycomb_core.scala
@@ -59,7 +59,7 @@ package doms.html:
 
 package formatting:
   given indentedHtmlFormatting: Html.Formatting = Html.Formatting(indented = true)
-  given flatHtmlFormatting: Html.Formatting = Html.Formatting(indented = false)
+  given compactHtmlFormatting: Html.Formatting = Html.Formatting(indented = false)
 
 package stylesheets:
   given uncheckedClasses: [classname <: Label: ValueOf] => NotGiven[classname =:= "apply"]

--- a/lib/honeycomb/src/core/soundness_honeycomb_core.scala
+++ b/lib/honeycomb/src/core/soundness_honeycomb_core.scala
@@ -44,10 +44,13 @@ package doms.html:
   export honeycomb.doms.html.html4Transitional
 
 package formatting:
-  export honeycomb.formatting.{indentedHtmlFormatting, flatHtmlFormatting}
+  export honeycomb.formatting.{indentedHtmlFormatting, compactHtmlFormatting}
 
 package attributives:
   export honeycomb.attributives.textAttributive
 
 package stylesheets:
   export honeycomb.stylesheets.uncheckedClasses
+
+package recoveries:
+  export honeycomb.recoveries.permissiveRecovery

--- a/lib/hyperbole/src/core/hyperbole.presentation.scala
+++ b/lib/hyperbole/src/core/hyperbole.presentation.scala
@@ -54,7 +54,7 @@ import digression.StackTrace
 // elsewhere.
 given tastySymbolTeletypeable: (palette: TastyPalette) => Tasty.Symbol is Teletypeable =
   symbol =>
-    import tableStyles.defaultTableStyle
+    import tableStyles.thickTableStyle
 
     val flags =
       symbol.flags.map: (flag, on) =>
@@ -113,7 +113,7 @@ private def expandTastyTree(tree: Tasty.Tree)(using palette: TastyPalette)
         case _ :: rest => rest
         case _         => Nil
 
-      val prefix: Text = rest.map(treeStyles.defaultTreeStyle.text(_)).join
+      val prefix: Text = rest.map(treeStyles.squareTreeStyle.text(_)).join
 
       TastyTreeExpansion
         ( e"$prefix$tag2 $text",

--- a/lib/hypotenuse/src/core/hypotenuse.Arithmetic.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Arithmetic.scala
@@ -38,7 +38,7 @@ import fulminate.*
 // The failure of an arithmetic *operation*, as distinct from a value that cannot be
 // represented (`Decimal.Error`, `Rational.Error`). Division and overflow are separate
 // `Reason`s rather than separate types because they are one concept — an operation with no
-// representable result — and `arithmeticOptions.division` / `.overflow` remain independent
+// representable result — and `arithmeticOptions.checkedDivision` / `checkedOverflow` remain independent
 // imports, so a caller still chooses which checks to switch on.
 object Arithmetic:
   object Error:

--- a/lib/hypotenuse/src/core/hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse_core.scala
@@ -632,139 +632,136 @@ package arithmeticOptions:
   // Importing one of these lexically outranks the companion `divisible`, so `a/b` on
   // rationals yields a `Double` in that scope — which is what lets `std` (whose variance
   // must divide to `Double`) resolve for rational collections.
-  object rationalDivision:
-    given q64: Q64 is Divisible:
-      type Operand = Q64
-      type Result = Double
+  given q64RationalDivision: Q64 is Divisible:
+    type Operand = Q64
+    type Result = Double
 
-      def divide(dividend: Q64, divisor: Q64): Double = dividend.double/divisor.double
+    def divide(dividend: Q64, divisor: Q64): Double = dividend.double/divisor.double
 
-    given q32: Q32 is Divisible:
-      type Operand = Q32
-      type Result = Double
+  given q32RationalDivision: Q32 is Divisible:
+    type Operand = Q32
+    type Result = Double
 
-      def divide(dividend: Q32, divisor: Q32): Double = dividend.double/divisor.double
+    def divide(dividend: Q32, divisor: Q32): Double = dividend.double/divisor.double
 
-  object division:
-    inline given unchecked: DivisionByZero:
-      type Wrap[result] = result
+  inline given uncheckedDivision: DivisionByZero:
+    type Wrap[result] = result
 
-      inline def divideU64(left: U64, right: U64): U64 =
-        U64((Long(left.bits)/Long(right.bits)).bits)
+    inline def divideU64(left: U64, right: U64): U64 =
+      U64((Long(left.bits)/Long(right.bits)).bits)
 
-      inline def divideS64(left: S64, right: S64): S64 = S64((left.long/right.long).bits)
-      inline def divideU32(left: U32, right: U32): U32 = U32((Int(left.bits)/Int(right.bits)).bits)
-      inline def divideS32(left: S32, right: S32): S32 = S32((left.int/right.int).bits)
+    inline def divideS64(left: S64, right: S64): S64 = S64((left.long/right.long).bits)
+    inline def divideU32(left: U32, right: U32): U32 = U32((Int(left.bits)/Int(right.bits)).bits)
+    inline def divideS32(left: S32, right: S32): S32 = S32((left.int/right.int).bits)
 
-      inline def divideU16(left: U16, right: U16): U16 =
-        U16((Short(left.bits)/Short(right.bits)).toShort.bits)
+    inline def divideU16(left: U16, right: U16): U16 =
+      U16((Short(left.bits)/Short(right.bits)).toShort.bits)
 
-      inline def divideS16(left: S16, right: S16): S16 = S16((left.short/right.short).toShort.bits)
-      inline def divideU8(left: U8, right: U8): U8 = U8((left.byte/right.byte).toByte.bits)
-      inline def divideS8(left: S8, right: S8): S8 = S8((left.byte/right.byte).toByte.bits)
+    inline def divideS16(left: S16, right: S16): S16 = S16((left.short/right.short).toShort.bits)
+    inline def divideU8(left: U8, right: U8): U8 = U8((left.byte/right.byte).toByte.bits)
+    inline def divideS8(left: S8, right: S8): S8 = S8((left.byte/right.byte).toByte.bits)
 
-    inline given checked: DivisionByZero:
-      type Wrap[result] = result raises Arithmetic.Error
-      
-      // The overrides below keep the opaque `Wrap[X]^` spelling: written as
-      // `X raises E`, the inline bodies lose the tactic the `raises` expansion
-      // provides, and the `^` covers the expansion's existential capture.
+  inline given checkedDivision: DivisionByZero:
+    type Wrap[result] = result raises Arithmetic.Error
+    
+    // The overrides below keep the opaque `Wrap[X]^` spelling: written as
+    // `X raises E`, the inline bodies lose the tactic the `raises` expansion
+    // provides, and the `^` covers the expansion's existential capture.
 
-      inline def divideU64(left: U64, right: U64): Wrap[U64]^ =
-        if Long(right.bits) == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero))
-        else U64((Long(left.bits)/Long(right.bits)).bits)
+    inline def divideU64(left: U64, right: U64): Wrap[U64]^ =
+      if Long(right.bits) == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero))
+      else U64((Long(left.bits)/Long(right.bits)).bits)
 
-      inline def divideS64(left: S64, right: S64): Wrap[S64]^ =
-        if right.long == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero)) else S64((left.long/right.long).bits)
+    inline def divideS64(left: S64, right: S64): Wrap[S64]^ =
+      if right.long == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero)) else S64((left.long/right.long).bits)
 
-      inline def divideU32(left: U32, right: U32): Wrap[U32]^ =
-        if right.long == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero))
-        else U32((Int(left.bits)/Int(right.bits)).bits)
+    inline def divideU32(left: U32, right: U32): Wrap[U32]^ =
+      if right.long == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero))
+      else U32((Int(left.bits)/Int(right.bits)).bits)
 
-      inline def divideS32(left: S32, right: S32): Wrap[S32]^ =
-        if right.int == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero)) else S32((left.int/right.int).bits)
+    inline def divideS32(left: S32, right: S32): Wrap[S32]^ =
+      if right.int == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero)) else S32((left.int/right.int).bits)
 
-      inline def divideU16(left: U16, right: U16): Wrap[U16]^ =
-        if right.int == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero))
-        else U16((Short(left.bits)/Short(right.bits)).toShort.bits)
+    inline def divideU16(left: U16, right: U16): Wrap[U16]^ =
+      if right.int == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero))
+      else U16((Short(left.bits)/Short(right.bits)).toShort.bits)
 
-      inline def divideS16(left: S16, right: S16): Wrap[S16]^ =
-        if right.int == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero))
-        else S16((left.short/right.short).toShort.bits)
+    inline def divideS16(left: S16, right: S16): Wrap[S16]^ =
+      if right.int == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero))
+      else S16((left.short/right.short).toShort.bits)
 
-      inline def divideU8(left: U8, right: U8): Wrap[U8]^ =
-        if right.int == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero)) else U8((left.byte/right.byte).toByte.bits)
+    inline def divideU8(left: U8, right: U8): Wrap[U8]^ =
+      if right.int == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero)) else U8((left.byte/right.byte).toByte.bits)
 
-      inline def divideS8(left: S8, right: S8): Wrap[S8]^ =
-        if right.int == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero)) else S8((left.byte/right.byte).toByte.bits)
+    inline def divideS8(left: S8, right: S8): Wrap[S8]^ =
+      if right.int == 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.DivisionByZero)) else S8((left.byte/right.byte).toByte.bits)
 
-  object overflow:
-    inline given unchecked: CheckOverflow:
-      type Wrap[result] = result
+  inline given uncheckedOverflow: CheckOverflow:
+    type Wrap[result] = result
 
-      inline def addU64(left: U64, right: U64): U64 = U64((Long(left.bits) + Long(right.bits)).bits)
-      inline def addS64(left: S64, right: S64): S64 = S64((left.long + right.long).bits)
-      inline def addU32(left: U32, right: U32): U32 = U32((Int(left.bits) + Int(right.bits)).bits)
-      inline def addS32(left: S32, right: S32): S32 = S32((left.int + right.int).bits)
+    inline def addU64(left: U64, right: U64): U64 = U64((Long(left.bits) + Long(right.bits)).bits)
+    inline def addS64(left: S64, right: S64): S64 = S64((left.long + right.long).bits)
+    inline def addU32(left: U32, right: U32): U32 = U32((Int(left.bits) + Int(right.bits)).bits)
+    inline def addS32(left: S32, right: S32): S32 = S32((left.int + right.int).bits)
 
-      inline def addU16(left: U16, right: U16): U16 =
-        U16((Short(left.bits) + Short(right.bits)).toShort.bits)
+    inline def addU16(left: U16, right: U16): U16 =
+      U16((Short(left.bits) + Short(right.bits)).toShort.bits)
 
-      inline def addS16(left: S16, right: S16): S16 = S16((left.short + right.short).toShort.bits)
-      inline def addU8(left: U8, right: U8): U8 = U8((left.byte + right.byte).toByte.bits)
-      inline def addS8(left: S8, right: S8): S8 = S8((left.byte + right.byte).toByte.bits)
+    inline def addS16(left: S16, right: S16): S16 = S16((left.short + right.short).toShort.bits)
+    inline def addU8(left: U8, right: U8): U8 = U8((left.byte + right.byte).toByte.bits)
+    inline def addS8(left: S8, right: S8): S8 = S8((left.byte + right.byte).toByte.bits)
 
-    inline given checked: CheckOverflow:
-      type Wrap[result] = result raises Arithmetic.Error
-      
-      // The overrides below keep the opaque `Wrap[X]^` spelling: written as
-      // `X raises E`, the inline bodies lose the tactic the `raises` expansion
-      // provides, and the `^` covers the expansion's existential capture.
+  inline given checkedOverflow: CheckOverflow:
+    type Wrap[result] = result raises Arithmetic.Error
+    
+    // The overrides below keep the opaque `Wrap[X]^` spelling: written as
+    // `X raises E`, the inline bodies lose the tactic the `raises` expansion
+    // provides, and the `^` covers the expansion's existential capture.
 
-      inline def addU64(left: U64, right: U64): Wrap[U64]^ =
-        val result: B64 = (Long(left.bits) + Long(right.bits)).bits
+    inline def addU64(left: U64, right: U64): Wrap[U64]^ =
+      val result: B64 = (Long(left.bits) + Long(right.bits)).bits
 
-        if U64((left.bits^result) & (right.bits^result)) < U64(0.bits)
-        then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow))
-        else U64(result)
+      if U64((left.bits^result) & (right.bits^result)) < U64(0.bits)
+      then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow))
+      else U64(result)
 
-      inline def addS64(left: S64, right: S64): Wrap[S64]^ =
-        val sum: Long = left.long + right.long
+    inline def addS64(left: S64, right: S64): Wrap[S64]^ =
+      val sum: Long = left.long + right.long
 
-        if ((left.long^sum) & (right.long^sum)) < 0L then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow)) else S64(sum.bits)
+      if ((left.long^sum) & (right.long^sum)) < 0L then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow)) else S64(sum.bits)
 
-      inline def addU32(left: U32, right: U32): Wrap[U32]^ =
-        val result: B32 = (Int(left.bits) + Int(right.bits)).bits
+    inline def addU32(left: U32, right: U32): Wrap[U32]^ =
+      val result: B32 = (Int(left.bits) + Int(right.bits)).bits
 
-        if U32((left.bits^result) & (right.bits^result)) < U32(0.bits)
-        then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow))
-        else U32(result)
+      if U32((left.bits^result) & (right.bits^result)) < U32(0.bits)
+      then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow))
+      else U32(result)
 
-      inline def addS32(left: S32, right: S32): Wrap[S32]^ =
-        val sum: Int = left.int + right.int
+    inline def addS32(left: S32, right: S32): Wrap[S32]^ =
+      val sum: Int = left.int + right.int
 
-        if ((left.int^sum) & (right.int^sum)) < 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow)) else S32(sum.bits)
+      if ((left.int^sum) & (right.int^sum)) < 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow)) else S32(sum.bits)
 
-      inline def addU16(left: U16, right: U16): Wrap[U16]^ =
-        val result: B16 = (Short(left.bits) + Short(right.bits)).toShort.bits
+    inline def addU16(left: U16, right: U16): Wrap[U16]^ =
+      val result: B16 = (Short(left.bits) + Short(right.bits)).toShort.bits
 
-        if U16((left.bits^result) & (right.bits^result)) < U16(0.toShort.bits)
-        then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow))
-        else U16(result)
+      if U16((left.bits^result) & (right.bits^result)) < U16(0.toShort.bits)
+      then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow))
+      else U16(result)
 
-      inline def addS16(left: S16, right: S16): Wrap[S16]^ =
-        val sum: Short = (left.short + right.short).toShort
+    inline def addS16(left: S16, right: S16): Wrap[S16]^ =
+      val sum: Short = (left.short + right.short).toShort
 
-        if ((left.short^sum) & (right.short^sum)) < 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow)) else S16(sum.bits)
+      if ((left.short^sum) & (right.short^sum)) < 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow)) else S16(sum.bits)
 
-      inline def addU8(left: U8, right: U8): Wrap[U8]^ =
-        val result: B8 = (left.short + right.short).toByte.bits
+    inline def addU8(left: U8, right: U8): Wrap[U8]^ =
+      val result: B8 = (left.short + right.short).toByte.bits
 
-        if U8((left.bits^result) & (right.bits^result)) < U8(0.toByte.bits)
-        then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow))
-        else U8(result)
+      if U8((left.bits^result) & (right.bits^result)) < U8(0.toByte.bits)
+      then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow))
+      else U8(result)
 
-      inline def addS8(left: S8, right: S8): Wrap[S8]^ =
-        val sum: Byte = (left.short + right.short).toByte
+    inline def addS8(left: S8, right: S8): Wrap[S8]^ =
+      val sum: Byte = (left.short + right.short).toByte
 
-        if ((left.short^sum) & (right.short^sum)) < 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow)) else S8(sum.bits)
+      if ((left.short^sum) & (right.short^sum)) < 0 then abort(Arithmetic.Error(Arithmetic.Error.Reason.Overflow)) else S8(sum.bits)

--- a/lib/hypotenuse/src/core/soundness_hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/soundness_hypotenuse_core.scala
@@ -43,4 +43,7 @@ export
       max, maximize, maximum, median, Decimal, Q32, Q64, Rational }
 
 package arithmeticOptions:
-  export hypotenuse.arithmeticOptions.{division, overflow, rationalDivision}
+  export
+    hypotenuse.arithmeticOptions
+    . { checkedDivision, checkedOverflow, q32RationalDivision, q64RationalDivision, uncheckedDivision,
+        uncheckedOverflow }

--- a/lib/hypotenuse/src/test/hypotenuse_test.scala
+++ b/lib/hypotenuse/src/test/hypotenuse_test.scala
@@ -161,7 +161,7 @@ object Tests extends Suite(m"Hypotenuse tests"):
       . assert(_ == t"177777")
 
     suite(m"Signed overflow detection"):
-      import arithmeticOptions.overflow.checked
+      import arithmeticOptions.checkedOverflow
       val co = summon[CheckOverflow]
 
       test(m"S64.MinValue + S64(-1) overflows"):
@@ -831,7 +831,7 @@ object Tests extends Suite(m"Hypotenuse tests"):
       . assert(_.lay(false)(_ == Q64(2, 3)))
 
       test(m"std resolves with the rationalDivision import"):
-        import arithmeticOptions.rationalDivision.q64
+        import arithmeticOptions.q64RationalDivision
         List(Q64(1), Q64(2), Q64(3)).std
       . assert(_.lay(false) { value => math.abs(value.double - math.sqrt(2.0/3.0)) < 1e-12 })
 

--- a/lib/iridescence/src/core/iridescence.Mixing.scala
+++ b/lib/iridescence/src/core/iridescence.Mixing.scala
@@ -41,7 +41,7 @@ package iridescence
 //
 // There is deliberately no default instance in this companion. A mode reachable through the
 // implicit scope would be found whenever the imported one did not apply — mixing CIELAB under
-// `import mixing.multiply` would quietly fall back to a proportional mix rather than being
+// `import mixing.multiplyMixing` would quietly fall back to a proportional mix rather than being
 // rejected — so the mode is always named by an import from `mixing`.
 trait Mixing:
   type Self <: Color

--- a/lib/iridescence/src/core/iridescence_core.scala
+++ b/lib/iridescence/src/core/iridescence_core.scala
@@ -62,42 +62,42 @@ package mixing:
   // The layer replaces the backdrop, so mixing it back in proportion leaves a plain weighted
   // average — what pairwise `mix` does, and the only mode that means anything in a space whose
   // coordinates are not confined to 0..1.
-  given proportional: [topic <: Color] => topic is Mixing = (_, layer) => layer
+  given proportionalMixing: [topic <: Color] => topic is Mixing = (_, layer) => layer
 
-  given multiply: [topic <: Color: Tonal] => topic is Mixing =
+  given multiplyMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) => backdrop*layer
 
-  given screen: [topic <: Color: Tonal] => topic is Mixing =
+  given screenMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) => backdrop + layer - backdrop*layer
 
-  given darken: [topic <: Color: Tonal] => topic is Mixing =
+  given darkenMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) => math.min(backdrop, layer)
 
-  given lighten: [topic <: Color: Tonal] => topic is Mixing =
+  given lightenMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) => math.max(backdrop, layer)
 
-  given difference: [topic <: Color: Tonal] => topic is Mixing =
+  given differenceMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) => math.abs(backdrop - layer)
 
-  given exclusion: [topic <: Color: Tonal] => topic is Mixing =
+  given exclusionMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) => backdrop + layer - 2*backdrop*layer
 
-  given linearDodge: [topic <: Color: Tonal] => topic is Mixing =
+  given linearDodgeMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) => math.min(1.0, backdrop + layer)
 
-  given linearBurn: [topic <: Color: Tonal] => topic is Mixing =
+  given linearBurnMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) => math.max(0.0, backdrop + layer - 1)
 
-  given hardLight: [topic <: Color: Tonal] => topic is Mixing =
+  given hardLightMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) => if layer <= 0.5 then 2*backdrop*layer else 1 - 2*(1 - backdrop)*(1 - layer)
 
   // Overlay is hard light with the two operands exchanged: the backdrop, rather than the layer,
   // decides whether the pair is multiplied or screened.
-  given overlay: [topic <: Color: Tonal] => topic is Mixing =
+  given overlayMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) =>
       if backdrop <= 0.5 then 2*backdrop*layer else 1 - 2*(1 - backdrop)*(1 - layer)
 
-  given softLight: [topic <: Color: Tonal] => topic is Mixing =
+  given softLightMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) =>
       if layer <= 0.5 then backdrop - (1 - 2*layer)*backdrop*(1 - backdrop) else
         val toward =
@@ -106,49 +106,49 @@ package mixing:
 
         backdrop + (2*layer - 1)*(toward - backdrop)
 
-  given colorDodge: [topic <: Color: Tonal] => topic is Mixing =
+  given colorDodgeMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) =>
       if backdrop == 0.0 then 0.0
       else if layer == 1.0 then 1.0
       else math.min(1.0, backdrop/(1 - layer))
 
-  given colorBurn: [topic <: Color: Tonal] => topic is Mixing =
+  given colorBurnMixing: [topic <: Color: Tonal] => topic is Mixing =
     (backdrop, layer) =>
       if backdrop == 1.0 then 1.0
       else if layer == 0.0 then 0.0
       else 1 - math.min(1.0, (1 - backdrop)/layer)
 
 package colorimetry:
-  given incandescentTungsten: Colorimetry = Colorimetry(109.850, 100, 35.585, 111.144, 100, 35.2)
+  given incandescentTungstenColorimetry: Colorimetry = Colorimetry(109.850, 100, 35.585, 111.144, 100, 35.2)
 
-  given oldDirectSunlightAtNoon: Colorimetry =
+  given oldDirectSunlightAtNoonColorimetry: Colorimetry =
     Colorimetry(99.0927, 100, 85.313, 99.178, 100, 84.3493)
 
-  given oldDaylight: Colorimetry = Colorimetry(98.074, 100, 118.232, 97.285, 100, 116.145)
-  given iccProfilePcs: Colorimetry = Colorimetry(96.422, 100, 82.521, 96.720, 100, 81.427)
-  given midMorningDaylight: Colorimetry = Colorimetry(95.682, 100, 92.149, 95.799, 100, 90.926)
-  given daylight: Colorimetry = Colorimetry(95.047, 100, 108.883, 94.811, 100, 107.304)
-  given srgb: Colorimetry = daylight
-  given adobeRgb: Colorimetry = daylight
-  given northSkyDaylight: Colorimetry = Colorimetry(94.972, 100, 122.638, 94.416, 100, 120.641)
-  given equalEnergy: Colorimetry = Colorimetry(100, 100, 100, 100, 100, 100)
-  given daylightFluorescentF1: Colorimetry = Colorimetry(92.834, 100, 103.665, 94.791, 100, 103.191)
-  given coolFluorescent: Colorimetry = Colorimetry(99.187, 100, 67.395, 103.280, 100, 69.026)
-  given whiteFluorescent: Colorimetry = Colorimetry(103.754, 100, 49.861, 108.968, 100, 51.965)
-  given warmWhiteFluorescent: Colorimetry = Colorimetry(109.147, 100, 38.813, 114.961, 100, 40.963)
-  given daylightFluorescentF5: Colorimetry = Colorimetry(90.872, 100, 98.723, 93.369, 100, 98.636)
-  given liteWhiteFluorescent: Colorimetry = Colorimetry(97.309, 100, 60.191, 102.148, 100, 62.074)
-  given daylightFluorescentF7: Colorimetry = Colorimetry(95.044, 100, 108.755, 95.792, 100, 107.687)
-  given d65Simulator: Colorimetry = daylightFluorescentF7
-  given sylvaniaF40: Colorimetry = Colorimetry(96.413, 100, 82.333, 97.115, 100, 81.135)
-  given d50Simulator: Colorimetry = sylvaniaF40
-  given coolWhiteFluorescent: Colorimetry = Colorimetry(100.365, 100, 67.868, 102.116, 100, 67.826)
-  given philipsTl85: Colorimetry = Colorimetry(96.174, 100, 81.712, 99.001, 100, 83.134)
-  given ultralume50: Colorimetry = philipsTl85
-  given philipsTl84: Colorimetry = Colorimetry(100.966, 100, 64.370, 103.866, 100, 65.627)
-  given ultralume40: Colorimetry = philipsTl84
-  given philipsTl83: Colorimetry = Colorimetry(108.046, 100, 39.228, 111.428, 100, 40.353)
-  given ultralume30: Colorimetry = philipsTl83
+  given oldDaylightColorimetry: Colorimetry = Colorimetry(98.074, 100, 118.232, 97.285, 100, 116.145)
+  given iccProfilePcsColorimetry: Colorimetry = Colorimetry(96.422, 100, 82.521, 96.720, 100, 81.427)
+  given midMorningDaylightColorimetry: Colorimetry = Colorimetry(95.682, 100, 92.149, 95.799, 100, 90.926)
+  given daylightColorimetry: Colorimetry = Colorimetry(95.047, 100, 108.883, 94.811, 100, 107.304)
+  given srgbColorimetry: Colorimetry = daylightColorimetry
+  given adobeRgbColorimetry: Colorimetry = daylightColorimetry
+  given northSkyDaylightColorimetry: Colorimetry = Colorimetry(94.972, 100, 122.638, 94.416, 100, 120.641)
+  given equalEnergyColorimetry: Colorimetry = Colorimetry(100, 100, 100, 100, 100, 100)
+  given daylightFluorescentF1Colorimetry: Colorimetry = Colorimetry(92.834, 100, 103.665, 94.791, 100, 103.191)
+  given coolFluorescentColorimetry: Colorimetry = Colorimetry(99.187, 100, 67.395, 103.280, 100, 69.026)
+  given whiteFluorescentColorimetry: Colorimetry = Colorimetry(103.754, 100, 49.861, 108.968, 100, 51.965)
+  given warmWhiteFluorescentColorimetry: Colorimetry = Colorimetry(109.147, 100, 38.813, 114.961, 100, 40.963)
+  given daylightFluorescentF5Colorimetry: Colorimetry = Colorimetry(90.872, 100, 98.723, 93.369, 100, 98.636)
+  given liteWhiteFluorescentColorimetry: Colorimetry = Colorimetry(97.309, 100, 60.191, 102.148, 100, 62.074)
+  given daylightFluorescentF7Colorimetry: Colorimetry = Colorimetry(95.044, 100, 108.755, 95.792, 100, 107.687)
+  given d65SimulatorColorimetry: Colorimetry = daylightFluorescentF7Colorimetry
+  given sylvaniaF40Colorimetry: Colorimetry = Colorimetry(96.413, 100, 82.333, 97.115, 100, 81.135)
+  given d50SimulatorColorimetry: Colorimetry = sylvaniaF40Colorimetry
+  given coolWhiteFluorescentColorimetry: Colorimetry = Colorimetry(100.365, 100, 67.868, 102.116, 100, 67.826)
+  given philipsTl85Colorimetry: Colorimetry = Colorimetry(96.174, 100, 81.712, 99.001, 100, 83.134)
+  given ultralume50Colorimetry: Colorimetry = philipsTl85Colorimetry
+  given philipsTl84Colorimetry: Colorimetry = Colorimetry(100.966, 100, 64.370, 103.866, 100, 65.627)
+  given ultralume40Colorimetry: Colorimetry = philipsTl84Colorimetry
+  given philipsTl83Colorimetry: Colorimetry = Colorimetry(108.046, 100, 39.228, 111.428, 100, 40.353)
+  given ultralume30Colorimetry: Colorimetry = philipsTl83Colorimetry
 
 package palettes:
   trait Reporting:

--- a/lib/iridescence/src/core/soundness_iridescence_core.scala
+++ b/lib/iridescence/src/core/soundness_iridescence_core.scala
@@ -44,12 +44,12 @@ export
 package colorimetry:
   export
     iridescence.colorimetry
-    . { adobeRgb, coolFluorescent, coolWhiteFluorescent, d50Simulator, d65Simulator, daylight,
-        daylightFluorescentF1, daylightFluorescentF5, daylightFluorescentF7, equalEnergy,
-        iccProfilePcs, incandescentTungsten, liteWhiteFluorescent, midMorningDaylight,
-        northSkyDaylight, oldDaylight, oldDirectSunlightAtNoon, philipsTl83, philipsTl84,
-        philipsTl85, srgb, sylvaniaF40, ultralume30, ultralume40, ultralume50, warmWhiteFluorescent,
-        whiteFluorescent }
+    . { adobeRgbColorimetry, coolFluorescentColorimetry, coolWhiteFluorescentColorimetry, d50SimulatorColorimetry, d65SimulatorColorimetry, daylightColorimetry,
+        daylightFluorescentF1Colorimetry, daylightFluorescentF5Colorimetry, daylightFluorescentF7Colorimetry, equalEnergyColorimetry,
+        iccProfilePcsColorimetry, incandescentTungstenColorimetry, liteWhiteFluorescentColorimetry, midMorningDaylightColorimetry,
+        northSkyDaylightColorimetry, oldDaylightColorimetry, oldDirectSunlightAtNoonColorimetry, philipsTl83Colorimetry, philipsTl84Colorimetry,
+        philipsTl85Colorimetry, srgbColorimetry, sylvaniaF40Colorimetry, ultralume30Colorimetry, ultralume40Colorimetry, ultralume50Colorimetry, warmWhiteFluorescentColorimetry,
+        whiteFluorescentColorimetry }
 
 package luminosity:
   export iridescence.luminosity.{darkBrightness, lightBrightness}
@@ -57,8 +57,8 @@ package luminosity:
 package mixing:
   export
     iridescence.mixing
-    . { colorBurn, colorDodge, darken, difference, exclusion, hardLight, lighten, linearBurn,
-        linearDodge, multiply, overlay, proportional, screen, softLight }
+    . { colorBurnMixing, colorDodgeMixing, darkenMixing, differenceMixing, exclusionMixing, hardLightMixing, lightenMixing, linearBurnMixing,
+        linearDodgeMixing, multiplyMixing, overlayMixing, proportionalMixing, screenMixing, softLightMixing }
 
 package themes:
   export iridescence.themes.solarizedTheme

--- a/lib/iridescence/src/test/iridescence_test.scala
+++ b/lib/iridescence/src/test/iridescence_test.scala
@@ -36,7 +36,7 @@ import scala.compiletime
 
 import soundness.*
 
-given Colorimetry = colorimetry.daylight
+given Colorimetry = colorimetry.daylightColorimetry
 
 object Tests extends Suite(m"Iridescence tests"):
   def run(): Unit =
@@ -201,7 +201,7 @@ object Tests extends Suite(m"Iridescence tests"):
       . assert(_ == Srgb(0.5, 0.5, 0.5))
 
     suite(m"Proportional mixing"):
-      import mixing.proportional
+      import mixing.proportionalMixing
 
       given Srgb is Checkable against Srgb = (left, right) =>
         left.red === (right.red +/- 1e-9)
@@ -269,63 +269,63 @@ object Tests extends Suite(m"Iridescence tests"):
         && left.blue === (right.blue +/- 1e-9)
 
       test(m"multiply darkens toward the product of the channels"):
-        import mixing.multiply
+        import mixing.multiplyMixing
         (1*Srgb(1.0, 0.5, 0.5) + 1*Srgb(0.5, 0.5, 1.0)).to[Srgb]
       . assert(_ === Srgb(0.75, 0.375, 0.5))
 
       test(m"screen lightens toward white"):
-        import mixing.screen
+        import mixing.screenMixing
         (1*Srgb(0.5, 0.5, 0.5) + 1*Srgb(0.5, 0.5, 0.5)).to[Srgb]
       . assert(_ === Srgb(0.625, 0.625, 0.625))
 
       test(m"darken pulls each channel toward the lower of the two"):
-        import mixing.darken
+        import mixing.darkenMixing
         (1*Srgb(0.2, 0.8, 0.5) + 1*Srgb(0.6, 0.4, 0.5)).to[Srgb]
       . assert(_ === Srgb(0.2, 0.6, 0.5))
 
       test(m"lighten pulls each channel toward the higher of the two"):
-        import mixing.lighten
+        import mixing.lightenMixing
         (1*Srgb(0.2, 0.8, 0.5) + 1*Srgb(0.6, 0.4, 0.5)).to[Srgb]
       . assert(_ === Srgb(0.4, 0.8, 0.5))
 
       test(m"difference pulls each channel toward the gap between them"):
-        import mixing.difference
+        import mixing.differenceMixing
         (1*Srgb(0.2, 0.8, 0.5) + 1*Srgb(0.6, 0.4, 0.5)).to[Srgb]
       . assert(_ === Srgb(0.3, 0.6, 0.25))
 
       test(m"a mode acts in proportion to the added daub's share"):
-        import mixing.multiply
+        import mixing.multiplyMixing
         (3*Srgb(1.0, 1.0, 1.0) + 1*Srgb(0.0, 0.0, 0.0)).to[Srgb]
       . assert(_ === Srgb(0.75, 0.75, 0.75))
 
       test(m"a smaller share of the same daub moves the backdrop less"):
-        import mixing.multiply
+        import mixing.multiplyMixing
         (9*Srgb(1.0, 1.0, 1.0) + 1*Srgb(0.0, 0.0, 0.0)).to[Srgb]
       . assert(_ === Srgb(0.9, 0.9, 0.9))
 
       test(m"a mode other than proportional is not commutative"):
-        import mixing.difference
+        import mixing.differenceMixing
         (3*Srgb(0.8, 0.8, 0.8) + 1*Srgb(0.2, 0.2, 0.2)).to[Srgb]
       . assert(_ === Srgb(0.75, 0.75, 0.75))
 
       test(m"the same two daubs in the other order give a different color"):
-        import mixing.difference
+        import mixing.differenceMixing
         (1*Srgb(0.2, 0.2, 0.2) + 3*Srgb(0.8, 0.8, 0.8)).to[Srgb]
       . assert(_ === Srgb(0.5, 0.5, 0.5))
 
       test(m"yellow and cyan multiply to a green, as paint mixes"):
-        import mixing.multiply
+        import mixing.multiplyMixing
         (1*WebColors.Yellow + 1*WebColors.Cyan).to[Srgb]
       . assert(_ === Srgb(0.5, 1, 0))
 
       test(m"a daub of no parts takes no part in the mix"):
-        import mixing.multiply
+        import mixing.multiplyMixing
         (0*Srgb(1.0, 0.0, 0.0) + 1*Srgb(0.0, 0.0, 1.0)).to[Srgb]
       . assert(_ === Srgb(0.0, 0.0, 1.0))
 
       test(m"a channel mode is rejected in a space with unbounded coordinates"):
         demilitarize:
-          import mixing.multiply
+          import mixing.multiplyMixing
           1*Cielab(0, 0, 0) + 1*Cielab(40, 20, 10)
         . map(_.message)
       . assert(!_.isEmpty)

--- a/lib/jacinta/src/bench/jacinta.Benchmarks.scala
+++ b/lib/jacinta/src/bench/jacinta.Benchmarks.scala
@@ -36,7 +36,7 @@ import scala.sys
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*

--- a/lib/jacinta/src/bench/jacinta.Benchmarks.scala
+++ b/lib/jacinta/src/bench/jacinta.Benchmarks.scala
@@ -49,7 +49,7 @@ import quantitative.*
 import rudiments.*
 import sedentary.*
 import spectacular.*
-import superlunary.embeddings.automatic
+import superlunary.embeddings.automaticEmbedding
 import symbolism.*
 import temporaryDirectories.systemTemporaryDirectory
 import turbulence.*

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -2566,7 +2566,7 @@ object Json extends Json2, Dynamic:
     private[jacinta] def field: Text = label
     protected def key: String = label.s
 
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
 
     def rewrite(kind: Text, json: Json): Json = unsafely(json.updateDynamic(key)(kind))
     // Reads the discriminator through direct AST access rather than a `Decodable` summon:

--- a/lib/jacinta/src/core/jacinta.conversions.scala
+++ b/lib/jacinta/src/core/jacinta.conversions.scala
@@ -30,9 +30,13 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package breviloquence
+package jacinta
 
-import rudiments.*
+import anticipation.*
+import prepositional.*
 
-object dynamicCborAccess:
-  inline given enabled: DynamicCborEnabler = !!
+// Importing `conversions.encodableToJson` brings a scoped `Conversion` into lexical scope that lets
+// any `Encodable in Json` value be supplied directly at `into[Json]` positions — in particular,
+// panopticon lens assignments such as `json.lens(_.name = "x")` — without an explicit `.json`.
+package conversions:
+  given encodableToJson: [entity: Encodable in Json] => Conversion[entity, Json] = _.encode

--- a/lib/jacinta/src/core/jacinta.dynamicAccess.scala
+++ b/lib/jacinta/src/core/jacinta.dynamicAccess.scala
@@ -30,66 +30,9 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package cataclysm
+package jacinta
 
-
-import anticipation.*
-import contextual.*
-import contingency.*
-import fulminate.*
-import nomenclature.*
-import prepositional.*
 import rudiments.*
-import symbolism.*
-import turbulence.*
-import vacuous.*
 
-// The `css"…"` typed CSS interpolator, wired through `contextual` like xylophone's
-// `x"…"` and honeycomb's `h"…"`. The transparent result is a `Css` (stylesheet) or a
-// `Css.Style` (inline style set), decided by the content (see `internal.expand`).
-extension (inline context: StringContext)
-  transparent inline def css: Interpolation = interpolation[Css | Css.Style](context)
-
-// The class and id names referenced anywhere in a stylesheet, including inside
-// nested rules and the selector-list arguments of `:is()`/`:not()`/`:nth-…(of)`.
-extension (css: Css)
-  def classes: Set[Name[CssClass]] =
-    val names: List[Name[CssClass]] = simples(css.rules).sweep:
-      case Simple.Class(name) => name
-
-    names.to[Set]
-
-  def ids: Set[Name[DomId]] =
-    val names: List[Name[DomId]] = simples(css.rules).sweep:
-      case Simple.Id(name) => name
-
-    names.to[Set]
-
-private def simples(nodes: List[Css.Node]): List[Simple] =
-  nodes.bind:
-    case Css.Node.Rule(selector, body) =>
-      listSimples(selector) + simples(body)
-    case Css.Node.At(_, _, body)       => body.lay(Nil)(simples)
-    case Css.Node.Declaration(_, _)    => Nil
-
-private def listSimples(list: SelectorList): List[Simple] =
-  list.selectors.bind: selector =>
-    ((selector.head :: selector.rest.map(_(1))): List[Compound]).bind(compoundSimples)
-
-private def compoundSimples(compound: Compound): List[Simple] =
-  compound.parts.bind:
-    case simple@ Simple.PseudoClass(_, argument)   =>
-      (simple :: argumentSimples(argument)): List[Simple]
-    case simple@ Simple.PseudoElement(_, argument) =>
-      (simple :: argumentSimples(argument)): List[Simple]
-    case simple                                    => List(simple)
-
-private def argumentSimples(argument: Optional[PseudoArgument]): List[Simple] =
-  argument.lay(Nil):
-    case PseudoArgument.Selectors(list) => listSimples(list)
-    case PseudoArgument.Nth(_, _, of)   => of.lay(Nil)(listSimples)
-    case PseudoArgument.Raw(_)          => Nil
-
-package formatting:
-  given indentedCssFormatting: Css.Formatting = Css.Formatting(newlines = true, spaces = true)
-  given compactCssFormatting: Css.Formatting = Css.Formatting(newlines = false, spaces = false)
+package dynamicAccess:
+  inline given dynamicJson: DynamicJsonEnabler = !!

--- a/lib/jacinta/src/core/jacinta.internal.scala
+++ b/lib/jacinta/src/core/jacinta.internal.scala
@@ -181,7 +181,7 @@ object internal:
     def plain: Expr[Json] =
       if Expr.summon[DynamicJsonEnabler].nil then halt:
         m"""
-          dynamic field access on an unverified `Json` requires `import dynamicJsonAccess.enabled`
+          dynamic field access on an unverified `Json` requires `import dynamicAccess.dynamicJson`
           (or verify the value against a schema first)
         """
 
@@ -241,7 +241,7 @@ object internal:
     def plain: Expr[Json] =
       if Expr.summon[DynamicJsonEnabler].nil then halt:
         m"""
-          dynamic field access on an unverified `Json` requires `import dynamicJsonAccess.enabled`
+          dynamic field access on an unverified `Json` requires `import dynamicAccess.dynamicJson`
           (or verify the value against a schema first)
         """
 

--- a/lib/jacinta/src/core/soundness_jacinta_core.scala
+++ b/lib/jacinta/src/core/soundness_jacinta_core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export
   jacinta
-  . { dynamicJsonAccess, DynamicJsonEnabler, j, jp, Json, Json2, jsonConversion, JsonPointer,
+  . { DynamicJsonEnabler, j, jp, Json, Json2, JsonPointer,
       NumberMode }
 
 package formatting:
@@ -48,3 +48,9 @@ package discriminables:
   export jacinta.discriminables.jsonByKindDiscriminable
   export jacinta.discriminables.jsonWrapperDiscriminable
   export jacinta.discriminables.jsonEnvelopeDiscriminable
+
+package dynamicAccess:
+  export jacinta.dynamicAccess.dynamicJson
+
+package conversions:
+  export jacinta.conversions.encodableToJson

--- a/lib/jacinta/src/records/jacinta.JsonBlueprint.scala
+++ b/lib/jacinta/src/records/jacinta.JsonBlueprint.scala
@@ -272,11 +272,11 @@ object JsonBlueprint:
     JsonBlueprint.intensional(_.as[Optional[JsonPointer]])
 
 
-  given regex: ("regex" is Intensional in JsonBlueprint from Json to (Regex in Jur)) =
+  given regex: ("regex" is Intensional in JsonBlueprint from Json to (Regex in JavaBaseRegex)) =
     JsonBlueprint.intensional: value => Regex(value.as[Text])
 
   given optionalRegex
-    :   ("regex?" is Intensional in JsonBlueprint from Json to Optional[Regex in Jur]) =
+    :   ("regex?" is Intensional in JsonBlueprint from Json to Optional[Regex in JavaBaseRegex]) =
     JsonBlueprint.intensional(_.as[Optional[Text]].let(Regex(_)))
 
   given array: ("array" is Structural[List] in JsonBlueprint from Json) = _.as[List[Json]].map(_)

--- a/lib/jacinta/src/schema/jacinta.JsonSchema.scala
+++ b/lib/jacinta/src/schema/jacinta.JsonSchema.scala
@@ -312,7 +312,7 @@ object JsonSchema extends Derivable[Schematic over JsonSchema]:
     type Form = Json
     type Self = JsonSchema
 
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
 
     def rewrite(kind: Text, json: Json): Json = unsafely(json.updateDynamic("type")(kind.lower))
     def variant(json: Json): Json = unsafely(json.updateDynamic("type")(Unset))

--- a/lib/jacinta/src/schema/jacinta_schema.scala
+++ b/lib/jacinta/src/schema/jacinta_schema.scala
@@ -45,7 +45,7 @@ import vacuous.*
 import wisteria.*
 import zephyrine.*
 
-import httpBackends.virtualMachineHttp
+import httpBackends.javaNetHttp
 import Json.Error.Reason
 
 package jsonPointerRegistries:
@@ -74,7 +74,7 @@ extension (json: Json)
   // current position within the schema (initially the root, `topic`) and `Origin`
   // records the root schema itself, so that the `Dynamic` navigation macros can
   // resolve fields and array indices against `topic` at compile time — with no
-  // `dynamicJsonAccess.enabled` import required.
+  // `dynamicAccess.dynamicJson` import required.
   //
   // The conformance check walks `schematic.schema(): JsonSchema` against the
   // value, raising `Json.Error` on the first structural mismatch (wrong type, or a

--- a/lib/jacinta/src/test/jacinta.ParserTests.scala
+++ b/lib/jacinta/src/test/jacinta.ParserTests.scala
@@ -42,7 +42,7 @@ import strategies.throwUnsafely
 import logging.silentLogging
 import charEncoders.utf8Encoder
 import environments.javaBaseEnvironment
-import gitCommands.environmentDefaultGitCommand
+import gitCommands.searchpathGitCommand
 import systems.javaBaseSystem
 import workingDirectories.javaBaseWorkingDirectory
 import internetAccess.online
@@ -50,10 +50,10 @@ import errorDiagnostics.stackTracesDiagnostics
 
 import scala.compiletime.*
 
-import filesystemOptions.dereferenceSymlinks.enabled
-import filesystemOptions.createNonexistentParents.enabled
+import filesystemOptions.dereferenceSymlinks
+import filesystemOptions.createNonexistentParents
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 import denominative.dysasymptotics.linearSize
 
 object ParserTests extends Suite(m"Jacinta JSON parser tests"):

--- a/lib/jacinta/src/test/jacinta.ParserTests.scala
+++ b/lib/jacinta/src/test/jacinta.ParserTests.scala
@@ -41,10 +41,10 @@ import interfaces.paths.pathOnLinux
 import strategies.throwUnsafely
 import logging.silentLogging
 import charEncoders.utf8Encoder
-import environments.javaEnvironment
+import environments.javaBaseEnvironment
 import gitCommands.environmentDefaultGitCommand
-import systems.javaSystem
-import workingDirectories.javaWorkingDirectory
+import systems.javaBaseSystem
+import workingDirectories.javaBaseWorkingDirectory
 import internetAccess.online
 import errorDiagnostics.stackTracesDiagnostics
 

--- a/lib/jacinta/src/test/jacinta.ValidationTests.scala
+++ b/lib/jacinta/src/test/jacinta.ValidationTests.scala
@@ -244,7 +244,7 @@ object ValidationTests extends Suite(m"Jacinta validation tests"):
       . assert(_ == 1)
 
     suite(m"Ventures and guards over Json decoding"):
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       test(m"Failed sibling reads both accrue; dependent steps are skipped"):
         var consistencyRan = false
         var constructed = false

--- a/lib/jacinta/src/test/jacinta.VerifyTests.scala
+++ b/lib/jacinta/src/test/jacinta.VerifyTests.scala
@@ -38,7 +38,7 @@ import soundness.*
 import charEncoders.utf8Encoder
 import strategies.throwUnsafely
 
-// NB: `dynamicJsonAccess.enabled` is deliberately *not* imported here — verified
+// NB: `dynamicAccess.dynamicJson` is deliberately *not* imported here — verified
 // `Json of T` navigation must work without it.
 
 case class Employee(name: Text, age: Int, email: Text) derives CanEqual
@@ -188,4 +188,4 @@ object VerifyTests extends Suite(m"Jacinta verify tests"):
         demilitarize:
           t"""{"name": "Alice"}""".read[Json].name
         . head.message
-      . assert(_.contains("dynamicJsonAccess.enabled"))
+      . assert(_.contains("dynamicAccess.dynamicJson"))

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -1362,7 +1362,7 @@ object Tests extends Suite(m"Jacinta Tests"):
       import decodables.instantJsonDecodable
       import decodables.durationJsonDecodable
       import aviation.*
-      import chronometries.unix
+      import chronometries.unixChronometry
       import abstractables.epochMillisecondsAbstractable
 
       test(m"Encode an Instant as a Long"):

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -342,7 +342,7 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(_ == None)
 
       test(m"Access an absent Optional dynamically"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         t"""{"y": 1}""".read[Json].missing.as[Optional[Int]]
       . assert(_ == Unset)
 
@@ -408,14 +408,14 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(_ == newBand)
 
       test(m"Update a JSON object dynamically"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val john = t"""{"name": "John", "age": 40}""".as[Json]
         val john2 = john.age = 41
         john2.as[Person]
       . assert(_ == Person("John", 41))
 
       test(m"Update a JSON array dynamically"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val array = t"""[1, 2, 3]""".as[Json]
         val array2 = array(1) = 5
         array2.as[List[Int]]
@@ -424,19 +424,19 @@ object Tests extends Suite(m"Jacinta Tests"):
       val org = Org("The Beatles", Entity("John", 40, List(Role("Leader")))).in[Json]
 
       test(m"Lens update on JSON"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val org2 = org.lens(_.leader.age = 41.in[Json])
         org2.as[Org]
       . assert(_ == Org("The Beatles", Entity("John", 41, List(Role("Leader")))))
 
       test(m"Lens update with optic on JSON"):
-        import dynamicJsonAccess.enabled, jsonConversion.encodable
+        import dynamicAccess.dynamicJson, conversions.encodableToJson
         val org2 = org.lens(_.leader.roles(Prim) = Role("-"))
         org2.as[Org]
       . assert(_ == Org("The Beatles", Entity("John", 40, List(Role("-")))))
 
       test(m"Deeper lens update with optic on JSON"):
-        import dynamicJsonAccess.enabled, jsonConversion.encodable
+        import dynamicAccess.dynamicJson, conversions.encodableToJson
         val org2 = org.lens(_.leader.roles(Prim).name = "-")
         org2.as[Org]
       . assert(_ == Org("The Beatles", Entity("John", 40, List(Role("-")))))
@@ -444,28 +444,28 @@ object Tests extends Suite(m"Jacinta Tests"):
       val band = Org("Q", Entity("John", 40, List(Role("a"), Role("b"), Role("c")))).in[Json]
 
       test(m"Lens reads a field by name"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         summon["name" is Lens from Json onto Json](org).as[String]
       . assert(_ == "The Beatles")
 
       test(m"Lens.modify transforms a field through a function"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val lens = summon["name" is Lens from Json onto Json]
         lens.modify(org)(json => (json.as[String]+"!").in[Json]).as[Org]
       . assert(_ == Org("The Beatles!", Entity("John", 40, List(Role("Leader")))))
 
       test(m"Each optic updates every array element"):
-        import dynamicJsonAccess.enabled, jsonConversion.encodable
+        import dynamicAccess.dynamicJson, conversions.encodableToJson
         band.lens(_.leader.roles(Each).name = "x").as[Org]
       . assert(_ == Org("Q", Entity("John", 40, List(Role("x"), Role("x"), Role("x")))))
 
       test(m"Filter optic updates only matching elements"):
-        import dynamicJsonAccess.enabled, jsonConversion.encodable
+        import dynamicAccess.dynamicJson, conversions.encodableToJson
         band.lens(_.leader.roles(Filter[Json](_.name.as[String] == "b")).name = "x").as[Org]
       . assert(_ == Org("Q", Entity("John", 40, List(Role("a"), Role("x"), Role("c")))))
 
       test(m"Setting an absent field inserts it"):
-        import dynamicJsonAccess.enabled, jsonConversion.encodable
+        import dynamicAccess.dynamicJson, conversions.encodableToJson
         org.lens(_.extra = 9).selectDynamic("extra").as[Int]
       . assert(_ == 9)
 
@@ -569,62 +569,62 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(_ == 3)
 
       test(m"Dynamic field access"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val person = t"""{"name": "Bob"}""".read[Json]
         person.name.as[Text]
       . assert(_ == t"Bob")
 
       test(m"Dynamic indexed access of array field"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val data = t"""{"nums": [4, 5, 6]}""".read[Json]
         data.nums(1).as[Int]
       . assert(_ == 5)
 
     suite(m"Json updates"):
       test(m"Add a field to an object via updateDynamic"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val base = t"""{"x": 1}""".read[Json]
         val updated = base.y = 2
         updated.show
       . assert(_ == t"""{"x":1,"y":2}""")
 
       test(m"Replace a field via updateDynamic"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val base = t"""{"x": 1, "y": 2}""".read[Json]
         val updated = base.x = 9
         updated.show
       . assert(_ == t"""{"x":9,"y":2}""")
 
       test(m"Update an array element"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val arr = t"""[1, 2, 3]""".read[Json]
         val updated = arr(1) = 9
         updated.show
       . assert(_ == t"[1,9,3]")
 
       test(m"Set a field to a string"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val base = t"""{"x": 1}""".read[Json]
         val updated = base.greeting = t"hi"
         updated.show
       . assert(_ == t"""{"x":1,"greeting":"hi"}""")
 
       test(m"Delete a field by assigning Unset"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val base = t"""{"x": 1, "y": 2}""".read[Json]
         val updated = base.x = Unset
         updated.show
       . assert(_ == t"""{"y":2}""")
 
       test(m"Delete a field whose value is a nested object"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val base = t"""{"x": {"k":1}, "y": 2}""".read[Json]
         val updated = base.x = Unset
         updated.show
       . assert(_ == t"""{"y":2}""")
 
       test(m"Deleting a missing field is a no-op"):
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val base = t"""{"x": 1}""".read[Json]
         val updated = base.missing = Unset
         updated.show
@@ -852,7 +852,7 @@ object Tests extends Suite(m"Jacinta Tests"):
       test(m"Read a Json value through the direct path"):
         t"""{"a": 1}""".read[Json in Json].as[Json]
       . assert: json =>
-          import dynamicJsonAccess.enabled
+          import dynamicAccess.dynamicJson
           unsafely(json.a.as[Int]) == 1
 
       test(m"A hand-written Parsable reads an object without an AST"):

--- a/lib/kaleidoscope/src/bench/kaleidoscope.Benchmarks.scala
+++ b/lib/kaleidoscope/src/bench/kaleidoscope.Benchmarks.scala
@@ -34,7 +34,7 @@ package kaleidoscope
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*

--- a/lib/kaleidoscope/src/core/kaleidoscope.Glob.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Glob.scala
@@ -109,7 +109,7 @@ case class Glob(tokens: Glob.Token*):
   // mechanism as the `r"…"` and `g"…"` interpolators. The engines cache compilation by
   // rendered pattern, so matching many candidates against one `Glob` compiles it only once.
   def matches[form](text: Text)
-    ( using backend: RegexBackend[form] = regexBackends.jur )
+    ( using backend: RegexBackend[form] = regexBackends.javaBaseRegex )
     ( using engine:  form is Regex.Engine )
   :   Boolean =
 

--- a/lib/kaleidoscope/src/core/kaleidoscope.JavaBaseRegex.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.JavaBaseRegex.scala
@@ -41,11 +41,11 @@ import denominative.*
 import rudiments.*
 import vacuous.*
 
-object Jur:
-  // In the subject type's companion (issue #1632), so `Regex in Jur` operations resolve with no
+object JavaBaseRegex:
+  // In the subject type's companion (issue #1632), so `Regex in JavaBaseRegex` operations resolve with no
   // import. The bodies previously lived as methods on `Regex` itself; they move here so that a
   // `Regex in Re2` cannot silently fall back to `java.util.regex`.
-  given engine: Jur is Regex.Engine:
+  given engine: JavaBaseRegex is Regex.Engine:
     def matches(regex: Regex, text: Text)(using scanner: Scanner): Boolean =
       scanner.nextStart match
         case index: Int =>
@@ -147,4 +147,4 @@ object Jur:
 
 // The phantom marker for the `java.util.regex` backend (or, on JS and Native, the platform's
 // emulation of it): the default `Form` of every `Regex`.
-sealed trait Jur
+sealed trait JavaBaseRegex

--- a/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
@@ -95,7 +95,7 @@ object Regex:
         val compiled = motif(regex)
 
         // Restarting from `end + 1` (not `end`) after a non-overlapping match reproduces the
-        // `Jur` engine's behaviour exactly, including its skipping of immediately-adjacent
+        // `JavaBaseRegex` engine's behaviour exactly, including its skipping of immediately-adjacent
         // matches. Positions advance over the raw slot bounds, since an empty match's
         // `Interval` does not record where it occurred.
         def recur(from: Int): Chain[Interval] =
@@ -125,7 +125,7 @@ object Regex:
             case _ =>
               ()
 
-          // The praxinoscope analogue of the `Jur` engine's sub-scan: a repeating group's span
+          // The praxinoscope analogue of the `JavaBaseRegex` engine's sub-scan: a repeating group's span
           // covers all its iterations, so the group's body is matched repeatedly over the span
           // to recover each iteration.
           def rescan(body: Text, region: Text): List[Text] =
@@ -178,8 +178,8 @@ object Regex:
         . or(None)
 
   // A matching backend, selected by the `Form` refinement of the `Regex` it operates on:
-  // `Regex in Jur` dispatches to `java.util.regex` and `Regex in Re2` to praxinoscope. The
-  // `Jur` instance lives in `Jur`'s companion; `Re2`'s companion is below this library, so its
+  // `Regex in JavaBaseRegex` dispatches to `java.util.regex` and `Regex in Re2` to praxinoscope. The
+  // `JavaBaseRegex` instance lives in `JavaBaseRegex`'s companion; `Re2`'s companion is below this library, so its
   // instance lives in this trait's companion instead (issue #1632).
   trait Engine:
     type Self
@@ -261,9 +261,9 @@ object Regex:
     given tactic: (ThrowTactic[Hazard, Any]^) = strategies.throwUnsafely
     parse(parts.map(_.tt))
 
-  def apply(text: Text): Regex in Jur raises Regex.Error = parse(List(text))
+  def apply(text: Text): Regex in JavaBaseRegex raises Regex.Error = parse(List(text))
 
-  def parse(parts: List[Text]): Regex in Jur raises Regex.Error =
+  def parse(parts: List[Text]): Regex in JavaBaseRegex raises Regex.Error =
     def validStart(part: Text): Boolean =
       val str = part.s
       str.startsWith("(") || str.startsWith("[") || str.startsWith(".") ||
@@ -441,7 +441,7 @@ object Regex:
 
     check(mainGroup.groups, true)
 
-    Regex(text, mainGroup.groups).to[Jur]
+    Regex(text, mainGroup.groups).to[JavaBaseRegex]
 
 
   def makePattern

--- a/lib/kaleidoscope/src/core/kaleidoscope.internal.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.internal.scala
@@ -142,7 +142,7 @@ object internal:
 
         Some(Motif.parse(regex.plainPattern))
 
-    val formType: TypeRepr = if re2Backend then TypeRepr.of[Re2] else TypeRepr.of[Jur]
+    val formType: TypeRepr = if re2Backend then TypeRepr.of[Re2] else TypeRepr.of[JavaBaseRegex]
 
     import praxinoscope.internal.motif
 

--- a/lib/kaleidoscope/src/core/kaleidoscope_core.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope_core.scala
@@ -50,5 +50,5 @@ extension (inline context: StringContext)
 sealed trait RegexBackend[form]
 
 package regexBackends:
-  given jur: RegexBackend[Jur] = new RegexBackend[Jur] {}
+  given javaBaseRegex: RegexBackend[JavaBaseRegex] = new RegexBackend[JavaBaseRegex] {}
   given re2: RegexBackend[Re2] = new RegexBackend[Re2] {}

--- a/lib/kaleidoscope/src/core/soundness_kaleidoscope_core.scala
+++ b/lib/kaleidoscope/src/core/soundness_kaleidoscope_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export kaleidoscope.{g, Glob, Jur, r, Regex, RegexBackend, Scanner}
+export kaleidoscope.{g, Glob, JavaBaseRegex, r, Regex, RegexBackend, Scanner}
 
 package regexBackends:
-  export kaleidoscope.regexBackends.{jur, re2}
+  export kaleidoscope.regexBackends.{javaBaseRegex, re2}

--- a/lib/kaleidoscope/src/test/kaleidoscope_test.scala
+++ b/lib/kaleidoscope/src/test/kaleidoscope_test.scala
@@ -225,49 +225,49 @@ object Tests extends Suite(m"Kaleidoscope tests"):
 
       suite(m"Scanner patterns"):
         test(m"Simple capture"):
-          Jur.engine.matchGroups(Regex.parse(List(t"foo", t"(bar)")), t"foobar")
+          JavaBaseRegex.engine.matchGroups(Regex.parse(List(t"foo", t"(bar)")), t"foobar")
           . map { (g: Array[List[Text | Char] | Optional[Text | Char]]^{}) =>
               g.readable.toList.to(proscenium.List) } // explicit: inference boxes the element captures
 
         . assert(_ == Some(List(t"bar")))
 
         test(m"Two captures"):
-          Jur.engine.matchGroups(Regex.parse(List(t"foo", t"(bar)", t"(baz)")), t"foobarbaz")
+          JavaBaseRegex.engine.matchGroups(Regex.parse(List(t"foo", t"(bar)", t"(baz)")), t"foobarbaz")
           . map { (g: Array[List[Text | Char] | Optional[Text | Char]]^{}) =>
               g.readable.toList.to(proscenium.List) } // explicit: inference boxes the element captures
 
         . assert(_ == Some(List(t"bar", t"baz")))
 
         test(m"Two captures, one repeating"):
-          Jur.engine.matchGroups(Regex.parse(List(t"foo", t"(bar)", t"(baz)*")), t"foobarbazbaz")
+          JavaBaseRegex.engine.matchGroups(Regex.parse(List(t"foo", t"(bar)", t"(baz)*")), t"foobarbazbaz")
           . map { (g: Array[List[Text | Char] | Optional[Text | Char]]^{}) =>
               g.readable.toList.to(proscenium.List) } // explicit: inference boxes the element captures
 
         . assert(_ == Some(List(t"bar", List(t"baz", t"baz"))))
 
         test(m"Two captures, both repeating"):
-          Jur.engine.matchGroups(Regex.parse(List(t"foo", t"(bar){4}", t"(baz)*")), t"foobarbarbarbarbazbaz")
+          JavaBaseRegex.engine.matchGroups(Regex.parse(List(t"foo", t"(bar){4}", t"(baz)*")), t"foobarbarbarbarbazbaz")
           . map { (g: Array[List[Text | Char] | Optional[Text | Char]]^{}) =>
               g.readable.toList.to(proscenium.List) } // explicit: inference boxes the element captures
 
         . assert(_ == Some(List(List(t"bar", t"bar", t"bar", t"bar"), List(t"baz", t"baz"))))
 
         test(m"Two captures, one optional and absent, one repeating"):
-          Jur.engine.matchGroups(Regex.parse(List(t"foo", t"(bar)+", t"(baz)?")), t"foobarbar")
+          JavaBaseRegex.engine.matchGroups(Regex.parse(List(t"foo", t"(bar)+", t"(baz)?")), t"foobarbar")
           . map { (g: Array[List[Text | Char] | Optional[Text | Char]]^{}) =>
               g.readable.toList.to(proscenium.List) } // explicit: inference boxes the element captures
 
         . assert(_ == Some(List(List(t"bar", t"bar"), Unset)))
 
         test(m"Two captures, one optional and present, one repeating"):
-          Jur.engine.matchGroups(Regex.parse(List(t"foo", t"(b.r)+", t"(baz)?")), t"fooberbirbaz")
+          JavaBaseRegex.engine.matchGroups(Regex.parse(List(t"foo", t"(b.r)+", t"(baz)?")), t"fooberbirbaz")
           . map { (g: Array[List[Text | Char] | Optional[Text | Char]]^{}) =>
               g.readable.toList.to(proscenium.List) } // explicit: inference boxes the element captures
 
         . assert(_ == Some(List(List(t"ber", t"bir"), t"baz")))
 
         test(m"Nested captures, one optional and present, one repeating"):
-          Jur.engine.matchGroups(Regex.parse(List(t"f(oo", t"(b.r)+", t"(baz)?)")), t"fooberbirbaz")
+          JavaBaseRegex.engine.matchGroups(Regex.parse(List(t"f(oo", t"(b.r)+", t"(baz)?)")), t"fooberbirbaz")
           . map { (g: Array[List[Text | Char] | Optional[Text | Char]]^{}) =>
               g.readable.toList.to(proscenium.List) } // explicit: inference boxes the element captures
 
@@ -732,7 +732,7 @@ object Tests extends Suite(m"Kaleidoscope tests"):
         ( t"", t"a", t"b", t"ab", t"abc", t"aab", t"aaab", t"abab", t"abababc", t"aabb",
           t"x42y", t"xyz", t"aaaa", t"abcd", t"abd", t"acd" )
 
-      test(m"Jur and Re2 engines agree on matches, seek and search"):
+      test(m"JavaBaseRegex and Re2 engines agree on matches, seek and search"):
         var failures: List[Text] = Nil
 
         patterns.each: pattern =>
@@ -751,7 +751,7 @@ object Tests extends Suite(m"Kaleidoscope tests"):
 
       . assert(_ == Nil)
 
-      test(m"Jur and Re2 engines agree on capture groups"):
+      test(m"JavaBaseRegex and Re2 engines agree on capture groups"):
         var failures: List[Text] = Nil
 
         def strip(result: Option[Array[List[Text | Char] | Optional[Text | Char]]^{}])
@@ -763,7 +763,7 @@ object Tests extends Suite(m"Kaleidoscope tests"):
           val regex = Regex.parse(List(pattern))
 
           inputs.each: input =>
-            val jvmResult = strip(Jur.engine.matchGroups(regex, input)(using Scanner(Unset)))
+            val jvmResult = strip(JavaBaseRegex.engine.matchGroups(regex, input)(using Scanner(Unset)))
 
             val re2Result =
               strip(Regex.Engine.re2.matchGroups(regex, input)(using Scanner(Unset)))

--- a/lib/legerdemain/src/core/legerdemain_core.scala
+++ b/lib/legerdemain/src/core/legerdemain_core.scala
@@ -62,7 +62,7 @@ extension [formulaic: {Formulaic, Encodable in Query}](value: formulaic)
 
 
 package formulations:
-  given defaultFormulation: Formulation:
+  given postFormulation: Formulation:
     def form(content: List[Html of Flow], submit: Optional[Text]): Html of Flow =
       Form
         ( action = t".", method = t"post" )

--- a/lib/legerdemain/src/core/soundness_legerdemain_core.scala
+++ b/lib/legerdemain/src/core/soundness_legerdemain_core.scala
@@ -38,4 +38,4 @@ export
       Formulation, RadioGroup, Widget }
 
 package formulations:
-  export legerdemain.formulations.defaultFormulation
+  export legerdemain.formulations.postFormulation

--- a/lib/locomotion/src/bench/locomotion.Benchmarks.scala
+++ b/lib/locomotion/src/bench/locomotion.Benchmarks.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package locomotion
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*

--- a/lib/locomotion/src/core/locomotion.conversions.scala
+++ b/lib/locomotion/src/core/locomotion.conversions.scala
@@ -30,13 +30,13 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package jacinta
+package locomotion
 
 import anticipation.*
 import prepositional.*
 
-// Importing `jsonConversion.encodable` brings a scoped `Conversion` into lexical scope that lets
-// any `Encodable in Json` value be supplied directly at `into[Json]` positions — in particular,
-// panopticon lens assignments such as `json.lens(_.name = "x")` — without an explicit `.json`.
-object jsonConversion:
-  given encodable: [entity: Encodable in Json] => Conversion[entity, Json] = _.encode
+// Importing `conversions.encodableToProtobuf` brings a scoped `Conversion` into lexical scope that
+// lets any `Encodable in Protobuf` value be supplied directly at lens-assignment positions, such
+// as `protobuf.lens(_.field = value)`, without an explicit `.protobuf`.
+package conversions:
+  given encodableToProtobuf: [entity: Encodable in Protobuf] => Conversion[entity, Protobuf] = _.encode

--- a/lib/locomotion/src/core/soundness_locomotion_core.scala
+++ b/lib/locomotion/src/core/soundness_locomotion_core.scala
@@ -32,5 +32,8 @@
                                                                                                   */
 package soundness
 
-export locomotion.{Protobuf, Protobuf2, protobufConversion, Packable, WireType,
+export locomotion.{Protobuf, Protobuf2, Packable, WireType,
     field}
+
+package conversions:
+  export locomotion.conversions.encodableToProtobuf

--- a/lib/locomotion/src/test/locomotion_test.scala
+++ b/lib/locomotion/src/test/locomotion_test.scala
@@ -257,7 +257,7 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
       . assert(_ == Person(t"Alice", 30))
 
     suite(m"Optics"):
-      import protobufConversion.encodable
+      import conversions.encodableToProtobuf
       // Protobuf is number-keyed: the `Ordinal` selects a field by number (Prim =
       // field 1). Wrapper encodes `point` at field 1 and `label` at field 2.
       def wrapper: Protobuf = Wrapper(Point(3, 4), t"origin").in[Protobuf]

--- a/lib/mandible/src/core/mandible.ClassSurface.scala
+++ b/lib/mandible/src/core/mandible.ClassSurface.scala
@@ -38,7 +38,7 @@ import java.lang.classfile.attribute as jlca
 import anticipation.*
 import gossamer.*
 import gossamer.collationComparable
-import gossamer.collations.codepoints
+import gossamer.collations.codepointCollation
 import rudiments.*
 import symbolism.*
 import vacuous.*

--- a/lib/mandible/src/core/mandible_core.scala
+++ b/lib/mandible/src/core/mandible_core.scala
@@ -53,10 +53,10 @@ import turbulence.*
 import vacuous.*
 
 import errorDiagnostics.stackTracesDiagnostics
-import filesystemOptions.dereferenceSymlinks.enabled
+import filesystemOptions.dereferenceSymlinks
 import interfaces.paths.pathOnLinux
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 
 def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using TemporaryDirectory)

--- a/lib/mandible/src/test/mandible_test.scala
+++ b/lib/mandible/src/test/mandible_test.scala
@@ -44,7 +44,7 @@ import classloaders.threadContextClassloader
 import logging.silentLogging
 import probates.cancelProbate
 import strategies.throwUnsafely
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 import threading.platformThreading
 import denominative.dysasymptotics.linearSize

--- a/lib/monotonous/src/test/monotonous_test.scala
+++ b/lib/monotonous/src/test/monotonous_test.scala
@@ -34,7 +34,7 @@ package monotonous
 
 import soundness.*
 
-import randomization.seededRandomization, randomization.sizes.uniformUpto100000
+import randomization.seededRandomization, randomization.sizes.uniformSizeUpto100000
 import errorDiagnostics.stackTracesDiagnostics
 
 given Seed = Seed(1L)

--- a/lib/murmuration/src/bench/murmuration.Benchmarks.scala
+++ b/lib/murmuration/src/bench/murmuration.Benchmarks.scala
@@ -49,7 +49,7 @@ import proscenium.*
 import quantitative.*
 import rudiments.*
 import sedentary.*
-import superlunary.embeddings.automatic
+import superlunary.embeddings.automaticEmbedding
 import symbolism.*
 import temporaryDirectories.systemTemporaryDirectory
 import vacuous.*

--- a/lib/murmuration/src/bench/murmuration.Benchmarks.scala
+++ b/lib/murmuration/src/bench/murmuration.Benchmarks.scala
@@ -37,7 +37,7 @@ import java.util as ju
 import scala.collection.mutable as scm
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*

--- a/lib/murmuration/src/test/murmuration_test.scala
+++ b/lib/murmuration/src/test/murmuration_test.scala
@@ -603,7 +603,7 @@ object Tests extends Suite(m"Murmuration tests"):
       test(m"a reference array sorts in place"):
         import sortingAlgorithms.quicksort
         import soundness.collationComparable
-        import collations.codepoints
+        import collations.codepointCollation
         val array = mutableCopy(List(t"c", t"a", t"b"))
         array.sort()
         List.from(array.readable)

--- a/lib/obligatory/src/json/obligatory.JsonRpc.scala
+++ b/lib/obligatory/src/json/obligatory.JsonRpc.scala
@@ -56,7 +56,7 @@ import urticose.*
 import vacuous.*
 import zephyrine.*
 
-import httpBackends.virtualMachineHttp
+import httpBackends.javaNetHttp
 
 object JsonRpc:
   // Requests in flight, by correlation id. Concurrent and self-evicting: the requesting thread
@@ -139,7 +139,7 @@ object JsonRpc:
   // Routes a response back to the caller awaiting it. A conformant peer answers with exactly one
   // of `result` and `error`, and the distinction matters: the second is a fault, not a value.
   def answer(json: Json): Unit =
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
     import strategies.throwUnsafely
 
     // `try`/`catch` rather than `safely`: a decodable cannot thread the boundary tactic under

--- a/lib/obligatory/src/json/obligatory.internal.scala
+++ b/lib/obligatory/src/json/obligatory.internal.scala
@@ -79,7 +79,7 @@ object internal:
 
     ' {
         json =>
-          import dynamicJsonAccess.enabled
+          import dynamicAccess.dynamicJson
           given Tactic[Json.Error] = strategies.throwUnsafely
 
           (safely(json.method.as[Text]): @scala.unchecked) match

--- a/lib/obligatory/src/test/obligatory_test.scala
+++ b/lib/obligatory/src/test/obligatory_test.scala
@@ -324,7 +324,7 @@ object Tests extends Suite(m"Obligatory Tests"):
       . assert(_ == t"pong")
 
     suite(m"JSON-RPC error responses"):
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       import Json.jsonEncodableInText
 
       test(m"a failure carries the fault in the error member"):

--- a/lib/octogenarian/src/core/octogenarian.Git.scala
+++ b/lib/octogenarian/src/core/octogenarian.Git.scala
@@ -58,7 +58,7 @@ import zephyrine.*
 
 import beneficence.*
 import enigmatic.*
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 import spectacular.*
 
 object Git:

--- a/lib/octogenarian/src/core/octogenarian.Worktree.scala
+++ b/lib/octogenarian/src/core/octogenarian.Worktree.scala
@@ -50,7 +50,7 @@ import vacuous.*
 
 import Git.Error.Reason.*
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 object Worktree:
   def apply[abstractable: Abstractable across Paths to Text](path: abstractable)

--- a/lib/octogenarian/src/core/octogenarian_core.scala
+++ b/lib/octogenarian/src/core/octogenarian_core.scala
@@ -45,7 +45,7 @@ import rudiments.*
 import serpentine.*
 
 package gitCommands:
-  given environmentDefaultGitCommand: ( WorkingDirectory, Git.Event is Loggable, Tactic[Name.Error],
+  given searchpathGitCommand: ( WorkingDirectory, Git.Event is Loggable, Tactic[Name.Error],
                                         Tactic[Path.Error], Tactic[Io.Error], Tactic[Exec.Error] )
   =>  (((Path on Linux) is Instantiable across Paths from Text)^)
   =>  Git.Command =

--- a/lib/octogenarian/src/core/soundness_octogenarian_core.scala
+++ b/lib/octogenarian/src/core/soundness_octogenarian_core.scala
@@ -38,4 +38,4 @@ export
       ReflogEntry, Refspec, Remote, ResetMode, SshUrl, Worktree, target, namespace, content }
 
 package gitCommands:
-  export octogenarian.gitCommands.environmentDefaultGitCommand
+  export octogenarian.gitCommands.searchpathGitCommand

--- a/lib/octogenarian/src/test/octogenarian_test.scala
+++ b/lib/octogenarian/src/test/octogenarian_test.scala
@@ -41,9 +41,9 @@ import soundness.*
 // brought in via `soundness.*`.
 import octogenarian.{content, namespace, target}
 
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 import logging.silentLogging
 import internetAccess.online
 

--- a/lib/octogenarian/src/test/octogenarian_test.scala
+++ b/lib/octogenarian/src/test/octogenarian_test.scala
@@ -51,14 +51,14 @@ import strategies.throwUnsafely
 import charEncoders.utf8Encoder
 import errorDiagnostics.stackTracesDiagnostics
 
-import filesystemOptions.dereferenceSymlinks.enabled
-import filesystemOptions.overwritePreexisting.enabled
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.deleteRecursively.enabled
+import filesystemOptions.dereferenceSymlinks
+import filesystemOptions.overwritePreexisting
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.deleteRecursively
 
-import gitCommands.environmentDefaultGitCommand
+import gitCommands.searchpathGitCommand
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Octogenarian Tests"):

--- a/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
+++ b/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
@@ -50,7 +50,7 @@ import vacuous.*
 import zephyrine.*
 
 import errorDiagnostics.stackTracesDiagnostics
-import httpBackends.virtualMachineHttp
+import httpBackends.javaNetHttp
 import queryParameters.arbitraryQueryParameter
 
 object Issuer:
@@ -137,7 +137,7 @@ class Issuer
 
                   . lest(OAuth.Error(OAuth.Error.Reason.Unauthorized))
 
-              import dynamicJsonAccess.enabled
+              import dynamicAccess.dynamicJson
 
               // The field decodings share only the resolution-scoped tactic; no aliased
               // writer.

--- a/lib/panopticon/src/bench/panopticon.Benchmarks.scala
+++ b/lib/panopticon/src/bench/panopticon.Benchmarks.scala
@@ -34,7 +34,7 @@ package panopticon
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import denominative.*

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -54,8 +54,8 @@ import zephyrine.*
 import Control.*
 import alphabets.base64Standard
 import charEncoders.utf8Encoder
-import crypto.permitDeprecatedCrypto
-import providers.javaStdlibProvider
+import cryptoPermits.permitDeprecatedCrypto
+import providers.javaBaseProvider
 
 object Message:
   // A formal `Message is Ingressive`, so the raw `Message` type satisfies the

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -38,7 +38,7 @@ import java.security.SecureRandom
 
 import anticipation.*
 import coaxial.*
-import coaxial.socketBackends.virtualMachineSockets
+import coaxial.socketBackends.javaBaseSockets
 import contingency.*
 import fulminate.Hazard
 import distillate.*
@@ -58,8 +58,8 @@ import urticose.*
 import vacuous.*
 
 import alphabets.base64Standard
-import crypto.permitDeprecatedCrypto
-import providers.javaStdlibProvider
+import cryptoPermits.permitDeprecatedCrypto
+import providers.javaBaseProvider
 
 // `true` exactly when the message type is the raw `Message`. A match type reduces
 // by subtyping — `Message` matches the first case, any other (e.g. `Ping over Json`)

--- a/lib/polysyllabic/src/bench/polysyllabic.Benchmarks.scala
+++ b/lib/polysyllabic/src/bench/polysyllabic.Benchmarks.scala
@@ -34,7 +34,7 @@ package polysyllabic
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import escritoire.*

--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -35,7 +35,7 @@ package probably
 
 import java.lang as jl
 
-import ambience.*, environments.javaEnvironment
+import ambience.*, environments.javaBaseEnvironment
 import anticipation.*
 import contingency.*
 import denominative.*
@@ -59,8 +59,8 @@ import themes.solarizedTheme
 import denominative.dysasymptotics.linearSize
 
 abstract class Suite(suiteName: Message) extends Testable(suiteName):
-  // The CURRENT `System.out`/`err`/`in` (`systemStdio`), read afresh at each use, rather than
-  // the process's file descriptors (`virtualMachineStdio`): an in-process host invoking the
+  // The CURRENT `System.out`/`err`/`in` (`javaLangSystemStdio`), read afresh at each use, rather than
+  // the process's file descriptors (`fileDescriptorStdio`): an in-process host invoking the
   // suite through `invoke` redirects `System.out` to its own stream for the duration, and the
   // FD-backed streams would bypass that redirection entirely (the report would go to the host
   // process's terminal, not the host's client). In a conventional `java -cp … <Suite>` run the
@@ -70,7 +70,7 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
   // expression which touches a suite object's statics initializes the whole suite there. In
   // that case the FD-backed streams are the only ones left to fall back to.
   def suiteIo: Stdio =
-    safely(stdios.systemStdio).or(stdios.virtualMachineStdio)
+    safely(stdios.javaLangSystemStdio).or(stdios.fileDescriptorStdio)
 
   private def makeRunner(selection: Selection): Runner[Report] = makeRunner(selection, Unset)
 

--- a/lib/probably/src/core/probably.AnsiRenderer.scala
+++ b/lib/probably/src/core/probably.AnsiRenderer.scala
@@ -60,7 +60,7 @@ import turbulence.*
 import vacuous.*
 
 import Format.measurable
-import tableStyles.defaultTableStyle
+import tableStyles.thickTableStyle
 
 // `Juxtaposition`'s renderer lives in `chiaroscuro.render`, not in the enum's companion, so it
 // is not in implicit scope. Without this import `cmp.teletype` below silently resolves to
@@ -580,7 +580,7 @@ private[probably] object AnsiRenderer:
 
     val maxHits = data.map(_.branches).maxOption
 
-    import treeStyles.defaultTreeStyle
+    import treeStyles.squareTreeStyle
 
     def describe(surface: Surface): Teletype =
       if surface.juncture.treeName == t"DefDef" then e"• ${surface.juncture.method.teletype}"

--- a/lib/probably/src/core/probably.Ci.scala
+++ b/lib/probably/src/core/probably.Ci.scala
@@ -39,7 +39,7 @@ import gossamer.*
 import vacuous.*
 
 object Ci:
-  import environments.javaEnvironment
+  import environments.javaBaseEnvironment
 
   def apply(): Boolean =
     githubActions || gitlabCi || circleCi || travisCi || jenkins || azurePipelines || teamCity ||

--- a/lib/probably/src/core/probably.GithubActions.scala
+++ b/lib/probably/src/core/probably.GithubActions.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package probably
 
-import ambience.*, environments.javaEnvironment
+import ambience.*, environments.javaBaseEnvironment
 import anticipation.*
 import contingency.*
 import denominative.*

--- a/lib/probably/src/core/probably.Runner.scala
+++ b/lib/probably/src/core/probably.Runner.scala
@@ -35,7 +35,7 @@ package probably
 import java.lang as jl
 
 
-import ambience.{System as _, *}, environments.javaEnvironment
+import ambience.{System as _, *}, environments.javaBaseEnvironment
 import anticipation.*
 import escapade.*
 import gossamer.*
@@ -44,7 +44,7 @@ import rudiments.*
 import turbulence.*
 import vacuous.*
 
-import stdios.virtualMachineStdio
+import stdios.fileDescriptorStdio
 import termcaps.environmentTermcap
 import beneficence.*
 import denominative.*

--- a/lib/probably/src/core/probably.Test.scala
+++ b/lib/probably/src/core/probably.Test.scala
@@ -41,7 +41,7 @@ import distillate.*
 import fulminate.*
 import gossamer.*
 import gossamer.collationComparable
-import gossamer.collations.codepoints
+import gossamer.collations.codepointCollation
 import hieroglyph.*
 import hypotenuse.*
 import nomenclature.*

--- a/lib/probably/src/core/probably_core.scala
+++ b/lib/probably/src/core/probably_core.scala
@@ -118,7 +118,7 @@ def suite[report](name: Name[Probing], description: Message)
 
 
 package harnesses:
-  given threadLocal: Harness:
+  given threadLocalHarness: Harness:
     private val delegate: Option[Harness] =
       Option(Runner.harnessThreadLocal.get()).map(_.nn).flatten
 
@@ -126,8 +126,8 @@ package harnesses:
       delegate.map(_.capture[value](name, value)).getOrElse(value)
 
 package autopsies:
-  given contrastExpectations: Autopsy:
+  given contrastAutopsy: Autopsy:
     type Analyse = true
 
-  given none: Autopsy:
+  given noAutopsy: Autopsy:
     type Analyse = false

--- a/lib/probably/src/core/soundness_probably_core.scala
+++ b/lib/probably/src/core/soundness_probably_core.scala
@@ -41,7 +41,10 @@ export
       Trial, Value, Verdict }
 
 package harnesses:
-  export probably.harnesses.threadLocal
+  export probably.harnesses.threadLocalHarness
 
 package autopsies:
-  export probably.autopsies.{contrastExpectations, none}
+  export probably.autopsies.{contrastAutopsy, noAutopsy}
+
+package decimalizers:
+  export probably.decimalizers.fourDecimalPlaces

--- a/lib/profanity/src/test/profanity.CaptureTests.scala
+++ b/lib/profanity/src/test/profanity.CaptureTests.scala
@@ -35,7 +35,7 @@ package profanity
 import soundness.*
 
 import classloaders.systemClassloader
-import environments.javaEnvironment
+import environments.javaBaseEnvironment
 import logging.silentLogging
 import strategies.throwUnsafely
 import threading.platformThreading

--- a/lib/profanity/src/test/profanity_test.scala
+++ b/lib/profanity/src/test/profanity_test.scala
@@ -37,10 +37,10 @@ import java.lang as jl
 import soundness.*
 
 import classloaders.systemClassloader
-import environments.javaEnvironment
-import systems.javaSystem
+import environments.javaBaseEnvironment
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 import logging.silentLogging
 import threading.platformThreading
 

--- a/lib/profanity/src/test/profanity_test.scala
+++ b/lib/profanity/src/test/profanity_test.scala
@@ -58,7 +58,7 @@ object Tests extends Suite(m"Profanity Tests"):
     supervise:
       val launcher = Enclave(t"profanity-fixture").dispatch:
         ' {
-            import executives.completions
+            import executives.completionsExecutive
             import interpreters.posixInterpreter
             import probates.cancelProbate
 

--- a/lib/punctuation/src/bench/punctuation.Benchmarks.scala
+++ b/lib/punctuation/src/bench/punctuation.Benchmarks.scala
@@ -34,7 +34,7 @@ package punctuation
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*

--- a/lib/reliquary/src/derive/reliquary.Materializer.scala
+++ b/lib/reliquary/src/derive/reliquary.Materializer.scala
@@ -47,8 +47,8 @@ import turbulence.*
 
 import Lira.Error.Reason
 import alphabets.hexLowerCase
-import filesystemBackends.virtualMachineFilesystem
-import filesystemOptions.overwritePreexisting.enabled
+import filesystemBackends.javaBaseFilesystem
+import filesystemOptions.overwritePreexisting
 
 // Derivation of conventional artifacts (§13.5): from a valid buildpath and a chosen universe,
 // each release's section is materialized and serialized as its canonical derivative JAR into a

--- a/lib/reliquary/src/test/reliquary_test.scala
+++ b/lib/reliquary/src/test/reliquary_test.scala
@@ -1062,7 +1062,7 @@ object Tests extends Suite(m"Reliquary Tests"):
 
     suite(m"Manifest signing"):
       import enigmatic.{MlDsa, Signing}
-      import gastronomy.providers.javaStdlibProvider
+      import gastronomy.providers.javaBaseProvider
 
       val mlDsa65: MlDsa[65] = summon[MlDsa[65]]
       val privateKey = mlDsa65.genKey()
@@ -1149,7 +1149,7 @@ object Tests extends Suite(m"Reliquary Tests"):
 
     suite(m"TEL schema resolution (LIRA-backed)"):
       import enigmatic.{MlDsa, Signing}
-      import gastronomy.providers.javaStdlibProvider
+      import gastronomy.providers.javaBaseProvider
 
       val mlDsa65: MlDsa[65] = summon[MlDsa[65]]
       val privateKey = mlDsa65.genKey()

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -114,7 +114,7 @@ extension [value](value: value)
 // A proof-carrying value compares as its unproven self: without this, strict equality rejects
 // comparing a `value & Populated` with a plain `value` (no `CanEqual` between them).
 given populatedEquality: [value] => CanEqual[value & Populated, value] = CanEqual.derived
-given populatedEquality2: [value] => CanEqual[value, value & Populated] = CanEqual.derived
+given populatedEqualityReversed: [value] => CanEqual[value, value & Populated] = CanEqual.derived
 
 extension [input, result](inline lambda: (=> input) => result)
   inline def upon(inline value: => input): result = lambda(value)

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -34,7 +34,7 @@ package rudiments
 
 import soundness.*
 import soundness.collationComparable
-import soundness.collations.codepoints
+import soundness.collations.codepointCollation
 import denominative.dysasymptotics.linearSize
 import soundness.sortingAlgorithms.timsort
 

--- a/lib/scintillate/src/bench/scintillate.Benchmarks.scala
+++ b/lib/scintillate/src/bench/scintillate.Benchmarks.scala
@@ -34,7 +34,7 @@ package scintillate
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import eucalyptus.*, logging.silentLogging

--- a/lib/scintillate/src/server/scintillate.Frontend.scala
+++ b/lib/scintillate/src/server/scintillate.Frontend.scala
@@ -44,7 +44,7 @@ object Frontend:
   // The companion default, outranked by a `frontends` given imported by name.
   given default: Frontend = Frontend.ThreadPerConnection
 
-// The choice package: `import frontends.reactive` selects the reactor.
+// The choice package: `import frontends.reactiveFrontend` selects the reactor.
 package frontends:
-  given threadPerConnection: Frontend = Frontend.ThreadPerConnection
-  given reactive: Frontend = Frontend.Reactive
+  given threadPerConnectionFrontend: Frontend = Frontend.ThreadPerConnection
+  given reactiveFrontend: Frontend = Frontend.Reactive

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -346,7 +346,7 @@ extends RequestServable:
   // A per-request server: handle every request (HTTP/1.1) or stream (HTTP/2)
   // with `handler`. The degenerate session with no per-connection setup. The
   // `Frontend` given selects the engine: the reactive selector loop for cleartext
-  // servers (`import frontends.reactive`), or a virtual-thread daemon per
+  // servers (`import frontends.reactiveFrontend`), or a virtual-thread daemon per
   // connection. A TLS server always takes the daemon path (`SSLSocket` cannot ride
   // a selector), as does `handleSession` (per-connection state is a per-thread
   // affair). Sessions and TLS aside, the two engines serve identical handlers.

--- a/lib/scintillate/src/server/scintillate_core.scala
+++ b/lib/scintillate/src/server/scintillate_core.scala
@@ -84,25 +84,25 @@ package httpServers:
         type Response = Http.Response
         type Server = Service }
 
-  given stdlibHttpd: [port <: (80 | 443 | 8080 | 8000)]
+  given jdkHttpserver: [port <: (80 | 443 | 8080 | 8000)]
   =>  ( tactic: Tactic[Httpd.Error], monitor: Monitor, probate: Probate )
   =>  ( loggable: Httpd.Event is Loggable, errorPage: WebserverErrorPage )
   =>  ((HttpdFor[port])^{tactic, monitor, caps.any}) =
     HttpProtocolic[port](false, true)
 
-  given stdlibPublicHttpd: [port <: (80 | 443 | 8080 | 8000)]
+  given jdkHttpserverPublic: [port <: (80 | 443 | 8080 | 8000)]
   =>  ( tactic: Tactic[Httpd.Error], monitor: Monitor, probate: Probate )
   =>  ( loggable: Httpd.Event is Loggable, errorPage: WebserverErrorPage )
   =>  ((HttpdFor[port])^{tactic, monitor, caps.any}) =
     HttpProtocolic[port](false, false)
 
-  given nativeHttpServer: [port <: (80 | 443 | 8080 | 8000)]
+  given soundnessHttpd: [port <: (80 | 443 | 8080 | 8000)]
   =>  ( tactic: Tactic[Httpd.Error], monitor: Monitor, probate: Probate )
   =>  ( loggable: Httpd.Event is Loggable, errorPage: WebserverErrorPage )
   =>  ((HttpdFor[port])^{tactic, monitor, caps.any}) =
     HttpProtocolic[port](true, true)
 
-  given nativePublicHttpServer: [port <: (80 | 443 | 8080 | 8000)]
+  given soundnessHttpdPublic: [port <: (80 | 443 | 8080 | 8000)]
   =>  ( tactic: Tactic[Httpd.Error], monitor: Monitor, probate: Probate )
   =>  ( loggable: Httpd.Event is Loggable, errorPage: WebserverErrorPage )
   =>  ((HttpdFor[port])^{tactic, monitor, caps.any}) =
@@ -139,7 +139,7 @@ package webserverErrorPages:
   private def prefix(using Classloader): Data = cp"/scintillate/error.pre.html".read[Data]
   private def postfix(using Classloader): Data = cp"/scintillate/error.post.html".read[Data]
 
-  given standardErrorPage: Classloader => WebserverErrorPage = (throwable, request) =>
+  given styledErrorPage: Classloader => WebserverErrorPage = (throwable, request) =>
     // Direct `Content`, not `.ascribe`: the inline re-elaboration freshens the chunk type.
     Http.Response(Unfulfilled(Content(media"text/html", Chain[Data](prefix, postfix))))
 

--- a/lib/scintillate/src/server/soundness_scintillate_server.scala
+++ b/lib/scintillate/src/server/soundness_scintillate_server.scala
@@ -44,12 +44,12 @@ export
       WebserverErrorPage }
 
 package frontends:
-  export scintillate.frontends.{threadPerConnection, reactive}
+  export scintillate.frontends.{threadPerConnectionFrontend, reactiveFrontend}
 
 package httpServers:
   // Hand-written forwarders rather than an `export`: synthesized export forwarders lose the
   // givens' capture-annotated refinement types (the zephyrine through/accepting finding).
-  given stdlibHttpd: [port <: (80 | 443 | 8080 | 8000)]
+  given jdkHttpserver: [port <: (80 | 443 | 8080 | 8000)]
   =>  ( tactic:  contingency.Tactic[scintillate.Httpd.Error],
         monitor: parasite.Monitor,
         probate: parasite.Probate )
@@ -59,18 +59,38 @@ package httpServers:
     // One erasing cast at the forwarding boundary (the wisteria `fieldInstance` pattern):
     // resolution finds the annotated instance, but its capture roots do not re-root through
     // a second given; the declared result type above restores the honest captures.
-    scintillate.httpServers.stdlibHttpd[port]
+    scintillate.httpServers.jdkHttpserver[port]
     . asInstanceOf[scintillate.httpServers.HttpdFor[port]]
 
-  given stdlibPublicHttpd: [port <: (80 | 443 | 8080 | 8000)]
+  given jdkHttpserverPublic: [port <: (80 | 443 | 8080 | 8000)]
   =>  ( tactic:  contingency.Tactic[scintillate.Httpd.Error],
         monitor: parasite.Monitor,
         probate: parasite.Probate )
   =>  ( loggable:  scintillate.Httpd.Event is anticipation.Loggable,
         errorPage: scintillate.WebserverErrorPage )
   =>  ((scintillate.httpServers.HttpdFor[port])^{tactic, monitor, caps.any}) =
-    scintillate.httpServers.stdlibPublicHttpd[port]
+    scintillate.httpServers.jdkHttpserverPublic[port]
+    . asInstanceOf[scintillate.httpServers.HttpdFor[port]]
+
+  given soundnessHttpd: [port <: (80 | 443 | 8080 | 8000)]
+  =>  ( tactic:  contingency.Tactic[scintillate.Httpd.Error],
+        monitor: parasite.Monitor,
+        probate: parasite.Probate )
+  =>  ( loggable:  scintillate.Httpd.Event is anticipation.Loggable,
+        errorPage: scintillate.WebserverErrorPage )
+  =>  ((scintillate.httpServers.HttpdFor[port])^{tactic, monitor, caps.any}) =
+    scintillate.httpServers.soundnessHttpd[port]
+    . asInstanceOf[scintillate.httpServers.HttpdFor[port]]
+
+  given soundnessHttpdPublic: [port <: (80 | 443 | 8080 | 8000)]
+  =>  ( tactic:  contingency.Tactic[scintillate.Httpd.Error],
+        monitor: parasite.Monitor,
+        probate: parasite.Probate )
+  =>  ( loggable:  scintillate.Httpd.Event is anticipation.Loggable,
+        errorPage: scintillate.WebserverErrorPage )
+  =>  ((scintillate.httpServers.HttpdFor[port])^{tactic, monitor, caps.any}) =
+    scintillate.httpServers.soundnessHttpdPublic[port]
     . asInstanceOf[scintillate.httpServers.HttpdFor[port]]
 
 package webserverErrorPages:
-  export scintillate.webserverErrorPages.{minimalErrorPage, stackTracesErrorPage, standardErrorPage}
+  export scintillate.webserverErrorPages.{minimalErrorPage, stackTracesErrorPage, styledErrorPage}

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -225,7 +225,7 @@ object Tests extends Suite(m"Scintillate tests"):
         . assert(_.s.split("200 OK").nn.length == 65)
 
         test(m"SocketServer.handle serves through the reactor when selected"):
-          import frontends.reactive
+          import frontends.reactiveFrontend
           val port = freePort()
 
           supervise:

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -60,9 +60,9 @@ import superlunary.*
 import symbolism.*
 import vacuous.*
 
-import systems.javaSystem
+import systems.javaBaseSystem
 import threading.platformThreading
-import workingDirectories.javaWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 import denominative.*
 import denominative.dysasymptotics.linearSize
 

--- a/lib/sedentary/src/core/sedentary.BenchmarkDevice.scala
+++ b/lib/sedentary/src/core/sedentary.BenchmarkDevice.scala
@@ -48,7 +48,7 @@ import urticose.*
 import vacuous.*
 
 import logging.silentLogging
-import workingDirectories.javaWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 import beneficence.*
 
 trait BenchmarkDevice extends Findable:

--- a/lib/sedentary/src/core/sedentary.Profile.scala
+++ b/lib/sedentary/src/core/sedentary.Profile.scala
@@ -56,9 +56,9 @@ import serpentine.*
 import superlunary.*
 import vacuous.*
 
-import systems.javaSystem
+import systems.javaBaseSystem
 import threading.platformThreading
-import workingDirectories.javaWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 // A profile test: where `Bench` measures how fast a fragment runs and `Stress` how it
 // scales, `Profile` measures where its time goes. The body is run repeatedly on a single

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -56,9 +56,9 @@ import serpentine.*
 import superlunary.*
 import vacuous.*
 
-import systems.javaSystem
+import systems.javaBaseSystem
 import threading.platformThreading
-import workingDirectories.javaWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 // A stress test: the memory/scaling counterpart of `Bench`. Where `Bench` times one operation
 // repeated serially on the calling thread, `Stress` runs the body concurrently on `concurrency`

--- a/lib/sedentary/src/test/sedentary_test.scala
+++ b/lib/sedentary/src/test/sedentary_test.scala
@@ -37,7 +37,7 @@ import soundness.*
 import classloaders.threadContextClassloader
 import environments.javaBaseEnvironment
 import strategies.throwUnsafely
-import superlunary.embeddings.automatic
+import superlunary.embeddings.automaticEmbedding
 import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 

--- a/lib/sedentary/src/test/sedentary_test.scala
+++ b/lib/sedentary/src/test/sedentary_test.scala
@@ -35,10 +35,10 @@ package sedentary
 import soundness.*
 
 import classloaders.threadContextClassloader
-import environments.javaEnvironment
+import environments.javaBaseEnvironment
 import strategies.throwUnsafely
 import superlunary.embeddings.automatic
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 
 given BenchmarkDevice = LocalhostDevice

--- a/lib/serpentine/src/bench/serpentine.Benchmarks.scala
+++ b/lib/serpentine/src/bench/serpentine.Benchmarks.scala
@@ -34,7 +34,7 @@ package serpentine
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import contingency.*, strategies.throwUnsafely
 import fulminate.*
 import hellenism.*, classloaders.threadContextClassloader

--- a/lib/sibylline/src/core/sibylline.Anthropic.scala
+++ b/lib/sibylline/src/core/sibylline.Anthropic.scala
@@ -42,7 +42,7 @@ import fulminate.*
 import gesticulate.*
 import gossamer.*
 import hieroglyph.*, charEncoders.utf8Encoder
-import jacinta.*, formatting.compactJsonFormatting, dynamicJsonAccess.enabled
+import jacinta.*, formatting.compactJsonFormatting, dynamicAccess.dynamicJson
 import monotonous.*, alphabets.base64Standard
 import obligatory.*
 import prepositional.*

--- a/lib/sibylline/src/core/sibylline.Gemini.scala
+++ b/lib/sibylline/src/core/sibylline.Gemini.scala
@@ -41,7 +41,7 @@ import distillate.*
 import fulminate.*
 import gossamer.*
 import hieroglyph.*, charEncoders.utf8Encoder
-import jacinta.*, formatting.compactJsonFormatting, dynamicJsonAccess.enabled
+import jacinta.*, formatting.compactJsonFormatting, dynamicAccess.dynamicJson
 import monotonous.*, alphabets.base64Standard
 import obligatory.*
 import prepositional.*

--- a/lib/sibylline/src/core/sibylline.OpenAI.scala
+++ b/lib/sibylline/src/core/sibylline.OpenAI.scala
@@ -41,7 +41,7 @@ import distillate.*
 import fulminate.*
 import gossamer.*
 import hieroglyph.*, charEncoders.utf8Encoder
-import jacinta.*, formatting.compactJsonFormatting, dynamicJsonAccess.enabled
+import jacinta.*, formatting.compactJsonFormatting, dynamicAccess.dynamicJson
 import monotonous.*, alphabets.base64Standard
 import obligatory.*
 import prepositional.*

--- a/lib/sibylline/src/test/sibylline.AnthropicTests.scala
+++ b/lib/sibylline/src/test/sibylline.AnthropicTests.scala
@@ -36,7 +36,7 @@ import soundness.*
 
 import charDecoders.utf8Decoder
 import charEncoders.utf8Encoder
-import dynamicJsonAccess.enabled
+import dynamicAccess.dynamicJson
 import errorDiagnostics.stackTracesDiagnostics
 import internetAccess.online
 import logging.silentLogging

--- a/lib/sibylline/src/test/sibylline.ProviderTests.scala
+++ b/lib/sibylline/src/test/sibylline.ProviderTests.scala
@@ -35,7 +35,7 @@ package sibylline
 import soundness.*
 
 import charEncoders.utf8Encoder
-import dynamicJsonAccess.enabled
+import dynamicAccess.dynamicJson
 import errorDiagnostics.stackTracesDiagnostics
 import internetAccess.online
 import logging.silentLogging

--- a/lib/sibylline/src/test/sibylline.ToolkitTests.scala
+++ b/lib/sibylline/src/test/sibylline.ToolkitTests.scala
@@ -34,7 +34,7 @@ package sibylline
 
 import soundness.*
 
-import dynamicJsonAccess.enabled
+import dynamicAccess.dynamicJson
 import errorDiagnostics.stackTracesDiagnostics
 import strategies.throwUnsafely
 

--- a/lib/stratiform/src/bench/stratiform.Benchmarks.scala
+++ b/lib/stratiform/src/bench/stratiform.Benchmarks.scala
@@ -37,7 +37,7 @@ import scala.sys
 import scala.language.unsafeNulls
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*

--- a/lib/stratiform/src/core/soundness_stratiform_core.scala
+++ b/lib/stratiform/src/core/soundness_stratiform_core.scala
@@ -34,5 +34,11 @@ package soundness
 
 export
   stratiform
-  . { DynamicTelEnabler, dynamicTelAccess, Revision, Mutation, Stratiform, Tel, Telp, Tel2,
-      Tel3, telConversion, TelReader, Tels, Tels2, tel }
+  . { DynamicTelEnabler, Revision, Mutation, Stratiform, Tel, Telp, Tel2,
+      Tel3, TelReader, Tels, Tels2, tel }
+
+package dynamicAccess:
+  export stratiform.dynamicAccess.dynamicTel
+
+package conversions:
+  export stratiform.conversions.encodableToTel

--- a/lib/stratiform/src/core/stratiform.DynamicTelEnabler.scala
+++ b/lib/stratiform/src/core/stratiform.DynamicTelEnabler.scala
@@ -35,11 +35,11 @@ package stratiform
 import rudiments.*
 
 // Phantom-typed gate for `tel.selectDynamic("…")` and friends. Importing
-// `dynamicTelAccess.enabled` brings the given into scope and unlocks the
+// `dynamicAccess.dynamicTel` brings the given into scope and unlocks the
 // dynamic syntax; without that import the dynamic methods are
 // inaccessible, mirroring jacinta's DynamicJsonEnabler pattern.
 
 sealed trait DynamicTelEnabler
 
-object dynamicTelAccess:
-  inline given enabled: DynamicTelEnabler = !!
+package dynamicAccess:
+  inline given dynamicTel: DynamicTelEnabler = !!

--- a/lib/stratiform/src/core/stratiform.Stratiform.scala
+++ b/lib/stratiform/src/core/stratiform.Stratiform.scala
@@ -112,7 +112,7 @@ object Stratiform:
       then
         halt:
           m"""
-            dynamic field access on an unverified `Tel` requires `import dynamicTelAccess.enabled`
+            dynamic field access on an unverified `Tel` requires `import dynamicAccess.dynamicTel`
             (or verify the value against a schema first)
           """
 
@@ -145,7 +145,7 @@ object Stratiform:
     def plain: Expr[Tel] =
       if Expr.summon[DynamicTelEnabler].nil then halt:
         m"""
-          dynamic field access on an unverified `Tel` requires `import dynamicTelAccess.enabled`
+          dynamic field access on an unverified `Tel` requires `import dynamicAccess.dynamicTel`
           (or verify the value against a schema first)
         """
 

--- a/lib/stratiform/src/core/stratiform.conversions.scala
+++ b/lib/stratiform/src/core/stratiform.conversions.scala
@@ -30,60 +30,13 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package gastronomy
-
-import scala.caps
-
-import java.security as js
-import java.util.zip as juz
+package stratiform
 
 import anticipation.*
-import corpuscular.*
-import gossamer.*
+import prepositional.*
 
-// The default hashing provider, backed by the JDK: `MessageDigest` for the
-// cryptographic hashes and `java.util.zip.CRC32` for the checksum. This is the
-// single home of `java.security`/`java.util.zip` usage in gastronomy. It does not
-// offer BLAKE3 (the JDK has no implementation) — use the Soundness provider.
-object JavaStdlibHashing extends Hashing:
-  def md5:  Hashing.Function = messageDigest(t"MD5")
-  def sha1: Hashing.Function = messageDigest(t"SHA1")
-  def sha2(bits: Int): Hashing.Function = messageDigest(t"SHA-$bits")
-
-  // The JDK has `java.util.zip` CRC-32 and Adler-32 (both intrinsified) but no CRC-64, so this
-  // provider simply does not offer `crc64`; the structural refinement means a CRC-64 digest
-  // resolves only under the Soundness provider, exactly as BLAKE3 does.
-  def adler32: Hashing.Function = new Hashing.Function:
-    def digestion(): Digestion^ = new Digestion:
-      private val state: juz.Adler32 = juz.Adler32()
-      update def append(bytes: Data): Unit = state.update(Array.unsafeJvm(bytes))
-
-      override update def append(array: Array[Byte]^{caps.any.rd}, start: Int, count: Int): Unit =
-        state.update(Array.unsafeJvm(array), start, count)
-
-      update def digest(): Data =
-        val v = state.getValue
-        Array(((v >>> 24) & 0xff).toByte, ((v >>> 16) & 0xff).toByte, ((v >>> 8) & 0xff).toByte,
-              (v & 0xff).toByte)
-
-  def crc32: Hashing.Function = new Hashing.Function:
-    def digestion(): Digestion^ = new Digestion:
-      private val state: juz.CRC32 = juz.CRC32()
-      update def append(bytes: Data): Unit = state.update(Array.unsafeJvm(bytes))
-
-      override update def append(array: Array[Byte]^{caps.any.rd}, start: Int, count: Int): Unit =
-        state.update(Array.unsafeJvm(array), start, count)
-
-      update def digest(): Data =
-        val value = state.getValue()
-        Array[Byte]((value >> 24).toByte, (value >> 16).toByte, (value >> 8).toByte, value.toByte)
-
-  private def messageDigest(name: Text): Hashing.Function = new Hashing.Function:
-    def digestion(): Digestion^ = new Digestion:
-      private val md: js.MessageDigest = js.MessageDigest.getInstance(name.s).nn
-      update def append(bytes: Data): Unit = md.update(Array.unsafeJvm(bytes))
-
-      override update def append(array: Array[Byte]^{caps.any.rd}, start: Int, count: Int): Unit =
-        md.update(Array.unsafeJvm(array), start, count)
-
-      update def digest(): Data = Array.unsafeFrozen(md.digest.nn)
+// Importing `conversions.encodableToTel` brings a scoped `Conversion` into lexical scope that lets
+// any `Encodable in Tel` value be supplied directly at lens-assignment positions, such as
+// `tel.lens(_.field = value)`, without an explicit `.tel`.
+package conversions:
+  given encodableToTel: [entity: Encodable in Tel] => Conversion[entity, Tel] = _.encode

--- a/lib/stratiform/src/test/stratiform.VerifyTests.scala
+++ b/lib/stratiform/src/test/stratiform.VerifyTests.scala
@@ -45,7 +45,7 @@ import vacuous.*
 import strategies.throwUnsafely
 import Tel.given
 
-// NB: `dynamicTelAccess.enabled` is deliberately *not* imported here — verified
+// NB: `dynamicAccess.dynamicTel` is deliberately *not* imported here — verified
 // `Tel of T` navigation must work without it.
 
 case class Worker(name: Text, age: Int) derives CanEqual
@@ -207,4 +207,4 @@ object VerifyTests extends Suite(m"Stratiform verify tests"):
         demilitarize:
           Worker(t"Alice", 30).encode.name
         . head.message
-      . assert(_.contains("dynamicTelAccess.enabled"))
+      . assert(_.contains("dynamicAccess.dynamicTel"))

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1419,7 +1419,7 @@ object Tests extends Suite(m"Stratiform Tests"):
       . assert(_ == Tel.Error.Reason.DuplicateLayerName)
 
     suite(m"Dynamic access"):
-      import dynamicTelAccess.enabled
+      import dynamicAccess.dynamicTel
 
       test(m"select-dynamic on encoded case class"):
         val doc = Tests.Person(t"Alice", 30).encode
@@ -1976,7 +1976,7 @@ object Tests extends Suite(m"Stratiform Tests"):
       def doc(source: String): Tel = source.tt.read[Tel]
 
       test(m"editing through the lens preserves surrounding formatting"):
-        import dynamicTelAccess.enabled
+        import dynamicAccess.dynamicTel
         val original = doc("# header\nname Alice\nemail a@example.com\n")
         val lens = summon["email" is Lens from Tel onto Tel]
         val updated = lens.modify(original)(_ => Tel.scalar(t"b@example.com"))
@@ -1997,7 +1997,7 @@ object Tests extends Suite(m"Stratiform Tests"):
       . assert(_ == t"name Bob\nemail b@example.com\n")
 
     suite(m"Tel.modify and Lens given"):
-      import dynamicTelAccess.enabled
+      import dynamicAccess.dynamicTel
       def doc(source: String): Tel = source.tt.read[Tel]
 
       test(m"modify replaces an existing field's compound"):
@@ -2026,7 +2026,7 @@ object Tests extends Suite(m"Stratiform Tests"):
       . assert(_ == t"Carol")
 
     suite(m"Optics: positional child traversal"):
-      import dynamicTelAccess.enabled
+      import dynamicAccess.dynamicTel
       def doc(source: String): Tel = source.tt.read[Tel]
       def contacts: Tel = doc("contacts\n  contact alice\n  contact bob\n")
 
@@ -2195,8 +2195,8 @@ object Tests extends Suite(m"Stratiform Tests"):
       import galilei.*
       import serpentine.*
       import inimitable.*
-      import galilei.filesystemBackends.virtualMachineFilesystem
-      import galilei.filesystemOptions.deleteRecursively.enabled
+      import galilei.filesystemBackends.javaBaseFilesystem
+      import galilei.filesystemOptions.deleteRecursively
 
       test(m"A file path opened Read & Write writes the mutation back"):
         val name: Text = Uuid().show

--- a/lib/superlunary/src/core/soundness_superlunary_core.scala
+++ b/lib/superlunary/src/core/soundness_superlunary_core.scala
@@ -32,4 +32,7 @@
                                                                                                   */
 package soundness
 
-export superlunary.{embeddings, Executor2, References, Rig, Stage, Stageable}
+export superlunary.{Executor2, References, Rig, Stage, Stageable}
+
+package embeddings:
+  export superlunary.embeddings.automaticEmbedding

--- a/lib/superlunary/src/core/superlunary.References.scala
+++ b/lib/superlunary/src/core/superlunary.References.scala
@@ -52,7 +52,7 @@ object References:
   // inside a hot loop — a benchmark body, for instance — would deserialize the transported
   // value on every iteration. The extracted instance is consequently SHARED between
   // evaluations, which is the intuitive semantics of splicing a value. The memoization is
-  // generated inline by `embeddings.automatic` rather than through a helper method: the
+  // generated inline by `embeddings.automaticEmbedding` rather than through a helper method: the
   // extraction is an inline call with deferred given summons, which must stay in statement
   // position in the staged program, not under a closure.
   class Boxed(val value: Any)

--- a/lib/superlunary/src/core/superlunary.Rig.scala
+++ b/lib/superlunary/src/core/superlunary.Rig.scala
@@ -54,7 +54,7 @@ import serpentine.*
 import spectacular.*
 
 import interfaces.paths.pathOnLinux
-import systems.javaSystem
+import systems.javaBaseSystem
 
 object Rig:
   // RemoteError → Rig.Error

--- a/lib/superlunary/src/core/superlunary_core.scala
+++ b/lib/superlunary/src/core/superlunary_core.scala
@@ -43,7 +43,7 @@ import anticipation.*
 import contingency.*
 import prepositional.*
 import interfaces.paths.pathOnLinux
-import systems.javaSystem
+import systems.javaBaseSystem
 
 object embeddings:
   inline given automatic: [value]

--- a/lib/superlunary/src/core/superlunary_core.scala
+++ b/lib/superlunary/src/core/superlunary_core.scala
@@ -45,8 +45,8 @@ import prepositional.*
 import interfaces.paths.pathOnLinux
 import systems.javaBaseSystem
 
-object embeddings:
-  inline given automatic: [value]
+package embeddings:
+  inline given automaticEmbedding: [value]
   =>  ( refs: References )
   =>  ( stageable: Stageable over refs.Transport )
   =>  Quotes

--- a/lib/superlunary/src/jvm/superlunary.Jvm.scala
+++ b/lib/superlunary/src/jvm/superlunary.Jvm.scala
@@ -45,7 +45,7 @@ import prepositional.*
 import serpentine.*
 
 import classloaders.systemClassloader
-import systems.javaSystem
+import systems.javaBaseSystem
 
 object Jvm extends Rig:
   type Result[output] = output

--- a/lib/superlunary/src/test/superlunary_test.scala
+++ b/lib/superlunary/src/test/superlunary_test.scala
@@ -40,7 +40,7 @@ import soundness.*
 
 import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
-import embeddings.automatic
+import embeddings.automaticEmbedding
 import strategies.throwUnsafely
 
 case class Example(name: Text, count: Long)

--- a/lib/superlunary/src/test/superlunary_test.scala
+++ b/lib/superlunary/src/test/superlunary_test.scala
@@ -38,7 +38,7 @@ import scala.quoted.*
 
 import soundness.*
 
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 import embeddings.automatic
 import strategies.throwUnsafely

--- a/lib/surveillance/src/core/soundness_surveillance_core.scala
+++ b/lib/surveillance/src/core/soundness_surveillance_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export surveillance.{NativeWatcher, PollingWatcher, Watch, watch, Watcher}
+export surveillance.{JavaBaseWatcher, PollingWatcher, Watch, watch, Watcher}
 
 package watchers:
-  export surveillance.watchers.{nativeWatcher, polling}
+  export surveillance.watchers.{javaBaseWatcher, polling}

--- a/lib/surveillance/src/core/surveillance.JavaBaseWatcher.scala
+++ b/lib/surveillance/src/core/surveillance.JavaBaseWatcher.scala
@@ -53,7 +53,7 @@ import vacuous.*
 // .WatchService`). A single service and a single polling thread are shared across every
 // registration; keys are reference-counted so the service is closed only once nothing is being
 // watched.
-object NativeWatcher extends Watcher:
+object JavaBaseWatcher extends Watcher:
   private case class WatchService(watchService: jnf.WatchService, pollLoop: Loop):
     import probates.awaitProbate
 
@@ -132,8 +132,8 @@ object NativeWatcher extends Watcher:
     Registration(pathWatches)
 
   private class PathWatch
-    ( private[NativeWatcher] val key:    jnf.WatchKey,
-      private[NativeWatcher] val base:   jnf.Path,
+    ( private[JavaBaseWatcher] val key:    jnf.WatchKey,
+      private[JavaBaseWatcher] val base:   jnf.Path,
                              val spool:  Relay[Watch.Event],
                              val filter: Text -> Boolean ):
 

--- a/lib/surveillance/src/core/surveillance.PollingWatcher.scala
+++ b/lib/surveillance/src/core/surveillance.PollingWatcher.scala
@@ -110,7 +110,7 @@ extends Watcher:
 
     directories.each: (directory, filter) => snapshots(directory) = scan(directory, filter)
 
-    // Sealed per the pure-façade convention (D6), like `NativeWatcher`: the handle is held
+    // Sealed per the pure-façade convention (D6), like `JavaBaseWatcher`: the handle is held
     // only to keep the supervised poll task alive for the registration's lifetime.
     val async: Optional[Task[Unit]] = safely:
       supervise:

--- a/lib/surveillance/src/core/surveillance.Watcher.scala
+++ b/lib/surveillance/src/core/surveillance.Watcher.scala
@@ -39,12 +39,12 @@ import contingency.*
 import turbulence.*
 
 // A `Watcher` is the backend that detects filesystem changes. The default (selected without any
-// import) is `NativeWatcher`, which delegates to the operating system's filewatching service. The
+// import) is `JavaBaseWatcher`, which delegates to the operating system's filewatching service. The
 // `watchers.polling` backend instead snapshots directories on a fixed interval, for filesystems or
 // platforms where native filewatching is unavailable or unreliable.
 
 object Watcher:
-  given default: Watcher = NativeWatcher
+  given default: Watcher = JavaBaseWatcher
 
   // A handle to a single backend registration; cancelling it stops delivery of further events for
   // the directories registered in the corresponding `watch` call.

--- a/lib/surveillance/src/core/surveillance_core.scala
+++ b/lib/surveillance/src/core/surveillance_core.scala
@@ -44,7 +44,7 @@ transparent inline def watch(using handle: Watch.Handle^): handle.type = handle
 export Watch.Event.{NewFile, NewDirectory, Modify, Delete}
 
 package watchers:
-  given nativeWatcher: Watcher = NativeWatcher
+  given javaBaseWatcher: Watcher = JavaBaseWatcher
 
   def polling[duration: Abstractable across Durations to Long](interval: duration): Watcher =
     PollingWatcher(interval)

--- a/lib/surveillance/src/test/surveillance_test.scala
+++ b/lib/surveillance/src/test/surveillance_test.scala
@@ -35,13 +35,13 @@ package surveillance
 import soundness.*
 
 import errorDiagnostics.emptyDiagnostics
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.overwritePreexisting.disabled
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.failOnPreexisting
 import strategies.throwUnsafely
 import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 
 object Tests extends Suite(m"Surveillance tests"):
   def run(): Unit =

--- a/lib/surveillance/src/test/surveillance_test.scala
+++ b/lib/surveillance/src/test/surveillance_test.scala
@@ -38,7 +38,7 @@ import errorDiagnostics.emptyDiagnostics
 import filesystemOptions.createNonexistentParents.enabled
 import filesystemOptions.overwritePreexisting.disabled
 import strategies.throwUnsafely
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 
 import filesystemBackends.virtualMachineFilesystem

--- a/lib/synesthesia/src/content/synesthesia.Content.scala
+++ b/lib/synesthesia/src/content/synesthesia.Content.scala
@@ -149,7 +149,7 @@ object Content:
     case User, Assistant
 
   object ContentBlock:
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
 
     private val typeTag = Json.discriminatedUnion[ContentBlock](t"type")
 

--- a/lib/synesthesia/src/core/synesthesia.Mcp.scala
+++ b/lib/synesthesia/src/core/synesthesia.Mcp.scala
@@ -382,7 +382,7 @@ object Mcp:
   case class Argument(name: Text, value: Text)
 
   object Reference:
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
 
     private val typeTag = Json.discriminatedUnion[Reference](t"type")
 
@@ -465,7 +465,7 @@ object Mcp:
     TextContent | ImageContent | AudioContent | ToolUseContent | ToolResultContent
 
   object ToolUseContent:
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
 
     private val typeTag = Json.discriminatedUnion[SamplingMessageContentBlock](t"type")
 

--- a/lib/synesthesia/src/test/synesthesia_test.scala
+++ b/lib/synesthesia/src/test/synesthesia_test.scala
@@ -69,7 +69,7 @@ object Tests extends Suite(m"Synesthesia Tests"):
     //   import internetAccess.online
     //   import supervisors.globalSupervisor
     //   import probates.cancelProbate
-    //   import httpServers.stdlibHttpd
+    //   import httpServers.jdkHttpserver
     //   import logging.silentLogging
     //   import webserverErrorPages.stackTracesErrorPage
     //   import classloaders.threadContextClassloader

--- a/lib/tarantula/src/core/tarantula.WebDriver.scala
+++ b/lib/tarantula/src/core/tarantula.WebDriver.scala
@@ -48,7 +48,7 @@ import gossamer.*
 import guillotine.*
 import hieroglyph.*, charEncoders.utf8Encoder, charDecoders.utf8Decoder,
     textSanitizers.strictSanitizer
-import jacinta.*, formatting.compactJsonFormatting, dynamicJsonAccess.enabled
+import jacinta.*, formatting.compactJsonFormatting, dynamicAccess.dynamicJson
 import monotonous.*, alphabets.base64Standard
 import parasite.*
 import prepositional.*

--- a/lib/tarantula/src/test/tarantula_test.scala
+++ b/lib/tarantula/src/test/tarantula_test.scala
@@ -43,16 +43,16 @@ import errorDiagnostics.stackTracesDiagnostics
 import formatting.compactJsonFormatting
 import internetAccess.online
 import logging.silentLogging
-import environments.javaEnvironment
+import environments.javaBaseEnvironment
 import probates.awaitProbate
-import stdios.virtualMachineStdio
-import systems.javaSystem
+import stdios.fileDescriptorStdio
+import systems.javaBaseSystem
 import termcaps.environmentTermcap
 import strategies.throwUnsafely
 import textSanitizers.skipSanitizer
 import threading.virtualThreading
 import webserverErrorPages.minimalErrorPage
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 object FakeDriver:
   // One request as the driver saw it. The body is `Unset` for a request that had none, so that a

--- a/lib/tarantula/src/test/tarantula_test.scala
+++ b/lib/tarantula/src/test/tarantula_test.scala
@@ -38,7 +38,7 @@ import soundness.*
 
 import charDecoders.utf8Decoder
 import charEncoders.utf8Encoder
-import dynamicJsonAccess.enabled
+import dynamicAccess.dynamicJson
 import errorDiagnostics.stackTracesDiagnostics
 import formatting.compactJsonFormatting
 import internetAccess.online
@@ -492,7 +492,7 @@ object Tests extends Suite(m"Tarantula tests"):
 
       // The real transport, only for this block: everything above deliberately runs against a
       // fake backend, and summoning both at once would be ambiguous.
-      import httpBackends.virtualMachineHttp
+      import httpBackends.javaNetHttp
 
       supervise:
         val port = freePort()

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -727,7 +727,7 @@ object Http:
   // its response. The URL is fully resolved (passed as `Text`) so non-JVM
   // backends can parse it themselves; redirects are handled by `Http.Client`, not
   // the backend. Backends are platform-specific, so each is summoned by an
-  // explicit import: `httpBackends.virtualMachineHttp` (`java.net.http`, in
+  // explicit import: `httpBackends.javaNetHttp` (`java.net.http`, in
   // `telekinesis.jvm`) on the JVM; other platforms or implementations (e.g.
   // HTTP/2) supply their own given.
   trait Backend:

--- a/lib/telekinesis/src/jvm/soundness_telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/soundness_telekinesis_jvm.scala
@@ -36,4 +36,4 @@ export telekinesis.{requestTransmissible, domainSocketFetchable, domainSocketHtt
     httpUrlSessional}
 
 package httpBackends:
-  export telekinesis.httpBackends.{nativeHttp, virtualMachineHttp}
+  export telekinesis.httpBackends.{soundnessHttp, javaNetHttp}

--- a/lib/telekinesis/src/jvm/telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/telekinesis_jvm.scala
@@ -40,7 +40,7 @@ import javax.net.ssl as jns
 
 import anticipation.*
 import coaxial.*
-import coaxial.socketBackends.virtualMachineSockets
+import coaxial.socketBackends.javaBaseSockets
 import contingency.*
 import telekinesis.*
 import distillate.*
@@ -149,7 +149,7 @@ package httpBackends:
   // The JVM transport, using `java.net.http`. Other platforms (e.g. Scala.js)
   // or implementations (e.g. an HTTP/2 client) supply their own `Http.Backend`
   // given instead.
-  given virtualMachineHttp: TlsAcceptance => Http.Backend = new Http.Backend:
+  given javaNetHttp: TlsAcceptance => Http.Backend = new Http.Backend:
     def request
       ( url:     Text,
         method:  Http.Method,
@@ -170,7 +170,7 @@ package httpBackends:
   // are drained eagerly before a connection is surrendered or closed, so
   // responses do not stream yet, and `101` upgrades are not supported (the
   // upgraded stream would never end).
-  given nativeHttp: (online: Online)
+  given soundnessHttp: (online: Online)
   =>  (backend: Socket.Backend, options: Every[Socket.Option.Tcp], buffering: Buffering, tls: Tls)
   =>  Http.Backend = new Http.Backend:
 
@@ -221,7 +221,7 @@ private def repackage(response: Http.Response, data: Data): Http.Response =
 
   response.status(response.textHeaders, body)
 
-// The pooled, kept-alive plaintext HTTP/1.1 exchange (see `httpBackends.nativeHttp`).
+// The pooled, kept-alive plaintext HTTP/1.1 exchange (see `httpBackends.soundnessHttp`).
 private def plaintextExchange
   ( host:    Host,
     tcpPort: Tcp.Port,

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -48,7 +48,7 @@ case class Person(name: Text, address: Address)
 
 object Tests extends Suite(m"Telekinesis tests"):
   def run(): Unit =
-    import httpBackends.virtualMachineHttp
+    import httpBackends.javaNetHttp
     import internetAccess.online
 
     suite(m"Response construction tests"):
@@ -599,9 +599,9 @@ object Tests extends Suite(m"Telekinesis tests"):
       server.start()
       val port: Int = server.getAddress.nn.getPort
 
-      import socketBackends.virtualMachineSockets
+      import socketBackends.javaBaseSockets
 
-      val backend: Http.Backend = httpBackends.nativeHttp
+      val backend: Http.Backend = httpBackends.soundnessHttp
 
       def fetchNative(target: Text, method: Http.Method = Http.Get, body: Text = t"")
       :   Http.Response =
@@ -712,9 +712,9 @@ object Tests extends Suite(m"Telekinesis tests"):
 
       given Tls = Tls(clientContext, verify = false)
 
-      import socketBackends.virtualMachineSockets
+      import socketBackends.javaBaseSockets
 
-      val backend: Http.Backend = httpBackends.nativeHttp
+      val backend: Http.Backend = httpBackends.soundnessHttp
 
       test(m"An ALPN-less server falls back to HTTP/1.1 over TLS"):
         val server = csnh.HttpsServer.create(InetSocketAddress("127.0.0.1", 0), 0).nn
@@ -941,13 +941,13 @@ object Tests extends Suite(m"Telekinesis tests"):
       . assert(identity)
 
       test(m"relaxed acceptance disables endpoint identification"):
-        import crypto.permitUntrustedCertificates
+        import cryptoPermits.permitUntrustedCertificates
         val (_, parameters) = TlsAcceptance().permitHostnameMismatch.materialize()
         parameters.getEndpointIdentificationAlgorithm == null
       . assert(identity)
 
       test(m"an expired-tolerant acceptance materializes a custom context"):
-        import crypto.permitUntrustedCertificates
+        import cryptoPermits.permitUntrustedCertificates
         val (context, _) = TlsAcceptance().permitExpired.materialize()
         context != javax.net.ssl.SSLContext.getDefault
       . assert(identity)
@@ -965,12 +965,12 @@ object Tests extends Suite(m"Telekinesis tests"):
       . assert(_ == (true, List(t"h2"), List(t"TLSv1.3"), true))
 
       test(m"a relaxed acceptance bridges with verification off"):
-        import crypto.permitUntrustedCertificates
+        import cryptoPermits.permitUntrustedCertificates
         TlsAcceptance().permitHostnameMismatch.tls().verify
       . assert(_ == false)
 
     suite(m"Certificate validation with relaxed acceptance"):
-      import crypto.permitUntrustedCertificates, crypto.permitUncheckedRevocation
+      import cryptoPermits.permitUntrustedCertificates, cryptoPermits.permitUncheckedRevocation
 
       test(m"expired certificate accepted under permitExpired"):
         given TlsAcceptance = TlsAcceptance().permitExpired

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -35,8 +35,8 @@ package turbulence
 import scala.collection.immutable.IndexedSeq
 
 import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
-import enigmatic.*, blockCipherMode.cbc, blockCipherPadding.pkcs7
-import gastronomy.providers.javaStdlibProvider, gastronomy.crypto.permitUnauthenticatedCrypto
+import enigmatic.*, blockCipherModes.cbc, blockCipherPaddings.pkcs7
+import gastronomy.providers.javaBaseProvider, gastronomy.cryptoPermits.permitUnauthenticatedCrypto
 import parasite.*, threading.virtualThreading, probates.panicProbate
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
@@ -174,7 +174,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
 
   // AES-256 key + a fixed key/IV for the JDK reference, generated/derived once.
   lazy val aesKey: SymmetricKey[Aes[256] over Cbc against Pkcs7] =
-    import enigmatic.cloaks.cloakHeap
+    import enigmatic.cloaks.heapCloak
     SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
   lazy val jdkKeyBytes: scala.Array[Byte] = scala.Array.tabulate(32)(i => (i*7 + 1).toByte)
   lazy val jdkIvBytes:  scala.Array[Byte] = scala.Array.tabulate(16)(i => (i*13 + 3).toByte)

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -34,7 +34,7 @@ package turbulence
 
 import scala.collection.immutable.IndexedSeq
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import enigmatic.*, blockCipherMode.cbc, blockCipherPadding.pkcs7
 import gastronomy.providers.javaStdlibProvider, gastronomy.crypto.permitUnauthenticatedCrypto
 import parasite.*, threading.virtualThreading, probates.panicProbate

--- a/lib/turbulence/src/core/soundness_turbulence_core.scala
+++ b/lib/turbulence/src/core/soundness_turbulence_core.scala
@@ -46,4 +46,4 @@ package lineSeparation:
     . { adaptiveLinefeedLineSeparation, carriageReturnLineSeparation,
         carriageReturnLinefeedLineSeparation, linefeedLineSeparation,
         strictCarriageReturnLineSeparation, strictLinefeedsLineSeparation,
-        virtualMachineLineSeparation }
+        javaBaseLineSeparation }

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -280,7 +280,7 @@ package lineSeparation:
   given adaptiveLinefeedLineSeparation
   :   LineSeparation(NewlineSeq.Lf, Action.Nl, Action.Nl, Action.Nl, Action.Nl)
 
-  given virtualMachineLineSeparation: LineSeparation = jl.System.lineSeparator.nn match
+  given javaBaseLineSeparation: LineSeparation = jl.System.lineSeparator.nn match
     case "\r\n"    => carriageReturnLinefeedLineSeparation
     case "\r"      => carriageReturnLineSeparation
     case "\n"      => linefeedLineSeparation

--- a/lib/turbulence/src/stdio/soundness_turbulence_stdio.scala
+++ b/lib/turbulence/src/stdio/soundness_turbulence_stdio.scala
@@ -35,4 +35,4 @@ package soundness
 export turbulence.{Err, In, Out, Stdio}
 
 package stdios:
-  export turbulence.stdios.{muteStdio, systemStdio, virtualMachineStdio}
+  export turbulence.stdios.{muteStdio, javaLangSystemStdio, fileDescriptorStdio}

--- a/lib/turbulence/src/stdio/turbulence_stdio.scala
+++ b/lib/turbulence/src/stdio/turbulence_stdio.scala
@@ -40,14 +40,14 @@ import anticipation.*
 package stdios:
   given muteStdio: Stdio = Stdio(null, null, null, termcapDefinitions.basicTermcap)
 
-  given systemStdio: (termcap: Termcap) => Stdio =
+  given javaLangSystemStdio: (termcap: Termcap) => Stdio =
     Stdio
       ( jl.System.out.nn,
         jl.System.err.nn,
         jl.System.in.nn,
         termcap )
 
-  given virtualMachineStdio: (termcap: Termcap) => Stdio =
+  given fileDescriptorStdio: (termcap: Termcap) => Stdio =
     Stdio
       ( ji.PrintStream(ji.FileOutputStream(ji.FileDescriptor.out)),
         ji.PrintStream(ji.FileOutputStream(ji.FileDescriptor.err)),

--- a/lib/ultimatum/src/core/soundness_ultimatum_core.scala
+++ b/lib/ultimatum/src/core/soundness_ultimatum_core.scala
@@ -42,10 +42,10 @@ export
 package inlineAnchoring:
   export
     ultimatum.inlineAnchoring
-    . { bottomDocked, topAnchored, topAfterResize, fullscreen, inline }
+    . { bottomDockedAnchoring, topAnchoring, topAfterResizeAnchoring, fullscreenAnchoring, flowAnchoring }
 
 package inlineGrowth:
-  export ultimatum.inlineGrowth.{scrollIntoScrollback, clampToScreen}
+  export ultimatum.inlineGrowth.{scrollbackGrowth, clampedGrowth}
 
 package inlineShrink:
-  export ultimatum.inlineShrink.{redockBottom, keepTop}
+  export ultimatum.inlineShrink.{redockBottomShrink, keepTopShrink}

--- a/lib/ultimatum/src/core/ultimatum.InlinePolicy.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlinePolicy.scala
@@ -40,17 +40,17 @@ enum InlineAnchoring:
   case TopAnchored     // pinned to rows 1..height from the first frame
   case TopAfterResize  // bottom-docked, then top-anchored after the first resize
   case Fullscreen      // take over the alternate screen buffer, top-anchored
-  case Inline          // render relative to the cursor, flowing with prior output
+  case Flow            // render relative to the cursor, flowing with prior output
 
 object InlineAnchoring:
   given default: InlineAnchoring = TopAfterResize
 
 package inlineAnchoring:
-  given bottomDocked: InlineAnchoring = InlineAnchoring.BottomDocked
-  given topAnchored: InlineAnchoring = InlineAnchoring.TopAnchored
-  given topAfterResize: InlineAnchoring = InlineAnchoring.TopAfterResize
-  given fullscreen: InlineAnchoring = InlineAnchoring.Fullscreen
-  given inline: InlineAnchoring = InlineAnchoring.Inline
+  given bottomDockedAnchoring: InlineAnchoring = InlineAnchoring.BottomDocked
+  given topAnchoring: InlineAnchoring = InlineAnchoring.TopAnchored
+  given topAfterResizeAnchoring: InlineAnchoring = InlineAnchoring.TopAfterResize
+  given fullscreenAnchoring: InlineAnchoring = InlineAnchoring.Fullscreen
+  given flowAnchoring: InlineAnchoring = InlineAnchoring.Flow
 
 // What happens when a frame is taller than the last while bottom-docked. The
 // default (`ScrollIntoScrollback`) preserves the historic behaviour.
@@ -62,8 +62,8 @@ object InlineGrowth:
   given default: InlineGrowth = ScrollIntoScrollback
 
 package inlineGrowth:
-  given scrollIntoScrollback: InlineGrowth = InlineGrowth.ScrollIntoScrollback
-  given clampToScreen: InlineGrowth = InlineGrowth.ClampToScreen
+  given scrollbackGrowth: InlineGrowth = InlineGrowth.ScrollIntoScrollback
+  given clampedGrowth: InlineGrowth = InlineGrowth.ClampToScreen
 
 // What happens when a frame is shorter than the last. The default
 // (`RedockBottom`) preserves the historic behaviour.
@@ -75,5 +75,5 @@ object InlineShrink:
   given default: InlineShrink = RedockBottom
 
 package inlineShrink:
-  given redockBottom: InlineShrink = InlineShrink.RedockBottom
-  given keepTop: InlineShrink = InlineShrink.KeepTop
+  given redockBottomShrink: InlineShrink = InlineShrink.RedockBottom
+  given keepTopShrink: InlineShrink = InlineShrink.KeepTop

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -101,7 +101,7 @@ extends GridSurface(widthFn(), 0):
   private var topAnchored: Boolean = anchoring match
     case InlineAnchoring.TopAnchored | InlineAnchoring.Fullscreen      => true
     case InlineAnchoring.BottomDocked | InlineAnchoring.TopAfterResize => false
-    case InlineAnchoring.Inline                                        => false
+    case InlineAnchoring.Flow                                        => false
 
   @scala.caps.unsafe.untrackedCaptures
   private var started: Boolean = false
@@ -225,7 +225,7 @@ extends GridSurface(widthFn(), 0):
     Out.print(frame.toString.tt)
 
   def flush(): Unit =
-    if anchoring == InlineAnchoring.Inline then flushInline() else flushDocked()
+    if anchoring == InlineAnchoring.Flow then flushInline() else flushDocked()
 
   private def flushDocked(): Unit =
     val rows    = heightFn()
@@ -498,7 +498,7 @@ extends GridSurface(widthFn(), 0):
     // `Inline` drops the cursor onto a fresh line right below the block, RELATIVELY (from
     // the caret down to the block's last row, then a newline that scrolls if at the foot),
     // so the following output — and the next inline block — continues immediately after it.
-    if anchoring == InlineAnchoring.Inline then
+    if anchoring == InlineAnchoring.Flow then
       val down = presentedRows - 1 - flowCursorRow
       if down > 0 then Out.print(csi.cud(down))
       Out.print(t"\r\n")

--- a/lib/ultimatum/src/demo/ultimatum_demo.scala
+++ b/lib/ultimatum/src/demo/ultimatum_demo.scala
@@ -37,7 +37,7 @@ import soundness.*
 import backstops.silentBackstop
 import bars.smoothBar
 import counters.paddedCounter
-import executives.completions
+import executives.completionsExecutive
 import gaugeGlyphs.unicodeGlyphs
 import interpreters.posixInterpreter
 import palettes.emberGaugePalette

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -484,7 +484,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
       // With `bottomDocked`, a resize never switches to top-anchoring: the block stays
       // docked and its rows are cleared at the bottom (row 3), not the top-left corner.
       test(m"bottomDocked keeps the block docked across a resize"):
-        import inlineAnchoring.bottomDocked
+        import inlineAnchoring.bottomDockedAnchoring
         val (bytes, stdio) = capturing()
         given Stdio = stdio
         val root = InlineRoot(3, 4)
@@ -498,7 +498,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
       // With `topAnchored`, the very first frame is pinned to rows 1..h (no bottom dock,
       // no scroll into scrollback).
       test(m"topAnchored pins the first frame to the top rows"):
-        import inlineAnchoring.topAnchored
+        import inlineAnchoring.topAnchoring
         val (bytes, stdio) = capturing()
         given Stdio = stdio
         val root = InlineRoot(3, 4)
@@ -508,7 +508,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
 
       // With `fullscreen`, the first present enters the alternate screen buffer.
       test(m"fullscreen enters the alternate screen on the first present"):
-        import inlineAnchoring.fullscreen
+        import inlineAnchoring.fullscreenAnchoring
         val (bytes, stdio) = capturing()
         given Stdio = stdio
         val root = InlineRoot(3, 4)
@@ -518,7 +518,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
 
       // ...and leaves it again on finish, restoring the pre-session screen.
       test(m"fullscreen leaves the alternate screen on finish"):
-        import inlineAnchoring.fullscreen
+        import inlineAnchoring.fullscreenAnchoring
         val (bytes, stdio) = capturing()
         given Stdio = stdio
         val root = InlineRoot(3, 4)
@@ -531,7 +531,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
       // With `keepTop`, a shrink holds the top row and clears below (row 4), rather than
       // re-docking down and clearing the row it vacated above.
       test(m"keepTop clears below the block on a shrink, holding the top"):
-        import inlineShrink.keepTop
+        import inlineShrink.keepTopShrink
         val (bytes, stdio) = capturing()
         given Stdio = stdio
         val root = InlineRoot(3, 4)
@@ -544,7 +544,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
       // With `clampToScreen`, a growing block grows upward in place; it never scrolls the
       // screen into scrollback (no `\e[9999B`).
       test(m"clampToScreen grows without scrolling into scrollback"):
-        import inlineGrowth.clampToScreen
+        import inlineGrowth.clampedGrowth
         val (bytes, stdio) = capturing()
         given Stdio = stdio
         val root = InlineRoot(3, 4)

--- a/lib/vivisection/src/dap/vivisection.Dap.scala
+++ b/lib/vivisection/src/dap/vivisection.Dap.scala
@@ -60,7 +60,7 @@ import vacuous.*
 // wire. Field names mirror the specification's exactly, including its `camelCase` and the
 // reserved-word `type`.
 object Dap:
-  import dynamicJsonAccess.enabled
+  import dynamicAccess.dynamicJson
 
   // Serves the protocol over the ambient standard streams until the input is exhausted — the
   // canonical stdio transport a frontend launches. All outgoing traffic flows through a single

--- a/lib/vivisection/src/dap/vivisection.DapSession.scala
+++ b/lib/vivisection/src/dap/vivisection.DapSession.scala
@@ -104,7 +104,7 @@ private[vivisection] class DapSession(emit: Json => Unit)
           note:       Diagnostics ):
 
   import strategies.throwUnsafely
-  import dynamicJsonAccess.enabled
+  import dynamicAccess.dynamicJson
 
   // This adapter juggles capabilities whose lifetimes its own state machine encloses. Its
   // callbacks — breakpoint handlers, bind notifications, session tasks — refer to it through

--- a/lib/vivisection/src/demo/vivisection_demoserver.scala
+++ b/lib/vivisection/src/demo/vivisection_demoserver.scala
@@ -43,9 +43,9 @@ import logging.silentLogging
 import probates.awaitProbate
 import socketBackends.virtualMachineSockets
 import strategies.throwUnsafely
-import systems.javaSystem
+import systems.javaBaseSystem
 import threading.virtualThreading
-import workingDirectories.javaWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 // A runnable Debug Adapter Protocol server over stdio: point a DAP frontend (VS Code with a
 // generic DAP launch configuration, say) at this executable and it drives a vivisection debug

--- a/lib/vivisection/src/demo/vivisection_demoserver.scala
+++ b/lib/vivisection/src/demo/vivisection_demoserver.scala
@@ -36,12 +36,12 @@ import soundness.*
 
 import backstops.stackTraceBackstop
 import errorDiagnostics.stackTracesDiagnostics
-import executives.completions
+import executives.completionsExecutive
 import internetAccess.online
 import interpreters.posixInterpreter
 import logging.silentLogging
 import probates.awaitProbate
-import socketBackends.virtualMachineSockets
+import socketBackends.javaBaseSockets
 import strategies.throwUnsafely
 import systems.javaBaseSystem
 import threading.virtualThreading

--- a/lib/vivisection/src/test/vivisection_test.scala
+++ b/lib/vivisection/src/test/vivisection_test.scala
@@ -43,7 +43,7 @@ import logging.silentLogging
 import strategies.throwUnsafely
 import internetAccess.online
 import workingDirectories.javaBaseWorkingDirectory
-import socketBackends.virtualMachineSockets
+import socketBackends.javaBaseSockets
 import systems.javaBaseSystem
 
 case class Attach(duplex: Duplex)
@@ -110,7 +110,7 @@ object Tests extends Suite(m"Vivisection tests"):
   // exercises the whole adapter (the request mapping, the live debuggee, breakpoints, inspection)
   // without the stdio transport, whose framing is covered by the round-trip codec test.
   class DapClient(handle: Json => Unit):
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
 
     private val seq = java.util.concurrent.atomic.AtomicInteger(0)
     private val inbox = java.util.concurrent.LinkedBlockingQueue[Json]()
@@ -166,7 +166,7 @@ object Tests extends Suite(m"Vivisection tests"):
   // both the server (on stdin EOF) and the reader (on its input closing) end naturally and the
   // supervision scope awaits them — nothing is force-cancelled.
   class DapStdioClient(toServer: java.io.OutputStream):
-    import dynamicJsonAccess.enabled
+    import dynamicAccess.dynamicJson
 
     private val seq = java.util.concurrent.atomic.AtomicInteger(0)
     private val inbox = java.util.concurrent.LinkedBlockingQueue[Json]()
@@ -957,7 +957,7 @@ object Tests extends Suite(m"Vivisection tests"):
     // load, launch, the stop, and inspection of a local rendered through its `Inspectable`
     // instance — asserting the protocol traffic a frontend would see.
     test(m"a DAP client launches, stops at a breakpoint and inspects a local"):
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       val classpathText = System.properties.java.`class`.path()
 
       supervise:
@@ -1009,7 +1009,7 @@ object Tests extends Suite(m"Vivisection tests"):
     // Evaluation and assignment over the wire: evaluate an expression against a stopped frame,
     // then set a variable and read it back.
     test(m"a DAP client evaluates and assigns over a stopped frame"):
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       val classpathText = System.properties.java.`class`.path()
 
       supervise:
@@ -1054,7 +1054,7 @@ object Tests extends Suite(m"Vivisection tests"):
     // the frame's locals; a member selection resolves the local's declared type's members; and a
     // fresh binding position offers nothing (the name is the programmer's to invent).
     test(m"a DAP client completes console input against a stopped frame"):
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       val classpathText = System.properties.java.`class`.path()
 
       supervise:
@@ -1111,7 +1111,7 @@ object Tests extends Suite(m"Vivisection tests"):
     // on a local shows its value and static type, and a hover on an arbitrary expression is
     // refused rather than executed — while the console still evaluates that same expression.
     test(m"a DAP client hovers without executing debuggee code"):
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       val classpathText = System.properties.java.`class`.path()
 
       supervise:
@@ -1169,7 +1169,7 @@ object Tests extends Suite(m"Vivisection tests"):
     // The transport itself, over real pipes: `initialize` and `disconnect` without ever opening
     // a debuggee, so this exercises the framing and the server's teardown-on-EOF in isolation.
     test(m"a DAP server initializes and disconnects over stdio"):
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
 
       supervise:
         dapStdioScenario: client =>
@@ -1185,7 +1185,7 @@ object Tests extends Suite(m"Vivisection tests"):
     // disconnect — all `Content-Length`-framed JSON over pipes, proving the transport and its
     // teardown carry a live debug session end to end, not just the adapter in isolation.
     test(m"a DAP server drives a live debuggee over stdio"):
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       val classpathText = System.properties.java.`class`.path()
 
       supervise:
@@ -1332,7 +1332,7 @@ object Tests extends Suite(m"Vivisection tests"):
     // origin and the real frame at its call site, each with its source; scopes against the
     // inline frame resolve to the enclosing physical frame.
     test(m"DAP expands an inline stop into subtle and real frames"):
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       val classpathText = System.properties.java.`class`.path()
 
       supervise:
@@ -1387,7 +1387,7 @@ object Tests extends Suite(m"Vivisection tests"):
 
     test(m"a DAP response carries its type, correlation and body"):
       import strategies.throwUnsafely
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       val request = Dap.Envelope(seq = 3, command = t"threads")
       val body = Dap.ThreadsBody(List(Dap.ThreadInfo(1, t"main"))).in[Json]
       val response = Dap.response(7, request, body)
@@ -1398,7 +1398,7 @@ object Tests extends Suite(m"Vivisection tests"):
 
     test(m"a DAP failure response reports its message"):
       import strategies.throwUnsafely
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       val request = Dap.Envelope(seq = 9, command = t"nonesuch")
       val failure = Dap.failure(2, request, t"unrecognized command")
       (failure.success.as[Boolean], failure.message.as[Text])
@@ -1412,7 +1412,7 @@ object Tests extends Suite(m"Vivisection tests"):
 
     test(m"a DAP event names itself and carries its body"):
       import strategies.throwUnsafely
-      import dynamicJsonAccess.enabled
+      import dynamicAccess.dynamicJson
       val event = Dap.event(4, t"stopped", Dap.StoppedBody(t"breakpoint", threadId = 1).in[Json])
       (event.`type`.as[Text], event.event.as[Text], event.body.reason.as[Text])
     . assert(_ == (t"event", t"stopped", t"breakpoint"))

--- a/lib/vivisection/src/test/vivisection_test.scala
+++ b/lib/vivisection/src/test/vivisection_test.scala
@@ -42,9 +42,9 @@ import probates.awaitProbate
 import logging.silentLogging
 import strategies.throwUnsafely
 import internetAccess.online
-import workingDirectories.javaWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 import socketBackends.virtualMachineSockets
-import systems.javaSystem
+import systems.javaBaseSystem
 
 case class Attach(duplex: Duplex)
 

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -36,10 +36,10 @@ import scala.caps
 
 import soundness.*
 import soundness.collationComparable
-import soundness.collations.codepoints
+import soundness.collations.codepointCollation
 import soundness.sortingAlgorithms.timsort
 
-import ambience.systems.javaSystem
+import ambience.systems.javaBaseSystem
 
 type TsInterface = Interface in Typescript at "/xenophile/definitions.ts"
 given tsInterface: TsInterface = Interface[Typescript](cp"/xenophile/definitions.ts")

--- a/lib/xylophone/src/bench/xylophone.Benchmarks.scala
+++ b/lib/xylophone/src/bench/xylophone.Benchmarks.scala
@@ -34,7 +34,7 @@ package xylophone
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*

--- a/lib/xylophone/src/core/soundness_xylophone_core.scala
+++ b/lib/xylophone/src/core/soundness_xylophone_core.scala
@@ -36,7 +36,7 @@ package soundness
 // reach xylophone's via `xylophone.Attributive` etc.
 export
   xylophone
-  . { Xml, Xml2, Xml3, XmlSchema, DynamicXmlEnabler, dynamicXmlAccess, x, xp,
+  . { Xml, Xml2, Xml3, XmlSchema, DynamicXmlEnabler, x, xp,
       XPath }
 
 package formatting:
@@ -44,3 +44,6 @@ package formatting:
 
 package optics:
   export xylophone.optics.{xmlEachOptical, xmlLens, xmlOrdinalOptical}
+
+package dynamicAccess:
+  export xylophone.dynamicAccess.dynamicXml

--- a/lib/xylophone/src/core/xylophone.DynamicXmlEnabler.scala
+++ b/lib/xylophone/src/core/xylophone.DynamicXmlEnabler.scala
@@ -35,12 +35,12 @@ package xylophone
 import rudiments.*
 
 // Phantom-typed gate for `xml.selectDynamic("…")` and friends. Importing
-// `dynamicXmlAccess.enabled` brings the given into scope and unlocks the
+// `dynamicAccess.dynamicXml` brings the given into scope and unlocks the
 // dynamic navigation syntax (`xml.foo`, `xml.foo(Prim)`); without that import
 // the dynamic methods are inaccessible, mirroring jacinta's
 // `DynamicJsonEnabler` and stratiform's `DynamicTelEnabler`.
 
 sealed trait DynamicXmlEnabler
 
-object dynamicXmlAccess:
-  inline given enabled: DynamicXmlEnabler = !!
+package dynamicAccess:
+  inline given dynamicXml: DynamicXmlEnabler = !!

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -4306,7 +4306,7 @@ sealed into trait Xml extends Dynamic, Topical, Documentary, Formal:
   // are not unique, so a dereference yields a `Fragment` of zero or more
   // matches). `xml.foo(ordinal)` picks a single one; the ordinal defaults to
   // `Prim`, so `xml.foo()` is the first match. Both are gated by an imported
-  // `DynamicXmlEnabler` (see `dynamicXmlAccess.enabled`).
+  // `DynamicXmlEnabler` (see `dynamicAccess.dynamicXml`).
 
   private def selfNodes: Array[Node]^{} = this match
     case Fragment(nodes*) => Array.from(nodes)

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -2251,17 +2251,17 @@ object Xml extends Tag.Container
     // reconciliation happens only at element / attribute capture points
     // and before any refill in `moreSlow`.
     def fromTextTracked(text: Text)(using XmlSchema): XmlParser =
-      import zephyrine.lineation.linefeedChars
+      import zephyrine.lineation.linefeedChar
       new XmlParser(Cursor[Text](text), tracking = true)
 
     // Native `Chain` sibling of `fromIteratorTracked`.
     def fromChainTracked(input: Chain[Text])(using XmlSchema): XmlParser =
-      import zephyrine.lineation.linefeedChars
+      import zephyrine.lineation.linefeedChar
       new XmlParser(Cursor[Text](input), tracking = true)
 
     // The legacy interoperation shape: a stdlib `Iterator` of chunks.
     def fromIteratorTracked(input: Iterator[Text])(using XmlSchema): XmlParser =
-      import zephyrine.lineation.linefeedChars
+      import zephyrine.lineation.linefeedChar
       new XmlParser(Cursor[Text](input), tracking = true)
 
   private[xylophone] final class XmlParser

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -1236,43 +1236,43 @@ object Tests extends Suite(m"Xylophone tests"):
 
     suite(m"Dynamic access"):
       test(m"Dynamic dereference selects a child element's text"):
-        import dynamicXmlAccess.enabled
+        import dynamicAccess.dynamicXml
         t"<root><foo>bar</foo></root>".read[Xml].foo().as[Text]
       . assert(_ == t"bar")
 
       test(m"Chained dynamic dereference navigates nested elements"):
-        import dynamicXmlAccess.enabled
+        import dynamicAccess.dynamicXml
         t"<a><b><c>42</c></b></a>".read[Xml].b().c().as[Int]
       . assert(_ == 42)
 
       test(m"Dynamic dereference flattens non-unique tags into a Fragment"):
-        import dynamicXmlAccess.enabled
+        import dynamicAccess.dynamicXml
         t"<r><x>1</x><x>2</x></r>".read[Xml].x.nodes.length
       . assert(_ == 2)
 
       test(m"Empty-parens dereference is the same as `(Prim)`"):
-        import dynamicXmlAccess.enabled
+        import dynamicAccess.dynamicXml
         val xml = t"<r><x>1</x><x>2</x></r>".read[Xml]
         xml.x() == xml.x(Prim)
       . assert(_ == true)
 
       test(m"An ordinal selects the nth matching element"):
-        import dynamicXmlAccess.enabled
+        import dynamicAccess.dynamicXml
         t"<r><x>1</x><x>2</x></r>".read[Xml].x(Sec).as[Int]
       . assert(_ == 2)
 
       test(m"Dynamic dereference flattens across multiple parents"):
-        import dynamicXmlAccess.enabled
+        import dynamicAccess.dynamicXml
         t"<r><a><b>1</b><b>2</b></a><a><b>3</b></a></r>".read[Xml].a.b.nodes.length
       . assert(_ == 3)
 
       test(m"A missing tag yields an empty Fragment"):
-        import dynamicXmlAccess.enabled
+        import dynamicAccess.dynamicXml
         t"<r><x>1</x></r>".read[Xml].nope.nodes.isEmpty
       . assert(_ == true)
 
       test(m"An out-of-range ordinal yields an empty Fragment"):
-        import dynamicXmlAccess.enabled
+        import dynamicAccess.dynamicXml
         t"<r><x>1</x></r>".read[Xml].x(Sec).nodes.isEmpty
       . assert(_ == true)
 
@@ -1283,7 +1283,7 @@ object Tests extends Suite(m"Xylophone tests"):
       . assert(identity)
 
     suite(m"Optics"):
-      import dynamicXmlAccess.enabled
+      import dynamicAccess.dynamicXml
       def doc: Xml = t"<doc><x>1</x><x>2</x><x>3</x></doc>".read[Xml]
 
       test(m"lens replaces the first matching child element"):

--- a/lib/ypsiloid/src/bench/ypsiloid.Benchmarks.scala
+++ b/lib/ypsiloid/src/bench/ypsiloid.Benchmarks.scala
@@ -34,7 +34,7 @@ package ypsiloid
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*

--- a/lib/ypsiloid/src/core/soundness_ypsiloid_core.scala
+++ b/lib/ypsiloid/src/core/soundness_ypsiloid_core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export
   ypsiloid
-  . { Yaml, yamlConversion, DynamicYamlEnabler, dynamicYamlAccess,
+  . { Yaml, DynamicYamlEnabler,
       y, yp, YamlPath }
 
 package formatting:
@@ -42,3 +42,9 @@ package formatting:
 
 package discriminables:
   export ypsiloid.discriminables.{yamlByTypeDiscriminable, yamlByKindDiscriminable}
+
+package dynamicAccess:
+  export ypsiloid.dynamicAccess.dynamicYaml
+
+package conversions:
+  export ypsiloid.conversions.encodableToYaml

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -6085,7 +6085,7 @@ extends Dynamic derives CanEqual:
 
   // Dynamic field access — `yaml.foo` desugars to `selectDynamic("foo")`.
   // Gated on an erased `DynamicYamlEnabler` so the feature is opt-in via
-  // `import dynamicYamlAccess.enabled`.
+  // `import dynamicAccess.dynamicYaml`.
   def selectDynamic(field: String)(using erased dynamicYamlEnabler: DynamicYamlEnabler): Yaml = apply(field.tt)
 
   def applyDynamic(field: String)(index: Int)(using erased dynamicYamlEnabler: DynamicYamlEnabler)

--- a/lib/ypsiloid/src/core/ypsiloid.conversions.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.conversions.scala
@@ -30,66 +30,13 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package cataclysm
-
+package ypsiloid
 
 import anticipation.*
-import contextual.*
-import contingency.*
-import fulminate.*
-import nomenclature.*
 import prepositional.*
-import rudiments.*
-import symbolism.*
-import turbulence.*
-import vacuous.*
 
-// The `css"…"` typed CSS interpolator, wired through `contextual` like xylophone's
-// `x"…"` and honeycomb's `h"…"`. The transparent result is a `Css` (stylesheet) or a
-// `Css.Style` (inline style set), decided by the content (see `internal.expand`).
-extension (inline context: StringContext)
-  transparent inline def css: Interpolation = interpolation[Css | Css.Style](context)
-
-// The class and id names referenced anywhere in a stylesheet, including inside
-// nested rules and the selector-list arguments of `:is()`/`:not()`/`:nth-…(of)`.
-extension (css: Css)
-  def classes: Set[Name[CssClass]] =
-    val names: List[Name[CssClass]] = simples(css.rules).sweep:
-      case Simple.Class(name) => name
-
-    names.to[Set]
-
-  def ids: Set[Name[DomId]] =
-    val names: List[Name[DomId]] = simples(css.rules).sweep:
-      case Simple.Id(name) => name
-
-    names.to[Set]
-
-private def simples(nodes: List[Css.Node]): List[Simple] =
-  nodes.bind:
-    case Css.Node.Rule(selector, body) =>
-      listSimples(selector) + simples(body)
-    case Css.Node.At(_, _, body)       => body.lay(Nil)(simples)
-    case Css.Node.Declaration(_, _)    => Nil
-
-private def listSimples(list: SelectorList): List[Simple] =
-  list.selectors.bind: selector =>
-    ((selector.head :: selector.rest.map(_(1))): List[Compound]).bind(compoundSimples)
-
-private def compoundSimples(compound: Compound): List[Simple] =
-  compound.parts.bind:
-    case simple@ Simple.PseudoClass(_, argument)   =>
-      (simple :: argumentSimples(argument)): List[Simple]
-    case simple@ Simple.PseudoElement(_, argument) =>
-      (simple :: argumentSimples(argument)): List[Simple]
-    case simple                                    => List(simple)
-
-private def argumentSimples(argument: Optional[PseudoArgument]): List[Simple] =
-  argument.lay(Nil):
-    case PseudoArgument.Selectors(list) => listSimples(list)
-    case PseudoArgument.Nth(_, _, of)   => of.lay(Nil)(listSimples)
-    case PseudoArgument.Raw(_)          => Nil
-
-package formatting:
-  given indentedCssFormatting: Css.Formatting = Css.Formatting(newlines = true, spaces = true)
-  given compactCssFormatting: Css.Formatting = Css.Formatting(newlines = false, spaces = false)
+// Importing `conversions.encodableToYaml` brings a scoped `Conversion` into lexical scope that lets
+// any `Encodable in Yaml` value be supplied directly at lens-assignment positions, such as
+// `yaml.lens(_.field = value)`, without an explicit `.yaml`.
+package conversions:
+  given encodableToYaml: [entity: Encodable in Yaml] => Conversion[entity, Yaml] = _.encode

--- a/lib/ypsiloid/src/core/ypsiloid.dynamicAccess.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.dynamicAccess.scala
@@ -30,13 +30,9 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package stratiform
+package ypsiloid
 
-import anticipation.*
-import prepositional.*
+import rudiments.*
 
-// Importing `telConversion.encodable` brings a scoped `Conversion` into lexical scope that lets
-// any `Encodable in Tel` value be supplied directly at lens-assignment positions, such as
-// `tel.lens(_.field = value)`, without an explicit `.tel`.
-object telConversion:
-  given encodable: [entity: Encodable in Tel] => Conversion[entity, Tel] = _.encode
+package dynamicAccess:
+  inline given dynamicYaml: DynamicYamlEnabler = !!

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -887,7 +887,7 @@ object Tests extends Suite(m"Ypsiloid Tests"):
       . assert(_ => true)
 
     suite(m"Dynamic access"):
-      import dynamicYamlAccess.enabled
+      import dynamicAccess.dynamicYaml
 
       test(m"Read a field via selectDynamic"):
         val y = t"{name: Alice, age: 30}".read[Yaml]
@@ -1080,7 +1080,7 @@ object Tests extends Suite(m"Ypsiloid Tests"):
       . assert(_ == List("~"))
 
     suite(m"Lens"):
-      import dynamicYamlAccess.enabled, yamlConversion.encodable
+      import dynamicAccess.dynamicYaml, conversions.encodableToYaml
 
       val org = Yaml.ast(NamedOuter(t"a", Inner(7)).in[Yaml].root)
 

--- a/lib/zephyrine/src/bench/zephyrine.Benchmarks.scala
+++ b/lib/zephyrine/src/bench/zephyrine.Benchmarks.scala
@@ -34,7 +34,7 @@ package zephyrine
 
 import scala.quoted.*
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import fulminate.*
@@ -116,7 +116,7 @@ object Benchmarks extends Suite(m"Zephyrine benchmarks"):
     n
 
   def cursorNextWithLinefeeds(text: Text): Int =
-    import zephyrine.lineation.linefeedChars
+    import zephyrine.lineation.linefeedChar
     val c = Cursor(Iterator(text))
     var n = 0
     while c.next() do n += 1

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -69,3 +69,6 @@ extension [out, transport](consume intake: (Intake[out] over transport)^)
 
 package parsing:
   export zephyrine.parsing.trackPositions
+
+package lineation:
+  export zephyrine.lineation.{carriageReturnByte, carriageReturnChar, linefeedByte, linefeedChar}

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -66,7 +66,7 @@ extension [value](value: value)(using positionable: value is Positionable)
     positionable.locateKey(value, path)
 
 package lineation:
-  inline given linefeedChars: Lineation:
+  inline given linefeedChar: Lineation:
     type Operand = Char
 
     inline def active: Boolean = true

--- a/lib/zeppelin/src/test/zeppelin_test.scala
+++ b/lib/zeppelin/src/test/zeppelin_test.scala
@@ -42,7 +42,7 @@ import filesystemOptions.dereferenceSymlinks.enabled
 import filesystemOptions.overwritePreexisting.enabled
 import logging.silentLogging
 import strategies.throwUnsafely
-import systems.javaSystem
+import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
 import textSanitizers.skipSanitizer
 

--- a/lib/zeppelin/src/test/zeppelin_test.scala
+++ b/lib/zeppelin/src/test/zeppelin_test.scala
@@ -36,10 +36,10 @@ import soundness.*
 
 import charDecoders.utf8Decoder
 import charEncoders.utf8Encoder
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.deleteRecursively.enabled
-import filesystemOptions.dereferenceSymlinks.enabled
-import filesystemOptions.overwritePreexisting.enabled
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.deleteRecursively
+import filesystemOptions.dereferenceSymlinks
+import filesystemOptions.overwritePreexisting
 import logging.silentLogging
 import strategies.throwUnsafely
 import systems.javaBaseSystem
@@ -49,7 +49,7 @@ import textSanitizers.skipSanitizer
 import _root_.java.io as ji
 import _root_.java.util.zip as juz
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Zeppelin tests"):

--- a/lib/ziggurat/src/core/ziggurat.Xeq.scala
+++ b/lib/ziggurat/src/core/ziggurat.Xeq.scala
@@ -52,11 +52,11 @@ import vacuous.*
 import charDecoders.utf8Decoder
 import charEncoders.utf8Encoder
 import classloaders.threadContextClassloader
-import filesystemBackends.virtualMachineFilesystem
-import filesystemOptions.dereferenceSymlinks.enabled
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.deleteRecursively.enabled
-import filesystemOptions.overwritePreexisting.enabled
+import filesystemBackends.javaBaseFilesystem
+import filesystemOptions.dereferenceSymlinks
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.deleteRecursively
+import filesystemOptions.overwritePreexisting
 import textSanitizers.skipSanitizer
 import rudiments.sortingAlgorithms.timsort
 

--- a/lib/ziggurat/src/packager/ziggurat.Packager.scala
+++ b/lib/ziggurat/src/packager/ziggurat.Packager.scala
@@ -53,16 +53,16 @@ import turbulence.*
 import urticose.*
 import vacuous.*
 import errorDiagnostics.emptyDiagnostics
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.deleteRecursively.enabled
-import filesystemOptions.overwritePreexisting.enabled
-import gastronomy.*, providers.javaStdlibProvider
-import httpBackends.virtualMachineHttp
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.deleteRecursively
+import filesystemOptions.overwritePreexisting
+import gastronomy.*, providers.javaBaseProvider
+import httpBackends.javaNetHttp
 import internetAccess.online
 import monotonous.*, alphabets.hexLowerCase
 
-import filesystemBackends.virtualMachineFilesystem
-import filesystemOptions.dereferenceSymlinks.enabled
+import filesystemBackends.javaBaseFilesystem
+import filesystemOptions.dereferenceSymlinks
 
 // Turns a `Packaging` configuration into a distributable. Each per-platform binary is the
 // application JAR appended to a bare reusable runner stub, obtained from `RunnerSource` —

--- a/lib/ziggurat/src/test/ziggurat_test.scala
+++ b/lib/ziggurat/src/test/ziggurat_test.scala
@@ -44,16 +44,16 @@ import termcaps.environmentTermcap
 
 import strategies.throwUnsafely
 import charEncoders.utf8Encoder
-import providers.javaStdlibProvider
+import providers.javaBaseProvider
 import alphabets.hexLowerCase
 import errorDiagnostics.stackTracesDiagnostics
 
-import filesystemOptions.dereferenceSymlinks.enabled
-import filesystemOptions.overwritePreexisting.enabled
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.deleteRecursively.enabled
+import filesystemOptions.dereferenceSymlinks
+import filesystemOptions.overwritePreexisting
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.deleteRecursively
 
-import filesystemBackends.virtualMachineFilesystem
+import filesystemBackends.javaBaseFilesystem
 import denominative.dysasymptotics.linearSize
 
 object Tests extends Suite(m"Ziggurat tests"):

--- a/lib/ziggurat/src/test/ziggurat_test.scala
+++ b/lib/ziggurat/src/test/ziggurat_test.scala
@@ -34,12 +34,12 @@ package ziggurat
 
 import soundness.*
 
-import systems.javaSystem
-import environments.javaEnvironment
+import systems.javaBaseSystem
+import environments.javaBaseEnvironment
 import temporaryDirectories.systemTemporaryDirectory
-import workingDirectories.defaultWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 import logging.silentLogging
-import stdios.virtualMachineStdio
+import stdios.fileDescriptorStdio
 import termcaps.environmentTermcap
 
 import strategies.throwUnsafely

--- a/nativelink/src/Main.scala
+++ b/nativelink/src/Main.scala
@@ -90,7 +90,7 @@ object Main:
     // `System.getenv` — SN-supported, so it works on native with no separate backend (the same is
     // true of turbulence's stdio and capricious's randomness: their core givens use SN-supported
     // `System.*`/`java.util.Random` APIs).
-    import environments.javaEnvironment
+    import environments.javaBaseEnvironment
     out.println("ambience HOME = "+summon[Environment].variable(t"HOME").or(t"?").s)
 
     // coaxial: a UDP loopback round-trip straight through the native `Socket.Backend` — bind a

--- a/nativelink/src/Main.scala
+++ b/nativelink/src/Main.scala
@@ -64,7 +64,7 @@ object Main:
 
     // galilei: a real filesystem round-trip driven straight through the native `FilesystemBackend`
     // (Scala Native javalib) — create a directory, observe it, delete it, observe it gone.
-    import galilei.filesystemBackends.native
+    import galilei.filesystemBackends.scalaNativeFilesystem
     val fs = summon[FilesystemBackend on Linux]
     val dir: Path on Linux = unsafely((% / "var" / "tmp" / "soundness-native-fs").on[Linux])
     if fs.exists(dir, false) then unsafely(fs.delete(dir))
@@ -95,7 +95,7 @@ object Main:
 
     // coaxial: a UDP loopback round-trip straight through the native `Socket.Backend` — bind a
     // datagram socket, dispatch a payload to it, receive it back.
-    import coaxial.socketBackends.native
+    import coaxial.socketBackends.scalaNativeSockets
     val sb = summon[Socket.Backend]
     val udpPort = Port.unsafe[Udp](55555)
     val server = sb.listenUdp(udpPort, Unset, Nil)

--- a/sample/tube/src/core/tube.scala
+++ b/sample/tube/src/core/tube.scala
@@ -9,7 +9,7 @@ import dsvFormats.csvWithHeaderFormat
 import enumIdentification.kebabCaseIdentifiable
 import environments.daemonClientEnvironment
 import errorDiagnostics.stackTracesDiagnostics
-import executives.completions
+import executives.completionsExecutive
 import homeDirectories.system
 import logging.silentLogging
 import codicils.cancel
@@ -21,7 +21,7 @@ import textSanitizers.skipSanitizer
 import threading.platformThreading
 import unhandledErrors.stackTrace
 import workingDirectories.daemonClientWorkingDirectory
-import httpServers.stdlibPublicHttpServer
+import httpServers.jdkHttpserverPublic
 import timeFormats.railwayTimeFormat
 
 erased given Naptan is Nominative under MustMatch["(|HUB[A-Z0-9]{3}|9[14]0[A-Z]+)"] = !!
@@ -59,7 +59,7 @@ extension (name: Name[Naptan]) def resolve(using Online): Name[Naptan] = name ma
       case error: Error => name
 
     . within:
-        import dynamicJsonAccess.enabled
+        import dynamicAccess.dynamicJson
         val json = Json.parse(url"https://api.tfl.gov.uk/StopPoint/$name".fetch())
 
         json.children.as[List[Json]]
@@ -151,9 +151,9 @@ object Data:
         cache.establish:
           import filesystemOptions.readAccess.enabled
           import filesystemOptions.writeAccess.disabled
-          import filesystemOptions.dereferenceSymlinks.enabled
+          import filesystemOptions.dereferenceSymlinks
           import filesystemOptions.createNonexistent.enabled
-          import filesystemOptions.createNonexistentParents.enabled
+          import filesystemOptions.createNonexistentParents
           val file: Path on Linux = Xdg.cacheHome[Path on Linux]/"tube.csv"
 
           val csv = if file.exists() then file.open(_.stream[Bytes].strict) else

--- a/src/bench/main/crossparse.Benchmarks.scala
+++ b/src/bench/main/crossparse.Benchmarks.scala
@@ -34,7 +34,7 @@ package crossparse
 
 import scala.sys
 
-import ambience.*, environments.javaEnvironment, systems.javaSystem
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
 import anticipation.*
 import breviloquence.*
 import contingency.*, strategies.throwUnsafely

--- a/src/bench/main/crossparse.matrix.scala
+++ b/src/bench/main/crossparse.matrix.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package crossparse
 
-import ambience.*, systems.javaSystem
+import ambience.*, systems.javaBaseSystem
 import anticipation.*
 import breviloquence.*
 import contingency.*, strategies.throwUnsafely

--- a/tests/android/builder/build.scala
+++ b/tests/android/builder/build.scala
@@ -34,14 +34,14 @@ package androidsample
 
 import soundness.*
 
-import ambience.systems.javaSystem
+import ambience.systems.javaBaseSystem
 import logging.silentLogging
-import stdios.virtualMachineStdio
+import stdios.fileDescriptorStdio
 import termcapDefinitions.basicTermcap
 import probates.cancelProbate
 import strategies.throwUnsafely
 import threading.platformThreading
-import workingDirectories.javaWorkingDirectory
+import workingDirectories.javaBaseWorkingDirectory
 
 import java.nio.file.{Files, Paths}
 

--- a/web/src/web/soundnessweb.Main.scala
+++ b/web/src/web/soundnessweb.Main.scala
@@ -7,11 +7,11 @@ import charDecoders.utf8Decoder
 import charEncoders.utf8Encoder
 import classloaders.scalaClassloader
 import probates.cancelProbate
-import environments.javaEnvironment
+import environments.javaBaseEnvironment
 import errorDiagnostics.stackTracesDiagnostics
 import httpServers.stdlibPublicHttpServer
 import logging.silentLogging
-import stdios.virtualMachineStdio
+import stdios.fileDescriptorStdio
 import stylesheets.uncheckedClasses
 import supervisors.globalSupervisor
 import termcaps.environmentTermcap

--- a/web/src/web/soundnessweb.Main.scala
+++ b/web/src/web/soundnessweb.Main.scala
@@ -9,7 +9,7 @@ import classloaders.scalaClassloader
 import probates.cancelProbate
 import environments.javaBaseEnvironment
 import errorDiagnostics.stackTracesDiagnostics
-import httpServers.stdlibPublicHttpServer
+import httpServers.jdkHttpserverPublic
 import logging.silentLogging
 import stdios.fileDescriptorStdio
 import stylesheets.uncheckedClasses


### PR DESCRIPTION
Defines the naming standard for importable contextual values in `doc/standards/given-naming.md` and applies it across every library. JVM-backed implementations are now named for the Java module that supplies them (`javaBaseFilesystem`, `javaNetHttp`, `jdkHttpserver`), other platforms by `scalaNative…`, `wasi…` and `javascript…`, and Soundness's own implementations by `soundness…`; bare choice words gain their role, toggle objects become uniquely named givens, and families never mirrored into `soundness` now are. The uniqueness check reads library sources as well as export files.

### Release notes

Importable givens have been renamed to a consistent scheme; `doc/migration/pending.md` lists every change. The most visible:

```scala
import filesystemBackends.javaBaseFilesystem   // was virtualMachineFilesystem
import httpBackends.javaNetHttp                // was virtualMachineHttp
import httpBackends.soundnessHttp              // was nativeHttp
import systems.javaBaseSystem                  // was javaSystem
import stdios.fileDescriptorStdio              // was virtualMachineStdio
import dynamicAccess.dynamicJson               // was dynamicJsonAccess.enabled
import filesystemOptions.deleteOnlyEmpty       // was deleteRecursively.disabled
import arithmeticOptions.checkedOverflow       // was overflow.checked
```

`defaultWorkingDirectory` and `lightweightLogFormat` are removed in favour of `javaBaseWorkingDirectory` and `untimestampedLogFormat`. The Scala Native filesystem and socket backends are now reachable as `filesystemBackends.scalaNativeFilesystem` and `socketBackends.scalaNativeSockets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
