### PR TITLE
Review every tutorial against main, check the examples mechanically, and add collections and LLM tutorials

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,7 +40,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   tutorial or an API a tutorial documents. flame is built against the latest *release*, so a
   failure that names something renamed since (listed in `doc/migration/pending.md`) is reported
   as TOLERATED, not STALE. The conventions the checker relies on — the `// does not compile`
-  marker and `doc/fixtures/<tutorial>.scala` preambles — are in `doc/standards/style.md`.
+  marker, `<!-- doccheck: skip -->` before a fence that cannot run in a REPL, the
+  `<!-- doccheck: language … -->` request, and `doc/fixtures/<tutorial>.scala` preambles — are
+  in `doc/standards/style.md`. From a shell without `flame` on the path, set
+  `FLAME=/path/to/flame`; a full run takes a couple of hours (hung fences cost two minutes
+  each), so run it in the background and read the summary from stderr. `HTTP 500` means flame
+  itself crashed on the fence.
 - `python3 etc/check-doc-coverage.py` (run by `make build`) maps every library to the tutorials
   that mention a name only it exports; a new library needs a tutorial, a section in an existing
   one, or an entry in the script's `INTERNAL` or `COVERED_BY` tables.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,6 +31,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   opaque `proscenium` types), rival monads using their own `flatMap` rather than Soundness's
   `bind`, and conversions crossing back over the greppable `.stdlib` bridge at the boundary.
 
+## Tutorial examples
+
+- Every ` ```scala ` fence in `doc/modules/*.md` is checked by `make doccheck` (or `make doccheck
+  DOC=<tutorial>`), which evaluates the fences in order through the flame REPL's JSON API
+  (`etc/doccheck.py`; needs the `flame` binary and the release synced into `~/.ivy2/local`) and
+  checks the names they use against the source (`etc/doccheck-names.py`). Run it after changing a
+  tutorial or an API a tutorial documents. flame is built against the latest *release*, so a
+  failure that names something renamed since (listed in `doc/migration/pending.md`) is reported
+  as TOLERATED, not STALE. The conventions the checker relies on — the `// does not compile`
+  marker and `doc/fixtures/<tutorial>.scala` preambles — are in `doc/standards/style.md`.
+- `python3 etc/check-doc-coverage.py` (run by `make build`) maps every library to the tutorials
+  that mention a name only it exports; a new library needs a tutorial, a section in an existing
+  one, or an entry in the script's `INTERNAL` or `COVERED_BY` tables.
+
 ## Code Style
 
 - Scala 3.8.3 with advanced language features (experimental modularity, null safety)

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,13 @@ ci:
 wasm-e2e:
 	./etc/ci/wasm-e2e.sh
 
+# Evaluate every tutorial example in doc/modules/ through the flame REPL (`make doccheck`, or
+# `make doccheck DOC=json` for one tutorial), and check the names the examples use against the
+# source. See etc/doccheck.py for what it needs and how it reads the results.
+doccheck:
+	python3 etc/doccheck-names.py $(DOC)
+	python3 etc/doccheck.py $(DOC)
+
 attest:
 	./etc/ci/attest.sh
 
@@ -105,4 +112,4 @@ matrix:
 	    $(foreach scala,3.6.1 3.6.2 3.6.3 3.6.4 3.7.0 3.7.1 3.7.1 main, \
 			    $(MAKE) bootstrap/$(scala):$(jdk);))
 
-.PHONY: publishLocal build dev ci wasm-e2e test bench matrix attest verify-attest push release xeq-build runners-build runners-fetch runners-release
+.PHONY: publishLocal build dev ci wasm-e2e doccheck test bench matrix attest verify-attest push release xeq-build runners-build runners-fetch runners-release

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ check-stdlib:
 build:
 	./mill groupCheck.validate
 	python3 etc/check-given-uniqueness.py
+	python3 etc/check-doc-coverage.py
 	./etc/check-stdlib-count.sh
 	./mill soundness.all
 	./mill benches.compile

--- a/doc/compatibility.tsv
+++ b/doc/compatibility.tsv
@@ -39,14 +39,17 @@ caesura	yes	yes	yes	js
 camouflage	yes	yes	yes	js	
 capricious	yes	yes	yes	wasi	backends: core+wasi
 cardinality	yes	yes	yes	js	
-clavichord	yes	yes	yes	js	
 cataclysm	yes	yes	no	js	
 charisma	yes	yes	yes	js	
 chiaroscuro	yes	yes	yes	js	
+clavichord	yes	yes	yes	js	
 coaxial	yes	core	core	wasi	backends: core+jvm+wasi; JVM-only submodule(s): jvm
+concordance	yes	yes	yes	js	
 contextual	yes	yes	yes	js	
 contingency	yes	yes	yes	js	
+corpuscular	yes	yes	yes	js	
 cosmopolite	yes	yes	yes	js	
+degustation	yes	no	no	no	wraps the Scala compiler's TASTy unpickler
 delicious	yes	yes	yes	js	JVM-only submodule(s): ansi, scala
 dendrology	yes	yes	yes	js	
 denominative	yes	yes	yes	js	
@@ -58,6 +61,7 @@ embarcadero	yes	core	core	core	backends: oci+oci-jvm; JVM-only submodule(s): con
 enigmatic	yes	no	yes	no	`javax.crypto` has no JS analogue; the Native build uses the OpenSSL provider; `asn1` cross-compiles everywhere
 escapade	yes	yes	yes	js	
 escritoire	yes	yes	yes	js	
+espionage	yes	no	no	no	transitively JVM-only through `obligatory.json`
 ethereal	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
 eucalyptus	yes	yes	yes	js	JVM-only submodule(s): syslog
 exegesis	yes	no	no	no	LSP server; depends on JVM-only `ethereal`/`exoskeleton`
@@ -94,6 +98,7 @@ mercator	yes	yes	yes	js
 metamorphose	yes	yes	yes	js	
 monotonous	yes	yes	yes	js	
 mosquito	yes	yes	yes	js	
+murmuration	yes	yes	yes	js	
 nomenclature	yes	yes	yes	js	
 obligatory	yes	yes	yes	js	JVM-only submodule(s): grpc, json
 octogenarian	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
@@ -107,6 +112,7 @@ pneumatic	yes	yes	yes	js	backends: flate-jvm+flate-native
 polaris	yes	yes	yes	js	
 polysyllabic	yes	yes	yes	js	
 polyvinyl	yes	yes	yes	js	
+praxinoscope	yes	yes	yes	js	
 prepositional	yes	yes	yes	js	
 prescience	yes	no	no	no	expansion-time instance evaluation via the macro classloader
 probably	yes	yes	yes	js	backends: coverage-jvm+coverage-native
@@ -116,6 +122,7 @@ proscenium	yes	yes	yes	js
 punctuation	yes	yes	no	js	JVM-only submodule(s): ansi
 quantitative	yes	yes	yes	js	
 querencia	yes	yes	no	js	
+reliquary	yes	no	no	no	`stratiform.binary` is transitively JVM-only
 revolution	yes	no	no	no	JAR manifests (`java.util.jar`)
 rudiments	yes	yes	yes	js	
 savagery	yes	yes	no	js	
@@ -132,6 +139,7 @@ symbolism	yes	yes	yes	js
 synesthesia	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
 tarantula	yes	no	no	no	browser automation; depends on JVM-only `guillotine`/`telekinesis.jvm`
 telekinesis	yes	core	no	wasi	backends: core+jvm+wasi; JVM-only submodule(s): jvm
+tessellate	yes	yes	yes	js	
 turbulence	yes	yes	yes	wasi	backends: core+wasi
 typonym	yes	yes	yes	js	
 ultimatum	yes	yes	yes	js	
@@ -141,6 +149,8 @@ urticose	yes	yes	yes	js
 vacuous	yes	yes	yes	js	
 vexillology	yes	yes	yes	js	
 vicarious	yes	yes	yes	js	
+virility	yes	yes	yes	js	
+vivisection	yes	no	no	no	JDI debugger over `coaxial.jvm`
 wisteria	yes	yes	yes	js	
 xenophile	yes	yes	yes	wasi	backends: core+wasm; JVM-only submodule(s): cffi, kotlin, native, scalanative
 xylophone	yes	yes	yes	js	JVM-only submodule(s): staged

--- a/doc/fixtures/testing.scala
+++ b/doc/fixtures/testing.scala
@@ -1,0 +1,32 @@
+// The tutorial's tests stand alone rather than inside a Suite's run(): a suite for them, and a
+// runner whose report is never rendered, so an assertion can run without a test harness.
+import soundness.*
+import stdios.javaLangSystemStdio
+import environments.javaBaseEnvironment
+
+given Testable = Testable(m"tutorial")
+
+given TestPalette = new TestPalette:
+  def background: Color in Srgb = Srgb(0, 0, 0)
+  def foreground: Color in Srgb = Srgb(1, 1, 1)
+  def unaccented: Color in Srgb = Srgb(1, 1, 1)
+  def informative: Color in Srgb = Srgb(1, 1, 1)
+  def subdued: Color in Srgb = Srgb(1, 1, 1)
+  def positive: Color in Srgb = Srgb(1, 1, 1)
+  def negative: Color in Srgb = Srgb(1, 1, 1)
+  def warning: Color in Srgb = Srgb(1, 1, 1)
+  def critical: Color in Srgb = Srgb(1, 1, 1)
+  def benchmark: Color in Srgb = Srgb(1, 1, 1)
+  def mixed: Color in Srgb = Srgb(1, 1, 1)
+  def cold: Color in Srgb = Srgb(1, 1, 1)
+  def warm: Color in Srgb = Srgb(1, 1, 1)
+  def hot: Color in Srgb = Srgb(1, 1, 1)
+  def accented: Color in Srgb = Srgb(1, 1, 1)
+  def highlight: Color in Srgb = Srgb(1, 1, 1)
+  def detail: Color in Srgb = Srgb(1, 1, 1)
+  def pass: Color in Srgb = Srgb(1, 1, 1)
+  def fail: Color in Srgb = Srgb(1, 1, 1)
+  def aspirePass: Color in Srgb = Srgb(1, 1, 1)
+  def aspireFail: Color in Srgb = Srgb(1, 1, 1)
+
+given Runner[Report] = Runner()

--- a/doc/modules/acp.md
+++ b/doc/modules/acp.md
@@ -1,13 +1,15 @@
 ## ACP
 
+<!-- doccheck: language captureChecking -->
+
 ### About
 
 The [Agent Client Protocol](https://agentclientprotocol.com/) is how an editor — or any program —
 drives a coding agent: Claude Code, Gemini CLI, and a growing set of others speak it over the
-agent's standard input and output. Espionage implements the client half of the protocol, version
-1, for programmatic use: spawn an agent, open a session, send a prompt, and watch its work stream
-back — messages, thoughts, tool calls, plans — while answering the requests it makes of you:
-permission to act, file access, terminals.
+agent's standard input and output. The client half of the protocol, version 1, is implemented for
+programmatic use: spawn an agent, open a session, send a prompt, and watch its work stream back —
+messages, thoughts, tool calls, plans — while answering the requests it makes of you: permission
+to act, file access, terminals.
 
 ### On ACP
 
@@ -17,55 +19,148 @@ notification for every chunk of progress, and requests that block its work until
 answers. A prompt is therefore not a function call but a *turn*: one long-lived request whose
 response arrives only after everything the agent did inside it.
 
-Espionage models the turn directly. `prompt` blocks until the agent reports why the turn ended,
-while the updates stream concurrently to handlers registered before connecting; the capabilities
-the client advertises are derived from those registrations, so the declaration can never disagree
-with the implementation. Everything comes from the `soundness` package:
+The turn is modeled directly. `prompt` blocks until the agent reports why the turn ended, while
+the updates stream concurrently to handlers registered before connecting; the capabilities the
+client advertises are derived from those registrations, so the declaration can never disagree
+with the implementation. A connection needs a few capabilities of its own: a way to run the reader
+and writer tasks, an error strategy, a working directory for the agent, and somewhere to print:
 
 ```scala
 import soundness.*
+
+import errorDiagnostics.stackTracesDiagnostics
+import probates.awaitProbate
+import stdios.javaLangSystemStdio
+import strategies.throwUnsafely
+import threading.virtualThreading
+import workingDirectories.javaBaseWorkingDirectory
 ```
+
+Every request and notification is a typed value rather than a JSON document, in the spirit of [honest signatures](../philosophy/honest-signatures.md).
 
 ### Connecting
 
 `Acp.connect` spawns the agent, exchanges `initialize`, and lends a connection for the duration
-of a block. The first block registers handlers; the second holds the live connection:
+of a block. The first block registers handlers; the second holds the live connection, reached
+through `Acp.connection`. Because the exchange runs as concurrent tasks, the whole thing sits
+inside a `supervise` block:
 
 ```scala
-Acp.connect(Acp.Agent(sh"claude-code-acp")):
-  Acp.updated:
-    Acp.update match
-      case Acp.AgentMessageChunk(Acp.TextContent(text, _)) => Out.print(text)
-      case other                                           => ()
+supervise:
+  Acp.connect(Acp.Agent(sh"claude-code-acp")):
+    Acp.updated:
+      Acp.update match
+        case Acp.AgentMessageChunk(Acp.TextContent(text, _)) => Out.print(text)
+        case other                                           => ()
 
-  Acp.permission:
-    Acp.options.filter(_.kind == Acp.PermissionOptionKind.AllowOnce).prim
-    . lay(Acp.Cancelled): option => Acp.Selected(option.optionId)
+    Acp.permission:
+      Acp.options.filter(_.kind == Acp.PermissionOptionKind.AllowOnce).prim
+      . lay(Acp.Cancelled): option => Acp.Selected(option.optionId)
 
-. apply:
-    val session = connection.newSession(workingDirectory[Text])
-    val stopReason = connection.prompt(session.sessionId, t"Fix the failing test")
+  . apply:
+      val session = Acp.connection.newSession(workingDirectory[Text])
+      Acp.connection.prompt(session.sessionId, t"Fix the failing test")
 ```
 
+The value of the second block is the value of `connect`; here it is the turn's stop reason. When
+the block returns, the exchange is torn down and a subprocess agent is killed, so nothing outlives
+the agent it speaks to. An agent that is already running — behind a socket, or a fixture in a
+test — connects through `Acp.Agent.streams(input, output)` instead of a command.
+
 An unregistered capability is never advertised: a client that registers no `readFile` handler
-reports no filesystem support, and a conformant agent will not ask.
+reports no filesystem support, and a conformant agent will not ask. `Acp.capabilities` adjusts the
+derived declaration as a last resort, applied at initialization.
+
+### Updates
+
+Every handler reads its payload through a contextual accessor — `Acp.update`, `Acp.options`,
+`Acp.path` — and every one is lent the `Acp.sessionId` it concerns. An update is one of the
+protocol's `SessionUpdate` cases:
+
+```scala
+def register(using Acp.Registry^): Unit = Acp.updated:
+  Acp.update match
+    case Acp.AgentMessageChunk(Acp.TextContent(text, _)) => Out.print(text)
+    case Acp.AgentThoughtChunk(Acp.TextContent(text, _)) => Out.print(t"(thinking) $text")
+    case Acp.UserMessageChunk(content)   => ()
+    case call: Acp.ToolCall              => Out.println(t"${call.title} (${call.kind})")
+    case update: Acp.ToolCallUpdate      => Out.println(t"${update.toolCallId}: ${update.status}")
+    case Acp.Plan(entries)               => entries.each { entry => Out.println(entry.content) }
+    case Acp.AvailableCommandsUpdate(commands) => ()
+    case Acp.CurrentModeUpdate(modeId)   => ()
+```
+
+### Permissions
+
+An agent about to act asks for permission, offering a list of options. The handler chooses one
+with `Acp.Selected`, or answers `Acp.Cancelled`. The option kinds are `AllowOnce`, `AllowAlways`,
+`RejectOnce` and `RejectAlways`, so a policy is a filter over them:
+
+```scala
+def allowAlways(using Acp.Registry^): Unit = Acp.permission:
+  Acp.options.filter(_.kind == Acp.PermissionOptionKind.AllowAlways).prim
+  . lay(Acp.Cancelled): option => Acp.Selected(option.optionId)
+```
 
 ### Filesystem and terminals
 
-The agent works with *your* view of the world if you offer one: `Acp.readFile` and
-`Acp.writeFile` serve the agent's file requests (including unsaved editor state, if you have
-any), and `Acp.terminals` supplies the five terminal operations as one bundle, since the protocol
-advertises them as a single capability.
+The agent works with *your* view of the world if you offer one. `Acp.readFile` serves the agent's
+requests to read a file — including unsaved editor state, if you have any — and `Acp.writeFile`
+its requests to write one. A read handler sees the `path`, and optionally a starting `line` and a
+`limit` on the number of lines; a write handler sees the `path` and the `content`:
+
+```scala
+import charEncoders.utf8Encoder
+import charDecoders.utf8Decoder
+import filesystemOptions.createNonexistentParents
+
+def files(using Acp.Registry^): Unit =
+  Acp.readFile:
+    Acp.path.as[Path on Linux].open[File]()(file.read[Text])
+
+  Acp.writeFile:
+    Acp.path.as[Path on Linux].create[File](): handle ?=>
+      handle.write(Acp.content)
+```
+
+Terminals are advertised as a single capability, so the five operations — create a terminal,
+read its output, wait for it to exit, kill it, and release it — are supplied together as one
+`Acp.Terminals` bundle to `Acp.terminals`.
+
+### Sessions
+
+`newSession` takes the working directory the agent should use and, optionally, a list of MCP
+servers (`Acp.McpServer`) to connect it to. `loadSession` resumes a session by its id, replaying
+its history through the update handler. An agent that offers modes reports them in the session's
+`modes`, and `setMode` switches between them. An agent that requires authentication says so with
+an `Acp.Error` whose reason is `AuthRequired`; `authenticate` answers with one of the methods the
+agent advertised at `initialize`.
+
+### Stop reasons
+
+`prompt` returns an `Acp.StopReason`: `EndTurn` when the agent finished, `MaxTokens` or
+`MaxTurnRequests` when it ran out of budget, `Refusal` when it declined, and `Cancelled` when the
+client canceled the turn.
 
 ### Cancellation
 
-`connection.cancel(sessionId)` notifies the agent, and the turn completes with the `Cancelled`
-stop reason. Permission requests pending at that moment — or arriving before the next turn — are
-answered `Cancelled` automatically, as the protocol requires; opening a new turn resets the
-session.
+`Acp.connection.cancel(sessionId)` notifies the agent, and the turn completes with the
+`Cancelled` stop reason. Permission requests pending at that moment — or arriving before the next
+turn — are answered `Cancelled` automatically, as the protocol requires; opening a new turn resets
+the session.
+
+### Errors
+
+Every fault the agent reports, and every fault in the exchange, is an `Acp.Error` whose reason is
+one of the JSON-RPC codes — `Parse`, `InvalidRequest`, `MethodNotFound`, `InvalidParams`,
+`Internal`, `AuthRequired` — or `Incompatible`, raised when the agent answers `initialize` with a
+protocol version other than 1. A fault raised inside a handler is converted into an error response
+carrying the reason's wire code, so a client bug is reported to the agent rather than hanging the
+turn. `connect` takes an optional `Acp.Observer`, which sees every message in both directions as
+it crosses the transport, for logging or a protocol trace.
 
 ### Content
 
 ACP adopts MCP's content vocabulary — `TextContent`, `ImageContent`, `AudioContent`,
-`ResourceLink`, `EmbeddedResource` — and Espionage shares those types with
-[synesthesia](mcp.md), so content crosses between the two protocols without translation.
+`ResourceLink`, `EmbeddedResource` — and the types are shared with [MCP](mcp.md), so content
+crosses between the two protocols without translation.

--- a/doc/modules/annotations.md
+++ b/doc/modules/annotations.md
@@ -19,6 +19,8 @@ marker on the case it distinguishes — because it sits beside the thing it desc
 with it. What has kept annotations underused in Scala is the reading side: runtime reflection is
 slow and untyped, and compiletime access means quotes-and-splices expertise.
 
+Reading annotations at compiletime, so that a misspelled name or a wrong type is a compile error, is [safety by construction](../philosophy/safety-by-construction.md).
+
 The `Annotated` typeclass hides the machinery. A request describes what is wanted — which
 annotation type, on which field, of which type — and the compiler supplies the answer as a value.
 Everything comes from the `soundness` package:
@@ -29,36 +31,58 @@ import soundness.*
 
 ### Reading annotations
 
-Given annotated definitions:
+An annotation is an ordinary case class extending `StaticAnnotation`. Given a few of them, and
+some definitions that carry them:
 
 ```scala
 final case class ident() extends StaticAnnotation
+final case class primary() extends StaticAnnotation
+final case class number(number: Int) extends StaticAnnotation
 
-case class Employee(person: Person, @ident code: Long)
+case class Person(name: Text, @ident email: Text)
+case class Employee(person: Person, @ident @primary code: Long)
+
+@number(10)
+case class Company(name: Text)
 ```
 
 the annotations of a field are summoned by naming the type and the field, and the query narrows by
 annotation type with `by`:
 
 ```scala
-summon[Employee is Annotated on "code"]()          // Set(ident())
-summon[Employee is Annotated by ident on "code"]() // just the ident annotations
+summon[Employee is Annotated on "code"]()          // Set(ident(), primary())
+summon[Employee is Annotated by ident on "code"]() // Set(ident())
 ```
 
-Annotations on the type itself, rather than a field, come from the plain form,
-`summon[Company is Annotated]()`.
+Annotations on the type itself, rather than a field, come from the plain form, and `fields` gives
+every annotated field at once:
+
+```scala
+summon[Company is Annotated]()                // Set(number(10))
+summon[Employee is Annotated by ident].fields  // Map(t"code" -> Set(ident()))
+```
+
+A field with no annotation of the requested type is simply absent from the map. Because the
+answer is computed as the code compiles, asking about a field the type does not have is a compile
+error, not an empty result.
 
 ### Finding the annotated field
 
 Often the question runs the other way: *which* field carries the annotation? When exactly one
-does, the summoned instance knows it:
+does, the summoned instance knows it, and — since finding the field is usually the prelude to
+reading or writing it — offers a [lens](optics.md) onto it:
 
 ```scala
-summon[Employee is Annotated by ident].field   // t"code"
+summon[Employee is Annotated by primary].field   // t"code"
+
+val person = Person(t"Jack", t"jack@example.com")
+summon[Person is Annotated by ident].lens(person)                          // t"jack@example.com"
+summon[Person is Annotated by ident].lens.update(person, t"jill@example.com")
 ```
 
 This is how a serialization library finds "the field marked as the identifier" without being told
-its name.
+its name. If more than one field carries the annotation, `field` is unavailable, because the
+instance's type records whether the match was unique.
 
 ### Variants of a sealed type
 
@@ -66,40 +90,92 @@ The cases of an enumeration or sealed trait are queried with `under`, mapping ea
 to its annotations:
 
 ```scala
+sealed trait Colored
+
+@number(3)
+case class Hsv(hue: Double, saturation: Double, @ident value: Double) extends Colored
+
+@primary()
+case class Rgb(red: Int, green: Int, blue: Int) extends Colored
+
 summon[Annotated under Colored].subtypes
-// Map(t"Rgb" -> Set(unique()), t"Hsv" -> Set(number(3)))
+// Map(t"Hsv" -> Set(number(3)), t"Rgb" -> Set(primary()))
+```
+
+### Parameterized annotations
+
+An annotation may take a type argument, and a query can filter by it. A bare `@marker(1)` infers
+`marker[Any]`, which a `marker[Any]` query sees and a `marker[Person]` query does not:
+
+```scala
+final case class marker[topic](id: Int) extends StaticAnnotation
+
+case class Marked(@marker[Person](1) @marker[Company](2) one: Int, @marker[Company](3) two: Int)
+
+summon[Marked is Annotated by marker[Person]].fields   // Map(t"one" -> Set(marker(1)))
+summon[Marked is Annotated by marker[Company]].fields  // both fields
 ```
 
 ### The `@name` annotation
 
-The `@name` annotation, defined here and honoured by every Soundness serialization format, renames
+The `@name` annotation, defined here and honored by every Soundness serialization format, renames
 a field or a variant on the wire. Bare, it applies to all formats; with a type argument, to one:
 
 ```scala
 case class Record(@name[Json](t"first_name") firstName: Text, @name(t"yob") year: Int)
 ```
 
-A format's derivation reads these through the same typeclass — the per-format rename overriding the
-bare default — which is why one annotation serves [JSON](json.md), [XML](xml.md),
-[YAML](yaml.md) and the rest identically.
+A format's derivation reads these through `relabelling`, which maps each renamed field to its
+serialized name with the per-format rename overriding the bare default — which is why one
+annotation serves [JSON](json.md), [XML](xml.md), [YAML](yaml.md) and the rest identically.
+`variantRelabelling` does the same for the cases of a sum type:
+
+```scala
+relabelling[Record, Json]   // Map(t"firstName" -> t"first_name", t"year" -> t"yob")
+relabelling[Record, Xml]    // Map(t"year" -> t"yob")
+```
+
+`fieldAnnotations[Record, name[Json]]` and `subtypeAnnotations` are the general forms behind
+these, returning only the fields or variants that carry the annotation in question.
 
 ### Reaching fields by name
 
 Alongside annotations, a case class's fields can be reached by name at runtime, with the mapping
 generated as the code compiles rather than by reflection. A `Dereferenceable` gives the field
-names, one field's value by name, and the whole record as a map:
+names, one field's value by name, and the whole record as a map. The instance is parameterized
+by the type the fields yield, so a record whose fields are all `Int` dereferences to `Int` — and
+the same instance can put a value back by name, which is why the yield type must be one every
+field accepts:
 
 ```scala
-val fields = summon[Employee is Dereferenceable to Any]
+case class Letters(alpha: Int, beta: Int, gamma: Int)
+val letters = Letters(1, 2, 3)
+val fields = summon[Letters is Dereferenceable to Int]
 
-fields.names(employee)          // the field names, in declaration order
-fields.select(employee, t"code")
-fields.members(employee)        // name to value
+fields.names(letters)            // List(t"alpha", t"beta", t"gamma")
+fields.select(letters, t"beta")  // 2
+fields.members(letters)          // Map(t"alpha" -> 1, t"beta" -> 2, t"gamma" -> 3)
 ```
 
-The instance is parameterized by the type the fields yield, so a record whose fields are all
-`Text` dereferences to `Text` rather than to `Any` — which is what makes a generic renderer or a
-template engine able to read a value's fields without casting.
+Where only the values of one type are wanted, `membersOfType` picks them out of any record,
+which is what makes a generic renderer or a template engine able to read a value's fields without
+casting:
+
+```scala
+letters.membersOfType[Int]   // List(1, 2, 3)
+```
+
+Each accessor is a [lens](optics.md), so a field found by name can be written as well as read;
+`update` replaces the named field and `modify` applies a function to it, each yielding a new
+record, or `Unset` where the name is not a constructor parameter:
+
+```scala
+val numbers = summon[Letters is Dereferenceable to Int]
+
+numbers.update(letters, t"beta", 20)        // Letters(1, 20, 3)
+numbers.modify(letters, t"gamma")(_*10)     // Letters(1, 2, 30)
+numbers.lens(t"epsilon")                    // Unset: not a field
+```
 
 Because the mapping is a compiled table of accessors, reaching a field costs a method call, and a
 name the type does not have is discovered where the table is built rather than by a reflective

--- a/doc/modules/archives.md
+++ b/doc/modules/archives.md
@@ -85,7 +85,7 @@ val script = Tar.Entry.File
     user  = UnixUser(1000, t"alice"),
     group = UnixGroup(1000, t"alice"),
     mtime = timestamp,
-    data  = TarBody(scriptText.in[Data]) )
+    data  = Tar.Body(scriptText.in[Data]) )
 ```
 
 A `Tarfile` of entries streams as tar blocks, or as the compressed forms the format usually
@@ -113,7 +113,7 @@ advances, but the sequence itself is not replayable. Opening the archive as `Tar
 underlying source in the same way as a ZIP archive, and takes the compression as a flag:
 
 ```scala
-archive.open[Tar](TarFlag.Gzip): tar ?=>
+archive.open[Tar](Tar.Flag.Gzip): tar ?=>
   tar.entries.map(_.entryName).to(List)
 ```
 

--- a/doc/modules/archives.md
+++ b/doc/modules/archives.md
@@ -4,7 +4,7 @@
 
 The two archive formats of everyday computing — [ZIP](https://en.wikipedia.org/wiki/ZIP_(file_format))
 and [tar](https://en.wikipedia.org/wiki/Tar_(computing)) — read and write as typed values. A
-`Zipfile` or a `Tarfile` is a stream of entries, each with a validated archive-relative path
+`Zipfile` or a `Tarfile` is a sequence of entries, each with a validated archive-relative path
 and streamed content, so an archive of any size is read entry by entry and written without
 assembling it in memory: a ZIP entry inflates as it is read, and a tar entry parses straight off
 the underlying source. Tar entries carry the Unix metadata the format exists to preserve — modes,
@@ -12,56 +12,73 @@ owners, modification times — as typed values.
 
 ### On archives
 
-Archives are streams pretending to be filesystems, and APIs for them tend to expose one pretence or
+Archives are streams pretending to be filesystems, and APIs for them tend to expose one pretense or
 the other badly: either a mutable random-access object that must be opened, mutated and remembered
 to close, or a raw stream of headers and bytes. Entry names are plain strings, so nothing prevents
 the classic mistakes — absolute paths, `..` traversal — and metadata is an afterthought of ints.
 
+Reading an archive lazily, through a scope that owns the file, is the shape described under [delimited scopes](../philosophy/delimited-scopes.md).
+
 Soundness treats an archive as data. Entries are immutable values; their paths are typed
 archive-relative [paths](paths.md) that cannot express an escape from the archive root; and
 reading, writing and compressing are the same streaming operations used everywhere else.
-Everything comes from the `soundness` package:
+Everything comes from the `soundness` package. Writing an archive to disk logs an event and can
+fail, so an error strategy and a logging choice are in scope, and the examples work in a
+directory of their own:
 
 ```scala
 import soundness.*
-import strategies.throwUnsafely
+
 import charEncoders.utf8Encoder
+import charDecoders.utf8Decoder
+import filesystemOptions.createNonexistentParents
+import logging.silentLogging
+import pathInterfaces.pathOnLinux
+import strategies.throwUnsafely
+import temporaryDirectories.javaBaseTemporaryDirectory
+
+val work = temporaryDirectory[Path on Linux] / "archives"
+work.create[Directory]()
 ```
 
 ### ZIP
 
-A ZIP archive reads from a path or from bytes, its entries a stream; an entry is looked up by
-its path, and its content reads as any type:
+Writing a ZIP archive takes entries — each an archive-relative path and a content source — and
+either writes to a path or serializes as a byte stream. Compression is a policy in scope,
+deflating by default and storing where deflation would not help:
 
 ```scala
-val zipfile = Zipfile.read(path)
-zipfile.entries.to(List).map(_.ref.encode)   // the entry names
-
-zipfile.entry(t"readme.txt".as[Path on Zip]).read[Text]
+val zipPath = work / "hello.zip"
+val entry = Zip.Entry(t"hello.txt".as[Path on Zip], t"Hello world".in[Data])
+Zipfile.write(zipPath)(List(entry))
 ```
 
-Writing takes entries — each a path and a content source — and either writes to a path or
-serializes as a byte stream. Compression is a policy in scope, deflating by default and storing
-where deflation would not help:
+An entry's path is a `Path on Zip`: relative to the archive root, so a text that names an absolute
+path or climbs above the root fails to parse rather than producing a malicious entry.
+
+An archive reads from a path or from bytes; an entry is looked up by its path, and its content
+reads as any type:
 
 ```scala
-val entry = Zip.Entry(t"hello.txt".as[Path on Zip], t"Hello world".in[Data])
-Zipfile.write(path)(List(entry))
+val zipfile = Zipfile.read(zipPath)
+zipfile.entries.map(_.ref.encode)                  // List(t"hello.txt")
+zipfile.entry(t"hello.txt".as[Path on Zip]).read[Text]   // t"Hello world"
 ```
 
 `write` also takes an optional `prefix` of raw bytes to place before the archive proper. The ZIP
 format locates its own directory from the end of the file rather than the start, so an archive
 concatenated onto arbitrary leading bytes still reads correctly — which is how a self-extracting
 or directly-executable archive is made, and how the [packaged](packaging.md) launchers carry their
-own JAR.
+own JAR. `Zipfile.rebase` corrects the one field of a very large (ZIP64) archive that a prefix
+does invalidate.
 
 An archive can also be *opened*, which makes its entries available for the duration of a scope
 and closes the underlying source at the end of it, in the same way as a
-[file](filesystem.md#reading-and-writing):
+[file](filesystem.md#reading-and-writing). Inside the scope, `zip` is the open handle:
 
 ```scala
-archive.open[Zip]():
-  zip.entries.length
+zipPath.open[Zip]():
+  zip.entries.size   // 1
 ```
 
 A JAR is a ZIP with a manifest, so opening one as `Jar` gives the same handle refined with the
@@ -69,30 +86,42 @@ main attributes parsed from `META-INF/MANIFEST.MF`, continuation lines rejoined 
 specification requires. An archive without a manifest simply has no attributes:
 
 ```scala
-jarfile.open[Jar]():
-  zip.manifest   // Map(t"Manifest-Version" -> t"1.0", t"Main-Class" -> …)
+val manifest = Zip.Entry(t"META-INF/MANIFEST.MF".as[Path on Zip], t"Manifest-Version: 1.0".in[Data])
+val jarPath = work / "hello.jar"
+Zipfile.write(jarPath)(List(manifest, entry))
+
+jarPath.open[Jar]():
+  zip.manifest   // Map(t"Manifest-Version" -> t"1.0")
 ```
+
+Errors are `Zip.Error`s whose reason says what was wrong: `NotFound` for an entry that is not
+there, `DuplicateEntry` when two entries share a path, `MissingEocd` when the bytes are not a ZIP
+archive at all.
 
 ### Tar
 
-A tar entry is one of the format's typed cases — a file, a directory, a link, a FIFO — with its
-Unix metadata spelled out:
+A tar entry is one of the format's typed cases — a file, a directory, a hard or symbolic link, a
+character or block device, a FIFO — with its Unix metadata spelled out. `Tar.Entry` builds the
+common case, a file, defaulting the mode, owner and timestamp; the case classes take everything
+explicitly:
 
 ```scala
+val readme = Tar.Entry(t"README".as[Relative on Tar], t"Read me first".in[Data])
+
 val script = Tar.Entry.File
   ( path  = t"bin/run".as[Relative on Tar],
     mode  = UnixMode(ownerExec = true, groupExec = true, otherExec = true),
     user  = UnixUser(1000, t"alice"),
     group = UnixGroup(1000, t"alice"),
-    mtime = timestamp,
-    data  = Tar.Body(scriptText.in[Data]) )
+    mtime = 0.bits.u32,
+    data  = Tar.Body(t"#!/bin/sh\necho hello\n".in[Data]) )
 ```
 
 A `Tarfile` of entries streams as tar blocks, or as the compressed forms the format usually
 travels in:
 
 ```scala
-val tarball = Tarfile(List(script))
+val tarball = Tarfile(List(readme, script))
 tarball.gzip      // a .tar.gz byte stream
 tarball.zlib
 tarball.deflate
@@ -103,27 +132,35 @@ one consumed entry advances the source past it, so an archive is never materiali
 compressed archive is simply a decompressed stream read the same way:
 
 ```scala
-Tarfile.read(source)
-Tarfile.read(source.decompress[Gzip])
+Tarfile.read(tarball.source[Data]).map(_.entryName)             // List(t"README", t"bin/run")
+Tarfile.read(tarball.gzip.decompress[Gzip]).map(_.entryName)
 ```
 
 Reading an archive this way is single-pass and single-owner: consume the entries in order, on
-one thread. An entry passed over remains readable, because its body memoizes when the iterator
+one thread. An entry passed over remains readable, because its body memoizes when the sequence
 advances, but the sequence itself is not replayable. Opening the archive as `Tar` scopes the
-underlying source in the same way as a ZIP archive, and takes the compression as a flag:
+underlying source in the same way as a ZIP archive, and takes the compression as a flag; `tar` is
+the open handle:
 
 ```scala
-archive.open[Tar](Tar.Flag.Gzip): tar ?=>
-  tar.entries.map(_.entryName).to(List)
+val tarPath = work / "hello.tar.gz"
+tarPath.create[File](): handle ?=>
+  handle.write(tarball.gzip)
+
+tarPath.open[Tar](Tar.Flag.Gzip):
+  tar.entries.map(_.entryName)
 ```
 
 A whole directory tree archives with `Tarfile.from(directory)` and unpacks with `extractTo`,
 connecting archives to the [filesystem](filesystem.md):
 
 ```scala
-Tarfile.from(sourceDirectory).gzip
-tarball.extractTo(destination)
+val unpacked = work / "unpacked"
+tarball.extractTo(unpacked)
+Tarfile.from(unpacked).entries.map(_.entryName)
 ```
 
-Long names are handled in POSIX's pax form by default, or GNU's, chosen when the archive is built;
-sparse files and pax extended headers round-trip faithfully.
+Long names are handled in POSIX's pax form by default, or GNU's, chosen when the archive is built
+(`Tarfile(entries, LongNameFormat.Gnu)`); sparse files and pax extended headers round-trip
+faithfully. A malformed archive raises a `Tar.Error` naming the fault — a bad checksum, an
+unparseable header field, a truncated body.

--- a/doc/modules/audio.md
+++ b/doc/modules/audio.md
@@ -98,7 +98,7 @@ recording.stop()
 
 `feed.supports[Stereo](44100.0*Hertz, 16)` asks whether a feed can honour a configuration
 before recording begins. Recording from a feed that is unavailable or misconfigured raises
-a `FeedError`. On macOS the JVM must have been granted microphone permission, or no feeds
+a `Feed.Error`. On macOS the JVM must have been granted microphone permission, or no feeds
 are available.
 
 ### Playback
@@ -115,7 +115,7 @@ playback.await()
 ```
 
 Playing to an outlet that is unavailable or cannot accept the audio's configuration raises
-an `OutletError`.
+an `Outlet.Error`.
 
 ### Scoped lines
 

--- a/doc/modules/audio.md
+++ b/doc/modules/audio.md
@@ -2,9 +2,9 @@
 
 ### About
 
-Soundness reads and writes audio, records it from the machine's inputs, and plays it
-through the machine's outputs. Reading a [WAV](https://en.wikipedia.org/wiki/WAV),
-[AIFF](https://en.wikipedia.org/wiki/Audio_Interchange_File_Format) or AU file yields an
+Audio reads and writes as typed values, records from the machine's inputs, and plays through the
+machine's outputs. Reading a [WAV](https://en.wikipedia.org/wiki/WAV),
+[AIFF](https://en.wikipedia.org/wiki/Audio_Interchange_File_Format), AIFC or AU file yields an
 `Audio` value — an immutable block of [PCM](https://en.wikipedia.org/wiki/Pulse-code_modulation)
 samples that knows its sample rate, channel count, bit depth, and every sample it holds.
 
@@ -20,6 +20,8 @@ played back at a fixed rate. The file formats differ mostly in their headers, no
 substance. Java's sound library exposes all of this through mutable objects and untyped
 formats, where a wrong channel count or bit depth surfaces as noise rather than an error.
 
+A sample's format living in its type is what makes an unsupported conversion a compile error: [impossible states](../philosophy/impossible-states.md) are simply not representable.
+
 Soundness presents the same capability as immutable, typed values. The format is part of
 the type, the sample rate is a genuine [quantity](quantities.md) in hertz rather than a
 bare number, and reading, converting and writing are the same polymorphic operations used
@@ -32,29 +34,48 @@ import strategies.throwUnsafely
 
 ### Reading audio
 
-Any source of bytes reads as audio when the expected format is named. Opening a file gives a
-handle that reads as an `Audio`, whose metadata is then available directly:
+Any source of bytes reads as audio when the expected format is named. These bytes are a
+complete WAV file — one channel, 16-bit signed samples at 8 kHz, four frames holding the values
+100, 200, 300 and 400 — small enough to write down:
 
 ```scala
-val audio = p"/home/work/sound.wav".on[Linux].open(_.read[Audio in Wave])
+val wav = hex"""524946462c00000057415645666d74201000000001000100401f0000803e00000200100064
+                617461080000006400c8002c019001"""
 
-audio.channels        // 2
-audio.frames          // 44100
+val audio = wav.read[Audio in Wave]
+
+audio.channels        // 1
+audio.frames          // 4
 audio.bitsPerSample   // 16
-audio.sampleRate      // 44100.0*Hertz
-audio.duration        // 1.0*Second
+audio.sampleRate      // 8000.0*Hertz
+audio.duration        // 0.0005*Second
 ```
 
 Reading can fail — the bytes may not hold audio in the named format — so it draws on the
-error strategy in scope. Applying an audio value to a channel and a frame returns that one
-sample:
+error strategy in scope, raising an `Audio.Error` that names the format expected. Applying an
+audio value to a channel and a frame returns that one sample:
 
 ```scala
-audio(0, 0)   // the first sample of the left channel
+audio(0, 0)   // 100
+audio(0, 2)   // 300
 ```
 
 Audio that is not already PCM is converted to 16-bit signed PCM as it is read, so every
-`Audio` value has the same simple internal form regardless of how it was stored.
+`Audio` value has the same simple internal form regardless of how it was stored. A file on disk
+reads the same way through its handle, for the duration of a scope, as any
+[file](filesystem.md) does:
+
+```scala
+import filesystemOptions.createNonexistentParents
+import pathInterfaces.pathOnLinux
+import temporaryDirectories.javaBaseTemporaryDirectory
+
+val wavPath = temporaryDirectory[Path on Linux] / "audio" / "tone.wav"
+wavPath.create[File](): handle ?=>
+  handle.write(wav)
+
+wavPath.open[File]()(file.read[Audio in Wave]).frames   // 4
+```
 
 ### Converting and writing
 
@@ -63,12 +84,20 @@ encoded bytes:
 
 ```scala
 val aiff: Data = audio.to[Aiff].read[Data]
-aiff.read[Audio in Aiff].frames   // 44100 — the audio survives the round trip
+aiff.read[Audio in Aiff].frames   // 4 — the audio survives the round trip
+aiff.read[Audio in Aiff](0, 2)    // 300
 ```
 
 Reading an `Audio` *as* bytes and reading bytes *as* an `Audio` are the same `read`
 operation in each direction, so writing a file is reading its audio as `Data` and sending
-that to the destination.
+that to the destination — or handing the audio value itself to the handle, since an `Audio`
+streams as its encoded bytes:
+
+```scala
+val aiffPath = temporaryDirectory[Path on Linux] / "audio" / "tone.aiff"
+aiffPath.create[File](): handle ?=>
+  handle.write(audio.to[Aiff])
+```
 
 ### Channel layouts
 
@@ -78,28 +107,29 @@ configuration of `n` channels. The layout is a typeclass, so its channel count i
 statically:
 
 ```scala
-summon[Stereo is ChannelLayout].channels      // 2
+summon[Stereo is ChannelLayout].channels       // 2
 summon[Surround[6] is ChannelLayout].channels  // 6
 ```
 
 ### Recording
 
-An input device is a `Feed`, and the machine's feeds are listed with `Feed.list`. A feed
-records at a chosen sample rate, bit depth and layout, producing a `Recording` whose
-`stream` yields audio in chunks until it is stopped:
+An input device is a `Feed`, and the machine's feeds are listed with `Feed.list`, each with
+a `name`, a `vendor` and a `description`, and the `configurations` it offers. A feed records
+at a chosen sample rate, bit depth and layout, producing a `Recording` whose `stream` yields
+audio in chunks until it is stopped. A machine may have no feeds at all, so the first one is
+an `Optional`:
 
 ```scala
-val feed = Feed.list.head
-
-val recording = feed.record[Stereo](44100.0*Hertz, bits = 16)
-val firstChunk = recording.stream.head
-recording.stop()
+Feed.list.prim.let: feed =>
+  if feed.supports[Stereo](44100.0*Hertz, 16) then
+    val recording = feed.record[Stereo](44100.0*Hertz, bits = 16)
+    val firstChunk: Optional[Audio across Stereo] = recording.stream.prim
+    recording.stop()
 ```
 
-`feed.supports[Stereo](44100.0*Hertz, 16)` asks whether a feed can honour a configuration
-before recording begins. Recording from a feed that is unavailable or misconfigured raises
-a `Feed.Error`. On macOS the JVM must have been granted microphone permission, or no feeds
-are available.
+`supports` asks whether a feed can honor a configuration before recording begins. Recording
+from a feed that is unavailable or misconfigured raises a `Feed.Error`. On macOS the JVM must
+have been granted microphone permission, or no feeds are available.
 
 ### Playback
 
@@ -108,10 +138,9 @@ a `Playback` that runs in the background; `await` blocks until it finishes, and 
 ends it early:
 
 ```scala
-val outlet = Outlet.list.head
-
-val playback = outlet.play(audio)
-playback.await()
+Outlet.list.prim.let: outlet =>
+  val playback = outlet.play(audio)
+  playback.await()
 ```
 
 Playing to an outlet that is unavailable or cannot accept the audio's configuration raises
@@ -122,14 +151,17 @@ an `Outlet.Error`.
 `record` and `play` suit open-ended use, where the device is held for as long as the program
 wants it. Where the device should be held for exactly one block, a line is *opened* instead, as
 [a file is](filesystem.md): the audio line lasts precisely as long as the scope, and the layout
-and configuration are given as the form and its flags.
+and configuration are given as the form and its flags — `PcmFlag.Rate`, `PcmFlag.Bits` and
+`PcmFlag.Chunk`:
 
 ```scala
-feed.open[Pcm across Stereo](Read, PcmFlag.Rate(48000), PcmFlag.Chunk(1024)): input ?=>
-  input.stream.head
+Feed.list.prim.let: feed =>
+  feed.open[Pcm across Stereo](Read, PcmFlag.Rate(48000), PcmFlag.Chunk(1024)): input ?=>
+    input.stream.prim
 
-outlet.open[Pcm](Write): out ?=>
-  out.play(audio)
+Outlet.list.prim.let: outlet =>
+  outlet.open[Pcm](Write): out ?=>
+    out.play(audio)
 ```
 
 Playing requires the `Write` grant, so a line opened for capture cannot be played to, and the

--- a/doc/modules/base-encoding.md
+++ b/doc/modules/base-encoding.md
@@ -33,6 +33,8 @@ import soundness.*
 import charEncoders.utf8Encoder
 ```
 
+Naming the alphabet as a type parameter, rather than passing a flag, is the [declarative context](../philosophy/declarative-context.md) style used throughout.
+
 ### Serializing bytes
 
 `serialize` renders bytes as text in a named encoding, drawing the character set from the alphabet
@@ -71,8 +73,14 @@ bytes.serialize[Base64]   // URL-safe characters
 ```
 
 A *strict* alphabet accepts only its own characters when decoding, while a tolerant one also accepts
-recognised equivalents — upper- and lower-case hexadecimal, say — so the strictness of a decode is a
-choice between imports.
+recognized equivalents — upper- and lower-case hexadecimal, say — so the strictness of a decode is a
+choice between imports: `hexLowerCase` reads either case, `hexStrictLowerCase` only its own.
+
+The full set is in the `alphabets` package. For Base64 it holds the standard, unpadded, URL-safe,
+XML, IMAP, YUI, Radix-64, bcrypt, SASL and uuencoding variants; for Base32 the upper- and lower-case
+forms (strict and tolerant), the extended-hex forms, z-base-32 (padded and unpadded), Geohash,
+word-safe and Crockford; for hexadecimal the upper- and lower-case forms and the "bioctal" one; and
+one each for octal, quaternary (including the DNA nucleotide alphabet, `ATCG`) and binary.
 
 ### Other bases
 
@@ -88,11 +96,11 @@ bytes.serialize[Hex]   // t"48656c6c6f"
 ### Encoding a stream
 
 An alphabet is also a [stream](streams.md) stage, so bytes are encoded as they flow rather than
-gathered first — which is what a base-encoded body written to a socket, or a large file armoured
+gathered first — which is what a base-encoded body written to a socket, or a large file armored
 for transport, requires:
 
 ```scala
-payload.stream.via(summon[Alphabet[Hex]])
+bytes.stream.via(summon[Alphabet[Hex]])
 ```
 
 The streaming and whole-value forms agree byte for byte, including at the boundaries where a

--- a/doc/modules/base-encoding.md
+++ b/doc/modules/base-encoding.md
@@ -51,7 +51,7 @@ bytes.serialize[Base64]   // t"SGVsbG8="
 ### Deserializing
 
 `deserialize` reads text back to bytes in the same encoding. A character outside the alphabet
-raises a `SerializationError`, so deserializing needs an error strategy in scope:
+raises a `Serialization.Error`, so deserializing needs an error strategy in scope:
 
 ```scala
 import strategies.throwUnsafely

--- a/doc/modules/binary-data.md
+++ b/doc/modules/binary-data.md
@@ -24,36 +24,66 @@ from the `soundness` package:
 import soundness.*
 ```
 
+Describing a layout once, and deriving both its reader and its writer, keeps the two from drifting apart — [correctness](../philosophy/correctness.md) by having one definition.
+
 ### Describing a layout
 
-A binary record is a case class of fixed-width fields:
+A binary record is a case class of fixed-width fields, given a `Debufferable` instance by
+derivation:
 
 ```scala
 case class Header(magic: B32, version: U16, flags: B16, length: U32)
+
+object Header:
+  given Header is Debufferable = Debufferable.derived
 ```
 
 Each field's width follows from its type — here four, two, two and four bytes — so the record is
-twelve bytes, and `byteWidth[Header]` says so without a value in hand.
+twelve bytes, and `byteWidth` says so without a value in hand:
+
+```scala
+byteWidth[Header]   // 12
+byteWidth[U16]      // 2
+```
+
+Records nest: a field whose type is itself a `Debufferable` record contributes its whole width,
+so a layout is composed from smaller layouts rather than flattened by hand.
 
 ### Reading
 
-`unpackFrom` reads a value of a chosen type from bytes at an offset, and within a `buffer` block,
-successive `unpack` calls read one value after another, the cursor advancing by each value's
-width:
+`unpackFrom` reads a value of a chosen type from bytes at an offset:
 
 ```scala
-val header = data.unpackFrom[Header](0)
+val data = hex"cafebabe0001000000000010"
 
-data.buffer:
-  val first = unpack[U32]
-  val second = unpack[U16]
+val header = data.unpackFrom[Header](0)
+header.version   // 1
+header.length    // 16
 ```
 
-An array of records unpacks by count, for the repeated sections binary formats favour:
+Within a `sextant` block — named for the instrument that reads a position — successive `unpack`
+calls read one value after another, the cursor advancing by each value's width:
 
 ```scala
-data.buffer:
-  val entries = unpack[IArray[Entry]](12)
+data.sextant:
+  val magic = unpack[B32]
+  val version = unpack[U16]
+  version
+```
+
+An array of records unpacks by count, for the repeated sections binary formats favor: the
+result of `unpack[Array[Pair]]` is a function from the count to the array, read when the count
+is known:
+
+```scala
+case class Pair(left: U16, right: U16)
+
+object Pair:
+  given Pair is Debufferable = Debufferable.derived
+
+hex"00010002000300040005000600070008".sextant:
+  val pairs = unpack[Array[Pair]](4)
+  pairs.length   // 4
 ```
 
 ### The typeclasses
@@ -61,35 +91,47 @@ data.buffer:
 `Debufferable` is the reading side — the sixteen sized numeric types have instances, and a case
 class derives its own from its fields — and `Bufferable` is the writing side, with the same
 derivation. `Unpackable` sits above both, and is what `unpack` resolves: it covers a single
-`Debufferable` value and, separately, an `IArray` of them, which is how a count-prefixed section
+`Debufferable` value and, separately, an array of them, which is how a count-prefixed section
 reads as one call rather than a loop.
 
 An instance states two things: `width`, the number of bytes the value occupies, and how to read
-those bytes from — or write them to — a `Buffer`. Both are visible to derivation, so a record's
+those bytes from — or write them to — a `Sextant`. Both are visible to derivation, so a record's
 total width is the sum of its fields' and every offset within it is computed at compiletime.
+`Debufferable.apply` builds an instance from a width and a function of the bytes and an offset,
+which is how the primitives are defined:
 
 ```scala
-trait Debufferable:
-  def width: Int
-  def debuffer(buffer: Buffer): Self
+case class Rgb(red: Byte, green: Byte, blue: Byte)
+
+object Rgb:
+  given Rgb is Debufferable =
+    Debufferable(3) { (bytes, offset) =>
+      Rgb(bytes.readUnchecked(offset), bytes.readUnchecked(offset + 1), bytes.readUnchecked(offset + 2)) }
 ```
 
 A format whose fields need more than fixed-width reads — a length-prefixed string, say — defines
-its own instance, and composes into derived records like any primitive. The sized types also fix
-the *interpretation*, not merely the width: `B32` is four raw bytes, `U32` reads them as an
-unsigned integer, `S32` as a signed one, and the plain Scala `Int`, `Short`, `Long` and `Byte`
-have instances too, for layouts that are easier to state in them.
+its own instance the same way, and composes into derived records like any primitive. The sized
+types also fix the *interpretation*, not merely the width: `B32` is four raw bytes, `U32` reads
+them as an unsigned integer, `S32` as a signed one, and the plain Scala `Int`, `Short`, `Long` and
+`Byte` have instances too, for layouts that are easier to state in them.
 
 `Bufferable` is the symmetric writing-side typeclass, deriving over products in the same way, so a
 layout is declared once and serves both directions.
 
-### The buffer is a capability
+### The sextant is a capability
 
-A `Buffer` carries a mutable read position, which makes unpacking an effect rather than a pure
+A `Sextant` carries a mutable read position, which makes unpacking an effect rather than a pure
 read, and the position is what makes successive `unpack` calls advance. It is therefore introduced
-by the `buffer { … }` block that scopes it, and is an *exclusive* capability: two readers sharing
-one position would each consume bytes the other expected, so the compiler prevents a buffer from
+by the `sextant { … }` block that scopes it, and is an *exclusive* capability: two readers sharing
+one position would each consume bytes the other expected, so the compiler prevents a sextant from
 being aliased or from escaping its block.
 
 `offset` reports the current position, for a format that must state where a section begins, and
-`advance` skips past padding or a field this reader does not need.
+`advance` skips past padding or a field this reader does not need:
+
+```scala
+data.sextant:
+  summon[Sextant].advance(4)      // skip the magic number
+  val version = unpack[U16]
+  summon[Sextant].offset          // 6
+```

--- a/doc/modules/bloom-filters.md
+++ b/doc/modules/bloom-filters.md
@@ -21,6 +21,8 @@ bit positions and remembers only the bits — a few bits per element regardless 
 size — but tuning one means choosing a bit-array size and a number of hash functions, a formula
 most code copies from a textbook, sometimes wrongly.
 
+The filter's error rate is fixed by its construction rather than checked at each use, which is [safety by construction](../philosophy/safety-by-construction.md).
+
 Soundness asks instead for the intent — expected size and target error rate — and computes the
 parameters. The error rate is a [bounded number](numbers.md), so a rate outside `[0, 1]` does not
 compile. Everything comes from the `soundness` package, with a hash provider in scope:
@@ -74,7 +76,7 @@ intended, not a guarantee that holds however it is filled.
 
 The hash algorithm is part of the filter's type, and the bit positions are derived from a single
 digest, extended by rehashing where more bits are needed than one digest provides. That means the
-algorithm in scope decides the filter's behaviour, and two filters over the same elements agree
+algorithm in scope decides the filter's behavior, and two filters over the same elements agree
 only if they agree on the algorithm.
 
 Because elements enter through the ordinary [hashing](hashing.md) machinery, a case class is

--- a/doc/modules/caching.md
+++ b/doc/modules/caching.md
@@ -15,6 +15,8 @@ to do when two threads want the same missing value, and when a cached value is t
 The map is easy; the decisions are where the bugs are — unbounded growth from no eviction, a
 stampede of recomputation from no coordination, stale data from no expiry.
 
+A cache that names its expiry in its type is a [declarative context](../philosophy/declarative-context.md): the policy is stated where the cache is, not at each read.
+
 Soundness makes the decisions the type: an `LruCache` is the bounded, evicting kind, and a `Cache`
 is the expiring, coordinated kind, its computation guarded so concurrent callers share one result.
 Everything comes from the `soundness` package:
@@ -27,25 +29,35 @@ import soundness.*
 
 An `LruCache` holds up to its capacity of keyed entries. Applying it with a key and a computation
 returns the cached value when the key is present, and otherwise runs the computation, stores the
-result, and evicts the least recently used entry if the cache is now too big:
+result, and evicts the least recently used entry if the cache is now too big. Here the
+computation is a lookup that counts how often it runs:
 
 ```scala
+var lookups = 0
+
+def expensiveLookup(key: Int): Text =
+  lookups += 1
+  t"value $key"
+
 val cache = LruCache[Int, Text](4)
 
 cache(1)(expensiveLookup(1))   // computes and stores
 cache(1)(expensiveLookup(1))   // returns the stored value; no computation
+lookups                        // 1
 ```
 
 Using an entry — reading or writing — marks it as recent, so the entries that survive are the ones
-the program keeps coming back to.
+the program keeps coming back to: after four further keys, key `1` has been evicted, and asking
+for it computes again.
 
 `contains` asks whether a key is held without computing anything and without marking it recent,
 and `remove` drops an entry — which is what an invalidation needs when the underlying data has
 changed and the cached value is known to be stale:
 
 ```scala
-cache.contains(1)   // is it cached?
-cache.remove(1)     // forget it
+cache.contains(1)   // true
+cache.remove(1)
+cache.contains(1)   // false
 ```
 
 The computation is passed by name, so nothing is evaluated on a hit. That is the whole point of
@@ -53,17 +65,31 @@ the shape: a cache whose value must be computed before it can be offered saves n
 
 ### An expiring value
 
-A `Cache` memoizes one value, with a lifetime after which it is recomputed. `establish` returns the
-current value, computing it only when none is held or the held one has expired:
+A `Cache` memoizes one value, with a lifetime after which it is recomputed. The lifetime is any
+[duration](time.md) — a quantity of seconds, here, with the interface that lets a `Cache` read it
+imported — and the cached type is stated in the expected type. `establish` returns the current
+value, computing it only when none is held or the held one has expired:
 
 ```scala
-val config = Cache[Configuration](5.0*Minute)
+import durationInterfaces.aviationDuration
+
+case class Configuration(port: Int)
+
+var loads = 0
+
+def loadConfiguration(): Configuration =
+  loads += 1
+  Configuration(8080)
+
+val config: Cache[Configuration] = Cache(5.0*Minute)
 
 config.establish(loadConfiguration())   // loads now
 config.establish(loadConfiguration())   // the same value, until five minutes pass
+loads                                   // 1
 ```
 
 The computation runs under a lock, so when the value is missing or expired and several threads ask
 at once, one computes and the rest receive its result — the
 [stampede](https://en.wikipedia.org/wiki/Cache_stampede) a bare lazy value cannot prevent. A
-`Cache` created without a lifetime computes its value once and keeps it.
+`Cache` created without a lifetime, `Cache[Configuration]()`, computes its value once and keeps
+it.

--- a/doc/modules/cbor.md
+++ b/doc/modules/cbor.md
@@ -120,7 +120,7 @@ Cbor.make(name = t"Anna".in[Cbor], age = 30.in[Cbor])
 
 ### Errors
 
-A malformed document or a failed conversion raises a `CborError` whose reason is specific —
+A malformed document or a failed conversion raises a `Cbor.Error` whose reason is specific —
 truncated input, an integer overflow, a wrong type, an absent field — so a protocol failure is
 diagnosed from the error rather than from a hex dump.
 
@@ -130,9 +130,9 @@ followed, trailing bytes name where the surplus begins, and a reserved head byte
 offset and its value.
 
 ```scala
-capture[CborError](Cbor.Ast.parse(data)).reason match
-  case CborError.Reason.Truncated(offset) => offset
-  case CborError.Reason.Trailing(offset)  => offset
+capture[Cbor.Error](Cbor.Ast.parse(data)).reason match
+  case Cbor.Error.Reason.Truncated(offset) => offset
+  case Cbor.Error.Reason.Trailing(offset)  => offset
   case _                                  => -1L
 ```
 

--- a/doc/modules/cbor.md
+++ b/doc/modules/cbor.md
@@ -16,41 +16,58 @@ device protocol, a cache entry, a message queue — that price buys nothing. CBO
 (maps, arrays, numbers, text, binary strings) in a compact binary form, but binary formats are
 usually consumed through byte-fiddling APIs far clumsier than their textual equivalents.
 
+The codec derives from the type, so the type is the schema: the [correctness](../philosophy/correctness.md) of the encoding follows from the definition rather than from tests.
+
 Soundness gives CBOR the full textual-format treatment: derived codecs, typed errors with reasons,
 dynamic access, and optics, so choosing the compact wire format costs no expressiveness in the
 code. Everything comes from the `soundness` package:
 
 ```scala
 import soundness.*
+import errorDiagnostics.stackTracesDiagnostics
 import strategies.throwUnsafely
 ```
 
 ### Encoding and decoding
 
-A value encodes with `in[Cbor]`, and CBOR data decodes to a type with `as` — or in one step, reading
-bytes straight to the type:
+A value encodes with `in[Cbor]`, and CBOR data decodes to a type with `as`:
 
 ```scala
 case class Person(name: Text, age: Int)
 
-val encoded = Person(t"Ada", 36).in[Cbor]       // a Cbor value
+val encoded = Person(t"Ada", 36).in[Cbor]   // a Cbor value
 encoded.as[Person]                          // Person(t"Ada", 36)
-
-stream.read[Person in Cbor]                 // bytes to Person directly
 ```
 
-The `@name[Cbor]` annotation renames a field on the wire, and a sealed hierarchy encodes with a
-discriminator declared once:
+A `Cbor` value is a tree; `Cbor.unseal` exposes it as a `Cbor.Ast`, which serializes to its bytes,
+and bytes read straight back to a type in one step, whether they arrive whole or as a
+[stream](streams.md) of chunks:
 
 ```scala
+val bytes: Data = Cbor.Ast.encodable.encoded(Cbor.unseal(encoded))
+bytes.length                        // 15
+
+Chain(bytes).read[Person in Cbor]   // Person(t"Ada", 36)
+```
+
+The `@name[Cbor]` [annotation](annotations.md) renames a field on the wire, and a sealed
+hierarchy encodes with a discriminator declared once:
+
+```scala
+enum Status:
+  case Active(since: Int)
+  case Retired
+
 given (Status is Discriminable in Cbor) = Cbor.discriminatedUnion(t"kind")
+
+Status.Active(2020).in[Cbor].as[Status]   // Status.Active(2020)
 ```
 
 An `Optional` field is omitted from the map when it is unset and supplied as `Unset` when the map
 lacks it, and a field with a default takes that default — so a message may gain fields without
 breaking readers that predate them.
 
-### Parsing directly, and from a stream
+### Parsing directly
 
 A type with a `Cbor.Parsable` instance is read straight from the bytes, with no intermediate tree
 built. The instance is derived at compiletime, composing a parser for that exact shape:
@@ -60,13 +77,13 @@ import breviloquence.Inlinable
 
 given (Person is Cbor.Parsable) = Inlinable.parsable[Person]
 
-data.read[Person in Cbor]
+Chain(bytes).read[Person in Cbor]   // parsed without building a tree
 ```
 
 The derivation composes the parser at expansion time, so it lives in a separate module from the
 runtime codecs and is imported by name.
 
-Reading also works over a [stream](streams.md) whose chunk boundaries fall anywhere: a value split
+Reading over a stream whose chunk boundaries fall anywhere works the same way: a value split
 across two chunks reads exactly as one that arrives whole, so a message need not be assembled
 before it is decoded.
 
@@ -74,11 +91,14 @@ before it is decoded.
 
 CBOR's tags annotate a value with its meaning — tag 1 is an epoch time, tag 2 a big integer, and
 the registry runs to hundreds. A tagged value keeps both its tag and the value inside it, so a
-document carrying tags round-trips without losing them:
+document carrying tags round-trips without losing them. These bytes are tag 1 around the integer
+1363896240:
 
 ```scala
+val document = Cbor.ast(Cbor.Ast.parse(hex"c11a514b67b0"))
+
 val ast = Cbor.unseal(document)
-ast.isTag && ast.tag.tag == 1L
+ast.isTag && ast.tag.tag == 1L   // true
 ```
 
 ### Diagnostic notation
@@ -88,7 +108,8 @@ can actually be read — and `show` produces it. Byte strings render as `h'…'`
 their JSON-like equivalents:
 
 ```scala
-Cbor.Ast.parse(bytes).show   // t"[1, 2, 3]", or t"h'01020304'"
+Cbor.Ast.parse(hex"83010203").show     // t"[1, 2, 3]"
+Cbor.Ast.parse(hex"4401020304").show   // t"h'01020304'"
 ```
 
 This is what to reach for when a message is not what it should be: the notation says what the
@@ -107,15 +128,15 @@ person.name.as[Text]                 // t"Ada"
 (person.age = 40).as[Person]         // Person(t"Ada", 40)
 ```
 
-Deeper updates use a lens, with `Each` and `Filter` optics touching many elements at once, exactly
-as for the textual formats.
+Deeper updates use a [lens](optics.md), with `Each` and `Filter` optics touching many elements at
+once, exactly as for the textual formats.
 
 ### Building directly
 
 A CBOR map is assembled from named arguments where no case class fits:
 
 ```scala
-Cbor.make(name = t"Anna".in[Cbor], age = 30.in[Cbor])
+Cbor.make(name = t"Anna".in[Cbor], age = 30.in[Cbor]).as[Person]   // Person(t"Anna", 30)
 ```
 
 ### Errors
@@ -127,13 +148,13 @@ diagnosed from the error rather than from a hex dump.
 Parse failures carry the byte offset at which they occurred, which for a binary format is the
 whole of the diagnosis: input that stops mid-value names the offset of the byte that should have
 followed, trailing bytes name where the surplus begins, and a reserved head byte names both its
-offset and its value.
+offset and its value. These bytes promise a three-element array and deliver two:
 
 ```scala
-capture[Cbor.Error](Cbor.Ast.parse(data)).reason match
-  case Cbor.Error.Reason.Truncated(offset) => offset
+capture[Cbor.Error](Cbor.Ast.parse(hex"830102")).reason match
+  case Cbor.Error.Reason.Truncated(offset) => offset   // 3
   case Cbor.Error.Reason.Trailing(offset)  => offset
-  case _                                  => -1L
+  case _                                   => -1L
 ```
 
 ### CBOR over HTTP

--- a/doc/modules/characters.md
+++ b/doc/modules/characters.md
@@ -56,7 +56,7 @@ enc"ABCDEF"   // does not compile: no such encoding
 ### Bad input
 
 A decoder consults the `TextSanitizer` in scope when it meets bytes that are not valid in its
-encoding. The strict sanitizer raises a `CharDecodeError` naming the position of the fault; the
+encoding. The strict sanitizer raises a `CharDecoder.Error` naming the position of the fault; the
 skip sanitizer drops the bad bytes; and the substitute sanitizer replaces them with `?`:
 
 ```scala
@@ -74,8 +74,8 @@ locally:
 
 locally:
   import textSanitizers.strictSanitizer
-  capture[CharDecodeError](charDecoders.utf8Decoder.decoded(badUtf8))
-  // CharDecodeError(1, enc"UTF-8")
+  capture[CharDecoder.Error](charDecoders.utf8Decoder.decoded(badUtf8))
+  // CharDecoder.Error(1, enc"UTF-8")
 ```
 
 Which behaviour is right depends on the data: strictness for input that should be trusted
@@ -88,7 +88,7 @@ reported, each with the position at which it occurred:
 
 ```scala
 validate[CharDecoder.Focus](DecodeIssues()):
-  case error: CharDecodeError => accrual + (prior.let(_.position).or(0), error)
+  case error: CharDecoder.Error => accrual + (prior.let(_.position).or(0), error)
 . protect:
     import textSanitizers.accrueSanitizer
     charDecoders.utf8Decoder.decoded(data)

--- a/doc/modules/characters.md
+++ b/doc/modules/characters.md
@@ -21,6 +21,8 @@ nothing in the code records which encoding was assumed. Meanwhile "one character
 idea: a flag emoji is two code points, an accented letter may be one or two, and a wide ideograph
 occupies two terminal columns — details that matter the moment text is measured or split.
 
+Naming the encoding as a given, rather than defaulting silently, is [declarative context](../philosophy/declarative-context.md) at the byte/text boundary.
+
 Soundness separates the choices. The encoding is a given, named at the use site; the treatment of
 undecodable bytes is another given, the *sanitizer*, so tolerating, substituting or rejecting bad
 input is a decision the code states; and width is measured through a metric chosen for the
@@ -61,6 +63,7 @@ skip sanitizer drops the bad bytes; and the substitute sanitizer replaces them w
 
 ```scala
 import strategies.throwUnsafely
+import errorDiagnostics.stackTracesDiagnostics
 
 val badUtf8 = Data(45, -62, 49, 48)   // a truncated two-byte sequence
 
@@ -78,20 +81,28 @@ locally:
   // CharDecoder.Error(1, enc"UTF-8")
 ```
 
-Which behaviour is right depends on the data: strictness for input that should be trusted
+Which behavior is right depends on the data: strictness for input that should be trusted
 absolutely, tolerance for text recovered from a lossy source. The choice is visible at the
 import.
 
 A fourth choice keeps both: `accrueSanitizer` carries on decoding, as the skipping one does, but
 records each fault so that the whole of a damaged input is recovered *and* every bad sequence is
-reported, each with the position at which it occurred:
+reported, each with the position at which it occurred. The faults accrue into a value of the
+caller's choosing — here, an [error](errors.md) that collects positions and faults — through
+`validate`, whose first block says how each fault joins the accumulation and whose `protect`
+block does the decoding:
 
 ```scala
+case class DecodeIssues(items: List[(Int, CharDecoder.Error)] = Nil)(using Diagnostics)
+extends Error(m"${items.size} decoding issues"):
+  def +(position: Int, error: CharDecoder.Error): DecodeIssues =
+    DecodeIssues(items :+ (position, error))
+
 validate[CharDecoder.Focus](DecodeIssues()):
   case error: CharDecoder.Error => accrual + (prior.let(_.position).or(0), error)
 . protect:
     import textSanitizers.accrueSanitizer
-    charDecoders.utf8Decoder.decoded(data)
+    charDecoders.utf8Decoder.decoded(badUtf8)   // t"-10", and one recorded issue at position 1
 ```
 
 This is what a tool importing a file of uncertain provenance wants: the text, plus a list of
@@ -143,7 +154,7 @@ printable — and reports its Unicode name; superscript and subscript forms are 
 Unicode defines them:
 
 ```scala
-'é'.description     // its Unicode character name
+'é'.description     // t"Latin Small Letter E With Acute", an Optional
 '\t'.control        // true
 '2'.superscript     // '²'
 ```
@@ -155,7 +166,7 @@ a combining accent. `GraphemeBreak.boundaries` finds the positions where one use
 character ends and the next begins, following the Unicode segmentation rules:
 
 ```scala
-GraphemeBreak.boundaries(t"🇬🇧🇫🇷")   // two graphemes, four code points
+GraphemeBreak.boundaries(t"🇬🇧🇫🇷")   // Array(0, 4, 8): two graphemes, four code points
 ```
 
 Code that truncates or reverses text at grapheme boundaries, rather than at arbitrary code

--- a/doc/modules/chemistry.md
+++ b/doc/modules/chemistry.md
@@ -3,7 +3,7 @@
 ### About
 
 The [periodic table](https://en.wikipedia.org/wiki/Periodic_table), chemical formulas, and chemical
-equations are modelled as values. All 118 elements are available by symbol; elements combine into
+equations are modeled as values. All 118 elements are available by symbol; elements combine into
 molecules and molecules into formulas with ordinary operators; and an equation joins two formulas
 with a typed reaction arrow, and can say whether it balances.
 
@@ -14,6 +14,8 @@ charge, a formula is a sum of molecules with coefficients, and an equation asser
 directed, reversible, or in equilibrium — between two formulas. Written as strings, none of that
 structure is available: `2H₂ + O₂` is just characters, and whether an equation balances is not a
 question a string can answer.
+
+Elements and formulas as typed values, with dimensioned masses, follow the same reasoning as [expressive errors](../philosophy/expressive-errors.md): a mistake should be a type error, not a wrong number.
 
 Soundness builds the structure from typed parts, so formulas are assembled by operators rather than
 parsed from text, rendered with correct subscripts and superscripts, and interrogated — an
@@ -29,7 +31,7 @@ Every element is a value on `PeriodicTable`, carrying its atomic number, symbol 
 are also reachable by number or symbol at runtime:
 
 ```scala
-import PeriodicTable.{H, O, C}
+import PeriodicTable.{H, O, C, Na, Cl, Fe}
 
 H.number             // 1
 PeriodicTable(6)     // carbon, as an Optional

--- a/doc/modules/classpath.md
+++ b/doc/modules/classpath.md
@@ -23,6 +23,8 @@ The Java API for this returns a `null` when a resource is absent, hands back a r
 None of it is typed, and a missing resource is discovered only when the `null` is
 dereferenced.
 
+Classpath entries and classloaders as typed values, rather than strings and globals, are [honest signatures](../philosophy/honest-signatures.md) for a part of the JVM that usually has none.
+
 Soundness treats a classpath resource as a path like any other, read with the same
 polymorphic `read`, and treats a classpath as an immutable value whose entries can be
 listed. A classloader is chosen explicitly, as a contextual value, rather than reached for
@@ -32,6 +34,7 @@ implicitly. Everything comes from the `soundness` package, with a classloader in
 import soundness.*
 import classloaders.threadContextClassloader
 import strategies.throwUnsafely
+import systems.javaBaseSystem
 ```
 
 ### Reading a resource
@@ -60,8 +63,9 @@ so a program can check for an optional resource rather than handle a failure.
 A resource reference names a path, not a thing: two classloaders may resolve the same path to
 different resources, or one to nothing at all, which is why the choice cannot be implicit in the
 reference and has to come from the context in which it is read. Which classloader resolves a
-resource is decided by the `given Classloader` in scope, chosen by import. The thread's context classloader suits most applications; the system, platform
-and Scala classloaders are the other standard choices:
+resource is decided by the `given Classloader` in scope, chosen by import. The thread's context
+classloader suits most applications; the system, platform and Scala classloaders are the other
+standard choices:
 
 ```scala
 import classloaders.systemClassloader
@@ -70,21 +74,22 @@ import classloaders.systemClassloader
 ### Inspecting the classpath
 
 A `LocalClasspath` is the classpath as a list of entries. The running program's classpath is
-the value of the `java.class.path` property, which decodes to one:
+the value of the `java.class.path` property, which decodes to one — reading the property needs
+the `System` in scope, imported above:
 
 ```scala
 val classpath = System.properties.java.`class`.path().as[LocalClasspath]
 ```
 
-Its `entries` are typed: a `ClasspathEntry` is a `Directory`, a `Jar`, a `Url`, or the
-`JavaRuntime` that supplies the JDK's own classes:
+Its `entries` are typed: a `Classpath.Entry` is a `Directory`, a `Jar`, a `Url`, or the
+`JavaRuntime` that supplies the JDK's own classes — and a *local* classpath's entries are
+statically known to exclude URLs, so a match over them need not handle that case:
 
 ```scala
-classpath.entries.each:
-  case ClasspathEntry.Directory(path) => Out.println(t"directory $path")
-  case ClasspathEntry.Jar(path)       => Out.println(t"archive $path")
-  case ClasspathEntry.Url(url)        => Out.println(t"url $url")
-  case ClasspathEntry.JavaRuntime     => Out.println(t"the Java runtime")
+classpath.entries.map:
+  case Classpath.Entry.Directory(path) => t"directory $path"
+  case Classpath.Entry.Jar(path)       => t"archive $path"
+  case Classpath.Entry.JavaRuntime     => t"the Java runtime"
 ```
 
 ### Loading services
@@ -94,7 +99,7 @@ mechanism finds the implementations of an interface declared on the classpath. `
 returns them, typed to the service:
 
 ```scala
-classpath.services[TestService].map(_.name)
+classpath.services[java.nio.file.spi.FileSystemProvider].map(_.getScheme)   // Set("file", "jar", …)
 ```
 
 ### Running under a classloader
@@ -104,6 +109,9 @@ classloader, restoring the previous one afterward. This scopes a change of class
 exactly the code that needs it — loading a plugin, say — rather than leaving it set:
 
 ```scala
-classloader.use:
-  // code here resolves classes against `classloader`
+classloaders.systemClassloader.use:
+  Classloader[Option[Int]]   // resolved against the system classloader
 ```
+
+`Classloader[T]` finds the classloader that loaded a type, which is how a plugin's own
+classloader is reached from one of its classes.

--- a/doc/modules/cli.md
+++ b/doc/modules/cli.md
@@ -6,7 +6,8 @@ A command-line application is an entry point that hands the program its argument
 interpretation of those arguments as subcommands, flags and operands, and tab
 completions for every shell. The unusual part is that the completions are derived from
 the same code that runs the command, so they cannot drift away from what the program
-actually does.
+actually does — and neither can the help text, the manpage, or the list of exit statuses,
+all of which are read off the program rather than written beside it.
 
 ### On the command line
 
@@ -23,26 +24,33 @@ a mode that produces suggestions instead of effects, so a flag that the program 
 for becomes a flag the program can suggest, and the completions agree with the program
 by construction.
 
+Every parameter and its parsing is declared in the type of the command, which is the [declarative context](../philosophy/declarative-context.md) style applied to the command line.
+
 The sections below start with a minimal entry point and build up through subcommands and
-flags to completions. Everything comes from the `soundness` package, together with a
-choice of argument interpreter and a few contextual values the entry point needs:
+flags to completions, help and manpages. Everything comes from the `soundness` package,
+together with a choice of argument interpreter and a few contextual values the entry point
+needs:
 
 ```scala
 import soundness.*
+
+import backstops.genericErrorMessageBackstop
 import executives.directExecutive
 import interpreters.posixInterpreter
-import backstops.genericErrorMessageBackstop
 import systems.javaBaseSystem
+import strategies.throwUnsafely
 ```
 
 ### An entry point
 
-The `application` method wraps a `@main` method, giving its body the program's context
-and expecting an `Exit` status in return:
+The `application` method wraps a program's entry point, giving its body the program's context
+and expecting an `Exit` status in return. It takes the arguments as a list of text, which is
+what an `Application` — an abstract class whose `main` method converts the JVM's arguments and
+whose `invoke` method is the body — hands it, so a complete program is one object extending
+`Application`; the examples here spell the call out:
 
 ```scala
-@main
-def mytool(args: IArray[Text]): Unit = application(args):
+def mytool(args: List[Text]): Unit = application(args):
   Out.println(t"Hello, world!")
   Exit.Ok
 ```
@@ -51,7 +59,7 @@ Packaged as an executable JAR whose `Main-Class` is `mytool`, this runs from the
 `Exit.Ok` reports success; `Exit.Fail(1)` — or any positive code — reports failure, and
 the status must be returned, not left implicit.
 
-An application can equally be written as a class extending `Application`, which supplies
+An application can equally be written as an object extending `Application`, which supplies
 the `main` method and asks only for an `invoke`:
 
 ```scala
@@ -67,7 +75,7 @@ Within the body, `arguments` is the list of arguments the program was given, eac
 `Argument`. Applying an argument yields its `Text`:
 
 ```scala
-application(args):
+def echo(args: List[Text]): Unit = application(args):
   arguments.each: argument =>
     Out.println(argument())
   Exit.Ok
@@ -82,8 +90,10 @@ It is worth separating two words that are often used interchangeably. *Arguments
 sequence of textual values the shell hands over; *parameters* are what they mean once
 interpreted. The arguments of `grep -rA4 pattern` are `-rA4` and `pattern`; its parameters are
 "search recursively", "show four lines of trailing context" and "search for `pattern`". The
-interpreter in scope — `posixInterpreter`, `posixClusteringInterpreter`, `simpleInterpreter` —
-is what turns the first into the second, which is why it is chosen by import rather than fixed.
+interpreter in scope is what turns the first into the second, which is why it is chosen by
+import rather than fixed: `posixInterpreter` reads `--long` and `-s` flags, and
+`posixClusteringInterpreter` additionally reads `-rA4` as `-r -A 4`, with a cluster's last
+letter taking the value; `simpleInterpreter` treats every argument as an operand.
 
 ### Subcommands
 
@@ -95,17 +105,23 @@ ordinary pattern:
 val Build = Subcommand(t"build", e"compile the project")
 val Test = Subcommand(t"test", e"run the tests")
 
-application(args):
+def tool1(args: List[Text]): Unit = application(args):
   arguments match
-    case Build() :: _ => Out.println(t"building…");  Exit.Ok
-    case Test() :: _  => Out.println(t"testing…");   Exit.Ok
+    case Build() :: _ => Out.println(t"building");  Exit.Ok
+    case Test() :: _  => Out.println(t"testing");   Exit.Ok
     case _            => Out.println(t"unknown command"); Exit.Fail(1)
 ```
 
 The description is written with the `e"…"` interpolator, which carries ANSI styling for
 shells that show it; a plain `Text` description works too. Subcommands nest: matching a
 subcommand and then matching again on the remaining arguments gives a tree of commands,
-each with its own flags.
+each with its own flags. A subcommand may be `hidden = true`, keeping it out of help and
+completions, and subcommands are gathered under headings in help with a `CommandGroup`:
+
+```scala
+val admin = CommandGroup(t"Admin commands", t"Commands for user administration.")
+val UserAdd = Subcommand(t"useradd", e"add a user account", group = admin)
+```
 
 ### Flags
 
@@ -115,10 +131,15 @@ flag's type is whatever the value should decode to — any type that can be read
 works without further ceremony:
 
 ```scala
-case Build() :: _ =>
-  val jobs: Optional[Int] = Flag[Int](t"jobs", aliases = List('j'))()
-  Out.println(t"building with ${jobs.or(1)} jobs")
-  Exit.Ok
+def tool2(args: List[Text]): Unit = application(args):
+  arguments match
+    case Build() :: _ =>
+      val jobs: Optional[Int] = Flag[Int](t"jobs", aliases = List('j'))()
+      Out.println(t"building with ${jobs.or(1)} jobs")
+      Exit.Ok
+
+    case _ =>
+      Exit.Fail(1)
 ```
 
 `aliases` gives short forms, so `--jobs 4`, `-j 4`, and `--jobs=4` are read alike.
@@ -141,23 +162,27 @@ derives its own name for it by convention. Declaring an application's identity a
 given Configurator.Prefix = Configurator.Prefix(t"myapp")
 
 val LogLevel = Setting[Text](t"logLevel", description = t"logging verbosity")
+val Home = Setting[Text](t"home", variable = t"MYAPP_HOME")
 ```
 
 Reading `LogLevel()` inside the CLI block consults, in order: the `--log-level`
 command-line flag, the `myapp.log.level` system property, and the `MYAPP_LOG_LEVEL`
 environment variable, returning `Optional` so a default is given the usual way,
-`LogLevel().or(t"info")`. Reading a setting registers its flag for tab completion, exactly
-as reading the flag directly would.
+`LogLevel().or(t"info")`. A setting whose environment variable does not follow the
+convention names it with `variable`, consulted between the flag and the cascade. Reading a
+setting registers its flag for tab completion, exactly as reading the flag directly would.
 
 Each source is a `Configurator` — a single abstract method from a setting's canonical
 name to an optional textual value — and the cascade is just composition with `++`, where
-the left side takes priority. Soundness does not prescribe a configuration-file format,
-but any source can join the cascade as a one-line lambda; defining a `Configurator` given
-replaces the standard cascade (the command-line flag always takes priority):
+the left side takes priority. No configuration-file format is prescribed, but any source can
+join the cascade as a one-line lambda; defining a `Configurator` given replaces the standard
+cascade (the command-line flag always takes priority):
 
 ```scala
-given Configurator = Configurator.properties ++ Configurator.environment
-  ++ { name => safely(config(name)) }
+def fromFile(name: Text): Optional[Text] = Unset   // consult a configuration file
+
+given (Environment, System) => Configurator =
+  Configurator.properties ++ Configurator.environment ++ { name => fromFile(name) }
 ```
 
 ### Exit status and errors
@@ -165,9 +190,21 @@ given Configurator = Configurator.properties ++ Configurator.environment
 The body returns an `Exit`: `Exit.Ok`, or `Exit.Fail(code)` for a failure. An error that
 escapes the body is caught by the *backstop* in scope, which turns it into an exit
 status rather than a stack trace — `genericErrorMessageBackstop` prints a short message
-and exits non-zero, while `stackTraceBackstop` prints the full trace, and
-`silentBackstop` prints nothing. Choosing a backstop is a matter of which one is
-imported.
+and exits non-zero, `exceptionMessageBackstop` prints the exception's own message,
+`stackTraceBackstop` prints the full trace, and `silentBackstop` prints nothing. Choosing
+a backstop is a matter of which one is imported.
+
+An exit code on its own says little to the user, so a failure that the program anticipates is
+better declared as a `Status`, an object carrying both the code and a description:
+
+```scala
+object CannotConnect extends Status(1, t"the server could not be reached")
+object BadConfig extends Status(2, t"the configuration file was invalid")
+```
+
+A `Status` is returned wherever an `Exit` is. Under the completions executive, below, the
+statuses a command can return are discovered from its code, and appear in its help and
+manpage without being listed anywhere else.
 
 ### Tab completions
 
@@ -175,7 +212,7 @@ Tab completion is one of the most useful things a command-line program offers: i
 discover features, preview the flags and values that are available, and avoid typing mistakes
 outright. It is also, conventionally, maintained separately from the program itself — a
 different script per shell, often written by different people, each approximating the command's
-behaviour by hardcoding its subcommands and flags, and sometimes going further to keep mutually
+behavior by hardcoding its subcommands and flags, and sometimes going further to keep mutually
 exclusive flags consistent with each other. The shells do not even agree on what a completion
 is: Bash offers the completion text alone, while Zsh and Fish can show a description beside it.
 The work is admirable and it is impossible to keep correct.
@@ -185,7 +222,9 @@ the arguments produces the completions, so they agree by construction. The per-s
 shrink to nothing of consequence — capture the incomplete command line, the cursor position and
 the shell's name, and hand them to the application in completions mode.
 
-Turning completions on replaces the default executive with the completions executive:
+Turning completions on replaces the default executive with the completions executive, imported
+where the entry point is defined so that it, rather than the direct executive, is the one in
+scope for that program:
 
 ```scala
 import executives.completionsExecutive
@@ -198,17 +237,18 @@ invocation. So the prelude does the argument handling, and the side effects live
 `execute`:
 
 ```scala
-@main
-def mytool(args: IArray[Text]): Unit = application(args):
-  arguments match
-    case Build() :: _ =>
-      val jobs = Flag[Int](t"jobs", aliases = List('j'))()
-      execute:
-        Out.println(t"building with ${jobs.or(1)} jobs")
-        Exit.Ok
+def mytool2(args: List[Text]): Unit =
+  import executives.completionsExecutive
+  application(args):
+    arguments match
+      case Build() :: _ =>
+        val jobs = Flag[Int](t"jobs", aliases = List('j'))()
+        execute:
+          Out.println(t"building with ${jobs().or(1)} jobs")
+          Exit.Ok
 
-    case _ =>
-      execute(Exit.Fail(1))
+      case _ =>
+        execute(Exit.Fail(1))
 ```
 
 Because matching `Build` and declaring the `--jobs` flag happen in the prelude, they run
@@ -220,16 +260,26 @@ disagree. The completions executive also withholds standard output from the prel
 since there is nowhere to send it while completing; `Out.println` is available only
 inside `execute`.
 
-The consequences run deeper than "a flag that is read is a flag that is offered", because the
-reading may be conditional — and then so is the offering, on *precisely the same condition*.
-Consider a command with a `-v` flag that turns on output, and a `--verbosity` flag meaningful
-only alongside it:
+A flag read in the prelude yields a `Prospective` handle rather than the value itself: its
+`present` and `absent` may be consulted at once — to decide what else to offer — but applying
+it to get the value is possible only inside `execute`. The consequences run deeper than "a
+flag that is read is a flag that is offered", because the reading may be conditional — and then
+so is the offering, on *precisely the same condition*. Consider a command with a `-v` flag that
+turns on output, and a `--verbosity` flag meaningful only alongside it:
 
 ```scala
-val verbose = Flag[Text](t"verbose", aliases = List('v'))()
+enum Verbosity:
+  case Quiet, Normal, Loud
 
-val verbosity: Optional[Verbosity] =
-  if verbose.present then Flag[Verbosity](t"verbosity")() else Unset
+def tool3(args: List[Text]): Unit =
+  import executives.completionsExecutive
+  application(args):
+    val verbose = Switch(t"verbose", aliases = List('v'))()
+    val verbosity = if verbose.present then Flag[Verbosity](t"verbosity")() else Unset
+
+    execute:
+      Out.println(t"verbosity: ${verbosity.let(_()).or(Verbosity.Normal)}")
+      Exit.Ok
 ```
 
 Pressing `tab` after a bare `-` runs this prelude. `-v` is checked for, and so becomes a
@@ -239,19 +289,44 @@ branch checking for `--verbosity` runs too, so `--verbosity` becomes a candidate
 anywhere; the conditional structure of the code is the conditional structure of the completions,
 however complex it becomes.
 
+### Required and validated flags
+
+A flag that must be present is declared with `require()` instead of `()`, and one whose value
+must also decode correctly with `validate()`. In the prelude each yields a `Requisite` handle
+whose value is unconditionally available inside `execute`, because a missing or malformed
+requisite stops the block from running at all. Every such flag is checked before the block
+starts, so the user learns of all of them at once, with exit status 2 by the usage-error
+convention, rather than one per run:
+
+```scala
+def tool4(args: List[Text]): Unit =
+  import executives.completionsExecutive
+  application(args):
+    val home = Flag[Text](t"home", description = t"the home directory").require()
+    val jobs = Flag[Int](t"jobs", description = t"parallel jobs").validate()
+
+    execute:
+      Out.println(t"building ${home()} with ${jobs()} jobs")
+      Exit.Ok
+```
+
+Inside `execute`, the same calls yield the value directly, raising `MissingFlagError` or
+`InvalidFlagError` immediately for the backstop to report. A required flag is also marked as
+required in the help text.
+
 ### The executive, and effectful methods
 
 The *executive* is what determines the return type of an entry point's body and the contextual
 values available inside it. `directExecutive` expects an `Exit` and supplies `Stdio`;
-`completions` expects an `Execution` and withholds `Stdio` until `execute`. Choosing one by
-import is what lets the entry-point API stay uniform while imposing genuinely different
+`completionsExecutive` expects an `Execution` and withholds `Stdio` until `execute`. Choosing
+one by import is what lets the entry-point API stay uniform while imposing genuinely different
 requirements on the code inside it.
 
 An `execute` block also supplies an erased `Effectful`. Nothing consumes it internally; its
 purpose is that a user-defined method may *demand* it:
 
 ```scala
-def deleteEverything()(using Effectful): Unit = …
+def deleteEverything()(using Effectful): Unit = ()
 ```
 
 Since an `Effectful` can be obtained only inside an `execute` block, such a method cannot be
@@ -270,16 +345,48 @@ suggest values with a `Discoverable` instance, and how to read a chosen value wi
 case class Mode(name: Text)
 
 given Mode is Discoverable = _ => List(t"debug", t"release").map(Suggestion(_))
-given Mode is Interpretable =
-  case argument :: Nil => Mode(argument())
-  case _               => Mode(t"debug")
 
-val mode = Flag[Mode](t"mode", description = t"build mode")()
+given Mode is Interpretable = new Interpretable:
+  type Self = Mode
+  def interpret(arguments: List[Argument]): Optional[Mode] = arguments match
+    case argument :: _ => Mode(argument())
+    case _             => Unset
+
+def tool5(args: List[Text]): Unit =
+  import executives.completionsExecutive
+  application(args):
+    val mode = Flag[Mode](t"mode", description = t"build mode")()
+    execute(Exit.Ok)
 ```
 
 With these in scope, `mytool build --mode ` offers `debug` and `release`. A `Suggestion`
 may carry a description, shown by shells that support it, and may be marked `incomplete`
-to complete a value one segment at a time, as for a file path.
+to complete a value one segment at a time, as for a file path. A flag whose type is `Pathname`
+completes filesystem paths this way out of the box, expanding a leading `~` as the shell would.
+
+### Help and manpages
+
+Because the prelude describes the whole interface — subcommands, flags, their descriptions,
+which flags are required, and which statuses each command can return — help needs no
+separate source. The completions executive rebuilds the interface as a `Help` tree by
+re-running the prelude with synthesized argument prefixes, and renders it in an aligned,
+man-page-style layout; the same tree renders as a
+[manpage](https://en.wikipedia.org/wiki/Man_page) in roff, with `roff`, which `Manpages.install`
+writes into place.
+
+Everything discovered is documented: a `Status` returned from an `execute` block appears
+under *Exit status*, and an environment variable read in the prelude appears under
+*Environment*. Descriptions that discovery cannot supply — what an environment variable
+means, an example invocation — are added through a `Manual`:
+
+```scala
+val manual = Manual
+  ( environment  = List(Manual.EnvironmentVariable(t"MYAPP_HOME", t"the home directory")),
+    examples     = List(Manual.Example(t"build with four jobs", t"mytool build --jobs 4")) )
+```
+
+Within a command, `explain` attaches a paragraph of local help to the current subcommand
+section, so a deep subcommand documents itself where it is defined.
 
 ### Installing completions
 
@@ -298,7 +405,7 @@ new subcommands and flags need no change to any script.
 ### Fast startup
 
 A command invoked for completion must start quickly, or the shell feels sluggish.
-Running the application as a daemon removes the JVM's startup cost from every
+Running the application as a [daemon](daemons.md) removes the JVM's startup cost from every
 invocation: the program stays resident and each command, including each completion
 request, is dispatched to the running process. The same body that `application` runs is
 run by `daemon`, so an application gains fast startup by changing how it is launched, not

--- a/doc/modules/collections.md
+++ b/doc/modules/collections.md
@@ -1,0 +1,265 @@
+## Collections
+
+### About
+
+Soundness has its own collection types — `List`, `Sequence`, `Set`, `Map` and the lazy `Chain` —
+and one vocabulary of operations over all of them, and over text, which traverses as its
+characters. The types are *opaque*: each is a thin, zero-cost wrapper over the standard library's
+structure, exposing a smaller, total API in which an operation that could fail returns an
+`Optional` rather than throwing, an operation whose cost is not what its name suggests is gated
+behind an explicit acknowledgment, and sorting names the algorithm it uses.
+
+The operations are typeclass-driven, so a new shape — a byte buffer, a parsed document, a stream
+of records — gains the whole vocabulary by supplying one instance, and the vocabulary reads the
+same whatever it is applied to.
+
+### On collections
+
+The standard library's collections are large, partial and quietly expensive. `head` throws on an
+empty list; `apply` on a `List` is linear but looks like an array read; `sorted` picks an
+algorithm for you and requires an `Ordering` that a `String` supplies without asking which
+language's order it means; and every type carries several hundred methods, many of them
+duplicates under other names.
+
+Soundness keeps the structures and replaces the surface. The wrappers are opaque, so nothing is
+copied and nothing costs more than before — a `List` is still a linked list — but the methods
+are the ones a program needs, each returning a type that says what it can and cannot do. Where a
+method's cost depends on the structure, the program says it knows: counting a linked list is a
+traversal, so a `List`'s `size` is available only where the *linear size* acknowledgment is in
+scope. Everything comes from the `soundness` package, with a sorting algorithm chosen for the
+examples that sort:
+
+```scala
+import soundness.*
+import sortingAlgorithms.timsort
+import strategies.throwUnsafely
+```
+
+### The types
+
+A `List` is a linked list, cheap to prepend to and to traverse; a `Sequence` is indexed, cheap to
+read at any position; a `Set` holds each element once; a `Map` pairs keys with values; and a
+`Chain` is a lazy sequence whose elements are computed as they are demanded and remembered
+afterwards, which may therefore be infinite. Each is constructed by applying its companion, and
+`Nil` is the empty list:
+
+```scala
+val numbers: List[Int] = List(3, 1, 2)
+val letters = Sequence(t"a", t"b", t"c")
+val primes = Set(2, 3, 5, 7)
+val ages = Map(t"Ada" -> 36, t"Bob" -> 41)
+val naturals: Chain[Int] = Chain.iterate(0)(_ + 1)
+```
+
+A list built from a known number of elements is typed as *populated*, and its `head`, `last`
+and `tail` are total on that type; on a `List` of unknown length they are not available, and the
+`Optional`-returning accessors are used instead.
+
+### Positions and access
+
+Positions are [ordinals](numbers.md), not integers: `Prim`, `Sec` and `Ter` name the first three,
+and `Ordinal.zerary` converts a zero-based index. Applying a collection to an ordinal reads the
+element there, as an `Optional`, since the position may lie beyond the end, and `prim`, `sec`
+and `ter` read the first few directly:
+
+```scala
+letters(Sec)                  // t"b"
+letters(Ordinal.zerary(7))    // Unset
+numbers.prim                  // 3
+numbers.last                  // 2
+```
+
+Indexing a `List` by position is a walk from its head, so it, and the accessors that walk more
+than a few elements, are gated behind the *linear access* acknowledgment, `dysasymptotics.linearAccess`,
+in the same way that `size` is gated behind `linearSize`. A `Sequence` has neither cost and needs
+neither import. The imports are cheap to write and say something true, which is the point: a
+program that indexes into a linked list in a loop has a quadratic algorithm, and should know it.
+
+```scala
+import dysasymptotics.{linearSize, linearAccess}
+
+numbers.size                  // 3
+numbers(Ter)                  // 2
+```
+
+### Traversing and transforming
+
+`each` visits every element, with the ordinal of each available as a contextual value;
+`map` transforms elements; `filter` keeps those matching a predicate; `bind` — the same operation
+the standard library calls `flatMap`, which is also available under that name so that
+comprehensions work — flattens the results; and `flat` flattens one level of nesting:
+
+```scala
+numbers.map(_*2)                     // List(6, 2, 4)
+numbers.filter(_ > 1)                // List(3, 2)
+numbers.bind(n => List(n, n))        // List(3, 3, 1, 1, 2, 2)
+List(List(1, 2), List(3)).flat       // List(1, 2, 3)
+
+for
+  n <- numbers
+  m <- List(10, 20)
+yield n + m
+```
+
+Every operation returns the shape it was given — mapping a `Set` gives a `Set`, filtering a
+`Chain` gives a lazy `Chain` — except where the result cannot be that shape: mapping a `Map`
+transforms its values and keeps its keys, while `remap` transforms its entries as pairs, and
+gives a `Map` where the results are pairs and a `List` where they are not.
+
+```scala
+ages.map(_ + 1)                          // Map(t"Ada" -> 37, t"Bob" -> 42)
+ages.remap { (name, age) => name }       // List(t"Ada", t"Bob")
+```
+
+### Searching and measuring
+
+`has` tests membership; `exists` tests a predicate; `count` counts matches; `fold` accumulates
+from an initial state; and `trace` is a `fold` that keeps every intermediate state, initial
+first:
+
+```scala
+numbers.has(2)                // true
+numbers.exists(_ > 2)         // true
+numbers.count(_ > 1)          // 2
+numbers.fold(0)(_ + _)        // 6
+numbers.trace(0)(_ + _)       // List(0, 3, 4, 6)
+```
+
+The least and greatest elements are `minimum` and `maximum`, each an `Optional` since the
+collection may be empty, and both defined for any element type with a comparison:
+
+```scala
+numbers.minimum   // 1
+numbers.maximum   // 3
+```
+
+### Reshaping
+
+`excerpt` takes a run by position, end-exclusive, and is total: bounds beyond the end clamp
+rather than fail. `zip` pairs elements positionally, stopping at the shorter side; `group` keys
+elements by a function into a `Map` of the source's own shape; `partition` splits by a
+predicate, keeping order on both sides; `span` splits at the first element failing a predicate;
+and `batched` cuts a collection into runs of at most a given size:
+
+```scala
+numbers.excerpt(1, 3)                   // List(1, 2)
+numbers.excerpt(2, 99)                  // List(2)
+numbers.zip(letters)                    // List((3, t"a"), (1, t"b"), (2, t"c"))
+List(1, 2, 3, 4).group(_%2)             // Map(1 -> List(1, 3), 0 -> List(2, 4))
+List(1, 2, 3, 4).partition(_%2 == 0)    // (List(2, 4), List(1, 3))
+List(1, 2, 3, 4).span(_ < 3)            // (List(1, 2), List(3, 4))
+List(1, 2, 3, 4, 5).batched(2)          // List(List(1, 2), List(3, 4), List(5))
+```
+
+`sweep` filters and maps in one pass, through a partial function:
+
+```scala
+numbers.sweep { case n if n > 1 => n*10 }   // List(30, 20)
+```
+
+### Duplicates and order
+
+`distinct` drops repeated elements, keeping the first of each; `deduplicate` does the same by a
+key; and `reverse` reverses any reversible shape, text included:
+
+```scala
+List(1, 2, 1, 3, 2).distinct              // List(1, 2, 3)
+List(10, 43, 22, 71, 52).deduplicate(_%10)   // List(10, 43, 22, 71)
+numbers.reverse                           // List(2, 1, 3)
+t"stressed".reverse                       // t"desserts"
+```
+
+A `Set` has no order, so it cannot be sorted, excerpted or deduplicated: those operations are
+simply absent from it, rather than defined to do something arbitrary.
+
+### Sorting
+
+Sorting has two ingredients, and both are explicit. The *comparison* comes from a `Comparable`
+instance for the element type — the numbers have one; [text](text.md) needs a collation to be
+chosen, since no order of text is natural — and the *algorithm* is a given selected by import
+from `sortingAlgorithms`: Timsort or Powersort for stability and speed on partly-ordered data,
+quicksort or heapsort where memory matters, and the simpler algorithms where the input is tiny.
+`sort` orders by the elements' own comparison and `order` by a key:
+
+```scala
+numbers.sort               // List(1, 2, 3)
+numbers.order(-_)          // List(3, 2, 1)
+letters.order(_.length)    // Sequence(t"a", t"b", t"c"): stable, so ties keep their order
+```
+
+With no algorithm in scope the sort does not compile, and with two in scope it is ambiguous —
+which is the compiler insisting that a choice has been made, since the algorithm decides
+whether equal elements keep their order and how the sort behaves on data that is nearly sorted
+already.
+
+### Sets and maps
+
+A `Set` supports the operations of set theory — `insert`, `except`, `intersect` and `concat` for
+union — and membership with `has`. A `Map` reads a value by key with `at`, as an `Optional`
+since the key may be absent, tests a key with `defines`, updates or adds with `define`, removes
+with `omit`, and exposes its `keys` and `values`:
+
+```scala
+primes.insert(11)             // Set(2, 3, 5, 7, 11)
+primes.intersect(Set(2, 4))   // Set(2)
+primes.except(Set(2, 3))      // Set(5, 7)
+
+ages.at(t"Ada")               // 36
+ages.at(t"Cy")                // Unset
+ages.defines(t"Ada")          // true
+ages.define(t"Cy", 29)        // a new map with three entries
+ages.omit(t"Bob")             // Map(t"Ada" -> 36)
+ages.keys                     // Set(t"Ada", t"Bob")
+```
+
+Every value is immutable: `define` and `omit` return new maps, and the original is unchanged,
+as [immutability](../philosophy/immutability.md) asks everywhere else.
+
+### Lazy chains
+
+A `Chain` computes its elements on demand and remembers them, so it can describe an infinite
+sequence — every natural number, every line a process will print — as long as only a finite
+prefix is ever forced. `#::` prepends an element without forcing what follows, `Chain.iterate`
+and `Chain.unfold` generate from a seed, `Chain.continually` repeats a value, and `keep` and
+`skip` take and drop a prefix without forcing the rest:
+
+```scala
+naturals.keep(5)                   // Chain(0, 1, 2, 3, 4)
+naturals.skip(10).keep(2)          // Chain(10, 11)
+Chain.continually(7).keep(3)       // Chain(7, 7, 7)
+
+def evens: Chain[Int] = naturals.filter(_%2 == 0)
+evens.prim                         // 0
+```
+
+Because a chain may be unbounded, `size` is not defined on it unless the program acknowledges
+that counting may not terminate, with `dysasymptotics.unboundedSize`. A lazily-parsed
+[stream](streams.md) or a recurrence of [dates](time.md) is a `Chain` for exactly this reason:
+the consumer decides how much is computed.
+
+### Text as a collection
+
+`Text` traverses as its characters, so the vocabulary above applies to it directly — `has`,
+`count`, `filter`, `reverse`, `subsumes` — and reshaping keeps it text where the result is
+characters:
+
+```scala
+t"hello".has('e')             // true
+t"hello".count(_ == 'l')      // 2
+t"hello".filter(_ != 'l')     // t"heo"
+t"hello world".subsumes(t"lo wo")   // true
+```
+
+### Crossing to the standard library
+
+Code that must hand a collection to a library written against the standard library crosses at
+the boundary with `stdlib`, which exposes the underlying structure without copying, and comes
+back with the companion's `from`:
+
+```scala
+numbers.stdlib                              // scala.collection.immutable.List(3, 1, 2)
+List.from(scala.collection.immutable.List(1, 2))   // List(1, 2)
+```
+
+Keeping the crossing explicit, and greppable, is what lets the rest of a program be written in
+the total vocabulary: the partial, larger API is reachable, but only where the code says so.

--- a/doc/modules/colors.md
+++ b/doc/modules/colors.md
@@ -40,6 +40,8 @@ import soundness.*
 given Colorimetry = colorimetry.daylightColorimetry
 ```
 
+A color's space living in its type is a small instance of [impossible states](../philosophy/impossible-states.md): mixing two spaces without converting cannot be written.
+
 ### Color spaces
 
 Each model is a type whose fields are its coordinates, given as fractions between 0
@@ -115,7 +117,7 @@ mixture.to[Hsl].hue.degrees   // 22.5
 ```
 
 Parts are proportions, so `5*Red + 3*Yellow` and `50*Red + 30*Yellow` are the same color,
-and a third daub is weighted against the total so far rather than against its neighbour:
+and a third daub is weighted against the total so far rather than against its neighbor:
 
 ```scala
 1*WebColors.Red + 1*WebColors.Lime + 1*WebColors.Blue   // an even third of each
@@ -123,10 +125,11 @@ and a third daub is weighted against the total so far rather than against its ne
 
 ### Mixing modes
 
-`proportional` averages the colors, which is what `mix` does. The other modes are the
-blend modes of Photoshop and GIMP — `multiply`, `screen`, `overlay`, `hardLight`,
-`softLight`, `darken`, `lighten`, `colorDodge`, `colorBurn`, `difference`, `exclusion`,
-`linearDodge` and `linearBurn` — and each is imported the same way:
+`proportionalMixing` averages the colors, which is what `mix` does. The other modes are the
+blend modes of Photoshop and GIMP — `multiplyMixing`, `screenMixing`, `overlayMixing`,
+`hardLightMixing`, `softLightMixing`, `darkenMixing`, `lightenMixing`, `colorDodgeMixing`,
+`colorBurnMixing`, `differenceMixing`, `exclusionMixing`, `linearDodgeMixing` and
+`linearBurnMixing` — and each is imported the same way from the `mixing` package:
 
 ```scala
 import mixing.multiplyMixing
@@ -136,11 +139,11 @@ import mixing.multiplyMixing
 
 A daub's share of the total parts acts as its opacity: the mode is applied at full
 strength and the result mixed back in that proportion, exactly as a layer's opacity
-slider works. Only `proportional` is therefore commutative — under any other mode
+slider works. Only proportional mixing is therefore commutative — under any other mode
 `5*Red + 3*Yellow` differs from `3*Yellow + 5*Red`, just as reordering two layers does.
 
-Every mode but `proportional` reads coordinates as fractions of full intensity, so they
-are offered only for sRGB, CMY and CMYK. Asking for `multiply` in CIELAB, where lightness
+Every mode but the proportional one reads coordinates as fractions of full intensity, so they
+are offered only for sRGB, CMY and CMYK. Asking for `multiplyMixing` in CIELAB, where lightness
 runs to 100, will not compile rather than quietly meaning something else.
 
 ### Adjusting
@@ -210,20 +213,41 @@ given Colorimetry = colorimetry.incandescentTungstenColorimetry
 WebColors.Ivory.to[Cielab]   // computed for tungsten light
 ```
 
+### Themes and palettes
+
+A `Theme` names a coordinated set of colors — a background, a foreground, a list of accents,
+and whether it is a light or a dark theme — and a `Palette` selects from one by role, offering
+`subdue` and `accent` to push a color toward the background or away from it. The Solarized
+theme is built in and chosen by import:
+
+```scala
+import themes.solarizedTheme
+
+Solarized.blue                 // Srgb(0.149, 0.545, 0.824)
+summon[Theme].luminosity       // Brightness.Dark
+```
+
+`luminosity.darkBrightness` and `luminosity.lightBrightness` select the variant of a theme
+that offers both, so terminal output styled through a palette adapts to the terminal's
+background.
+
 ### Pixel layouts
 
-A colour on screen is not usually a triple of doubles but a packed integer, and how it is packed
+A color on screen is not usually a triple of doubles but a packed integer, and how it is packed
 varies: eight bits per channel with or without alpha, five-six-five for a 16-bit display, ten bits
-per channel for high dynamic range, a single channel for greyscale. A *layout* states that packing
+per channel for high dynamic range, a single channel for grayscale. A *layout* states that packing
 as a tuple of channel types, most significant first, and the compiler works out the rest:
 
 ```scala
 type Rgb565 = (Red[5], Green[6], Blue[5])
 
-compiletime.constValue[Channel.TotalBits[Rgb]]      // 24
-summon[Channel.Storage[Rgb565] =:= Short]           // the narrowest type that fits
-summon[Channel.Storage[Tuple1[Grey[8]]] =:= Byte]
+compiletime.constValue[iridescence.Channel.TotalBits[Rgb]]      // 24
+summon[iridescence.Channel.Storage[Rgb565] =:= Short]           // the narrowest type that fits
+summon[iridescence.Channel.Storage[Tuple1[Grey[8]]] =:= Byte]
 ```
+
+`Channel` is reached through its library package here because the umbrella already exports a
+`Channel` of its own, the WebSocket channel.
 
 Each channel's shift and mask follow from its position in the tuple, computed as the code
 compiles, so reading a channel from a packed pixel is a single shift-and-mask instruction with no
@@ -232,4 +256,4 @@ to and from `Chroma`, `Srgb` and `Cmyk` exactly where its layout supports it —
 alpha channel has no alpha to read.
 
 This is what [images](images.md) use to give a raster typed pixel access, and it is where a
-colour computed in one of the perceptual spaces above ends up when it reaches a screen.
+color computed in one of the perceptual spaces above ends up when it reaches a screen.

--- a/doc/modules/compiler.md
+++ b/doc/modules/compiler.md
@@ -131,7 +131,7 @@ through, and a setting that configures nothing on the path is rejected before an
 
 Edges whose tools have prerequisites come from providers that demand evidence of them, so an edge
 whose tooling is absent cannot be built: `sjsEdges.wasi()` needs a probed `WasiToolchain` and a
-`WitWorld`, and `nativeEdges()` probes for `clang`.
+`Wasi.World`, and `nativeEdges()` probes for `clang`.
 
 Formats are values, and their identity is value equality, so wherever a parameter changes what a
 user receives, it is a constructor parameter and each parameterization is a distinct node: the
@@ -206,12 +206,12 @@ A WASI component — a `Wasi(Wasi.Version.Wasip2)`, a component-model `.wasm` wh
 exports are described by WIT — has two prerequisites beyond the linker, both demanded by the edge
 provider, so an edge without them cannot be constructed: a `WasiToolchain`, evidence that the
 native tools the link shells out to (`wasm-tools` and the scala-wasm fork of `wit-bindgen`) are
-present, obtainable only through the probing constructor `WasiToolchain()`; and a `WitWorld`,
+present, obtainable only through the probing constructor `WasiToolchain()`; and a `Wasi.World`,
 naming the directory of WIT packages and the world to link against:
 
 ```scala
 given WasiToolchain = WasiToolchain()
-given WitWorld = WitWorld(witDirectory, t"my-world")
+given Wasi.World = Wasi.World(witDirectory, t"my-world")
 
 val toolchain = Toolchain(sjsEdges(), List(sjsEdges.wasi()), ociEdges())
 toolchain.produce(emission, Universe.Sjsir, OciImage, destination)
@@ -229,7 +229,7 @@ require no native tooling at all — the linker is an ordinary JVM library.
 ### Native binaries
 
 The native edges shell out to `clang` and `clang++`, so `nativeEdges` probes for them once and
-raises `ToolchainError` if either is missing. It takes the triples to target, defaulting to the
+raises `Toolchain.Error` if either is missing. It takes the triples to target, defaulting to the
 build host's own:
 
 ```scala

--- a/doc/modules/compiler.md
+++ b/doc/modules/compiler.md
@@ -29,6 +29,8 @@ import soundness.*
 import strategies.throwUnsafely
 ```
 
+A compilation described as a value and run by a toolchain is [direct style](../philosophy/direct-style.md): the build is code, checked like any other.
+
 ### Configuring a compiler
 
 A `Scalac` is parameterized by its language version and carries its options — each a typed value,

--- a/doc/modules/compression.md
+++ b/doc/modules/compression.md
@@ -28,27 +28,44 @@ byte for byte, and a value compressed one way decompresses the other. Everything
 
 ```scala
 import soundness.*
+
+import charDecoders.utf8Decoder
+import charEncoders.utf8Encoder
+import strategies.throwUnsafely
 ```
+
+A compression scheme is a stage in a pipeline rather than a wrapper around a stream, which is [composability](../philosophy/composability.md) in its most literal form.
 
 ### Compressing a value
 
 A block of bytes compresses and decompresses by naming the format:
 
 ```scala
-val payload = t"the quick brown fox".in[Data]
+val payload = t"the quick brown fox jumps over the lazy dog".in[Data]
 
 val compressed = payload.compress[Gzip]
-compressed.decompress[Gzip]   // the original bytes
+compressed.decompress[Gzip].utf8   // t"the quick brown fox jumps over the lazy dog"
 ```
 
 ### Compressing a stream
 
 The same names attach to a stream, where they become pipeline stages: the data is transformed as
-it flows, and nothing larger than the pipeline's buffers is held:
+it flows, and nothing larger than the pipeline's buffers is held. Writing a compressed
+[file](filesystem.md) and reading it back is the compressor and decompressor placed on either
+side of the disk:
 
 ```scala
-file.stream.compress[Gzip].writeTo(destination)
-archive.stream.decompress[Gzip].read[Text]
+import filesystemOptions.createNonexistentParents
+import pathInterfaces.pathOnLinux
+import temporaryDirectories.javaBaseTemporaryDirectory
+
+val archive = temporaryDirectory[Path on Linux] / "compression" / "fox.txt.gz"
+
+archive.create[File](): handle ?=>
+  handle.write(payload.stream.compress[Gzip])
+
+archive.open[File]()(file.stream.decompress[Gzip].read[Text])
+// t"the quick brown fox jumps over the lazy dog"
 ```
 
 Whole-value and streaming forms interoperate freely: a value compressed as a whole decompresses
@@ -60,6 +77,11 @@ through a stream, and a stream's output decompresses as a value.
 header, timestamp and CRC that `.gz` files carry. These are the formats of HTTP content
 encoding, ZIP entries and PNG chunks, and they are the fastest of the set.
 
+```scala
+payload.compress[Zlib].decompress[Zlib] == payload      // true
+payload.compress[Deflate].decompress[Deflate] == payload
+```
+
 `Brotli` compresses smaller than DEFLATE at comparable speed, and is the modern web's content
 encoding. Both directions need the whole value before producing output — the decoder because
 backward references may reach across the entire window, the encoder because it chooses its
@@ -68,14 +90,18 @@ framing from the total length — so a Brotli stage buffers where a DEFLATE stag
 `Xz` is the high-ratio codec: LZMA2 inside the `.xz` container, with a CRC-64 check, matching
 what the `xz` command-line tool produces. `Lzma2` is the same codec without the container
 framing, standing to `Xz` as `Deflate` stands to `Gzip`. Both default to preset 6; presets 0 to
-3 favour speed and 4 to 9 favour ratio, and an explicit preset is selected with
-`Xz.compress(stream, preset)` or `Xz.compressor(preset)`.
+3 favor speed and 4 to 9 favor ratio, and an explicit preset is selected with
+`Xz.compress(stream, preset)` or `Xz.compressor(preset)`:
+
+```scala
+payload.compress[Xz].decompress[Xz] == payload   // true
+```
 
 `Lzw` is the compression of TIFF and PDF streams. The JDK offers no implementation of it at all,
-so this one is written from the specification. Its `earlyChange` parameter — both sides widening their
-codes one table entry sooner — is on by default, which is what TIFF, PDF and every known encoder
-produce; the parameterized `Lzw.compressor` and `Lzw.decompressor` serve formats that state it
-explicitly.
+so this one is written from the specification. Its `earlyChange` parameter — both sides widening
+their codes one table entry sooner — is on by default, which is what TIFF, PDF and every known
+encoder produce; the parameterized `Lzw.compressor` and `Lzw.decompressor` serve formats that
+state it explicitly.
 
 ### Where compression appears
 

--- a/doc/modules/concurrency.md
+++ b/doc/modules/concurrency.md
@@ -199,7 +199,7 @@ The provided schedules cover the usual choices — `exponentialForeverTenacity`,
 `exponentialFiveTimesTenacity` and `exponentialTenTimesTenacity` back off geometrically, while
 the `fixedNoDelay` variants retry immediately, forever or a bounded number of times — and
 `Tenacity.exponential` and `Tenacity.fixed`, with `limit`, build others. Running out of attempts
-raises a `RetryError` naming how many were made.
+raises a `Tenacity.Error` naming how many were made.
 
 Within the block, `surrender()` gives up immediately without consuming further attempts, and
 `persevere()` asks for another, so a body can distinguish a failure worth retrying from one that

--- a/doc/modules/concurrency.md
+++ b/doc/modules/concurrency.md
@@ -5,21 +5,21 @@
 Concurrency in Soundness is structured. A task is spawned inside a supervised scope that owns it, and
 the scope does not complete until its tasks have. A task runs a computation on a thread and yields a
 result that is awaited; a failure in a task propagates to the scope rather than vanishing; and
-cancelling a scope cancels everything beneath it. Whether tasks run on the JVM's platform threads or
+canceling a scope cancels everything beneath it. Whether tasks run on the JVM's platform threads or
 its lightweight virtual threads is a choice made in scope. The reasoning behind this shape
 is set out under [structured concurrency](../philosophy/structured-concurrency.md).
 
 ### On concurrency
 
 Unstructured concurrency leaks. A thread started with no owner can outlive the code that started it;
-an exception thrown on it disappears unless someone thought to catch it; and cancelling a piece of
+an exception thrown on it disappears unless someone thought to catch it; and canceling a piece of
 work means tracking down every thread it spawned. The lifetimes of concurrent tasks bear no relation
 to the structure of the code, so reasoning about what is still running, and what happened to it, is
 hard.
 
 Soundness gives concurrent work the same shape as ordinary blocks. Every task is a child of the scope
 that spawned it, and a scope waits for its children before it finishes, so no task outlives its
-scope. A failure travels up to the scope, and cancelling the scope cancels its children. The result
+scope. A failure travels up to the scope, and canceling the scope cancels its children. The result
 is that a concurrent program nests, and its structure is visible. Everything comes from the
 `soundness` package, with a thread model and a completion policy in scope:
 
@@ -45,9 +45,11 @@ supervise:
 `async` spawns a task, which runs concurrently and yields its result from `await`:
 
 ```scala
+def expensiveComputation(): Int = (1 to 1000000).sum
+
 supervise:
   val task = async(expensiveComputation())
-  task.await()
+  task.await()   // 1784293664
 ```
 
 Because the task belongs to the enclosing scope, the scope accounts for it whether or not it is
@@ -62,28 +64,28 @@ task rather than of the scope at the top.
 
 ### Why a parent waits
 
-A task may not finish — produce a result or be cancelled — until its children have finished, and
+A task may not finish — produce a result or be canceled — until its children have finished, and
 that is what makes a completed task safe to reason about. Consider a parent that returns almost
 immediately while a child goes on logging:
 
 ```scala
-supervise:
-  val writer = openWriter()
+var written = 0
 
+supervise:
   val parent = async:
     async:
       for i <- 0 to 10 do
-        snooze(1.0*Second)
-        writer.write(t"still running")
+        snooze(0.01*Second)
+        written += 1
 
     t"complete"
 
-  report(parent.await())
-  writer.close()
+  parent.await()   // t"complete"
+  written          // 11
 ```
 
-Nothing stands between the parent and its result, so were `await` to return at once, the writer
-would be closed while the child was still writing to it. Instead `parent.await()` does not return
+Nothing stands between the parent and its result, so were `await` to return at once, `written`
+would be read while the child was still counting. Instead `parent.await()` does not return
 until the child has settled — which is the invariant in general: once a task has been awaited, no
 further execution can take place on the resources captured in its body, including any that
 escaped through a child.
@@ -95,21 +97,23 @@ with `race`, and `map` and `bind` derive one task from another:
 
 ```scala
 supervise:
-  Seq(async(1), async(2), async(3)).sequence.await()   // Seq(1, 2, 3)
-  async(3).bind(n => async(n + 4)).await()             // 7
+  List(async(1), async(2), async(3)).sequence.await()   // List(1, 2, 3)
+  async(3).bind(n => async(n + 4)).await()              // 7
 ```
 
 `sequence` runs its tasks in parallel and collects the results *in order*, so the ordering of the
 results says nothing about the order in which they finished. `race` returns the first to finish
-and the rest are cancelled, since their results were not wanted.
+and the rest are canceled, since their results were not wanted.
 
 ### Naming tasks
 
-A task may be given a name, checked as the code compiles against the rules for a task name — no
-path separators, since names compose into a hierarchy mirroring the scope tree:
+`task` is `async` with a name, checked as the code compiles against the rules for a task name — no
+path separators, since names compose into a hierarchy mirroring the scope tree. Inside the task,
+`monitor.name` is the full path:
 
 ```scala
-val name: Name[Async] = n"worker"
+supervise:
+  task(n"worker")(monitor.name).await()   // t"worker"
 ```
 
 Named tasks make a running program legible: a stack trace, a monitor dump or a debugger shows
@@ -117,7 +121,7 @@ Named tasks make a running program legible: a stack trace, a monitor dump or a d
 
 ### Cancellation
 
-A task is cancelled with `cancel`, and a cancellable task cooperates by pausing at points where it
+A task is canceled with `cancel`, and a cancellable task cooperates by pausing at points where it
 can be interrupted. A `snooze` is such a point, so a task sleeping on one wakes to its cancellation
 rather than running on:
 
@@ -125,31 +129,33 @@ rather than running on:
 supervise:
   val task = async:
     snooze(10.0*Second)
-    compute()
+    expensiveComputation()
   task.cancel()   // the snoozing task is interrupted
 ```
 
 Work that does not pause has to volunteer its own cancellation points. `relent()` is that
-point: while the task is running normally it does nothing, and if the task has been cancelled it
+point: while the task is running normally it does nothing, and if the task has been canceled it
 stops there, without producing a value. A task whose body never calls `relent()` and never pauses
-cannot be cancelled at all, and must run to completion.
+cannot be canceled at all, and must run to completion.
 
 ```scala
-val task = async:
-  for i <- 0 to 10 do
-    delay(1.0*Second)
-    relent()
-    writer.write(t"still running")
+supervise:
+  val task = async:
+    for i <- 0 to 10 do
+      delay(0.1*Second)
+      relent()
+      written += 1
+  task.cancel()
 ```
 
-Cancelled at the `relent()`, this task never reaches the `write` on the next line. It does
-still wait out the full second first, because `delay` is uninterruptible — which is the
+Cancelled at the `relent()`, this task never reaches the increment on the next line. It does
+still wait out the delay first, because `delay` is uninterruptible — which is the
 distinction the next section is about.
 
 ### Pausing
 
 Four methods stop the current strand temporarily, spanning two independent choices: whether the
-pause can end early because the task was cancelled, and whether it is expressed as a duration or
+pause can end early because the task was canceled, and whether it is expressed as a duration or
 as the instant to wake at.
 
 |                     | duration   | instant      |
@@ -171,7 +177,9 @@ is chosen by name:
 
 ```scala
 import abstractables.millisecondsAbstractable
-snooze(200L)  // 200 milliseconds
+
+supervise:
+  snooze(200L)  // 200 milliseconds
 ```
 
 The alternatives are `nanosecondsAbstractable` and `microsecondsAbstractable`; the three share a
@@ -187,12 +195,23 @@ around it is a busy-loop with nothing at the call site to say so.
 
 Work that fails for a transient reason should be tried again, and the *schedule* on which it is
 retried is a value rather than a loop written at each call site. `retry` runs a block under the
-`Tenacity` in scope, which decides how long to wait before each attempt and when to stop:
+`Tenacity` in scope, which decides how long to wait before each attempt and when to stop. The
+block is lent two operations: `persevere()` asks for another attempt, and `surrender()` gives up
+at once:
 
 ```scala
 import retryTenacities.exponentialTenTimesTenacity
 
-retry(fetchRemoteValue())
+var attempts = 0
+
+def fetchRemoteValue(): Optional[Text] =
+  attempts += 1
+  if attempts < 3 then Unset else t"payload"
+
+supervise:
+  retry: (surrender, persevere) ?=>
+    fetchRemoteValue().or(persevere())
+// t"payload", on the third attempt
 ```
 
 The provided schedules cover the usual choices — `exponentialForeverTenacity`,
@@ -201,14 +220,13 @@ the `fixedNoDelay` variants retry immediately, forever or a bounded number of ti
 `Tenacity.exponential` and `Tenacity.fixed`, with `limit`, build others. Running out of attempts
 raises a `Tenacity.Error` naming how many were made.
 
-Within the block, `surrender()` gives up immediately without consuming further attempts, and
-`persevere()` asks for another, so a body can distinguish a failure worth retrying from one that
-never will be.
+A body therefore distinguishes a failure worth retrying from one that never will be, and the
+schedule decides the rest.
 
 ### Promises
 
 A `Promise` is a value that will be supplied later, perhaps by another thread. One side awaits it and
-the other fulfils it, which is how work running elsewhere hands back a result:
+the other fulfills it, which is how work running elsewhere hands back a result:
 
 ```scala
 supervise:
@@ -232,7 +250,7 @@ was never intended for it.
 ### Cancellation in both directions
 
 Cancelling a scope cancels its children, and the *probate* decides what happens to a child that is
-still running when its parent's body completes. Under `cancelProbate` the child is cancelled;
+still running when its parent's body completes. Under `cancelProbate` the child is canceled;
 under `awaitProbate` the parent waits for it; under `failProbate` the parent's `await` raises a
 checked `Async.Error`; and under `panicProbate` it panics instead.
 
@@ -254,10 +272,21 @@ The thread model is chosen by import: `virtualThreading` runs tasks on virtual t
 to spawn in great numbers, while `platformThreading` uses platform threads. Virtual threads exist
 only from Java 21, so `virtualThreading` fails at runtime on an older JVM; `adaptiveThreading`
 takes virtual threads where they exist and falls back to platform threads where they do not, which
-is what an application that cannot dictate its JVM should import. A separate choice, the
+is what an application that cannot dictate its JVM should import. On Scala.js, where there are no
+threads at all, `javascriptThreading` schedules tasks on the event loop, and the same `supervise`,
+`async` and `await` code runs unchanged. A separate choice, the
 *probate*, decides what a scope does with a child that has not finished when the scope ends —
 `cancelProbate` cancels it, `awaitProbate` waits for it — so the policy for tidying up concurrent work
 is explicit rather than assumed.
+
+An `await` may also be given a duration, after which it raises `Async.Error` rather than waiting
+on, so a task that has taken too long is abandoned at a point the code chooses:
+
+```scala
+supervise:
+  val slow = async(delay(10.0*Second))
+  safely(slow.await(0.1*Second))   // Unset: the deadline passed
+```
 
 ### Suspension as an effect
 

--- a/doc/modules/cryptography.md
+++ b/doc/modules/cryptography.md
@@ -29,9 +29,13 @@ a provider in scope:
 
 ```scala
 import soundness.*
-import strategies.throwUnsafely
-import providers.javaBaseProvider
+
+import charEncoders.utf8Encoder
+import charDecoders.utf8Decoder
 import cloaks.heapCloak
+import errorDiagnostics.stackTracesDiagnostics
+import providers.javaBaseProvider
+import strategies.throwUnsafely
 ```
 
 There is deliberately no default `Cloak`: constructing any secret value — a password, a
@@ -90,8 +94,7 @@ password.show                                  // t"Password(•••)"
 
 ### Public-key encryption and signing
 
-An RSA key pair encrypts toward the public key and decrypts with the private; a DSA pair signs
-with the private key and verifies with the public:
+An RSA key pair encrypts toward the public key and decrypts with the private:
 
 ```scala
 val privateKey = PrivateKey.generate[Rsa[2048]]()
@@ -99,39 +102,56 @@ val privateKey = PrivateKey.generate[Rsa[2048]]()
 val message = privateKey.public.uncloak:
   t"secret".encrypt(InitializationVector.random)
 
-privateKey.uncloak(message.decrypt.as[Text])
+privateKey.uncloak(message.decrypt.as[Text])   // t"secret"
+```
 
-val signer = PrivateKey.generate[Dsa[2048]]()
+Signing runs the other way: the private key signs, and anyone holding the public key verifies.
+RSA, DSA, ECDSA and ML-DSA — the lattice-based scheme standardized as FIPS 204, for a
+post-quantum signature — all sign the same way; the digest an RSA or ECDSA signature is computed
+over is chosen from the `signatureDigests` package:
+
+```scala
+import signatureDigests.sha256Signature
+
+val document = t"an important document"
+
+val signer = PrivateKey.generate[Ecdsa[256]]()
 val signature = signer.sign(document)
-signer.public.verify(document, signature)   // true
+
+signer.public.verify(document, signature)             // true
+signer.public.verify(t"a forged document", signature) // false
 ```
 
 ### HMAC
 
-A message authenticates with `hmac`, over any of the [hash](hashing.md) algorithms, rendered
-through the usual [base encodings](base-encoding.md):
+A message authenticates with `hmac` under a shared secret, over any of the [hash](hashing.md)
+algorithms, rendered through the usual [base encodings](base-encoding.md):
 
 ```scala
-message.hmac[Sha2[256]](secretKey).serialize[Hex]
+val secret = t"shared secret".in[Data]
+document.hmac[Sha2[256]](secret).serialize[Hex]
 ```
 
 ### PEM
 
 Keys travel in [PEM](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) form. A public key
 exports freely; exporting a *private* key demands the `Divulgence` marker — one more place where
-handling secret material is deliberate:
+handling secret material is deliberate. A `Pem` value carries its label and its bytes, and
+serializes to the familiar armored text:
 
 ```scala
-privateKey.public.pem.serialize
+val pemText = privateKey.public.pem.serialize   // t"-----BEGIN PUBLIC KEY-----…"
 privateKey.pem(Divulgence)
-pemText.read[Pem]
+
+pemText.read[Pem].label   // Pem.Label.PublicKey
 ```
 
 PEM parses incrementally, so a source holding many blocks — a certificate chain, a bundle of
 keys — yields them one at a time, lazily, rather than as one parsed document:
 
 ```scala
-chainText.read[Chain[Pem]].map(_.label).to(List)
+val chainText = t"$pemText\n$pemText"
+chainText.read[Chain[Pem]].map(_.label).to[List]   // two public-key labels
 ```
 
 Text that is not part of a block — the `subject=…` lines OpenSSL writes between certificates —
@@ -162,26 +182,55 @@ decoding and re-encoding reproduce the original bytes exactly. That property is 
 a signature over a certificate's `TBSCertificate` depends on: a structure can be taken apart,
 inspected, and put back together without disturbing the bytes the signature covers.
 
+### Certificates
+
+An [X.509](https://en.wikipedia.org/wiki/X.509) certificate binds a public key to a
+*distinguished name* for a period of validity, signed by its issuer. A self-signed certificate —
+the kind a development server or a private certificate authority needs — is generated from a
+subject, a private key, a validity [period](time.md) and a serial number, with the
+`dNSName` alternatives a TLS client will check:
+
+```scala
+import chronometries.unixChronometry
+
+val subject = Distinguished(commonName = t"example.com", organization = t"Example", country = t"GB")
+val validity = Instant(1_700_000_000_000L) ~ Instant(1_900_000_000_000L)
+
+val certificate =
+  Certificate.selfSigned(subject, privateKey, validity, BigInt(1), alternatives = List(t"example.com"))
+
+certificate.pem.serialize   // t"-----BEGIN CERTIFICATE-----…"
+```
+
+A certificate is an `Asn1` value underneath, so its fields are readable through the same
+structure, and `authority = true` marks it as one that may sign others.
+
 ### Keystores
 
 A [PKCS#12](https://en.wikipedia.org/wiki/PKCS_12) keystore is opened for the duration of a
 scope, with the password given as a flag — an opaque `Password`, so its cleartext is reached only
 through the scoped `Cleartext` capability, and the character array the platform needs is zeroed
-once the store is loaded:
+once the store is loaded. Inside the scope, `keystore` is the open store:
 
 ```scala
-path.open[Keystore](Password(t"sesame")):
-  keystore.aliases
-  keystore.certificate(t"server")
+import pathInterfaces.pathOnLinux
+import temporaryDirectories.javaBaseTemporaryDirectory
+
+val storePath = temporaryDirectory[Path on Linux] / "cryptography" / "store.p12"
+
+def readAliases(): List[Text] =
+  storePath.open[Keystore](Password(t"sesame")):
+    keystore.certificate(t"server")   // Unset, unless the store holds that alias
+    keystore.aliases
 ```
 
 A missing alias is `Unset`. A wrong password and a corrupt store are deliberately
-indistinguishable — both are `Unreadable` — since telling them apart would say which of the two
-went wrong to someone guessing.
+indistinguishable — both are `Unreadable` in the `Keystore.Error` — since telling them apart
+would say which of the two went wrong to someone guessing.
 
 ### Weak algorithms
 
 Encrypting with DES, RC2, 1024-bit RSA, ECB mode or any unauthenticated block cipher requires a
-permission from the `crypto` package in scope — the same [permit machinery](hashing.md) that gates
-MD5 and SHA-1 — so accepting legacy cryptography is an explicit, auditable decision rather than a
-default.
+permission from the `cryptoPermits` package in scope — the same [permit machinery](hashing.md)
+that gates MD5 and SHA-1 — so accepting legacy cryptography is an explicit, auditable decision
+rather than a default.

--- a/doc/modules/cryptography.md
+++ b/doc/modules/cryptography.md
@@ -72,7 +72,7 @@ key.uncloak:
   t"Hello world".in[Data].stream.encrypt(InitializationVector.random).memoize.decrypt.as[Text]
 ```
 
-Decrypting with the wrong key raises a `CryptoError` naming the failure. AES's mode and padding
+Decrypting with the wrong key raises a `Crypto.Error` naming the failure. AES's mode and padding
 may also be fixed in the key's type — `Aes[256] over Cbc against Pkcs7` — and a pairing the
 specification forbids does not compile.
 
@@ -131,7 +131,7 @@ PEM parses incrementally, so a source holding many blocks — a certificate chai
 keys — yields them one at a time, lazily, rather than as one parsed document:
 
 ```scala
-chainText.read[LazyList[Pem]].map(_.label).to(List)
+chainText.read[Chain[Pem]].map(_.label).to(List)
 ```
 
 Text that is not part of a block — the `subject=…` lines OpenSSL writes between certificates —
@@ -153,7 +153,7 @@ bytes.as[Asn1]                   // the same value again
 
 DER is canonical, so a document has exactly one valid encoding, and the codec enforces that in
 both directions: an overlong length, a non-minimal integer, an unsorted `SET`, an indefinite
-length, or trailing bytes all raise an `Asn1Error` whose reason names the fault and the byte
+length, or trailing bytes all raise an `Asn1.Error` whose reason names the fault and the byte
 offset at which it was found.
 
 Decoding is total. A tag this layer does not model — `T61String`, `BMPString`, `ENUMERATED`, an

--- a/doc/modules/css.md
+++ b/doc/modules/css.md
@@ -30,6 +30,8 @@ import strategies.throwUnsafely
 import formatting.indentedCssFormatting
 ```
 
+Properties checked as the code compiles are [safety by construction](../philosophy/safety-by-construction.md) applied to a language usually validated in a browser.
+
 ### Writing CSS
 
 The `css"…"` interpolator writes a stylesheet, checked as the code compiles, and substitutes typed
@@ -61,7 +63,7 @@ is a length and cannot be confused with a number or an angle:
 90.0*Deg
 ```
 
-The physical units CSS shares with the real world — centimetres, points, seconds — are the same
+The physical units CSS shares with the real world — centimeters, points, seconds — are the same
 quantities used everywhere else in Soundness.
 
 ### Parsing
@@ -70,9 +72,11 @@ CSS text parses with `read`, validating every declaration and accumulating *all*
 rather than stopping at the first — the shape a linter or a build step needs:
 
 ```scala
+import errorDiagnostics.stackTracesDiagnostics
+
 t"a { color: red }".read[Css]
 
-capture[Css.Errors](t"a { colour: red }".read[Css]).errors.head.reason
+capture[Css.Errors](t"a { colour: red }".read[Css]).errors(0).reason
 // Css.Error.Reason.UnknownProperty(t"colour")
 ```
 
@@ -131,8 +135,8 @@ Parsing checks property names against the known set, so a misspelling is an erro
 declaration that silently does nothing:
 
 ```scala
-capture[Css.Errors](t"a { colour: red }".read[Css]).errors.head.reason
-// Css.Error.Reason.UnknownProperty(t"colour")
+capture[Css.Errors](t"a { colour: red; width: wide }".read[Css]).errors.map(_.reason)
+// List(Css.Error.Reason.UnknownProperty(t"colour"), Css.Error.Reason.BadValue(…))
 ```
 
 Errors accumulate: a rule with several bad declarations reports all of them, so a stylesheet is
@@ -148,6 +152,11 @@ stylesheet declares — so a misspelled class name in a template is a compile er
 attribute is used without saying which:
 
 ```scala
+import classloaders.threadContextClassloader
+
 given (Styles at "/site.css") = Styles(cp"/site.css")
 import cssBindings.checkedBinding
 ```
+
+The resource is read as the code compiles, so the stylesheet must be on the compiler's
+classpath, and the binding's type names the resource it was read from.

--- a/doc/modules/css.md
+++ b/doc/modules/css.md
@@ -72,11 +72,11 @@ rather than stopping at the first — the shape a linter or a build step needs:
 ```scala
 t"a { color: red }".read[Css]
 
-capture[CssErrors](t"a { colour: red }".read[Css]).errors.head.reason
-// CssError.Reason.UnknownProperty(t"colour")
+capture[Css.Errors](t"a { colour: red }".read[Css]).errors.head.reason
+// Css.Error.Reason.UnknownProperty(t"colour")
 ```
 
-Each `CssError` carries its line, column and reason — an unknown property, a bad value, a malformed
+Each `Css.Error` carries its line, column and reason — an unknown property, a bad value, a malformed
 selector — so a stylesheet's faults are reported precisely.
 
 ### Rendering
@@ -131,12 +131,12 @@ Parsing checks property names against the known set, so a misspelling is an erro
 declaration that silently does nothing:
 
 ```scala
-capture[CssErrors](t"a { colour: red }".read[Css]).errors.head.reason
-// CssError.Reason.UnknownProperty(t"colour")
+capture[Css.Errors](t"a { colour: red }".read[Css]).errors.head.reason
+// Css.Error.Reason.UnknownProperty(t"colour")
 ```
 
 Errors accumulate: a rule with several bad declarations reports all of them, so a stylesheet is
-corrected in one pass. The error type is plural — `CssErrors` — because reporting one fault at a
+corrected in one pass. The error type is plural — `Css.Errors` — because reporting one fault at a
 time from a document that has several is the wrong shape for the job.
 
 ### Checking class names against a stylesheet

--- a/doc/modules/csv.md
+++ b/doc/modules/csv.md
@@ -21,6 +21,8 @@ likely to be separated by tabs or semicolons. Code that splits on commas handles
 and the mapping from columns to a program's own types is usually written out by hand and kept in
 step by discipline.
 
+Rows decode to case classes through the same derivation as every other format, so the shape of the data is checked once, as [correctness](../philosophy/correctness.md) prefers.
+
 Soundness derives that mapping from the case class the data should become. Parsing respects
 quoting and escaping; the format — delimiter, quote character, whether a header is present — is an
 explicit value rather than a guess; and decoding a row to a type, or a type to a row, is a single
@@ -39,7 +41,7 @@ Text reads as a `Sheet`, whose `rows` are `Dsv` values — one per line, split i
 to the format:
 
 ```scala
-t"hello,world".read[Sheet].rows.head   // Dsv(t"hello", t"world")
+t"hello,world".read[Sheet].rows(Prim)   // Dsv(t"hello", t"world")
 ```
 
 A `Sheet` is materialized: its rows are an array, replayable, indexable and cheap to compare. A
@@ -48,7 +50,8 @@ the rows one at a time, parsed by the same reader, so a quoted cell spanning chu
 boundaries is handled exactly as it is in a materialized sheet:
 
 ```scala
-source.rows.map(_[Text](t"name").or(t"?")).to(List)
+t"name,age\nalpha,1\nbeta,2".source[Text].rows.map(_[Text](t"name").or(t"?")).to(List)
+// List(t"name", t"alpha", t"beta")
 ```
 
 ### Decoding to a case class
@@ -57,17 +60,17 @@ A row decodes into a case class with `as`, taking the cells in order; a nested c
 consumes as many columns as it has fields:
 
 ```scala
-case class Name(first: Text, last: Text)
-case class Person(id: Int, name: Name, age: Int)
+case class FullName(first: Text, last: Text)
+case class Person(id: Int, name: FullName, age: Int)
 
-t"1,Ada,Lovelace,36".read[Sheet].rows.head.as[Person]
-// Person(1, Name(t"Ada", t"Lovelace"), 36)
+t"1,Ada,Lovelace,36".read[Sheet].rows(Prim).let(_.as[Person])
+// Person(1, FullName(t"Ada", t"Lovelace"), 36)
 ```
 
 Reading straight to a type combines the two steps, decoding a single record from text:
 
 ```scala
-t"hello,world".read[Name in Dsv]   // Name(t"hello", t"world")
+t"hello,world".read[FullName in Dsv]   // FullName(t"hello", t"world")
 ```
 
 ### Headers
@@ -76,9 +79,9 @@ When the data begins with a header row, the header-bearing format matches each c
 field of the same name, so the order of the columns need not match the order of the fields:
 
 ```scala
-import dsvFormats.csvWithHeaderFormat
-
-t"last,first\nLovelace,Ada".read[Name in Dsv]   // Name(t"Ada", t"Lovelace")
+locally:
+  import dsvFormats.csvWithHeaderFormat
+  t"last,first\nLovelace,Ada".read[FullName in Dsv]   // FullName(t"Ada", t"Lovelace")
 ```
 
 ### Encoding
@@ -87,8 +90,8 @@ A case class encodes to a row with `dsv`, and a sequence of them to a `Sheet`; r
 result with `show` produces the delimited text:
 
 ```scala
-Name(t"Ada", t"Lovelace").dsv          // Dsv(t"Ada", t"Lovelace")
-Seq(Name(t"Ada", t"Lovelace")).dsv.show   // t"Ada,Lovelace"
+FullName(t"Ada", t"Lovelace").dsv               // Dsv(t"Ada", t"Lovelace")
+List(FullName(t"Ada", t"Lovelace")).dsv.show    // t"Ada,Lovelace"
 ```
 
 ### Formats
@@ -97,9 +100,9 @@ The format in scope decides the delimiter and quoting. `csvFormat` and `tsvForma
 choices, each with a header-bearing variant, and `ssvFormat` separates on spaces:
 
 ```scala
-import dsvFormats.tsvFormat
-
-Seq(Name(t"Ada", t"Lovelace")).dsv.show   // t"Ada\tLovelace"
+locally:
+  import dsvFormats.tsvFormat
+  List(FullName(t"Ada", t"Lovelace")).dsv.show   // t"Ada\tLovelace"
 ```
 
 A cell is quoted only when it contains the delimiter, a quote, or a line break, and a quote
@@ -114,11 +117,7 @@ consumes, so a decoder knows where one field ends and the next begins even when 
 nested:
 
 ```scala
-case class Name(first: Text, last: Text)
-case class Person(id: Int, name: Name, age: Int)
-
-Spannable.derived[Person].spans().to(List)   // List(1, 2, 1)
-Spannable.derived[Person].spans().sum        // 4 columns in total
+Spannable.derived[Person].spans()   // Array(1, 2, 1): four columns in total
 ```
 
 Positional decoding is inherently brittle, and worth being clear-eyed about: adding a field to a
@@ -160,8 +159,7 @@ place in the parser's row buffer, with no row value built at all:
 ```scala
 case class Stat(name: Text, count: Int, note: Optional[Text])
 
-object Stat:
-  given parsable: Stat is Dsv.Parsable = Dsv.Parsable.derived
+given Stat is Dsv.Parsable = Dsv.Parsable.derived
 
 t"z,9,note".read[Stat in Dsv]           // Stat(t"z", 9, t"note")
 t"a,1\nb,2".read[List[Stat] in Dsv]     // both records
@@ -170,7 +168,7 @@ t"a,1\nb,2".read[List[Stat] in Dsv]     // both records
 A stream yields records the same way, through `rowsOf`:
 
 ```scala
-source.rowsOf[Stat].map(_.count).to(List)
+t"x,1\ny,2".source[Text].rowsOf[Stat].map(_.count).to(List)   // List(1, 2)
 ```
 
 Fields are matched by header name where the format has a header and positionally where it does
@@ -184,7 +182,7 @@ the type asked for:
 ```scala
 import dynamicAccess.dynamicDsv
 
-val row = t"greeting,number\nhello,23".read[Sheet].rows.head
+val row = t"greeting,number\nhello,23".read[Sheet].rows(Prim)
 row.number[Int]   // 23
 ```
 
@@ -193,4 +191,25 @@ row.number[Int]   // 23
 A spreadsheet exported from elsewhere is rarely wrong in only one place, and a decoder that stops
 at the first bad cell makes fixing it a series of guesses. Under an accruing strategy, every cell
 that fails is reported — missing cells and unparseable ones together — each identified by its
-column, so one pass over a file yields the whole list of what to correct.
+column, so one pass over a file yields the whole list of what to correct. The accumulation is a
+value of the caller's choosing, here an [error](errors.md) collecting each fault with the column
+it was found in, and `Validate` says how each fault joins it, focused on the `CellRef` the
+decoder was reading:
+
+```scala
+import errorDiagnostics.stackTracesDiagnostics
+
+case class Issues(items: List[(Text, Dsv.Error)] = Nil)(using Diagnostics)
+extends Error(m"${items.size} decoding issues"):
+  def +(column: Text, error: Dsv.Error): Issues = Issues(items :+ (column, error))
+
+case class Measurement(name: Text, age: Int, height: Int)
+
+val damaged = t"name,age,height\nAlice,thirty,tall".read[Sheet].rows(Prim)
+
+Validate[Issues, [r] =>> r raises Dsv.Error, CellRef]
+  ( Issues(),
+    { case error: Dsv.Error => accrual + (prior.let(_.column).or(t"#"), error) } )
+. protect(damaged.as[Measurement])
+. items.map(_(0))   // List(t"age", t"height")
+```

--- a/doc/modules/daemons.md
+++ b/doc/modules/daemons.md
@@ -3,7 +3,7 @@
 ### About
 
 A JVM command-line tool pays the JVM's startup cost — and loses the just-in-time compiler's
-accumulated optimisation — on every invocation, which makes even a fast program feel slow at the
+accumulated optimization — on every invocation, which makes even a fast program feel slow at the
 shell. Soundness removes that cost by making the application resident: the first invocation starts
 a daemon, and every later one is dispatched to the running process by a small native launcher,
 with its arguments, environment, working directory, standard streams and signals all forwarded
@@ -22,15 +22,18 @@ environment and working directory, its own stdin and exit code, Ctrl-C reaching 
 invocation and not the daemon. And the daemon must manage itself: starting on demand, shutting
 down when idle, surviving upgrades.
 
+A daemon that serves each invocation against that invocation's own environment is [declarative context](../philosophy/declarative-context.md) taken seriously: nothing about the caller is global.
+
 Soundness handles those details in a per-platform native launcher and a protocol over a Unix
 domain socket, so the Scala application simply runs — many invocations concurrently, each with its
 own faithful context. Everything comes from the `soundness` package, alongside the CLI machinery:
 
 ```scala
 import soundness.*
+
+import backstops.stackTraceBackstop
 import executives.completionsExecutive
 import interpreters.posixInterpreter
-import backstops.stackTraceBackstop
 import threading.virtualThreading
 ```
 
@@ -47,6 +50,10 @@ def mytool(): Unit = cli:
     Exit.Ok
 ```
 
+`cli` takes no arguments: the launcher forwards them, with the environment, working directory
+and standard streams of the invoking shell, and the body sees them through the same `arguments`,
+`Out` and `Exit` as an ordinary application.
+
 The first run starts the daemon; later runs connect to it and return at native-tool speed. Tab
 completions gain the most: each completion request is an invocation, and a resident process
 answers in milliseconds.
@@ -62,10 +69,13 @@ An invocation traps the signals it cares about, and the response reaches the cod
 invocation, not the shared process:
 
 ```scala
-execute:
-  trap:
-    case signal: UnixSignal => SignalResponse.Accept
-  longRunningWork()
+def longRunningWork(): Exit = Exit.Ok
+
+def watch(): Unit = cli:
+  execute:
+    trap:
+      case signal: UnixSignal => SignalResponse.Accept
+    longRunningWork()
 ```
 
 The daemon retires itself after six idle hours, when its state files are removed, or on demand —
@@ -80,10 +90,13 @@ inside the line. `cooked` asks the launcher for canonical mode for the duration 
 raw mode is restored afterwards:
 
 ```scala
-execute:
-  service.cooked:
-    Out.println(t"Name?")
-    In.read[Text]
+def ask(): Unit = cli:
+  execute:
+    val name = service.cooked:
+      Out.println(t"Name?")
+      In.read[Text]
+    Out.println(t"Hello, $name")
+    Exit.Ok
 ```
 
 Echo and line editing then come from the terminal driver itself. A launcher with no such channel
@@ -93,11 +106,19 @@ Echo and line editing then come from the terminal driver itself. A launcher with
 
 Concurrent invocations of one daemon share a typed *bus*: an invocation broadcasts a message and
 others observe the stream, which is how "the running watch command notices that another invocation
-just changed the configuration" is expressed:
+just changed the configuration" is expressed. The message type is the type argument to `cli`, so
+every invocation of the daemon agrees on what can be sent:
 
 ```scala
-service.broadcast(ConfigChanged)
-service.bus   // a Stream of messages from other invocations
+enum Message:
+  case ConfigChanged
+
+def configure(): Unit = cli[Message]:
+  execute:
+    service.broadcast(Message.ConfigChanged)
+    service.bus.each:
+      case Message.ConfigChanged => Out.println(t"another invocation changed the configuration")
+    Exit.Ok
 ```
 
 ### Packaging
@@ -150,10 +171,16 @@ ethereal-sign sign --key release-keys/myapp.seed --in dist/myapp --out dist/myap
 ```
 
 That output is simultaneously a valid executable and a valid upgrade candidate. The application
-applies one by pointing `Upgrade` at any source of bytes:
+applies one by pointing `Upgrade` at any source of bytes — a URL, a file, a response body — and
+`Upgrade` does not return, because on success the running process is replaced:
 
 ```scala
-Upgrade(url"https://releases.example.com/myapp.signed")
+import environments.javaBaseEnvironment
+import systems.javaBaseSystem
+import errorDiagnostics.stackTracesDiagnostics
+import internetAccess.online
+
+def upgrade(): Nothing = Upgrade(url"https://releases.example.com/myapp.signed")
 ```
 
 The bytes are written aside, a fresh launcher starts and the old process exits; the new launcher

--- a/doc/modules/database.md
+++ b/doc/modules/database.md
@@ -25,6 +25,8 @@ import soundness.*
 import strategies.throwUnsafely
 ```
 
+A query built from typed fragments cannot be assembled into something the database will reject: [safety by construction](../philosophy/safety-by-construction.md) applied to SQL.
+
 ### Declaring a database
 
 The relations form the database's type — `A -< B` reads "an `A` may have `B`s":

--- a/doc/modules/database.md
+++ b/doc/modules/database.md
@@ -69,7 +69,7 @@ box.assign(shelf)        // does not compile: no Box -< Shelf relation
 The last line is the point: the schema is not documentation but a type, and an operation outside it
 never runs because it never compiles.
 
-`ref` finds the reference for a value already stored, raising a `DataError` where it is not —
+`ref` finds the reference for a value already stored, raising a `Database.Error` where it is not —
 which is how a value arriving from elsewhere is matched to what the database already holds,
 rather than stored a second time.
 

--- a/doc/modules/debugging.md
+++ b/doc/modules/debugging.md
@@ -1,12 +1,16 @@
 ## Debugging
 
+<!-- doccheck: language captureChecking -->
+
 ### About
 
 A JVM can be debugged from another JVM over the
 [Java Debug Wire Protocol](https://docs.oracle.com/en/java/javase/21/docs/specs/jdwp/jdwp-spec.html),
 and Soundness speaks it directly over a socket. A debuggee is launched under the agent or attached
 to where it already runs, and the session that results sets breakpoints, steps threads, reads
-frames and receives the VM's events as typed values — with no dependency on `com.sun.jdi`.
+frames and variables, evaluates expressions in the stopped program, and receives the VM's events
+as typed values — with no dependency on `com.sun.jdi`. The same session serves an editor over the
+[Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/).
 
 ### On debugging from the outside
 
@@ -16,27 +20,35 @@ resume, disconnect — is left to the caller to get right. Anything built on it 
 which is why debuggers are large programs rather than small ones.
 
 The protocol underneath is straightforward: length-prefixed packets, big-endian, with identifier
-widths negotiated once at the start of the connection. Modelling it directly gives typed
+widths negotiated once at the start of the connection. Modeling it directly gives typed
 identifiers that cannot be confused for each other, a session confined to a scope by
 [capture checking](../philosophy/capture-checking.md), and events as a stream to consume rather
-than callbacks to register. Everything comes from the `soundness` package:
+than callbacks to register. Everything comes from the `soundness` package; a session runs its
+reader as a task, so it needs a [thread model](concurrency.md) in scope and lives inside
+`supervise`:
 
 ```scala
 import soundness.*
+
+import probates.awaitProbate
 import strategies.throwUnsafely
+import stdios.javaLangSystemStdio
+import threading.virtualThreading
 ```
 
 ### Opening a session
 
 A `Debuggee` describes a program to run under the debug agent — a command, the port to listen on,
 and whether the VM should suspend before running `main`, which is what a breakpoint in
-initialization needs:
+initialization needs. Its `session` lends a `Debug` capability to a block, reached through
+`debug`:
 
 ```scala
-val target = Debuggee(sh"java -cp $classpath com.example.Main", port = 5005)
+def inspect(classpath: Text): List[Text] = supervise:
+  val target = Debuggee(sh"java -cp $classpath com.example.Main", port = 5005)
 
-target.session:
-  session.threads()
+  target.session:
+    debug.threads().map(debug.name(_))
 ```
 
 The command is launched with the agent option inserted, the connection waits for the VM to begin
@@ -53,51 +65,88 @@ The VM's threads are listed, named, suspended and resumed individually or togeth
 suspended thread's call stack reads as frames paired with their locations:
 
 ```scala
-session.suspend()
-
-session.threads().each: thread =>
-  Out.println(session.name(thread))
-  session.frames(thread).each: (frame, location) =>
-    report(location)
-
-session.resume()
+def stacks()(using Debug^): Unit = debug.suspend() yet
+  debug.threads().each: thread =>
+    debug.frames(thread).each: (frame, location) =>
+      Out.println(t"${debug.name(thread)}: ${location.index}")
+  debug.resume()
 ```
 
-### Breakpoints and stepping
+### Breakpoints
 
-A breakpoint is an event request at a location, and the request identifier it returns is what
-later clears it. The *suspend policy* decides how much of the VM stops when it is hit — the whole
-VM, only the thread that hit it, or nothing at all:
+A breakpoint is set on a source file and line, or on a class and method, and takes a *handler*
+that runs whenever a thread stops there. The handler is lent a `Halt`: a view over the stopped
+thread — its `frames()`, its `variables()`, the exception in flight if that is why it stopped —
+which cannot outlive the stop, since once the thread resumes every identifier it handed out may
+be stale. A handler that wants the thread left suspended says so with `remain()`; otherwise the
+thread resumes when the handler returns:
 
 ```scala
-val request = session.breakpoint(location, Jdwp.SuspendPolicy.EventThread)
+def watch()(using Debug^): Unit =
+  debug.breakpoint(t"Main.scala", Ordinal.uniary(42)): stop ?=>
+    stop.variables().each: variable =>
+      Out.println(t"${variable.name}: ${variable.erased}")
 
-session.clear(Jdwp.EventKind.Breakpoint, request)
+  debug.breakpoint(t"com.example.Ledger", t"deposit"): stop ?=>
+    stop.remain()
 ```
 
-Stepping is a request too, made against a suspended thread. The *depth* says whether to step into
-a call, over it, or out of the current frame, and the *size* whether a step is one bytecode
-instruction or one source line:
+Breakpoints on inlined code work by position: the file and line where the code was written
+rather than where the compiler placed it, recovered from the source maps the compiler records.
+A `logpoint` prints a message at a location without stopping; `watch` stops when a field is read
+or written; `exceptions` stops when one is thrown. The request identifier a breakpoint returns is
+what later clears it, and the *suspend policy* decides how much of the VM stops when it is hit —
+the whole VM, only the thread that hit it, or nothing at all:
 
 ```scala
-session.step(thread, Jdwp.StepDepth.Into, Jdwp.StepSize.Line)
+def once(location: Jdwp.Location)(using Debug^): Unit =
+  val request = debug.breakpoint(location, Jdwp.SuspendPolicy.EventThread)
+  debug.clear(Jdwp.EventKind.Breakpoint, request)
 ```
+
+### Stepping
+
+Stepping is a request against a suspended thread, with a handler for where it lands. The *depth*
+says whether to step into a call, over it, or out of the current frame. Inlined calls step as the
+source reads — into the inlined body, line by line — rather than as the bytecode was laid out:
+
+```scala
+def stepOver(thread: ThreadId)(using Debug^): Unit =
+  debug.step(thread, Jdwp.StepDepth.Over): stop ?=>
+    stop.frames().prim.let: (frame, location) =>
+      Out.println(stop.describe(location)(0))
+```
+
+### Evaluating expressions
+
+With the `Evaluator` in scope, an expression is compiled against the stopped frame's locals and
+injected into the running debuggee, so `total + 1` in a handler means what it would mean at that
+line of the source. This is what a debugger's console and hover use, and it is also how an editor
+shows the compiler-inferred type of a name.
 
 ### Events
 
-The VM reports what happened as composite events, and `events` is the stream of them, so a
-debugger's main loop is an ordinary traversal rather than a set of registered callbacks:
+Underneath the handlers, the VM reports what happened as composite events, and `events` is the
+stream of them, so a debugger's main loop can equally be an ordinary traversal:
 
 ```scala
-session.events.each: composite =>
-  composite.events.each:
-    case Jdwp.Event.Breakpoint(request, thread, location) => report(thread, location)
-    case Jdwp.Event.SingleStep(request, thread, location) => report(thread, location)
-    case other                                            => ()
+def trace()(using Debug^): Unit =
+  debug.events.each: composite =>
+    composite.events.each:
+      case Jdwp.Event.Breakpoint(request, thread, location) => Out.println(t"stopped at ${location.index}")
+      case Jdwp.Event.SingleStep(request, thread, location) => Out.println(t"stepped to ${location.index}")
+      case other                                            => ()
 ```
 
 Requests and replies are correlated asynchronously, so many commands may be in flight at once and
 an event arriving during one does not disturb it.
+
+### Serving an editor
+
+`Dap.listen` serves the session over the Debug Adapter Protocol on a TCP port, so any editor that
+speaks it — VS Code, and most others — launches, stops, steps, inspects variables and evaluates
+through this implementation. Completions, hover types and inline-aware stepping all pass through
+to the editor.
 
 ### The protocol vocabulary
 

--- a/doc/modules/decoding.md
+++ b/doc/modules/decoding.md
@@ -53,16 +53,16 @@ fails:
 import strategies.throwUnsafely
 
 t"123".as[Int]    // 123
-t"hello".as[Int]  // raises a NumberError
+t"hello".as[Int]  // raises a Number.Error
 ```
 
-A `NumberError` reports both the offending text and why it failed: text that is
+A `Number.Error` reports both the offending text and why it failed: text that is
 not a number at all is _unparseable_, while a number outside the target type's
 range is _out of range_. Decoding to a `Byte` distinguishes the two:
 
 ```scala
-t"300".as[Byte]   // raises a NumberError: 300 is out of range for a Byte
-t"abc".as[Byte]   // raises a NumberError: abc is unparseable
+t"300".as[Byte]   // raises a Number.Error: 300 is out of range for a Byte
+t"abc".as[Byte]   // raises a Number.Error: abc is unparseable
 ```
 
 Instances come built in for the primitive number types, for `Char`, and for types

--- a/doc/modules/decoding.md
+++ b/doc/modules/decoding.md
@@ -30,10 +30,14 @@ text, and text `is Extractable to Int` reads _toward_ an integer.
 The everyday surface is small — the `as` method and the `As` extractor — and
 the sections below start there before turning to the typeclasses underneath and
 how to write instances for your own types. Everything comes from the `soundness`
-package:
+package. Decoding can fail — the text might not be a number — so it needs an
+error-handling strategy in scope; the `throwUnsafely` strategy raises an exception
+when a decode fails:
 
 ```scala
 import soundness.*
+import strategies.throwUnsafely
+import errorDiagnostics.stackTracesDiagnostics
 ```
 
 ### Decoding a value
@@ -42,18 +46,8 @@ The `as` method reads a typed value out of text. The target type is supplied
 explicitly, and a matching `Decodable` instance does the work:
 
 ```scala
-t"123".as[Int]   // 123
-```
-
-Decoding can fail — the text might not be a number — so it needs an error-handling
-strategy in scope. The `throwUnsafely` strategy raises an exception when a decode
-fails:
-
-```scala
-import strategies.throwUnsafely
-
-t"123".as[Int]    // 123
-t"hello".as[Int]  // raises a Number.Error
+t"123".as[Int]            // 123
+safely(t"hello".as[Int])  // Unset: the decoding raised a Number.Error
 ```
 
 A `Number.Error` reports both the offending text and why it failed: text that is
@@ -61,8 +55,8 @@ not a number at all is _unparseable_, while a number outside the target type's
 range is _out of range_. Decoding to a `Byte` distinguishes the two:
 
 ```scala
-t"300".as[Byte]   // raises a Number.Error: 300 is out of range for a Byte
-t"abc".as[Byte]   // raises a Number.Error: abc is unparseable
+capture[Number.Error](t"300".as[Byte]).reason   // Number.Error.Reason.OutOfRange
+capture[Number.Error](t"abc".as[Byte]).reason   // Number.Error.Reason.Unparseable
 ```
 
 Instances come built in for the primitive number types, for `Char`, and for types
@@ -184,7 +178,7 @@ t"North" match
 Some types accept an empty input and some do not, and a form or a configuration
 often needs to know which before it asks for a value. A `Requirable` instance
 answers that: a type is _required_ when an empty input cannot produce one. The
-judgement follows from the type's decoder, so no separate declaration is needed —
+judgment follows from the type's decoder, so no separate declaration is needed —
 the decoder is simply run against the empty text, and whether it succeeds is the
 answer:
 
@@ -204,9 +198,6 @@ ordinal — each returning `Optional` rather than raising, since neither a name 
 an index is guaranteed to correspond to a case:
 
 ```scala
-enum Direction:
-  case North, South, East, West
-
 val enumerable = summon[Direction is Enumerable]
 
 enumerable.values             // every case, in order
@@ -228,8 +219,13 @@ header written `Content-Type` and read `contentType`. An `Identifiable` states
 both directions of such a mapping as a pair of text functions:
 
 ```scala
-val snakeCase = Identifiable[Column](encoder, decoder)
+case class Column()
+
+val snakeCase = Identifiable[Column](_.uncamel.snake, _.cut(t"_").camel)
 ```
+
+The two functions convert a name into the convention and back, using the
+[text](text.md) operations that split a name into words and join them again.
 
 Because it is a `Typeclass.Pure`, the compiler knows the conversion captures
 nothing, so it may be shared freely and applied wherever the naming convention
@@ -242,18 +238,20 @@ instance is writing the single conversion function; the framework supplies the
 `as` method, the `As` extractor and the rest.
 
 A `Decodable` instance maps an input to a value, mapping each recognized form to
-its result:
+its result. For a compass heading read from a single letter:
 
 ```scala
-enum Direction:
-  case North, South, East, West
+enum Heading:
+  case N, S, E, W
 
-object Direction:
-  given (Direction is Decodable in Text) =
-    case t"N" => North
-    case t"S" => South
-    case t"E" => East
-    case t"W" => West
+object Heading:
+  given (Heading is Decodable in Text) =
+    case t"north" => N
+    case t"south" => S
+    case t"east"  => E
+    case t"west"  => W
+
+t"north".as[Heading]   // Heading.N
 ```
 
 An `Extractable` instance returns an `Optional` result — `Unset` for the inputs it

--- a/doc/modules/derivation.md
+++ b/doc/modules/derivation.md
@@ -21,11 +21,16 @@ Writing them by hand is boilerplate that drifts; writing a macro per typeclass i
 libraries do not have. What is wanted is a statement of the two general rules — products combine,
 coproducts choose — from which every concrete instance follows.
 
+Derivation is what makes [small APIs](../philosophy/small-apis.md) possible: a typeclass needs two rules, not an instance per type.
+
 Soundness's engine — the successor to Magnolia — provides exactly that, as ordinary inheritance
-rather than macro-writing. Everything comes from the `soundness` package:
+rather than macro-writing. Everything comes from the `soundness` package, with the complexity
+import that permits indexing the arrays of fields a derivation produces:
 
 ```scala
 import soundness.*
+import dysasymptotics.linearAccess
+import strategies.throwUnsafely
 ```
 
 ### Products, sums and typeclasses
@@ -59,11 +64,11 @@ instances are handed to it, and it may be contravariant. (Nothing is used up; th
 which way the value travels.)
 
 ```scala
-trait Show[value]:                     // consumer
-  def show(value: value): Text
+trait Presenting[value]:                 // consumer
+  def present(value: value): Text
 
-trait Default[+value]:                 // producer
-  def apply(): value
+trait Producing[+value]:                 // producer
+  def produce(): value
 ```
 
 The distinction matters because the two derive differently: a consumer folds over the fields of a
@@ -73,7 +78,7 @@ value it was given, while a producer has no value to fold over and must build on
 
 A typeclass gains derivation by extending `Derivation` (or `ProductDerivation` where only case
 classes make sense) and implementing `conjunction` for products and `disjunction` for coproducts.
-A Show-like typeclass, in full:
+A Show-like typeclass, in full, with the extension method that makes it convenient to call:
 
 ```scala
 trait Presentation[value]:
@@ -87,12 +92,15 @@ object Presentation extends Derivation[Presentation]:
     value =>
       fields(value):
         [field] => field => t"$label=${contextual.present(field)}"
-      . mkString(s"${typeName[derivation]}(", ", ", ")").tt
+      . join(t"${typeName[derivation]}(", t", ", t")")
 
   inline def disjunction[derivation: SumReflection]: Presentation[derivation] =
     value =>
       variant(value):
         [variant <: derivation] => variant => contextual.present(variant)
+
+extension [value](value: value)
+  def present(using presentation: Presentation[value]): Text = presentation.present(value)
 ```
 
 `fields` folds over a product's fields, giving each one its `label`, its position, and the
@@ -133,11 +141,28 @@ Nested structures derive recursively: a case class of case classes needs nothing
 Inside `conjunction`, each field carries more than its value. `label` is the field's name as
 written, `index` its position, `typeName` the enclosing type's name, and `contextual` the instance
 of the typeclass being derived for that field's type. A derivation can therefore produce something
-that mentions the structure, not only something that folds over it:
+that mentions the structure, not only something that folds over it — here, the labels of a
+product's fields, with no value in hand, through `contexts`. Since derivation composes the
+instances of a product's fields, every field type needs one, even where — as for the labels of a
+`Text` or an `Int`, which have none — it is trivial:
 
 ```scala
-Labels.derived[Person].labels    // List(t"name", t"age", t"male")
-Labels.derived[Empty].labels     // Nil
+trait Labels[value]:
+  def labels: List[Text]
+
+object Labels extends ProductDerivation[Labels]:
+  given Labels[Text] = new Labels[Text] { def labels: List[Text] = Nil }
+  given Labels[Int] = new Labels[Int] { def labels: List[Text] = Nil }
+
+  inline def conjunction[derivation <: Product: ProductReflection]: Labels[derivation] =
+    val fieldLabels = contexts[derivation]() { [field] => context => label }
+    new Labels[derivation]:
+      def labels: List[Text] = fieldLabels.to[List]
+
+case class Empty()
+
+Labels.derived[Person].labels    // List(t"name", t"age")
+Labels.derived[Empty].labels     // List()
 ```
 
 An empty product is a product with no fields, and a single-field product is not special-cased —
@@ -151,24 +176,42 @@ case rather than at the sum, and the case's own label is available for a discrim
 A producer has no instance to fold over, so instead of `fields` it uses `build`, which constructs
 a new instance of the product. Its lambda receives the typeclass instance for each field — the
 only thing capable of making a value of a type the body cannot see — and returns that field's
-value:
+value. A parser of comma-separated fields, in full:
 
 ```scala
-inline def conjunction[derivation <: Product: ProductReflection]: Readable[derivation] = text =>
-  build[derivation]:
-    [field] => readable => readable.read(column(index))
+trait Parsing[value]:
+  def parse(text: Text): value
+
+object Parsing extends ProductDerivation[Parsing]:
+  given Parsing[Text] = identity(_)
+  given Parsing[Int] = _.s.toInt
+
+  inline def conjunction[derivation <: Product: ProductReflection]: Parsing[derivation] =
+    text =>
+      val columns = text.cut(t",")
+      build[derivation]:
+        [field] => parsing => parsing.parse(columns(Ordinal.zerary(index)).or(t""))
+
+t"Ada,36".read[Person]   // does not compile: Parsing is the typeclass, not Readable
+Parsing.derived[Person].parse(t"Ada,36")   // Person(t"Ada", 36)
 ```
 
 The sum counterpart is `delegate`, which takes the label of the variant to build and dispatches to
 that variant's instance. Unlike `variant`, which can read the answer off a value it was given,
-`delegate` is told which variant to produce, so the label usually comes out of the input:
+`delegate` is told which variant to produce, so the label usually comes out of the input — here,
+a `Date:` or `DateTime:` prefix — and a label naming no variant raises a `Variant.Error`:
 
 ```scala
-inline def disjunction[derivation: SumReflection]: Readable[derivation] = text =>
-  text.cut(t":") match
-    case List(prefix, rest) =>
-      delegate[derivation](prefix):
-        [variant <: derivation] => context => context.read(rest)
+object ParsingSums extends Derivation[Parsing]:
+  inline def conjunction[derivation <: Product: ProductReflection]: Parsing[derivation] =
+    Parsing.conjunction[derivation]
+
+  inline def disjunction[derivation: SumReflection]: Parsing[derivation] =
+    text =>
+      text.cut(t":") match
+        case List(prefix, rest) =>
+          delegate[derivation](prefix):
+            [variant <: derivation] => parsing => parsing.parse(rest)
 ```
 
 Where the produced value is wrapped in a type constructor — a parser returning an `Optional`, a
@@ -177,33 +220,42 @@ for that constructor, and threads the fields through it.
 
 ### Typeclasses over two values
 
-Some typeclasses take two values of the same type: `Eq` is the obvious one. Folding over the
-fields of the left value is easy, but the right value's corresponding field is the problem. Doing
-it by hand would mean building parallel arrays of left fields, right fields and instances, and the
-moment those values are separated from the lambda that typed them, their types erase and only
-casts put them back together.
+Some typeclasses take two values of the same type: an equivalence is the obvious one. Folding over
+the fields of the left value is easy, but the right value's corresponding field is the problem.
+Doing it by hand would mean building parallel arrays of left fields, right fields and instances,
+and the moment those values are separated from the lambda that typed them, their types erase and
+only casts put them back together.
 
-`complement` avoids that. Inside the fold for one value, it retrieves the corresponding field of
-*another* value of the same type, typed identically — so it is compatible with the same
-`contextual` instance:
-
-```scala
-inline def conjunction[derivation <: Product: ProductReflection]: Eq[derivation] =
-  (left, right) =>
-    fields(left):
-      [field] => leftField => contextual.equal(leftField, complement(right))
-    . all { equal => equal }
-```
-
-For sums it works the same way but returns an `Optional`, since the two values need not be the
-same variant — and if they are not, there is no meaningfully-typed value to return:
+`dereference` and `complement` avoid that. Inside `contexts`, `dereference` is a function from
+the product to the current field, typed with that field's type, so the same field can be pulled
+out of *both* values and handed to the one `contextual` instance. For sums, `complement` does
+the corresponding job inside `variant`, retrieving the other value narrowed to the same case; it
+returns an `Optional`, since the two values need not be the same variant — and if they are not,
+there is no meaningfully-typed value to return:
 
 ```scala
-inline def disjunction[derivation: SumReflection]: Eq[derivation] =
-  (left, right) =>
-    variant(left):
-      [variant <: derivation] => leftValue =>
-        complement(right).lay(false)(contextual.equal(leftValue, _))
+trait Equivalence[value]:
+  def equal(left: value, right: value): Boolean
+
+object Equivalence extends Derivation[Equivalence]:
+  given Equivalence[Int] = _ == _
+  given Equivalence[Text] = _.lower == _.lower
+
+  inline def conjunction[derivation <: Product: ProductReflection]: Equivalence[derivation] =
+    (left, right) =>
+      contexts[derivation]():
+        [field] => equivalence =>
+          val extract: derivation => field = dereference
+          equivalence.equal(extract(left), extract(right))
+      . all { boolean => boolean }
+
+  inline def disjunction[derivation: SumReflection]: Equivalence[derivation] =
+    (left, right) =>
+      variant(left):
+        [variant <: derivation] => leftValue =>
+          complement(right).lay(false)(contextual.equal(leftValue, _))
+
+Equivalence.derived[Person].equal(Person(t"Ada", 36), Person(t"ADA", 36))   // true
 ```
 
 Different variants compare unequal; the same variant compares through the instance both share.
@@ -216,15 +268,25 @@ case, so a derivation can restrict itself to such enumerations and reject the re
 of its own:
 
 ```scala
-inline def disjunction[derivation: SumReflection]: Show[derivation] = value =>
-  inline if choice[derivation] then
-    variant(value):
-      [variant <: derivation] => arm => t"${typeName[derivation]}.${contextual.show(arm)}"
-  else compiletime.error("cannot derive Show for this ADT")
+trait Naming[value]:
+  def name(value: value): Text
+
+object Naming extends Derivation[Naming]:
+  inline def conjunction[derivation <: Product: ProductReflection]: Naming[derivation] =
+    value => typeName[derivation]
+
+  inline def disjunction[derivation: SumReflection]: Naming[derivation] = value =>
+    inline if choice[derivation] then
+      variant(value):
+        [variant <: derivation] => arm => t"${typeName[derivation]}.${contextual.name(arm)}"
+    else scala.compiletime.error("cannot derive Naming for a sum whose variants carry data")
+
+Naming.derived[Month].name(Month.Mar)   // t"Month.Mar"
 ```
 
 The `inline if` matters: it forces `choice` to be evaluated as the code compiles, so the
-`compiletime.error` branch is either eliminated or reached, and reaching it fails the build.
+`scala.compiletime.error` branch is either eliminated or reached, and reaching it fails the
+build.
 
 For such an enumeration, `singleton` turns a label back into the value it names, `variantLabels`
 lists the labels, and `choices` folds over every variant without needing a value to dispatch on —
@@ -236,11 +298,21 @@ A case class may give its fields default values, and a decoder usually wants the
 from the input should take the default the author wrote rather than fail. Within the lambdas of
 `fields`, `contexts` and `build`, a contextual `Default[Optional[field]]` is available, and
 calling `default` yields an `Optional[field]` — the declared default, or `Unset` where the field
-has none:
+has none. A parser that tolerates missing trailing columns:
 
 ```scala
-[field] => readable =>
-  if index < columns.length then readable.read(columns(index)) else default.or(abort(Missing()))
+object LenientParsing extends ProductDerivation[Parsing]:
+  inline def conjunction[derivation <: Product: ProductReflection]: Parsing[derivation] =
+    text =>
+      val columns = text.cut(t",")
+      build[derivation]:
+        [field] => parsing =>
+          columns(Ordinal.zerary(index)).let(parsing.parse(_))
+          . or(default.or(panic(m"no column and no default for $label")))
+
+case class Settings(name: Text, retries: Int = 3)
+
+LenientParsing.derived[Settings].parse(t"primary")   // Settings(t"primary", 3)
 ```
 
 ### Deriving beyond codecs
@@ -251,6 +323,8 @@ product field by field:
 
 ```scala
 import arithmetic.addable
+
+case class Pair(label: Text, count: Int)
 
 Pair(t"foo", 10) + Pair(t"bar", 15)   // Pair(t"foobar", 25)
 ```
@@ -282,6 +356,8 @@ have to summon itself part-way through. Defining the instance on the type's comp
 enum Tree derives Presentation:
   case Leaf
   case Branch(left: Tree, value: Int, right: Tree)
+
+Tree.Branch(Tree.Leaf, 1, Tree.Leaf).present   // t"Branch(left=Leaf, value=1, right=Leaf)"
 ```
 
 ### Choosing between candidate instances
@@ -293,24 +369,36 @@ tends to resolve one ambiguity by creating another elsewhere.
 
 The reliable fix is to make the choice explicit rather than to rank it. Turn the competing
 `given`s into ordinary methods and write a single `derived` that selects among them in order with
-`summonFrom`:
+`scala.compiletime.summonFrom`:
 
 ```scala
-object Debug:
-  inline given derived[value]: Debug[value] = value =>
-    compiletime.summonFrom:
-      case encoder: Encoder[value] => encoder.encode(value)
-      case given Show[value]       => value.show
-      case _                       => value.toString.tt
+trait Rendering[value]:
+  def render(value: value): Text
+
+object Rendering:
+  inline given derived[Value]: Rendering[Value] = item =>
+    scala.compiletime.summonFrom:
+      case presentation: Presentation[Value] => presentation.present(item)
+      case given (Value is Showable)         => item.show
+      case _                                 => item.toString.tt
+
+extension [value](value: value)
+  def render(using rendering: Rendering[value]): Text = rendering.render(value)
+
+Person(t"Ada", 36).render   // through Presentation, which Person derives
+3.14.render                 // through Showable, which Double has
 ```
 
-Read plainly: use an `Encoder` if one exists; otherwise a `Show`, brought into scope for the
-right-hand side; otherwise fall back. The order in the source *is* the priority, which is why this
-is easier to reason about than a lattice of implicit scopes.
+Read plainly: use a `Presentation` if one exists; otherwise a `Showable`, brought into scope for
+the right-hand side; otherwise fall back. The order in the source *is* the priority, which is why
+this is easier to reason about than a lattice of implicit scopes. (The type parameter is
+capitalized here for a reason: in a `summonFrom` pattern a lowercase type name would be read as a
+fresh pattern variable rather than as the given's own parameter.)
 
 The same technique gives derivation without exposing it: define `conjunction` and `disjunction` on
 an ordinary object rather than the companion, and call `derived` on it explicitly wherever an
-instance is wanted. Nothing then reaches implicit search unless it is asked for.
+instance is wanted — as `ParsingSums` and `LenientParsing` did above. Nothing then reaches implicit
+search unless it is asked for.
 
 ### Per-field instances
 
@@ -318,7 +406,10 @@ Occasionally one field of one type needs a different instance from the default �
 for one column, an override for one path. `specifically` builds such an override map by naming the
 paths, checked against the type's actual structure:
 
+<!-- doccheck: skip -->
 ```scala
+case class Org(cto: Person, ceo: Person)
+
 val custom: Org is Specific over (Codec in Json) =
   specifically:
     case root.cto.name() => nameCodec

--- a/doc/modules/diffing.md
+++ b/doc/modules/diffing.md
@@ -11,17 +11,20 @@ patch, inverted, serialized in the familiar unix format and parsed back, and ref
 
 ### On differences
 
-The diff is one of computing's quiet workhorses — version control, synchronisation, test output —
+The diff is one of computing's quiet workhorses — version control, synchronization, test output —
 and it is almost always consumed as text, the output of a tool, parsed by eye or by regex. Yet a
 diff is data: a precise, minimal edit script computed by
 [Myers' algorithm](http://www.xmailserver.org/diff2.pdf), useful far beyond source files whenever
 two versions of any sequence must be reconciled.
+
+A diff is an immutable value that can be inspected, rendered or applied, in keeping with [immutability](../philosophy/immutability.md) everywhere else.
 
 Soundness computes it as a value over any elements, not just lines of text, with equality — or a
 looser similarity — supplied by the caller. Everything comes from the `soundness` package:
 
 ```scala
 import soundness.*
+import strategies.throwUnsafely
 ```
 
 ### Computing a diff
@@ -30,12 +33,13 @@ import soundness.*
 deletion (`Del`), or an unchanged element (`Par`), with the positions in each sequence:
 
 ```scala
-diff(t"AC".chars, t"ABC".chars)
+diff(Sequence('A', 'C'), Sequence('A', 'B', 'C'))
 // Diff(Par(0, 0, 'A'), Ins(1, 'B'), Par(1, 2, 'C'))
 ```
 
 The script is minimal — the fewest insertions and deletions that turn the left sequence into the
-right.
+right. The elements may be anything: characters, lines of text, records. A third argument
+replaces equality with a comparison of the caller's choosing.
 
 ### Applying a patch
 
@@ -43,8 +47,11 @@ A diff applied to the original sequence yields the target, so a difference compu
 transmitted and replayed:
 
 ```scala
-val changes = diff(original, revised)
-changes.patch(original)   // the revised sequence
+val original = List(t"foo", t"bar", t"baz")
+val revised = List(t"foo", t"quux", t"bop", t"baz")
+
+val changes = diff(Sequence(t"foo", t"bar", t"baz"), Sequence(t"foo", t"quux", t"bop", t"baz"))
+changes.patch(original)   // List(t"foo", t"quux", t"bop", t"baz")
 ```
 
 `flip` inverts a diff, turning the patch that goes forward into the one that goes back.
@@ -52,15 +59,16 @@ changes.patch(original)   // the revised sequence
 ### Aligned differences
 
 A raw diff reports a changed element as a deletion plus an insertion, but for display — and for
-comparing structured records — it is more useful to *pair* them, recognising the new element as a
+comparing structured records — it is more useful to *pair* them, recognizing the new element as a
 modification of the old. `rdiff` does this, taking a similarity predicate and producing `Sub`
 entries where a deletion and insertion match:
 
 ```scala
 import proximities.levenshteinProximity
+import caseSensitivity.caseSensitive
 
-val italian = IArray(t"zero", t"uno", t"due", t"tre")
-val spanish = IArray(t"cero", t"uno", t"dos", t"tres")
+val italian = Sequence(t"zero", t"uno", t"due", t"tre")
+val spanish = Sequence(t"cero", t"uno", t"dos", t"tres")
 
 diff(italian, spanish).rdiff(_.proximity(_) < 4)
 // RDiff(Sub(0, 0, t"zero", t"cero"), Par(1, 1, t"uno"),
@@ -86,10 +94,9 @@ A diff of text serializes to the conventional format tools expect, and that form
 a `Diff`, so a patch file is readable data:
 
 ```scala
-import strategies.throwUnsafely
+val patch: Chain[Text] = changes.serialize   // the lines of a unix diff
 
-changes.serialize            // a Stream[Text] in unix diff format
-diffStream.read[Diff[Text]]  // parsed back to a value
+patch.read[Diff[Text]].patch(original)      // List(t"foo", t"quux", t"bop", t"baz")
 ```
 
 ### Redrafts
@@ -102,11 +109,13 @@ A *redraft* is the forgiving form. It states only the lines to remove and the li
 unchanged lines omitted entirely, and finds where they belong:
 
 ```scala
+val source = Sequence(t"line1", t"line2", t"line3")
+
 Redraft.parse(Chain(t"- line2", t"+ new line 2a")).patch(source)
-// the second line replaced
+// List(t"line1", t"new line 2a", t"line3")
 
 Redraft.parse(Chain(t"+ line0")).patch(source)
-// inserted before the first line
+// List(t"line0", t"line1", t"line2", t"line3")
 ```
 
 Where a redraft is ambiguous — the lines it names appear more than once — that is reported rather
@@ -115,12 +124,14 @@ than resolved by guessing, so an edit is never applied in the wrong place.
 ### Evolution
 
 A diff compares two versions. An *evolution* tracks an element through many, so that a value
-present in the first version and the last can be recognised as the same value even where it
+present in the first version and the last can be recognized as the same value even where it
 disappeared and returned in between:
 
 ```scala
+val versions = List(List('d', 'o', 'g'), List('c', 'a', 't'), List('d', 'o', 'g'))
 val evolution = evolve(versions)
-evolution(Ter)   // the third version, reconstructed
+
+evolution(Ter)   // List('d', 'o', 'g'): the third version, reconstructed
 ```
 
 Each version is addressed by ordinal, and reconstructing one gives back exactly what it was — the

--- a/doc/modules/diffing.md
+++ b/doc/modules/diffing.md
@@ -102,10 +102,10 @@ A *redraft* is the forgiving form. It states only the lines to remove and the li
 unchanged lines omitted entirely, and finds where they belong:
 
 ```scala
-Redraft.parse(LazyList(t"- line2", t"+ new line 2a")).patch(source)
+Redraft.parse(Chain(t"- line2", t"+ new line 2a")).patch(source)
 // the second line replaced
 
-Redraft.parse(LazyList(t"+ line0")).patch(source)
+Redraft.parse(Chain(t"+ line0")).patch(source)
 // inserted before the first line
 ```
 

--- a/doc/modules/display.md
+++ b/doc/modules/display.md
@@ -20,6 +20,8 @@ when debugging, and nothing stops it being called on a value with no sensible te
 The familiar `Show` typeclass fixes the trustworthiness but still collapses the two
 audiences into one.
 
+Separating what a value is from how it is displayed, through typeclasses chosen by import, is [decoupling](../philosophy/decoupling.md) at the smallest scale.
+
 Two typeclasses keep them apart. `Showable` is deliberately demanding — its absence is the
 signal that a value is not meant for display — while `Inspectable` is deliberately total, so
 debugging output is never blocked. Everything comes from the `soundness` package:
@@ -62,7 +64,9 @@ unambiguous:
 
 ```scala
 case class Person(name: Text, age: Int)
+```
 
+```scala
 Person(t"Simon", 72).inspect      // t"Person(name:t\"Simon\" ╱ age:72)"
 List(t"one", t"two").inspect      // t"""[t"one", t"two"]"""
 (5: Optional[Int]).inspect        // t"｢5｣"
@@ -96,8 +100,14 @@ Enumerations and sealed hierarchies derive too, and a case object renders as its
 than with empty parentheses, since it has no fields to show:
 
 ```scala
-(Dog(t"Rex"): Animal).inspect   // t"""Dog(name:t"Rex")"""
-(Cat: Animal).inspect           // t"Cat"
+enum Animal:
+  case Dog(name: Text)
+  case Cat
+```
+
+```scala
+(Animal.Dog(t"Rex"): Animal).inspect   // t"""Dog(name:t"Rex")"""
+(Animal.Cat: Animal).inspect           // t"Cat"
 ```
 
 ### The fallback chain

--- a/doc/modules/docker.md
+++ b/doc/modules/docker.md
@@ -51,7 +51,7 @@ def entry(name: Text, content: Text): Tar.Entry =
      user  = UnixUser(0),
      group = UnixGroup(0),
      mtime = 0.bits.u32,
-     data  = TarBody(content.in[Data]) )
+     data  = Tar.Body(content.in[Data]) )
 
 val layer = Layer(Tarfile(List(entry(t"hello.txt", t"hello world\n"))))
 ```
@@ -138,7 +138,7 @@ archive.open[Image](): handle ?=>
 
 Reaching a layer three ways makes the cost explicit: `compressed` yields the stored bytes
 untouched, `layer` decompresses them as a stream, and `verified` decompresses and checks the
-content against the digest the manifest declares, raising an `OciError` if they disagree.
+content against the digest the manifest declares, raising an `Oci.Error` if they disagree.
 
 A reader that does not already know which kind of artifact it has opened asks for `config`,
 which dispatches on the config descriptor's media type — so telling a component from a
@@ -148,7 +148,7 @@ filesystem is a question the archive answers, not one the caller has to have kno
 archive.open[Image](): handle ?=>
   handle.config match
     case config: WasmConfig  => config.component  // a component: run it in a Wasm engine
-    case config: ImageConfig => config.rootfs     // a filesystem: unpack and run it
+    case config: Image.Config => config.rootfs     // a filesystem: unpack and run it
 ```
 
 ### Connecting to a daemon

--- a/doc/modules/docker.md
+++ b/doc/modules/docker.md
@@ -23,6 +23,8 @@ of its bytes. The format is exact: a layer has one digest for its uncompressed t
 another for its compressed blob, and a manifest ties them together by those digests. Get a
 digest wrong and the image is silently invalid.
 
+Building an image as a value, rather than by running a tool, is [direct style](../philosophy/direct-style.md): the steps are ordinary code, checked as it compiles.
+
 Running such an image is the job of a daemon, and containerd — the runtime beneath Docker
 and Kubernetes — is driven over a gRPC protocol on a local socket. Soundness represents the
 image format as values whose digests it computes, and the daemon's protocol as methods that
@@ -31,10 +33,11 @@ tar layers; both halves come from the `soundness` package:
 
 ```scala
 import soundness.*
-import providers.javaBaseProvider
+
 import alphabets.hexLowerCase
 import charEncoders.utf8Encoder
 import formatting.compactJsonFormatting
+import providers.javaBaseProvider
 import strategies.throwUnsafely
 ```
 
@@ -91,6 +94,8 @@ not the distribution format but what the configuration says the artifact *is*.
 [Wasm OCI Artifact](https://tag-runtime.cncf.io/wgs/wasm/deliverables/wasm-oci-artifact/):
 
 ```scala
+val component: Data = hex"0061736d01000000"   // a compiled component's bytes
+
 val artifact =
   Image.wasm
    ( component,
@@ -116,12 +121,20 @@ but read from the WIT world the component was linked against, which is the autho
 statement of the same contract:
 
 ```scala
-val world: WitDialect.World = WitDialect.worlds(source).stdlib(t"http")
+val wit = t"""package example:service;
+
+world http {
+  import wasi:io/streams@0.2.0;
+  export wasi:http/incoming-handler@0.2.0;
+}"""
+
+val world: WitDialect.World = WitDialect.worlds(wit)(t"http")
 Image.wasm(component, exports = world.exports, imports = world.imports)
 ```
 
-Anthology does exactly this on its edge producing an `OciImage`, so a compilation can go from
-source to a distributable artifact along one path, with nothing stating the contract twice.
+The [compiler](compiler.md) does exactly this on its edge producing an OCI image, so a
+compilation can go from source to a distributable artifact along one path, with nothing stating
+the contract twice.
 
 ### Reading an image
 
@@ -129,11 +142,13 @@ An existing OCI archive — a file or a block of bytes — is read by *opening* 
 its contents available for the duration of a scope and no longer:
 
 ```scala
+val archive: Data = image.archive.source[Data].memoize
+
 archive.open[Image](): handle ?=>
-  handle.index                                    // the top-level index
-  handle.manifest                                 // the manifest it names
-  handle.imageConfig                              // the image configuration
-  handle.verified(handle.manifest.layers.head)    // a layer, digest-checked
+  handle.index                                        // the top-level index
+  handle.manifest                                     // the manifest it names
+  handle.imageConfig                                  // the image configuration
+  handle.verified(handle.manifest.layers.prim.vouch)  // a layer, digest-checked
 ```
 
 Reaching a layer three ways makes the cost explicit: `compressed` yields the stored bytes
@@ -158,15 +173,14 @@ bound to a namespace. Because the connection holds background work, it lives ins
 supervised scope:
 
 ```scala
-supervise:
-  val client = Containerd(endpoint, namespace = t"default")
+def report(endpoint: Grpc.Channel^): Unit = supervise:
+  val client = Containerd(endpoint, t"default")
   client.version()
 ```
 
-Here `endpoint` is an HTTP/2 endpoint over containerd's Unix socket, established through
-Soundness's [HTTP](http-server.md) and socket support. Every call to the daemon may fail —
-the socket, the protocol, or the request itself — so the calls draw on the error strategy
-in scope.
+Here `endpoint` is a [gRPC](rpc.md) channel over containerd's Unix socket, established through
+Soundness's HTTP/2 and [socket](sockets.md) support. Every call to the daemon may fail — the
+socket, the protocol, or the request itself — so the calls draw on the error strategy in scope.
 
 ### Containers, images and namespaces
 
@@ -174,12 +188,13 @@ The client lists and inspects what the daemon holds, and creates and deletes it.
 result is a typed record:
 
 ```scala
-val containers = client.containers()
-val one = client.container(t"web")
-(one.id, one.image, one.labels)
+def inspect(client: Containerd): Unit =
+  val containers = client.containers()
+  val one = client.container(t"web")
+  (one.id, one.image, one.labels)
 
-client.images()      // the images known to the daemon
-client.namespaces()  // the namespaces on the daemon
+  client.images()      // the images known to the daemon
+  client.namespaces()  // the namespaces on the daemon
 ```
 
 `createContainer`, `deleteContainer`, `createNamespace` and their counterparts make the
@@ -191,12 +206,13 @@ A container is a definition; a *task* is a running instance of one. A task is cr
 container with the root filesystem to mount, then started, waited on, and killed:
 
 ```scala
-val rootfs = List(Mount(t"overlay", t"overlay", t"/", List(t"lowerdir=/a")))
+def run(client: Containerd): Unit =
+  val rootfs = List(Mount(t"overlay", t"overlay", t"/", List(t"lowerdir=/a")))
 
-client.createTask(t"web", rootfs)
-val pid = client.startTask(t"web")
-client.waitTask(t"web")
-client.killTask(t"web", signal = 15)
+  client.createTask(t"web", rootfs)
+  val pid = client.startTask(t"web")
+  client.waitTask(t"web")
+  client.killTask(t"web", signal = 15)
 ```
 
 `client.task(t"web")` returns the task's current `Workload`, whose `state` reports whether

--- a/doc/modules/email.md
+++ b/doc/modules/email.md
@@ -43,7 +43,7 @@ t"Your order has shipped.".send
 ```
 
 An HTML document sends as an HTML message the same way, and failure to deliver raises a
-`CourierError` naming the sender, recipient and subject at fault.
+`Courier.Error` naming the sender, recipient and subject at fault.
 
 ### Composing
 

--- a/doc/modules/email.md
+++ b/doc/modules/email.md
@@ -24,11 +24,16 @@ package, with a courier and a sender in scope:
 
 ```scala
 import soundness.*
+
 import couriers.resendCourier
+import internetAccess.online
+import strategies.throwUnsafely
 
 given Sender = Sender(email"noreply@example.com")
-given Resend.ApiKey = Resend.ApiKey(apiKeyText)
+given Resend.ApiKey = Resend.ApiKey(t"re_123456789")
 ```
+
+A message assembled from typed parts, with its addresses validated as the code compiles, is [safety by construction](../philosophy/safety-by-construction.md) for mail.
 
 ### Sending
 
@@ -37,9 +42,10 @@ Anything *sendable* — text, an [HTML](html.md) document, or a fully-composed `
 one address or a list:
 
 ```scala
-t"Your order has shipped.".send
-  ( subject = t"Shipping confirmation",
-    to      = email"customer@example.com" )
+def notify(): Resend.Receipt =
+  t"Your order has shipped.".send
+    ( subject = t"Shipping confirmation",
+      to      = email"customer@example.com" )
 ```
 
 An HTML document sends as an HTML message the same way, and failure to deliver raises a
@@ -49,17 +55,24 @@ An HTML document sends as an HTML message the same way, and failure to deliver r
 
 A richer message is built as an `Email`: a body of text, HTML, or both — the both-form delivering
 `multipart/alternative`, so capable clients show the HTML and others the text — with attachments
-added by `attach`:
+added by `attach`. An `Asset` is a named, typed source of bytes, its filename and
+[media type](media-types.md) carried with it:
 
 ```scala
-val message = Email(Email.Message(Email.Content(Email.Body(textVersion, htmlVersion))))
+val textVersion = t"Sales rose 4% in August."
+val htmlVersion = t"<p>Sales rose <b>4%</b> in August.</p>"
+val report = Asset(t"report.csv", media"text/csv", Chain(t"month,sales\nAugust,104".in[Data]))
+
+val message = Email(Map(), Email.Message(Email.Content(Email.Body(textVersion, htmlVersion))))
   . attach(report)
 
-message.send(subject = t"Monthly report", to = recipients)
+def distribute(recipients: List[EmailAddress]): Resend.Receipt =
+  message.send(subject = t"Monthly report", to = recipients)
 ```
 
-Anything *attachable* — a named, typed source of bytes — attaches directly, its filename and
-[media type](media-types.md) carried with it.
+Plain text is itself sendable, so `Email(t"hello")` is the one-line form, and an email reports
+its `text`, `html`, `attachments` and `inlines` back, so a composed message can be inspected
+before it goes.
 
 ### Couriers
 

--- a/doc/modules/environment.md
+++ b/doc/modules/environment.md
@@ -46,7 +46,7 @@ Environment.editor    // Text — the value of EDITOR
 Environment.columns   // Int  — COLUMNS, decoded to a number
 ```
 
-A variable that is not set raises an `EnvironmentError`, which the strategy in scope turns into
+A variable that is not set raises an `Environment.Error`, which the strategy in scope turns into
 an exception, an absent value, or a handled failure as the caller chooses.
 
 ### System properties
@@ -68,7 +68,7 @@ System.properties.os.name()        // Text
 System.properties.file.separator() // Char
 ```
 
-An undefined property raises a `PropertyError`, handled like any other.
+An undefined property raises a `Property.Error`, handled like any other.
 
 ### The working directory
 

--- a/doc/modules/environment.md
+++ b/doc/modules/environment.md
@@ -20,6 +20,8 @@ should be a number arrives as text; and nothing records that a piece of code dep
 particular variable being set. The dependence is invisible, and the parsing is left to each
 caller to get right.
 
+Taking the environment as a capability rather than a global is what [honest signatures](../philosophy/honest-signatures.md) require: a method's dependence on its surroundings is visible in its type.
+
 Soundness turns each source into a capability. An `Environment`, a `System`, a
 `WorkingDirectory` are contextual values a method requires when it reads from them, so the
 dependence is in the type; and each read decodes to the expected type, failing loudly when a
@@ -30,9 +32,10 @@ supplied:
 
 ```scala
 import soundness.*
+
 import environments.javaBaseEnvironment
-import systems.javaBaseSystem
 import strategies.throwUnsafely
+import systems.javaBaseSystem
 ```
 
 ### Environment variables
@@ -42,7 +45,7 @@ conventional upper-snake-case form — `Environment.editor` reads `EDITOR`. The 
 type the variable is known to hold, decoded from its text:
 
 ```scala
-Environment.editor    // Text — the value of EDITOR
+Environment.home      // Text — the value of HOME
 Environment.columns   // Int  — COLUMNS, decoded to a number
 ```
 
@@ -79,11 +82,14 @@ in its signature.
 
 ### Overriding for a block
 
-Because the environment is a capability, a block can be run against a modified one. `variables`
-supplies overrides for the code it encloses, leaving the surrounding environment untouched:
+Because the environment is a capability, a block can be run against a different one. An
+`Environment` is a single function from a variable's name to its optional value, so one built
+for a test — or one layering overrides on the real environment — is a few lines, and a given in
+a narrower scope takes precedence:
 
 ```scala
-variables(EDITOR = t"vim"):
+locally:
+  given Environment = name => if name == t"EDITOR" then t"vim" else Unset
   Environment.editor   // t"vim" within this block
 ```
 
@@ -100,11 +106,13 @@ is what lets each invocation be served against the environment it actually came 
 ### Standard directories
 
 The [XDG base directory specification](https://specifications.freedesktop.org/basedir-spec/latest/)
-says where a program's data, configuration, cache and state belong, honouring the user's
+says where a program's data, configuration, cache and state belong, honoring the user's
 environment where it is set and falling back to the specification's defaults where it is not.
 `Xdg` gives each of them, and the search paths for data and configuration:
 
 ```scala
+import pathInterfaces.pathOnLinux
+
 Xdg.configHome[Path on Linux]   // ~/.config, or $XDG_CONFIG_HOME
 Xdg.cacheHome[Path on Linux]
 Xdg.dataDirs[Path on Linux]     // the search path, in order
@@ -123,6 +131,6 @@ reporting into a typed value — `X86(64)`, `Arm(64)`, `Ppc(64, littleEndian = t
 so code that must choose a native library or a code path by architecture matches on a value
 rather than on a string whose spelling varies by platform.
 
-`termcaps.environmentTermcap` reports what the terminal can do, deciding colour depth from
+`termcaps.environmentTermcap` reports what the terminal can do, deciding color depth from
 `COLORTERM` where it is set and from `tput` otherwise, which is how styled output degrades
 correctly on a terminal that cannot show it.

--- a/doc/modules/errors.md
+++ b/doc/modules/errors.md
@@ -37,6 +37,15 @@ import soundness.*
 import errorDiagnostics.stackTracesDiagnostics
 ```
 
+The examples that follow revolve around one fallible operation — connecting to a port, which
+fails when the port is taken — standing in for any operation that can fail:
+
+```scala
+case class Connection(port: Int)
+
+def available(port: Int): Boolean = port > 1024
+```
+
 ### Defining an error
 
 An error is a case class extending `Error`, with a message written using the `m"…"`
@@ -73,7 +82,7 @@ a method, `raise` reports an error, and `abort` reports one and stops:
 
 ```scala
 def connect(port: Int): Connection raises PortError =
-  if available(port) then open(port) else abort(PortError(port))
+  if available(port) then Connection(port) else abort(PortError(port))
 ```
 
 The requirement propagates. A method that calls `connect` must itself either declare `raises
@@ -96,15 +105,17 @@ At the point a fallible operation is used, a *strategy* in scope decides what a 
 ```scala
 import strategies.throwUnsafely
 
-connect(8080)   // returns a Connection, or throws PortError
+connect(8080)   // Connection(8080)
 ```
+
+With that strategy, `connect(80)` throws a `PortError` as an ordinary exception.
 
 `safely` runs a block and turns any failure into an absent result, so a failure becomes `Unset`
 rather than an exception; `unsafely` asserts that no failure will occur; and `capture` returns
 the error itself, for testing that the right failure is produced:
 
 ```scala
-safely(connect(8080))          // Optional[Connection] — Unset on failure
+safely(connect(80))                    // Unset
 capture[PortError](connect(80)).port   // 80
 ```
 
@@ -118,7 +129,11 @@ Two further declarations widen the choice beyond a scope. An error marked `Unche
 thrown without being handled — it is a marker typeclass with no members, so the given can be
 `erased`:
 
+<!-- doccheck: skip -->
 ```scala
+case class AsciiError(char: Char)(using Diagnostics)
+extends Error(m"the character $char is not ASCII")
+
 erased given AsciiError is Unchecked
 ```
 
@@ -126,9 +141,10 @@ An error declared `Fatal` ends the process, and says with what status. This suit
 initialization, where there is no meaningful way to continue:
 
 ```scala
-given InitError is Fatal = error =>
-  Log.info(m"error during initialization: $error")
-  Exit(127)
+case class InitError(reason: Text)(using Diagnostics)
+extends Error(m"initialization failed: $reason")
+
+given InitError is Fatal = error => Exit.Fail(127)
 ```
 
 ### Recovering
@@ -138,14 +154,30 @@ given InitError is Fatal = error =>
 
 ```scala
 recover:
-  case PortError(port) => fallbackConnection
+  case PortError(port) => Connection(8080)
 . protect:
-    connect(8080)
+    connect(80)
+// Connection(8080)
 ```
 
-`mitigate` instead replaces one error with another, translating a low-level failure into the
-error a caller expects before it propagates. Both compose: a `mitigate` inside a `recover`
-turns one error into another and then handles it.
+A handler matching a union of error types registers for each member, so one `recover` can
+answer several kinds of failure. `mitigate` instead replaces one error with another, translating
+a low-level failure into the error a caller expects before it propagates. Both compose: a
+`mitigate` inside a `recover` turns one error into another and then handles it:
+
+<!-- doccheck: skip -->
+```scala
+case class ServiceError(detail: Text)(using Diagnostics)
+extends Error(m"the service could not start: $detail")
+
+def start(port: Int): Connection raises ServiceError =
+  mitigate:
+    case PortError(port) => ServiceError(t"port $port unavailable")
+  . protect:
+      connect(port)
+
+capture[ServiceError](start(80)).detail   // t"port 80 unavailable"
+```
 
 ### Accumulating failures
 
@@ -154,16 +186,31 @@ document — should gather every failure and report them together. `raise` (unli
 records an error and continues, and `accrue` folds the recorded errors into one:
 
 ```scala
-accrue(Invalid(Nil)) { (all, error) => all.add(error) }:
-  case error => ()
-. protect:
-    validateName(form)
-    validateEmail(form)
-    validateAge(form)
+case class Invalid(problems: List[Text])(using Diagnostics)
+extends Error(m"${problems.size} problems")
+
+case class Form(name: Text, email: Text, age: Int)
+
+def validateName(form: Form): Unit raises PortError =
+  if form.name == t"" then raise(PortError(1))
+
+def validateAge(form: Form): Unit raises PortError =
+  if form.age < 0 then raise(PortError(2))
+
+val form = Form(t"", t"nobody", -1)
+
+capture[Invalid]:
+  accrue(Invalid(Nil)) { (all, error) => Invalid(all.problems :+ error.message.text) }
+    { case error: PortError => () }
+  . protect:
+      validateName(form)
+      validateAge(form)
+. problems.size   // 2
 ```
 
 Each field is checked even if an earlier one failed, and the accumulated `Invalid` carries all
-the problems at once.
+the problems at once. The first block folds each raised error into the accumulation; the second
+says which errors the accrual handles.
 
 The difference between the two is in their return types. `abort` returns `Nothing`: there is no
 value to give back, so it leaves. `raise` returns a value — an *ersatz* value, a stand-in — so
@@ -189,14 +236,19 @@ the block recorded nothing, or the `Failed` marker if it did. An `abort` inside 
 scope — so sibling ventures each contribute their full error set independently:
 
 ```scala
-def decodePerson(json: Json): Person raises Json.Error =
-  val name: Venture[Text] = venture(json.name.as[Text])
-  val role: Venture[Role] = venture(json.role.as[Role])
+import dynamicAccess.dynamicJson
 
-  venture(checkConsistency(name(), role()))
+case class Person(name: Text, age: Int)
+
+def decodePerson(json: Json): Person raises Json.Error =
+  val name = venture(json.name.as[Text])
+  val age = venture(json.age.as[Int])
+
+  venture:
+    if name().length > age() then abort(Json.Error(Json.Error.Reason.Absent))
 
   guard:
-    Person(name(), role())
+    Person(name(), age())
 ```
 
 Forcing a venture with `name()` requires a *skip-scope* in context — an enclosing `venture` or
@@ -238,7 +290,7 @@ asserting on a failure needs. A block that succeeds is itself an error — an `E
 since the test was checking the wrong thing:
 
 ```scala
-capture[PortError](connect(80)).port
+capture[PortError](connect(80)).port   // 80
 ```
 
 `attempt` makes no such demand, returning an `Attempt` that is either a success carrying the value
@@ -249,24 +301,6 @@ attempt[PortError](connect(80))   // Attempt.Success(…) or Attempt.Failure(…
 ```
 
 `amalgamate` combines several fallible computations, gathering their errors into one.
-
-### Deferring a fallible computation
-
-A fallible computation cannot be stored as an ordinary value, because its ability to fail is part
-of its type and needs a tactic to discharge. `defer` holds the unapplied body, and applying it
-runs it against whatever tactic is in scope *then*:
-
-```scala
-val held = defer(riskyOperation())
-
-recover:
-  case error => fallback
-. protect:
-    held()
-```
-
-Each application re-evaluates the body, so a deferred computation is a recipe rather than a cached
-result — which is what makes it usable under a different strategy each time.
 
 ### Translating and escalating
 
@@ -289,5 +323,16 @@ which is cheaper where an error is expected and handled rather than investigated
 That choice is available because none of this is built on throwing. `abort` and `raise` use
 Scala's `boundary` and `break`, so leaving a computation with an error does not construct a stack
 trace unless one was asked for, and an error is no more expensive to build than any other
-immutable value. Failure being a normal part of a program's behaviour rather than an exceptional
+immutable value. Failure being a normal part of a program's behavior rather than an exceptional
 one, it should not cost more than the code that succeeds.
+
+### When a contextual value is missing
+
+Much of the above relies on a given being in scope, and the compiler's ordinary report of a
+missing one — "No given instance of type … was found" — says only that the search failed, not
+where. With `import soundness.*` a diagnostic hook is in scope that explains the failure instead:
+the message names the value being resolved, the candidate instances that were considered, and for
+each the nested requirement that could not be met, as a tree. A decoder that fails to derive
+because one field's type has no instance is therefore reported at that field, and a strategy
+missing from a fallible call is named as the strategy, with the choice packages that supply one.
+The hook does nothing when resolution succeeds, so it costs nothing in a compiling program.

--- a/doc/modules/filesystem.md
+++ b/doc/modules/filesystem.md
@@ -75,7 +75,7 @@ import charEncoders.utf8Encoder
 import charDecoders.utf8Decoder
 
 file.open[File](Write, OpenFlag.Create): handle ?=>
-  handle.write(LazyList(t"Hello, world".in[Data]))
+  handle.write(Chain(t"Hello, world".in[Data]))
 
 val text = file.open[File]()(file.stream.read[Data]).utf8
 ```
@@ -132,7 +132,7 @@ nothing behind:
 
 ```scala
 target.create[File](): handle ?=>
-  handle.write(LazyList(t"payload".in[Data]))
+  handle.write(Chain(t"payload".in[Data]))
 
 target.create[Directory](): dir ?=>
   (dir/"inner.txt").overwrite(t"hello")

--- a/doc/modules/filesystem.md
+++ b/doc/modules/filesystem.md
@@ -2,16 +2,17 @@
 
 ### About
 
-Soundness reads and writes files on disk through the typed [paths](paths.md) it already knows
-how to describe. A `Path on Linux` gains the operations that touch the disk — opening it to read
-or write, creating it as a file or a directory, listing its children, copying, moving and
-deleting — each declaring the errors it may raise and logging what it does. How an operation
-behaves in the awkward cases, such as whether a copy overwrites an existing file or a delete
-recurses into a directory, is decided by policy values chosen in scope.
+Files on disk are read and written through the typed [paths](paths.md) that already describe
+them. A `Path on Linux` gains the operations that touch the disk — opening it to read or write,
+creating it as a file or a directory, listing its children, copying, moving and deleting — each
+declaring the errors it may raise and logging what it does. How an operation behaves in the
+awkward cases, such as whether a copy overwrites an existing file or a delete recurses into a
+directory, is decided by policy values chosen in scope.
 
 Beyond individual files, the standard directory locations of a system — the home directory, the
-cache, `/usr/share` — are named values, and a directory can be watched for changes, yielding a
-stream of the files created, modified and deleted beneath it.
+cache, `/usr/share` — are named values; a directory can be watched for changes, yielding a
+stream of the files created, modified and deleted beneath it; and a file can be locked,
+memory-mapped, tagged with extended attributes, or searched for along a path of directories.
 
 ### On the filesystem
 
@@ -30,11 +31,16 @@ operations need brought into scope:
 
 ```scala
 import soundness.*
+
+import charDecoders.utf8Decoder
+import charEncoders.utf8Encoder
+import filesystemOptions.createNonexistentParents
+import filesystemOptions.deleteRecursively
+import filesystemOptions.overwritePreexisting
+import pathInterfaces.pathOnLinux
 import strategies.throwUnsafely
 import systems.javaBaseSystem
-import temporaryDirectories.systemTemporaryDirectory
-import filesystemOptions.overwritePreexisting
-import filesystemOptions.deleteRecursively
+import temporaryDirectories.javaBaseTemporaryDirectory
 ```
 
 ### Files and directories
@@ -43,10 +49,10 @@ A path names a location; whether it is a file or a directory is a matter of what
 there. A temporary directory and a fresh name give a path to work with:
 
 ```scala
-val directory = temporaryDirectory[Path on Local]/Uuid().show
+val directory = temporaryDirectory[Path on Linux] / "filesystem" / Uuid().show
 directory.create[Directory]()
 
-val file = directory/t"notes.txt"
+val file = directory / "notes.txt"
 file.create[File]()
 ```
 
@@ -56,11 +62,11 @@ anything by default: creating over something that exists, or under a parent that
 it for the whole file:
 
 ```scala
-target.create[File](CreateFlag.Replace)
-target.create[Directory](CreateFlag.Parents)
+file.create[File](CreateFlag.Replace)
+(directory / "deep" / "nested").create[Directory](CreateFlag.Parents)
 ```
 
-`Fifo` and `Socket` are entries too, created the same way.
+`Fifo` and `Sock` are entries too, created the same way.
 
 ### Reading and writing
 
@@ -68,24 +74,22 @@ A file is read and written by *opening* it. `open` names the form to open the pa
 mode to open it in, and runs a block with a handle for its capability. The handle exists only
 for the duration of the block, so the descriptor cannot outlive the scope that owns it — the
 shape described under [delimited scopes](../philosophy/delimited-scopes.md), and enforced by
-[capture checking](../philosophy/capture-checking.md):
+[capture checking](../philosophy/capture-checking.md). Inside the block, `file` is the open
+handle:
 
 ```scala
-import charEncoders.utf8Encoder
-import charDecoders.utf8Decoder
-
 file.open[File](Write, OpenFlag.Create): handle ?=>
   handle.write(Chain(t"Hello, world".in[Data]))
 
-val text = file.open[File]()(file.stream.read[Data]).utf8
+file.open[File]()(file.read[Text])   // t"Hello, world"
 ```
 
 Where a whole small file is wanted, and the ceremony of a scope buys nothing, `read` and `write`
 act directly on the path:
 
 ```scala
-path.write(t"Hello world")
-path.read[Text]
+file.write(t"Hello world")
+file.read[Text]   // t"Hello world"
 ```
 
 The mode is not merely a runtime flag: it is carried in the handle's type as a set of *grants*.
@@ -100,11 +104,11 @@ path obtained from one open directory cannot be written under another:
 
 ```scala
 directory.open[Directory](Read & Write): dir ?=>
-  (dir/"greeting.txt").overwrite(t"Hello directory")
-  dir.base.entries.to(List).map(_.name)
+  (dir / "greeting.txt").overwrite(t"Hello directory")
+  dir.base.entries.map(_.name)   // List(t"notes.txt", t"greeting.txt", …)
 ```
 
-### Exclusive access
+### Exclusive and shared access
 
 `Exclusive` is a third grant, alongside `Read` and `Write`, and it means what it says: no other
 scope in the program may hold an overlapping path open while it lasts. Overlap is by containment,
@@ -112,7 +116,7 @@ not by equality — a directory and something beneath it overlap; two siblings d
 
 ```scala
 directory.open[Directory](Read & Exclusive): dir ?=>
-  // nothing else in this program may open `directory` or anything under it
+  ()   // nothing else in this program may open `directory` or anything under it
 ```
 
 Two ordinary reads may coexist. An exclusive open conflicts with an overlapping open in either
@@ -121,7 +125,10 @@ direction — whether the exclusive scope is the outer or the inner one — and 
 as corruption later. The claim is released when the scope ends, however it ends.
 
 For a *file* rather than a directory, `Exclusive` additionally takes an operating-system lock, so
-exclusivity holds against other processes and not merely within this one.
+exclusivity holds against other processes and not merely within this one. `Shared` is the
+reader's counterpart: any number of shared holders may coexist, and an exclusive open waits for
+them, or fails at once if the lock is requested without blocking. A lock may also cover a byte
+range rather than the whole file, for the record-oriented layouts databases use.
 
 ### Creating as a scope
 
@@ -131,18 +138,20 @@ written within the scope is committed when the block completes, and a scope that
 nothing behind:
 
 ```scala
+val target = directory / "payload.bin"
+
 target.create[File](): handle ?=>
   handle.write(Chain(t"payload".in[Data]))
 
-target.create[Directory](): dir ?=>
-  (dir/"inner.txt").overwrite(t"hello")
+(directory / "inner").create[Directory](): dir ?=>
+  (dir / "inner.txt").overwrite(t"hello")
 ```
 
 A *scratch* directory is created and removed by its scope, whether the scope succeeds or fails:
 
 ```scala
-base.open[Scratch](Read & Write): scratch ?=>
-  (scratch/"file.txt").overwrite(t"data")
+directory.open[Scratch](Read & Write): scratch ?=>
+  (scratch / "file.txt").overwrite(t"data")
 ```
 
 ### The opening pattern, generally
@@ -157,18 +166,18 @@ rather than being implied by the target: the same path opens as a `File`, as a `
 different handle with a different repertoire. The form may be omitted where a target has only one
 instance; where it has several, the ambiguity is reported with the alternatives listed.
 
-Three things follow uniformly. The *mode* — `Read`, `Write`, `Exclusive` and their combinations —
-is carried in the handle's type, so the grants requested are the operations permitted. Flags after
-the mode belong to the instance, so they are specific to the kind of thing being opened, and
-irrelevant flags do not typecheck. And the handle is a capability confined to the block, so
-neither it nor anything derived from it can escape.
+Three things follow uniformly. The *mode* — `Read`, `Write`, `Exclusive`, `Shared` and their
+combinations — is carried in the handle's type, so the grants requested are the operations
+permitted. Flags after the mode belong to the instance, so they are specific to the kind of thing
+being opened, and irrelevant flags do not typecheck. And the handle is a capability confined to
+the block, so neither it nor anything derived from it can escape.
 
 `create` is the same pattern for something that does not yet exist, and `session` for a target
 whose access is a conversation with something running — a [browser](web-automation.md), a
 [debuggee](debugging.md) — rather than a handle over stored bytes. In each case the scope is the
 lifetime, and the end of the block is the end of the access.
 
-### Memory-mapped access
+### Positional access
 
 A file opened as `Ram` is memory-mapped, and serves positional reads and writes without
 streaming through it. The `Write` grant is required to write, as everywhere else:
@@ -181,26 +190,31 @@ file.open[Ram](Read & Write): ram ?=>
   ram(3L) = t"XYZ".in[Data]
 ```
 
+A `Slice` is a window onto part of a file — an offset and an extent — opened for reading or
+writing like a file of its own, so a region of a large file streams in or out without the rest
+being touched, and a write cannot stray outside its window.
+
 ### Copying, moving and deleting
 
 A path copies, moves, symlinks or deletes with operations that name the destination or act in
-place. Each consults the policy in scope for the awkward cases, and each may raise an `Io.Error`:
+place. Each consults the policy in scope for the awkward cases, and each may raise an `Io.Error`.
 
 Those policies are not defaults that can be left alone. Moving a file onto a path where something
 already exists either destroys that thing or refuses to; neither answer is right in general, and
-choosing one silently would make the wrong programs compile. So `moveTo` requires
-`overwritePreexisting` to be either `enabled` or `disabled` in scope, and calling it with neither
-is a compile error. The point is not only to be unpresumptuous but to be instructive: a reader who
-had not realised the question needed answering is told that it does.
+choosing one silently would make the wrong programs compile. So `moveTo` requires either
+`overwritePreexisting` or `failOnPreexisting` in scope, and calling it with neither is a compile
+error. The point is not only to be unpresumptuous but to be instructive: a reader who had not
+realized the question needed answering is told that it does.
 
-The choice also changes what must be handled. With `disabled` in scope a collision is a failure to
-deal with; with `enabled` it cannot arise, and the obligation goes away with it. Being contextual
-values, the policies can be imported for a file or narrowed to a single block.
+The choice also changes what must be handled. With `failOnPreexisting` in scope a collision is a
+failure to deal with; with `overwritePreexisting` it cannot arise, and the obligation goes away
+with it. Being contextual values, the policies can be imported for a file or narrowed to a single
+block.
 
 ```scala
-file.copyTo(directory/t"backup.txt")
-file.moveTo(directory/t"renamed.txt")
-file.delete()
+file.copyTo(directory / "backup.txt")
+file.moveTo(directory / "renamed.txt")
+(directory / "backup.txt").delete()
 ```
 
 `copyInto` and `moveInto` place a path *inside* a destination directory, keeping its name;
@@ -213,10 +227,33 @@ A directory's immediate children stream from `children`, and its whole subtree f
 `descendants`. A path reports whether it exists, its size, and what kind of entry it is:
 
 ```scala
-directory.children       // Stream[Path on Local]
-file.existent()          // true
-file.size()              // the size in bytes
+directory.children.map(_.name)        // the entries' names
+(directory / "renamed.txt").existent()   // true
+(directory / "renamed.txt").filesize()   // the size in bytes
 ```
+
+A `glob` selects children by pattern, with `*` matching within a name and a whole-segment `**`
+spanning directories:
+
+```scala
+directory.glob(glob"*.txt").map(_.name)   // List(t"renamed.txt", …)
+```
+
+### Extended attributes and volumes
+
+The filesystem a path sits on is a typed fact about it: `Ext4`, `Btrfs`, `Apfs`, `Ntfs` and
+`Dos` are the *axes* a path can be matched against, and a filesystem that supports extended
+attributes lets a path carry named metadata beyond its contents:
+
+```scala
+file match
+  case Apfs(path) => path.attribute(t"origin", t"soundness".in[Data]) yet path.attributes()
+  case Ext4(path) => path.attribute(t"origin", t"soundness".in[Data]) yet path.attributes()
+  case _          => Nil
+```
+
+On btrfs, `subvolume` reports the subvolume a path belongs to, and `subvolumeRoot` whether it
+is the top of one.
 
 ### Standard directories
 
@@ -225,10 +262,10 @@ home directory and the paths beneath it, and the system directories under the ro
 navigating and applying:
 
 ```scala
-Home()             // the user's home directory
-Home.Cache()       // ~/.cache
-Home.Local.Bin()   // ~/.local/bin
-Base.Usr.Share()   // /usr/share
+Home[Path on Linux]()             // the user's home directory
+Home.Cache[Path on Linux]()       // ~/.cache
+Home.Local.Bin[Path on Linux]()   // ~/.local/bin
+Base.Usr.Share[Path on Linux]()   // /usr/share
 ```
 
 Each object is named for the directory it stands for, capitalized, with any leading `.` dropped —
@@ -236,23 +273,44 @@ Each object is named for the directory it stands for, capitalized, with any lead
 is `Base.Var.Lib`. Writing a standard location this way rather than as text means a
 mistyped directory is a compile error.
 
-The resolution honours the environment where the [specification](environment.md) says it should:
+The resolution honors the environment where the [specification](environment.md) says it should:
 `Home.Config` is normally `$HOME/.config`, but resolves to `$XDG_CONFIG_HOME` where the user has
 set it. Applying a layout constructs a value of whichever directory type is asked for, so the same
 names serve a `Path on Linux` and any other representation.
 
-### Watching for changes
+### Search paths
 
-A directory is watched by opening it as `Watch`, which yields a stream of `WatchEvent`s — a
-file created, modified or deleted. The registration lasts exactly as long as the block:
+Many files are looked up not at one location but along a list of them — an icon in whichever of
+the XDG data directories holds it, a configuration file in the first of several places. A
+`Searchpaths.Stems` instance names the directories to try, in order, and a relative path on
+the corresponding plane resolves with `search` to the first stem holding it, or `Unset`:
 
 ```scala
-directory.open[Watch](): watcher ?=>
-  watcher.stream.each:
-    case WatchEvent.NewFile(dir, file) => Out.println(t"created $file")
-    case WatchEvent.Modify(dir, file)  => Out.println(t"modified $file")
-    case WatchEvent.Delete(dir, file)  => Out.println(t"deleted $file")
-    case _                             => ()
+given Searchpaths.Stems on Xdg.Data onto Linux = new Searchpaths.Stems:
+  type Plane = Xdg.Data
+  type Target = Linux
+  val stems: List[Path on Linux] = List(directory, directory / "inner")
+
+(% / "inner.txt").on[Xdg.Data].search()   // the copy under `inner`
+```
+
+`dataSearch` and `configSearch` supply the XDG data and configuration search paths from the
+environment, so a program's resources are found wherever the user's system keeps them.
+
+### Watching for changes
+
+A directory is watched by opening it as `Watch`, which yields a stream of `Watch.Event`s — a
+file created, modified or deleted, a directory created. The registration lasts exactly as long
+as the block:
+
+```scala
+def observe(): Unit =
+  directory.open[Watch](): watcher ?=>
+    watcher.stream.each:
+      case Watch.Event.NewFile(dir, file) => Out.println(t"created $file")
+      case Watch.Event.Modify(dir, file)  => Out.println(t"modified $file")
+      case Watch.Event.Delete(dir, file)  => Out.println(t"deleted $file")
+      case _                              => ()
 ```
 
 Several paths are watched together by opening a list of them, which yields one event stream
@@ -267,7 +325,7 @@ Nothing above names a platform API. The primitive operations a filesystem must o
 open, read, write, list, link, delete — are gathered into a `FilesystemBackend` for a plane,
 and everything else is defined in terms of them. The `java.nio` implementation is
 `filesystemBackends.javaBaseFilesystem`, and a WASI implementation over `wasi:filesystem` is
-supplied by `galilei.wasi`, so the same code reads and writes files on the JVM and inside a
-WebAssembly component. An operation a backend cannot support raises an `Io.Error` whose reason
+supplied for WebAssembly components, so the same code reads and writes files on the JVM and
+inside a component. An operation a backend cannot support raises an `Io.Error` whose reason
 is `Unsupported`, rather than approximating it. Narrowing the platform's surface to a seam
 this small is [decoupling](../philosophy/decoupling.md) applied within a module.

--- a/doc/modules/flags.md
+++ b/doc/modules/flags.md
@@ -15,6 +15,8 @@ worth keeping — a `Set[Color]` costs an allocation and pointers for what one w
 the untyped access is not: nothing stops testing a bit that means something else, or a bit that
 means nothing.
 
+A flag whose type says what it means cannot be passed where another is expected, which is [impossible states](../philosophy/impossible-states.md) for switches.
+
 `Flags` keeps the word and types the bits by an enumeration. Each case owns a bit position by its
 ordinal; testing and setting use the case itself; and the whole value converts to an ordinary `Set`
 when set-like operations are wanted. Everything comes from the `soundness` package:

--- a/doc/modules/fonts.md
+++ b/doc/modules/fonts.md
@@ -4,7 +4,7 @@
 
 A [TrueType or OpenType](https://en.wikipedia.org/wiki/TrueType) font file is binary data with a
 well-defined internal structure — tables of glyphs, mappings and metrics — and Soundness reads it
-directly. A `Ttf` loads from any source of bytes, resolves characters to glyphs, and answers the
+directly. An `Sfnt` loads from any source of bytes, resolves characters to glyphs, and answers the
 question typography code most often asks: how wide is this text in this font?
 
 ### On font metrics
@@ -13,6 +13,8 @@ Text does not have a width; text *in a font* does. Laying out a heading, sizing 
 a line to fit a measure — each needs the advance widths that live inside the font file, in tables
 indexed through a character-to-glyph mapping. Reaching them usually means a rendering toolkit
 brought in for what is, at heart, table lookup in a documented binary format.
+
+A font parsed directly from its tables, with every value typed, follows [safety by construction](../philosophy/safety-by-construction.md): an invalid font is rejected on loading, not at first use.
 
 Soundness parses the format itself: the font is a value, its tables read lazily, and its metrics
 are ordinary method calls. Everything comes from the `soundness` package:
@@ -24,15 +26,23 @@ import strategies.throwUnsafely
 
 ### Loading a font
 
-`Ttf` reads a font from any streamable source of bytes — a file, a classpath resource, a URL. The
-same reader serves OpenType fonts, which share the table structure:
+`Sfnt` reads a font from any streamable source of bytes — a file, a classpath resource, a URL.
+The name is the format's own: an *sfnt* is the table container that both TrueType and OpenType
+share, and the two specializations are told apart by their tables — a `CFF ` table means
+PostScript outlines, so the font is an `Opentype`; otherwise it is a `Truetype`:
 
+<!-- doccheck: skip -->
 ```scala
-val font = Ttf(cp"/fonts/text.ttf")
+val font: Sfnt = Sfnt(cp"/fonts/text.ttf")
+
+font match
+  case truetype: Truetype => truetype.subset(t"Hello")   // glyph outlines are TrueType
+  case opentype: Opentype => opentype                    // outlines are PostScript
 ```
 
-A file that is not a font, or lacks a table an operation needs, raises a `Font.Error` naming the
-problem.
+Constructing a font from bytes is total; the tables parse lazily, so a file that is not a font,
+or lacks a table an operation needs, raises a `Font.Error` naming the problem when that table is
+first read.
 
 ### Measuring text
 
@@ -40,7 +50,7 @@ problem.
 multiplies by the point size to give a physical width:
 
 ```scala
-val measure = font.width(t"Hello world")   // a Quantity[Ems[1]]
+def measure(font: Sfnt): Quantity[Ems[1]] = font.width(t"Hello world")
 ```
 
 Because the result is a typed [quantity](quantities.md), an em-width cannot be mistaken for a
@@ -52,13 +62,12 @@ Character-level questions go through the glyph machinery: a character resolves t
 each glyph carries its advance width and left side bearing, in the font's design units:
 
 ```scala
-font.advanceWidth('H')     // the horizontal advance, in font units
-font.leftSideBearing('H')
+def metrics(font: Sfnt): (Int, Int) = (font.advanceWidth('H'), font.leftSideBearing('H'))
 ```
 
-The font's header exposes the scaling factor — units per em — that relates design units to em
-measurements, along with the glyph bounding box and the ascender and descender heights that
-vertical layout needs.
+The font's `head` table exposes the scaling factor — units per em — that relates design units to
+em measurements, along with the glyph bounding box, and `hhea` the ascender and descender heights
+that vertical layout needs.
 
 Character-to-glyph mapping covers the `cmap` subtable formats fonts actually use, and the best
 subtable is chosen by Unicode preference rather than by taking the first one present. A character
@@ -67,13 +76,11 @@ the font does not map yields the missing glyph, rather than an error or a wrong 
 ### Names and metadata
 
 A font describes itself in its `name`, `post` and `OS/2` tables, and those descriptions are read
-directly rather than guessed at:
+directly rather than guessed at; the names are `Optional`, since a font need not record them:
 
 ```scala
-font.fontName      // the PostScript name
-font.familyName    // the family name
-font.post.italicAngle
-font.os2.capHeight
+def describe(font: Sfnt): Text =
+  t"${font.fontName.or(t"?")} (${font.familyName.or(t"?")}), ${font.post.italicAngle.show}°"
 ```
 
 Records are decoded from both UTF-16BE and Macintosh encodings, preferring Windows-English where
@@ -83,10 +90,10 @@ which is exactly what building a [PDF](pdf.md) font descriptor needs.
 ### Subsetting
 
 Embedding a whole font to render a page of text is wasteful, and often not permitted. `subset`
-builds a new font containing only the glyphs a given set of characters needs:
+builds a new TrueType font containing only the glyphs a given set of characters needs:
 
 ```scala
-val reduced = font.subset(t"Hello world")
+def reduce(font: Truetype): Truetype = font.subset(t"Hello world")
 ```
 
 Subsetting is not simply a matter of keeping the glyphs a text maps to. A composite glyph is

--- a/doc/modules/fonts.md
+++ b/doc/modules/fonts.md
@@ -31,7 +31,7 @@ same reader serves OpenType fonts, which share the table structure:
 val font = Ttf(cp"/fonts/text.ttf")
 ```
 
-A file that is not a font, or lacks a table an operation needs, raises a `FontError` naming the
+A file that is not a font, or lacks a table an operation needs, raises a `Font.Error` naming the
 problem.
 
 ### Measuring text

--- a/doc/modules/foreign-interop.md
+++ b/doc/modules/foreign-interop.md
@@ -22,6 +22,8 @@ Scala is a string, a C function a hand-declared binding, and the authoritative d
 `.d.ts`, the header, the IDL — sit unread while the programmer transcribes them, imperfectly, by
 hand. The mistakes are exactly the ones the foreign compiler would have caught.
 
+Checking a foreign call against the foreign world's own definitions as the code compiles is [safety by construction](../philosophy/safety-by-construction.md) across a language boundary.
+
 Soundness reads the declarations instead. The definition file is parsed at compiletime, each
 navigation step is resolved against it, and a member that does not exist, or an argument of the
 wrong foreign type, is a Scala compile error. Everything comes from the `soundness` package:
@@ -32,9 +34,11 @@ import soundness.*
 
 ### Loading an interface
 
-An `Interface` binds an ecosystem to a definition file on the classpath. Each supported grammar —
-TypeScript declarations, C headers, WebIDL, WIT — is a `Dialect` the ecosystem names:
+An `Interface` binds an ecosystem to a definition file on the classpath, read as the code
+compiles, so the file must be on the compiler's classpath. Each supported grammar — TypeScript
+declarations, C headers, WebIDL, WIT — is a `Dialect` the ecosystem names:
 
+<!-- doccheck: skip -->
 ```scala
 given (Interface in Typescript at "/definitions.ts") =
   Interface[Typescript](cp"/definitions.ts")
@@ -46,6 +50,7 @@ A `Foreign` value stands for a value of a foreign type, and its members navigate
 foreign declarations were Scala. Each step's type comes from the declarations, so the refinement
 tracks exactly what the foreign type system says:
 
+<!-- doccheck: skip -->
 ```scala
 val foo: Foreign of "Foo" from Typescript = Foreign["Foo", Typescript]
 
@@ -66,8 +71,9 @@ A JVM library written in Kotlin sits on the same classpath, so its declarations 
 file: they are in the classfiles, in the `@Metadata` a Kotlin compiler writes. Those declarations
 are read at compiletime, and a *facade* wraps a live value so that its members are reached as
 though they were Scala's — each access materializing as a direct, statically-typed JVM call, with
-no reflection and no wrapper object:
+no reflection and no wrapper object. With the Kotlin standard library on the classpath:
 
+<!-- doccheck: skip -->
 ```scala
 val pair = make[kotlin.Pair[Text, Text]](t"a", t"b")
 val first: Text = pair.first
@@ -78,7 +84,7 @@ regex.matches(t"123")                          // true
 
 `make` constructs a value, `companion` reaches a companion object's members, and `singleton`
 reaches an object's. Types substitute through, so `pair.first` is a `Text` and not an `Any`, and
-`Text` passes wherever a `CharSequence` is expected. Kotlin's nullability is honoured: a nullable
+`Text` passes wherever a `CharSequence` is expected. Kotlin's nullability is honored: a nullable
 result is an `Optional`, absent where Kotlin would return null.
 
 Properties read as members and `var` properties accept assignment, through the getters and
@@ -86,6 +92,7 @@ setters Kotlin generated; assigning to a `val` does not compile. A Kotlin functi
 takes an ordinary Scala lambda, whose own parameter is a facade over the Kotlin type, so the
 value inside it navigates too:
 
+<!-- doccheck: skip -->
 ```scala
 regex.replace(t"a1b2", (m: Facade over kotlin.text.MatchResult) => t"<${m.value}>")
 // t"a<1>b<2>"
@@ -101,3 +108,22 @@ performs nothing itself. What runs the expression is the ecosystem's business: t
 ecosystem renders it to JavaScript for an event handler, and a WebAssembly ecosystem lowers WIT
 calls to imports. The checking is the point: by the time an expression leaves Scala, every step of
 it has been verified against the foreign world's own definitions.
+
+### Java's own types
+
+The JVM's standard library has types for the things Soundness has its own types for — paths,
+URLs, instants, durations — and code that meets both worlds needs to cross between them without
+copying values by hand. Rather than converting, each Java type is made a *representation* of the
+Soundness concept: `java.io.File` stands as a path, `java.net.URL` as a URL, and
+`java.time.Instant`, `java.util.Date` or a bare `Long` of milliseconds as an instant, so any
+operation that asks for its result "as a path" or "as an instant" can produce the Java type
+directly. Which representation is meant is a choice, made by import:
+
+```scala
+import instantInterfaces.javaTimeInstant
+import durationInterfaces.javaLongDuration
+```
+
+With those in scope, a [time](time.md) read from a file or a clock arrives as a
+`java.time.Instant`, and a duration as a `Long` of milliseconds, ready to hand to a Java API
+that expects them, while the rest of the program keeps Soundness's own types.

--- a/doc/modules/forms.md
+++ b/doc/modules/forms.md
@@ -3,7 +3,7 @@
 ### About
 
 An HTML form is a user interface to a data type, and Soundness generates one from the type
-itself. A case class produces a form — a labelled input per field, the widget chosen by the
+itself. A case class produces a form — a labeled input per field, the widget chosen by the
 field's type — and a submission decodes back into the case class, with validation failures
 attached to the fields that caused them. Nested case classes become nested fieldsets, so the form
 mirrors the data's structure.
@@ -15,6 +15,8 @@ and validation of what comes back. The two halves are kept consistent by hand, a
 the data — a new field, a renamed one, a stricter type — must be made in both, or the form drifts
 from the data it claims to collect.
 
+Deriving a form and its decoder from one type keeps them in agreement, which is [correctness](../philosophy/correctness.md) through a single source of truth.
+
 Deriving both halves from one type removes the duplication. The type says what fields exist and
 what each accepts; the widgets follow from the field types — a `Boolean` is a checkbox, an
 enumeration a selection, text a field; and decoding a submission applies the same validated types
@@ -24,6 +26,7 @@ a message pointing at the email field. Everything comes from the `soundness` pac
 ```scala
 import soundness.*
 import formulations.postFormulation
+import strategies.throwUnsafely
 ```
 
 ### Rendering a form
@@ -48,7 +51,9 @@ as `leader.name`. It decodes to the type with `as`, and a failure carries a poin
 fault:
 
 ```scala
-query.as[Organization]   // an Organization, or typed errors per field
+val query = t"leader.name=Ada&leader.email=ada%40example.com&name=Acme".as[Query]
+
+query.as[Organization]   // Organization(Person(t"Ada", email"ada@example.com"), t"Acme")
 ```
 
 Because the fields decode through the same types used everywhere — an `EmailAddress` must parse, a
@@ -57,12 +62,12 @@ doing its usual work at the boundary.
 
 ### The form cycle
 
-A form is a loop: render, submit, re-render with errors, until the value is complete. The
-[HTTP server](http-server.md) integration runs that loop with `orchestrate`, delivering a complete
-typed value when validation passes and the re-rendered form, faults attached, when it does not —
-so a handler deals in values, not requests.
+A form is a loop: render, submit, re-render with errors, until the value is complete. `elicit`
+takes the submitted `Query` and the validation state, so the re-rendered form shows what was
+entered with the faults attached to their fields; a [server](http-server.md) handler runs the
+loop by decoding on success and re-rendering on failure, and so deals in values, not requests.
 
-### Customising appearance
+### Customizing appearance
 
 How a form and its rows render is a `Formulation` — the frame around the widgets, the placement of
 labels and error messages. `postFormulation` gives a plain, unstyled rendering; an application

--- a/doc/modules/gauges.md
+++ b/doc/modules/gauges.md
@@ -7,7 +7,7 @@ still alive, how fast bytes are moving, which step of a pipeline is running. Sou
 these as *gauges* — spinners, progress bars, meters, sparklines, counters and step indicators —
 either embedded in a terminal layout or drawn on their own at the cursor.
 
-A gauge is chosen by the *type* of the thing it displays. What it looks like, what colours it uses
+A gauge is chosen by the *type* of the thing it displays. What it looks like, what colors it uses
 and which characters it may draw with are three separate decisions, each made by one import, and
 none of them disturbs the other two.
 
@@ -18,13 +18,21 @@ decides what fits. The two are kept consistent by hand, and the result is a bar 
 eighty columns and corrupt at thirty — a row that overruns, a label that pushes the bar off the
 edge, or a percentage that disagrees with the bar beside it.
 
+A gauge design chosen by import, independent of the status it draws, is [decoupling](../philosophy/decoupling.md) between meaning and rendering.
+
 Separating the two removes the duplication. A design says how to draw a status at whatever width it
 is given, and how narrow it can usefully go; the layout says how much room there is. Neither needs
 to know what the other decided. A bar handed six cells re-quantizes to six; handed three it becomes
-a percentage; handed one it becomes a single shade. Everything comes from the `soundness` package:
+a percentage; handed one it becomes a single shade. Everything comes from the `soundness` package,
+with a text metric in scope, since a gauge is laid out by the width of what it draws, a palette
+(without one, an adaptive palette is chosen from what the terminal reports, which needs the
+terminal's capabilities in scope), and standard output for the examples that print:
 
 ```scala
 import soundness.*
+import textMetrics.uniformMetric
+import palettes.solarizedDarkGaugePalette
+import stdios.javaLangSystemStdio
 ```
 
 ### Statuses
@@ -91,8 +99,10 @@ Importing a design by name replaces it, and nothing else changes:
 
 ```scala
 import bars.arrowheadBar
-import spinners.moonPhaseSpinner
 ```
+
+A spinner and a bar are two designs for the same status, so only one of them can be imported at
+a time; `spinners.moonPhaseSpinner` in place of the bar above would animate moon phases instead.
 
 The families are `spinners`, `bars`, `meters`, `sparklines`, `counters`, `standings`,
 `processions` and `timers`. There are around forty spinners, from single-cell braille and block
@@ -101,9 +111,9 @@ default through segmented pips and gradient fills to `[###---]`; six meters (bat
 needle, bullet, column and ASCII); four sparklines; nine counters; five status markers; and five
 step indicators.
 
-### Colours and glyphs
+### Colors and glyphs
 
-Colour is an independent axis. A `GaugePalette` names its colours by *role* — `fill`, `track`,
+Color is an independent axis. A `GaugePalette` names its colors by *role* — `fill`, `track`,
 `leadingEdge`, `caption`, `muted`, `success`, `warning`, `danger` — so one design renders under any
 palette:
 
@@ -112,10 +122,10 @@ import palettes.solarizedDarkGaugePalette
 ```
 
 Ten palettes ship, including a hue-free `monochromeGaugePalette` and an `ansiSixteenGaugePalette`
-whose colours are the canonical values a sixteen-colour terminal actually has. With no import, an
+whose colors are the canonical values a sixteen-color terminal actually has. With no import, an
 adaptive palette picks by what the terminal reports.
 
-The character repertoire is a third axis, and degrades the whole catalogue at once:
+The character repertoire is a third axis, and degrades the whole catalog at once:
 
 ```scala
 import gaugeGlyphs.asciiGlyphs
@@ -123,7 +133,7 @@ import gaugeGlyphs.asciiGlyphs
 
 Every design has an ASCII rendering, and every design that prefers exotic glyphs declares what to
 fall back to — so emoji designs become their BMP siblings where the terminal cannot show them, and
-under `asciiGlyphs` everything emits seven-bit output. No design carries its meaning in colour
+under `asciiGlyphs` everything emits seven-bit output. No design carries its meaning in color
 alone, so a gauge written to a file or read by someone who cannot distinguish red from green still
 says what it means.
 
@@ -132,16 +142,19 @@ says what it means.
 `gauge` builds a pane, taking a `Reading` — a mutable cell holding the current status. Assigning to
 the cell publishes the value and repaints, so a gauge driven from a background task updates itself:
 
+<!-- doccheck: skip -->
 ```scala
 val progress = Reading(Fraction(0.0))
+val work = List(1, 2, 3, 4, 5)
 
-async:
-  work.each: item =>
-    process(item)
-    progress() = Fraction.of(done, total)
+supervise:
+  async:
+    work.each: item =>
+      snooze(0.5*Second)
+      progress() = Fraction.of(item, work.size)
 
-interactive: terminal ?=>
-  form(Occupancy.Inline)(stack(gauge(progress)))
+  interactive: terminal ?=>
+    conduct(Occupancy.Inline)(stack(gauge(progress)))
 ```
 
 A gauge reports its design's intrinsic size on every solve, so it takes part in the layout rather
@@ -149,25 +162,27 @@ than assuming a width: an elastic design fills what it is given, an inelastic on
 status glyph) is held to its own width, and a multi-row design like a checklist grows the layout to
 its step count. A gauge accepts no input, so Tab skips over it.
 
-A design that animates declares how often it wants redrawing; the form takes the shortest period
-over the gauges on screen and runs one timer for all of them, and none at all when nothing is
-animating.
+A design that animates declares how often it wants redrawing; the conducted layout takes the
+shortest period over the gauges on screen and runs one timer for all of them, and none at all
+when nothing is animating.
 
 ### Standalone
 
 Outside a layout, `whilst` shows a gauge at the cursor for the duration of a block and erases it
 afterwards:
 
+<!-- doccheck: skip -->
 ```scala
 whilst(Reading(Fraction.indeterminate)):
-  slowThing()
+  snooze(2.0*Second)
 ```
 
 `gaugeLine` renders a single frame for a caller doing its own drawing — the shape to use when the
 redrawing is already handled:
 
 ```scala
-Out.print(e"\r${gaugeLine(Fraction.of(done, total), 40)} $done/$total${csi.el()}")
+def frame(done: Int, total: Int)(using Stdio): Unit =
+  Out.print(e"\r${gaugeLine(Fraction.of(done, total), 40)} $done/$total${csi.el()}")
 ```
 
 ### Degradation
@@ -196,20 +211,23 @@ while looking like the whole series, which is worse than showing less.
 uses, so it is not a style choice and needs no import:
 
 ```scala
-gauge(Reading(Captioned(Fraction.indeterminate, t"resolving dependencies")))
+val captioned = gauge(Reading(Captioned(Fraction.indeterminate, t"resolving dependencies")))
 ```
 
 A `Sequence[Step]` renders as a checklist, a breadcrumb, a chain of beads, a numbered position or a
 powerline ribbon:
 
+<!-- doccheck: skip -->
 ```scala
-val steps =
+import processions.checklistProcession
+
+val steps: Sequence[Step] =
   Sequence
     ( Step(t"resolve", Standing.Succeeded),
       Step(t"compile", Standing.Running),
       Step(t"publish", Standing.Pending) )
 
-gauge(Reading(steps))   // with `import processions.checklistProcession`
+val checklist = gauge(Reading(steps))
 ```
 
 drawing, at three rows:

--- a/doc/modules/generic-data.md
+++ b/doc/modules/generic-data.md
@@ -56,7 +56,7 @@ Person(t"John", 30).pojo    // Array("John", 30)
 
 Because both sides derive the codec from the same type definition, the encoding needs no schema on
 the wire — but it also means both sides must agree on that definition, and a mismatch surfaces as
-a typed `PojoError` when decoding, not as silent corruption.
+a typed `Pojo.Error` when decoding, not as silent corruption.
 
 `Pojo` is an opaque type over the JDK types it permits, so a `Pojo` cannot be confused with an
 arbitrary `Object`, and the only way to produce one is through an encoder. Decoding is fallible

--- a/doc/modules/generic-data.md
+++ b/doc/modules/generic-data.md
@@ -6,7 +6,7 @@ A value sometimes has to leave the world where its class is known — crossing i
 classloader, another process, or a staging boundary — and arrive intact. The `Pojo` representation
 carries any Scala value using only the types every JVM context shares: boxed primitives, strings,
 and arrays of objects. A case class or enumeration converts to a `Pojo` and back with derived
-codecs, so the value survives the crossing without its class travelling with it.
+codecs, so the value survives the crossing without its class traveling with it.
 
 ### On classloader-neutral data
 
@@ -16,8 +16,10 @@ receiving side cannot cast it back: the "same" class from another loader is a di
 Full serialization solves this with heavy machinery; passing strings solves it by giving up
 structure.
 
+Working on the generic representation of a value, without losing its structure, is what lets one codec serve every format — [composability](../philosophy/composability.md) between formats.
+
 A `Pojo` keeps the structure and drops the class. A product becomes an array of its fields, a
-variant a labelled pair, a primitive its boxed self — all types defined by the JDK itself, equally
+variant a labeled pair, a primitive its boxed self — all types defined by the JDK itself, equally
 meaningful on both sides of any boundary. This is the transport beneath [staged](staging.md)
 remote execution. Everything comes from the `soundness` package:
 
@@ -50,8 +52,11 @@ declaration order, an enumeration case is a pair of its name and its payload, an
 their boxed forms:
 
 ```scala
+enum Light:
+  case Red, Amber, Green
+
 Person(t"John", 30).pojo    // Array("John", 30)
-(Color.Green: Color).pojo   // Array("Green", Array())
+(Light.Green: Light).pojo   // Array("Green", Array())
 ```
 
 Because both sides derive the codec from the same type definition, the encoding needs no schema on

--- a/doc/modules/geography.md
+++ b/doc/modules/geography.md
@@ -3,7 +3,7 @@
 ### About
 
 Angles, positions on the Earth, and the compass are typed values. An `Angle` is a genuine angular
-quantity — constructed in degrees or radians, added and scaled modularly, normalised to a principal
+quantity — constructed in degrees or radians, added and scaled modularly, normalized to a principal
 value — rather than a bare number whose unit is a matter of memory. A `Location` is a latitude and
 longitude packed into a single value, from which bearings, angular distances and
 [geohashes](https://en.wikipedia.org/wiki/Geohash) are computed, and a bearing renders as a compass
@@ -16,12 +16,16 @@ degrees and another as radians, with nothing in the type to arbitrate. Angles al
 10° — and code that forgets the modulus accumulates rotations that compare unequal when they should
 not. Positions inherit both problems twice over, once per coordinate.
 
+Angles and locations as dimensioned values, rather than bare doubles, are [impossible states](../philosophy/impossible-states.md) ruled out: a latitude cannot be added to a distance.
+
 Soundness makes the angle a type of its own, constructed through its unit and closed under modular
 arithmetic, so a bare number never stands for an angle and wrapping is built into the operations.
-Everything comes from the `soundness` package:
+Everything comes from the `soundness` package; an angle's textual form, degrees with a `°`, is
+a named given imported alongside:
 
 ```scala
 import soundness.*
+import soundness.angleShowable
 ```
 
 ### Angles
@@ -72,6 +76,8 @@ angular distance between two points along the great circle; and the geohash of t
 chosen precision:
 
 ```scala
+import compassBearings.eightPointCompassBearing
+
 val here = Location(51.5.deg, 0.1.deg)
 val there = Location(48.9.deg, 2.4.deg)
 

--- a/doc/modules/git.md
+++ b/doc/modules/git.md
@@ -19,7 +19,7 @@ the output is text in a format that must be parsed by hand; and nothing distingu
 from a tag name from a commit hash until Git rejects one.
 
 Soundness wraps the command line in a typed API. Each operation is a method that names its
-requirements and the errors it can raise; a `GitBranch`, `GitTag` and `GitHash` are separate types,
+requirements and the errors it can raise; a `Git.Branch`, `Git.Tag` and `GitHash` are separate types,
 so one cannot be passed where another is meant; and the output of `log`, `status` or `diff` is parsed
 into values. Everything comes from the `soundness` package, with the `git` command located and the
 capabilities the operations need in scope:
@@ -35,14 +35,14 @@ import strategies.throwUnsafely
 
 ### Opening or creating a repository
 
-An existing repository opens with `GitRepo.at`, and a new one is created with `Git.init`, which
+An existing repository opens with `Git.Repo.at`, and a new one is created with `Git.init`, which
 returns a `Worktree` — a repository together with a working tree:
 
 ```scala
-val worktree = Git.init(directory, initialBranch = GitBranch(t"main"))
+val worktree = Git.init(directory, initialBranch = Git.Branch(t"main"))
 ```
 
-`Git.initBare` creates a bare repository, one with no working tree, returning a `GitRepo`.
+`Git.initBare` creates a bare repository, one with no working tree, returning a `Git.Repo`.
 
 ### Making a commit
 
@@ -71,9 +71,9 @@ Branches and tags are created, listed and switched between with typed references
 reference to merge and a fast-forward policy:
 
 ```scala
-worktree.makeBranch(GitBranch(t"feature"))
-worktree.checkout(GitBranch(t"main"))
-worktree.merge(GitBranch(t"feature"), ff = FastForward.Never, message = t"Merge feature")
+worktree.makeBranch(Git.Branch(t"feature"))
+worktree.checkout(Git.Branch(t"main"))
+worktree.merge(Git.Branch(t"feature"), ff = FastForward.Never, message = t"Merge feature")
 ```
 
 ### Cloning, pulling and pushing
@@ -89,7 +89,7 @@ cloned.repo.log().to(List)
 
 ### References
 
-A `GitBranch`, `GitTag` and `GitHash` name the three kinds of reference, and a `Refspec` is any of
+A `Git.Branch`, `Git.Tag` and `GitHash` name the three kinds of reference, and a `Refspec` is any of
 them or a relative expression such as `Refspec.head()` for `HEAD`. Because each is its own type, an
 operation that expects a branch will not accept a tag, and a hash carries the guarantee that it is a
 well-formed forty-character identifier.
@@ -120,8 +120,8 @@ similarity indices, binary files, mode changes, and files with no trailing newli
 created is stated rather than inherited from configuration:
 
 ```scala
-worktree.merge(GitBranch(t"feature"), ff = FastForward.Only)
-worktree.merge(GitBranch(t"feature"), ff = FastForward.Never, message = t"Merge feature")
+worktree.merge(Git.Branch(t"feature"), ff = FastForward.Only)
+worktree.merge(Git.Branch(t"feature"), ff = FastForward.Never, message = t"Merge feature")
 ```
 
 `cherryPick` and `revert` apply and undo a single commit's changes. A conflict is a typed failure

--- a/doc/modules/git.md
+++ b/doc/modules/git.md
@@ -18,19 +18,29 @@ means assembling command strings, and a mistyped subcommand or a malformed ref i
 the output is text in a format that must be parsed by hand; and nothing distinguishes a branch name
 from a tag name from a commit hash until Git rejects one.
 
+Repository operations that report their failures in their types, and cannot be run without the capabilities they need, are [honest signatures](../philosophy/honest-signatures.md) for version control.
+
 Soundness wraps the command line in a typed API. Each operation is a method that names its
-requirements and the errors it can raise; a `Git.Branch`, `Git.Tag` and `GitHash` are separate types,
+requirements and the errors it can raise; a `Git.Branch`, `Git.Tag` and `Git.Hash` are separate types,
 so one cannot be passed where another is meant; and the output of `log`, `status` or `diff` is parsed
 into values. Everything comes from the `soundness` package, with the `git` command located and the
 capabilities the operations need in scope:
 
 ```scala
 import soundness.*
+
+import charEncoders.utf8Encoder
+import filesystemOptions.createNonexistentParents
 import gitCommands.searchpathGitCommand
-import workingDirectories.javaBaseWorkingDirectory
 import internetAccess.online
 import logging.silentLogging
+import pathInterfaces.pathOnLinux
 import strategies.throwUnsafely
+import temporaryDirectories.javaBaseTemporaryDirectory
+import workingDirectories.javaBaseWorkingDirectory
+
+val directory = temporaryDirectory[Path on Linux] / "git" / Uuid().show
+directory.create[Directory]()
 ```
 
 ### Opening or creating a repository
@@ -50,9 +60,11 @@ Staging and committing are methods on the worktree; the resulting commit's hash 
 resolving `HEAD`:
 
 ```scala
-worktree.add(worktree.path/t"notes.txt")
+(worktree.path / "notes.txt").write(t"Remember the milk")
+worktree.add(worktree.path / "notes.txt")
 worktree.commit(t"Add notes")
-val hash = worktree.repo.revParse(Refspec.head())
+
+val hash = worktree.repo.revParse(Refspec.head())   // the new commit's Git.Hash
 ```
 
 ### Inspecting history
@@ -61,8 +73,7 @@ val hash = worktree.repo.revParse(Refspec.head())
 message:
 
 ```scala
-worktree.repo.log().map(_.message.head).to(List)
-// List(t"Add notes", …)
+worktree.repo.log().map(_.message.prim).to(List)   // List(t"Add notes")
 ```
 
 ### Branches and tags
@@ -73,7 +84,6 @@ reference to merge and a fast-forward policy:
 ```scala
 worktree.makeBranch(Git.Branch(t"feature"))
 worktree.checkout(Git.Branch(t"main"))
-worktree.merge(Git.Branch(t"feature"), ff = FastForward.Never, message = t"Merge feature")
 ```
 
 ### Cloning, pulling and pushing
@@ -83,13 +93,13 @@ capability and runs asynchronously, returning a process whose progress can be ob
 result is taken with `complete`:
 
 ```scala
-val cloned = Git.clone(source, target).complete()
-cloned.repo.log().to(List)
+val cloned = Git.clone(worktree.path, directory / "clone").complete()
+cloned.repo.log().to(List).size   // 1
 ```
 
 ### References
 
-A `Git.Branch`, `Git.Tag` and `GitHash` name the three kinds of reference, and a `Refspec` is any of
+A `Git.Branch`, `Git.Tag` and `Git.Hash` name the three kinds of reference, and a `Refspec` is any of
 them or a relative expression such as `Refspec.head()` for `HEAD`. Because each is its own type, an
 operation that expects a branch will not accept a tag, and a hash carries the guarantee that it is a
 well-formed forty-character identifier.
@@ -105,9 +115,11 @@ carries the paths on both sides, the kind of change — added, modified, deleted
 and its hunks, each hunk a list of edits:
 
 ```scala
+(worktree.path / "notes.txt").write(t"Remember the milk and the eggs")
+
 val files = worktree.diff().to(List)
-files.head.changeKind      // ChangeKind.Modified
-files.head.hunks.flatMap(_.edits)
+files.prim.let(_.changeKind)                 // ChangeKind.Modified
+files.prim.let(_.hunks.flatMap(_.edits))     // the edits, hunk by hunk
 ```
 
 The same parser reads a patch from anywhere — a file, an email, a code-review comment — so a tool

--- a/doc/modules/graphs.md
+++ b/doc/modules/graphs.md
@@ -61,7 +61,7 @@ what "why is this here, and what breaks if I remove it" asks for.
 and `subgraph` restricts the graph to a chosen set of nodes.
 
 Everything that could encounter a cycle says so: `sorted`, `reachable`, `descendants` and their
-kin raise a `DagError`, since a cyclic graph has no topological order and no finite reachable set.
+kin raise a `Dag.Error`, since a cyclic graph has no topological order and no finite reachable set.
 `hasCycle` asks the question directly, for code that would rather check than handle.
 
 ### Folding over a graph

--- a/doc/modules/graphs.md
+++ b/doc/modules/graphs.md
@@ -21,6 +21,8 @@ graph libraries carry the weight of arbitrary graphs — cycles included — and
 rather than values; more often, projects hand-roll a topological sort over a `Map` and inherit its
 edge cases.
 
+A graph that cannot be constructed with a cycle is an [impossible state](../philosophy/impossible-states.md) ruled out at the point of construction.
+
 A `Dag` is a value: immutable, transformable, and specific to the acyclic case, so a cycle is a
 typed error rather than an infinite loop. Everything comes from the `soundness` package:
 
@@ -35,11 +37,15 @@ A `Dag` is built from edges, from nodes with their dependency sets, or by explor
 node through a dependency function:
 
 ```scala
-val dag = Dag(8 -> 4, 8 -> 6, 6 -> 3, 6 -> 2, 4 -> 2)
+val dag = Dag(8 -> Set(4, 6), 6 -> Set(3, 2), 4 -> Set(2), 3 -> Set(), 2 -> Set())
 
 12.explore(n => (1 until n).filter(n % _ == 0).to(Set))
 // the divisibility graph beneath 12
 ```
+
+The first form names every node with its dependencies; `Dag(8 -> 4, 8 -> 6, 6 -> 3)` builds a
+graph from edges alone, and `Dag(Set(2, 3, 4, 6, 8))(dependencies)` from a set of nodes and a
+function giving each one's dependencies.
 
 ### Ordering and reachability
 
@@ -47,14 +53,14 @@ val dag = Dag(8 -> 4, 8 -> 6, 6 -> 3, 6 -> 2, 4 -> 2)
 node after its dependencies — and reachability queries slice the graph around a node:
 
 ```scala
-dag.sorted             // dependencies before dependents
-dag.reachable(8)       // everything 8 depends on, transitively
+dag.sorted             // List(2, 3, 4, 6, 8): dependencies before dependents
+dag.reachable(8)       // Set(2, 3, 4, 6): everything 8 depends on, transitively
 dag.descendants(8)     // the sub-graph beneath 8
 dag.invert             // the graph with every edge reversed
 ```
 
 `ancestors` is the counterpart of `descendants`, giving what depends on a node rather than what it
-depends on, and `lineage` gives both together — the node's whole causal neighbourhood, which is
+depends on, and `lineage` gives both together — the node's whole causal neighborhood, which is
 what "why is this here, and what breaks if I remove it" asks for.
 
 `sources` gives the nodes with no dependencies, which is where a build or an installation starts,
@@ -70,7 +76,7 @@ A traversal computes a value for every node from the values of the nodes it depe
 order that guarantees the dependencies are computed first:
 
 ```scala
-dag.traversal[Int]((childValues, node) => childValues.sum + 1)
+dag.traversal[Int]((childValues, node) => childValues.sum + 1)   // one more than the sum beneath
 ```
 
 This is the shape of most real work over a dependency graph — computing a build order's costs,

--- a/doc/modules/hashing.md
+++ b/doc/modules/hashing.md
@@ -22,6 +22,8 @@ byte array. The algorithm is unchecked, so a typo is a runtime failure; the inpu
 to bytes by hand before hashing; the output must be rendered to text by hand after; and nothing
 discourages reaching for a broken algorithm.
 
+Naming the algorithm as a type rather than a string is [safety by construction](../philosophy/safety-by-construction.md): a digest of one algorithm cannot be confused with another's.
+
 Soundness fixes each of these. The algorithm is a type, checked at the call site. Any value with a
 `Digestible` instance is hashed directly, and case classes and collections derive theirs, so the
 value's own structure is what gets hashed. The result renders through the base encodings. And a weak
@@ -32,8 +34,11 @@ hashing provider and an alphabet in scope:
 
 ```scala
 import soundness.*
-import providers.javaBaseProvider
+
 import alphabets.hexLowerCase
+import charEncoders.utf8Encoder
+import providers.javaBaseProvider
+import strategies.throwUnsafely
 ```
 
 ### Hashing a value
@@ -42,7 +47,7 @@ import alphabets.hexLowerCase
 
 ```scala
 t"Hello world".digest[Sha2[256]].serialize[Hex]
-// the 64-character hexadecimal SHA-256 digest
+// t"64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c"
 ```
 
 The provider in scope supplies the algorithms — `javaBaseProvider` for the SHA and MD5 family and
@@ -53,8 +58,9 @@ algorithm in its type — `Digest in Sha2[256]` — so a field declared that way
 computes without the call restating it:
 
 ```scala
-case class Block(digest: Digest in Sha2[256], payload: Json)
+case class Block(digest: Digest in Sha2[256], payload: Text)
 
+val payload = t"""{"amount": 100}"""
 Block(payload.digest, payload)
 ```
 
@@ -88,7 +94,9 @@ sizes the chunks happen to arrive in — including chunks of one byte, and windo
 way into a buffer:
 
 ```scala
-file.stream.digest[Sha2[256]].serialize[Hex]
+val chunks = Chain(t"Hello ".in[Data], t"wor".in[Data], t"ld".in[Data])
+chunks.checksum[Sha2[256]].serialize[Hex]
+// t"64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c", as for the whole text
 ```
 
 This is what makes a digest computable over a [stream](streams.md) with bounded memory, and it is
@@ -116,6 +124,22 @@ import alphabets.base64Standard
 t"Hello world".digest[Sha2[256]].serialize[Base64]
 ```
 
+### Self-describing digests
+
+A digest's bytes say nothing about the algorithm that produced them, so a digest stored or sent
+alone can be checked only by something that already knows how it was made. A
+[Multihash](https://multiformats.io/multihash/) prefixes the digest with a code for its algorithm
+and its length, so it describes itself, which is what content-addressed storage and the
+distributed protocols built on it exchange:
+
+```scala
+Multihash(t"Hello world".digest[Sha2[256]]).serialize
+// 0x12, 0x20, then the thirty-two bytes of the SHA-256 digest
+```
+
+The algorithm code comes from the digest's type, so a multihash cannot claim an algorithm other
+than the one that computed it.
+
 ### Weak algorithms
 
 MD5 and SHA-1 are broken for security purposes, and remain only for compatibility. Digesting with
@@ -124,17 +148,24 @@ one requires a permission in scope, so the choice is visible and deliberate:
 ```scala
 import cryptoPermits.permitDisallowedCrypto
 
-t"Hello world".digest[Md5].serialize[Hex]
+t"Hello world".digest[Md5].serialize[Hex]   // t"3e25960a79dbc69b674cd4ec67a72c62"
 ```
 
 Without such an import, `digest[Md5]` and `digest[Sha1]` do not compile; the strong algorithms need
 no permission.
 
-### Checksums of streams
+### Checksums
 
-A source of bytes — a file, a download — is checksummed without holding it all in memory, by
-digesting its stream as it flows:
+`Crc32`, `Crc64` and `Adler32` are not hashes but checksums: they detect accidental corruption
+and defend against nothing, so they sit behind a permit of their own, which concedes only that no
+adversary is in the threat model:
 
 ```scala
-val fingerprint = source.checksum[Sha2[256]]
+import cryptoPermits.permitNonCryptographicHashes
+
+t"123456789".digest[Crc32].serialize[Hex]   // t"cbf43926"
 ```
+
+A source of bytes — a file, a download — is checksummed without holding it all in memory, by
+digesting its stream as it flows, exactly as `checksum` did above, and a digest of any algorithm
+is a value: comparable, showable, and usable as a key.

--- a/doc/modules/html.md
+++ b/doc/modules/html.md
@@ -9,7 +9,7 @@ the HTML specification as the code compiles, so a `<br>` given children, or a `<
 given a `src` attribute, is a compile error rather than malformed output.
 
 The same representation reads HTML back from text, files, or a URL, matches it with
-patterns, and serialises it — directly or as a stream. Above the level of individual
+patterns, and serializes it — directly or as a stream. Above the level of individual
 tags, whole pages can be assembled from reusable parts: a masthead, a hero, a set of
 panels, each contributing its own markup, styles, and document metadata.
 
@@ -27,7 +27,7 @@ Soundness encodes the specification in the types, so an invalid document becomes
 afterwards. Each tag is a value whose type knows its name, what it may contain, and what
 attributes it admits, and the rules of the specification are enforced where the markup is
 written. The vocabulary, the
-containment rules, and the parsing and emitting behaviour all come from a contextual
+containment rules, and the parsing and emitting behavior all come from a contextual
 description of the specification — currently the
 [WHATWG HTML Living Standard](https://html.spec.whatwg.org/), what most people mean by
 "HTML" today — which other specifications could replace.
@@ -38,6 +38,8 @@ specification and the tag vocabulary it defines:
 ```scala
 import soundness.*
 import htmlDoms.whatwg.*
+import strategies.throwUnsafely
+import attributives.textAttributive
 ```
 
 An HTML value has the general type `Html`. Its nodes are `Element`s, `Comment`s,
@@ -53,7 +55,7 @@ adds children:
 
 ```scala
 Br                                  // <br>
-Img(src = "image.jpg")              // <img src="image.jpg">
+Img(src = t"image.jpg")             // <img src="image.jpg">
 Div(Hr, P("Hello world"))           // <div><hr><p>Hello world</p></div>
 Textarea(name = "details", rows = 5)("Details go here")
 // <textarea name="details" rows="5">Details go here</textarea>
@@ -99,7 +101,7 @@ each is checked in its position:
 
 ```scala
 val content = t"important"
-val location = t"dog.jpg"
+val location = url"https://example.com/dog.jpg"
 
 h"<p>$content</p>"          // a body-content substitution
 h"<img src=$location>"      // an attribute-value substitution
@@ -107,7 +109,8 @@ h"<!--$content-->"          // a comment substitution
 ```
 
 Body content must be HTML acceptable as a child of the enclosing element; an
-attribute value must suit the attribute; a comment must be showable.
+attribute value must suit the attribute — `src` takes a URL, so a `Text` in its place would be
+rejected — and a comment must be showable.
 
 ### Attributes
 
@@ -123,23 +126,22 @@ Img(width = pixels)   // <img width="64">
 ```
 
 The set of types accepted out of the box is still incomplete. Until it is filled, the
-simplest course is to make `Text` acceptable for every attribute with one import:
-
-```scala
-import attributives.textAttributive
-```
+simplest course is to make `Text` acceptable for every attribute with one import —
+`attributives.textAttributive`, already in scope above, which is what lets `src = "image.jpg"`
+stand where a URL is expected.
 
 The `class` attribute is awkward, because `class` is a Scala keyword. Rather than
 write it in backticks, name the class as a method on the tag:
 
 ```scala
-given (Stylesheet of "info") = Stylesheet()
+import stylesheets.uncheckedClasses
+
 P.info("body text")   // <p class="info">body text</p>
 ```
 
-The contextual `Stylesheet` value is what makes the class name legitimate, so a
-mistyped class is caught. Where that check is not wanted, freeform class names are
-enabled with `import stylesheets.uncheckedClasses`.
+`uncheckedClasses` permits any class name. Binding a [stylesheet](css.md) instead makes the
+names it defines the only legitimate ones, so a mistyped class is caught as the code compiles,
+and a name the stylesheet declares as an id renders as one.
 
 ### Fragments
 
@@ -158,7 +160,7 @@ list items declares itself to produce `"li"` content:
 
 ```scala
 given (List[Text] is Renderable in "li") =
-  list => Fragment(list.map(Li(_))*)
+  list => Fragment(list.map(Li(_)).nodes*)
 ```
 
 With that in scope a `List[Text]` can be rendered directly, placed inside a `<ul>`, or
@@ -178,7 +180,7 @@ marks which end — and an attribute is added, or replaced, by assignment:
 
 ```scala
 val image = h"""<img src="puppy.jpg">"""
-val described = image.alt = "An image of a young dog"
+val described = image.alt = t"An image of a young dog"
 // <img src="puppy.jpg" alt="An image of a young dog">
 ```
 
@@ -191,7 +193,7 @@ resource — with `read` or `load`. `load` reads a whole document, returning a
 `Document[Html]` with a `Doctype` header and a root `<html>` node:
 
 ```scala
-val document = url"https://example.com/index.html".load[Html]
+val document = t"<html><head><title>Hello</title></head><body><p>Hello</p></body></html>".load[Html]
 ```
 
 `read` is for fragments. Called as `read[Html]`, it accepts anything from a single
@@ -238,10 +240,13 @@ real HTML against the DOM structure rather than the source text — so a pattern
 with closing tags matches input written without them:
 
 ```scala
+val html = h"<li>two</li>"
+
 html match
   case h"<li>one</li>" => 1
   case h"<li>two</li>" => 2
   case _               => Unset
+// 2
 ```
 
 Holes bind the pieces a pattern captures. Because an `<li>` may hold text or elements,
@@ -290,8 +295,10 @@ which compose in the order the traits are mixed:
 
 ```scala
 case class HomePage(content: Html of Flow)
-extends Archetype, Masthead, Hero, StandardMetadata:
-  def pageTitle = t"Welcome"
+extends Archetype, Masthead, Hero(t"Welcome"), StandardMetadata(t"A home page"):
+  override def pageTitle = t"Welcome"
+
+HomePage(P("Hello world")).document
 ```
 
 The assembled value renders to a `Document[Html]` with a leading doctype and an inline

--- a/doc/modules/http-client.md
+++ b/doc/modules/http-client.md
@@ -114,7 +114,7 @@ retry on a fresh connection. Other platforms supply their own backends the same 
 ### Redirects
 
 Redirects are followed by default, up to a limit. Importing a stricter policy stops them, after
-which a redirect response is delivered as an `HttpError` carrying the redirect status:
+which a redirect response is delivered as an `Http.Error` carrying the redirect status:
 
 ```scala
 import httpRedirections.doNotFollowRedirects
@@ -122,11 +122,11 @@ import httpRedirections.doNotFollowRedirects
 
 ### Errors
 
-A response outside the success range raises an `HttpError`, which carries the status and headers so
+A response outside the success range raises an `Http.Error`, which carries the status and headers so
 the caller can react to what went wrong:
 
 ```scala
-capture[HttpError](url"https://example.com/missing".fetch().receive[Text]).status   // Http.NotFound
+capture[Http.Error](url"https://example.com/missing".fetch().receive[Text]).status   // Http.NotFound
 ```
 
 A request that cannot connect at all — an unresolvable host, a refused connection, a TLS failure —

--- a/doc/modules/http-client.md
+++ b/doc/modules/http-client.md
@@ -19,18 +19,25 @@ bytes, and hands back a response whose status must be checked by hand and whose 
 by hand. The URL might be malformed, a header name might be misspelled, the body's media type might
 not match its bytes, and none of this is caught until the request runs — if then.
 
+A request that must state its failure modes, and a response decoded to a type, follow [error handling](../philosophy/error-handling.md) as it applies everywhere else.
+
 Soundness types each part. The URL is validated where it is written; a header argument is checked
 against the header it sets, so `accept` takes a media type and not any string; the body carries its
 media type with it; and the response reads into a chosen type. A non-success status and a
 connection failure are distinct typed errors. That a request touches the network is itself visible,
-as the `Online` capability it demands. Everything comes from the `soundness` package:
+as the `Online` capability it demands. Everything comes from the `soundness` package, with a
+transport chosen by import — the JVM's own `java.net.http` here, and the alternatives below:
 
 ```scala
 import soundness.*
+
+import charEncoders.utf8Encoder
+import charDecoders.utf8Decoder
+import errorDiagnostics.stackTracesDiagnostics
+import httpBackends.javaNetHttp
 import internetAccess.online
 import logging.silentLogging
 import strategies.throwUnsafely
-import charEncoders.utf8Encoder
 ```
 
 ### A GET request
@@ -81,9 +88,11 @@ A single request opens a connection and closes it. Where several requests go to 
 a *session* opens one connection and lends it to a scope, so the requests within share it:
 
 ```scala
+val request = Http.Request(Http.Get, 1.1, t"example.com".as[Host], t"/", Nil, () => Http.emptyBody())
+
 url"https://example.com".session: session ?=>
-  session.fetch(request)
-  session.fetch(request)
+  session.fetch(request).status
+  session.fetch(request).status
 ```
 
 The protocol is fixed for the session's lifetime. For `https`, ALPN chooses it during the TLS
@@ -103,7 +112,9 @@ The transport is a given. `httpBackends.javaNetHttp` uses the JVM's own `java.ne
 `java.net.http` involved:
 
 ```scala
-import httpBackends.soundnessHttp
+locally:
+  import httpBackends.soundnessHttp
+  url"https://example.com/".fetch().status   // Http.Ok
 ```
 
 The native backend pools kept-alive HTTP/1.1 connections per origin, and negotiates by ALPN over
@@ -130,10 +141,10 @@ capture[Http.Error](url"https://example.com/missing".fetch().receive[Text]).stat
 ```
 
 A request that cannot connect at all — an unresolvable host, a refused connection, a TLS failure —
-raises a `ConnectError` naming the reason:
+raises a `Connect.Error` naming the reason:
 
 ```scala
-capture[ConnectError](url"http://no-such-host.invalid/".fetch()).reason   // ConnectError.Reason.Dns
+capture[Connect.Error](url"http://no-such-host.invalid/".fetch()).reason
 ```
 
 A TLS failure is distinguished from a network one, and its own reason says at which stage it

--- a/doc/modules/http-server.md
+++ b/doc/modules/http-server.md
@@ -9,7 +9,7 @@ raw-socket backend speaks modern HTTP/1.1 — keep-alive, pipelining, chunked bo
 `100-continue` and protocol upgrades — on a virtual thread per connection, and speaks HTTP/2 on
 any connection whose TLS handshake negotiates it.
 
-Above HTTP/1.1 sit the neighbouring protocols: [WebSockets](https://en.wikipedia.org/wiki/WebSocket)
+Above HTTP/1.1 sit the neighboring protocols: [WebSockets](https://en.wikipedia.org/wiki/WebSocket)
 upgrade a request into a message stream handled as a state machine, and HTTP/2 multiplexes many
 requests over one connection, for browsers and for the gRPC-style protocols that require it.
 
@@ -26,43 +26,55 @@ A Soundness handler is a block of code; everything else is values. Everything co
 
 ```scala
 import soundness.*
-import strategies.throwUnsafely
+
 import charEncoders.utf8Encoder
-import threading.virtualThreading
+import errorDiagnostics.stackTracesDiagnostics
+import formatting.compactJsonFormatting
+import logging.silentLogging
 import probates.awaitProbate
+import strategies.throwUnsafely
+import threading.virtualThreading
 import webserverErrorPages.minimalErrorPage
 ```
+
+A handler that states what it needs and what it may fail with is an [honest signature](../philosophy/honest-signatures.md), and the reason a server can be tested without a socket.
 
 ### A server
 
 `SocketServer` listens on a port and runs the handler for each request; the returned service stops
-the server when cancelled:
+the server when canceled:
 
 ```scala
-supervise:
+def hello(): Unit = supervise:
   val server = SocketServer(8080).handle:
     Http.Response(Http.Ok)(t"Hello, world!")
 ```
+
+The port is bound when `handle` is called, and the service runs on tasks of the enclosing
+`supervise`, so the block lasts as long as the server does.
 
 Within the handler, `request` is the current request — its method, target, headers, cookies and
 body — so routing is a `match`:
 
 ```scala
-SocketServer(8080).handle:
-  request.target match
-    case t"/"       => Http.Response(Http.Ok)(homePage)
-    case t"/status" => Http.Response(Http.Ok)(t"OK")
-    case _          => Http.Response(Http.NotFound)(t"No such page")
+val homePage = t"<h1>Welcome</h1>"
+
+def routed(): Unit = supervise:
+  SocketServer(8080).handle:
+    request.target match
+      case t"/"       => Http.Response(Http.Ok)(homePage)
+      case t"/status" => Http.Response(Http.Ok)(t"OK")
+      case _          => Http.Response(Http.NotFound)(t"No such page")
 ```
 
 ### Responses
 
 `Http.Response` takes a status, headers as named arguments, and a body of any type with a
 `Servable` instance — text, bytes, [HTML](html.md), [JSON](json.md) — which supplies the media
-type, so what is served and how it is labelled cannot disagree:
+type, so what is served and how it is labeled cannot disagree:
 
 ```scala
-Http.Response(Http.Ok, cacheControl = t"no-cache")(document)
+Http.Response(Http.Ok, cacheControl = t"no-cache")(t"""{"status": "ok"}""".read[Json])
 Http.Response(Http.Found, location = t"/elsewhere")()
 ```
 
@@ -79,10 +91,16 @@ Messages are typed — raw frames, text, or any type carried over JSON:
 ```scala
 case class Ping(value: Int)
 
-SocketServer(8080).handle:
-  webSocket(): (ping: Ping over Json) =>
-    Reply(Ping(ping.value + 1).over[Json], ())
+def pinger(): Unit = supervise:
+  SocketServer(8080).handle:
+    webSocket(): (ping: Ping over Json) =>
+      Control.Reply(Ping(ping.value + 1).over[Json], ())
 ```
+
+A handler answers with `Control.Reply` to send a message and carry on, `Control.Continue` to
+carry on silently, `Control.Conclude` to send a final message and close, or
+`Control.Terminate` to close at once. The handler's state, here `()`, is threaded from one
+message to the next.
 
 The implementation handles the protocol's sharp edges — masking, fragmentation, ping–pong,
 UTF-8 validation, close codes — and conforms to the
@@ -103,8 +121,8 @@ A TLS listening socket offers `h2` then `http/1.1` by ALPN, and a connection tha
 contract is unchanged, so an existing application serves HTTP/2 with no alteration:
 
 ```scala
-supervise:
-  SocketServer(8443, ssl = sslContext).handle:
+def secure(context: javax.net.ssl.SSLContext): Unit = supervise:
+  SocketServer(8443, ssl = context).handle:
     Http.Response(Http.Ok)(t"Hello over h2!")
 ```
 
@@ -114,6 +132,6 @@ one connection run concurrently. The engine implements flow control, trailers, a
 frame types it does not act on — `PRIORITY`, `PUSH_PROMISE`, extensions — rather than failing
 the connection.
 
-Cleartext h2c with prior knowledge — the flavour used between services — is spoken over an
+Cleartext h2c with prior knowledge — the flavor used between services — is spoken over an
 `Http2.Endpoint`, which is also an [HTTP client](http-client.md) transport, and carries the
 [gRPC](rpc.md) support built on top of it.

--- a/doc/modules/hyphenation.md
+++ b/doc/modules/hyphenation.md
@@ -29,6 +29,8 @@ import soundness.*
 import hyphenations.englishHyphenation
 ```
 
+Breaking text at the right points is a pure function of the language's patterns, and stays one — an instance of [immutability](../philosophy/immutability.md) in a domain that tempts stateful iteration.
+
 ### Hyphenating
 
 `hyphenate` inserts a hyphen character at each permissible break. The default is the Unicode
@@ -53,8 +55,8 @@ t"hyphenation".hyphenate(hyphen = '-', leftMin = 4)   // t"hyphen-ation"
 through as segments of their own:
 
 ```scala
-t"the algorithm".syllables.to(Seq)
-// Seq(t"the", t" ", t"al", t"go", t"rithm")
+t"the algorithm".syllables.to(List)
+// List(t"the", t" ", t"al", t"go", t"rithm")
 ```
 
 ### Break points
@@ -112,5 +114,5 @@ reassembling the segments reproduces the original text exactly.
 
 A language for which no pattern set has been loaded hyphenates nothing rather than guessing:
 `hyphenate` returns the text unchanged, and `breakPoints` is empty. A line-wrapping algorithm
-therefore degrades to breaking at spaces, which is the correct behaviour, rather than inventing
+therefore degrades to breaking at spaces, which is the correct behavior, rather than inventing
 breaks in a language whose rules it does not know.

--- a/doc/modules/images.md
+++ b/doc/modules/images.md
@@ -27,25 +27,32 @@ from the `soundness` package:
 
 ```scala
 import soundness.*
+import errorDiagnostics.stackTracesDiagnostics
 import strategies.throwUnsafely
 ```
 
+A raster whose format and color model are in its type follows [safety by construction](../philosophy/safety-by-construction.md): a conversion that cannot be done cannot be written.
+
 ### Reading
 
-A source of bytes reads as a raster of a named format:
+A source of bytes reads as a raster of a named format. These bytes are a complete PNG — a
+two-by-one image whose left pixel is red and right pixel blue — small enough to write down:
 
 ```scala
+val data = hex"""89504e470d0a1a0a0000000d49484452000000020000000108020000007b40e8dd
+                 0000000d4944415478da63f8cf0004ff01070001ff3d7d8c490000000049454e44ae426082"""
+
 val image = data.read[Raster in Png]
 
-image.width       // in pixels
-image.height
-image.landscape   // true when wider than tall
+image.width       // 2
+image.height      // 1
+image.landscape   // true
 ```
 
 Bytes that are not the named format raise a `Raster.Error` naming the format that failed:
 
 ```scala
-capture[Raster.Error](data.read[Raster in Jpeg])   // when data is a PNG
+capture[Raster.Error](data.read[Raster in Jpeg])   // the data is a PNG, not a JPEG
 ```
 
 ### Pixels
@@ -54,7 +61,8 @@ Applying an image to coordinates reads a pixel as a `Chroma` — a color with by
 connects the image to all the [color](colors.md) machinery:
 
 ```scala
-image(0, 0).red   // the red channel of the top-left pixel
+image(0, 0).red   // 255: the red channel of the left pixel
+image(1, 0).blue  // 255
 ```
 
 An image is also *built* from a pixel function, which is how test images and generated graphics

--- a/doc/modules/images.md
+++ b/doc/modules/images.md
@@ -42,10 +42,10 @@ image.height
 image.landscape   // true when wider than tall
 ```
 
-Bytes that are not the named format raise a `RasterError` naming the format that failed:
+Bytes that are not the named format raise a `Raster.Error` naming the format that failed:
 
 ```scala
-capture[RasterError](data.read[Raster in Jpeg])   // when data is a PNG
+capture[Raster.Error](data.read[Raster in Jpeg])   // when data is a PNG
 ```
 
 ### Pixels

--- a/doc/modules/internationalization.md
+++ b/doc/modules/internationalization.md
@@ -19,6 +19,8 @@ looked up by name at runtime. Nothing connects the keys in the code to the keys 
 a missing translation, a misspelled key, or a language file that lags behind the others all
 surface as runtime fallbacks — usually in front of the one user who chose that language.
 
+A locale as a type parameter, rather than a runtime string, means a missing translation is a compile error: [safety by construction](../philosophy/safety-by-construction.md).
+
 Soundness puts the translations in the code and the language set in the type. Each language is a
 value that lifts a translation into a single-language `Polyglot`, alternatives combine with `|`,
 and the combined type is the intersection of the languages provided. Code that requires a
@@ -60,7 +62,7 @@ it does not carry is a compile error.
 
 The user's language usually arrives at runtime — from an HTTP header, an environment variable, a
 setting. A language code decodes to a `Locale`, falling back to English for a code that is not
-recognised:
+recognized:
 
 ```scala
 val locale = t"fr".as[Locale[en & pl & fr & de & es]]

--- a/doc/modules/interpolation.md
+++ b/doc/modules/interpolation.md
@@ -59,8 +59,8 @@ idea — text becomes one argument, a list becomes several, and any type with th
 splices safely:
 
 ```scala
-given Insertion[Parameters, Text] = value => Parameters(value)
-given Insertion[Parameters, List[Text]] = xs => Parameters(xs*)
+given Insertion[Sh.Parameters, Text] = value => Sh.Parameters(value)
+given Insertion[Sh.Parameters, List[Text]] = xs => Sh.Parameters(xs*)
 ```
 
 Because insertion is a typeclass, a new type becomes substitutable by declaring one instance,
@@ -78,8 +78,12 @@ label, so the parser can proceed as though the hole contained a representative t
 substituted type — `"0"` for a number, `""""` for a string:
 
 ```scala
-given Substitution[SqlInput, Int, "0"] = IntInput(_)
-given Substitution[SqlInput, Text, "\"\""] = StrInput(_)
+enum SqlInput:
+  case IntInput(value: Int)
+  case StrInput(value: Text)
+
+given Substitution[SqlInput, Int, "0"] = SqlInput.IntInput(_)
+given Substitution[SqlInput, Text, "\"\""] = SqlInput.StrInput(_)
 ```
 
 The interpolator's compiletime interpretation of the literal can then depend on what was inserted,
@@ -105,8 +109,10 @@ plus separate runtime parser can make.
 `parts` is a tuple of the literal fragments as singleton string types, so the interpolator sees
 the text of each; `origins` carries where each fragment began in the source file, so an error
 reported against a character within a fragment resolves to that character's position in the file
-rather than to the start of the expression:
+rather than to the start of the expression. The media-type interpolator's instance, in outline,
+hands both to a macro:
 
+<!-- doccheck: skip -->
 ```scala
 inline given interpolable: MediaType is Interpolable:
   transparent inline def interpolate[parts <: Tuple, origins <: Tuple](inline insertions: Any*)
@@ -138,4 +144,4 @@ compiles, and the interpolator's machinery buys nothing over the runtime parser 
 
 The convention throughout is therefore to offer both — `url"…"` for a literal and `as[Url]` for
 text obtained at runtime — with the same code behind each, so a program can move a value from one
-to the other without a change in behaviour.
+to the other without a change in behavior.

--- a/doc/modules/json.md
+++ b/doc/modules/json.md
@@ -21,7 +21,7 @@ that remembers what it is. Converting a `Json` to a Scala value, or a Scala valu
 `Json`, is done by an encoder or decoder that the compiler derives from the type's
 own shape — a case class becomes an object, an enumeration becomes a tagged union —
 so there is nothing to write and nothing to keep in step by hand. When a conversion
-cannot be made, it raises a `JsonError` that names the reason and, where it can, the
+cannot be made, it raises a `Json.Error` that names the reason and, where it can, the
 position in the source.
 
 The same derivation produces a schema, and from a schema two further guarantees
@@ -190,7 +190,7 @@ given Shape is Discriminable in Json = Json.DiscriminantEnvelope(t"type", t"valu
 Each works both through the tree and through [direct parsing](#case-classes-and-enumerations),
 and direct parsing does not require the tag to come first: a document whose `type` field trails
 its `value` reads just as one whose tag leads. A wrapper object with more than one key is not a
-valid variant, and raises `JsonError.Reason.Absent` rather than guessing which key was meant.
+valid variant, and raises `Json.Error.Reason.Absent` rather than guessing which key was meant.
 
 Anything more exotic is a `Discriminable` written by hand — three methods saying how to attach a
 tag, how to read one, and how to reach the variant — and codecs derived from it work unchanged.
@@ -323,16 +323,16 @@ List(1, 2, 3).in[Json].show   // pretty-printed across several lines
 
 ### Errors
 
-A conversion that cannot be made raises a `JsonError` whose reason says what went
+A conversion that cannot be made raises a `Json.Error` whose reason says what went
 wrong: a value of the wrong type, a required field that is absent, or a number
 outside the target's range. The reason can be inspected:
 
 ```scala
-capture[JsonError](t""""abc"""".read[Json].as[Int]).reason
-// JsonError.Reason.NotType(JsonPrimitive.String, JsonPrimitive.Number)
+capture[Json.Error](t""""abc"""".read[Json].as[Int]).reason
+// Json.Error.Reason.NotType(Json.Primitive.String, Json.Primitive.Number)
 
-capture[JsonError](t"""{}""".read[Json].as[Person]).reason
-// JsonError.Reason.Absent
+capture[Json.Error](t"""{}""".read[Json].as[Person]).reason
+// Json.Error.Reason.Absent
 ```
 
 When decoding runs under an accruing error strategy, the errors are collected rather
@@ -346,9 +346,9 @@ two places yields four errors, pointed at `#/person/age`, `#/person/email` and s
 tree's faults in one pass, each locatable, rather than the first fault and nothing else:
 
 ```scala
-Validate[Issues, [r] =>> r raises JsonError, Json.Focus]
+Validate[Issues, [r] =>> r raises Json.Error, Json.Focus]
   ( Issues(),
-    { case error: JsonError => accrual + (prior.let(_.pointer.encode).or(t"#"), error) } )
+    { case error: Json.Error => accrual + (prior.let(_.pointer.encode).or(t"#"), error) } )
 . protect(document.as[Contact])
 ```
 
@@ -370,7 +370,7 @@ predicates for each kind and a `primitive` naming it:
 
 ```scala
 Json.unseal(t"42".read[Json]).isLong          // true
-Json.unseal(t""""x"""".read[Json]).primitive  // JsonPrimitive.String
+Json.unseal(t""""x"""".read[Json]).primitive  // Json.Primitive.String
 ```
 
 The predicates are finer than the primitives: `isLong` and `isDouble` distinguish the two
@@ -474,7 +474,7 @@ and string formats such as `date-time` and `email` are represented by
 
 A document is checked against the shape a type expects with `verify`. On success it
 returns the same document, now carrying that type, ready to decode or to navigate; on
-failure it raises a `JsonError`:
+failure it raises a `Json.Error`:
 
 ```scala
 case class Employee(name: Text, age: Int, email: Text)
@@ -566,7 +566,7 @@ record.children.head.weight  // a Double, per the schema
 ```
 
 Constraints in the schema are enforced as the values are read: a value failing a
-`pattern` raises a `JsonBlueprintError`, and a number outside a declared `minimum` and
+`pattern` raises a `JsonBlueprint.Error`, and a number outside a declared `minimum` and
 `maximum` raises a bounds error. The shape of the data is taken from the schema and
 checked by the compiler, without a Scala type mirroring it.
 

--- a/doc/modules/json.md
+++ b/doc/modules/json.md
@@ -30,15 +30,18 @@ of a verified document can be read with the compiler rejecting any path the sche
 does not allow. The sections below start with parsing and the everyday conversions,
 then build toward schemas, validation, and the integrations with other types.
 
+A JSON value is immutable and every operation on it returns a new one, in keeping with [immutability](../philosophy/immutability.md).
+
 These examples assume a few imports — the package, an error strategy, a text
 encoding, and a choice of output formatting:
 
 ```scala
 import soundness.*
 
-import strategies.throwUnsafely
 import charEncoders.utf8Encoder
+import errorDiagnostics.stackTracesDiagnostics
 import formatting.compactJsonFormatting
+import strategies.throwUnsafely
 ```
 
 ### Parsing
@@ -102,9 +105,11 @@ fields are taken from the token stream as they arrive, so no `Json` tree is ever
 saved is the whole intermediate structure — allocation, boxing, and a second traversal:
 
 ```scala
-object Person:
-  given parsable: Person is Json.Parsable = Json.Parsable.derived
+given Person is Json.Parsable = Json.Parsable.derived
 ```
+
+The instance belongs in the type's companion object in ordinary code, where it is found without
+an import.
 
 The tree route remains for documents whose shape is not known in advance, or where the tree is
 itself the point.
@@ -346,10 +351,20 @@ two places yields four errors, pointed at `#/person/age`, `#/person/email` and s
 tree's faults in one pass, each locatable, rather than the first fault and nothing else:
 
 ```scala
+case class Address(street: Text, postcode: Text)
+case class Contact(person: Person, address: Address)
+
+case class Issues(items: List[(Text, Json.Error)] = Nil)(using Diagnostics)
+extends Error(m"${items.size} problems"):
+  def +(pointer: Text, error: Json.Error): Issues = Issues(items :+ (pointer, error))
+
+val damaged = t"""{"person": {"name": 1}, "address": {"street": 2}}""".read[Json]
+
 Validate[Issues, [r] =>> r raises Json.Error, Json.Focus]
   ( Issues(),
     { case error: Json.Error => accrual + (prior.let(_.pointer.encode).or(t"#"), error) } )
-. protect(document.as[Contact])
+. protect(damaged.as[Contact])
+. items.map(_(0))   // List(t"#/person/name", t"#/person/age", t"#/address/street", t"#/address/postcode")
 ```
 
 Missing and wrong-typed fields accrue together, and a field that is absent contributes exactly
@@ -507,8 +522,15 @@ alice.verify[Employee].name.deeper     // does not compile: a scalar has no fiel
 Navigation runs to any depth, through nested objects and into arrays, with each step checked:
 
 ```scala
-posting.verify[Posting].workplace.city.as[Text]
-squad.verify[Squad].members(1).name.as[Text]
+case class Workplace(city: Text)
+case class Posting(title: Text, workplace: Workplace)
+case class Squad(members: List[Person])
+
+val posting = t"""{"title": "Engineer", "workplace": {"city": "Tallinn"}}""".read[Json]
+val squad = t"""{"members": [{"name": "Ada", "age": 36}, {"name": "Bob", "age": 41}]}""".read[Json]
+
+posting.verify[Posting].workplace.city.as[Text]   // t"Tallinn"
+squad.verify[Squad].members(1).name.as[Text]      // t"Bob"
 ```
 
 Verified navigation needs no `dynamicJsonAccess` import — the schema, not a blanket enabler, is
@@ -526,13 +548,16 @@ awkward field calls for. A `Specific` names the path instead, so an override app
 spine and nowhere else:
 
 ```scala
+case class Staffer(name: Text, age: Int)
+case class Firm(boss: Staffer, deputy: Staffer)
+
 val shout: Text is Json.Encodable = Json.Encodable(() => Morphology.Str): text => Json(text.upper)
 
 given (Firm is Specific over Json.Encodable) =
   specifically:
     case root.deputy.name() => shout
 
-Firm(Worker(t"ann", 30), Worker(t"bob", 40)).in[Json].show
+Firm(Staffer(t"ann", 30), Staffer(t"bob", 40)).in[Json].show
 // t"""{"boss":{"name":"ann","age":30},"deputy":{"name":"BOB","age":40}}"""
 ```
 
@@ -542,11 +567,14 @@ elements — the way to change how the members of one list are written without c
 everywhere:
 
 ```scala
+val nameOnly: Person is Json.Encodable =
+  Json.Encodable(() => Morphology.Str): person => Json(person.name)
+
 given (Crew is Specific over Json.Encodable) =
   specifically:
-    case root.members() =>
-      given Worker is Json.Encodable = nameOnly
-      summon[List[Worker] is Json.Encodable]
+    case root.rowers() =>
+      given Person is Json.Encodable = nameOnly
+      summon[List[Person] is Json.Encodable]
 ```
 
 ### Typed records from a schema
@@ -559,10 +587,26 @@ schema declares — a string as `Text`, a number as `Double`, a `format: "email"
 as an `EmailAddress`, a `pattern` field as a `Regex` — and a field the schema does not
 describe is a compile error:
 
+<!-- doccheck: skip -->
 ```scala
+object Catalogue extends JsonBlueprint(t"""{
+  "type": "object",
+  "required": ["name", "children"],
+  "properties": {
+    "name": { "type": "string" },
+    "email": { "type": "string", "format": "email" },
+    "children": {
+      "type": "array",
+      "items": { "weight": { "type": "number", "minimum": 0 } }
+    }
+  }
+}""".read[Json].as[JsonBlueprint.Doc])
+
+val input = t"""{"name": "Bicycle", "children": [{"weight": 9.5}]}""".read[Json]
+
 val record = Catalogue.record(input)
-record.name                  // a Text,   per the schema
-record.children.head.weight  // a Double, per the schema
+record.name                       // t"Bicycle", a Text per the schema
+record.children.prim.let(_.weight)   // 9.5, a Double per the schema
 ```
 
 Constraints in the schema are enforced as the values are read: a value failing a

--- a/doc/modules/library-archives.md
+++ b/doc/modules/library-archives.md
@@ -31,6 +31,8 @@ container, so there is nothing for a naming convention to get wrong. Everything 
 import soundness.*
 ```
 
+An identity computed from the API itself, rather than declared, is [correctness](../philosophy/correctness.md) applied to versioning.
+
 ### Atoms and API identity
 
 The unit of API identity is an *atom*: one externally-visible feature of a library, reduced by a
@@ -42,6 +44,10 @@ classes:
   changed. Breaking one breaks a compiled consumer.
 - A **replaceable** atom may be replaced — same key, new value — within a minor release. A
   consumer compiled against the old value is behaviourally stale but not broken.
+
+The atoms are computed from the compiled library itself, not declared: the TASTy files of a
+release are unpickled against their dependency classpath and every externally-visible feature is
+reduced to its atom, so the API identity is what the compiler sees and nothing else.
 
 A release's *snapshot* is the hash of its complete, sorted atom set: its API identity as a single
 value. Because atom hashes are domain-separated by discipline, the snapshot is well-defined even
@@ -106,7 +112,7 @@ derivative that varied with the tool that built it could not be identified by ha
 A discipline is the language-specific half: it reads a compiled artifact and emits its atoms.
 `OpaqueDiscipline` treats content as an opaque blob with no API surface, which is right for
 resources; `ResourceDiscipline` and `CapabilityDiscipline` handle the other content the format
-recognises; and a language canonicalizer — TASTy, for Scala — plugs in through the same interface.
+recognizes; and a language canonicalizer — TASTy, for Scala — plugs in through the same interface.
 The core deals only in atoms, so it needs to know nothing about any language.
 
 One consequence shapes the interface: a replaceable atom's content may refer to something in

--- a/doc/modules/llm.md
+++ b/doc/modules/llm.md
@@ -1,0 +1,214 @@
+## Language Models
+
+### About
+
+A conversation with a large language model is typed at every step: the provider and model are
+values, a conversation is a *session* that accumulates its history and token usage, a reply is a
+value that says why the model stopped, streamed output is pulled off the live connection, tools
+are ordinary Scala methods the model may call, and a structured answer is decoded to a case
+class against a schema derived from it. One vocabulary serves Anthropic's Messages API, OpenAI's
+Chat Completions and Responses APIs — and any server compatible with the former, such as vLLM,
+Ollama or Groq — and Google's Gemini.
+
+### On language models
+
+Each provider's API is a JSON dialect: a request with the model, the messages so far and a
+handful of tuning knobs; a reply with content blocks, a stop reason and token counts; a streaming
+variant that sends deltas; and a tool-calling protocol that returns arguments as JSON for the
+program to act on and report back. The dialects differ in every detail and agree in every
+concept, and the concepts are what a program cares about.
+
+Soundness models the concepts once — messages, replies, usage, tools, stop reasons — and
+translates them onto each wire in a per-provider *dialect*. A conversation is a session
+confined to a block by [capture checking](../philosophy/capture-checking.md): the pure values it
+produces leave freely, while the session itself and any stream in flight cannot, so a connection
+cannot be held open by accident. Everything comes from the `soundness` package, with the HTTP
+backend, network access and logging a client needs:
+
+```scala
+import soundness.*
+import httpBackends.javaNetHttp
+import internetAccess.online
+import logging.silentLogging
+import strategies.throwUnsafely
+import charEncoders.utf8Encoder
+```
+
+### Providers and models
+
+A provider value names the model and carries the API key, and its tuning is applied by methods
+that each return a new value, so a configured model is a plain immutable value that can be
+shared and reused:
+
+```scala
+val key = t"sk-ant-…"
+
+val claude = Anthropic(t"claude-sonnet-4-5", key).prompted(t"Be terse.").limit(1024)
+val gpt = OpenAI(t"gpt-5", t"sk-…").warmth(0.2)
+val gemini = Gemini(t"gemini-2.5-pro", t"AIza…")
+val local = OpenAI.compatible(url"http://localhost:11434/v1", t"llama3")
+```
+
+`prompted` sets the system prompt, `limit` the maximum output tokens, `warmth` the temperature,
+`sampling` the nucleus threshold, `stopping` the stop sequences, `iterating` the tool-loop limit,
+`primed` a history to start from, and `on` an alternative base URL. A knob left unset is omitted
+from the request rather than sent as a default, so the provider's own defaults apply. An
+OpenAI-compatible server takes an optional key, and OpenAI's Responses API is reached from an
+`OpenAI` value with `responses`.
+
+### A conversation
+
+A session is opened on a provider with `session`, and inside the block the `llm` accessor reaches
+it. `ask` sends a message and returns the model's `Reply`; the session records both, so a second
+`ask` continues the conversation:
+
+<!-- doccheck: skip -->
+```scala
+val reply: Llm.Reply = claude.session:
+  llm.ask(t"What is the tallest mountain in Estonia?")
+  llm.ask(t"And how tall is it?")
+
+reply.text    // the assistant's answer, as text
+reply.stop    // Llm.Stop.Ended, or why the model stopped
+reply.usage   // Llm.Usage(input, output, …): the tokens the last turn cost
+```
+
+A `Reply` is pure data — its message, its stop reason, its usage, and the model and identifier
+the provider reported — so it may leave the block, as may a snapshot of `llm.history` or the
+folded `llm.usage`. The session itself may not: returning it, or anything that captures it, is a
+compile error, which is what makes it impossible to use a session after its block has closed
+the connection.
+
+### Streaming
+
+`stream` sends a message and returns a `Response` whose `text` is an iterator of fragments,
+pulled synchronously off the connection as they arrive, and whose `events` are the finer-grained
+deltas. When the stream has been consumed, `reply()` assembles the complete reply — even after
+partial consumption, since the remainder is read on demand — and commits the turn to the
+history. A stream that is abandoned commits nothing, so a failed turn is simply retried:
+
+<!-- doccheck: skip -->
+```scala
+claude.session:
+  val response = llm.stream(t"Write a limerick about Tallinn.")
+  response.text.each(Out.print(_))
+  response.reply()
+```
+
+The response, like the session, is confined to the block.
+
+### Tools
+
+A tool is a method annotated `@ability`, described with `@about`, on an object that a `Toolkit`
+is built from. The JSON schema for each tool's parameters is derived from the method's parameter
+types, so the model is told exactly what the method accepts, and a contextual parameter the
+method needs is summoned where the toolkit is constructed rather than exposed to the model:
+
+```scala
+object Broker:
+  val quotes = Map(t"AAPL" -> 189.3, t"MSFT" -> 412.7)
+
+  @ability
+  @about(t"Look up the current price of a stock ticker")
+  def price(ticker: Text): Double = quotes.at(ticker).or(0.0)
+
+val broker = Toolkit(Broker)
+broker.specs.map(_.name)   // List(t"price")
+```
+
+With a `Toolkit` given in scope, `ask` runs the whole loop: it offers the tools to the model, runs
+the tool the model calls, reports the result, and continues until the model answers in text or
+the iteration limit is reached. A tool that fails, or a call with malformed arguments, is
+reported to the model as an error result it can recover from, rather than aborting the
+conversation:
+
+<!-- doccheck: skip -->
+```scala
+claude.session:
+  given Toolkit = broker
+  llm.ask(t"Compare AAPL and MSFT.")   // calls price twice, then answers
+```
+
+Every turn the loop makes is committed to the history, so the record shows the calls the model
+made and what it was told. A loop that does not converge raises `Llm.Error` with the reason
+`ToolLoopExceeded`, at the limit set by `iterating`. The `@about` annotation is shared with the
+[MCP](mcp.md) integration, so one description serves a method exposed both as an MCP tool and
+as a model ability.
+
+### Structured answers
+
+`elicit` asks for an answer of a given type. The type's JSON schema is derived and presented to
+the model as the one tool it must call, and the arguments it supplies are decoded to the type —
+so the result is a value, not text to be parsed, on every provider, including local servers that
+have no native structured-output mode:
+
+```scala
+case class Verdict(ticker: Text, rating: Text, confidence: Double)
+```
+
+<!-- doccheck: skip -->
+```scala
+local.session:
+  llm.elicit[Verdict](t"Summarize your recommendation for AAPL.")
+```
+
+A reply that ignores the forced tool, or arguments that do not decode, raise `Llm.Error` with
+the reason `Malformed`, so a malformed answer is an error to handle rather than a value that
+looks right.
+
+### Messages and content
+
+The vocabulary the dialects share is small. A `Llm.Message` has a `Role` — user or assistant —
+and a list of `Llm.Content`: text, an image or document from inline bytes or a URL, a tool call
+with its arguments, a tool result, the model's thinking where the provider exposes it, and an
+`Opaque` block preserving verbatim any content a provider sends that is not otherwise modeled,
+so nothing is lost in translation:
+
+```scala
+val question = Llm.Message(Llm.Role.User, t"How many bones are in the human hand?")
+
+val illustrated = Llm.Message
+  ( Llm.Role.User,
+    List
+      ( Llm.Content.Textual(t"What is in this picture?"),
+        Llm.Content.Graphic(Llm.Content.Source.Remote(url"https://example.com/hand.png")) ) )
+```
+
+`ask` and `stream` accept a message as readily as text, which is how images and documents are
+sent.
+
+### Errors and retries
+
+Every failure is a `Llm.Error` whose reason is one of a fixed set — `Unreachable`,
+`Unauthorized`, `Invalid`, `NotFound`, `TooLarge`, `RateLimited`, `Overloaded`, `Malformed`,
+`Interrupted`, `ToolLoopExceeded` — or `Provider`, carrying a code the provider reported that
+maps to none of them, so the wire's own error is never lost. A rate limit or an overload is
+retried automatically, honoring the delay the provider asks for, before it is raised:
+
+<!-- doccheck: skip -->
+```scala
+recover:
+  case Llm.Error(Llm.Error.Reason.Unauthorized, detail) => Out.println(t"check the API key")
+  case Llm.Error(Llm.Error.Reason.TooLarge, detail)     => Out.println(t"shorten the conversation")
+. protect:
+    claude.session(llm.ask(t"Hello"))
+```
+
+### Counting tokens
+
+Anthropic reports the token count of a prospective conversation without running it, which is
+how a program decides whether a document fits before sending it:
+
+<!-- doccheck: skip -->
+```scala
+claude.countTokens(List(question), system = t"Be terse.")   // the input tokens it would cost
+```
+
+### Testing without a provider
+
+Because every provider is a dialect over an HTTP backend, a program that talks to a model is
+tested by substituting the backend with one that returns scripted responses, and the dialect
+tests in the library do exactly that: seventy-odd offline tests replay recorded replies, streamed
+deltas and error envelopes through each dialect, and prove with compile-time checks that a
+session or a live stream cannot escape its block. A program built on the same vocabulary inherits
+that testability: the model is a value, and a value can be faked.

--- a/doc/modules/logging.md
+++ b/doc/modules/logging.md
@@ -57,7 +57,7 @@ supervise:
   // logging within here is written to standard output
 ```
 
-Narrowing the first parameter filters by kind: a `Logger[HttpEvent, Message]` receives
+Narrowing the first parameter filters by kind: a `Logger[Http.Event, Message]` receives
 HTTP events and nothing else, so the events of one library can be routed or silenced
 independently of the rest.
 
@@ -104,15 +104,15 @@ A level reflects frequency and severity together:
 A method opts into logging by naming its event type in its return type with `logs`:
 
 ```scala
-def fetch(url: HttpUrl): HttpResponse logs HttpEvent = ...
+def fetch(url: HttpUrl): Http.Response logs Http.Event = ...
 ```
 
 The requirement propagates: a method that calls `fetch` must itself admit
-`HttpEvent`, either by declaring it or by having a logger for it in scope. A method
+`Http.Event`, either by declaring it or by having a logger for it in scope. A method
 that logs more than one kind of event chains the declarations:
 
 ```scala
-def stop(server: Server): Unit logs HttpEvent logs ExecEvent = ...
+def stop(server: Server): Unit logs Http.Event logs Exec.Event = ...
 ```
 
 ### Event types
@@ -123,13 +123,13 @@ message. Keeping the values typed — rather than pre-formatting them — lets e
 render them its own way:
 
 ```scala
-object ExecEvent:
-  given (ExecEvent is Communicable) =
+object Exec.Event:
+  given (Exec.Event is Communicable) =
     case ProcessStart(command)   => m"starting process $command"
     case AbortProcess(pid)       => m"the process with PID $pid was aborted"
     case KillProcess(pid)        => m"killed process with PID $pid"
 
-enum ExecEvent:
+enum Exec.Event:
   case ProcessStart(command: Command)
   case AbortProcess(pid: Pid)
   case KillProcess(pid: Pid)
@@ -138,7 +138,7 @@ enum ExecEvent:
 The event is then logged by value, at the point the side effect happens:
 
 ```scala
-Log.info(ExecEvent.ProcessStart(command))
+Log.info(Exec.Event.ProcessStart(command))
 ```
 
 A module that builds on another's work reuses its events rather than duplicating
@@ -146,7 +146,7 @@ them. Transcribing one event into a case of another threads the wrapped event th
 unchanged — so a module that shells out reuses the process events of the shell:
 
 ```scala
-given (GitEvent transcribes ExecEvent) = GitEvent.Exec(_)
+given (Git.Event transcribes Exec.Event) = Git.Event.Exec(_)
 ```
 
 ### Cost when disabled
@@ -186,8 +186,8 @@ A single block can be logged with everything suppressed, regardless of the logge
 scope, with `mute`:
 
 ```scala
-mute[ExecEvent]:
-  // ExecEvent logging is suppressed here
+mute[Exec.Event]:
+  // Exec.Event logging is suppressed here
 ```
 
 Importing `logging.silentLogging` suppresses all logging for a whole file, which is

--- a/doc/modules/logging.md
+++ b/doc/modules/logging.md
@@ -2,217 +2,245 @@
 
 ### About
 
-Soundness provides typesafe logging. A method that logs declares as much in its return
-type, with the `logs` infix type, and emits a value of a typed event rather than a
-string: instead of returning `Int` we would return `Int logs SomeEvent`. A logger placed in the caller's scope receives those events and writes them
-somewhere — a terminal, a file, the system log. With no logger in scope, logging is
-silent and costs nothing, so declaring that a method logs imposes no obligation on the
-code that calls it. A `logs` clause is an
-[honest signature](../philosophy/honest-signatures.md) at work: it states what the method
-actually emits, so a caller knows what there is to route.
+Logging is typesafe. A method that logs declares as much in its return type, with the `logs`
+infix type, and emits a value of a typed event rather than a string: instead of returning `Int`
+it returns `Long logs Backup.Event`, for the event type defined below. A logger placed in the caller's scope receives those events and
+writes them somewhere — a terminal, a file, the system log. With no logger in scope, logging is
+silent and costs nothing, so declaring that a method logs imposes no obligation on the code
+that calls it. A `logs` clause is an [honest signature](../philosophy/honest-signatures.md) at
+work: it states what the method actually emits, so a caller knows what there is to route.
 
-Because a logger is an ordinary contextual value, several can be in scope at once, and
-every event fans out to each of them. Each logger determines its own severity threshold, its
-own rendering and its own destination. The decision of where logs go, and at what detail, belongs to the
-application, not to the libraries it uses. Choosing that by what is in scope is
+Because a logger is an ordinary contextual value, several can be in scope at once, and every
+event fans out to each of them. Each logger determines its own severity threshold, its own
+rendering and its own destination. The decision of where logs go, and at what detail, belongs to
+the application, not to the libraries it uses. Choosing that by what is in scope is
 [declarative context](../philosophy/declarative-context.md).
 
 ### On logging
 
-Most logging is typed as strings, and is always on. A log statement formats a message
-eagerly, whether or not anything will read it, and the cost — building the string,
-evaluating its interpolations — is paid even when the level is disabled, so careful
-code guards every statement with a level check. The message itself is an opaque
-string, so a sink cannot reformat it, filter on its contents, or redact a field it did
-not know was there.
+Most logging is typed as strings, and is always on. A log statement formats a message eagerly,
+whether or not anything will read it, and the cost — building the string, evaluating its
+interpolations — is paid even when the level is disabled, so careful code guards every statement
+with a level check. The message itself is an opaque string, so a sink cannot reformat it, filter
+on its contents, or redact a field it did not know was there.
 
-Soundness separates the three concerns. A method states _that_ it logs, and _what_ it
-logs, in its type; the event it emits carries typed fields, not formatted text;
-and _where_ the event goes, and _how_ it renders, is decided by the loggers in scope.
-The argument to a log call is passed by name and forced only if some sink will record
-it, so a disabled statement evaluates nothing — log calls can be written freely,
-without guards. When no logger is in scope at all, the machinery compiles away to
-nothing.
+Soundness separates the three concerns. A method states _that_ it logs, and _what_ it logs, in
+its type; the event it emits carries typed fields, not formatted text; and _where_ the event
+goes, and _how_ it renders, is decided by the loggers in scope. The argument to a log call is
+passed by name and forced only if some sink will record it, so a disabled statement evaluates
+nothing — log calls can be written freely, without guards. When no logger is in scope at all,
+the machinery compiles away to nothing.
 
-The names come from the `soundness` package. A logging program also needs a rendering
-format and the concurrency context a logger writes under:
+The names come from the `soundness` package. A logging program also needs a rendering format,
+somewhere to write, and the concurrency context a logger writes under:
 
 ```scala
 import soundness.*
+
 import logFormats.timestampedLogFormat
-import probates.cancelProbate
+import probates.awaitProbate
+import stdios.javaLangSystemStdio
+import strategies.throwUnsafely
 import threading.virtualThreading
 ```
 
 ### Setting up a logger
 
-A `Logger` writes events to a destination. Placing one in scope as a given makes it
-the sink for everything logged within that scope. Its two type parameters say which
-events it accepts — `Any` for all of them — and the form they are rendered through. A
-logger writing to standard output is enough to see log output:
+A `Logger` writes events to a destination. Placing one in scope as a given makes it the sink for
+everything logged within that scope. Its two type parameters say which events it accepts — `Any`
+for all of them — and the form they are rendered through. A logger writing to standard output is
+enough to see log output:
 
+<!-- doccheck: skip -->
 ```scala
 supervise:
   given Logger[Any, Message] = Logger(Out)
-  // logging within here is written to standard output
+  Log.info(m"the logger is in scope")   // written to standard output, with a timestamp
 ```
 
-Narrowing the first parameter filters by kind: a `Logger[Http.Event, Message]` receives
-HTTP events and nothing else, so the events of one library can be routed or silenced
-independently of the rest.
+Narrowing the first parameter filters by kind: a `Logger[Http.Event, Message]` receives HTTP
+events and nothing else, so the events of one library can be routed or silenced independently of
+the rest.
 
-`Logger` runs its writes on a background thread, so it needs the ambient concurrency
-context that `supervise` provides. The format in scope — here `timestampedLogFormat`,
-which prefixes each line with a timestamp and level — decides how an event renders to
-text; `untimestampedLogFormat` omits the timestamp.
+`Logger` runs its writes on a background thread, so it needs the ambient concurrency context that
+`supervise` provides. The format in scope — here `timestampedLogFormat`, which prefixes each line
+with a timestamp and level — decides how an event renders to text; `untimestampedLogFormat`
+omits the timestamp, and `ansiTimestampedLogFormat` colors the level for a terminal.
 
 A threshold drops everything below a chosen level:
 
+<!-- doccheck: skip -->
 ```scala
-given Logger[Any, Message] = Logger(Out, level = Level.Warn)
+supervise:
+  given Logger[Any, Message] = Logger(Out, level = Level.Warn)
+  Log.info(m"not written")
+  Log.warn(m"written")
 ```
 
 ### Logging a message
 
-The simplest thing to log is a message, written with the `m"…"` interpolator, and this
-suits application code, where the author controls both the logging and the reading. A
-library should instead define a dedicated event type — described below — so its events
-stay structured and filterable. Four methods log a message at a given level:
+The simplest thing to log is a message, written with the `m"…"` interpolator, and this suits
+application code, where the author controls both the logging and the reading. A library should
+instead define a dedicated event type — described below — so its events stay structured and
+filterable. Four methods log a message at a given level:
 
 ```scala
-Log.fine(m"starting...")
-Log.info(m"connected to $remote")
-Log.warn(m"retrying after timeout")
-Log.fail(m"could not open $path")
+def report(remote: Text, path: Text): Unit =
+  Log.fine(m"starting...")
+  Log.info(m"connected to $remote")
+  Log.warn(m"retrying after timeout")
+  Log.fail(m"could not open $path")
 ```
+
+Without a logger in scope, `report` compiles and logs nothing: a message is `Loggable` by
+default, so a method that logs only messages needs no declaration.
 
 ### Levels
 
 A level reflects frequency and severity together:
 
-- **`Fine`** — high-frequency, per-unit detail useful only while debugging: each frame,
-  each packet, each file opened. Normally switched off, so it can be verbose.
+- **`Fine`** — high-frequency, per-unit detail useful only while debugging: each frame, each
+  packet, each file opened. Normally switched off, so it can be verbose.
 - **`Info`** — one line per significant operation or lifecycle milestone: a connection
   established, a server now listening, a download finished.
-- **`Warn`** — a recoverable or unexpected-but-handled condition: a forced kill, a
-  connection reset, a fallback taken.
-- **`Fail`** — an operation that failed unrecoverably, emitted alongside the error
-  being raised. Used sparingly.
-
-### Declaring that a method logs
-
-A method opts into logging by naming its event type in its return type with `logs`:
-
-```scala
-def fetch(url: HttpUrl): Http.Response logs Http.Event = ...
-```
-
-The requirement propagates: a method that calls `fetch` must itself admit
-`Http.Event`, either by declaring it or by having a logger for it in scope. A method
-that logs more than one kind of event chains the declarations:
-
-```scala
-def stop(server: Server): Unit logs Http.Event logs Exec.Event = ...
-```
+- **`Warn`** — a recoverable or unexpected-but-handled condition: a forced kill, a connection
+  reset, a fallback taken.
+- **`Fail`** — an operation that failed unrecoverably, emitted alongside the error being raised.
+  Used sparingly.
 
 ### Event types
 
-An event is an enumeration whose cases carry the relevant values as typed fields,
-paired with a `Communicable` instance in its companion that maps each case to a
-message. Keeping the values typed — rather than pre-formatting them — lets each sink
-render them its own way:
+An event is an enumeration whose cases carry the relevant values as typed fields, paired with a
+`Communicable` instance in its companion that maps each case to a message. Keeping the values
+typed — rather than pre-formatting them — lets each sink render them its own way:
 
 ```scala
-object Exec.Event:
-  given (Exec.Event is Communicable) =
-    case ProcessStart(command)   => m"starting process $command"
-    case AbortProcess(pid)       => m"the process with PID $pid was aborted"
-    case KillProcess(pid)        => m"killed process with PID $pid"
+object Backup:
+  enum Event:
+    case Started(source: Text)
+    case Copied(source: Text, bytes: Long)
+    case Failed(source: Text)
 
-enum Exec.Event:
-  case ProcessStart(command: Command)
-  case AbortProcess(pid: Pid)
-  case KillProcess(pid: Pid)
+  object Event:
+    given Event is Communicable =
+      case Started(source)       => m"backing up $source"
+      case Copied(source, bytes) => m"copied $source ($bytes bytes)"
+      case Failed(source)        => m"could not back up $source"
 ```
 
-The event is then logged by value, at the point the side effect happens:
+### Declaring that a method logs
+
+A method opts into logging by naming its event type in its return type with `logs`, and then
+logs the event by value, at the point the side effect happens:
 
 ```scala
-Log.info(Exec.Event.ProcessStart(command))
+def backup(source: Text): Long logs Backup.Event =
+  Log.info(Backup.Event.Started(source))
+  val bytes = source.length.toLong
+  Log.info(Backup.Event.Copied(source, bytes))
+  bytes
 ```
 
-A module that builds on another's work reuses its events rather than duplicating
-them. Transcribing one event into a case of another threads the wrapped event through
-unchanged — so a module that shells out reuses the process events of the shell:
+The requirement propagates: a method that calls `backup` must itself admit `Backup.Event`,
+either by declaring it or by having a logger for it in scope. A method that logs more than one
+kind of event chains the declarations, `Unit logs Http.Event logs Exec.Event`.
+
+A module that builds on another's work reuses its events rather than duplicating them.
+Transcribing one event into a case of another threads the wrapped event through unchanged — so
+a module that schedules backups reuses the backup events:
 
 ```scala
-given (Git.Event transcribes Exec.Event) = Git.Event.Exec(_)
+enum Schedule:
+  case Ran(event: Backup.Event)
+  case Skipped(reason: Text)
+
+object Schedule:
+  given Schedule is Communicable =
+    case Ran(event)       => m"scheduled: ${event.communicate}"
+    case Skipped(reason)  => m"skipped: $reason"
+
+given (Schedule transcribes Backup.Event) = Schedule.Ran(_)
+
+def nightly(): Unit logs Schedule =
+  backup(t"/home")
+  Log.info(Schedule.Skipped(t"nothing else to do"))
 ```
+
+With the transcription in scope, `backup`'s events are accepted by `nightly`'s declaration,
+wrapped as `Schedule.Ran`, and a logger for `Schedule` sees both.
 
 ### Cost when disabled
 
-The argument to every `Log` method is taken by name, and the level is checked before
-the argument is forced. When no logger accepts an event at its level — including when
-no logger is in scope at all — the event is never constructed and its fields are never
-evaluated. A disabled log statement therefore costs nothing, and log calls need no
-guard.
+The argument to every `Log` method is taken by name, and the level is checked before the
+argument is forced. When no logger accepts an event at its level — including when no logger is in
+scope at all — the event is never constructed and its fields are never evaluated. A disabled log
+statement therefore costs nothing, and log calls need no guard.
 
-This is why an event should carry its original typed values and leave formatting to
-its `Communicable`: the rendering happens only if the event is actually recorded.
-The exception is a value whose rendering depends on context available only at the call
-site, which should be rendered there, into the event:
-
-```scala
-Log.info(Io.Event.Move(source.show, destination.show))
-```
-
-The `show` still runs only when the event is logged, because the argument is by name.
+This is why an event should carry its original typed values and leave formatting to its
+`Communicable`: the rendering happens only if the event is actually recorded. The exception is
+a value whose rendering depends on context available only at the call site, which should be
+rendered there, into the event — and the rendering still runs only when the event is logged,
+because the argument is by name.
 
 ### Routing to several places
 
-Because a logger is just a contextual value, more than one can be in scope, and an
-event reaches every one. Two loggers — one to a file, one to the terminal — both
-receive each event, and each applies its own threshold, so the file can keep `Fine`
-detail while the terminal shows only `Warn` and `Fail`:
+Because a logger is just a contextual value, more than one can be in scope, and an event reaches
+every one. Two loggers — one to a file, one to the terminal — both receive each event, and each
+applies its own threshold, so the file can keep `Fine` detail while the terminal shows only
+`Warn` and `Fail`:
 
 ```scala
-given fileLog: Logger[Any, Message] = Logger(logFile, level = Level.Fine)
-given terminalLog: Logger[Any, Message] = Logger(Out, level = Level.Warn)
+import charEncoders.utf8Encoder
+import filesystemOptions.createNonexistentParents
+import pathInterfaces.pathOnLinux
+import temporaryDirectories.javaBaseTemporaryDirectory
+
+val logFile = temporaryDirectory[Path on Linux] / "logging" / "app.log"
+logFile.create[File]()
+
+supervise:
+  given fileLog: Logger[Any, Message] = Logger(logFile, level = Level.Fine)
+  given terminalLog: Logger[Any, Message] = Logger(Out, level = Level.Warn)
+  Log.fine(m"only the file sees this")
+  Log.warn(m"both see this")
 ```
 
 ### Silencing
 
-A single block can be logged with everything suppressed, regardless of the loggers in
-scope, with `mute`:
+A single block can be run with a kind of event suppressed, regardless of the loggers in scope,
+with `mute`:
 
 ```scala
-mute[Exec.Event]:
-  // Exec.Event logging is suppressed here
+supervise:
+  given Logger[Any, Message] = Logger(Out)
+
+  mute[Backup.Event]:
+    backup(t"/var")   // its events are dropped here
 ```
 
-Importing `logging.silentLogging` suppresses all logging for a whole file, which is
-useful where a dependency logs but the output is unwanted.
+Importing `logging.silentLogging` suppresses all logging for a whole file, which is useful where
+a dependency logs but the output is unwanted.
 
 ### Writing good logs
 
-Log only observable side effects that have latency or a failure mode — network,
-filesystem, process, and external-service operations. Pure, in-memory work such as
-hashing, parsing, or arithmetic produces no log output, however expensive.
+Log only observable side effects that have latency or a failure mode — network, filesystem,
+process, and external-service operations. Pure, in-memory work such as hashing, parsing, or
+arithmetic produces no log output, however expensive.
 
-A message should be specific. Name the resource it concerns — an address and port, a
-path, a process id, a URL — and quantify when it is cheap to do so, with byte counts,
-elapsed milliseconds, or status codes. Never log secrets: credentials, tokens,
-cookies, key material, or whole request and response bodies. Log a redaction, a size,
-or a short preview instead.
+A message should be specific. Name the resource it concerns — an address and port, a path, a
+process id, a URL — and quantify when it is cheap to do so, with byte counts, elapsed
+milliseconds, or status codes. Never log secrets: credentials, tokens, cookies, key material, or
+whole request and response bodies. Log a redaction, a size, or a short preview instead.
 
-Messages are lowercase, terse, present-tense, and carry no trailing period,
-interpolating the relevant context:
+Messages are lowercase, terse, present-tense, and carry no trailing period, interpolating the
+relevant context:
 
 ```scala
-m"connected to $remote"
-m"opened $path for reading"
-m"downloaded $url ($size bytes in ${elapsed}ms)"
+def describe(remote: Text, path: Text, url: Text, size: Long, elapsed: Long): List[Message] = List
+  ( m"connected to $remote",
+    m"opened $path for reading",
+    m"downloaded $url ($size bytes in ${elapsed}ms)" )
 ```
 
-A message that says only that something happened — `m"a failure occurred"` — is not
-enough; name what failed and include the identifier.
+A message that says only that something happened — `m"a failure occurred"` — is not enough; name
+what failed and include the identifier.

--- a/doc/modules/lsp.md
+++ b/doc/modules/lsp.md
@@ -119,7 +119,7 @@ A handler that cannot answer raises a typed fault, and continues:
 
 ```scala
   command(t"demo.run"):
-    raise(LspError(LspError.Reason.RequestFailed, t"nothing to run"))
+    raise(Lsp.Error(Lsp.Error.Reason.RequestFailed, t"nothing to run"))
     Unset
 ```
 
@@ -146,7 +146,7 @@ Lsp.Server(sh"rust-analyzer").session: server ?=>
 
 Requests return the same types a server's handlers return — `Optional[Hover]`,
 `CompletionList`, `List[Location]` — and notifications (`open`, `edit`, `save`, `close`)
-return nothing. An error response from the server is raised as an `LspError` carrying the
+return nothing. An error response from the server is raised as an `Lsp.Error` carrying the
 reason its wire code names, rather than being awaited forever. Requests are answered on a
 task of their own, so several may be in flight at once, and may come back in any order.
 

--- a/doc/modules/lsp.md
+++ b/doc/modules/lsp.md
@@ -9,7 +9,7 @@ underneath — JSON-RPC messages, their length-prefixed framing, the bookkeeping
 documents, and the capabilities announced to the editor — is handled, so the code that
 remains is the language logic.
 
-The protocol's vocabulary is modelled as ordinary types. A `Position` is a line and a
+The protocol's vocabulary is modeled as ordinary types. A `Position` is a line and a
 character, a `Range` is two positions, a `Diagnostic` is a range with a severity and a
 message; a hover response, a completion list, a set of document symbols each have their
 type. A handler receives these as typed values and returns them as typed values, never as
@@ -20,9 +20,11 @@ hand-assembled JSON.
 An editor that understands LSP can use any language's server, and a language that provides
 a server works in any such editor. That leverage is why the protocol exists, and it is
 also why the protocol is large: dozens of request and notification types, each with its
-own JSON shape, exchanged over a framed stream. Implementing it by hand means marshalling
+own JSON shape, exchanged over a framed stream. Implementing it by hand means marshaling
 JSON and tracking document versions, work that has nothing to do with the language being
 served.
+
+Declaring a server's methods as typed handlers, with the protocol's messages as values, keeps the implementation [honest](../philosophy/honest-signatures.md) about what it supports.
 
 Soundness does that work once. Each message type is a Scala type with a derived JSON codec,
 each request is dispatched to the matching registered handler, and the open documents are
@@ -30,13 +32,20 @@ tracked — with incremental edits applied — for the server. What is left to w
 part that is specific to a language: what a hover shows, what completions to offer, which
 diagnostics to report. Everything comes from the `soundness` package, and the LSP
 vocabulary itself — handler registration, the ambient document, the protocol types — from
-`Lsp`, imported inside the server's own object:
+`Lsp`, imported inside the server's own object, where it takes precedence over any name the
+umbrella exports:
 
 ```scala
 import soundness.*
 
-object DemoServer:
-  import Lsp.*
+import backstops.stackTraceBackstop
+import executives.completionsExecutive
+import interpreters.posixInterpreter
+import probates.awaitProbate
+import stdios.javaLangSystemStdio
+import errorDiagnostics.stackTracesDiagnostics
+import strategies.throwUnsafely
+import threading.virtualThreading
 ```
 
 ### Defining a server
@@ -51,20 +60,43 @@ Inside a handler, the current document is ambient: `document` is a live view of 
 document the request concerns, with its text, line access, position/offset conversion and
 the word under a position; `workspace` reaches the other open documents and what the
 editor reported at initialization; and request payloads such as `position` are ambient
-too, so no URIs or parameters are threaded by hand.
+too, so no URIs or parameters are threaded by hand. A whole server, with its `main` in the
+resident-daemon idiom described below:
 
 ```scala
-Lsp.listen(t"Demo", t"0.1.0"):
-  hover:
-    document.word(position).let: word =>
-      Hover(MarkupContent(value = t"**$word**"))
+object DemoServer:
+  import Lsp.*
 
-  complete():
-    CompletionList
-      ( items = List
-          ( CompletionItem(label = t"alpha", kind = CompletionItemKind.Keyword),
-            CompletionItem(label = t"beta",  kind = CompletionItemKind.Keyword) ) )
+  def main(args: Array[Text]): Unit = cli:
+    execute:
+      supervise:
+        Lsp.listen(t"Demo", t"0.1.0"):
+          hover:
+            document.word(position).let: word =>
+              Hover(MarkupContent(value = t"**$word**"))
+
+          complete():
+            CompletionList
+              ( items = List
+                  ( CompletionItem(label = t"alpha", kind = CompletionItemKind.Keyword),
+                    CompletionItem(label = t"beta",  kind = CompletionItemKind.Keyword) ) )
+
+          opened:
+            client.publishDiagnostics
+              ( document.uri,
+                List
+                  ( Diagnostic
+                      ( range    = document.fullRange,
+                        severity = DiagnosticSeverity.Warning,
+                        message  = t"a diagnostic for the whole document" ) ) )
+
+          command(t"demo.run"):
+            raise(Lsp.Error(Lsp.Error.Reason.RequestFailed, t"nothing to run"))
+            Unset
+      Exit.Ok
 ```
+
+The fragments that follow each belong inside such a `listen` block.
 
 Registrations exist for the full protocol surface: definitions, references, document
 symbols, formatting, renaming, code actions, signature help, folding, semantic tokens,
@@ -77,8 +109,10 @@ The server tracks each open document as the editor reports it, applying incremen
 changes at the protocol's UTF-16 offsets. The lifecycle can be observed by registering
 `opened`, `changed`, `saved` and `closed` handlers, each of which sees the document's
 current state. From any handler, `client` is the channel back to the editor, which is how
-a server pushes diagnostics — errors and warnings — rather than waiting to be asked:
+a server pushes diagnostics — errors and warnings — rather than waiting to be asked, as the
+`opened` registration above does:
 
+<!-- doccheck: skip -->
 ```scala
   opened:
     client.publishDiagnostics
@@ -101,13 +135,12 @@ message as the JSON body it was carried as — inbound before it is parsed, so a
 that fails to decode is observed too, and outbound before it is framed:
 
 ```scala
-  val observer = new Lsp.Observer:
-    def received(message: Text): Unit = log.put(t"recv $message")
-    def sent(message: Text): Unit = log.put(t"send $message")
-
-  Lsp.listen(t"Demo", t"0.1.0", observer):
-    ...
+val observer = new Lsp.Observer:
+  def received(message: Text): Unit = Err.println(t"recv $message")
+  def sent(message: Text): Unit = Err.println(t"send $message")
 ```
+
+Passing it as `Lsp.listen(t"Demo", t"0.1.0", observer)` traces the exchange on standard error.
 
 What the observer does with a message is the server's own concern: a debugging aid that
 streams it to a second process, a trace file, or nothing at all. Omitting the parameter
@@ -115,13 +148,8 @@ observes nothing.
 
 ### Reporting errors
 
-A handler that cannot answer raises a typed fault, and continues:
-
-```scala
-  command(t"demo.run"):
-    raise(Lsp.Error(Lsp.Error.Reason.RequestFailed, t"nothing to run"))
-    Unset
-```
+A handler that cannot answer raises a typed fault, and continues, as the `demo.run` command
+above does with `Lsp.Error(Lsp.Error.Reason.RequestFailed, t"nothing to run")`.
 
 A raised fault pre-empts the handler's result: for a request it becomes a JSON-RPC error
 response with the reason's wire code and the request's own id; for a notification, which
@@ -137,11 +165,12 @@ channel, lends a connection for the duration of a block, and disposes of both af
 connection cannot escape the block, so it can never outlive the server that answers it.
 
 ```scala
-Lsp.Server(sh"rust-analyzer").session: server ?=>
-  server.initialize(root = t"file:///project")
-  server.initialized()
-  server.open(t"file:///project/src/main.rs", t"rust", source)
-  server.hover(t"file:///project/src/main.rs", Position(10, 4))
+def query(source: Text): Optional[Lsp.Hover] = supervise:
+  Lsp.Server(sh"rust-analyzer").session: server ?=>
+    server.initialize(root = t"file:///project")
+    server.initialized()
+    server.open(t"file:///project/src/main.rs", t"rust", source)
+    server.hover(t"file:///project/src/main.rs", Lsp.Position(10, 4))
 ```
 
 Requests return the same types a server's handlers return — `Optional[Hover]`,
@@ -156,9 +185,9 @@ it acts on. A listener is supplied contextually:
 
 ```scala
 given diagnostics: Lsp.Listener = new Lsp.Listener:
-  override def diagnostics(uri: Text, version: Optional[Int], reports: List[Diagnostic])
+  override def diagnostics(uri: Text, version: Optional[Int], reports: List[Lsp.Diagnostic])
   :   Unit =
-    reports.each { report => Out.println(t"$uri: ${report.message}") }
+    reports.each { report => Err.println(t"$uri: ${report.message}") }
 ```
 
 ### Proxying a server
@@ -169,13 +198,20 @@ amending what it chooses to. `Lsp.proxy` runs that exchange, and the block regis
 amendments:
 
 ```scala
-Lsp.proxy(Lsp.Server(sh"rust-analyzer")):
-  rewrite.capabilities(_.copy(hoverProvider = true))
+object DemoProxy:
+  import Lsp.*
 
-  rewrite.hover: hover =>
-    hover.copy(contents = MarkupContent(value = t"_(proxied)_ ${hover.contents.value}"))
+  def main(args: Array[Text]): Unit = cli:
+    execute:
+      supervise:
+        Lsp.proxy(Lsp.Server(sh"rust-analyzer")):
+          rewrite.capabilities(_.copy(hoverProvider = true))
 
-  rewrite.diagnostics(_.filter(_.severity != DiagnosticSeverity.Hint))
+          rewrite.hover: hover =>
+            hover.copy(contents = MarkupContent(value = t"_(proxied)_ ${hover.contents.value}"))
+
+          rewrite.diagnostics(_.filter(_.severity != DiagnosticSeverity.Hint))
+      Exit.Ok
 ```
 
 Everything not registered is forwarded byte for byte: methods this library does not model,
@@ -189,6 +225,7 @@ method name and a `Json => Json` for anything without a combinator of its own. F
 messages there are two more hooks — `rewrite.outbound` and `rewrite.inbound` — each
 returning what should become of the message:
 
+<!-- doccheck: skip -->
 ```scala
 rewrite.outbound: (method, message) =>
   if method == t"textDocument/inlineValue" then Transit.Drop else Transit.Forward
@@ -203,6 +240,7 @@ scope as `upstream` throughout the registration block, so a hook may ask a quest
 own — typically for the project state only the server knows — and `rewrite.connected` runs
 once, on a task of its own, as soon as that session is open:
 
+<!-- doccheck: skip -->
 ```scala
 Lsp.proxy(Lsp.Server(sh"jdtls")):
   val classpath: Promise[Json] = Promise()
@@ -227,18 +265,8 @@ the editor waits with it. `rewrite.connected` has a task of its own and may awai
 ### Running the server
 
 `Lsp.listen` serves standard input until it is exhausted, so a server object supplies a
-small `main` in the resident-daemon idiom:
-
-```scala
-  def main(args: Array[Text]): Unit = cli:
-    execute:
-      supervise:
-        Lsp.listen(t"Demo", t"0.1.0"):
-          ...
-      Exit.Ok
-```
-
-An editor configured to launch the object as its language server exchanges JSON-RPC with
+small `main` in the resident-daemon idiom, as `DemoServer` above does: the `cli` entry point,
+an `execute` block, and `supervise` for the tasks the server runs. An editor configured to launch the object as its language server exchanges JSON-RPC with
 it over the pipe, and each request arrives at the matching handler.
 
 ### Fast startup

--- a/doc/modules/markdown.md
+++ b/doc/modules/markdown.md
@@ -20,6 +20,8 @@ it are not interchangeable: a heading may contain a link, but a link may not con
 representation that treats every node alike lets such nonsense be built, and pushes the check to
 whatever consumes the tree.
 
+A document parsed to a typed tree, rather than rendered straight to HTML, is what makes it [composable](../philosophy/composability.md) with the rest of a program.
+
 Soundness keeps the levels apart in the types. The block structure is the `Layout` enumeration and the
 inline structure the `Prose` enumeration, and a document's type records which it holds. Parsing
 produces a complete CommonMark tree, and rendering it to HTML yields exactly the content model each
@@ -43,8 +45,10 @@ rather than holding the source. Only the tree, and each paragraph's deferred raw
 retained, so a long document is parsed without ever being materialized:
 
 ```scala
-val streamed = Parser.parse(source)
-readme.read[Markdown of Layout]
+val readme = t"# Readme\n\nThe first paragraph.\n\nThe second."
+
+Parser.parse(readme.stream).children.size   // 3
+readme.read[Markdown of Layout].children.size
 ```
 
 The whole CommonMark conformance suite passes through the streaming entry, one character per
@@ -67,9 +71,10 @@ The document's `children` are `Layout` nodes, and each carries its inline conten
 document can be inspected or transformed by matching on the tree:
 
 ```scala
-document.children.head match
+document.children.prim match
   case Layout.Heading(_, level, Prose.Textual(text)) => (level, text)
   case _                                             => (0, t"")
+// (1, t"Title")
 ```
 
 `Layout` covers headings, paragraphs, block quotes, ordered and bullet lists, code blocks and

--- a/doc/modules/mathematical-markup.md
+++ b/doc/modules/mathematical-markup.md
@@ -38,7 +38,7 @@ Math(Msup(Mi(t"x"), Mn(t"2"))).xml.show
 MathML text reads back with `read[Math]`, and a document round-trips unchanged — attributes the
 model does not interpret are preserved rather than dropped. A root element that is not `<math>`
 raises a `Mathml.Error` naming what was found instead. `html` embeds an expression as a foreign
-element in an HTML tree, and `MathmlReader.read` extracts it again.
+element in an HTML tree, and `Mathml.Reader.read` extracts it again.
 
 A `Math` also has a `display` — block or inline — which decides whether the browser sets it as a
 displayed equation or within running text.

--- a/doc/modules/mathematical-markup.md
+++ b/doc/modules/mathematical-markup.md
@@ -16,6 +16,8 @@ formula runs to several lines that no one can read as mathematics. The alternati
 different way: TeX is compact and expressive but needs a large renderer and produces something the
 browser cannot introspect, and an image loses the content entirely.
 
+Markup built from typed values rather than strings is [safety by construction](../philosophy/safety-by-construction.md) for a notation that is easy to get subtly wrong.
+
 Ergo takes the middle path. It is a compact linear notation, one glyph per structural role, which
 parses to MathML and serializes back — so the source stays readable, the output is a real
 document tree, and the round trip is exact. Everything comes from the `soundness` package:
@@ -31,6 +33,10 @@ an operator, `Mrow` for a group, and `Msup`, `Msub`, `Mfrac`, `Msqrt` and the re
 structures. `Math` is the root, and `xml` renders it:
 
 ```scala
+import Mathml.*
+import errorDiagnostics.stackTracesDiagnostics
+import strategies.throwUnsafely
+
 Math(Msup(Mi(t"x"), Mn(t"2"))).xml.show
 // <math xmlns="http://www.w3.org/1998/Math/MathML"><msup><mi>x</mi><mn>2</mn></msup></math>
 ```
@@ -96,22 +102,22 @@ both `largeop` and `stretchy` on the `=`.
 
 Enumerated and boolean attributes have one bare glyph per value and take no parameter — a boolean
 is `⇿` for true and `↮` for false. Because they never take a group, `=◆(a)` is `=` with
-`largeop="true"`, *times* `(a)`. Open-valued attributes — lengths, colours, integers — take their
+`largeop="true"`, *times* `(a)`. Open-valued attributes — lengths, colors, integers — take their
 value in the active grouping bracket, read verbatim: under `(` grouping, `x●(red)` sets
 `mathcolor="red"`.
 
-Grouping decides what a directive applies to: `(x↗2)●(red)` colours the whole superscript, while
-`x↗2●(red)` colours only the `2`.
+Grouping decides what a directive applies to: `(x↗2)●(red)` colors the whole superscript, while
+`x↗2●(red)` colors only the `2`.
 
 | Glyphs | Attribute | Meaning |
 |---|---|---|
 | `⧆` / `⧄` | `displaystyle` | display style, or inline/text style |
 | `⌄[±n]` | `scriptlevel` | relative script size; `+n` shrinks |
 | `◻` / `▭` | `display` | block or inline, on the root |
-| `●[colour]` | `mathcolor` | foreground colour |
-| `▨[colour]` | `mathbackground` | background colour |
+| `●[colour]` | `mathcolor` | foreground color |
+| `▨[colour]` | `mathbackground` | background color |
 | `⟑[length]` | `mathsize` | font size |
-| `⦱` | `mathvariant` | upright, cancelling automatic italicisation |
+| `⦱` | `mathvariant` | upright, canceling automatic italicisation |
 | `⊩` / `⫣` | `dir` | left-to-right or right-to-left |
 | `⊰` / `⊹` / `⊱` | `form` | prefix, infix or postfix operator |
 | `∥` / `∤` | `fence` | mark as a fence |

--- a/doc/modules/mathematics.md
+++ b/doc/modules/mathematics.md
@@ -24,11 +24,15 @@ shape mismatch becomes an exception — or worse, silent nonsense — long after
 Soundness puts the dimensions in the types. A `Vector[Int, 3]` and a `Vector[Int, 2]` are different
 types; a `Matrix[…, 2, 3]` multiplies a `Matrix[…, 3, 2]` and nothing else; and the element type is
 generic over anything with the right arithmetic, which is how units flow through. Everything comes
-from the `soundness` package:
+from the `soundness` package, and arithmetic between plain numbers and these types relies on the
+compiler's `into` conversions, so that language feature is enabled too:
 
 ```scala
 import soundness.*
+import scala.language.experimental.into
 ```
+
+Dimensions in the types of vectors and matrices make a mismatched multiplication a compile error — [impossible states](../philosophy/impossible-states.md) for linear algebra.
 
 ### Complex numbers
 
@@ -45,14 +49,17 @@ The components may be any type with the arithmetic the operation needs — inclu
 complex impedance keeps its units:
 
 ```scala
-Complex(1.0*Metre/Second, 9.0*Metre/Second).show   // t"(1.00 + 9.00ℐ) m·s¯¹"
+val real = 1.0*Metre/Second
+val imaginary = 9.0*Metre/Second
+
+Complex(real, imaginary).show   // t"(1.00 + 9.00ℐ) m·s¯¹"
 ```
 
 A complex number can equally be written by adding to a multiple of the imaginary unit, or given in
 polar form as a modulus and an `Angle`:
 
 ```scala
-0.8 + 1.8*i                       // Complex(0.8, 1.8)
+Complex(0.8, 0.0) + i*1.8            // Complex(0.8, 1.8)
 Complex(12*Kilo(Gram), 0.3845.rad)   // from modulus and argument
 ```
 
@@ -148,9 +155,10 @@ a typed error:
 ```scala
 import strategies.throwUnsafely
 
-val shuffle = Permutation(Series(3, 1, 4, 2, 0, 5))
-shuffle(List(t"zero", t"one", t"two", t"three", t"four", t"five"))
-// List(t"three", t"one", t"four", t"two", t"zero", t"five")
+val shuffle = Permutation(Sequence(3, 1, 4, 2, 0, 5))
+val items = List(t"zero", t"one", t"two", t"three", t"four", t"five")
+
+shuffle(items)   // List(t"three", t"one", t"four", t"two", t"zero", t"five")
 
 shuffle.inverse(shuffle(items)) == items   // always true
 ```
@@ -165,7 +173,7 @@ Since the number *is* the permutation, it can be given directly, and both repres
 read back:
 
 ```scala
-Permutation(Factoradic(45)) == Permutation(Series(1, 4, 2, 3, 0))   // true
+Permutation(Factoradic(45)) == Permutation(Sequence(1, 4, 2, 3, 0))   // true
 
 shuffle.lehmer      // the Lehmer code, as a List[Int]
 shuffle.expansion   // the reordered indexes

--- a/doc/modules/mcp.md
+++ b/doc/modules/mcp.md
@@ -18,6 +18,8 @@ descriptions. Writing that self-description by hand duplicates the code it descr
 drift; the schema says one thing, the implementation another, and the model's tool calls fail in
 ways it cannot see.
 
+Tools declared as typed methods, with their schemas derived, are [correctness](../philosophy/correctness.md) by construction: the schema cannot disagree with the code.
+
 Deriving the description from the implementation removes the gap. The method *is* the tool: its
 name, its parameter types, its result type generate the listing, and dispatch goes straight to it.
 Everything comes from the `soundness` package:
@@ -28,12 +30,16 @@ import soundness.*
 
 ### A server
 
-A server extends `McpServer`, names itself, and defines its capabilities as annotated methods:
+A server extends `Mcp.Server`, names itself, and defines its capabilities as annotated methods.
+Each connected client gets a `Session`, created by `initialize`, in which the server may keep
+per-client state:
 
 ```scala
-object AssistantTools extends McpServer():
+val colors = Map(t"sky" -> t"blue", t"grass" -> t"green")
+
+object AssistantTools extends Mcp.Server():
   class Session() extends Mcp.Session
-  def initialize(): Session = Session()
+  def initialize(): Session = new Session()
 
   def name: Text = t"assistant-tools"
   def description: Text = t"Utilities for the assistant"
@@ -42,7 +48,7 @@ object AssistantTools extends McpServer():
 
   @tool
   @about("Look up the color of a named thing")
-  def color(name: Text): Text = lookup(name)
+  def color(name: Text): Text = colors.at(name).or(t"unknown")
 ```
 
 The tool's input schema — a `name` of type string — and its result schema are derived from the
@@ -55,12 +61,20 @@ notifications, and `elicit` asks the user for structured input mid-call, its for
 derived schema:
 
 ```scala
-@tool
-def deploy(target: Text)(using client: Mcp.Client): Text =
-  client.log(t"Preparing deployment to $target")
-  case class Confirmation(proceed: Boolean)
-  client.elicit[Confirmation](t"Deploy to production?")
-  finishDeployment(target)
+object Deployer extends Mcp.Server():
+  class Session() extends Mcp.Session
+  def initialize(): Session = new Session()
+  def name: Text = t"deployer"
+  def description: Text = t"Deploys the application"
+  def version: Semver = v"1.0.0"
+  def prompts: List[Mcp.Prompt] = Nil
+
+  @tool
+  def deploy(target: Text)(using client: Mcp.Client): Text =
+    client.log(t"Preparing deployment to $target")
+    case class Confirmation(proceed: Boolean)
+    client.elicit[Confirmation](t"Deploy to production?")
+    t"deployed to $target"
 ```
 
 ### Resources and prompts
@@ -70,13 +84,21 @@ def deploy(target: Text)(using client: Mcp.Client): Text =
 and `agent` interpolators:
 
 ```scala
-@resource("docs://readme")
-@about("The project readme")
-def readme: Text = readmeText
+object Documentation extends Mcp.Server():
+  class Session() extends Mcp.Session
+  def initialize(): Session = new Session()
+  def name: Text = t"documentation"
+  def description: Text = t"The project's documentation"
+  def version: Semver = v"1.0.0"
+  def prompts: List[Mcp.Prompt] = Nil
 
-@prompt
-def review(topic: Text): List[Discourse] =
-  List(human"Please review the $topic and summarize any problems.")
+  @resource("docs://readme")
+  @about("The project readme")
+  def readme: Text = t"# Readme\n\nStart with `make build`."
+
+  @prompt
+  def review(topic: Text): List[Discourse] =
+    List(human"Please review the $topic and summarize any problems.")
 ```
 
 ### Serving
@@ -86,10 +108,11 @@ GET, sessions tracked by header — and mounts inside an ordinary [HTTP server](
 handler:
 
 ```scala
-SocketServer(8080).handle:
-  request.path match
-    case % /: t"mcp" => AssistantTools.serve
-    case _           => Http.Response(Http.NotFound)(t"Not found")
+def serve(): Unit = supervise:
+  SocketServer(8080).handle:
+    request.path match
+      case % /: t"mcp" => AssistantTools.serve
+      case _           => Http.Response(Http.NotFound)(t"Not found")
 ```
 
 A client configured with that endpoint discovers the tools, resources and prompts, and everything

--- a/doc/modules/mcp.md
+++ b/doc/modules/mcp.md
@@ -32,7 +32,7 @@ A server extends `McpServer`, names itself, and defines its capabilities as anno
 
 ```scala
 object AssistantTools extends McpServer():
-  class Session() extends McpSession
+  class Session() extends Mcp.Session
   def initialize(): Session = Session()
 
   def name: Text = t"assistant-tools"
@@ -50,13 +50,13 @@ signature; `@about` supplies the description the model reads when deciding to ca
 
 ### Talking back to the client
 
-A tool that takes a `using McpClient` can speak to the client while it runs: `log` streams progress
+A tool that takes a `using Mcp.Client` can speak to the client while it runs: `log` streams progress
 notifications, and `elicit` asks the user for structured input mid-call, its form described by a
 derived schema:
 
 ```scala
 @tool
-def deploy(target: Text)(using client: McpClient): Text =
+def deploy(target: Text)(using client: Mcp.Client): Text =
   client.log(t"Preparing deployment to $target")
   case class Confirmation(proceed: Boolean)
   client.elicit[Confirmation](t"Deploy to production?")

--- a/doc/modules/media-types.md
+++ b/doc/modules/media-types.md
@@ -70,7 +70,7 @@ check needs no network and no service. A newer or site-specific list placed earl
 classpath supersedes it — the file is a newline-delimited list of media types with suffixes but
 without parameters.
 
-Text that is not a media type raises a `MediaTypeError` naming the reason — a missing slash, an
+Text that is not a media type raises a `MediaType.Error` naming the reason — a missing slash, an
 invalid character, an unknown suffix.
 
 ### Types that know their media type

--- a/doc/modules/media-types.md
+++ b/doc/modules/media-types.md
@@ -19,8 +19,10 @@ uploads — parse into their typed parts.
 Media types look like free text and are not: the grammar distinguishes registered types from
 vendor trees, suffixes carry meaning (`svg+xml` *is* XML), and parameters like `charset` change
 interpretation. Because they are usually handled as strings, a typo produces a syntactically
-plausible type that no consumer recognises — and since receivers tend to fall back rather than
-fail, the mistake shows up as subtly wrong behaviour far away.
+plausible type that no consumer recognizes — and since receivers tend to fall back rather than
+fail, the mistake shows up as subtly wrong behavior far away.
+
+Checking a media type as the code compiles is [safety by construction](../philosophy/safety-by-construction.md) applied to a string that is otherwise trusted.
 
 Soundness parses them fully, validates literals against the registry itself, and types the value.
 Everything comes from the `soundness` package:
@@ -28,6 +30,7 @@ Everything comes from the `soundness` package:
 ```scala
 import soundness.*
 import strategies.throwUnsafely
+import charEncoders.utf8Encoder
 ```
 
 ### Writing a media type
@@ -80,6 +83,8 @@ anyone re-stating what it is: text is `text/plain`, and anything with a filename
 extension. `ascribe` pairs any byte source with an explicit media type where none is intrinsic:
 
 ```scala
+val data = t"raw bytes".in[Data]
+
 data.ascribe(media"application/octet-stream")   // a Content: bytes plus their type
 ```
 
@@ -93,6 +98,13 @@ with its disposition, name, optional filename, headers and body stream — parse
 a large upload streams rather than accumulating:
 
 ```scala
-val upload = Multipart.parse(stream)
-upload.at(t"avatar").let(_.filename)   // the uploaded file's name, if present
+val body =
+  t"--xyz\r\n" +
+  t"Content-Disposition: form-data; name=\"avatar\"; filename=\"me.png\"\r\n" +
+  t"\r\n" +
+  t"pixels\r\n" +
+  t"--xyz--\r\n"
+
+val upload = Multipart.parse(Chain(body.in[Data]))
+upload.at(t"avatar").let(_.filename)   // t"me.png"
 ```

--- a/doc/modules/metaprogramming.md
+++ b/doc/modules/metaprogramming.md
@@ -17,6 +17,8 @@ Scala 3's macros are principled and under-tooled. A macro author stares at expan
 innocent question — "what givens of this type are in scope?" — because implicit search answers with
 one, or ambiguity. These gaps are generic; every macro project refills them.
 
+Macros that check as the code compiles are how much of [safety by construction](../philosophy/safety-by-construction.md) is achieved elsewhere in Soundness.
+
 Soundness fills them once. Everything comes from the `soundness` package:
 
 ```scala
@@ -34,7 +36,7 @@ trait Plugin
 given alpha: Plugin = new Plugin {}
 given beta: Plugin = new Plugin {}
 
-every[Plugin].values.length   // 2
+every[Plugin].values.size   // 2
 ```
 
 This inverts the usual configuration flow: instead of one value naming all the options, each option
@@ -83,8 +85,10 @@ container written without any of this in mind participates anyway.
 Two operations follow immediately, and are the reason it is worth having:
 
 ```scala
-List(Some(1), Some(2), Some(3)).sequence      // Some(List(1, 2, 3))
-List(t"1", t"2", t"x").traverse(parseNumber)  // the failure, not a list of failures
+def parseNumber(text: Text): Option[Int] = safely(text.as[Int]).let(Some(_)).or(None)
+
+List[Option[Int]](Some(1), Some(2), Some(3)).sequence   // Some(List(1, 2, 3))
+List(t"1", t"2", t"x").traverse(parseNumber)  // None: the failure, not a list of failures
 ```
 
 `sequence` turns a collection of containers inside out, and `traverse` maps a fallible function
@@ -123,7 +127,7 @@ code, which makes them useful for answering questions about the language itself.
 `1 + x` for a `val x = 5` shows the `Apply` of a `Select` over a `Literal` and an `Ident`; doing
 the same for a `val y: 5 = 5` shows a single `Literal`, because the singleton type let the
 compiler fold the addition away. Inside a macro, where a `Quotes` is available, the `syntax` and
-`semantics` extension methods do the same for an `Expr` or a `Symbol`, and the result is coloured
+`semantics` extension methods do the same for an `Expr` or a `Symbol`, and the result is colored
 through a `TastyPalette` so it reads at a terminal.
 
 A macro that must fail does so with `halt`, which takes a `Message` — so a macro's compile errors
@@ -139,8 +143,10 @@ instructions, each instruction with its operand-stack state reconstructed, and a
 can be compiled and disassembled in one step:
 
 ```scala
-Classfile[SomeType].let(_.methods.find(_.name == t"run")).let(_.bytecode)
-// the JVM instructions, with stack states, ready to render
+import classloaders.threadContextClassloader
+
+Classfile[Exit].let(_.methods.map(_.name))   // the methods of the compiled class
+// each method's `bytecode` is the JVM instructions, with stack states, ready to render
 ```
 
 This is the foundation for performance work that must verify, rather than assume, what the

--- a/doc/modules/money.md
+++ b/doc/modules/money.md
@@ -137,7 +137,7 @@ isin"GB00BH4HKS3"           // does not compile: wrong length
 Luhn.check(17893729974L)    // true
 ```
 
-An `IsinError` says which rule was broken — the length, the country prefix, the permitted
+An `Isin.Error` says which rule was broken — the length, the country prefix, the permitted
 characters, or the Luhn check on the final digit — so a rejected identifier can be reported
 precisely rather than as "invalid".
 

--- a/doc/modules/money.md
+++ b/doc/modules/money.md
@@ -29,6 +29,7 @@ by name:
 
 ```scala
 import soundness.*
+import scala.language.experimental.into
 import currencies.{Eur, Gbp}
 import currencyStyles.localCurrencyStyle
 ```

--- a/doc/modules/names.md
+++ b/doc/modules/names.md
@@ -30,6 +30,7 @@ literal, at runtime by validated decoding. This is the mechanism beneath the ele
 
 ```scala
 import soundness.*
+import errorDiagnostics.stackTracesDiagnostics
 import strategies.throwUnsafely
 ```
 

--- a/doc/modules/names.md
+++ b/doc/modules/names.md
@@ -61,13 +61,13 @@ val bad: Name[Tag] = n"0hello"   // does not compile: must not start with 0
 
 ### Validating at runtime
 
-Text from outside becomes a name through the same rules, raising a `NameError` that names the
+Text from outside becomes a name through the same rules, raising a `Name.Error` that names the
 rule violated:
 
 ```scala
 Name[Tag](t"release")   // a Name[Tag]
 
-capture[NameError](Name[Tag](t"0hello")).message.show
+capture[Name.Error](Name[Tag](t"0hello")).message.show
 // t"the name 0hello is not valid because it must not start with 0"
 ```
 
@@ -83,7 +83,7 @@ that is the whole rule:
 ```scala
 Name[CssClass](t"main-nav")   // a valid CSS identifier
 
-capture[NameError](Name[DomId](t"a b")).message.show
+capture[Name.Error](Name[DomId](t"a b")).message.show
 // t"the name a b is not valid because it must be a valid DOM id"
 ```
 

--- a/doc/modules/network-addresses.md
+++ b/doc/modules/network-addresses.md
@@ -142,6 +142,6 @@ mac"01-23-45-ab-cd-ef"
 ### Parsing at runtime
 
 Every identifier that has a literal form also decodes from text with `as`, naming the target type.
-A value that does not conform raises a typed error — an `HostnameError`, an `IpAddressError`, an
-`EmailAddressError` — that names precisely what was wrong, so a program validating user input can
+A value that does not conform raises a typed error — an `Hostname.Error`, an `IpAddress.Error`, an
+`EmailAddress.Error` — that names precisely what was wrong, so a program validating user input can
 report the fault rather than merely rejecting the value.

--- a/doc/modules/network-addresses.md
+++ b/doc/modules/network-addresses.md
@@ -18,6 +18,8 @@ between them exist only in the programmer's head, and a value that is not really
 travels through the program until something tries to use it and fails — a validation done late, if at
 all, and far from where the bad value entered.
 
+An address that cannot be constructed invalid is [safety by construction](../philosophy/safety-by-construction.md) in its simplest form.
+
 Soundness gives each identifier its own type, and validates it at the earliest possible moment: a
 literal as it compiles, and text on the instant it is decoded. A `Hostname`, an `EmailAddress`, a
 `Port` are known to be well-formed, and their parts are typed too — a URL's port is a number, its host

--- a/doc/modules/numbers.md
+++ b/doc/modules/numbers.md
@@ -31,7 +31,8 @@ numeric type is expected:
 
 ```scala
 import soundness.*
-import language.experimental.genericNumberLiterals
+import scala.language.experimental.genericNumberLiterals
+import scala.language.experimental.into
 ```
 
 ### Numeric types
@@ -41,8 +42,9 @@ methods:
 
 ```scala
 val count: U64 = 123
-val small: U8 = count.u8     // narrower, explicit
+val small: U8 = 200
 val signed: S32 = 42
+val widened: S32 = small.s32   // wider, and so always safe
 ```
 
 The name carries the meaning: `U*` is unsigned, `S*` is two's-complement signed, `F*` is
@@ -65,7 +67,7 @@ big + big   // raises Arithmetic.Error rather than wrapping negative
 
 Division by zero is checked the same way, by importing `arithmeticOptions.checkedDivision`,
 after which `/` may raise a `Arithmetic.Error`. Where the check is not imported, the operations
-keep their bare machine behaviour and cost nothing.
+keep their bare machine behavior and cost nothing.
 
 The two checks are independent, so a program that must not wrap but is content to trust its
 divisors imports only the first. Both are `inline`, and the unchecked forms compile to the same
@@ -176,7 +178,7 @@ Division cannot always be exact, so it says what it wants: a scale and a roundin
 rather than assumed.
 
 ```scala
-left.divide(right, scale = 10, Decimal.Rounding.HalfEven)
+Decimal(1, 0).divide(Decimal(3, 0), scale = 10, Decimal.Rounding.HalfEven)   // 0.3333333333
 ```
 
 The implementation is pure Scala rather than a wrapper over the JVM's `BigDecimal`, so decimals

--- a/doc/modules/numbers.md
+++ b/doc/modules/numbers.md
@@ -53,18 +53,18 @@ different types, and mixing them is a deliberate conversion rather than an accid
 
 By default arithmetic behaves as the hardware does, wrapping on overflow. Importing the
 checked given changes the result type of `+`, `-` and `*` to one that can raise
-`OverflowError`, so an overflow becomes a handled failure rather than a silent wrap:
+`Arithmetic.Error`, so an overflow becomes a handled failure rather than a silent wrap:
 
 ```scala
 import arithmeticOptions.checkedOverflow
 import strategies.throwUnsafely
 
 val big: S32 = 2000000000
-big + big   // raises OverflowError rather than wrapping negative
+big + big   // raises Arithmetic.Error rather than wrapping negative
 ```
 
 Division by zero is checked the same way, by importing `arithmeticOptions.checkedDivision`,
-after which `/` may raise a `DivisionError`. Where the check is not imported, the operations
+after which `/` may raise a `Arithmetic.Error`. Where the check is not imported, the operations
 keep their bare machine behaviour and cost nothing.
 
 The two checks are independent, so a program that must not wrap but is content to trust its
@@ -157,7 +157,7 @@ sign, an arbitrary magnitude and a decimal scale:
 ```scala
 Decimal(1234567890123L)
 Decimal(-1234567, 4)      // -123.4567
-Decimal(0.1)              // raises a DecimalError if the double is not exact
+Decimal(0.1)              // raises a Decimal.Error if the double is not exact
 Decimal.parse(t"-12.34e+2")
 ```
 

--- a/doc/modules/oauth.md
+++ b/doc/modules/oauth.md
@@ -21,6 +21,8 @@ exchange of code for tokens, expiry tracking, and the refresh exchange when an a
 out. Implemented ad hoc, the steps scatter across handlers, and the question "is this request
 authorized for what it is about to do?" is answered by convention.
 
+Each step of the flow as a typed value, with the wrong sequence unrepresentable, is [impossible states](../philosophy/impossible-states.md) applied to a protocol.
+
 Soundness structures the flow around the handler that needs it. The provider is an `Issuer` value;
 sessions carry the per-user state; and scope requirements are types, checked where the protected
 code is written. Everything comes from the `soundness` package:
@@ -39,8 +41,8 @@ val issuer = Issuer
   ( init     = url"https://provider.example/oauth/authorize",
     exchange = url"https://provider.example/oauth/token",
     redirect = url"https://app.example/callback",
-    client   = clientId,
-    secret   = clientSecret )
+    client   = t"my-app",
+    secret   = t"s3cr3t" )
 ```
 
 ### Protecting a handler
@@ -51,8 +53,9 @@ redirected to the provider; one with it runs the block, the `Authorization` in s
 
 ```scala
 val readUser = Scope(t"read:user")
+val profilePage = t"<h1>Your profile</h1>"
 
-issuer.oauth:
+def profile()(using Http.Request): Http.Response = issuer.oauth:
   issuer.require(readUser):
     Http.Response(Http.Ok)(profilePage)
 ```

--- a/doc/modules/oauth.md
+++ b/doc/modules/oauth.md
@@ -65,6 +65,6 @@ does not send its user back through the consent screen.
 The `Authorization` in scope carries the access token and granted scopes, and supplies the
 standard `Authorization: Bearer …` header to outgoing [HTTP](http-client.md) requests, so calling
 the provider's API on the user's behalf is an ordinary fetch with the authorization applied.
-Asking an authorization for a scope it does not hold raises an `OAuthError`, whose reasons also
+Asking an authorization for a scope it does not hold raises an `OAuth.Error`, whose reasons also
 cover the flow's other failures — a denied consent, an unexpected status from the provider, a
 response that would not parse — each named for diagnosis.

--- a/doc/modules/openapi.md
+++ b/doc/modules/openapi.md
@@ -11,10 +11,12 @@ does not compile.
 
 ### On API specifications
 
-An OpenAPI document is a machine-readable contract, and the usual way to honour it is code
+An OpenAPI document is a machine-readable contract, and the usual way to honor it is code
 generation: a build step emits a client, which is compiled, versioned and kept in sync by
 tooling. The contract is enforced, but at the price of generated sources and a build pipeline —
 and when the generator is skipped, calls are made against remembered URLs and hoped-for schemas.
+
+A specification derived from the types that serve it cannot fall out of date, which is [correctness](../philosophy/correctness.md) by construction rather than by review.
 
 Soundness reads the specification during compilation instead. There is no generated code to
 maintain; the client *is* the specification, interpreted by the compiler, and a drift between
@@ -28,9 +30,10 @@ import internetAccess.online
 
 ### A typed client
 
-`Api` reads a specification from the classpath — JSON or YAML — and the resulting value navigates
-by path:
+`Api` reads a specification from the classpath — JSON or YAML — as the code compiles, and the
+resulting value navigates by path:
 
+<!-- doccheck: skip -->
 ```scala
 val api = Api(cp"/apis/petstore.json")
 
@@ -48,6 +51,7 @@ An endpoint is invoked with its method, query parameters as named arguments, and
 a value; `call` executes the request and decodes the response as the type asked for — which must
 conform to the response schema the specification declares:
 
+<!-- doccheck: skip -->
 ```scala
 case class Pet(id: Int, name: Text, tag: Optional[Text] = Unset)
 

--- a/doc/modules/openapi.md
+++ b/doc/modules/openapi.md
@@ -58,7 +58,7 @@ api.sessions(token).delete.call[Unit]()  // 204, no body
 ```
 
 Asking for a type the response schema does not support is a compile error; a response outside the
-success range raises an `ApiError` carrying the status.
+success range raises an `Api.Error` carrying the status.
 
 ### Wire formats
 
@@ -72,4 +72,4 @@ than remembered.
 The specification itself is also a value: `OpenApi` decodes an OpenAPI 3.x document from JSON or
 YAML into typed parts — info, servers, paths, operations, parameters, component schemas — for
 tooling that inspects APIs rather than calling them. A document of an unsupported version, or one
-that will not parse, raises an `OpenApiError` naming the fault.
+that will not parse, raises an `OpenApi.Error` naming the fault.

--- a/doc/modules/optics.md
+++ b/doc/modules/optics.md
@@ -47,8 +47,8 @@ Several updates apply together, and updates sharing a prefix rebuild the shared 
 
 ```scala
 company.lens
-  ( _.ceo.roles = Nil,
-    _.ceo.name = t"Bill" )
+  ( _.ceo.name = t"Bill",
+    _.name = t"Acme Ltd" )
 ```
 
 ### Reaching into collections
@@ -79,9 +79,12 @@ with the identical syntax — one skill, both worlds:
 
 ```scala
 import dynamicAccess.dynamicJson, conversions.encodableToJson
+import formatting.compactJsonFormatting
 
-json.lens(_.leader.age = 41)
-json.lens(_.leader.roles(Each).name = t"member")
+val json = company.in[Json]
+
+json.lens(_.ceo.name = t"Bill").show
+json.lens(_.ceo.roles(Each).name = t"member").show
 ```
 
 ### Lenses as values
@@ -90,8 +93,8 @@ Underneath the syntax, a lens is an ordinary value — a getter and setter pair 
 summoned, passed around and composed, for the cases where the access itself is the abstraction:
 
 ```scala
-val nameLens = summon["name" is Lens from Json onto Json]
-nameLens.modify(document)(transform)
+val nameLens = summon["name" is Lens from Person]
+nameLens.modify(company.ceo)(_.upper)   // Person(t"JOHN", …)
 ```
 
 Two lenses `compose` into one, so a path can be assembled from parts held separately — a lens onto
@@ -105,11 +108,16 @@ The same path syntax that writes an update can name a position without going the
 maps paths to values, which is how a derived typeclass is overridden at one field rather than for
 a whole type:
 
+<!-- doccheck: skip -->
 ```scala
-val orgSpecific: Org is Specific over (Codec in Json) =
+case class Org(ceo: Person, cto: Person)
+
+val shout: Text is Json.Encodable = Json.Encodable(() => Morphology.Str): text => Json(text.upper)
+
+val orgSpecific: Org is Specific over Json.Encodable =
   specifically:
-    case root.cto.name() => nameCodec
-    case root.ceo.age()  => ageCodec
+    case root.cto.name() => shout
+    case root.ceo.name() => shout
 ```
 
 The paths are checked against the type's structure as the code compiles, so a misspelled field or
@@ -117,8 +125,9 @@ a path that does not exist is a compile error, and each value must have the righ
 field it names. The result is an ordinary map keyed by the path, which a derivation consults as it
 visits each field:
 
+<!-- doccheck: skip -->
 ```scala
-orgSpecific.instances.keySet   // Set("cto.name", "ceo.age")
+orgSpecific.instances.keys   // Set("cto.name", "ceo.name")
 ```
 
 This is what the [JSON](json.md) per-field encoder override is built on, and the mechanism is not

--- a/doc/modules/optional-values.md
+++ b/doc/modules/optional-values.md
@@ -59,8 +59,10 @@ optionality is flat, `let` serves where both `map` and `flatMap` would be needed
 `Option` — a function that itself returns an `Optional` does not add a layer:
 
 ```scala
+def initial(text: Text): Optional[Char] = text.chars.prim
+
 name.let(_.upper)                 // Optional[Text], upper-cased when present
-name.let(_.take(1)).let(initial)  // chains without nesting
+name.let(_.keep(1)).let(initial)  // chains without nesting
 ```
 
 `lay` handles both cases at once, giving a fallback for absence and a function for presence,
@@ -76,19 +78,22 @@ name.lay(0)(_.length)   // the length when present, 0 when absent
 that fails a predicate:
 
 ```scala
-if name.present then greet(name.vouch)
+name.present               // true
 name.mask(_.length > 64)   // Unset if unreasonably long, else unchanged
 ```
 
 ### Requiring a value
 
-Where a value is known to be present, `vouch` asserts it, panicking if the assertion is
-wrong. `presume` instead falls back to the type's default — an empty text, a zero, an empty
+Where a value is known to be present, `assume` asserts it, throwing an `Optional.Error` if the
+assertion is wrong — and, since that is an unchecked assertion, it requires the capability to
+throw. `presume` instead falls back to the type's default — an empty text, a zero, an empty
 list — for types that declare one:
 
 ```scala
-name.vouch       // the Text, or a panic if it was Unset
-nickname.presume // t"" — the default Text
+import scala.unsafeExceptions.canThrowAny
+
+name.assume        // t"Alice"
+nickname.presume   // t"": the default Text
 ```
 
 ### Absence from collections
@@ -97,7 +102,7 @@ A collection of optional values compacts to the values that are present, droppin
 `Unset`:
 
 ```scala
-List(t"a", Unset, t"c").compact   // List(t"a", t"c")
+List[Optional[Text]](t"a", Unset, t"c").compact   // List(t"a", t"c")
 ```
 
 ### Building an optional
@@ -107,9 +112,13 @@ Any value becomes optional by a condition. `unless` discards it when a predicate
 function is defined:
 
 ```scala
-count.unless(_ == 0)            // Unset when count is zero
-input.puncture(t"")            // Unset for the empty string
-value.only { case n if n > 0 => n*n }
+val count = 0
+val input = t""
+val value = 7
+
+count.unless(_ == 0)                     // Unset: count is zero
+input.puncture(t"")                      // Unset: the empty string
+value.only { case n if n > 0 => n*n }    // 49
 ```
 
 ### Working with `Option`
@@ -157,9 +166,11 @@ to. Instances exist for the types with an obvious zero — empty text, zero, an 
 and a type declares its own by defining one:
 
 ```scala
-given Default[Volume] = Volume(0)
+case class Volume(level: Int)
+given Default[Volume] = () => Volume(0)
 
-setting.presume   // Volume(0) where the setting is unset
+val setting: Optional[Volume] = Unset
+setting.presume   // Volume(0), since the setting is unset
 ```
 
 A `Default` is a by-name thunk rather than a value, so a default that is expensive to compute is

--- a/doc/modules/packaging.md
+++ b/doc/modules/packaging.md
@@ -18,6 +18,8 @@ itself — and what it should weigh is its own code, not megabytes of dependenci
 on a public repository. And when the tool is a library, its bundled dependencies must not fight
 the host application's: the oldest deployment problem on the JVM.
 
+A distributable described as a value in the build is [direct style](../philosophy/direct-style.md) applied to packaging.
+
 Everything comes from the `soundness` package:
 
 ```scala
@@ -32,7 +34,12 @@ produces a polyglot installer script carrying every platform's launcher and the 
 choosing the right one where it runs; *download* keeps the script small, fetching the platform's
 launcher on demand and verifying it by [hash](hashing.md):
 
+<!-- doccheck: skip -->
 ```scala
+val jarPath = t"/tmp/mytool.jar".decode[Path on Linux]
+val outputPath = t"/tmp/mytool".decode[Path on Linux]
+val runnerSource = Packaging.RunnerSource.Remote(Runners.baseUrl, Runners.hashes)
+
 val packaging = Packaging
   ( name         = t"mytool",
     targets      = List(t"linux-amd64", t"darwin-arm64"),
@@ -54,6 +61,7 @@ compiled and bundled in one path rather than packaged as a separate step afterwa
 bundle runs from `Jar` rather than from a universe, and the delivery mode is part of the node's
 identity, since each is a different distributable:
 
+<!-- doccheck: skip -->
 ```scala
 Toolchain(jarEdges(), xeqEdges()).produce
   ( Deliverable.Emission(out, classpath),
@@ -120,6 +128,7 @@ separate one. Classfiles dex to Dalvik bytecode as a `Dex` archive, and `Apk` go
 further: the dexed code, a binary `AndroidManifest.xml`, zip-aligned and signed, ready to install.
 Asking for the `Apk` runs both tools, since that is the path between the two formats:
 
+<!-- doccheck: skip -->
 ```scala
 Toolchain(dexEdges(), apkEdges()).produce
   ( Deliverable.Emission(output, classpath),

--- a/doc/modules/paths.md
+++ b/doc/modules/paths.md
@@ -102,8 +102,10 @@ A path matches in a pattern with the `/:` extractor, peeling names from the fron
 be taken apart as readily as it is built:
 
 ```scala
+val path = t"/home/work".as[Path on Linux]
+
 path match
-  case root /: t"home" /: rest => rest
+  case root /: t"home" /: rest => rest   // ? / "work"
   case _                       => path.relative
 ```
 

--- a/doc/modules/patterns.md
+++ b/doc/modules/patterns.md
@@ -229,7 +229,7 @@ t"" match
 ```
 
 The same scanner is available at runtime for patterns built from dynamic text,
-where it reports a `RegexError` naming the position and the reason — a bad
+where it reports a `Regex.Error` naming the position and the reason — a bad
 repetition such as `{2,1}`, an unclosed group, or a capture inside a repeating
 group, which cannot bind a fixed set of variables and so is forbidden.
 

--- a/doc/modules/patterns.md
+++ b/doc/modules/patterns.md
@@ -33,6 +33,8 @@ the `soundness` package:
 import soundness.*
 ```
 
+A pattern checked as the code compiles, with its groups typed, is [safety by construction](../philosophy/safety-by-construction.md) for regular expressions.
+
 ### Matching
 
 The `r"…"` interpolator writes a regular expression, and in a `match` it behaves as
@@ -161,6 +163,7 @@ A pattern can also bind on the left of a definition, where it stands for an
 extraction that the code asserts will succeed. This pulls several captures out of
 one expression at once:
 
+<!-- doccheck: skip -->
 ```scala
 val r"$prefix([a-z0-9._%+-]+)@$domain([a-z0-9.-]+)\.$tld([a-z]{2,6})" =
   t"test@example.com": @unchecked
@@ -201,8 +204,10 @@ APIs leave to documentation and hope. Substitution in [text](text.md) is overloa
 that basis:
 
 ```scala
-text.sub(r"\s+", t" ")    // collapse runs of whitespace
-text.sub(t"\s+", t" ")    // replace the four literal characters
+val spaced = t"too   many    spaces"
+
+spaced.sub(r"\s+", t" ")     // collapse runs of whitespace
+spaced.sub(t"\\s+", t" ")    // replace the three literal characters, of which there are none
 ```
 
 Because a glob compiles to a regular expression, a `g"…"` is a `Regex` too, and usable anywhere
@@ -217,21 +222,40 @@ message that points at the offending character. An unbalanced bracket is caught
 before the program runs:
 
 ```scala
-t"" match
-  case r"hello(world" =>   // does not compile: the group is never closed
+t"" match { case r"hello(world" => () }   // does not compile: the group is never closed
 ```
 
 So is an interpolated variable that does not stand in front of a group to capture:
 
 ```scala
-t"" match
-  case r"hello${space}world" =>   // does not compile: nothing for `space` to bind
+val space = t" "
+t"" match { case r"hello${space}world" => () }   // does not compile: nothing for `space` to bind
 ```
 
 The same scanner is available at runtime for patterns built from dynamic text,
 where it reports a `Regex.Error` naming the position and the reason — a bad
 repetition such as `{2,1}`, an unclosed group, or a capture inside a repeating
 group, which cannot bind a fixed set of variables and so is forbidden.
+
+### Choosing an engine
+
+The default engine is the JVM's own, whose backtracking accepts every construct of its syntax
+but can take exponential time on a pathological pattern and input — the
+[catastrophic backtracking](https://en.wikipedia.org/wiki/ReDoS) that turns a regular expression
+applied to untrusted input into a denial of service. `re2` is a pure-Scala automaton engine that
+guarantees linear time in the length of the input, at the cost of the constructs an automaton
+cannot express — backreferences and lookaround. The engine is a given, so a program chooses it
+with an import and the patterns are unchanged:
+
+```scala
+import regexBackends.re2
+
+t"hello world" match
+  case r"hello $name(.*)" => name   // t"world", in time linear in the input
+```
+
+A pattern using a construct the engine does not support is rejected as the code compiles, where
+the pattern is a literal, rather than at the first match.
 
 ### Globs
 

--- a/doc/modules/pdf.md
+++ b/doc/modules/pdf.md
@@ -27,12 +27,37 @@ lazily, decoded through its filter chain, rather than materialized on arrival. W
 is damaged past the point its cross-reference table can be trusted, it can be recovered by
 scanning the file for objects directly.
 
-Everything comes from the `soundness` package:
+Reading a document lazily through a scope that owns the file is the shape described under [delimited scopes](../philosophy/delimited-scopes.md).
+
+Everything comes from the `soundness` package, with a text encoding for the content that will
+be written:
 
 ```scala
 import soundness.*
 import strategies.throwUnsafely
+import charEncoders.utf8Encoder
 ```
+
+### Creating a document
+
+A document is created at a path, and written within the scope of the block: a fresh document has
+a catalog and an empty page tree, and `appendPage` adds a page with the media box it should have.
+Boxes are [quantities](quantities.md) in points, not bare numbers, so an A4 page is 595 by 842
+points:
+
+```scala
+val a4 = Pdf.Rect
+  ( Quantity[Points[1]](0.0), Quantity[Points[1]](0.0),
+    Quantity[Points[1]](595.0), Quantity[Points[1]](842.0) )
+
+val path = t"/tmp/tutorial.pdf"
+
+path.create[Pdf](CreateFlag.Replace): doc ?=>
+  doc.appendPage(a4)
+```
+
+The file is written whole to a temporary sibling and moved onto the target atomically, so a
+failure part way through leaves nothing behind.
 
 ### Opening a document
 
@@ -40,8 +65,8 @@ A document is opened from a path or from bytes, and read within the scope of the
 `pdf` accessor reaches the contextual document:
 
 ```scala
-PdfFile(path).open[Pdf]():
-  pdf.version.major
+PdfFile(path).open():
+  pdf.version.major   // 1
 ```
 
 Opening for writing takes the `Read & Write` mode, and yields the document as a handle whose
@@ -49,12 +74,13 @@ editing operations are reachable only with the `Write` grant:
 
 ```scala
 PdfFile(path).open(Read & Write): doc ?=>
-  doc.setRotation(doc.pages(0), Page.Rotation.Quarter)
+  doc.setRotation(doc.page(Prim), Page.Rotation.Quarter)
 ```
 
 An encrypted document is opened by supplying its password, which is checked as the document is
 opened rather than when a string is first decrypted:
 
+<!-- doccheck: skip -->
 ```scala
 PdfFile(path).open(Password(t"open sesame")):
   pdf.info.title
@@ -65,17 +91,17 @@ a `Pdf.Error` naming the encryption it cannot use.
 
 ### Pages
 
-The page tree flattens into a sequence, with each page's geometry resolved against the
-inheritance the format allows — a media box declared on the tree root applies to every page
-beneath it, a crop box defaults to the media box, and a trim box to the crop box. Boxes are
-[quantities](quantities.md) in points, not bare numbers:
+The page tree flattens into a sequence, indexed by [ordinal](numbers.md) — `Prim` is the first
+page — with each page's geometry resolved against the inheritance the format allows: a media box
+declared on the tree root applies to every page beneath it, a crop box defaults to the media box,
+and a trim box to the crop box:
 
 ```scala
 PdfFile(path).open():
-  pdf.pages.length
-  pdf.pages(0).mediaBox.width       // Quantity[Points[1]]
-  pdf.pages(0).rotation             // Page.Rotation.Quarter
-  pdf.pages(1).width                // axes exchanged, if quarter-turned
+  pdf.pageCount                     // 1
+  pdf.page(Prim).mediaBox.width     // 595 points, as a Quantity[Points[1]]
+  pdf.page(Prim).rotation           // Page.Rotation.Quarter, after the edit above
+  pdf.page(Prim).width              // 842 points: the axes exchange when quarter-turned
 ```
 
 A page's `width` and `height` account for its rotation, and a `/UserUnit` scales the boxes, so
@@ -89,7 +115,7 @@ adjacent shows run together:
 
 ```scala
 PdfFile(path).open():
-  pdf.pages(0).text
+  pdf.page(Prim).text
 ```
 
 Positioned runs are available too, for a reader that needs coordinates rather than a paragraph.
@@ -103,11 +129,11 @@ old `/Dests` dictionary, and bookmarks form a tree of `Bookmark` values:
 
 ```scala
 PdfFile(path).open():
-  pdf.info.title
-  pdf.destinations.at(t"intro")
-  pdf.bookmarks
-  pdf.attachments.head.filename
-  pdf.pages(0).annotations
+  pdf.info.title                            // Optional[Text]
+  pdf.destinations.at(t"intro")             // Optional[Destination]
+  pdf.bookmarks                             // List[Bookmark]
+  pdf.attachments.prim.let(_.filename)      // the first attachment's name, if any
+  pdf.page(Prim).annotations                // List[Annotation]
 ```
 
 An annotation is a typed case — `Annotation.Link` with its rectangle and URI, `Annotation.Note`
@@ -127,9 +153,9 @@ PdfFile(path).open(Read & Write): doc ?=>
       Pdf.Operator.Offset(72, 720), Pdf.Operator.ShowText(winAnsi(t"Written")),
       Pdf.Operator.EndText )
 
-  doc.setContents(doc.pages(0), operators)
+  doc.setContents(doc.page(Prim), operators)
   doc.setInfo(Pdf.Info(t"A Title", t"An Author", Unset, Unset, Unset, Unset, Unset, Unset))
-  doc.addLink(doc.pages(0), rect, uri = t"https://soundness.dev/")
+  doc.addLink(doc.page(Prim), a4, uri = t"https://soundness.dev/")
 ```
 
 `appendPage` and `removePage` change the page tree, `setBox` and `setRotation` change a page's
@@ -137,14 +163,15 @@ geometry, and `setBookmarks` and `setAnnotations` replace those structures whole
 operations that need a new object use `allocate` and `newStream`, which take the next free
 object number.
 
-A [TrueType font](fonts.md) is embedded with `embedFont`, which writes the program as a
-`FontFile2` and builds the simple WinAnsi font dictionary around it; `addResource` names it on a
-page so content can select it:
+A [TrueType font](fonts.md) — any `Sfnt`, loaded here from a classpath resource — is embedded
+with `embedFont`, which writes the program as a `FontFile2` and builds the simple WinAnsi font
+dictionary around it; `addResource` names it on a page so content can select it:
 
+<!-- doccheck: skip -->
 ```scala
 PdfFile(path).open(Read & Write): doc ?=>
-  val font = doc.embedFont(Ttf(fontProgram), t"MyFont")
-  doc.addResource(doc.pages(0), t"Font", t"F1", font)
+  val font = doc.embedFont(Sfnt(cp"/fonts/text.ttf"), t"MyFont")
+  doc.addResource(doc.page(Prim), t"Font", t"F1", font)
 ```
 
 ### Stream payloads
@@ -157,8 +184,8 @@ and TIFF predictors that often follow them. The payload arrives as a
 ```scala
 PdfFile(path).open():
   pdf(2, 0) match
-    case body: Cos.Body => pdf.spring(body)()
-    case _              => Stream()
+    case body: Cos.Body => pdf.spring(body)().read[Data].length
+    case _              => 0
 ```
 
 ### Recovering a damaged document

--- a/doc/modules/pdf.md
+++ b/doc/modules/pdf.md
@@ -61,7 +61,7 @@ PdfFile(path).open(Password(t"open sesame")):
 ```
 
 The standard security handler is supported through RC4 and AES-256; a public-key handler raises
-a `PdfError` naming the encryption it cannot use.
+a `Pdf.Error` naming the encryption it cannot use.
 
 ### Pages
 
@@ -96,7 +96,7 @@ Positioned runs are available too, for a reader that needs coordinates rather th
 
 ### Metadata, navigation and attachments
 
-The document information dictionary reads as a `PdfInfo`, with its dates parsed from PDF's `D:`
+The document information dictionary reads as a `Pdf.Info`, with its dates parsed from PDF's `D:`
 format — including its offset, where one is given — and a malformed date reported as absent
 rather than as an error. Named destinations resolve through either the modern name tree or the
 old `/Dests` dictionary, and bookmarks form a tree of `Bookmark` values:
@@ -123,12 +123,12 @@ document.
 ```scala
 PdfFile(path).open(Read & Write): doc ?=>
   val operators = List
-    ( PdfOperator.BeginText, PdfOperator.SetFont(t"F1", 12),
-      PdfOperator.Offset(72, 720), PdfOperator.ShowText(winAnsi(t"Written")),
-      PdfOperator.EndText )
+    ( Pdf.Operator.BeginText, Pdf.Operator.SetFont(t"F1", 12),
+      Pdf.Operator.Offset(72, 720), Pdf.Operator.ShowText(winAnsi(t"Written")),
+      Pdf.Operator.EndText )
 
   doc.setContents(doc.pages(0), operators)
-  doc.setInfo(PdfInfo(t"A Title", t"An Author", Unset, Unset, Unset, Unset, Unset, Unset))
+  doc.setInfo(Pdf.Info(t"A Title", t"An Author", Unset, Unset, Unset, Unset, Unset, Unset))
   doc.addLink(doc.pages(0), rect, uri = t"https://soundness.dev/")
 ```
 

--- a/doc/modules/processes.md
+++ b/doc/modules/processes.md
@@ -137,11 +137,11 @@ file descriptor, and it renders and parses in its own form.
 ### Failure
 
 A command that cannot be run at all — a missing binary, a directory that is not executable —
-raises an `ExecError` carrying the command that failed, so the error names what was attempted
+raises an `Exec.Error` carrying the command that failed, so the error names what was attempted
 rather than reporting an operating-system errno:
 
 ```scala
-capture[ExecError](sh"no-such-binary".exec[Text]()).command.arguments.head
+capture[Exec.Error](sh"no-such-binary".exec[Text]()).command.arguments.head
 // t"no-such-binary"
 ```
 

--- a/doc/modules/processes.md
+++ b/doc/modules/processes.md
@@ -16,6 +16,8 @@ interpolated value can smuggle in extra arguments or a shell metacharacter; buil
 be safe and the convenience is gone. Either way the output comes back as a raw stream to be decoded,
 buffered and closed by hand, and the exit status is an integer to remember to check.
 
+A process whose result type and failure modes are in its signature is an [honest signature](../philosophy/honest-signatures.md) for something usually driven by side effect.
+
 Soundness parses the command structure at compiletime, so quoting is understood before the program
 runs, and each substituted value is escaped for its exact position — a value spliced where a single
 argument is expected stays one argument, however it is spelled. The output is interpreted by the
@@ -25,14 +27,16 @@ strategy in scope:
 
 ```scala
 import soundness.*
-import workingDirectories.javaBaseWorkingDirectory
+
+import errorDiagnostics.stackTracesDiagnostics
 import logging.silentLogging
 import strategies.throwUnsafely
+import workingDirectories.javaBaseWorkingDirectory
 ```
 
 ### Defining a command
 
-`sh"…"` builds a `Command`, splitting on whitespace and honouring quotes as a shell would:
+`sh"…"` builds a `Command`, splitting on whitespace and honoring quotes as a shell would:
 
 ```scala
 sh"ls -la"   // Command(t"ls", t"-la")
@@ -127,8 +131,11 @@ its `pid`, and the process object itself — for the occasions where a signal mu
 process tree inspected:
 
 ```scala
-job.pid          // Pid(…), rendered as ↯1234
-job.process      // the underlying OS process
+val sleeper = sh"sleep 30".fork[Unit]()
+
+sleeper.pid          // Pid(…), rendered as ↯1234
+sleeper.process      // the underlying OS process
+sleeper.kill()
 ```
 
 A `Pid` is a distinct type rather than a number, so it cannot be confused with an exit code or a
@@ -141,7 +148,7 @@ raises an `Exec.Error` carrying the command that failed, so the error names what
 rather than reporting an operating-system errno:
 
 ```scala
-capture[Exec.Error](sh"no-such-binary".exec[Text]()).command.arguments.head
+capture[Exec.Error](sh"no-such-binary".exec[Text]()).command.arguments.prim
 // t"no-such-binary"
 ```
 

--- a/doc/modules/protobuf.md
+++ b/doc/modules/protobuf.md
@@ -122,6 +122,6 @@ case class Unnumbered(value: Int, other: Int)   // fields 1 and 2
 
 ### Errors
 
-A malformed message raises a `ProtobufError` naming the problem and the byte offset — truncated
+A malformed message raises a `Protobuf.Error` naming the problem and the byte offset — truncated
 input, a malformed varint, an unexpected wire type, a missing required field — so wire-level faults
 are debugged from the error rather than a hex dump.

--- a/doc/modules/protobuf.md
+++ b/doc/modules/protobuf.md
@@ -15,6 +15,8 @@ files, a generator emits source code, and the build keeps the two in step. That 
 cross-language schemas, but for a Scala program talking to a Scala program — or one that simply
 must speak an existing proto3 protocol — it is machinery without benefit.
 
+Field numbers and types living in the case class, and the encoder derived from them, keep the wire format and the code in agreement — [correctness](../philosophy/correctness.md) with one definition.
+
 Soundness derives the wire format from the case class itself. Field numbers, the one thing proto3
 needs that Scala does not, come from an annotation; everything else — varints, zig-zag encoding,
 length-delimited messages, packed repeated fields — follows from the field types, and the encoding
@@ -38,8 +40,11 @@ Encoding produces the message value and then its bytes; decoding reads bytes bac
 ```scala
 val bytes = Person(t"Alice", 30).in[Protobuf].encode   // the wire bytes
 
-Stream(bytes).read[Person in Protobuf]             // Person(t"Alice", 30)
+Chain(bytes).read[Person in Protobuf]                  // Person(t"Alice", 30)
 ```
+
+Decoding may also stop at the generic message, to be inspected or converted later: `read[Protobuf]`
+gives a `Protobuf` value, and `as[Person]` converts it.
 
 Fields left unannotated number themselves in declaration order, and the numbers may be sparse —
 `@field(3)` and `@field(7)` with nothing between — as protocol evolution requires.
@@ -47,7 +52,7 @@ Fields left unannotated number themselves in declaration order, and the numbers 
 ### Field types
 
 The Scala type decides the proto3 encoding. The sized [numeric types](numbers.md) map onto proto3's
-integer flavours precisely — an unsigned `U32` is a `uint32` varint, a signed `S32` uses zig-zag
+integer flavors precisely — an unsigned `U32` is a `uint32` varint, a signed `S32` uses zig-zag
 `sint32`, a `B32` is a `fixed32` — text is length-delimited, an `Optional` field may be absent, a
 `List` of numbers packs, and a `Map` becomes the standard repeated key–value entries:
 
@@ -64,7 +69,7 @@ A nested case class is a nested message, and an enumeration or sealed hierarchy 
 ### Presence, repetition and maps
 
 Proto3's treatment of absence is a well-known source of confusion, and the type says which
-behaviour applies. An `Optional` field has explicit presence: unset, it writes nothing, and reads
+behavior applies. An `Optional` field has explicit presence: unset, it writes nothing, and reads
 back as `Unset` — distinct from a field that is present and zero.
 
 A `List` field is repeated, and keeps its order and its default elements: a list of `0, 1, 2`
@@ -90,7 +95,12 @@ without disturbing the rest:
 ```scala
 import conversions.encodableToProtobuf
 
-wrapper.lens(_(Prim) = Point(7, 8).in[Protobuf]).as[Wrapper]
+case class Point(@field(1) x: Int, @field(2) y: Int)
+case class Wrapper(@field(1) point: Point, @field(2) label: Text)
+
+val wrapper: Protobuf = Wrapper(Point(3, 4), t"origin").in[Protobuf]
+
+wrapper.lens(_(Prim) = Point(7, 8)).as[Wrapper]   // Wrapper(Point(7, 8), t"origin")
 ```
 
 This is what to use where a message must be relayed with one field altered and everything else —

--- a/doc/modules/quantities.md
+++ b/doc/modules/quantities.md
@@ -12,7 +12,7 @@ design constraint rather than an optimization; see [zero cost](../philosophy/zer
 ### On quantities
 
 A bare number carries no units: the figure `5` says nothing about whether it counts
-metres, feet, seconds or kilograms. Code that loses track of the answer has caused
+meters, feet, seconds or kilograms. Code that loses track of the answer has caused
 real disasters, the
 [loss of a Mars orbiter](https://en.wikipedia.org/wiki/Mars_Climate_Orbiter#Cause_of_failure)
 among them, when one component worked in newtons and another in pound-force. The
@@ -29,10 +29,15 @@ this survives to runtime: a `Quantity` is an opaque `Double`, and its operations
 inline away, so the safety is paid for entirely at compiletime.
 
 Units, prefixes and the quantity operations all come from the `soundness`
-package:
+package. Arithmetic between a plain number and a quantity relies on the compiler's
+`into` conversions, so that language feature is enabled too, and a `Decimalizer`
+in scope fixes how many significant figures a quantity shows with:
 
 ```scala
 import soundness.*
+import scala.language.experimental.into
+
+given Decimalizer = Decimalizer(3)
 ```
 
 ### Quantities and units
@@ -71,10 +76,7 @@ Adding quantities whose dimensions disagree is a compile error, and the message
 names the mismatch in plain words rather than in terms of types:
 
 ```scala
-Metre + 2*Second
-// does not compile:
-// the left operand represents distance, but the right operand represents time;
-// these are incompatible physical quantities
+Metre + 2*Second   // does not compile: the left operand represents distance, but the right operand represents time; these are incompatible physical quantities
 ```
 
 The check is by dimension, not merely by unit, so a length cannot be added to an
@@ -115,9 +117,13 @@ target unit family:
 (3*Metre).convert[Feet]    // 9.8425… feet
 ```
 
-`normalize` does the same, written with the fully-powered unit type:
+`normalize` does the same, written with the fully-powered unit type. An hour is not
+one of the predefined unit values, but a unit is only a quantity of one, so it is a
+one-line definition:
 
 ```scala
+val Hour: Quantity[Hours[1]] = Quantity(1.0)
+
 (2*Hour).normalize[Seconds[1]]   // 7200 seconds
 (1*Inch).normalize[Metres[1]]    // 0.0254 metres
 ```
@@ -190,7 +196,7 @@ does not compile — which is exactly the gap `===` fills.
 
 The named SI units — `Newton`, `Joule`, `Watt`, `Pascal`, `Volt` and many more —
 are defined in terms of the base units, so they interoperate with them. A force in
-newtons and a length in metres multiply to an energy that displays in joules.
+newtons and a length in meters multiply to an energy that displays in joules.
 Every quantity can also name its own dimension, worked out from its units:
 
 ```scala
@@ -219,11 +225,11 @@ Seven base dimensions are defined, each with its units type and the value naming
 | `Heat`              | `Kelvins`   | `Kelvin`  |
 
 The named derived units are defined in terms of those, so each carries its full dimensions rather
-than being a distinct kind of thing: `Hertz` (one per second), `Newton` (metre-kilogram per second
-squared), `Pascal` (newton per square metre), `Joule` (newton-metre), `Watt` (joule per second),
+than being a distinct kind of thing: `Hertz` (one per second), `Newton` (meter-kilogram per second
+squared), `Pascal` (newton per square meter), `Joule` (newton-meter), `Watt` (joule per second),
 `Coulomb` (second-ampere), `Volt` (watt per ampere), `Farad` (coulomb per volt), `Ohm` (volt per
-ampere), `Siemens` (ampere per volt), `Weber` (volt-second), `Tesla` (weber per square metre),
-`Henry` (weber per ampere), `Lux` (candela per square metre), `Becquerel` (one per second), `Gray`
+ampere), `Siemens` (ampere per volt), `Weber` (volt-second), `Tesla` (weber per square meter),
+`Henry` (weber per ampere), `Lux` (candela per square meter), `Becquerel` (one per second), `Gray`
 and `Sievert` (joule per kilogram), and `Katal` (mole per second). The CGS and imperial systems are
 provided alongside them — `Dyne`, `Erg`, `Gauss`, `Poise`, `Foot`, `Furlong`, `Stone` and the rest.
 
@@ -406,7 +412,7 @@ like any other:
 import temperatureScales.celsiusScale
 (zero[Temperature] + 300*Kelvin).show   // t"26.9 °C"
 
-(Fahrenheit(100) - zero[Temperature]).to[Rankines].show   // t"560 °R"
+(Fahrenheit(100) - zero[Temperature]).convert[Rankines].show   // t"560 °R"
 ```
 
 Reading the same temperature on a different scale is a matter of importing a
@@ -425,9 +431,9 @@ a list of seconds is in seconds squared, and the standard deviation back in
 seconds:
 
 ```scala
-List(1*Second, 2*Second, 3*Second).total        // 6 seconds
-List(1*Second, 2*Second, 3*Second).mean.vouch    // 2 seconds
-List(1*Second, 2*Second, 3*Second).std.vouch     // √(2/3) seconds
+List(1*Second, 2*Second, 3*Second).total   // 6 seconds
+List(1*Second, 2*Second, 3*Second).mean    // 2 seconds, or Unset for an empty list
+List(1*Second, 2*Second, 3*Second).std     // √(2/3) seconds, likewise Optional
 ```
 
 ### Quantifying your own types
@@ -480,7 +486,7 @@ distance. Passing an argument in the wrong units, or returning the wrong dimensi
 is a compile error rather than a number that is quietly wrong.
 
 The same calculation can be written once for any consistent choice of units, rather
-than fixed to metres and seconds. A `transparent inline def` resolves its units at
+than fixed to meters and seconds. A `transparent inline def` resolves its units at
 each call, so its parameters can be left abstract; the relationships the formula
 relies on are then stated as the constraints that a velocity times a time and an
 acceleration times a time squared can each be formed, and that the two results can

--- a/doc/modules/randomness.md
+++ b/doc/modules/randomness.md
@@ -15,6 +15,8 @@ Randomness hides assumptions. `math.random()` answers only one narrow question �
 depended on chance cannot be replayed; and whether the generator is predictable, which is harmless
 in a simulation and fatal in a token generator, is nowhere visible in the code.
 
+A random source as a capability rather than a global is [declarative context](../philosophy/declarative-context.md): reproducibility follows from the scope, not from discipline.
+
 Soundness separates the concerns and names each one. Where randomness is used is delimited by a
 block; which generator supplies it — seeded for reproducibility, secure for secrets — is an import;
 what distribution shapes a number is a given; and any type reachable from these gains a random
@@ -75,8 +77,10 @@ bounds it at a hundred elements. A type whose values need more care than field-b
 defines its own instance, or maps an existing one:
 
 ```scala
+import randomDistributions.uniformUnitIntervalDistribution
+
 case class Latitude(degrees: Double)
-given Latitude is Randomizable = summon[Double is Randomizable].map(d => Latitude(d % 90))
+given Latitude is Randomizable = summon[Double is Randomizable].map(d => Latitude(d*180 - 90))
 ```
 
 Where field-by-field generation *is* right, an instance derives from the type, so a case class of
@@ -91,6 +95,8 @@ failing run and supplying it again reproduces exactly the same values — includ
 generated collections, which are drawn from the same generator:
 
 ```scala
+import randomSizes.uniformSizeUpto100
+
 Seed(42L).stochastic:
   arbitrary[List[Int]]()
 ```
@@ -110,7 +116,7 @@ A `Random` in scope also shuffles a sequence and answers a fair coin-toss, the s
 that otherwise get hand-rolled badly:
 
 ```scala
-stochastic:
+stochastic: (random: Random) ?=>
   random.shuffle(List(1, 2, 3, 4, 5))
   toss()   // true or false, evenly
 ```

--- a/doc/modules/randomness.md
+++ b/doc/modules/randomness.md
@@ -70,7 +70,7 @@ be confused: the difference is written at the import.
 
 ### Collections and custom types
 
-A random collection needs a size, chosen as a `RandomSize` given — `randomSizes.uniformSizeUpto100`
+A random collection needs a size, chosen as a `Random.Size` given — `randomSizes.uniformSizeUpto100`
 bounds it at a hundred elements. A type whose values need more care than field-by-field generation
 defines its own instance, or maps an existing one:
 

--- a/doc/modules/records.md
+++ b/doc/modules/records.md
@@ -29,12 +29,32 @@ cannot drift from the code, because the code's types *are* the schema's. Everyth
 import soundness.*
 ```
 
+A record typed by its schema at compiletime is [safety by construction](../philosophy/safety-by-construction.md) with no class written by hand.
+
 ### Using records
 
-A schema object — here a `JsonBlueprint` built from a JSON Schema document — offers a `record`
-method that turns raw data into a typed record:
+A schema object — here a `JsonBlueprint` built from a JSON Schema document, declared in a file of
+its own — offers a `record` method that turns raw data into a typed record:
 
+<!-- doccheck: skip -->
 ```scala
+object Catalogue extends JsonBlueprint(t"""{
+  "type": "object",
+  "required": ["name", "children"],
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer" },
+    "children": {
+      "type": "array",
+      "items": { "weight": { "type": "number", "minimum": 0 } }
+    }
+  }
+}""".read[Json].as[JsonBlueprint.Doc])
+```
+
+<!-- doccheck: skip -->
+```scala
+val input = t"""{"name": "Bicycle", "children": [{"weight": 9.5}]}""".read[Json]
 val record = Catalogue.record(input)
 
 record.name                  // Text, because the schema says string
@@ -56,6 +76,7 @@ nested objects, arrays.
 
 The schema object then exposes the one-line macro that makes it usable:
 
+<!-- doccheck: skip -->
 ```scala
 transparent inline def record(json: Json): Record = ${build('json)}
 ```
@@ -67,6 +88,7 @@ the calling code was compiled.
 `Record`, but what it actually returns is a *structural refinement* of it — for a schema of three
 fields, the type
 
+<!-- doccheck: skip -->
 ```scala
 Record { def age: Double; def name: Text; def employed: Boolean }
 ```

--- a/doc/modules/rpc.md
+++ b/doc/modules/rpc.md
@@ -3,7 +3,7 @@
 ### About
 
 A remote procedure call pretends a method call crosses the network, and Soundness makes the
-pretence typed at both ends. An RPC interface is an ordinary trait whose methods are marked
+pretense typed at both ends. An RPC interface is an ordinary trait whose methods are marked
 `@rpc`; from that one definition, a *server* dispatches incoming calls to an implementation and a
 *client* stub turns method calls into wire messages — for
 [JSON-RPC 2.0](https://www.jsonrpc.org/specification) over HTTP, and for
@@ -21,12 +21,18 @@ correlation, error envelopes. Writing it by hand for each interface invites the 
 client and server disagreeing about a parameter name — and code generators reintroduce the build
 machinery that in-language derivation avoids.
 
+Deriving both ends of a protocol from one trait is [correctness](../philosophy/correctness.md) by construction: client and server cannot disagree about a method they share.
+
 Soundness derives both sides from the trait. The trait is the single source of truth; the macro
 reads its `@rpc` methods, their parameter names and types, and produces dispatch and stub code
-whose encodings agree by construction. Everything comes from the `soundness` package:
+whose encodings agree by construction. Everything comes from the `soundness` package, with an
+encoding for the bytes that cross the wire:
 
 ```scala
 import soundness.*
+import strategies.throwUnsafely
+import charEncoders.utf8Encoder
+import charDecoders.utf8Decoder
 ```
 
 ### An interface
@@ -51,8 +57,19 @@ an optional response — ready to sit behind any transport, typically an [HTTP](
 handler. On the calling side, `remote` manufactures a client from the same trait:
 
 ```scala
-val dispatch = JsonRpc.serve[Echo](implementation)
+object EchoService extends Echo:
+  def call(request: Ping): Pong = Pong(request.message)
 
+val dispatch = JsonRpc.serve[Echo](EchoService)
+```
+
+The dispatcher is a function from a request `Json` document to an optional response — a
+notification produces none — and is called from a route handler with the request body. On the
+calling side, `remote` manufactures a client from the same trait, which sends each call as a
+request to the URL:
+
+<!-- doccheck: skip -->
+```scala
 val echo = remote[Echo](url"https://api.example.com/rpc")
 echo.call(Ping(t"hello"))   // a JSON-RPC request over HTTP
 ```
@@ -63,9 +80,13 @@ The same trait shape serves gRPC. A `Grpc.Channel` opens over an [HTTP/2](http-s
 connection, and `Grpc.remote` derives the stub — a method returning a value makes a unary call,
 one returning a `Stream` a server-streaming call — with payloads as Protocol Buffers messages:
 
+<!-- doccheck: skip -->
 ```scala
+import threading.platformThreading
+
 supervise:
-  val channel = Grpc.Channel(endpoint)
+  val endpoint = Endpoint(t"localhost", Port[Tcp](50051))
+  val channel = Grpc.Channel(Http2.Endpoint(endpoint, t"localhost"))
   val echo = Grpc.remote[Echo](channel, t"echo.Echo")
 
   echo.call(Ping(t"ping"))   // a unary gRPC call
@@ -78,12 +99,13 @@ A non-OK response raises a `Grpc.Error` carrying the canonical status code — `
 
 An `Sse` value is one event of an SSE stream, with its event name, data lines, id and retry
 interval; a stream of them serves as `text/event-stream`, and an `Sse.Source` buffers events with
-replay from a client's last-seen id — the reconnection behaviour the protocol calls for:
+replay from a client's last-seen id — the reconnection behavior the protocol calls for:
 
 ```scala
 val source = Sse.Source(capacity = 128)
-source.put(update)
-source.stream(start = lastEventId)
+source.put(t"first update")
+source.put(t"second update")
+source.stream(start = 1)   // the events from id 1 onward, then those that follow
 ```
 
 ### Framing
@@ -92,12 +114,17 @@ Message boundaries in a raw stream are recovered with `frames`, naming the conve
 length prefix, a `Content-Length` header as LSP uses, or line endings:
 
 ```scala
-stream.iterator.frames[LengthPrefix]     // length-prefixed messages
-input.iterator.frames[ContentLength]     // header-framed messages, byte-counted
-lines.iterator.frames[CrLf]              // CRLF-separated lines
-lines.iterator.frames[Linefeed]          // or bare linefeeds, or CR alone
-framed.iterator.frames[Grpc.Framing]      // gRPC's flag byte and 4-byte length
+val prefixed = Chain(Data(0, 0, 0, 2, 104, 105))
+val headed = Chain(t"Content-Length: 2\r\n\r\nhi".in[Data])
+val lines = Chain(t"one\r\ntwo\r\n")
+
+prefixed.iterator.frames[LengthPrefix]     // length-prefixed messages: "hi"
+headed.iterator.frames[ContentLength]      // header-framed messages, byte-counted: "hi"
+lines.iterator.frames[CrLf]                // CRLF-separated lines: "one", "two"
+lines.iterator.frames[Linefeed]            // or bare linefeeds, or CR alone
 ```
+
+gRPC's own framing — a flag byte and a four-byte length — is `Grpc.Framing`, used the same way.
 
 Framing is independent of how the bytes arrive. A message split across three chunks, two messages
 in one chunk, and a final message with no terminator are all handled, because the framer keeps its
@@ -120,7 +147,7 @@ round-tripped. A gRPC message's framing is one flag byte and a four-byte length,
 is checked to produce exactly that:
 
 ```scala
-Grpc.Framing.encode(payload)   // 00 00 00 00 05, then the payload
+Grpc.Framing.encode(t"hello".in[Data])   // 00 00 00 00 05, then the five bytes
 ```
 
 HPACK's header compression is verified against every example in

--- a/doc/modules/rpc.md
+++ b/doc/modules/rpc.md
@@ -59,29 +59,29 @@ echo.call(Ping(t"hello"))   // a JSON-RPC request over HTTP
 
 ### gRPC
 
-The same trait shape serves gRPC. A `GrpcChannel` opens over an [HTTP/2](http-server.md)
+The same trait shape serves gRPC. A `Grpc.Channel` opens over an [HTTP/2](http-server.md)
 connection, and `Grpc.remote` derives the stub — a method returning a value makes a unary call,
 one returning a `Stream` a server-streaming call — with payloads as Protocol Buffers messages:
 
 ```scala
 supervise:
-  val channel = GrpcChannel(endpoint)
+  val channel = Grpc.Channel(endpoint)
   val echo = Grpc.remote[Echo](channel, t"echo.Echo")
 
   echo.call(Ping(t"ping"))   // a unary gRPC call
 ```
 
-A non-OK response raises a `GrpcError` carrying the canonical status code — `NotFound`,
+A non-OK response raises a `Grpc.Error` carrying the canonical status code — `NotFound`,
 `Unauthenticated` and the rest — as a typed value.
 
 ### Server-sent events
 
 An `Sse` value is one event of an SSE stream, with its event name, data lines, id and retry
-interval; a stream of them serves as `text/event-stream`, and an `SseSource` buffers events with
+interval; a stream of them serves as `text/event-stream`, and an `Sse.Source` buffers events with
 replay from a client's last-seen id — the reconnection behaviour the protocol calls for:
 
 ```scala
-val source = SseSource(capacity = 128)
+val source = Sse.Source(capacity = 128)
 source.put(update)
 source.stream(start = lastEventId)
 ```
@@ -96,7 +96,7 @@ stream.iterator.frames[LengthPrefix]     // length-prefixed messages
 input.iterator.frames[ContentLength]     // header-framed messages, byte-counted
 lines.iterator.frames[CrLf]              // CRLF-separated lines
 lines.iterator.frames[Linefeed]          // or bare linefeeds, or CR alone
-framed.iterator.frames[GrpcFraming]      // gRPC's flag byte and 4-byte length
+framed.iterator.frames[Grpc.Framing]      // gRPC's flag byte and 4-byte length
 ```
 
 Framing is independent of how the bytes arrive. A message split across three chunks, two messages
@@ -104,11 +104,11 @@ in one chunk, and a final message with no terminator are all handled, because th
 own position rather than assuming chunk boundaries mean anything:
 
 ```scala
-LazyList(t"one\ntwo\nth", t"ree").iterator.frames[Linefeed].to(List)
+Chain(t"one\ntwo\nth", t"ree").iterator.frames[Linefeed].to(List)
 // List("one", "two", "three")
 ```
 
-A truncated or malformed frame raises a `FrameError` naming what was wrong, so a protocol failure
+A truncated or malformed frame raises a `Framing.Error` naming what was wrong, so a protocol failure
 is a diagnosis rather than a hang.
 
 ### Verifying a wire format
@@ -120,7 +120,7 @@ round-tripped. A gRPC message's framing is one flag byte and a four-byte length,
 is checked to produce exactly that:
 
 ```scala
-GrpcFraming.encode(payload)   // 00 00 00 00 05, then the payload
+Grpc.Framing.encode(payload)   // 00 00 00 00 05, then the payload
 ```
 
 HPACK's header compression is verified against every example in

--- a/doc/modules/sockets.md
+++ b/doc/modules/sockets.md
@@ -29,6 +29,8 @@ import soundness.*
 import strategies.throwUnsafely
 import threading.platformThreading
 import probates.awaitProbate
+import logging.silentLogging
+import charDecoders.utf8Decoder
 ```
 
 ### Serving
@@ -36,14 +38,16 @@ import probates.awaitProbate
 `listen` binds a socket and runs a handler for each arrival — a connection for TCP and domain
 sockets, a packet for UDP — each on its own daemon. The returned service stops the listener:
 
+<!-- doccheck: skip -->
 ```scala
+def response(request: Stream[Data]): Stream[Data] = request
+
 supervise:
   val port = Port[Tcp]()   // an unused ephemeral port
 
-  val server = port.listen[Data]: connection =>
-    response(connection.stream())
-
-  server.stop()
+  port.listen[Data](connection => response(connection.stream())):
+    // the server runs for the duration of this block
+    ()
 ```
 
 The endpoint decides the shape of the handler, on both sides. A stateful endpoint hands the
@@ -54,9 +58,11 @@ datagram without the handler having to state which it is dealing with.
 A UDP handler receives a `Packet` — the datagram with its sender — and answers with a reply or
 silence:
 
+<!-- doccheck: skip -->
 ```scala
-udpPort.listen[Data]: packet =>
-  UdpResponse.Reply(acknowledge(packet.data))
+supervise:
+  Port[Udp]().listen[Data](packet => UdpResponse.Reply(packet.data)):
+    ()
 ```
 
 ### Clients
@@ -64,6 +70,7 @@ udpPort.listen[Data]: packet =>
 A request–response client sends a message and reads the reply stream with `transmit`; a message is
 anything *transmissible* — bytes, text, or any value that encodes to text:
 
+<!-- doccheck: skip -->
 ```scala
 val reply = DomainSocket(t"/run/service.sock").transmit(t"request")
 ```
@@ -73,10 +80,11 @@ state, reply, or conclude — so a client-side protocol is a state machine rathe
 reads and writes. `duplex` opens a persistent bidirectional connection, sending and receiving
 independently, which is the transport beneath [HTTP/2](http-server.md):
 
+<!-- doccheck: skip -->
 ```scala
-socket.duplex: duplex =>
-  duplex.send(Stream(request))
-  duplex.stream.head
+DomainSocket(t"/run/service.sock").duplex: duplex =>
+  duplex.send(Stream(t"request".in[Data]))
+  duplex.stream.prim
 ```
 
 ### Sessions
@@ -86,7 +94,10 @@ it to the block, and closes it when the block ends. The result type is quantifie
 block, so a value still borrowing the live connection cannot escape it, while a memoized value
 can:
 
+<!-- doccheck: skip -->
 ```scala
+val endpoint = Endpoint(ip"127.0.0.1", Port[Tcp](8080))
+
 endpoint.session: connection ?=>
   converse(connection)
 ```
@@ -154,8 +165,9 @@ be checked later.
 `Control` saying what happens next. `Continue` carries the new state — or none, leaving it
 unchanged — and `Terminate` ends the conversation:
 
+<!-- doccheck: skip -->
 ```scala
-socket.exchange(initial):
+endpoint.exchange(initial):
   case (state, message) =>
     if done(message) then Terminate else Continue(next(state, message))
 ```

--- a/doc/modules/sockets.md
+++ b/doc/modules/sockets.md
@@ -106,7 +106,7 @@ one socket. Offering nothing preserves the plain-TLS handshake that `wss` peers 
 
 Nothing above names a platform API. The primitive operations each role needs — bind and accept,
 connect and converse, receive and reply, dispatch a datagram — are gathered into a
-`SocketBackend`, and the loops that compose them stay platform-neutral. The
+`Socket.Backend`, and the loops that compose them stay platform-neutral. The
 `java.nio.channels` implementation is `socketBackends.javaBaseSockets`, and backends over
 `wasi:sockets` and over Scala Native's sockets supply the same operations, so the same protocol
 code runs on the JVM, inside a WebAssembly component, and in a native binary. An operation a
@@ -165,6 +165,6 @@ happens to be in a sequence of interleaved reads and writes.
 
 ### Errors
 
-Binding can fail — the port in use, permission denied — as a `BindError`, and an established
-connection can fail during accept, transmission or close as a `ConnectionError`, each naming its
+Binding can fail — the port in use, permission denied — as a `Bind.Error`, and an established
+connection can fail during accept, transmission or close as a `Socket.Error`, each naming its
 reason.

--- a/doc/modules/stack-traces.md
+++ b/doc/modules/stack-traces.md
@@ -17,6 +17,8 @@ compiler's, not the programmer's. For error *values* — the kind [Soundness err
 are — the trace should be a value too: comparable, transformable, renderable where and how the
 program chooses.
 
+A trace as an immutable value that can be trimmed, resolved and rendered follows [immutability](../philosophy/immutability.md) into diagnostics.
+
 `StackTrace` is that value. Everything comes from the `soundness` package:
 
 ```scala
@@ -29,10 +31,11 @@ Any `Throwable` converts to a `StackTrace` — its class, its message, its frame
 another `StackTrace`:
 
 ```scala
+val exception = Exception("boom")
 val trace = exception.stackTrace
 
-trace.frames.head.method   // the topmost method, demangled
-trace.cause                // an Optional[StackTrace]
+trace.frames.prim.let(_.method)   // the topmost method, demangled
+trace.cause                       // an Optional[StackTrace]
 ```
 
 `crop` and `drop` trim frames — the machinery below a test framework's entry point, say — so a
@@ -52,7 +55,7 @@ Whether Soundness's own errors capture traces at all is the `Diagnostics` choice
 
 Demangling can only tidy a compiled name up. `$anonfun$3` becomes `λ₃`, which says a lambda ran
 but not *which* lambda — and the names that most need explaining are exactly the ones the compiler
-mints after its output is pickled: anonymous functions, initialisers, bridges, specialisations. No
+mints after its output is pickled: anonymous functions, initializers, bridges, specializations. No
 amount of rewriting recovers them, because the information is not in the name.
 
 Position does what name cannot. The compiler records the extent of every definition, so the line a
@@ -69,20 +72,24 @@ definition's own source name, and what kind of definition it is. `displayClass` 
 where they are not, so a renderer needs no branch of its own:
 
 ```scala
-frame.displayClass    // the enclosing definitions, in source terms
-frame.displayMethod   // the definition's own name
-frame.source.let(_.kind)
+trace.frames.prim.let: frame =>
+  frame.displayClass         // the enclosing definitions, in source terms
+  frame.displayMethod        // the definition's own name
+  frame.source.let(_.kind)   // Kind.Method, Kind.Lambda, Kind.Constructor, …
 ```
 
 The `Kind` distinguishes a method from a lambda, a value, a constructor, an extension or a default
 argument — and, separately, marks the kinds that are pure plumbing: bridges, forwarders,
-initialisers and specialisations, which `plumbing` reports so that a renderer can dim or drop
+initializers and specializations, which `plumbing` reports so that a renderer can dim or drop
 them.
 
 Resolution costs one file read per top-level class named in the trace, so it is opt-in rather than
-automatic. A trace already in hand is resolved explicitly instead of by import:
+automatic. A trace already in hand is resolved explicitly instead of by import, through whichever
+[classloader](classpath.md) can find the compiled classes:
 
 ```scala
+import classloaders.threadContextClassloader
+
 trace.resolved
 ```
 
@@ -97,8 +104,10 @@ A `Codepoint` is the source file and line of a call site, captured automatically
 asks for one as a given:
 
 ```scala
-def note(message: Text)(using codepoint: Codepoint): Unit =
-  record(t"${codepoint.text}: $message")   // e.g. app.scala:42
+def note(message: Text)(using codepoint: Codepoint): Text =
+  t"${codepoint.text}: $message"   // e.g. app.scala:42: message
+
+note(t"checkpoint")
 ```
 
 This is how Soundness's logs, tests and caches know where they were called from, without any caller

--- a/doc/modules/staging.md
+++ b/doc/modules/staging.md
@@ -27,12 +27,15 @@ one expression. Scala's staging machinery already knows how to compile a quoted 
 runtime and how to splice values into it; what it fixes is *where* the result runs. Compiling both
 sides *together*, and delimiting them with quotes and splices, puts the contract back under the
 compiler's control: remote code is written beside the local code that calls it, checked with it,
-marshalled for it, and maintained in lockstep with it.
+marshaled for it, and maintained in lockstep with it.
+
+Code that is checked here and run elsewhere is [safety by construction](../philosophy/safety-by-construction.md) extended across a process boundary.
 
 ### Quotes, splices and phases
 
 The syntax is Scala's own, and it is worth restating what it means. In a macro:
 
+<!-- doccheck: skip -->
 ```scala
 def say(user: String)(using Quotes): Expr[Unit] =
   val name: Expr[String] = Expr(user)
@@ -52,7 +55,7 @@ another file is that quotes and splices nest and interleave at expression granul
 compiler checks consistency *across* the phases.
 
 Soundness makes the "where" a value: a `Rig` says how code is deployed and invoked, and `dispatch`
-does the rest — compilation, caching per call site, marshalling of captured values in and results
+does the rest — compilation, caching per call site, marshaling of captured values in and results
 out. Everything comes from the `soundness` package:
 
 ```scala
@@ -102,6 +105,7 @@ Two rigs come provided. `Jvm` compiles the block and runs it in a fresh JVM subp
 isolation, at process-startup cost — while `Isolation` runs it in the same process under an
 isolated classloader, cheap and contained:
 
+<!-- doccheck: skip -->
 ```scala
 Isolation.dispatch:
   '{ t"computed in an isolated classloader" }
@@ -163,10 +167,10 @@ That distinction is load-bearing. One call site inside an inline method may expa
 tree at each use, and keying on the call site alone would silently re-run the first expansion for
 every subsequent one. Keying on the tree means several distinct expansions from one site each
 compile once, while calls that differ only in the data they transport share a single compilation —
-which is the behaviour that makes dispatching from a generic or inline context safe.
+which is the behavior that makes dispatching from a generic or inline context safe.
 
 A spliced value is evaluated once per dispatch, not once per occurrence: `${job.name}` used twice
-in a block refers to the same marshalled value rather than evaluating `job.name` twice.
+in a block refers to the same marshaled value rather than evaluating `job.name` twice.
 
 ### Errors across the boundary
 

--- a/doc/modules/streams.md
+++ b/doc/modules/streams.md
@@ -52,6 +52,11 @@ for the text/byte boundary:
 import soundness.*
 import charEncoders.utf8Encoder
 import charDecoders.utf8Decoder
+import strategies.throwUnsafely
+import pathInterfaces.pathOnLinux
+import filesystemOptions.overwritePreexisting
+import filesystemOptions.createNonexistentParents
+import stdios.javaLangSystemStdio
 ```
 
 ### Reading a source
@@ -74,7 +79,10 @@ process's output — so reading a URL as text and reading a file as bytes are th
 `writeTo` sends a value to a destination that knows how to consume it. The source may be text,
 bytes, or a stream of either, and the destination's `Writable` instance receives it:
 
+<!-- doccheck: skip -->
 ```scala
+val destination = t"/tmp/streams-tutorial.txt".decode[Path on Linux]
+
 source.writeTo(destination)
 ```
 
@@ -84,12 +92,12 @@ A type becomes a source by describing how it turns into a stream, and a sink by 
 it consumes one. Each is a single-method typeclass:
 
 ```scala
-case class Record(fields: List[Text])
+case class Row(name: Text, count: Int)
 
-given Record is Streamable by Text = record => Stream(record.fields.join(t","))
+given Row is Streamable by Text over Credit = row => Stream(t"${row.name},${row.count}")
 ```
 
-With that instance in scope a `Record` can be `read`, `writeTo` a destination, or `stream`ed,
+With that instance in scope a `Row` can be `read`, `writeTo` a destination, or `stream`ed,
 without any further definitions.
 
 ### Streaming a value
@@ -99,7 +107,7 @@ instance, naming the element type:
 
 ```scala
 val bytes = t"The quick brown fox".in[Data].stream   // Stream[Data]
-val text = document.source[Text]                     // Stream[Text]
+val text = Row(t"apples", 3).source[Text]            // Stream[Text]
 ```
 
 ### Composing a pipeline
@@ -109,6 +117,7 @@ side, and the whole chain runs on the consumer's thread as nested refills — no
 queues, no intermediate collections. Each stage takes what the last one produced, which is
 [composability](../philosophy/composability.md) in its most literal form:
 
+<!-- doccheck: skip -->
 ```scala
 file.stream.via(decompressor).via(decoder)
 ```
@@ -119,9 +128,10 @@ present themselves as stages.
 
 A pipeline ends in a *terminal* operation, which drains the endpoint and closes it:
 
+<!-- doccheck: skip -->
 ```scala
-stream.memoize                          // drain into one immutable value
-stream.sweep((storage, start, n) => …)  // drain, seeing each raw window
+stream.memoize                                   // drain into one immutable value
+stream.sweep((storage, start, n) => count += n)  // drain, seeing each raw window
 ```
 
 `sweep` — and `gather`, its accumulating counterpart — expose the raw window rather than boxed
@@ -133,6 +143,7 @@ and `drop`.
 Where a pipeline ends in a *push* chain rather than a value, `pump` is the single point at which
 data crosses from the pull side to the push side:
 
+<!-- doccheck: skip -->
 ```scala
 stream.pump(intake)
 ```
@@ -193,13 +204,18 @@ draw on concurrency, so they run inside a supervised scope:
 
 ```scala
 import threading.platformThreading
+import probates.cancelProbate
 
-supervise(Confluence(first, second, third))
+val first = Stream(t"one")
+val second = Stream(t"two")
+val third = Stream(t"three")
+
+supervise(Confluence(first, second, third).memoize)
 ```
 
 `Divergence` is the opposite: one source is delivered to several subscribers, each chunk
 materialized once and shared immutably between them. A full subscriber queue parks the pump, so
-the slowest subscriber gates the source — the correct behaviour for replication.
+the slowest subscriber gates the source — the correct behavior for replication.
 
 ### Tuning backpressure
 
@@ -239,5 +255,4 @@ a whole value; see [compression](compression.md) for the formats available:
 
 ```scala
 Data(1, 2, 3, 5, 8).compress[Gzip].decompress[Gzip]   // the original bytes
-file.stream.decompress[Gzip].read[Text]
 ```

--- a/doc/modules/svg.md
+++ b/doc/modules/svg.md
@@ -22,7 +22,10 @@ little languages are rendered by the types that understand them. Everything come
 
 ```scala
 import soundness.*
+import strategies.throwUnsafely
 ```
+
+Figures as typed values, with coordinates that are quantities, follow [impossible states](../philosophy/impossible-states.md): a malformed drawing cannot be written.
 
 ### Shapes
 
@@ -104,7 +107,7 @@ A linear gradient is a definition with typed stops, each an offset in `[0, 1]` �
 [color](colors.md):
 
 ```scala
-LinearGradient(Svg.Id(t"fade"), Stop(0.0, WebColors.Red), Stop(1.0, WebColors.Blue))
+Svg.LinearGradient(Svg.Id(t"fade"), Stop(0.0, WebColors.Red), Stop(1.0, WebColors.Blue))
 ```
 
 ### Documents
@@ -118,13 +121,17 @@ Document(drawing, enc"UTF-8").show   // <?xml version="1.0" …?><svg …>
 ```
 
 Parsing runs the other way, reading SVG text back into typed figures and definitions, so a drawing
-produced elsewhere can be inspected, measured or altered rather than merely embedded:
+produced elsewhere can be inspected, measured or altered rather than merely embedded. The
+[XML](xml.md) parser beneath it takes a schema, and SVG's own vocabulary is validated by the
+figure types, so the free-form schema is the one to use:
 
 ```scala
+given XmlSchema = XmlSchema.Freeform
+
 val svg = t"""<svg width="50" height="50"><rect x="0" y="0" width="10" height="10"/></svg>"""
         . read[Svg]
 
-(svg.width, svg.height, svg.figures.length)   // (50.0f, 50.0f, 1)
+(svg.width, svg.height, svg.figures.size)   // (50.0f, 50.0f, 1)
 ```
 
 Because an `Svg` is an [XML](xml.md) value underneath, a drawing embeds directly into an

--- a/doc/modules/svg.md
+++ b/doc/modules/svg.md
@@ -89,12 +89,12 @@ Rectangle((0, 0), 10, 5).translate(+(3, 4))
 
 ### Identifiers
 
-A figure or definition may carry an `SvgId`, which is what a gradient reference, an animation
+A figure or definition may carry an `Svg.Id`, which is what a gradient reference, an animation
 target or a `<use>` element needs to name it. The identifier is a distinct type rather than text,
 so a reference to a definition that does not exist is not silently rendered:
 
 ```scala
-Outline(id = SvgId(t"plus")).moveTo((0, 0)).closed
+Outline(id = Svg.Id(t"plus")).moveTo((0, 0)).closed
 ```
 
 ### Gradients and color
@@ -104,7 +104,7 @@ A linear gradient is a definition with typed stops, each an offset in `[0, 1]` â
 [color](colors.md):
 
 ```scala
-LinearGradient(SvgId(t"fade"), Stop(0.0, WebColors.Red), Stop(1.0, WebColors.Blue))
+LinearGradient(Svg.Id(t"fade"), Stop(0.0, WebColors.Red), Stop(1.0, WebColors.Blue))
 ```
 
 ### Documents

--- a/doc/modules/syntax-highlighting.md
+++ b/doc/modules/syntax-highlighting.md
@@ -25,6 +25,8 @@ from the `soundness` package:
 import soundness.*
 ```
 
+A highlighted token that knows its type is [composability](../philosophy/composability.md) between the compiler and the renderer.
+
 ### Highlighting
 
 `Scala.highlight` tokenizes source into lines of accented tokens — keywords, identifiers, numbers,
@@ -51,9 +53,10 @@ With a compiler and classpath in scope, `typecheckedScala` runs the frontend, an
 carries the type the compiler gave it — the difference between coloring `xs` as an identifier and
 knowing it is a `List[Int]`:
 
+<!-- doccheck: skip -->
 ```scala
-given Scalac[3.8] = Scalac[3.8](Nil)
-given LocalClasspath = classpath
+given Scalac[3.8, Universe.Classfile] = Scalac[3.8](Nil)
+given LocalClasspath = LocalClasspath()
 import highlighting.typecheckedScala
 
 val typed = Scala.highlight(t"val xs = List(1, 2, 3)")

--- a/doc/modules/tables.md
+++ b/doc/modules/tables.md
@@ -17,6 +17,8 @@ others, prose columns can wrap where identifiers cannot, and below some width a 
 dropped than mangled — and that negotiation is exactly what a layout engine can do and a format
 string cannot.
 
+Separating a table's scaffold from its data and its width is [decoupling](../philosophy/decoupling.md), and what lets one definition render at any width.
+
 Soundness computes the layout per rendering: each column declares how it may shrink, and the
 engine distributes the available width, wrapping with [hyphenation](hyphenation.md) where wrapping
 is allowed. Everything comes from the `soundness` package, with a style, a metric, and an overflow
@@ -28,6 +30,8 @@ import tableStyles.thickTableStyle
 import textMetrics.uniformMetric
 import columnAttenuation.ignoreAttenuation
 import hyphenations.englishHyphenation
+import stdios.javaLangSystemStdio
+import strategies.throwUnsafely
 ```
 
 ### A table from a case class
@@ -36,8 +40,15 @@ A sequence of case classes tabulates directly, a column per field, titled from t
 `grid` lays it out at a width and produces the lines:
 
 ```scala
-case class Library(id: Text, name: Text, linesOfCode: Int, year: Int, description: Text)
+case class Codebase(id: Text, name: Text, linesOfCode: Int, year: Int, description: Text)
 
+val libraries = List
+  ( Codebase(t"gossamer", t"Gossamer", 4200, 2019, t"Statically-checked text operations"),
+    Codebase(t"jacinta", t"Jacinta", 3800, 2020, t"JSON parsing and serialization"),
+    Codebase(t"escritoire", t"Escritoire", 1900, 2018, t"Tabular layout for the terminal") )
+```
+
+```scala
 libraries.tabulation.grid(80).render.each(Out.println(_))
 ```
 
@@ -49,7 +60,7 @@ Three types are at work, and knowing which is which explains where each decision
 no data. A `Tabulation` is data arranged by a scaffold: an array of textual values, one per row
 and column, no longer referring to the row type at all. A `Grid` is a tabulation fitted to a
 particular width, which is the point at which a column may shrink or vanish. `tabulation` above
-derived a scaffold for `Library` and applied it in one step; the sections below take the stages
+derived a scaffold for `Codebase` and applied it in one step; the sections below take the stages
 separately, which is what gives control over both the layout and the width.
 
 ### Explicit columns
@@ -59,7 +70,7 @@ wraps; a `Collapsible` column vanishes when the layout falls below its threshold
 `Shortened` column truncates with an ellipsis:
 
 ```scala
-val table = Scaffold[Library]
+val table = Scaffold[Codebase]
   ( Column(t"Name")(_.name),
     Column(t"Identifier", sizing = columnar.Collapsible(0.9))(_.id),
     Column(t"LoC", sizing = columnar.Collapsible(0.3))(_.linesOfCode),
@@ -75,8 +86,8 @@ return a mixture of `Text` and `Int` without a type annotation between them. Tha
 the *title* fixes the textual type: a `Textual` instance is resolved for the title's type, that
 instance names the typeclass — usually `Show` — that converts other values into it, and each
 lambda's result type is shown through it. The table's own cell type is then the least upper bound
-of its columns'. So `table` above is a `Scaffold[Library, Text]`, and writing the titles as
-`e"Name"` instead of `t"Name"` would have made it a `Scaffold[Library, Teletype]`, with colour and
+of its columns'. So `table` above is a `Scaffold[Codebase, Text]`, and writing the titles as
+`e"Name"` instead of `t"Name"` would have made it a `Scaffold[Codebase, Teletype]`, with color and
 style available in every cell.
 
 The `Collapsible` thresholds are meaningful only relative to each other. They are compared against
@@ -184,7 +195,7 @@ raises the slack on the remaining columns, without reintroducing the ones alread
 them spread into what is left. Experimentally this produces markedly better results than stopping
 at the first fit.
 
-The search rests on one requirement, which any custom `Columnar` must honour: a column must
+The search rests on one requirement, which any custom `Columnar` must honor: a column must
 respond *monotonically* to slack. Decreasing the slack may leave a column the same width, but it
 must never make it wider. `Paragraph`, `Collapsible`, `Fixed` and `Shortened` are simply the
 strategies provided; the concept is open, and a sizing strategy that responds to slack in some
@@ -265,7 +276,7 @@ And `minimalTableStyle` leaves a single rule beneath the titles and nothing else
 `midOnlyTableStyle` is the same, but reserves blank lines above and below where the outer rules
 would be, so the table keeps its vertical spacing without drawing them. Styled
 [terminal text](terminal.md) works as cell content in every style, so a table of
-highlighted or coloured values lays out by its visible width, not the length of its escape codes.
+highlighted or colored values lays out by its visible width, not the length of its escape codes.
 
 ### Alignment
 
@@ -286,7 +297,7 @@ A derived table titles its columns from the field names, capitalized — `linesO
 so the Scala field keeps its name and the table gets its own:
 
 ```scala
-given TableRelabelling[Library]:
+given TableRelabelling[Codebase]:
   def relabelling() = Map(t"linesOfCode" -> t"LoC")
 ```
 
@@ -300,8 +311,8 @@ one type useless for another. `contramap` adapts it, so a column defined once �
 alignment, sizing and title — serves every type that can produce the value it displays:
 
 ```scala
-val nameColumn = Column[Text](t"Name")(identity)
-val libraryName = nameColumn.contramap[Library](_.name)
+val nameColumn = Column[Text, Text, Text](t"Name")(identity)
+val codebaseName = nameColumn.contramap[Codebase](_.name)
 ```
 
 ### Tabulating something that is not a case class
@@ -314,25 +325,25 @@ columns are computed.
 ### When the table does not fit
 
 Below some width, no arrangement of columns is satisfactory, and what should happen then is a
-policy rather than a fixed behaviour. The `columnAttenuation` given decides: `ignoreAttenuation`
+policy rather than a fixed behavior. The `columnAttenuation` given decides: `ignoreAttenuation`
 renders anyway, at whatever quality the width allows, while `failAttenuation` raises a
-`TableError` rather than producing something misleading.
+`Table.Error` rather than producing something misleading.
 
 The limit is not abstract. In the table above, the *Description* column can never be narrower
 than the longest single word it contains — `Statically-checked` — so below about 36 characters no
 slack will make it fit, however much the rest collapses.
 
-`TableError` is a checked error like any other, carrying the minimum width the table needed and
+`Table.Error` is a checked error like any other, carrying the minimum width the table needed and
 the width it was given, so a handler can say something useful rather than merely failing:
 
 ```scala
 import columnAttenuation.failAttenuation
 
 recover:
-  case TableError(minimum, available) =>
+  case Table.Error(minimum, available) =>
     Out.println(t"The table needs a width of at least $minimum to be shown.")
 . protect:
-    Out.println(table.grid(width))
+    Out.println(table.tabulate(libraries).grid(30))
 ```
 
 A report written to a file, where nobody will see that the columns were mangled, wants the

--- a/doc/modules/tel.md
+++ b/doc/modules/tel.md
@@ -20,6 +20,8 @@ all three at once — indentation-structured for people, schema-typed for machin
 presentation-preserving, so a program that modifies a configuration file does not destroy its
 comments and formatting.
 
+Typing a document against its schema at compiletime is [safety by construction](../philosophy/safety-by-construction.md) applied to configuration.
+
 A TEL document is a tree of *compounds*: a keyword, its space-separated atoms, and indented
 children. The schema layer assigns each compound a type, and Soundness carries that typing through
 to Scala. Everything comes from the `soundness` package:
@@ -27,6 +29,7 @@ to Scala. Everything comes from the `soundness` package:
 ```scala
 import soundness.*
 import strategies.throwUnsafely
+import charEncoders.utf8Encoder
 ```
 
 ### The language
@@ -53,8 +56,8 @@ t"name Alice\nage 30\n".read[Tel].as[Person]   // Person(t"Alice", 30)
 t"name Alice\nage 30\n".read[Person in Tel]    // the same, in one step
 ```
 
-Encoding runs the other way: `tel` produces a `Tel` from a value, a compound per field, ready to
-render or to embed in a larger document.
+Encoding runs the other way: `in[Tel]` produces a `Tel` from a value, a compound per field, ready
+to render or to embed in a larger document.
 
 A literal document is written with the `tel"…"` interpolator, parsed as the code compiles, with
 each substitution encoded through its own static type. A malformed literal is a compile error
@@ -83,7 +86,7 @@ a compile error:
 case class Office(name: Text, city: Text)
 case class Assignment(worker: Person, office: Office)
 
-val doc = Assignment(Person(t"Bob", 2), Office(t"Main", t"Town")).encode
+val doc = Assignment(Person(t"Bob", 2), Office(t"Main", t"Town")).in[Tel]
 
 doc.verify[Assignment].office.city.as[Text]   // t"Town"
 ```
@@ -94,8 +97,8 @@ styles visibly distinct. A keyword may legitimately repeat, which a single-value
 express, so `fields` returns every matching child in document order:
 
 ```scala
-t"item 1\nitem 2\nitem 3\n".read[Tel].fields(t"item").map(_.primaryAtom).toList
-// List(t"1", t"2", t"3")
+t"item 1\nitem 2\nitem 3\n".read[Tel].fields(t"item").map(_.primaryAtom)
+// Array(t"1", t"2", t"3")
 ```
 
 ### Editing without destroying the file
@@ -104,6 +107,10 @@ The reason a TEL document keeps its comments, blank lines and layout is so that 
 change one value and write the file back without reformatting everything a person wrote.
 
 `modify` replaces a field's compound, or appends it where the field is absent:
+
+```scala
+val document = t"name Alice\nage 30\n".read[Tel]
+```
 
 ```scala
 import dynamicAccess.dynamicTel
@@ -117,8 +124,7 @@ remark to a compound, inserting or removing a child:
 
 ```scala
 val pointer = Tel.Pointer.of(t"name")
-Mutation(document, Mutation.Op.UpdateAtom(pointer, 0, t"Bob")).document.vouch.show
-// t"name Bob\n"
+Mutation(document, List(Mutation.Op.UpdateAtom(pointer, 0, t"Bob"))).show   // t"name Bob\n"
 ```
 
 The result is a document, not a string, so a sequence of edits composes and the file is rendered
@@ -180,19 +186,30 @@ at once requires.
 A single source may hold several documents in sequence, and reads as a list of them:
 
 ```scala
+val source = t"name Alice\n"
+
 source.read[List[Tel]]
 ```
 
 ### Typed records from a schema
 
-Where the schema is authoritative and no Scala type mirrors it, a `TelBlueprint` reads it at
-compiletime and produces typed records from matching documents. Each field reads at the type the
-schema declares, an optional field is absent where the document omits it, and a *flag* field —
-a keyword with no value — reads as a boolean, `true` where present and `false` where not:
+Where the schema is authoritative, a `TelBlueprint` — an object declared in a file of its own,
+holding the schema and the one-line `record` macro — reads it at compiletime and produces typed
+records from matching documents. Each field reads at the type the schema declares, an optional
+field is absent where the document omits it, and a *flag* field — a keyword with no value —
+reads as a boolean, `true` where present and `false` where not:
 
+<!-- doccheck: skip -->
+```scala
+object ContactRecords extends TelBlueprint(Tels.tels[Person](t"person")):
+  transparent inline def record(tel: Tel): Record = ${build('tel)}
+```
+
+<!-- doccheck: skip -->
 ```scala
 val record = ContactRecords.record(t"name Alice\nage 30\n".read[Tel])
 record.name       // t"Alice", per the schema
+record.age        // 30
 ```
 
 A field the schema does not describe is a compile error, so the shape of the data is taken from
@@ -212,7 +229,10 @@ A *self-contained* BinTEL frame carries its schema with it, so a document can tr
 that has never seen its schema and still decode:
 
 ```scala
-Bintel.selfContained(document, schemaDocument)
+val greeting = t"name Alice\n".read[Tel]
+val greetingSchema = t"name greeting\n\ndocument\n  field name Identifier\n".read[Tel]
+
+Bintel.selfContained(greeting, greetingSchema)
 ```
 
 The alternative is to send the data alone and identify the schema by its *signature* — a short

--- a/doc/modules/terminal-emulator.md
+++ b/doc/modules/terminal-emulator.md
@@ -12,7 +12,7 @@ the scroll region — as an immutable value that a test can inspect cell by cell
 A terminal application's output is not text but a program in the terminal's control language:
 cursor moves, style changes, screen clears interleaved with characters. Asserting on that byte
 stream directly is brittle — many sequences produce the same screen — and asserting on nothing
-leaves the interactive behaviour untested. What a test wants to check is the *effect*: what the
+leaves the interactive behavior untested. What a test wants to check is the *effect*: what the
 screen shows, where the cursor is, what color a cell became.
 
 A `Pty` computes that effect, implementing the VT100 and xterm control sequences — cursor
@@ -24,6 +24,8 @@ wide characters occupying two cells and grapheme clusters kept whole. Everything
 import soundness.*
 import strategies.throwUnsafely
 ```
+
+A screen as an immutable value that each escape sequence transforms is [immutability](../philosophy/immutability.md) applied to something usually mutated in place.
 
 ### Feeding a terminal
 
@@ -79,8 +81,8 @@ carriage return, line feed, backspace and tabs advancing to the next eight-colum
 positioning, erasing and scrolling sequences behave as a terminal's do: `ED 2` clears the screen,
 `EL 2` clears the line, and the cursor save and restore pair works as `DECSC` and `DECRC`.
 
-Styling comes through `SGR`: the attribute flags, the sixteen palette colours with their bright
-variants as distinct entries, the 256-colour palette, and 24-bit colour. Resetting with `SGR 0`
+Styling comes through `SGR`: the attribute flags, the sixteen palette colors with their bright
+variants as distinct entries, the 256-color palette, and 24-bit color. Resetting with `SGR 0`
 affects the cells written afterwards, not those already on screen, exactly as a terminal does.
 
 DEC private modes are honoured where they change what a test would observe — `?25` hiding and

--- a/doc/modules/terminal.md
+++ b/doc/modules/terminal.md
@@ -25,7 +25,10 @@ session is a scoped block that restores the terminal however it exits. Everythin
 
 ```scala
 import soundness.*
+import stdios.javaLangSystemStdio
 ```
+
+A raw-mode session as a scoped block that restores the terminal however it exits is [delimited scopes](../philosophy/delimited-scopes.md) applied to the terminal.
 
 ### Styled text
 
@@ -55,13 +58,13 @@ which is what makes that work — and it means a substitution can depend on what
 type becomes usable as one by giving it a `Stylize` instance:
 
 ```scala
-case class Fade(amount: Double)
+case object Toggle
 
-given Stylize[Fade] = fade => Stylize(style => style.copy(fg = style.fg.hsv.shade(fade.amount).srgb))
+given Stylize[Toggle.type] = _ => Stylize(style => style.copy(bold = !style.bold))
 ```
 
-`Fade(0.5)` then darkens whatever the text's color happens to be, leaving its hue alone, rather
-than replacing it with a fixed color.
+`$Toggle(…)` then emboldens plain text and unemboldens bold text, deciding from the style it
+finds rather than imposing a fixed one.
 
 A `Teletype` behaves as [text](text.md) — it cuts, joins and pads, styles preserved — and renders
 per terminal: full 24-bit color on a capable terminal, the nearest palette color on an older one,
@@ -72,7 +75,12 @@ and plain text when output is not a terminal at all, so logs never fill with esc
 `interactive` opens a raw-mode session, within which the terminal's events — keypresses, window
 resizes, focus changes, pastes — arrive as typed values:
 
+<!-- doccheck: skip -->
 ```scala
+def handle(char: Char): Unit = ()
+def finish(): Unit = ()
+def resize(rows: Int, cols: Int): Unit = ()
+
 interactive: terminal ?=>
   terminal.eventIterator().each:
     case Keypress.CharKey(char)  => handle(char)
@@ -82,7 +90,7 @@ interactive: terminal ?=>
 ```
 
 The decoding covers modifier combinations, function keys, the kitty keyboard protocol and
-bracketed paste, so `Ctrl(Alt(Left))` is a value to match, not a byte sequence to recognise.
+bracketed paste, so `Ctrl(Alt(Left))` is a value to match, not a byte sequence to recognize.
 
 A `Keypress` is an ordinary `CharKey`, a `FunctionKey`, one of the named editing keys — `Tab`,
 `Enter`, `Backspace`, `Delete`, `Escape`, `Insert`, `Home`, `End`, `PageUp`, `PageDown` and the
@@ -91,7 +99,7 @@ held with it, nesting outwards:
 
 ```scala
 Keypress.Ctrl('A')
-Keypress.Ctrl(Keypress.Shift(Keypress.Enter))
+Keypress.Shift(Keypress.Enter)
 ```
 
 The wrappers accept only what can meaningfully be modified, so `Shift(CharKey('a'))` does not
@@ -112,6 +120,7 @@ A line of input, with cursor movement and editing keys handled, is a `LineEditor
 options is a `SelectMenu`. Each is a pure state machine — an event in, a new state out — asked for
 its result in one call:
 
+<!-- doccheck: skip -->
 ```scala
 interactive: terminal ?=>
   LineEditor().ask: text =>
@@ -125,9 +134,11 @@ interactive widgets, `strip` and `stack` to arrange them in columns and rows, an
 them. `form` runs the arrangement — full-screen on the alternate buffer, or *inline*, as a live
 block at the cursor that leaves scrollback intact:
 
+<!-- doccheck: skip -->
 ```scala
 interactive: terminal ?=>
-  val sidebar = border(BorderStyle.rounded)(menu(pages, pages.head, maxWidth = 20))
+  val pages = List(t"Home", t"Settings", t"About")
+  val sidebar = border(BorderStyle.rounded)(menu(pages, pages.prim.or(t""), maxWidth = 20))
   val body = border(BorderStyle.heavy)(editor(LineEditor()))
 
   form(Occupancy.Inline)(strip(sidebar, body))

--- a/doc/modules/testing.md
+++ b/doc/modules/testing.md
@@ -23,6 +23,7 @@ first-class test subjects. Everything comes from the `soundness` package:
 
 ```scala
 import soundness.*
+import strategies.throwUnsafely
 ```
 
 ### Suites and tests
@@ -46,8 +47,10 @@ recorded distinctly, neither failing the build nor forgotten.
 Approximate comparison is built in for the numeric cases where exact equality is wrong:
 
 ```scala
+val results = List(0.01, -0.02, 0.015)
+
 test(m"the mean converges"):
-  results.mean.vouch
+  results.total/results.size
 . assert(_ === 0.0 +/- 0.02)
 ```
 
@@ -73,6 +76,9 @@ test(m"double every value").over(Axis(t"n")(1, 2, 3, 4)): n =>
 An enumeration's companion is an axis in its own right, needing no list of values:
 
 ```scala
+enum Codec:
+  case Binary, Textual, Compressed
+
 test(m"enum companions form axes").over(Codec): codec =>
   codec.ordinal
 . assert((codec, ordinal) => ordinal >= 0 && ordinal < 3)
@@ -112,6 +118,8 @@ down to the field that changed, rather than as two unrelated entries the reader 
 compile errors as values:
 
 ```scala
+import classloaders.threadContextClassloader
+
 test(m"a malformed version literal is rejected"):
   demilitarize:
     v"1.2"
@@ -146,10 +154,11 @@ set, so every kind renders the same way and charts the same way.
 A `Bench` measures speed. Its body is a quoted expression, [staged](staging.md) and dispatched in
 its own JVM, so the measurement is not distorted by the rest of the suite:
 
+<!-- doccheck: skip -->
 ```scala
 val bench = Bench()
 
-bench(m"decode directly")(target = 1*Second, operationSize = size):
+bench(m"decode directly")(target = 1*Second, operationSize = 1000):
   '{ Benchmarks.decodeUsersDirect() }
 ```
 
@@ -158,22 +167,24 @@ live set retained under sustained concurrency. It runs for a wall-clock target a
 concurrency, and may be given a constrained heap or a CPU limit, so a design can be shown to hold
 up where it matters:
 
+<!-- doccheck: skip -->
 ```scala
 val stress = Stress()
 val constrained = Stress(heap = t"128m")
 
 stress(m"cross-thread hand-off")(target = 2*Second, concurrency = 16):
-  '{ … }
+  '{ Benchmarks.handOff() }
 ```
 
 A `Profile` answers where the time went, rendering a histogram of the hottest methods by self
-time from JFR execution samples, coloured by package:
+time from JFR execution samples, colored by package:
 
+<!-- doccheck: skip -->
 ```scala
 val profile = Profile()
 
 profile(m"pipeline hotspots")(target = 5*Second):
-  '{ … }
+  '{ Benchmarks.pipeline() }
 ```
 
 Benchmarks spread over axes as tests do, staging one program per distinct implementation and

--- a/doc/modules/text.md
+++ b/doc/modules/text.md
@@ -33,6 +33,8 @@ import soundness.*
 import textMetrics.uniformMetric
 ```
 
+Text operations that require a collation, an encoding or a metric to be named are [declarative context](../philosophy/declarative-context.md): nothing about text is assumed.
+
 ### Writing text
 
 The `t"…"` interpolator builds a `Text`, substituting any value that can be shown. The
@@ -107,6 +109,22 @@ Character-level filters keep or drop by a predicate:
 t"HELLOworld".keep(_.isUpper)   // t"HELLO"
 ```
 
+### Sorting and comparing text
+
+Text has no natural order: whether `café` sorts before or after `caff` depends on the collation,
+and a program that sorts text without saying which is making a choice it does not know it is
+making. So sorting text, or comparing it with `<`, needs a *collation* in scope, and without one
+the sort does not compile. `unicodeCollation` applies the Unicode Collation Algorithm — dictionary
+order, ranking accents before case — and `codepointCollation` orders by code point, which is fast
+and stable but places supplementary characters after the whole basic plane:
+
+```scala
+import collations.unicodeCollation
+
+List(t"caff", t"café", t"cafe").sort   // List(t"cafe", t"café", t"caff")
+t"apple" < t"banana"                    // true
+```
+
 ### Case conventions
 
 Text splits into words and rejoins in a naming convention. `uncamel` breaks a camel-case or
@@ -124,8 +142,8 @@ truncating if need be. Each measures width through the `Text is Measurable` give
 here `uniformMetric`, which counts every character as one column:
 
 ```scala
-t"123".pad(5, Rtl)         // t"  123"
-t"123".fit(5, Rtl, '.')    // t"..123"
+t"123".pad(5, Bidi.Rtl)         // t"  123"
+t"123".fit(5, Bidi.Rtl, '.')    // t"..123"
 ```
 
 ### Searching
@@ -136,7 +154,7 @@ the last returning an `Optional` position rather than a sentinel:
 ```scala
 t"hello world".contains(t"ello")   // true
 t"hello world".offsetOf(t"o")      // an Optional position, present here
-t"banana".count(t"a")              // 3
+t"banana".count(_ == 'a')          // 3
 ```
 
 ### Bytes
@@ -168,10 +186,11 @@ needs it to be fast. A `Lexicon` is a
 inequality the distance metric obeys to prune most of the vocabulary without measuring it:
 
 ```scala
+val words = List(t"book", t"boot", t"cook", t"look", t"bake")
 val lexicon = Lexicon(words)
 
-lexicon.search("book", 0)   // exact matches only
-lexicon.search("booq", 1)   // everything within one edit
+lexicon.search(t"book", 0)   // exact matches only
+lexicon.search(t"booq", 1)   // everything within one edit
 ```
 
 A search at distance zero is an exact lookup; widening the radius admits progressively more
@@ -192,14 +211,14 @@ dictionary.size          // 2
 
 ### Graphemes and width
 
-A character is not a unit of text a person would recognise. `é` may be one code point or two, and
+A character is not a unit of text a person would recognize. `é` may be one code point or two, and
 a family emoji is several joined together, so counting `Char`s answers the wrong question.
 `Writing` gives a text's *grapheme clusters* — what a reader would call characters — and the
 boundaries between them:
 
 ```scala
-Writing(t"abc").graphemeCount   // 3
-Writing(t"").boundaries.toList  // List(0)
+Writing(t"abc").graphemeCount      // 3
+Writing(t"").boundaries.length     // 1: the single boundary at position 0
 ```
 
 Nor is a grapheme one column wide on a terminal. Under a metric in scope, `metrics` gives the
@@ -221,7 +240,7 @@ Turning a number into text involves a choice — how many digits are worth showi
 every `show` of a floating-point number consults:
 
 ```scala
-Decimalizer(3).decimalize(-math.Pi)   // t"-3.14"
+Decimalizer(3).decimalize(-3.14159)   // t"-3.14"
 ```
 
 The same value therefore renders consistently everywhere in a program, and changing the precision

--- a/doc/modules/time.md
+++ b/doc/modules/time.md
@@ -451,7 +451,7 @@ spring.instant   // pushed forward to 01:30 UTC by default
 ```scala
 import gapPolicies.rejectGapPolicy
 Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant
-// raises a TimeError: the local time never happens
+// raises a Moment.Error: the local time never happens
 ```
 
 When the clocks fall back, an hour repeats, and a reading in the overlap names two
@@ -478,7 +478,7 @@ short notice:
 Tzdb.parse(t"northamerica", lines)
 ```
 
-A file that does not exist, or a line the format does not permit, raises a `TzdbError` naming the
+A file that does not exist, or a line the format does not permit, raises a `Tzdb.Error` naming the
 fault rather than silently producing a zone with the wrong rules.
 
 ### Calendars

--- a/doc/modules/time.md
+++ b/doc/modules/time.md
@@ -54,10 +54,12 @@ import soundness.*
 
 Operations that can fail — parsing text, constructing a date from runtime
 integers — need an error-handling strategy in scope. The `throwUnsafely` strategy
-raises an exception on failure:
+raises an exception on failure. Reading the current time needs a *chronometry* — a
+source of instants — and the Unix clock is the ordinary choice:
 
 ```scala
 import strategies.throwUnsafely
+import chronometries.unixChronometry
 ```
 
 ### Dates
@@ -313,14 +315,16 @@ code must supply. Clamping lands on the last valid day; overflowing spills into 
 next month:
 
 ```scala
-import monthEnds.clampMonthEnd
-2024-Jan-31 + 1*Month   // 2024-Feb-29
-2024-Feb-29 + 1*Year    // 2025-Feb-28
+locally:
+  import monthEnds.clampMonthEnd
+  2024-Jan-31 + 1*Month   // 2024-Feb-29
+  2024-Feb-29 + 1*Year    // 2025-Feb-28
 ```
 
 ```scala
-import monthEnds.overflowMonthEnd
-2024-Jan-31 + 1*Month   // 2024-Mar-2
+locally:
+  import monthEnds.overflowMonthEnd
+  2024-Jan-31 + 1*Month   // 2024-Mar-2
 ```
 
 Subtracting one date from another counts the days between them:
@@ -359,7 +363,6 @@ type. The `Unix` timeline — POSIX time — counts milliseconds from the
 [Unix epoch](https://en.wikipedia.org/wiki/Unix_time):
 
 ```scala
-import chronometries.unixChronometry
 
 val epoch = Instant(0L)   // 1970-01-01T00:00:00Z
 ```
@@ -399,8 +402,8 @@ demanded:
 ```scala
 import calendars.gregorianCalendar
 
-(Instant(0L) ~ Instant(3_600_000L)).segments(15*Minute).length   // 4
-Period(2024-Jan-1, 2030-Jan-1).by(1*Day).take(3).to(List)
+(Instant(0L) ~ Instant(3_600_000L)).segments(15*Minute).size   // 4
+Period(2024-Jan-1, 2030-Jan-1).by(1*Day).keep(3)
 // List(2024-Jan-1, 2024-Jan-2, 2024-Jan-3)
 ```
 
@@ -475,6 +478,8 @@ newer than the platform's own can be loaded, which matters when a government cha
 short notice:
 
 ```scala
+val lines = Chain(t"Zone\tAmerica/Nowhere\t-5:00\t-\tEST")
+
 Tzdb.parse(t"northamerica", lines)
 ```
 
@@ -549,19 +554,19 @@ sequence:
 ```scala
 import calendars.gregorianCalendar
 
-Recurrence(2024-Jan-1, 1*Day, 3).occurrences.to(List)
-// List(2024-Jan-1, 2024-Jan-2, 2024-Jan-3)
+Recurrence(2024-Jan-1, 1*Day, 3).occurrences
+// Chain(2024-Jan-1, 2024-Jan-2, 2024-Jan-3)
 ```
 
 A recurrence with no repetition count runs forever, so it is consumed with a
 bound — every occurrence up to a date, or those falling within a window:
 
 ```scala
-Recurrence(2024-Jan-1, 1*Week).until(2024-Jan-22).to(List)
-// List(2024-Jan-1, 2024-Jan-8, 2024-Jan-15)
+Recurrence(2024-Jan-1, 1*Week).until(2024-Jan-22)
+// Chain(2024-Jan-1, 2024-Jan-8, 2024-Jan-15)
 
-Recurrence(2024-Jan-1, 1*Week).within(Period(2024-Jan-5, 2024-Jan-20)).to(List)
-// List(2024-Jan-8, 2024-Jan-15)
+Recurrence(2024-Jan-1, 1*Week).within(Period(2024-Jan-5, 2024-Jan-20))
+// Chain(2024-Jan-8, 2024-Jan-15)
 ```
 
 A recurrence encodes to and decodes from its ISO 8601 form, and the `rec`
@@ -569,8 +574,8 @@ interpolator writes one as a checked literal:
 
 ```scala
 Recurrence(2024-Jan-1, 1*Day, 5).encode   // R5/2024-01-01/P1D
-rec"R3/2024-01-01/P1M".occurrences.to(List)
-// List(2024-Jan-1, 2024-Feb-1, 2024-Mar-1)
+rec"R3/2024-01-01/P1M".occurrences
+// Chain(2024-Jan-1, 2024-Feb-1, 2024-Mar-1)
 ```
 
 ### Recurrence rules
@@ -587,8 +592,8 @@ The simplest rule repeats at its frequency, taking the date from its start:
 ```scala
 import calendars.gregorianCalendar
 
-Rrule(2024-Jan-15, Frequency.Monthly, count = 4).occurrences.to(List)
-// List(2024-Jan-15, 2024-Feb-15, 2024-Mar-15, 2024-Apr-15)
+Rrule(2024-Jan-15, Frequency.Monthly, count = 4).occurrences
+// Chain(2024-Jan-15, 2024-Feb-15, 2024-Mar-15, 2024-Apr-15)
 ```
 
 The `byDay` field selects weekdays, optionally by ordinal. The third Monday of a
@@ -597,12 +602,12 @@ month is `WeekdayOrdinal(Mon, 3)`; the last Friday counts back from the end with
 
 ```scala
 Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3)), count = 2)
-    .occurrences.to(List)
-// List(2024-Jan-15, 2024-Feb-19)
+    .occurrences
+// Chain(2024-Jan-15, 2024-Feb-19)
 
 Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Fri, -1)), count = 2)
-    .occurrences.to(List)
-// List(2024-Jan-26, 2024-Feb-23)
+    .occurrences
+// Chain(2024-Jan-26, 2024-Feb-23)
 ```
 
 Fields combine. The fourth Thursday of November is a yearly rule narrowed to one
@@ -610,20 +615,20 @@ month and one weekday:
 
 ```scala
 Rrule(2024-Jan-1, Frequency.Yearly, byMonth = List(Nov),
-    byDay = List(WeekdayOrdinal(Thu, 4)), count = 2).occurrences.to(List)
-// List(2024-Nov-28, 2025-Nov-27)
+    byDay = List(WeekdayOrdinal(Thu, 4)), count = 2).occurrences
+// Chain(2024-Nov-28, 2025-Nov-27)
 ```
 
 A frequency can carry an interval — every second week, every third day — and a rule
 can run weekly across several weekdays:
 
 ```scala
-Rrule(2024-Jan-1, Frequency.Weekly, interval = 2, count = 3).occurrences.to(List)
-// List(2024-Jan-1, 2024-Jan-15, 2024-Jan-29)
+Rrule(2024-Jan-1, Frequency.Weekly, interval = 2, count = 3).occurrences
+// Chain(2024-Jan-1, 2024-Jan-15, 2024-Jan-29)
 
 Rrule(2024-Jan-1, Frequency.Weekly, byDay = List(WeekdayOrdinal(Mon),
-    WeekdayOrdinal(Wed), WeekdayOrdinal(Fri)), count = 4).occurrences.to(List)
-// List(2024-Jan-1, 2024-Jan-3, 2024-Jan-5, 2024-Jan-8)
+    WeekdayOrdinal(Wed), WeekdayOrdinal(Fri)), count = 4).occurrences
+// Chain(2024-Jan-1, 2024-Jan-3, 2024-Jan-5, 2024-Jan-8)
 ```
 
 The `bySetPos` field picks from each period's expansion by position, which
@@ -633,8 +638,8 @@ candidates:
 ```scala
 Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon),
     WeekdayOrdinal(Tue), WeekdayOrdinal(Wed), WeekdayOrdinal(Thu),
-    WeekdayOrdinal(Fri)), bySetPos = List(-1), count = 2).occurrences.to(List)
-// List(2024-Jan-31, 2024-Feb-29)
+    WeekdayOrdinal(Fri)), bySetPos = List(-1), count = 2).occurrences
+// Chain(2024-Jan-31, 2024-Feb-29)
 ```
 
 Frequencies below a day apply to timestamps, where `byHour` and `byMinute` expand
@@ -642,7 +647,7 @@ within each day:
 
 ```scala
 Rrule(Timestamp(2024-Jan-1, Clockface(0, 0, 0)), Frequency.Daily,
-    byHour = List(9, 17), count = 3).occurrences.to(List)
+    byHour = List(9, 17), count = 3).occurrences
 // the 9th and 17th hours of each day
 ```
 
@@ -653,8 +658,8 @@ Rrule(2024-Jan-1, Frequency.Monthly, interval = 2, count = 10,
     byDay = List(WeekdayOrdinal(Mon, 3))).encode
 // FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYDAY=3MO
 
-Rrule.parse(t"FREQ=MONTHLY;BYDAY=-1FR", 2024-Jan-1).occurrences.take(2).to(List)
-// List(2024-Jan-26, 2024-Feb-23)
+val lastFridays: Chain[Date] = Rrule.parse(t"FREQ=MONTHLY;BYDAY=-1FR", 2024-Jan-1).occurrences
+lastFridays.keep(2)   // Chain(2024-Jan-26, 2024-Feb-23)
 ```
 
 Several rules and individual dates combine into a `RecurrenceSet`, which merges its
@@ -663,8 +668,8 @@ sources into one ascending stream, adds explicit dates, and removes exceptions:
 ```scala
 val weekly = Rrule(2024-Jan-1, Frequency.Weekly, count = 4)
 RecurrenceSet(include = List(weekly.occurrences), rdates = List(2024-Jan-10),
-    exdates = List(2024-Jan-15)).occurrences.to(List)
-// List(2024-Jan-1, 2024-Jan-8, 2024-Jan-10, 2024-Jan-22)
+    exdates = List(2024-Jan-15)).occurrences
+// Chain(2024-Jan-1, 2024-Jan-8, 2024-Jan-10, 2024-Jan-22)
 ```
 
 ### Describing recurrences

--- a/doc/modules/trees.md
+++ b/doc/modules/trees.md
@@ -2,7 +2,7 @@
 
 ### About
 
-Hierarchies — file listings, dependency graphs, organisational structures — draw as text with
+Hierarchies — file listings, dependency graphs, organizational structures — draw as text with
 box-drawing characters: a `TreeDiagram` renders a tree, and the DAG diagrams render
 [graphs](graphs.md) whose nodes may have several parents, in the dense style or the lane style
 familiar from `git log --graph`. Each diagram is a value producing lines, so the output prints,
@@ -15,6 +15,8 @@ which of its ancestors have later siblings, so the drawing state threads through
 traversal. Directed acyclic graphs are harder still — a node with two parents cannot be drawn as a
 tree at all, and laying out the connecting lanes is a real algorithm.
 
+A diagram computing tiles, and a style rendering them, is [decoupling](../philosophy/decoupling.md) between structure and appearance.
+
 Soundness separates the layout from the rendering: a diagram computes rows of *tiles*, and a style
 maps tiles to characters, so the same layout renders in Unicode or ASCII, plain or styled.
 Everything comes from the `soundness` package:
@@ -22,6 +24,7 @@ Everything comes from the `soundness` package:
 ```scala
 import soundness.*
 import treeStyles.squareTreeStyle
+import stdios.javaLangSystemStdio
 ```
 
 ### Trees
@@ -32,8 +35,16 @@ instance on the node type — and renders through a function from node to label:
 ```scala
 case class Taxon(name: Text, children: List[Taxon] = Nil)
 
-val diagram = TreeDiagram.by[Taxon](_.children)(animalia)
+val animalia = Taxon
+  ( t"animalia",
+    List(Taxon(t"chordata", List(Taxon(t"mammalia"))), Taxon(t"arthropoda")) )
 
+val diagram = TreeDiagram.by[Taxon](_.children)(animalia)
+```
+
+The diagram renders each node through a function from node to label, giving the lines to print:
+
+```scala
 diagram.render(_.name).each(Out.println(_))
 // animalia
 // ├─chordata
@@ -76,7 +87,7 @@ characters stay the style's business, and the meaning stays the caller's.
 ```scala
 diagram.nodes    // the node of each line, in drawing order
 diagram.tiles    // the tiles of each line
-diagram.map { tiles => node => renderMyself(tiles, node) }
+diagram.map { tiles => node => t"${tiles.size} ${node.name}" }
 ```
 
 A `TreeTile` is one of four things: a branch, a last branch, an extender carrying a line down past
@@ -88,7 +99,7 @@ val myStyle = TextualTreeStyle[Text](t"  ", t"└─", t"├─", t"│ ")
 ```
 
 Because the style is parameterized by the line type rather than fixed to `Text`, a diagram renders
-directly into styled [terminal output](terminal.md), with the tree furniture in one colour and the
+directly into styled [terminal output](terminal.md), with the tree furniture in one color and the
 labels in another, and the widths still computed correctly.
 
 ### Supplying the tree
@@ -97,7 +108,7 @@ A tree can be given in two ways. `TreeDiagram.by` takes a function from node to 
 suits a structure that is already in hand:
 
 ```scala
-TreeDiagram.by[Taxon](_.children)(root)
+TreeDiagram.by[Taxon](_.children)(animalia)
 ```
 
 `TreeDiagram.apply` instead takes roots and finds children through an `Expandable` instance on the
@@ -107,7 +118,7 @@ path, a dependency, a syntax node:
 ```scala
 given Taxon is Expandable = _.children
 
-TreeDiagram(root)
+TreeDiagram(animalia)
 ```
 
 The lines are produced lazily, so a large or deep tree is drawn as far as it is consumed rather

--- a/doc/modules/trees.md
+++ b/doc/modules/trees.md
@@ -126,5 +126,5 @@ in a grid of connecting tiles, which is what a small graph with complicated edge
 suits a long graph with few concurrent branches. `LayeredDagDiagram` arranges nodes into levels
 by depth, which suits showing what depends on what rather than what happened in what order.
 
-All three take a `Dag`, and all three raise a `DagError` where the graph is not acyclic — a cycle
+All three take a `Dag`, and all three raise a `Dag.Error` where the graph is not acyclic — a cycle
 has no drawing, so it is reported rather than approximated.

--- a/doc/modules/uuid.md
+++ b/doc/modules/uuid.md
@@ -14,6 +14,8 @@ with a wrong digit, or a value that is not a UUID at all, is indistinguishable f
 until something parses it and fails. Nothing marks, in the type, that a particular string is a
 well-formed identifier.
 
+A UUID that cannot be constructed malformed is [safety by construction](../philosophy/safety-by-construction.md) in its simplest form.
+
 A `Uuid` is a value that is known to be well-formed. A literal is validated as the code compiles,
 runtime parsing reports a typed `Uuid.Error` rather than returning a broken value, and the
 identifier's 128 bits are available directly for the occasional need to inspect or combine them.

--- a/doc/modules/uuid.md
+++ b/doc/modules/uuid.md
@@ -15,7 +15,7 @@ until something parses it and fails. Nothing marks, in the type, that a particul
 well-formed identifier.
 
 A `Uuid` is a value that is known to be well-formed. A literal is validated as the code compiles,
-runtime parsing reports a typed `UuidError` rather than returning a broken value, and the
+runtime parsing reports a typed `Uuid.Error` rather than returning a broken value, and the
 identifier's 128 bits are available directly for the occasional need to inspect or combine them.
 Everything comes from the `soundness` package:
 
@@ -42,14 +42,14 @@ uuid"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c"
 
 ### Parsing
 
-Text parsed at runtime may not be a UUID, so `Uuid.parse` reports a `UuidError` on failure,
+Text parsed at runtime may not be a UUID, so `Uuid.parse` reports a `Uuid.Error` on failure,
 handled by the strategy in scope; `Uuid.extract` instead yields an `Optional`, and the same
 extractor serves in a pattern:
 
 ```scala
 import strategies.throwUnsafely
 
-Uuid.parse(t"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c")   // a Uuid, or raises UuidError
+Uuid.parse(t"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c")   // a Uuid, or raises Uuid.Error
 
 t"not-a-uuid" match
   case Uuid(id) => id      // a well-formed identifier

--- a/doc/modules/versioning.md
+++ b/doc/modules/versioning.md
@@ -27,7 +27,7 @@ import strategies.throwUnsafely
 ### Versions
 
 The `v"…"` interpolator writes a version, checked as the code compiles; text parses to the same
-type, raising a `SemverError` for a malformed version:
+type, raising a `Semver.Error` for a malformed version:
 
 ```scala
 val version = v"1.4.2"
@@ -56,7 +56,7 @@ attributes are named values, and reading one gives its proper type:
 import manifestAttributes.*
 
 val manifest = Manifest
-  ( ManifestVersion(),
+  ( ManifestVersion(()),
     MainClass(fqcn"com.example.Main"),
     CreatedBy(t"Soundness") )
 

--- a/doc/modules/versioning.md
+++ b/doc/modules/versioning.md
@@ -17,6 +17,8 @@ zeros are illegal, what a prerelease identifier may contain — and the preceden
 the subtle ones: numeric identifiers compare numerically, `1.0.0-alpha` precedes `1.0.0`, and build
 metadata never affects ordering. Rules that precise belong in a type.
 
+A version that cannot be constructed invalid, and compares as the specification says, is [safety by construction](../philosophy/safety-by-construction.md).
+
 Everything comes from the `soundness` package:
 
 ```scala

--- a/doc/modules/web-automation.md
+++ b/doc/modules/web-automation.md
@@ -90,7 +90,7 @@ browser.awaitUntil(browser.title() == t"Done")
 
 The policy is a `Tenacity` — the same [retry schedules](concurrency.md#retrying) used elsewhere —
 so the interval and the number of attempts belong to the caller,
-and exhausting them raises a `RetryError`. These poll the plural endpoint, which reports absence
+and exhausting them raises a `Tenacity.Error`. These poll the plural endpoint, which reports absence
 as an empty list rather than as an error, and that is deliberate: a session's error strategy is
 fixed when it opens, so a failure raised inside the polled block could not be caught here to drive
 the next attempt.

--- a/doc/modules/web-automation.md
+++ b/doc/modules/web-automation.md
@@ -5,7 +5,7 @@
 Driving a browser and scripting a page are two sides of web automation, and Soundness covers both.
 A browser is driven from Scala through the [WebDriver](https://www.w3.org/TR/webdriver2/) protocol:
 Chrome or Firefox is launched, a session opened, pages navigated, and elements found, clicked and
-typed into — the machinery of end-to-end testing. And browser-side behaviour is written as *typed*
+typed into — the machinery of end-to-end testing. And browser-side behavior is written as *typed*
 JavaScript: DOM expressions checked against the browser's own
 [WebIDL](https://en.wikipedia.org/wiki/Web_IDL) interface definitions as the code compiles,
 rendered to JavaScript for a page's event handlers.
@@ -13,9 +13,11 @@ rendered to JavaScript for a page's event handlers.
 ### On automating the web
 
 Browser automation scripts are stringly typed twice over: elements are located by selector strings,
-and injected behaviour is JavaScript in string literals, unchecked until the browser runs it. A
+and injected behavior is JavaScript in string literals, unchecked until the browser runs it. A
 misspelled DOM method — `getElementByld` — is exactly the kind of mistake a compiler exists to
 catch, and exactly the kind these strings hide.
+
+A session confined to its block, and typed page scripts checked against the DOM's own definitions, follow [delimited scopes](../philosophy/delimited-scopes.md) and [safety by construction](../philosophy/safety-by-construction.md).
 
 Soundness types both layers: element location goes through the same typed selectors and validated
 identifiers used by [CSS](css.md) and [HTML](html.md), and DOM scripting is checked against the
@@ -31,6 +33,7 @@ import soundness.*
 A browser session launches the driver, opens a session, and closes both when the block ends —
 whether it returns or throws. Within it, the session navigates and queries:
 
+<!-- doccheck: skip -->
 ```scala
 WebDriver.Chrome.headless.session:
   browser.navigateTo(url"https://example.com/")
@@ -52,15 +55,19 @@ Elements are located by typed criteria — a CSS selector list, a validated DOM 
 an HTML tag — with `/` returning every match and `element` exactly one. Elements found within
 elements descend the tree:
 
+<!-- doccheck: skip -->
 ```scala
-val heading = browser.element(H1)                    // by tag
-val items = browser / SelectorList.read(t"nav li")   // by CSS selector
+WebDriver.Chrome.headless.session:
+  val heading = browser.element(H1)                    // by tag
+  val items = browser / SelectorList.read(t"nav li")   // by CSS selector
+  val field = browser.element(Name[DomId](t"query"))   // by id
+  val button = browser.element(Button)
 
-heading.click()
-heading.innerText()                        // the rendered text
-field.value(t"search terms")               // type into an input
-field.property(t"value")                   // the live DOM property, not the markup
-button.screenshot()                        // a Raster in Png of the element
+  heading.click()
+  heading.innerText()                        // the rendered text
+  field.value(t"search terms")               // type into an input
+  field.property(t"value")                   // the live DOM property, not the markup
+  button.screenshot()                        // a Raster in Png of the element
 ```
 
 Anything a locator cannot express is reached with `execute`, which runs JavaScript in the page
@@ -73,6 +80,7 @@ error code the driver reported, its message and the browser-side stack trace.
 Most of what makes browser automation flaky is timing, and the protocol helps with only part of
 it. WebDriver's *implicit* timeout covers find commands, and is set once for the session:
 
+<!-- doccheck: skip -->
 ```scala
 browser.timeouts(WebDriver.Session.Timeouts(`implicit` = 5000L))
 ```
@@ -81,6 +89,7 @@ Nothing else has a server-side notion of waiting. For a button that becomes enab
 whose text changes, `awaitElement`, `awaitElements` and `awaitUntil` poll under the retry policy
 in scope:
 
+<!-- doccheck: skip -->
 ```scala
 import retryTenacities.exponentialTenTimesTenacity
 
@@ -97,12 +106,14 @@ the next attempt.
 
 ### Typed page scripting
 
-Behaviour attached to a page — an `onclick`, an `onchange` — is written as a typed DOM expression
+Behavior attached to a page — an `onclick`, an `onchange` — is written as a typed DOM expression
 rather than a JavaScript string. The `document` and `window` values navigate the DOM's real
 interfaces, checked against WebIDL, and render to JavaScript where an [HTML](html.md) attribute
 expects a script:
 
 ```scala
+import htmlDoms.whatwg.*
+
 Button(onclick = document.getElementById(t"foo").focus())
 // renders onclick="document.getElementById('foo').focus()"
 ```

--- a/doc/modules/xml.md
+++ b/doc/modules/xml.md
@@ -32,6 +32,8 @@ import strategies.throwUnsafely
 given XmlSchema = XmlSchema.Freeform
 ```
 
+An XML value that is immutable, with every edit returning a new value, follows [immutability](../philosophy/immutability.md).
+
 ### Parsing
 
 Text becomes an `Xml` value with `read`, and `load` reads a whole document, keeping its `<?xml?>`
@@ -46,6 +48,8 @@ with its `Header` — the version, and the encoding and standalone declarations 
 given — so a document round-trips with its declaration intact rather than losing it on the way in:
 
 ```scala
+import threading.platformThreading
+
 supervise:
   t"""<?xml version="1.0"?><root>content</root>""".load[Xml]
 // Document(elem(t"root", TextNode(t"content")), Header(t"1.0", Unset, Unset))
@@ -112,11 +116,11 @@ t"<Worker><name>Alice</name><age>30</age></Worker>".read[Worker in Xml]
 // Worker(t"Alice", 30)
 ```
 
-A field marked `@attribute` becomes an attribute rather than a child element, and round-trips as
+A field marked `@Xml.attribute` becomes an attribute rather than a child element, and round-trips as
 one:
 
 ```scala
-case class Book(title: Text, @attribute isbn: Text)
+case class Book(title: Text, @Xml.attribute isbn: Text)
 
 Book(t"Dune", t"0441013597").in[Xml]
 // x"""<Book isbn="0441013597"><title>Dune</title></Book>"""
@@ -128,8 +132,8 @@ element of an enumeration's *variant* too, so a `Light.Stop` may travel as `<red
 
 ```scala
 enum Light:
-  case @name[Xml](t"red") Stop(seconds: Int)
-  case @name(t"green") Go(seconds: Int)
+  @name[Xml](t"red") case Stop(seconds: Int)
+  @name(t"green") case Go(seconds: Int)
   case Wait(seconds: Int)
 
 (Light.Stop(30): Light).in[Xml]   // x"<red><seconds>30</seconds></red>"
@@ -223,6 +227,27 @@ xp"/root/child".encode         // t"/root[1]/child[1]"
 Paths are what positions and accrued errors are reported against, so an error from decoding a
 large document names the element that caused it.
 
+### Querying with XPath
+
+The same interpolator writes a full [XPath 1.0](https://www.w3.org/TR/xpath-10/) expression, and
+a document answers it. `select` returns the matching nodes as a fragment, `selectText` the text
+of the first match, and `evaluate` the value of any expression — a number, a boolean, a string or
+a node set — as an `XPath.Value`. Axes, predicates on attributes and text, and the core function
+library are all supported, which is what a browser-automation locator or a configuration lookup
+needs:
+
+```scala
+val page = t"""<app><div id="main"><button data-test="submit">Submit</button>
+                 <ul><li>one</li><li>two</li><li>three</li></ul></div></app>""".read[Xml]
+
+page.selectText(xp"//button[text()='Submit']/@data-test")   // t"submit"
+page.selectText(xp"/app/div[1]/ul/li[2]")                    // t"two"
+page.evaluate(xp"count(//li)")                               // XPath.Value.Numeric(3)
+```
+
+An expression the engine does not support, or a variable it was not given, raises an
+`XPath.Error` saying so.
+
 ### Positions and errors
 
 A malformed document raises a `ParseError` whose position is not merely a line number but a range:
@@ -235,6 +260,7 @@ Positions of *well-formed* content are recorded on request, in the same way as f
 ```scala
 import parsing.trackPositions
 
+val source = t"<root><child/></root>"
 val tracked = source.load[Xml]
 ```
 

--- a/doc/modules/xml.md
+++ b/doc/modules/xml.md
@@ -22,7 +22,7 @@ compounded by an interface that checks nothing.
 Soundness derives the conversion between XML and a Scala type from the type itself — a case class
 becomes an element with a child per field, an enumeration becomes an element named for its case — so
 there is nothing to keep in step by hand. Navigation is checked, literals are checked as they are
-written, and a failed conversion is a typed `XmlError`. Everything comes from the `soundness`
+written, and a failed conversion is a typed `Xml.Error`. Everything comes from the `soundness`
 package, with a schema and an error strategy in scope:
 
 ```scala
@@ -90,7 +90,7 @@ signature, or where a downstream consumer matches on the prefix.
 ### Reading values
 
 An `Xml` value converts to a Scala type with `as`. Content that cannot be read as the target type
-raises an `XmlError`:
+raises an `Xml.Error`:
 
 ```scala
 x"<message>42</message>".as[Int]   // 42
@@ -136,7 +136,7 @@ enum Light:
 ```
 
 A sum type decodes by its element label, so the element's name selects the variant; a label
-naming no variant raises an `XmlError` rather than falling through to a default.
+naming no variant raises an `Xml.Error` rather than falling through to a default.
 
 ### What decoding tolerates
 

--- a/doc/modules/yaml.md
+++ b/doc/modules/yaml.md
@@ -29,6 +29,8 @@ import soundness.*
 import strategies.throwUnsafely
 ```
 
+Decoding straight to a typed value, through the same derivation as every other format, is [correctness](../philosophy/correctness.md) with one definition of the data.
+
 ### Parsing and decoding
 
 Text reads as a `Yaml` value, and decodes to a Scala type with `as`; reading straight to a type
@@ -91,11 +93,13 @@ Aliases resolve as the document is read, whatever the anchored node was — a sc
 sequence or mapping, or a whole block:
 
 ```scala
+case class Inner(n: Int)
+
 t"a: &x 1\nb: *x".read[Yaml].as[Map[Text, Int]]
 // Map(t"a" -> 1, t"b" -> 1)
 
 t"defaults: &d\n  n: 7\nuse: *d".read[Yaml].as[Map[Text, Inner]]
-// both keys hold the same mapping
+// Map(t"defaults" -> Inner(7), t"use" -> Inner(7)): both keys hold the same mapping
 ```
 
 This is what makes YAML configuration files terse, and what makes a naive parser get them wrong.

--- a/doc/standards/style.md
+++ b/doc/standards/style.md
@@ -100,3 +100,8 @@ one tutorial. Two conventions make that possible:
   form one continuous session. Where a tutorial needs a value it cannot sensibly construct
   in prose — a path that must exist, a running service — put the binding in
   `doc/fixtures/<tutorial>.scala`, which the checker evaluates before the first fence.
+- A fence that cannot run in a REPL session — one that opens a browser, binds a socket, reads a
+  terminal, dispatches a JVM, or is a macro sketch — is preceded by the line
+  `<!-- doccheck: skip -->`. It is still read by the name check, so it keeps every name it uses
+  defined. A tutorial whose samples need a language feature the session lacks asks for it with
+  `<!-- doccheck: language captureChecking -->` anywhere in the document.

--- a/doc/standards/style.md
+++ b/doc/standards/style.md
@@ -87,3 +87,16 @@ Samples should be complete — including imports where necessary, though wildcar
 are fine — and should follow on from one another: a term with a given name means the
 same thing throughout a document, and a single identifier is never assigned more than
 once.
+
+Every sample is checked mechanically. `make doccheck` evaluates each ` ```scala ` fence of a
+tutorial, in order, through the flame REPL (`etc/doccheck.py`), and checks the names the
+samples use against the source (`etc/doccheck-names.py`); `make doccheck DOC=json` checks
+one tutorial. Two conventions make that possible:
+
+- A line that is meant not to compile carries a trailing `// does not compile` comment (with
+  an optional explanation after a colon). The checker submits it on its own and reports it if
+  it compiles after all.
+- A sample must introduce every name it uses, in a fence of the same tutorial, so the fences
+  form one continuous session. Where a tutorial needs a value it cannot sensibly construct
+  in prose — a path that must exist, a running service — put the binding in
+  `doc/fixtures/<tutorial>.scala`, which the checker evaluates before the first fence.

--- a/doc/tags.md
+++ b/doc/tags.md
@@ -21,14 +21,17 @@ caesura: csv tsv dsv spreadsheet sheet delimited-values
 camouflage: cache lru-cache memoization
 capricious: random rng probability gaussian gamma distribution sampling seed
 cardinality: refinement-types numeric-range bounded-numbers ranges
-clavichord: keyboard keypress keys modifiers input
 cataclysm: css stylesheet selectors keyframes media-queries fonts typesafe-css
 charisma: chemistry periodic-table chemical-equation molecule chemical-formula
 chiaroscuro: diff comparison contrast similarity test-assertions decomposition
+clavichord: keyboard keypress keys modifiers input
 coaxial: socket tcp udp networking domain-socket bindable connection
+concordance: collections concatenation appendable prependable joining
 contextual: string-interpolation interpolator typesafe-interpolation custom-interpolators
 contingency: error-handling exceptions tactics recovery validation effects
+corpuscular: checksum crc32 crc64 adler32 non-cryptographic-hash integrity
 cosmopolite: i18n internationalization locale language polyglot l10n
+degustation: tasty api-surface api-atoms inspection library-identity
 delicious: semantic-diagnostics compiler-errors explanations diagnostics
 dendrology: tree-diagram dag-diagram ascii-tree visualization tree-rendering
 denominative: ordinal indexing zero-based one-based interval
@@ -40,6 +43,7 @@ embarcadero: docker container container-runtime
 enigmatic: cryptography aes rsa hmac encryption signing pem public-key
 escapade: ansi-escape terminal-styling colors text-style hyperlink ribbon teletype
 escritoire: table tabulation grid box-drawing terminal-tables column-alignment
+espionage: acp agent-client-protocol coding-agent ide-integration json-rpc
 ethereal: daemon ipc background-process service-installer client-server
 eucalyptus: logging logs realm logger structured-logging
 exegesis: lsp language-server-protocol ide-integration
@@ -76,6 +80,7 @@ mercator: functor monad applicative typeclass functional-programming
 metamorphose: permutations combinatorics factoradic lehmer
 monotonous: base64 base32 hex binary-encoding base-encoding serialization
 mosquito: matrix linear-algebra math vector
+murmuration: collections typeclasses traversable foldable mappable filterable
 nomenclature: name-validation type-level constraints refinement-types string-literal-types
 obligatory: rpc json-rpc sse server-sent-events framing length-prefix protocol
 octogenarian: git version-control git-repository commit ssh-url
@@ -89,6 +94,7 @@ pneumatic: compression deflate gzip zlib brotli xz lzma2 lzw
 polaris: binary-serialization buffer pack unpack byte-buffer
 polysyllabic: hyphenation liang-algorithm line-breaking typesetting
 polyvinyl: structural-types records anonymous-records type-providers
+praxinoscope: regex re2 automaton linear-time regex-engine redos
 prepositional: typeclass type-infrastructure refinement-types abstract-types
 prescience: staging macro-typeclass code-generation expansion-time
 probably: testing test-runner property-testing benchmark assertions
@@ -98,6 +104,7 @@ proscenium: re-exports stdlib utilities boilerplate-reduction
 punctuation: markdown commonmark prose text-formatting
 quantitative: units quantities dimensional-analysis si-units measurements physics
 querencia: dom browser typed-dom web-ui client-side
+reliquary: lira library-archive release publication api-identity versioning
 revolution: jar-manifest semver versioning
 rudiments: utilities core-library bijection loops indexable
 savagery: svg vector-graphics 2d-graphics path shapes
@@ -114,6 +121,7 @@ symbolism: operators arithmetic typeclass operator-overloading algebra
 synesthesia: mcp model-context-protocol llm ai-protocol
 tarantula: webdriver browser-automation chrome firefox safari edge selenium headless
 telekinesis: http http-client cookies authentication rest-client web-requests
+tessellate: layout box-drawing reflow alignment flex text-layout
 turbulence: streams io stdio streaming reactive line-separation
 typonym: type-level type-list type-map heterogeneous reflection
 ultimatum: terminal-layout panes progress-bar spinner gauge sparkline tui
@@ -123,6 +131,8 @@ urticose: hostname email-address ip-address mac-address port network-identifiers
 vacuous: optional null-safety option maybe nullable
 vexillology: bit-flags flags enumeration bitfield
 vicarious: catalog proxy type-indexed records
+virility: roff manpage man-page troff documentation cli-help
+vivisection: debugging jdi breakpoints stepping dap debug-adapter variables
 wisteria: derivation product-types sum-types case-class typeclass-derivation magnolia
 xenophile: ffi foreign-interop wit webidl typescript kotlin wasm native
 xylophone: xml xml-schema typesafe-xml dynamic-xml

--- a/etc/check-doc-coverage.py
+++ b/etc/check-doc-coverage.py
@@ -24,6 +24,7 @@ Focus Client Server Session Request Response Message Header Body Content Source 
 
 # Libraries that are infrastructure for other libraries, not something a reader uses directly.
 INTERNAL = {
+    'rudiments',      # foundation utilities used by every tutorial; nothing to teach on their own
     'anticipation', 'prepositional', 'proscenium', 'murmuration', 'corpuscular', 'tessellate',
     'beneficence', 'umbrageous', 'prescience', 'frontier', 'symbolism', 'denominative',
     'concordance', 'delicious', 'prophesy', 'stenography', 'wisteria', 'polaris',
@@ -40,6 +41,11 @@ COVERED_BY = {
     'digression': ['stack-traces.md'],
     'sibylline': ['llm.md'],
     'murmuration': ['collections.md'],
+    'praxinoscope': ['patterns.md'],     # selected as `regexBackends.re2`, a kaleidoscope name
+    'cardinality': ['numbers.md'],       # bounded numbers are written with the `~` type operator
+    'chiaroscuro': ['testing.md'],       # the contrast rendering behind a failed assertion
+    'diuretic': ['foreign-interop.md'],  # adapters for java.io.File, java.net.URL and the time types
+    'perihelion': ['http-server.md'],    # websockets, reached through the HTTP server and client
 }
 
 def exported_names():

--- a/etc/check-doc-coverage.py
+++ b/etc/check-doc-coverage.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Map every library under lib/ to the tutorials in doc/modules/ that cover it, and fail if
+any library is covered by none (roadmap item doc-4).
+
+A tutorial never names a library — it says "Soundness" — so coverage is judged by the names
+a library exports into the umbrella (its `soundness_<component>.scala` files): a tutorial
+mentioning a type that only that library exports covers it. Names exported by more than one
+library (`Error`, `Text`, …) are no evidence and are ignored. Libraries whose exported names
+are too few or too short to be found that way are mapped by hand in COVERED_BY, and libraries
+that are plumbing rather than user-facing are listed in INTERNAL and need no tutorial.
+
+Usage:
+    python3 etc/check-doc-coverage.py            # report uncovered libraries; exit 1 if any
+    python3 etc/check-doc-coverage.py --table    # print the full library → tutorials table
+Run by `make build`.
+"""
+import collections, glob, os, re, sys
+
+EXPORT = re.compile(r'\bexport\s+([\w.]+)\s*\.\s*(?:\{([^}]*)\}|(\w+))', re.S)
+STOP = set('''Error Errors Text Data List Set Map Optional Unset Nil Type Value Name Key Result Reason
+Event Config Info Id Path Kind Mode Style Format Status Flag Option Options Entry Field Node Element
+Focus Client Server Session Request Response Message Header Body Content Source Target Target
+'''.split())
+
+# Libraries that are infrastructure for other libraries, not something a reader uses directly.
+INTERNAL = {
+    'anticipation', 'prepositional', 'proscenium', 'murmuration', 'corpuscular', 'tessellate',
+    'beneficence', 'umbrageous', 'prescience', 'frontier', 'symbolism', 'denominative',
+    'concordance', 'delicious', 'prophesy', 'stenography', 'wisteria', 'polaris',
+}
+
+# Libraries whose coverage the export-name heuristic cannot see, mapped by hand.
+COVERED_BY = {
+    'exegesis': ['lsp.md'],
+    'espionage': ['acp.md'],
+    'degustation': ['library-archives.md'],
+    'reliquary': ['library-archives.md'],
+    'virility': ['cli.md'],
+    'ziggurat': ['packaging.md'],
+    'digression': ['stack-traces.md'],
+    'sibylline': ['llm.md'],
+    'murmuration': ['collections.md'],
+}
+
+def exported_names():
+    """library → the capitalised names it exports into the umbrella."""
+    names = collections.defaultdict(set)
+    for path in glob.glob('lib/*/src/*/soundness_*.scala'):
+        library = path.split(os.sep)[1]
+        text = open(path, encoding='utf-8', errors='replace').read()
+        for _, group, single in EXPORT.findall(text):
+            for item in (group.split(',') if group else [single]):
+                item = item.strip()
+                if ' as ' in item:
+                    item = item.split(' as ')[-1].strip()
+                if re.fullmatch(r'[A-Z][A-Za-z0-9]{2,}', item) and item not in STOP:
+                    names[library].add(item)
+    return names
+
+def main():
+    table = '--table' in sys.argv
+    libraries = sorted(os.path.basename(p) for p in glob.glob('lib/*'))
+    names = exported_names()
+    owners = collections.defaultdict(set)
+    for library, exported in names.items():
+        for name in exported:
+            owners[name].add(library)
+    unique = {library: {n for n in exported if len(owners[n]) == 1} for library, exported in names.items()}
+
+    docs = {}
+    for path in sorted(glob.glob('doc/modules/*.md')):
+        docs[os.path.basename(path)] = set(re.findall(r'\b[A-Z][A-Za-z0-9]{2,}\b', open(path, encoding='utf-8').read()))
+
+    coverage = {}
+    for library in libraries:
+        covering = {doc for doc, words in docs.items() if words & unique.get(library, set())}
+        covering |= {doc for doc in COVERED_BY.get(library, []) if doc in docs}
+        coverage[library] = sorted(covering)
+
+    if table:
+        for library in libraries:
+            tag = ' (internal)' if library in INTERNAL else ''
+            print(f'{library}{tag}: {" ".join(coverage[library]) or "-"}')
+        return
+
+    uncovered = [l for l in libraries if not coverage[l] and l not in INTERNAL]
+    for library in uncovered:
+        print(f'uncovered: lib/{library} — no tutorial in doc/modules mentions a name only it exports')
+    missing = {doc for docs_ in COVERED_BY.values() for doc in docs_ if doc not in docs}
+    for doc in sorted(missing):
+        print(f'COVERED_BY names a tutorial that does not exist yet: {doc}')
+    print(f'{len(libraries) - len(uncovered)}/{len(libraries)} libraries covered', file=sys.stderr)
+    sys.exit(1 if uncovered or missing else 0)
+
+if __name__ == '__main__':
+    main()

--- a/etc/doccheck-names.py
+++ b/etc/doccheck-names.py
@@ -128,7 +128,10 @@ def main():
                     if member != '*' and member not in members:
                         print(f'{doc}:{number}: import names no known given or member: {member}')
                         problems += 1
-                for name in CAPITALISED.findall(code):
+                for match in CAPITALISED.finditer(code):
+                    name = match.group(1)
+                    # A capitalised named argument (`ContainerConfig(Cmd = …)`) is a field, not a type.
+                    if re.match(r'\s*=(?!=)', code[match.end():]): continue
                     if name.isupper() or name in IGNORED or name in declared_in_doc or name in declared_in_source or name in exported:
                         continue
                     if name in seen:

--- a/etc/doccheck-names.py
+++ b/etc/doccheck-names.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Check the names the tutorials' ```scala examples use against the source of `main`.
+
+The examples under doc/modules/ are prose, so nothing compiles them against the tree they
+live in. This script does the mechanical part: every `import family.member` in a fence must
+name a member declared somewhere under lib/, every capitalised name must be declared in lib/
+(or by the fences themselves), and a short list of retired vocabulary must not appear at all.
+For a missing name it looks for the `// OldName → New.Name` comment the API-nesting drive
+left beside each renamed type, and prints the replacement.
+
+Usage:
+    python3 etc/doccheck-names.py             # every tutorial
+    python3 etc/doccheck-names.py json time   # named tutorials
+Exit status is 1 if anything is reported.
+"""
+import glob, os, re, sys
+
+FENCE_OPEN = re.compile(r'^```scala\s*$')
+FENCE_CLOSE = re.compile(r'^```\s*$')
+CHOICE_IMPORT = re.compile(r'^\s*import\s+([a-z]\w*)\.([a-zA-Z]\w*)\s*$')
+CHOICE_IMPORTS = re.compile(r'^\s*import\s+([a-z]\w*)\.\{([^}]*)\}\s*$')
+CAPITALISED = re.compile(r'(?<![\w."`$])([A-Z][A-Za-z0-9]{2,})\b')
+DECLARATION = re.compile(r'\b(?:case class|class|object|enum|trait|type|case|given|val|def)\s+([A-Z][A-Za-z0-9]*)')
+RENAME = re.compile(r'//\s*([A-Z]\w*)\s*→\s*([A-Za-z][\w.]*)')
+STRING_OR_COMMENT = re.compile(r'"(?:[^"\\]|\\.)*"|//.*$')
+
+# Vocabulary retired from the Soundness API; each pattern maps to what replaced it. Only names
+# verified absent from lib/ belong here: `Iterator`, `Ordering`, `distinct` and `sorted` all survive.
+RETIRED = [
+    (re.compile(r'\bLazyList\b'), 'LazyList: use List, Chain or Progression (#1693)'),
+    (re.compile(r'\.sortBy\b'), '.sortBy: use order (#1909)'),
+    (re.compile(r'\bproscenium\.compat\b'), 'proscenium.compat: deleted (#1848)'),
+    (re.compile(r'\bTypename\b'), 'Typename: renamed Designator (#1685)'),
+]
+
+# Names that are Scala, Java or prose, not Soundness API, and so need no declaration.
+IGNORED = set('''
+Int Long Short Byte Char Boolean Double Float Unit String Nothing Any AnyRef AnyVal Null Array
+Seq Some None Option Either Left Right Try Success Failure Tuple Product Function Vector Range
+Predef Math StringContext Class ClassTag Throwable Exception Error RuntimeException Iterable
+BigInt BigDecimal Numeric Integral Fractional Serializable Comparable Runnable Thread Object
+Nil List Set Map Text Data Optional Unset IArray Chain Progression Expr Type Quotes Tuple1 Tuple2
+Benchmarks Suite Tests
+'''.split())
+
+def fences(path):
+    lines = open(path, encoding='utf-8').read().split('\n')
+    inside, start, buffer = False, 0, []
+    for number, line in enumerate(lines, 1):
+        if not inside:
+            if FENCE_OPEN.match(line):
+                inside, start, buffer = True, number + 1, []
+        elif FENCE_CLOSE.match(line):
+            yield start, buffer
+            inside = False
+        else:
+            buffer.append(line)
+
+def source_text():
+    """All library source (not tests, benches or demos), concatenated, plus the rename comments."""
+    chunks, renames = [], {}
+    for path in glob.glob('lib/*/src/*/*.scala'):
+        if any(part in path for part in ('/src/test', '/src/bench', '/src/demo', '/src/example')):
+            continue
+        text = open(path, encoding='utf-8', errors='replace').read()
+        chunks.append(text)
+        for old, new in RENAME.findall(text):
+            renames.setdefault(old, new)
+    return '\n'.join(chunks), renames
+
+def main():
+    docs = [d if d.endswith('.md') else os.path.join('doc', 'modules', d + '.md') for d in sys.argv[1:]] \
+        or sorted(glob.glob('doc/modules/*.md'))
+    source, renames = source_text()
+    declared_in_source = set(re.findall(r'(?:class|object|enum|trait|type|val|def|given|case)\s+([A-Z][A-Za-z0-9]*)', source))
+    exported = set(re.findall(r'\b([A-Z][A-Za-z0-9]*)\b', '\n'.join(
+        open(p, encoding='utf-8', errors='replace').read() for p in glob.glob('lib/*/src/*/soundness_*.scala'))))
+    members = set(re.findall(r'\b(?:given|val|def|object|lazy val|export)\s+(?:[\w.{}, ]*\bas\s+)?(\w+)', source))
+    members |= set(re.findall(r'\bas\s+(\w+)', source))
+
+    problems = 0
+    for doc in docs:
+        declared_in_doc = set()
+        for _, lines in fences(doc):
+            for line in lines:
+                declared_in_doc.update(DECLARATION.findall(line))
+                cases = re.match(r'\s*case\s+([A-Z]\w*(?:\s*,\s*[A-Z]\w*)*)\s*(?:$|//|\()', line)
+                if cases:
+                    declared_in_doc.update(n.strip() for n in cases.group(1).split(','))
+        seen = set()
+        prose = []
+        inside = False
+        for number, line in enumerate(open(doc, encoding='utf-8').read().split('\n'), 1):
+            if FENCE_OPEN.match(line) or (inside and FENCE_CLOSE.match(line)):
+                inside = not inside
+            elif not inside and line.startswith('```'):
+                inside = True
+            elif not inside:
+                for span in re.findall(r'`([^`]+)`', line):
+                    prose.append((number, span))
+        # Prose names are checked more loosely than fence names — prose legitimately mentions JDK
+        # classes, PDF operators and hypothetical types — so only a compound name of the kind the
+        # API-nesting drive retired (`FooError`, `FooEvent`, …) or one with a recorded rename counts.
+        for number, span in prose:
+            for name in CAPITALISED.findall(span):
+                if name.isupper() or name in IGNORED or name in declared_in_doc or name in declared_in_source \
+                        or name in exported or name in seen:
+                    continue
+                if name not in renames and not re.search(r'[a-z](Error|Errors|Event|Reader|Writer|Backend)$', name):
+                    continue
+                seen.add(name)
+                hint = f' (source says: {name} → {renames[name]})' if name in renames else ''
+                print(f'{doc}:{number}: unknown name in prose: {name}{hint}')
+                problems += 1
+        for start, lines in fences(doc):
+            for offset, line in enumerate(lines):
+                number = start + offset
+                code = STRING_OR_COMMENT.sub('', line)
+                for pattern, message in RETIRED:
+                    if pattern.search(code):
+                        print(f'{doc}:{number}: retired vocabulary: {message}')
+                        problems += 1
+                single = CHOICE_IMPORT.match(line)
+                multi = CHOICE_IMPORTS.match(line)
+                names = [single.group(2)] if single else \
+                    [n.strip() for n in multi.group(2).split(',') if n.strip() and n.strip() != 'given'] if multi else []
+                for member in names:
+                    if member != '*' and member not in members:
+                        print(f'{doc}:{number}: import names no known given or member: {member}')
+                        problems += 1
+                for name in CAPITALISED.findall(code):
+                    if name.isupper() or name in IGNORED or name in declared_in_doc or name in declared_in_source or name in exported:
+                        continue
+                    if name in seen:
+                        continue
+                    seen.add(name)
+                    hint = f' (source says: {name} → {renames[name]})' if name in renames \
+                        else ' (declared neither in lib/ nor in this tutorial\'s examples)'
+                    print(f'{doc}:{number}: unknown name: {name}{hint}')
+                    problems += 1
+    print(f'{problems} problem(s)', file=sys.stderr)
+    sys.exit(1 if problems else 0)
+
+if __name__ == '__main__':
+    main()

--- a/etc/doccheck.py
+++ b/etc/doccheck.py
@@ -71,6 +71,53 @@ def component_jars(version):
         jars.append(path)
     return jars
 
+RENAMED = re.compile(r'`(?:[a-z]\w*\.)?([a-z]\w*)\.([A-Za-z]\w*)`(?:\s*\([^)]*\))?\s+renamed\s+to\s+`([A-Za-z]\w*)`')
+RENAMED_GROUP = re.compile(r'`(?:[a-z]\w*\.)?([a-z]\w*)\.\{([^}]*)\}`(?:\s*\([^)]*\))?\s+renamed\s+to\s+`\{([^}]*)\}`')
+FLATTENED = re.compile(r'`([a-z]\w*)\.([a-z]\w*)\.([A-Za-z]\w*)` → `([A-Za-z]\w*)`')
+
+def release_names():
+    """(family, new name) → old name, for every given the migration notes say was renamed since
+    the last release; the driver retries a failed import under the old name."""
+    older = {}
+    try:
+        text = open('doc/migration/pending.md', encoding='utf-8').read().replace('\n', ' ')
+    except OSError:
+        return older
+    for family, old, new in RENAMED.findall(text):
+        older[(family, new)] = old
+    for family, olds, news in RENAMED_GROUP.findall(text):
+        for old, new in zip([n.strip() for n in olds.split(',')], [n.strip() for n in news.split(',')]):
+            older[(family, new)] = old
+    for family, subfamily, old, new in FLATTENED.findall(text):
+        older[(family, new)] = f'{subfamily}.{old}'
+    # A whole choice package renamed, or a nested family flattened to one level: every member of
+    # the new family maps to the same member of the old.
+    for old, new in re.findall(r'[Cc]hoice package `(?:[a-z]\w*\.)*([a-z]\w*)` renamed to `(?:[a-z]\w*\.)*([a-z]\w*)`', text):
+        older[(new, '*')] = old
+    # A member flattened from a nested object (`dereferenceSymlinks.enabled` → `dereferenceSymlinks`)
+    # keeps its family; an object member replaced by a choice package moves families.
+    for old, new in re.findall(r'`([a-z]\w*\.[a-z]\w*)`\s+→\s+`([a-z]\w*)`', text):
+        older[('*', new)] = old
+        # The same shape also records a nested family flattened to one (`interfaces.paths` →
+        # `pathInterfaces`): as a family, its members keep their names under the old path.
+        older.setdefault((new, '*'), old)
+    for old, new in re.findall(r'`(?:[a-z]\w*\.)*([a-z]\w*\.[a-z]\w*)` \(object member\) replaced by `(?:[a-z]\w*\.)*([a-z]\w*\.[a-z]\w*)`', text):
+        family, member = new.split('.')
+        older[(family, member)] = '=' + old
+    for old, new in re.findall(r'`(?:[a-z]\w*\.)*([a-z]\w*\.[a-z]\w*)` replaced by `(?:[a-z]\w*\.)*([a-z]\w*\.[a-z]\w*)`', text):
+        family, member = new.split('.')
+        older.setdefault((family, member), '=' + old)
+    # A whole family renamed with a dotted old path (`honeycomb.doms.html` (…) renamed to
+    # `honeycomb.htmlDoms`): members and sub-packages keep their names under the old path.
+    for old, new in re.findall(r'`(?:[a-z]\w*\.)?([a-z]\w*\.[a-z]\w*)`(?:\s*\([^)]*\))?\s+renamed\s+to\s+`(?:[a-z]\w*\.)?([a-z]\w*)`', text):
+        older.setdefault((new, '*'), old)
+    for family, suffix in re.findall(r'Every member of `(?:[a-z]\w*\.)*([a-z]\w*)` gains the suffix `(\w+)`', text):
+        for old, new in re.findall(r'`([a-z]\w*)` → `([a-z]\w*' + suffix + r')`', text):
+            older[(family, new)] = old
+        for old in re.findall(r'`([a-z]\w*)`(?=,| become)', text):
+            older.setdefault((family, old + suffix), old)
+    return older
+
 def migration_names():
     """Every identifier mentioned in doc/migration/pending.md: a diagnostic naming one of them
     is drift between the release and `main`, not a stale example."""
@@ -85,6 +132,13 @@ def migration_names():
                 names.add(word)
     return names
 
+LANGUAGE_MARKER = re.compile(r'<!-- doccheck: language (\w+) -->')
+
+def doc_features(path):
+    """Language features a tutorial asks for itself, with a `<!-- doccheck: language X -->` line:
+    capture checking, for one whose examples write capture annotations."""
+    return LANGUAGE_MARKER.findall(open(path, encoding='utf-8').read())
+
 class Fence:
     def __init__(self, line, code):
         self.line = line          # markdown line of the fence's first code line
@@ -95,11 +149,22 @@ def fences(path):
     """The ```scala fences of a tutorial, in order, with `// does not compile` lines split out."""
     result = []
     lines = open(path, encoding='utf-8').read().split('\n')
-    inside, start, buffer = False, 0, []
+    inside, start, buffer, skip = False, 0, [], False
     for number, line in enumerate(lines, 1):
         if not inside:
-            if FENCE_OPEN.match(line):
+            if line.strip() == '<!-- doccheck: skip -->':
+                skip = True
+            elif FENCE_OPEN.match(line):
                 inside, start, buffer = True, number + 1, []
+                if skip:
+                    skip = False
+                    inside = False
+                    # Consume the fence without recording it.
+                    for later in lines[number:]:
+                        number += 1
+                        if FENCE_CLOSE.match(later):
+                            break
+                    continue
             continue
         if FENCE_CLOSE.match(line):
             fence = Fence(start, [])
@@ -212,17 +277,29 @@ def classify(reply, tolerated):
         return 'UNDEFINED'
     return 'STALE'
 
+FULL = False
+OLDER = {}
+
 def summarise(reply):
-    """The first meaningful line of a reply's diagnostics (or output), for the report."""
+    """The first meaningful line of a reply's diagnostics (or output), for the report — or all of
+    it under --full, indented beneath the verdict."""
     text = reply['diagnostics'].strip() or reply['output'].strip()
-    return text.split('\n')[0][:160] if text else ''
+    if not text:
+        return ''
+    if FULL:
+        return '\n' + '\n'.join('        ' + line for line in text.split('\n'))
+    return text.split('\n')[0][:160]
 
 def prepare(server, path, jars, args, replay):
     """A fresh session for `path`: settings, the release's jars, the fixture preamble, then the
     submissions in `replay` (fences that already ran before a hang), in that order."""
     name = os.path.basename(path)[:-3]
     session = server.session()
-    for setting in ['/set experimental'] + [f'/set {s}' for s in args.set]:
+    # The language features Soundness itself compiles with (build.mill's `settings.scalaOptions`),
+    # as far as flame offers them: an example using `erased`, a bounded numeric literal or a
+    # `tracked` parameter needs them switched on in the session.
+    features = ['erasedDefinitions', 'genericNumberLiterals', 'modularity'] + args.language + doc_features(path)
+    for setting in ['/set experimental'] + [f'/set {s}' for s in args.set] + [f'/language {f}' for f in features]:
         server.eval(session, setting)
     started = time.time()
     for jar in jars:
@@ -232,10 +309,48 @@ def prepare(server, path, jars, args, replay):
     if jars and args.verbose:
         print(f'{path}: loaded {len(jars)} jars in {time.time() - started:.1f}s', file=sys.stderr)
     fixture = os.path.join('doc', 'fixtures', name + '.scala')
-    fixture_reply = server.eval(session, open(fixture, encoding='utf-8').read()) if os.path.exists(fixture) else None
+    fixture_reply = None
+    if os.path.exists(fixture):
+        lines = open(fixture, encoding='utf-8').read().split('\n')
+        fixture_reply = server.eval(session, '\n'.join(lines))
+        if fixture_reply['status'] != 'ran':
+            # Like a fence: keep the imports that resolve (shimmed to the release's names where
+            # they were renamed since), then try the rest of the fixture without them.
+            for line in lines:
+                if line.startswith('import '):
+                    resubmit_import(server, session, line, replay, args.timeout)
+            # Then each blank-line-separated definition on its own, so one that needs a given the
+            # release lacks does not take the others down with it.
+            rest = '\n'.join(l for l in lines if not l.startswith('import '))
+            failed = None
+            for block in re.split(r'\n\s*\n', rest):
+                if block.strip():
+                    retry = server.eval(session, block, args.timeout)
+                    if retry['status'] != 'ran' and failed is None:
+                        failed = retry
+            fixture_reply = failed or {'status': 'ran', 'output': '', 'value': '', 'diagnostics': []}
     for code in replay:
         server.eval(session, code, args.timeout)
     return session, fixture_reply
+
+def resubmit_import(server, session, line, replay, timeout):
+    """Submit one import on its own, falling back to the release's name for a given renamed
+    since; a resolving form is added to `replay` so a restarted daemon gets it too."""
+    if server.eval(session, line, timeout)['status'] == 'ran':
+        replay.append(line)
+        return
+    m = re.match(r'import ([a-z]\w*)\.([A-Za-z]\w*(?:\.\*)?)$', line.strip())
+    older = m and (OLDER.get((m.group(1), m.group(2))) or OLDER.get(('*', m.group(2))))
+    family = m and OLDER.get((m.group(1), '*'))
+    shim = None
+    if older and older.startswith('='):
+        shim = f'import {older[1:]}'
+    elif older:
+        shim = f'import {m.group(1)}.{older}'
+    elif family:
+        shim = f'import {family}.{m.group(2)}'
+    if shim and server.eval(session, shim, timeout)['status'] == 'ran':
+        replay.append(shim)
 
 def check(server, path, jars, tolerated, args):
     counts = {}
@@ -256,7 +371,15 @@ def check(server, path, jars, tolerated, args):
                 report(fence.line, 'HUNG', reply['diagnostics'])
                 session, _ = prepare(server, path, jars, args, replay)
                 continue
-            replay.append(code)
+            if reply['status'] == 'ran':
+                replay.append(code)
+            else:
+                # A rejected submission is discarded whole, imports included, so every later fence
+                # would fail for want of them. Resubmit the fence's imports on their own, so the
+                # ones that resolve stay in scope and the report shows the fence's real fault.
+                for line in fence.code:
+                    if line.startswith('import '):
+                        resubmit_import(server, session, line, replay, args.timeout)
             verdict = classify(reply, tolerated)
             report(fence.line, verdict, summarise(reply) if verdict != 'OK' else '')
             if args.values and reply['status'] == 'ran' and (reply['value'] or reply['output']):
@@ -275,18 +398,23 @@ def check(server, path, jars, tolerated, args):
 
 def main():
     sys.stdout.reconfigure(line_buffering=True)
+    global FULL, OLDER
     parser = argparse.ArgumentParser(description=__doc__.split('\n')[0])
     parser.add_argument('docs', nargs='*', help='tutorial names (json) or paths; default: all of doc/modules')
     parser.add_argument('--port', type=int, default=8765)
     parser.add_argument('--release', help='the Soundness release flame is built against (default: the most-populated version in ~/.ivy2/local)')
     parser.add_argument('--values', action='store_true', help='print each fence\'s printed output, value and type')
     parser.add_argument('--verbose', '-v', action='store_true', help='report OK fences too')
+    parser.add_argument('--full', action='store_true', help='print every line of a failing fence\'s diagnostics')
     parser.add_argument('--no-classload', action='store_true', help='use only the components flame bundles')
-    parser.add_argument('--set', action='append', default=[], metavar='SETTING', help='extra `/set` (e.g. captureChecking)')
+    parser.add_argument('--set', action='append', default=[], metavar='SETTING', help='extra `/set` (e.g. explain)')
+    parser.add_argument('--language', action='append', default=[], metavar='FEATURE', help='extra `/language` feature (e.g. namedTuples)')
     parser.add_argument('--keep', action='store_true', help='leave the flame server running afterwards')
     parser.add_argument('--batch', type=int, default=4, help='tutorials per flame daemon before it is restarted')
     parser.add_argument('--timeout', type=int, default=120, help='seconds to wait for one fence before reporting it HUNG')
     args = parser.parse_args()
+    FULL = args.full
+    OLDER = release_names()
 
     docs = [d if d.endswith('.md') else os.path.join('doc', 'modules', d + '.md') for d in args.docs] \
         or sorted(glob.glob('doc/modules/*.md'))

--- a/etc/doccheck.py
+++ b/etc/doccheck.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Evaluate every ```scala example in the tutorials under doc/modules/ through the flame REPL,
+and report each fence as ran, rejected, or thrown.
+
+flame (the Soundness REPL, https://github.com/propensive/flame) exposes its engine as a JSON
+API when started with `flame serve`: `POST /api/sessions` creates a named session and
+`POST /api/sessions/<name>/eval` with `{"code": "..."}` evaluates a whole submission in it,
+answering `{"status": "ran"|"error", "value", "tpe", "output", "name", "diagnostics"}`. Each
+tutorial runs in a fresh session, so its samples follow on from one another exactly as
+doc/standards/style.md promises they do, and nothing leaks between tutorials.
+
+flame is built against the latest Soundness *release*, while the tutorials document `main`, so
+a rejection can be honest drift rather than a stale example: a diagnostic that names an
+identifier recorded in doc/migration/pending.md is reported as TOLERATED; one whose only
+complaints are `Not found` names — a placeholder the prose introduced but no fence defined —
+as UNDEFINED; and everything else as STALE. A line carrying a `// does not compile` comment is
+submitted on its own and must be rejected; one that compiles is reported as NEGATIVE-FAILED. A
+runtime exception is THREW, and a fence that gives no reply within --timeout seconds is HUNG (the
+session is then rebuilt and the fences before it replayed, so later fences still see them).
+
+Because flame bundles only a curated subset of the Soundness components, every JVM component
+jar of the release is added to the session with `/classload` first (from ~/.ivy2/local, where
+`make sync-releases` installs a release). Entries added this way come last on the classpath,
+so they only supplement what flame already has.
+
+Usage:
+    python3 etc/doccheck.py                     # every tutorial
+    python3 etc/doccheck.py json time           # named tutorials
+    python3 etc/doccheck.py --values quantities # also print each fence's value and type
+Run it with `make doccheck` (or `make doccheck DOC=json`). Needs `flame` on the PATH (or the
+FLAME environment variable) and the release synced into ~/.ivy2/local.
+"""
+import argparse, glob, json, os, re, socket, subprocess, sys, time, urllib.request, urllib.error
+
+FLAME = os.environ.get('FLAME', 'flame')
+IVY = os.path.expanduser('~/.ivy2/local/dev.propensive')
+FENCE_OPEN = re.compile(r'^```scala\s*$')
+FENCE_CLOSE = re.compile(r'^```\s*$')
+NEGATIVE = re.compile(r"//\s*(?:does\s+not|doesn't|will\s+not|won't|cannot|can't)\s+compile\b", re.I)
+IDENT = re.compile(r'`([^`]+)`')
+WORD = re.compile(r'[A-Za-z_][\w]*')
+ANSI = re.compile(r'\x1b\[[0-9;?]*[A-Za-z]')
+PLATFORM_ONLY = {'wasi', 'plugin'}
+CAMEL = re.compile(r'[a-z]+[A-Z]\w*|[A-Z]\w*\.[A-Z]\w*')
+
+def release_version():
+    """The release flame is built against. A full release syncs every component into
+    ~/.ivy2/local, whereas a handful of bundle or plugin jars may sit there at a later version,
+    so the most-populated version is the one to use."""
+    counts = {}
+    for path in glob.glob(os.path.join(IVY, '*', '*')):
+        version = os.path.basename(path)
+        if re.fullmatch(r'\d+\.\d+\.\d+', version):
+            counts[version] = counts.get(version, 0) + 1
+    if not counts:
+        return None
+    return max(counts, key=lambda v: (counts[v], tuple(int(n) for n in v.split('.'))))
+
+def component_jars(version):
+    """Every JVM component jar of `version` in ~/.ivy2/local (the Scala.js and Native variants
+    carry a platform suffix and are skipped)."""
+    jars = []
+    for path in sorted(glob.glob(os.path.join(IVY, '*', version, 'jars', '*.jar'))):
+        component = path.split(os.sep)[-4]
+        if component.endswith('_sjs1_3') or component.endswith('_native0.5_3'):
+            continue
+        # A WASI backend cannot load into a JVM session (its package object links against WASI
+        # imports the JVM lacks), and the bundles and compiler plugins add nothing.
+        if component.rsplit('-', 1)[-1] in PLATFORM_ONLY or component.startswith('soundness'):
+            continue
+        jars.append(path)
+    return jars
+
+def migration_names():
+    """Every identifier mentioned in doc/migration/pending.md: a diagnostic naming one of them
+    is drift between the release and `main`, not a stale example."""
+    names = set()
+    try:
+        text = open('doc/migration/pending.md', encoding='utf-8').read()
+    except OSError:
+        return names
+    for code in IDENT.findall(text):
+        for word in WORD.findall(code):
+            if CAMEL.fullmatch(word):
+                names.add(word)
+    return names
+
+class Fence:
+    def __init__(self, line, code):
+        self.line = line          # markdown line of the fence's first code line
+        self.code = code          # the code lines
+        self.negatives = []       # (markdown line, code) lines that must be rejected
+
+def fences(path):
+    """The ```scala fences of a tutorial, in order, with `// does not compile` lines split out."""
+    result = []
+    lines = open(path, encoding='utf-8').read().split('\n')
+    inside, start, buffer = False, 0, []
+    for number, line in enumerate(lines, 1):
+        if not inside:
+            if FENCE_OPEN.match(line):
+                inside, start, buffer = True, number + 1, []
+            continue
+        if FENCE_CLOSE.match(line):
+            fence = Fence(start, [])
+            for offset, code in enumerate(buffer):
+                if NEGATIVE.search(code):
+                    fence.negatives.append((start + offset, NEGATIVE.split(code)[0].rstrip().rstrip('/').rstrip()))
+                else:
+                    fence.code.append(code)
+            # Drop leading and trailing blank lines, keep interior ones (they may sit inside a definition).
+            while fence.code and not fence.code[0].strip():
+                fence.code.pop(0); fence.line += 1
+            while fence.code and not fence.code[-1].strip():
+                fence.code.pop()
+            if fence.code or fence.negatives:
+                result.append(fence)
+            inside = False
+        else:
+            buffer.append(line)
+    if inside:
+        raise SystemExit(f'{path}:{start}: unterminated ```scala fence')
+    return result
+
+class Server:
+    """A `flame serve` process on `port`, started and stopped here.
+
+    flame runs as an Ethereal daemon: the `flame serve` process is a thin client of a JVM that
+    outlives it. Sessions are never released, and each one holds a compiler over the whole
+    release, so a long run exhausts the daemon's heap; `stop` therefore ends the daemon too, and
+    the driver restarts the pair every few tutorials."""
+    def __init__(self, port, verbose):
+        self.port, self.verbose, self.process = port, verbose, None
+        self.base = f'http://localhost:{port}'
+
+    def up(self):
+        try:
+            with socket.create_connection(('localhost', self.port), timeout=0.5):
+                return True
+        except OSError:
+            return False
+
+    def start(self):
+        if self.up():
+            raise SystemExit(f'port {self.port} is already in use; pass --port to choose another')
+        log = open('/tmp/doccheck-flame-serve.log', 'a')
+        try:
+            self.process = subprocess.Popen([FLAME, 'serve', '--port', str(self.port)], stdout=log, stderr=log,
+                                            stdin=subprocess.DEVNULL)
+        except OSError as error:
+            raise SystemExit(f'cannot start {FLAME}: {error} (set FLAME=/path/to/flame)')
+        for _ in range(120):
+            if self.up():
+                return
+            time.sleep(0.5)
+        raise SystemExit('flame serve did not come up; see /tmp/doccheck-flame-serve.log')
+
+    def stop(self):
+        if self.process:
+            self.process.terminate()
+            try:
+                self.process.wait(10)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+            self.process = None
+        # The daemon JVM behind the client, identified by the name Ethereal gives it.
+        subprocess.run(['pkill', '-f', 'ethereal.name=flame'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        for _ in range(20):
+            if not self.up():
+                break
+            time.sleep(0.5)
+        time.sleep(1)
+
+    def post(self, path, body=None, timeout=600):
+        data = json.dumps(body).encode() if body is not None else b''
+        request = urllib.request.Request(self.base + path, data=data, method='POST',
+                                         headers={'Content-Type': 'application/json'})
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as error:
+            return {'status': 'error', 'diagnostics': f'HTTP {error.code}: {error.read().decode(errors="replace")}'}
+        except (TimeoutError, socket.timeout, urllib.error.URLError) as error:
+            if 'timed out' in str(error).lower() or isinstance(error, (TimeoutError, socket.timeout)):
+                return {'status': 'hung', 'diagnostics': f'no reply within {timeout}s'}
+            raise
+
+    def session(self):
+        return self.post('/api/sessions')['session']
+
+    def eval(self, session, code, timeout=600):
+        reply = self.post(f'/api/sessions/{session}/eval', {'code': code}, timeout)
+        for key in ('value', 'tpe', 'output', 'name', 'diagnostics', 'base'):
+            reply[key] = ANSI.sub('', reply.get(key, '') or '')
+        return reply
+
+def classify(reply, tolerated):
+    """OK, THREW, TOLERATED, UNDEFINED or STALE for a submission that was expected to run."""
+    if reply['status'] == 'ran':
+        return 'OK'
+    diagnostics = reply['diagnostics']
+    # A runtime exception is reported with the captured output and a stack trace.
+    if '\n\tat ' in diagnostics or diagnostics.lstrip().startswith(('java.', 'scala.', 'Exception')):
+        return 'THREW'
+    for word in WORD.findall(diagnostics):
+        if word in tolerated:
+            return 'TOLERATED'
+    # A fence whose only faults are names it never introduced — a `path`, a `Person` the prose
+    # assumed — is incomplete rather than wrong about the API; it needs a definition or a fixture.
+    notices = [n.strip() for n in diagnostics.split('; ') if n.strip()]
+    if notices and all(n.startswith('Not found:') for n in notices):
+        return 'UNDEFINED'
+    return 'STALE'
+
+def summarise(reply):
+    """The first meaningful line of a reply's diagnostics (or output), for the report."""
+    text = reply['diagnostics'].strip() or reply['output'].strip()
+    return text.split('\n')[0][:160] if text else ''
+
+def prepare(server, path, jars, args, replay):
+    """A fresh session for `path`: settings, the release's jars, the fixture preamble, then the
+    submissions in `replay` (fences that already ran before a hang), in that order."""
+    name = os.path.basename(path)[:-3]
+    session = server.session()
+    for setting in ['/set experimental'] + [f'/set {s}' for s in args.set]:
+        server.eval(session, setting)
+    started = time.time()
+    for jar in jars:
+        reply = server.eval(session, f'/classload {jar}')
+        if reply['status'] != 'ran':
+            print(f'{path}: classload of {jar} failed: {summarise(reply)}', file=sys.stderr)
+    if jars and args.verbose:
+        print(f'{path}: loaded {len(jars)} jars in {time.time() - started:.1f}s', file=sys.stderr)
+    fixture = os.path.join('doc', 'fixtures', name + '.scala')
+    fixture_reply = server.eval(session, open(fixture, encoding='utf-8').read()) if os.path.exists(fixture) else None
+    for code in replay:
+        server.eval(session, code, args.timeout)
+    return session, fixture_reply
+
+def check(server, path, jars, tolerated, args):
+    counts = {}
+    def report(line, verdict, detail=''):
+        counts[verdict] = counts.get(verdict, 0) + 1
+        if verdict != 'OK' or args.verbose:
+            print(f'{path}:{line}: {verdict}' + (f': {detail}' if detail else ''))
+    replay = []
+    session, fixture_reply = prepare(server, path, jars, args, replay)
+    if fixture_reply is not None:
+        ok = fixture_reply['status'] == 'ran'
+        report(0, 'OK' if ok else 'FIXTURE-FAILED', '' if ok else summarise(fixture_reply))
+    for fence in fences(path):
+        if fence.code:
+            code = '\n'.join(fence.code)
+            reply = server.eval(session, code, args.timeout)
+            if reply['status'] == 'hung':
+                report(fence.line, 'HUNG', reply['diagnostics'])
+                session, _ = prepare(server, path, jars, args, replay)
+                continue
+            replay.append(code)
+            verdict = classify(reply, tolerated)
+            report(fence.line, verdict, summarise(reply) if verdict != 'OK' else '')
+            if args.values and reply['status'] == 'ran' and (reply['value'] or reply['output']):
+                shown = reply['output'].rstrip()
+                if reply['value']:
+                    shown = (shown + '\n' if shown else '') + f"{reply['name']} = {reply['value']}: {reply['tpe']}"
+                for line in shown.split('\n'):
+                    print(f'{path}:{fence.line}:     {line}')
+        for line, code in fence.negatives:
+            reply = server.eval(session, code, args.timeout)
+            if reply['status'] == 'error':
+                report(line, 'OK')
+            else:
+                report(line, 'NEGATIVE-FAILED', f'documented as not compiling, but it ran: {code.strip()}')
+    return counts
+
+def main():
+    sys.stdout.reconfigure(line_buffering=True)
+    parser = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    parser.add_argument('docs', nargs='*', help='tutorial names (json) or paths; default: all of doc/modules')
+    parser.add_argument('--port', type=int, default=8765)
+    parser.add_argument('--release', help='the Soundness release flame is built against (default: the most-populated version in ~/.ivy2/local)')
+    parser.add_argument('--values', action='store_true', help='print each fence\'s printed output, value and type')
+    parser.add_argument('--verbose', '-v', action='store_true', help='report OK fences too')
+    parser.add_argument('--no-classload', action='store_true', help='use only the components flame bundles')
+    parser.add_argument('--set', action='append', default=[], metavar='SETTING', help='extra `/set` (e.g. captureChecking)')
+    parser.add_argument('--keep', action='store_true', help='leave the flame server running afterwards')
+    parser.add_argument('--batch', type=int, default=4, help='tutorials per flame daemon before it is restarted')
+    parser.add_argument('--timeout', type=int, default=120, help='seconds to wait for one fence before reporting it HUNG')
+    args = parser.parse_args()
+
+    docs = [d if d.endswith('.md') else os.path.join('doc', 'modules', d + '.md') for d in args.docs] \
+        or sorted(glob.glob('doc/modules/*.md'))
+    for doc in docs:
+        if not os.path.exists(doc):
+            raise SystemExit(f'no such tutorial: {doc}')
+
+    version = args.release or release_version()
+    jars = [] if args.no_classload or not version else component_jars(version)
+    if version:
+        print(f'checking against Soundness {version} (flame\'s release); {len(jars)} component jars', file=sys.stderr)
+    tolerated = migration_names()
+
+    server = Server(args.port, args.verbose)
+    server.start()
+    totals = {}
+    try:
+        for index, doc in enumerate(docs):
+            if index and index % args.batch == 0:
+                server.stop()
+                server.start()
+            counts = check(server, doc, jars, tolerated, args)
+            for verdict, count in counts.items():
+                totals[verdict] = totals.get(verdict, 0) + count
+            summary = ', '.join(f'{count} {verdict}' for verdict, count in sorted(counts.items()))
+            print(f'{doc}: {summary}', file=sys.stderr)
+    finally:
+        if not args.keep:
+            server.stop()
+    print('total: ' + ', '.join(f'{count} {verdict}' for verdict, count in sorted(totals.items())), file=sys.stderr)
+    bad = sum(count for verdict, count in totals.items() if verdict not in ('OK', 'TOLERATED'))
+    sys.exit(1 if bad else 0)
+
+if __name__ == '__main__':
+    main()

--- a/lib/wisteria/src/test/wisteria_doccheck.scala
+++ b/lib/wisteria/src/test/wisteria_doccheck.scala
@@ -1,0 +1,170 @@
+package wisteria
+
+import soundness.*
+import dysasymptotics.linearAccess
+import strategies.throwUnsafely
+
+// A compile-time mirror of doc/modules/derivation.md's samples (the ultimatum_doccheck.scala
+// precedent): a documented derivation that does not compile is worse than no example at all.
+object DerivationTutorial:
+  sealed trait Temporal
+
+  enum Month:
+    case Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec
+
+  case class Date(day: Int, month: Month, year: Int) extends Temporal
+  case class Time(hour: Int, minute: Int)
+  case class DateTime(date: Date, time: Time) extends Temporal
+
+  trait Presenting[value]:                 // consumer
+    def present(value: value): Text
+
+  trait Producing[+value]:                 // producer
+    def produce(): value
+
+  trait Presentation[value]:
+    def present(value: value): Text
+
+  object Presentation extends Derivation[Presentation]:
+    given Presentation[Text] = identity(_)
+    given Presentation[Int] = _.toString.tt
+
+    inline def conjunction[derivation <: Product: ProductReflection]: Presentation[derivation] =
+      value =>
+        fields(value):
+          [field] => field => t"$label=${contextual.present(field)}"
+        . join(t"${typeName[derivation]}(", t", ", t")")
+
+    inline def disjunction[derivation: SumReflection]: Presentation[derivation] =
+      value =>
+        variant(value):
+          [variant <: derivation] => variant => contextual.present(variant)
+
+  extension [value](value: value)
+    def present(using presentation: Presentation[value]): Text = presentation.present(value)
+
+  case class Person(name: Text, age: Int) derives Presentation
+
+  Person(t"Ada", 36).present   // t"Person(name=Ada, age=36)"
+
+  trait Labels[value]:
+    def labels: List[Text]
+
+  object Labels extends ProductDerivation[Labels]:
+    given Labels[Text] = new Labels[Text] { def labels: List[Text] = Nil }
+    given Labels[Int] = new Labels[Int] { def labels: List[Text] = Nil }
+
+    inline def conjunction[derivation <: Product: ProductReflection]: Labels[derivation] =
+      val fieldLabels = contexts[derivation]() { [field] => context => label }
+      new Labels[derivation]:
+        def labels: List[Text] = fieldLabels.to[List]
+
+  case class Empty()
+
+  Labels.derived[Person].labels    // List(t"name", t"age")
+  Labels.derived[Empty].labels     // List()
+
+  trait Parsing[value]:
+    def parse(text: Text): value
+
+  object Parsing extends ProductDerivation[Parsing]:
+    given Parsing[Text] = identity(_)
+    given Parsing[Int] = _.s.toInt
+
+    inline def conjunction[derivation <: Product: ProductReflection]: Parsing[derivation] =
+      text =>
+        val columns = text.cut(t",")
+        build[derivation]:
+          [field] => parsing => parsing.parse(columns(Ordinal.zerary(index)).or(t""))
+
+  Parsing.derived[Person].parse(t"Ada,36")   // Person(t"Ada", 36)
+
+  object ParsingSums extends Derivation[Parsing]:
+    inline def conjunction[derivation <: Product: ProductReflection]: Parsing[derivation] =
+      Parsing.conjunction[derivation]
+
+    inline def disjunction[derivation: SumReflection]: Parsing[derivation] =
+      text =>
+        text.cut(t":") match
+          case List(prefix, rest) =>
+            delegate[derivation](prefix):
+              [variant <: derivation] => parsing => parsing.parse(rest)
+
+  trait Equivalence[value]:
+    def equal(left: value, right: value): Boolean
+
+  object Equivalence extends Derivation[Equivalence]:
+    given Equivalence[Int] = _ == _
+    given Equivalence[Text] = _.lower == _.lower
+
+    inline def conjunction[derivation <: Product: ProductReflection]: Equivalence[derivation] =
+      (left, right) =>
+        contexts[derivation]():
+          [field] => equivalence =>
+            val extract: derivation => field = dereference
+            equivalence.equal(extract(left), extract(right))
+        . all { boolean => boolean }
+
+    inline def disjunction[derivation: SumReflection]: Equivalence[derivation] =
+      (left, right) =>
+        variant(left):
+          [variant <: derivation] => leftValue =>
+            complement(right).lay(false)(contextual.equal(leftValue, _))
+
+  Equivalence.derived[Person].equal(Person(t"Ada", 36), Person(t"ADA", 36))   // true
+
+  trait Naming[value]:
+    def name(value: value): Text
+
+  object Naming extends Derivation[Naming]:
+    inline def conjunction[derivation <: Product: ProductReflection]: Naming[derivation] =
+      value => typeName[derivation]
+
+    inline def disjunction[derivation: SumReflection]: Naming[derivation] = value =>
+      inline if choice[derivation] then
+        variant(value):
+          [variant <: derivation] => arm => t"${typeName[derivation]}.${contextual.name(arm)}"
+      else scala.compiletime.error("cannot derive Naming for a sum whose variants carry data")
+
+  Naming.derived[Month].name(Month.Mar)   // t"Month.Mar"
+
+  object LenientParsing extends ProductDerivation[Parsing]:
+    inline def conjunction[derivation <: Product: ProductReflection]: Parsing[derivation] =
+      text =>
+        val columns = text.cut(t",")
+        build[derivation]:
+          [field] => parsing =>
+            columns(Ordinal.zerary(index)).let(parsing.parse(_))
+            . or(default.or(panic(m"no column and no default for $label")))
+
+  case class Settings(name: Text, retries: Int = 3)
+
+  LenientParsing.derived[Settings].parse(t"primary")   // Settings(t"primary", 3)
+
+  import arithmetic.addable
+
+  case class Pair(label: Text, count: Int)
+
+  Pair(t"foo", 10) + Pair(t"bar", 15)   // Pair(t"foobar", 25)
+
+  enum Tree derives Presentation:
+    case Leaf
+    case Branch(left: Tree, value: Int, right: Tree)
+
+  Tree.Branch(Tree.Leaf, 1, Tree.Leaf).present   // t"Branch(left=Leaf, value=1, right=Leaf)"
+
+  trait Rendering[value]:
+    def render(value: value): Text
+
+  object Rendering:
+    inline given derived[Value]: Rendering[Value] = item =>
+      scala.compiletime.summonFrom:
+        case presentation: Presentation[Value] => presentation.present(item)
+        case given (Value is Showable)         => item.show
+        case _                                 => item.toString.tt
+
+  extension [value](value: value)
+    def render(using rendering: Rendering[value]): Text = rendering.render(value)
+
+  Person(t"Ada", 36).render   // through Presentation, which Person derives
+  3.14.render                 // through Showable, which Double has


### PR DESCRIPTION
Every tutorial in `doc/modules` has been reviewed against `main`: examples corrected to the current API and checked mechanically through the flame REPL, prose brought in line with the style standard, coverage added for capabilities that had none, every tutorial linked to the philosophy page its design embodies, and two new tutorials written for the native collections and the language-model client. The checker itself — `make doccheck`, a static name check and a documentation-coverage check now run by `make build` — is added alongside.

## Release notes

The tutorials at `doc/modules/*.md` are current again. Every ` ```scala ` fence is evaluated in order through the flame REPL by `make doccheck` (or `make doccheck DOC=json` for one tutorial), the names the fences use are checked against the source by `etc/doccheck-names.py`, and `etc/check-doc-coverage.py` — run by `make build` — fails if a library has no tutorial mentioning it. A line meant not to compile carries a trailing `// does not compile` comment; a fence that needs a browser, socket or terminal is preceded by `<!-- doccheck: skip -->`; a tutorial's fixed bindings live in `doc/fixtures/<tutorial>.scala`. The conventions are in `doc/standards/style.md`.

Two tutorials are new. `collections.md` covers `List`, `Sequence`, `Set`, `Map` and the lazy `Chain`, the shared vocabulary over them (and over text), ordinal access and the complexity acknowledgments that gate a linked list's `size` and indexing, sorting with an explicitly chosen algorithm, and the `stdlib` bridge:

```scala
import sortingAlgorithms.timsort

List(3, 1, 2).order(-_)            // List(3, 2, 1)
Chain.iterate(0)(_ + 1).keep(5)    // Chain(0, 1, 2, 3, 4)
```

`llm.md` covers sibylline: providers as values, sessions confined to their block, streaming, tools declared with `@ability`, structured answers with `elicit`, and the typed `Llm.Error` reasons:

```scala
val claude = Anthropic(t"claude-sonnet-4-5", key).prompted(t"Be terse.").limit(1024)

claude.session:
  given Toolkit = Toolkit(Broker)
  llm.ask(t"Compare AAPL and MSFT.")
  llm.elicit[Verdict](t"Summarize your recommendation.")
```

Among the existing tutorials, the largest revisions are to cli (settings, exit statuses, `require`/`validate`, help and manpages), cryptography (ECDSA and ML-DSA signing, certificates, keystores), debugging (the `debug` accessor, `Halt` and `Dap.listen`), derivation (rewritten around complete typeclass objects, mirrored by a compile-checked test in wisteria), filesystem (locking, extended attributes, search paths, globs and watching), hashing (checksums and Multihash), logging, patterns (the RE2 engine), pdf (creating a document before reading it), text (collation-based sorting) and xml (XPath querying). Ten libraries missing from `doc/tags.md` and `doc/compatibility.tsv` are added. Library gaps found while checking are filed as issues #1945 to #1955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
