### PR TITLE
Resolve exported names when rendering types outside a macro

### DIFF
--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -205,3 +205,18 @@ not yet been recorded here.
   select the instance itself. Effect: an implicit search made while type parameters are still
   undetermined (e.g. `join`'s `element`/`textual`) is no longer resolved with those parameters
   instantiated to `Any`. Inferred types of code that already compiled are unchanged. (#1944)
+
+## stenography
+
+- `stenography.Imports` gains `Imports.exports(scope: Designator)(using
+  dotty.tools.dotc.core.Contexts.Context): Set[Designator]`, the targets (type and companion) of
+  the `export` aliases declared in `scope`, and `Imports.resolve(designators: Set[Designator],
+  direct: Set[Designator])(using Context): Imports`, which is `Imports(designators, direct)` with
+  `direct` extended by `exports` of each of `designators`. `delicious.Reifier` gains
+  `imports(designators: Set[Designator], direct: Set[Designator]): Imports`, `Imports.resolve`
+  under the reifier's own context. Code which builds an `Imports` by hand from a set of wildcard
+  imports for `Syntax#text` or `Designator#text` (a REPL abbreviating types against its session's
+  imports) should build it through `Reifier#imports` or `Imports.resolve` instead: only then does
+  a type reached through an `export` in a wildcard-imported scope (`jacinta.Json` under `import
+  soundness.*`) render by its leaf name (`Json`) rather than qualified (`jacinta.Json`). The
+  macro path (`Syntax.name`, `Syntax.designator`) already did this and is unchanged. (#1959)

--- a/lib/delicious/src/scala/delicious.Reifier.scala
+++ b/lib/delicious/src/scala/delicious.Reifier.scala
@@ -46,6 +46,8 @@ import dotty.tools.io.VirtualFile
 
 import java.util as ju
 
+import scala.collection.immutable as sci
+
 import anticipation.*
 import gossamer.*
 import hellenism.*
@@ -136,6 +138,14 @@ class Reifier(classpath: LocalClasspath):
     // expects the quote-cache context property that macro-expansion contexts
     // carry; a standalone context must install it explicitly.
     QuotesCache.init(run.runContext.fresh)
+
+  /** An `Imports` for rendering against this reifier's classpath: `direct` is extended by the
+   *  targets of every `export` alias declared in each of `designators`, so a type reached
+   *  through a wildcard-imported prelude (`jacinta.Json` under `import soundness.*`) renders
+   *  by its leaf name, as the user would write it. */
+  def imports(designators: sci.Set[Designator], direct: sci.Set[Designator]): Imports =
+    given Contexts.Context = runContext
+    Imports.resolve(designators, direct)
 
   /** The stenography rendering of a type marker's TASTy payload, or `Unset`
    *  if there is no payload or it cannot be unpickled: a diagnostic must never

--- a/lib/delicious/src/test/delicious_test.scala
+++ b/lib/delicious/src/test/delicious_test.scala
@@ -34,6 +34,7 @@ package delicious
 
 import java.nio.file.{Files, Paths}
 
+import scala.collection.immutable as sci
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 import soundness.*
@@ -319,6 +320,47 @@ object Tests extends Suite(m"Delicious Tests"):
               // came through stenography; `Bad.Local` proves placeholder substitution.
               rendered.subsumes(t"java.lang.String") && rendered.subsumes(t"Bad.Local")
             }
+
+    // The running JVM's own classpath carries stenography's classes together with its
+    // `soundness` export file, so under `import soundness.*` the alias `soundness.Syntax`
+    // re-exports `stenography.Syntax` — the same shape as `jacinta.Json` in a REPL session.
+    val ownClasspath: LocalClasspath =
+      val entries: List[Classpath.Entry.Directory | Classpath.Entry.Jar] =
+        java.lang.System.getProperty("java.class.path").nn.tt
+        . cut(java.io.File.pathSeparator.nn.tt)
+        . filter(_ != t"")
+        . map: entry =>
+            if entry.ends(t".jar") then Classpath.Entry.Jar(entry) else Classpath.Entry.Directory(entry)
+
+      LocalClasspath(entries*)
+
+    val ownReifier = Reifier(ownClasspath)
+    val soundnessScope: sci.Set[Designator] = sci.Set(Designator(t"soundness"))
+    val syntaxType: Designator = Designator(t"stenography#Syntax")
+
+    test(m"A wildcard-imported prelude's export makes its target direct"):
+      ownReifier.imports(soundnessScope, sci.Set()).hasDirect(syntaxType)
+    . assert(_ == true)
+
+    test(m"A prelude's export makes the target's companion direct too"):
+      ownReifier.imports(soundnessScope, sci.Set()).hasDirect(Designator(t"stenography.Syntax"))
+    . assert(_ == true)
+
+    test(m"An exported type renders by its leaf name under the exporting import"):
+      Syntax.Simple(syntaxType).text(using ownReifier.imports(soundnessScope, sci.Set()))
+    . assert(_ == t"Syntax")
+
+    test(m"Without export resolution the same type stays qualified"):
+      Syntax.Simple(syntaxType).text(using Imports(soundnessScope, sci.Set()))
+    . assert(_ == t"stenography.Syntax")
+
+    test(m"A scope which declares no exports adds nothing"):
+      ownReifier.imports(sci.Set(Designator(t"stenography")), sci.Set()).direct
+    . assert(_ == sci.Set())
+
+    test(m"An unresolvable scope adds nothing and does not throw"):
+      ownReifier.imports(sci.Set(Designator(t"no.such.scope")), sci.Set()).direct
+    . assert(_ == sci.Set())
 
   def proscalaLibrary(): Optional[java.nio.file.Path] =
     val home = java.lang.System.getProperty("user.home").nn

--- a/lib/stenography/src/core/stenography.Syntax.scala
+++ b/lib/stenography/src/core/stenography.Syntax.scala
@@ -465,7 +465,6 @@ object Syntax:
         case termRef@TermRef(prefix, name) =>
           apply(prefix) match
             case value@Value(designator) =>
-              if repr.toString.contains("inline") then System.out.nn.println(name)
               if isPackage(name) then value else Value(Designator.Term(designator, name))
 
             case simple@Simple(designator) =>

--- a/lib/stenography/src/core/stenography.internal.scala
+++ b/lib/stenography/src/core/stenography.internal.scala
@@ -86,7 +86,8 @@ object internal:
     // Drill into every scope whose members are reachable unqualified from here — each wildcard
     // import that's in scope (including the REPL-accumulated ones across earlier lines,
     // captured by `metaprogramming.imports`) and this unit's own package — and harvest two
-    // things from a single pass over its declarations.
+    // things from a single pass over its declarations. (`Imports.exports` is the same harvest
+    // of the first, for a scope named from outside any macro.)
     //
     // The `direct` set holds type aliases carrying the `Exported` flag. Those aliases' *target*
     // types are reachable via just their leaf in the current scope, so we render them that way.
@@ -128,7 +129,7 @@ object internal:
   // Everything worth knowing about one scope whose members are reachable unqualified: the
   // targets of its `Exported` aliases, and the infix type aliases it declares which refine a
   // single type member.
-  private def scopeInfo(using Quotes, dotty.tools.dotc.core.Contexts.Context)
+  private[stenography] def scopeInfo(using Quotes, dotty.tools.dotc.core.Contexts.Context)
     ( rootSym: dotty.tools.dotc.core.Symbols.Symbol )
   :   (List[Designator], List[(String, Text)]) =
 

--- a/lib/stenography/src/test/stenography_probe_test.scala
+++ b/lib/stenography/src/test/stenography_probe_test.scala
@@ -30,52 +30,13 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package stenography
+package stenographyProbe
 
-import scala.collection.immutable as sci
-import scala.util.control.NonFatal
+import soundness.*
 
-import anticipation.*
-import vacuous.*
-
-object Imports:
-  val empty: Imports = Imports(sci.Set(), sci.Set())
-
-  // The designators reachable by their leaf name through the `export` aliases declared in
-  // `scope`, a package or object such as `soundness`: each alias's target type, and its
-  // companion. This is the non-macro counterpart of the harvest `internal.name` performs for
-  // every wildcard import at a macro expansion site, for callers which render types outside
-  // any macro (a REPL abbreviating a diagnostic against the session's imports) and so must
-  // build their `Imports` by hand. Rendering a target goes through `Syntax`, which needs the
-  // quote cache installed on the context — a macro's context has it; a standalone one must
-  // install it, as `delicious.Reifier` does. A scope which does not resolve, or whose
-  // declarations cannot be read, contributes nothing: a rendering must never throw.
-  def exports(scope: Designator)(using context: dotty.tools.dotc.core.Contexts.Context)
-  :   sci.Set[Designator] =
-
-    import dotty.tools.dotc.core.Denotations
-    import dotty.tools.dotc.core.Names.termName
-
-    def path(designator: Designator): String = designator.parent.lay(designator.name.s): parent =>
-      s"${path(parent)}.${designator.name}"
-
-    try
-      val denotation = Denotations.staticRef(termName(path(scope)), generateStubs = false)
-      if !denotation.exists then sci.Set() else
-        given quotes: scala.quoted.Quotes = scala.quoted.runtime.impl.QuotesImpl()
-        given Bindings = Bindings()
-        stenography.internal.scopeInfo(denotation.symbol)(0).toSet
-    catch case NonFatal(_) => sci.Set()
-
-  // `Imports(designators, direct)`, with `direct` extended by the `exports` of every one of
-  // `designators`, so that a type reached through a wildcard-imported prelude renders as the
-  // user would write it.
-  def resolve(designators: sci.Set[Designator], direct: sci.Set[Designator])
-       (using dotty.tools.dotc.core.Contexts.Context)
-  :   Imports =
-
-    Imports(designators, direct ++ designators.flatMap(exports))
-
-case class Imports(designators: sci.Set[Designator], direct: sci.Set[Designator]):
-  def has(designator: Designator): Boolean = designators.contains(designator)
-  def hasDirect(designator: Designator): Boolean = direct.contains(designator)
+// A package other than `stenography`, so the own-package rule cannot shorten the name: only the
+// `export stenography.Syntax` alias reached through `import soundness.*` can, which is the same
+// shape as `jacinta.Json` under the same import.
+object Probe:
+  def exportedName: Text = Syntax.name[stenography.Syntax]
+  def companionName: Text = Syntax.name[stenography.Syntax.type]

--- a/lib/stenography/src/test/stenography_test.scala
+++ b/lib/stenography/src/test/stenography_test.scala
@@ -165,6 +165,14 @@ object Tests extends Suite(m"Stenography Tests"):
       Syntax.name[turbulence.Streamable]
     . assert(_ == t"turbulence.Streamable")
 
+    test(m"An exported type renders by its leaf name under the exporting import"):
+      stenographyProbe.Probe.exportedName
+    . assert(_ == t"Syntax")
+
+    test(m"An exported type's companion renders by its leaf name too"):
+      stenographyProbe.Probe.companionName
+    . assert(_ == t"Syntax.type")
+
     test(m"Show typeclass type"):
       Syntax.name[Addable by Int to Double]
     . assert(_ == t"Addable by Int to Double")


### PR DESCRIPTION
Stenography can now abbreviate a type reached through an `export` in a wildcard-imported scope when the rendering happens outside a macro: `Imports.exports` and `Imports.resolve` look up what a named scope exports under any compiler context, and `delicious.Reifier#imports` does so under the reifier's own, so a REPL rendering `jacinta.Json` against a session that has `import soundness.*` shows `Json`, as the user would write it.

## Release notes

Stenography's macro path (`Syntax.name`, `Syntax.designator`) has long rendered a type by its leaf name when an `export` alias in a wildcard-imported scope makes it reachable that way. Code that builds a `stenography.Imports` by hand, such as a REPL abbreviating diagnostics against its session's imports, could not do the same, because a set of import statements does not say what each scope exports. So `jacinta.Json` stayed qualified under `import soundness.*`.

Two new members of the `Imports` companion close that gap:

```scala
// The targets (type and companion) of the `export` aliases declared in `scope`
def exports(scope: Designator)(using Contexts.Context): Set[Designator]

// `Imports(designators, direct)`, with `direct` extended by the exports of each designator
def resolve(designators: Set[Designator], direct: Set[Designator])(using Contexts.Context): Imports
```

A scope that does not resolve, or whose declarations cannot be read, contributes nothing rather than throwing. `delicious.Reifier` gains `imports(designators, direct)`, which runs `Imports.resolve` under the context it already builds over its classpath:

```scala
val reifier = Reifier(classpath)
given Imports = reifier.imports(Set(Designator(t"soundness")), Set())

syntax.text   // `Json`, not `jacinta.Json`
```

Consumers that currently construct `Imports(designators, direct)` directly for rendering should switch to `Reifier#imports` or `Imports.resolve` to get exported names abbreviated. The macro path is unchanged. A stray debug print in `Syntax`'s `TermRef` branch has also been removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
