### PR TITLE
Ziggurat: `Xeq.dispatcher`, the nothing-embedded polyglot bootstrap

### DIFF
--- a/lib/ziggurat/res/core/ziggurat/xeq-dispatcher.bat
+++ b/lib/ziggurat/res/core/ziggurat/xeq-dispatcher.bat
@@ -1,0 +1,29 @@
+set "label=windows-x64"
+if /i "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "label=windows-arm64"
+set "assets="
+for /f "delims=" %%a in ('findstr /b /c:"assets:" "%~f0"') do if not defined assets set "assets=%%a"
+set "assets=%assets:assets:=%"
+set "row="
+for %%r in (%assets%) do echo(%%r|findstr /b /c:"%label%=" >nul 2>&1 && set "row=%%r"
+if not defined row (echo No executable for %label%>&2 & exit /b 1)
+set "row=%row:*==%"
+for /f "tokens=1,2 delims=|" %%u in ("%row%") do (set "url=%%u" & set "hash=%%v")
+set "exe=%~dpn0.exe"
+set "t=%TEMP%\~zigdp%RANDOM%.tmp"
+call :xeq_msg 33 ████████ 0 "Downloading…"
+where curl >nul 2>&1
+if %errorlevel% equ 0 (curl -fsSL "%url%" -o "%t%") else (powershell -NoProfile -Command "Invoke-WebRequest -Uri '%url%' -OutFile '%t%'")
+if not exist "%t%" exit /b 1
+for %%S in ("%t%") do set "size=%%~zS"
+call :xeq_msg 32 ████████ 1 "Downloaded %size% bytes"
+call :xeq_msg 33 ████████ 0 "Verifying SHA-256…"
+set "g="
+for /f "skip=1 tokens=*" %%H in ('certutil -hashfile "%t%" SHA256') do if not defined g set "g=%%H"
+set "g=%g: =%"
+if /i "%g%" neq "%hash%" (echo Hash mismatch>&2 & del "%t%" & exit /b 1)
+call :xeq_msg 32 ████████ 1 "Verified SHA-256"
+move /y "%t%" "%exe%" >nul
+"%exe%" %*
+set "code=%errorlevel%"
+del "%~f0" 2>nul
+exit /b %code%

--- a/lib/ziggurat/res/core/ziggurat/xeq-dispatcher.ps1
+++ b/lib/ziggurat/res/core/ziggurat/xeq-dispatcher.ps1
@@ -1,0 +1,28 @@
+$s = $MyInvocation.MyCommand.Definition
+$arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x64' }
+$label = "windows-$arch"
+$lines = Get-Content -Path $s
+$assets = ($lines -match '^assets:' | Select-Object -First 1) -replace '^assets:'
+$row = ($assets -split ',' | Where-Object { $_.StartsWith("$label=") } | Select-Object -First 1)
+if (-not $row) { [Console]::Error.WriteLine("No executable for $label"); exit 1 }
+$value = $row.Substring($label.Length + 1)
+$url, $hash = $value -split '\|', 2
+$exe = [IO.Path]::ChangeExtension($s, 'exe')
+$t = "$exe.tmp"
+xeq_msg 33 '████████' 0 'Downloading…'
+try { Invoke-WebRequest -Uri $url -OutFile $t -UseBasicParsing } catch {
+    [Console]::Error.WriteLine("Download failed"); exit 1
+}
+$size = (Get-Item $t).Length
+xeq_msg 32 '████████' 1 "Downloaded $size bytes"
+xeq_msg 33 '████████' 0 'Verifying SHA-256…'
+$g = (Get-FileHash -Path $t -Algorithm SHA256).Hash
+if ($g -ne $hash) {
+    [Console]::Error.WriteLine("Hash mismatch"); Remove-Item $t; exit 1
+}
+xeq_msg 32 '████████' 1 'Verified SHA-256'
+Move-Item -Force $t $exe
+& $exe @args
+$code = $LASTEXITCODE
+Remove-Item -Force $s
+exit $code

--- a/lib/ziggurat/res/core/ziggurat/xeq-dispatcher.sh
+++ b/lib/ziggurat/res/core/ziggurat/xeq-dispatcher.sh
@@ -1,0 +1,44 @@
+os=$(uname -s)
+arch=$(uname -m)
+
+case "$os" in
+  Darwin)                os=macos ;;
+  Linux)                 os=linux ;;
+  MINGW*|MSYS*|CYGWIN*)  os=windows ;;
+  *)  printf "Unsupported OS: %s\n" "$os" >&2; exit 1 ;;
+esac
+
+case "$arch" in
+  x86_64|AMD64)   arch=x64 ;;
+  aarch64|arm64)  arch=arm64 ;;
+  *)              printf "Unsupported architecture: %s\n" "$arch" >&2; exit 1 ;;
+esac
+
+label="${os}-${arch}"
+s=$(realpath "$0")
+row=$(sed -n 's/^assets://p' "$s" | head -1 | tr ',' '\n' | grep "^${label}=" | head -1)
+if [ -z "$row" ]
+then printf "No executable for %s\n" "$label" >&2; exit 1
+fi
+value=${row#*=}
+url=${value%%|*}
+hash=${value#*|}
+t="$s.tmp"
+xeq_msg 33 ████████ 0 "Downloading…"
+if command -v curl >/dev/null 2>&1
+then curl -fsSL "$url" -o "$t" || exit 1
+elif command -v wget >/dev/null 2>&1
+then wget -qO "$t" "$url" || exit 1
+else printf 'Need curl or wget\n' >&2; exit 1
+fi
+size=$(wc -c < "$t" | tr -d ' ')
+xeq_msg 32 ████████ 1 "Downloaded $size bytes"
+xeq_msg 33 ████████ 0 "Verifying SHA-256…"
+g=$( { sha256sum "$t" 2>/dev/null || shasum -a 256 "$t"; } | cut -d' ' -f1)
+if [ "$g" != "$hash" ]
+then printf 'Hash mismatch\n' >&2; rm -f "$t"; exit 1
+fi
+xeq_msg 32 ████████ 1 "Verified SHA-256"
+chmod +x "$t"
+mv "$t" "$s"
+exec "$s" "$@"

--- a/lib/ziggurat/src/core/ziggurat.Xeq.scala
+++ b/lib/ziggurat/src/core/ziggurat.Xeq.scala
@@ -126,6 +126,37 @@ object Xeq:
     builder.add(t"#>\n")
     builder.text.in[Data](using charEncoders.utf8Encoder)
 
+  // The polyglot per-platform dispatcher: the smallest possible cross-platform artefact.
+  // NOTHING is embedded except an `assets:` table of `label=url|hash` rows in which each URL
+  // is a COMPLETE per-platform executable (not a bare stub, and no JAR rides along). At run
+  // time the script detects its platform, downloads that one executable, verifies its
+  // SHA-256, replaces itself with it, and re-invokes with the original arguments — so the
+  // second invocation, and every one after it, is the real binary. On POSIX systems the
+  // replacement is in place (a file's name does not govern how it executes); on Windows —
+  // where a `.bat` or `.ps1` cannot become a binary under its own name — the executable is
+  // written beside the script as `<name>.exe`, the script deletes itself, and `PATHEXT`
+  // ordering resolves subsequent invocations to the `.exe`. `entries` are
+  // `(label, executable-url, executable-sha256)`.
+  def dispatcher(entries: List[(Text, Text, Text)]): Data =
+    val template = cp"/ziggurat/xeq.tmpl".read[Text]
+    val bat      = cp"/ziggurat/xeq-dispatcher.bat".read[Text]
+    val ps1      = cp"/ziggurat/xeq-dispatcher.ps1".read[Text]
+    val sh       = cp"/ziggurat/xeq-dispatcher.sh".read[Text]
+
+    val prefix: Text =
+      template.cut(t"@@BAT@@").join(bat).cut(t"@@PS1@@").join(ps1).cut(t"@@SH@@").join(sh)
+
+    val rows: List[Text] = entries.map: (label, url, hash) => t"$label=$url|$hash"
+
+    val builder = StringBuilder()
+    builder.add(prefix)
+    if !prefix.ends(t"\n") then builder.add('\n')
+    builder.add(t"assets:")
+    builder.add(rows.join(t","))
+    builder.add('\n')
+    builder.add(t"#>\n")
+    builder.text.in[Data](using charEncoders.utf8Encoder)
+
   // The polyglot online launcher. Unlike `installer` (which embeds every bare stub), this
   // embeds only the application JAR — once, as the `data` payload, exactly as `installer`
   // does — plus an `assets:` table of `label=url|hash`. At runtime the launcher downloads
@@ -226,10 +257,25 @@ object Xeq:
       write(outputPath, onlineLauncher(jarData, entries))
 
 
+  // Builds a dispatcher from a manifest of `label<TAB>url<TAB>sha256` rows, one per
+  // platform, naming the finished executables wherever they are published.
+  private def dispatcherMain(output: Text, manifest: Text): Unit = unsafely:
+    val entries: List[(Text, Text, Text)] =
+      manifest.as[Path on Linux].read[Text].cut(t"\n").map(_.trim)
+      . filter(_ != t"")
+      . map: line =>
+          val fields = line.cut(t"\t")
+          (fields.prim.or(t""), fields.stdlib.lift(1).getOrElse(t""), fields.reverse.prim.or(t""))
+
+    write(output.as[Path on Linux], dispatcher(entries))
+
   def main(args: scala.Array[String]): Unit =
     args.iterator.toList.to(List) match
       case "installer" :: output :: staging :: Nil =>
         installerMain(output.tt, staging.tt)
+
+      case "dispatcher" :: output :: manifest :: Nil =>
+        dispatcherMain(output.tt, manifest.tt)
 
       case "downloader" :: output :: url :: hash :: Nil =>
         downloaderMain(output.tt, url.tt, hash.tt)
@@ -239,6 +285,7 @@ object Xeq:
 
       case _ =>
         System.err.nn.println("usage: ziggurat.Xeq installer <output-file> <staging-dir>")
+        System.err.nn.println("       ziggurat.Xeq dispatcher <output-file> <manifest.tsv>")
         System.err.nn.println("       ziggurat.Xeq downloader <output-file> <url> <sha256>")
 
         System.err.nn.println(

--- a/lib/ziggurat/src/test/ziggurat_test.scala
+++ b/lib/ziggurat/src/test/ziggurat_test.scala
@@ -156,6 +156,65 @@ object Tests extends Suite(m"Ziggurat tests"):
         script.utf8.contains(t"index:data=1")
       .assert(_ == true)
 
+    def stageDispatcher(entries: List[(Text, Text, Text)]): Path on Linux =
+      val dir = tempDir()
+      val script = dir / t"dispatch"
+      script.create[File]()
+      script.open[File](Write): handle ?=>
+        handle.write(Chain(Xeq.dispatcher(entries)))
+      script.executable() = true
+      script
+
+    suite(m"dispatcher()"):
+      val entries: proscenium.List[(Text, Text, Text)] =
+        labels.map(fileEntry(tempDir(), _, t"#!/bin/sh\n"))
+      val script: Data = Xeq.dispatcher(entries)
+
+      test(m"output starts with bash shebang"):
+        script.utf8.starts(t"#!/usr/bin/env bash")
+      .assert(_ == true)
+
+      test(m"assets line contains every label"):
+        val text = script.utf8
+        labels.all { label => text.contains(t"$label=") }
+      .assert(_ == true)
+
+      test(m"embeds no payload at all"):
+        script.utf8.contains(t"index:")
+      .assert(_ == false)
+
+      // The downloaded "executable" reports its arguments, so this exercises the whole
+      // contract at once: platform selection, download, verification, self-replacement and
+      // re-invocation with the original arguments.
+      test(m"downloads, verifies, replaces itself and re-invokes with arguments"):
+        val dir = tempDir()
+        val entries: proscenium.List[(Text, Text, Text)] = proscenium.List.from:
+          labels.stdlib.map: (label: Text) =>
+            fileEntry(dir, label, t"#!/bin/sh\necho \"ran $label $$@\"\nexit 0\n")
+        val dispatch = stageDispatcher(entries)
+        sh"$dispatch --flag operand".exec[Text]().trim
+      .assert(_ == t"ran $hostLabel --flag operand")
+
+      test(m"after the first run, the script has become the executable"):
+        val dir = tempDir()
+        val entries: proscenium.List[(Text, Text, Text)] = proscenium.List.from:
+          labels.stdlib.map: (label: Text) =>
+            fileEntry(dir, label, t"#!/bin/sh\necho again\n")
+        val dispatch = stageDispatcher(entries)
+        sh"$dispatch".exec[Text]()
+        sh"$dispatch".exec[Text]().trim
+      .assert(_ == t"again")
+
+      test(m"rejects an executable whose hash does not match"):
+        val dir = tempDir()
+        val badHash = t"0"*64
+        val entries: proscenium.List[(Text, Text, Text)] = proscenium.List.from:
+          labels.stdlib.map: (label: Text) =>
+            fileEntry(dir, label, t"#!/bin/sh\necho oops\n", badHash)
+        val dispatch = stageDispatcher(entries)
+        sh"$dispatch".exec[Exit]()
+      .assert(_ != Exit.Ok)
+
     suite(m"native macOS download"):
       // The "stub" served here exits before the appended JAR bytes are reached, so the
       // launcher's download → verify → append-embedded-JAR → exec path runs end-to-end.


### PR DESCRIPTION
## What

`Xeq.dispatcher`: the fourth, and smallest, member of the Xeq polyglot family — for an
application whose **complete per-platform executables are already published**. Nothing is
embedded but an `assets:` table of `label=url|sha256` rows.

Run under any shell (renamed to `.bat`/`.ps1` on Windows, as with every Xeq polyglot), the
~6 kB script:

1. detects its platform (`uname` on POSIX, incl. MINGW/MSYS/Cygwin → `windows`;
   `PROCESSOR_ARCHITECTURE` on cmd/PowerShell),
2. downloads that platform's executable,
3. verifies its SHA-256 against the embedded hash,
4. **replaces itself with it** — in place on POSIX; beside itself as `<name>.exe` on Windows
   (a `.bat` cannot become a binary under its own name), deleting the script so `PATHEXT`
   resolves future invocations to the `.exe`,
5. re-invokes with the original arguments.

So the first invocation bootstraps, and every one after it is the real native binary.

## How it differs from the existing modes

| mode | embeds | downloads |
|---|---|---|
| `installer` | every stub + JAR | nothing |
| `onlineLauncher` | the JAR | one bare stub, then appends |
| `downloader` | nothing | one fixed URL |
| **`dispatcher`** | **nothing** | **the platform's finished executable** |

The CLI gains `ziggurat.Xeq dispatcher <output> <manifest.tsv>` (rows of
`label<TAB>url<TAB>sha256`).

## Testing

Six new cases in the ziggurat suite, exercising the full contract over `file://` URLs:
platform selection, download, SHA-256 verification (including rejection on mismatch),
self-replacement (a second invocation runs the replaced file directly), and argument
forwarding. Suite passes 19/19.

Also verified live against a real release: a dispatcher generated from
[fume 0.1.0](https://github.com/propensive/fume/releases/tag/0.1.0)'s five per-platform
executables downloaded `fume-macos-arm64` (535 kB), verified it, replaced itself (`file`
reports Mach-O where a shell script had been), and printed `fume 0.1.0`; the second
invocation ran natively.

The `.bat` and `.ps1` sections follow `xeq-downloader`'s mechanics but are untested on a
real Windows machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
