### PR TITLE
Frontier's catch-all no longer succeeds as an implicit candidate (fixes #1942)

### DIFF
--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -319,3 +319,12 @@ not yet been recorded here.
 
 - `honeycomb.doms.html` (`whatwg`, `html4Transitional`) renamed to `honeycomb.htmlDoms`; the
   `doms` package no longer exists. (#1943)
+
+## frontier
+
+- `frontier.context.explainMissingContext` and `soundness.explainMissingContext` no longer
+  succeed as an implicit candidate when the search resolves without them; the candidate now
+  always fails (its diagnostic is used only if the whole search fails), leaving the compiler to
+  select the instance itself. Effect: an implicit search made while type parameters are still
+  undetermined (e.g. `join`'s `element`/`textual`) is no longer resolved with those parameters
+  instantiated to `Any`. Inferred types of code that already compiled are unchanged. (#1944)

--- a/lib/frontier/src/core/frontier.internal.scala
+++ b/lib/frontier/src/core/frontier.internal.scala
@@ -51,8 +51,7 @@ object internal:
   // typer, so a non-transparent `explanation` would leave the macro splice
   // unexpanded while `explainMissingContext` is tried as a candidate — the
   // search would spuriously succeed and the abort would fire only at the
-  // `inlining` phase. Transparency also lets Case B1's precise type reach the
-  // call site.
+  // `inlining` phase.
   transparent inline def explanation[target]: target = ${explain[target]}
 
   private object SafeInlined:
@@ -534,11 +533,21 @@ object internal:
       report.errorAndAbort(Diagnostic.render(buildDiagnostic(missing)).s)
 
     seek(TypeRepr.of[target], Nil, 1).absolve match
-      case Found(_, expr) =>
-        // Return the resolved term at its own (precise) static type, not
-        // widened to `target`; `transparent` then surfaces the precise type to
-        // the call site.
-        expr.asInstanceOf[Expr[target]]
+      case Found(name, _) =>
+        // The search resolves without the catch-all, so the catch-all must fail
+        // rather than return the found term: the inliner instantiated every open
+        // type variable of the searched type (to `Any`, via `flipBottom`) before
+        // this macro ran, and a successful candidate would commit those
+        // instantiations to the caller — which mis-inferred `join`'s `element`
+        // as `Any` (#1942). Failing discards the candidate's typer state, and the
+        // compiler then finds the same instance itself, in the implicit scope,
+        // with inference intact. The catch-all thus never contributes a term; it
+        // is purely diagnostic. This message can surface only if the overall
+        // search fails for a reason the re-search did not see.
+        val found = Diagnostic.Found(name, Unset, proscenium.Nil)
+        val tree = Diagnostic.Resolving(name, Unset, proscenium.List(found))
+        val headline = t"contextual value resolves without the catch-all"
+        report.errorAndAbort(Diagnostic.render(tree, headline).s)
 
       case m: Missing =>
         emit(m)

--- a/lib/frontier/src/test/frontier_test.scala
+++ b/lib/frontier/src/test/frontier_test.scala
@@ -201,6 +201,68 @@ object Tests extends Suite(m"Frontier Tests"):
       . filter(_.error).map(_.message)
     . assert(_ == Nil)
 
+    // The catch-all must never *succeed* as a candidate: the inliner instantiates
+    // the open type variables of a tentative search (to `Any`) before the macro
+    // runs, and a successful candidate would commit them. Frontier aborts even
+    // when the search resolves without it, leaving inference of e.g. `join`'s
+    // `element` to the compiler (#1942).
+
+    test(m"a bare join over mapped elements compiles under import soundness.*"):
+      demilitarize:
+        import soundness.*
+        val y = List(t"a", t"b").map(_.upper).join
+      . filter(_.error).map(_.message)
+    . assert(_ == Nil)
+
+    test(m"a bare join compiles with the frontier.context catch-all in scope"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        val y = List(t"a", t"b").map(_.upper).join
+      . filter(_.error).map(_.message)
+    . assert(_ == Nil)
+
+    test(m"join with a separator compiles with the catch-all in scope"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        val y = List(t"a", t"b").join(t", ")
+      . filter(_.error).map(_.message)
+    . assert(_ == Nil)
+
+    test(m"a stdlib List joins with the catch-all in scope"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        val y = scala.collection.immutable.List(t"a", t"b").map(_.upper).join
+      . filter(_.error).map(_.message)
+    . assert(_ == Nil)
+
+    test(m"the catch-all does not change join's inferred type"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        val y = List(t"a", t"b").join
+        val z: Text = y
+      . filter(_.error).map(_.message)
+    . assert(_ == Nil)
+
+    test(m"a later using clause still pins a type parameter left open earlier"):
+      demilitarize:
+        import frontier.context.explainMissingContext
+        trait Pin[self] { type Operand }
+        type PinBy[self, element] = Pin[self] { type Operand = element }
+        object Pin:
+          given any: [self, element] => PinBy[self, element] =
+            new Pin[self] { type Operand = element }
+        trait Only[t]
+        object Only:
+          given int: Only[Int] = new Only[Int] {}
+        extension [self, element, wide >: element](value: self)
+          (using pin: PinBy[self, element])
+          (using only: Only[wide])
+          def pinned: wide = ???
+        val n = 1.pinned
+        val m: Int = n
+      . filter(_.error).map(_.message)
+    . assert(_ == Nil)
+
     // `read` now resolves an ordinary `Readable` instance, so a missing
     // decoder is an ordinary failed implicit search that Frontier explains —
     // listing the `Readable` pipelines and what each still requires.


### PR DESCRIPTION
Frontier's `explainMissingContext` catch-all used to return the found term as its own expansion whenever a search resolved without it, so it won every resolvable search from contextual scope. The compiler's inliner instantiates an inline call's open type arguments (to `Any`) before the macro runs, and a successful candidate committed those instantiations, so a search made while a type parameter was still open, such as `join`'s `element`, resolved at `Any` and the next using clause failed. The catch-all now aborts in that case too: the candidate fails, the compiler finds the same instance itself with inference intact, and the catch-all is purely diagnostic.

### Release notes

- **frontier**: `frontier.context.explainMissingContext` and `soundness.explainMissingContext` never contribute a term to a successful implicit search. Code such as the following compiles again with frontier on the classpath:

  ```scala
  import soundness.*
  val y = List(t"a", t"b").map(_.upper).join   // was: `Any is Textual` not found
  ```

  Resolvable searches under the catch-all now also run the compiler's own implicit-scope search, which delegation previously skipped. Inferred types of code that already compiled are unchanged.

Fixes #1942.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
