### PR TITLE
Prove Atomic's zero cost, rename copyFrom to place, and let a Scribe grow

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2881,7 +2881,7 @@ object rudiments extends Library:
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
 
-  object test extends Tests(core, abacist.core, quantitative.units):
+  object test extends Tests(core, abacist.core, quantitative.units, mandible.core):
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions())
 

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -157,7 +157,7 @@ not yet been recorded here.
   `AtomicReferenceArray[vacuous.Optional[value]]`. `LongAdder`, `DoubleAdder`, `LongAccumulator`,
   `DoubleAccumulator`, `AtomicMarkableReference`, `AtomicStampedReference` and the three
   `*FieldUpdater` classes are not wrapped. `Atomic.Int` and `Atomic.Long` shadow `scala.Int` and
-  `scala.Long` under `import Atomic.*`, which is not an intended usage. (#NNNN)
+  `scala.Long` under `import Atomic.*`, which is not an intended usage. (#1957)
 - A match type `Atomic[value]` reduces to `Atomic.Int` for `Int`, `Atomic.Long` for `Long`,
   `Atomic.Bool` for `Boolean`, and `Atomic.Ref[value]` otherwise. It does not reduce for an
   abstract type parameter, nor for an opaque type whose representation is not visible at the use
@@ -167,7 +167,7 @@ not yet been recorded here.
   `Atomic(false)` and `Atomic(reference)` construct the corresponding cell; an explicit type
   argument (`Atomic[Int](0)`) applies the generic arm and does not conform. Every operation is
   `inline` and compiles to the same bytecode as the `java.util.concurrent.atomic` call it
-  replaces. (#NNNN)
+  replaces. (#1957)
 - Reads are `atomic()` (`get`), stores are `atomic() = value` (`set`) and `atomic.publish(value)`
   (`lazySet`); `atomic.swap(value)` is `getAndSet` and `atomic.replace(expected, updated)` is
   `compareAndSet`. `Atomic.Ref#apply()` returns `value` rather than `value | Null`, so no call
@@ -175,7 +175,7 @@ not yet been recorded here.
   `.nn` on the underlying `AtomicReference` would have thrown. The three array types are indexed
   by `denominative.Ordinal`; `Atomic.Refs#apply` returns `vacuous.Optional[value]` because a fresh
   reference array is null-filled, while `Atomic.Ints#apply` and `Atomic.Longs#apply` return the
-  primitive, because a fresh primitive array holds zeros. (#NNNN)
+  primitive, because a fresh primitive array holds zeros. (#1957)
 - Transitions are `atomic.ere(transition)`, yielding the value the transition displaced, and
   `atomic.since(transition)`, yielding the value it installed — replacing `getAndUpdate` and
   `updateAndGet` respectively. They are defined on `Atomic.Int`, `Atomic.Long`, `Atomic.Bool` and
@@ -187,15 +187,17 @@ not yet been recorded here.
   the transition beta-reduced into it. No `java.util.function.UnaryOperator` and no closure is
   allocated in either case. A transition may be re-run under contention and so must be pure; a
   transition which applies a function value obtained from outside is rejected at compiletime.
-  (#NNNN)
+  (#1957)
 - `ere` is overloaded to take a value directly, so `bool.ere(true)` is `getAndSet(true)` without a
   lambda. There is no `since` counterpart, which would return its own argument. The value overload
   is unreachable on an `Atomic.Ref[value]` whose `value` is a function type, where `ere` resolves
-  to the transition overload and fails to compile; use `ref() = supplied`. (#NNNN)
+  to the transition overload and fails to compile; use `ref() = supplied`. (#1957)
 - `Atomic.Ref#revise(transition)` takes a function value rather than a literal, for a transition
   whose shape cannot be read, and yields the value it installed. It is `inline`, so no closure is
   allocated, but the purity obligation is unchecked: the transition may be re-run under
-  contention. (#NNNN)
+  contention. (#1957)
+- `rudiments.test` now depends on `mandible.core`, which asserts the bytecode `Atomic`'s
+  operations compile to. No effect on `rudiments` itself. (#1960)
 
 ## frontier
 

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -199,6 +199,16 @@ not yet been recorded here.
 - `rudiments.test` now depends on `mandible.core`, which asserts the bytecode `Atomic`'s
   operations compile to. No effect on `rudiments` itself. (#1960)
 
+## proscenium
+
+- `proscenium.Array#copyFrom(source, sourceStart, targetStart, count)` renamed to `place`, with
+  two further overloads: `place(source)` copies the whole source to the start, and
+  `place(source, at)` copies it to `at`. Behaviour unchanged. The name matches
+  `rudiments.place` and `concordance.Scribe#place`, which already meant copying a source into
+  the receiver; `snapshot` remains its counterpart, copying out into a fresh array. Indices stay
+  `Int` rather than `Ordinal`, as `Array`'s `apply`/`update`/`readUnchecked` do, because
+  `denominative` sits above `proscenium`. (#1960)
+
 ## frontier
 
 - `frontier.context.explainMissingContext` and `soundness.explainMissingContext` no longer

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -209,6 +209,17 @@ not yet been recorded here.
   `Int` rather than `Ordinal`, as `Array`'s `apply`/`update`/`readUnchecked` do, because
   `denominative` sits above `proscenium`. (#1960)
 
+## concordance
+
+- `rudiments.Scribe` can now grow. `Array.collect[element](hint)(lambda)` lends an unsized
+  scribe which extends as it is written and yields exactly what was written, where
+  `Array.scribe[element](size)(lambda)` continues to lend a fixed-size scribe, to return an array
+  of exactly `size`, and to clamp rather than grow. Existing `Array.scribe` behaviour is
+  unchanged. (#1960)
+- `rudiments.Scribe#append` gains two bulk overloads at the cursor: `append(source)` and
+  `append(source, from, count)`, both taking `Array[element]^{}`. `place` still requires an
+  `Ordinal in scribe.type` and so remains available only to a sized scribe. (#1960)
+
 ## frontier
 
 - `frontier.context.explainMissingContext` and `soundness.explainMissingContext` no longer

--- a/doc/philosophy/immutability.md
+++ b/doc/philosophy/immutability.md
@@ -51,8 +51,8 @@ sub-structure between two values would be a bug.
 
 ## Where mutation survives, and why
 
-Immutability is a property of values, not a prohibition on the machine. Three places in
-Soundness are deliberately mutable, and each is confined:
+Immutability is a property of values, not a prohibition on the machine. Four places in
+Soundness are deliberately mutable. Three of them are confined:
 
 A **builder** mutates a buffer it exclusively owns and yields an immutable value at the
 end. Nothing observes the intermediate states, so nothing depends on them.
@@ -72,6 +72,27 @@ must outlive it.
 
 The pattern is the same in all three: mutation is a local implementation technique with
 a proof of confinement, never a property of a value that others can see.
+
+An **atomic cell** is the exception, and it is worth naming as one rather than hiding.
+An `Atomic[Int]` or `Atomic.Ref[State]` is deliberately *not* confined: its whole purpose
+is that two threads see one location, so no aliasing analysis can help and none is
+attempted. What replaces confinement is a different guarantee. The location is a single
+machine word, and every operation on it is indivisible, so there is no intermediate state
+for another thread to observe. The type does not promise that the mutation is invisible;
+it promises that it cannot be caught half-done.
+
+That is why the operations are named for which value they hand back. `count.ere(_ + 1)`
+yields the value it displaced and `count.since(_ + 1)` the value it installed, so a caller
+can tell whether it, and not somebody else, made the transition — the question that only
+arises once mutation is shared, and the one a `var` cannot answer:
+
+```scala
+if !closed.ere(true) then shutdown()    // true only for the call that closed it
+```
+
+Shared cells are a low-level tool, and the collection uses them where concurrency is the
+subject: supervising tasks, accumulating errors across a scope, and the hand-off rings
+beneath the streaming kernel. They are not how a value is modelled.
 
 ## What it costs
 

--- a/lib/anthology/src/apk/anthology.Apk.scala
+++ b/lib/anthology/src/apk/anthology.Apk.scala
@@ -201,7 +201,7 @@ object Apk extends Format.Application:
       var offset = 0
 
       parts.foreach: part =>
-        buffer.copyFrom(part, 0, offset, part.length)
+        buffer.place(part, 0, offset, part.length)
         offset += part.length
 
       Array.freeze(buffer)
@@ -232,7 +232,7 @@ object Apk extends Format.Application:
         val end = math.min(offset + chunkSize, until)
         val length = end - offset
         val chunk = Array.allocate[Byte](length)
-        chunk.copyFrom(data, offset, 0, length)
+        chunk.place(data, offset, 0, length)
         val prefixed = concat(Array(0xa5.toByte), u32(length.toLong), Array.freeze(chunk))
         builder += sha256(prefixed)
         offset = end
@@ -309,7 +309,7 @@ object Apk extends Format.Application:
       // The EOCD is copied out so its central-directory offset can be patched, so the buffer is
       // built exclusively here rather than laundered out of a frozen `slice`.
       val eocd = Array.allocate[Byte](unsigned.length - eocdOffset)
-      eocd.copyFrom(unsigned, eocdOffset, 0, eocd.length)
+      eocd.place(unsigned, eocdOffset, 0, eocd.length)
       for i <- 0 until 4 do eocd(16 + i) = patch.readable(i)
 
       concat(section1, signingBlock, centralDirectory, Array.freeze(eocd))
@@ -317,5 +317,5 @@ object Apk extends Format.Application:
     private def slice(data: Data, from: Int, until: Int): Data =
       val length = until - from
       val buffer = Array.allocate[Byte](length)
-      buffer.copyFrom(data, from, 0, length)
+      buffer.place(data, from, 0, length)
       Array.freeze(buffer)

--- a/lib/bitumen/src/core/bitumen.Tar.scala
+++ b/lib/bitumen/src/core/bitumen.Tar.scala
@@ -148,7 +148,7 @@ object Tar:
 
           while position < 512 && replenish() do
             val count = (chunk.length - offset).min(512 - position)
-            block.copyFrom(chunk, offset, position, count)
+            block.place(chunk, offset, position, count)
             offset += count
             position += count
 
@@ -496,7 +496,7 @@ object Tar:
         var offset = 0
 
         memo.each: chunk =>
-          whole.copyFrom(chunk, 0, offset, chunk.length)
+          whole.place(chunk, 0, offset, chunk.length)
           offset += chunk.length
 
         Array.freeze(whole)

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -1073,53 +1073,52 @@ object Cbor extends Cbor2, Dynamic:
 
     // Reads an indefinite-length byte string by concatenating its definite-
     // length chunks (each prefixed with major type 2) until a Break stop code.
-    // Uses `ByteArrayOutputStream` so chunk bytes flow through bulk `write`
-    // (≈ `System.arraycopy`) without per-byte boxing into `java.lang.Byte`.
+    // Chunk bytes flow through `Scribe`'s bulk `append` (one `System.arraycopy` per chunk)
+    // rather than a byte at a time, which is why the JDK buffer was reached for here.
     private def readIndefiniteByteString(): Array[Byte]^{} raises Cbor.Error =
-      val buffer = new java.io.ByteArrayOutputStream
-      var done = false
+      Array.collect[Byte](): buffer =>
+        var done = false
 
-      while !done do
-        expect(1)
-        val head = data(offset) & 0xFF
+        while !done do
+          expect(1)
+          val head = data(offset) & 0xFF
 
-        if head == Break then
-          offset += 1
-          done = true
-        else
-          val major = head >>> 5
-          val info = head & 0x1F
-          if major != 2 then abort(Cbor.Error(Reason.Reserved(offset.toLong, head)))
-          val chunkOffset = offset.toLong
-          offset += 1
-          val length = boundedLength(readLength(info, chunkOffset), chunkOffset)
-          buffer.write(data, offset, length)
-          offset += length
-
-      buffer.toByteArray.nn.asInstanceOf[Array[Byte]^{}]
+          if head == Break then
+            offset += 1
+            done = true
+          else
+            val major = head >>> 5
+            val info = head & 0x1F
+            if major != 2 then abort(Cbor.Error(Reason.Reserved(offset.toLong, head)))
+            val chunkOffset = offset.toLong
+            offset += 1
+            val length = boundedLength(readLength(info, chunkOffset), chunkOffset)
+            buffer.append(Array.unsafeFrozen(data), offset, length)
+            offset += length
 
     private def readIndefiniteTextString(): String raises Cbor.Error =
-      val buffer = new java.io.ByteArrayOutputStream
-      var done = false
+      val collected = Array.collect[Byte](): buffer =>
+        var done = false
 
-      while !done do
-        expect(1)
-        val head = data(offset) & 0xFF
+        while !done do
+          expect(1)
+          val head = data(offset) & 0xFF
 
-        if head == Break then
-          offset += 1
-          done = true
-        else
-          val major = head >>> 5
-          val info = head & 0x1F
-          if major != 3 then abort(Cbor.Error(Reason.Reserved(offset.toLong, head)))
-          val chunkOffset = offset.toLong
-          offset += 1
-          val length = boundedLength(readLength(info, chunkOffset), chunkOffset)
-          buffer.write(data, offset, length)
-          offset += length
+          if head == Break then
+            offset += 1
+            done = true
+          else
+            val major = head >>> 5
+            val info = head & 0x1F
+            if major != 3 then abort(Cbor.Error(Reason.Reserved(offset.toLong, head)))
+            val chunkOffset = offset.toLong
+            offset += 1
+            val length = boundedLength(readLength(info, chunkOffset), chunkOffset)
+            buffer.append(Array.unsafeFrozen(data), offset, length)
+            offset += length
 
-      val bytes = buffer.toByteArray.nn
+      val bytes = Array.unsafeJvm(collected)
+
       decodeUtf8(bytes, 0, bytes.length, 0L)
 
     private inline def decodeUtf8

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -338,7 +338,7 @@ object Cbor extends Cbor2, Dynamic:
 
       if (count&1) == 1 then elements else
         val padded = Array.allocate[Any](count + 1)
-        padded.copyFrom(elements, 0, 0, count)
+        padded.place(elements, 0, 0, count)
         padded(count) = Sentinel
         Array.freeze(padded)
 
@@ -1892,14 +1892,14 @@ class Cbor(private[breviloquence] val root: Cbor.Ast) extends Dynamic derives Ca
     root.index(field) match
       case -1 =>
         val out = Array.allocate[Any](length + 2)
-        out.copyFrom(array, 0, 0, length)
+        out.place(array, 0, 0, length)
         out(length) = field
         out(length + 1) = value.root
         Cbor.ast(Cbor.Ast(Array.freeze(out)))
 
       case index =>
         val out = Array.allocate[Any](length)
-        out.copyFrom(array, 0, 0, length)
+        out.place(array, 0, 0, length)
         out(index*2 + 1) = value.root
         Cbor.ast(Cbor.Ast(Array.freeze(out)))
 

--- a/lib/concordance/src/core/rudiments.Scribe.scala
+++ b/lib/concordance/src/core/rudiments.Scribe.scala
@@ -62,11 +62,20 @@ object Scribe:
   // carrier and its members. Minting a scribe grants only bounds-confined access to the
   // array, so the public mint is not a safety hole; the freeze soundness argument belongs
   // to `Array.scribe`, which confines the scribe it mints to one lambda.
-  final class Core private[rudiments] (val buffer: AnyRef):
+  final class Core private[rudiments] (buffer0: AnyRef, val growable: Boolean):
     // Untracked: the cursor is reached only through the scribe, which the lender confines
     // to one lambda; `Stateful` would force capability typing onto a transient builder.
     @scala.caps.unsafe.untrackedCaptures
     var mark: Int = 0
+
+    // Reassignable, which is the whole of what growth needed: a branded `Ordinal` stays valid
+    // when the array only ever grows, so the brand is a lower bound on validity rather than an
+    // exact claim, and nothing about the confinement argument changes. A scribe whose size was
+    // given is NOT growable — `Array.scribe` promises an array of exactly that size, and its
+    // callers rely on it — so `append` and `place` still clamp there, and only the unsized
+    // lender extends.
+    @scala.caps.unsafe.untrackedCaptures
+    var buffer: AnyRef = buffer0
   // Written out (not a SAM lambda): the lambda form infers a capture-annotated `Self`
   // (`Scribe[element]^{any.rd}`), which then fails to match capture-free summons.
   given countable: [element] => Scribe[element] is Countable:
@@ -74,7 +83,23 @@ object Scribe:
       self.asInstanceOf[Core].buffer.asInstanceOf[scala.Array[element]].length
 
   def apply[element](buffer: scala.Array[element]^): Scribe[element] =
-    new Core(buffer.asInstanceOf[AnyRef])
+    new Core(buffer.asInstanceOf[AnyRef], false)
+
+  private[rudiments] def growing[element](buffer: scala.Array[element]): Scribe[element] =
+    new Core(buffer.asInstanceOf[AnyRef], true)
+
+  // Doubling, so appending n elements costs O(n) rather than O(n²). Only reached from a
+  // growable scribe.
+  private[rudiments] def reserve[element: ClassTag](core: Core, extra: Int): Unit =
+    val target = core.buffer.asInstanceOf[scala.Array[element]^]
+    val required = core.mark + extra
+
+    if required > target.length then
+      var capacity = (target.length*2).max(16)
+      while capacity < required do capacity *= 2
+      val bigger: scala.Array[element]^ = new scala.Array[element](capacity)
+      System.arraycopy(target, 0, bigger, 0, core.mark)
+      core.buffer = bigger.asInstanceOf[AnyRef]
 
   private[rudiments] inline def over[element, result](buffer: scala.Array[element]^)
     ( inline lambda: (scribe: Scribe[element]) => (Interval in scribe.type) => result )
@@ -98,22 +123,59 @@ object Scribe:
     // cursor and advances it, clamping silently at the end of the buffer, so no position a
     // caller can reach is out of range. The dominant safe form for compaction and filtering
     // loops, whose write index advances irregularly while the read index scans.
-    inline def append(value: element): Unit =
+    inline def append(value: element)(using ClassTag[element]): Unit =
       val core = scribe.asInstanceOf[Core]
+      if core.growable then Scribe.reserve[element](core, 1)
       val target = core.buffer.asInstanceOf[scala.Array[element]^]
+
       if core.mark < target.length then
         target(core.mark) = value
         core.mark += 1
+
+    // Bulk append at the cursor. `place` cannot serve here: it takes an `Ordinal in
+    // scribe.type`, and an unsized scribe hands out no branded extent to draw one from. This is
+    // the operation `ByteArrayOutputStream.write(bytes)` was reached for, and the reason the
+    // class was used at all — one `arraycopy` per chunk rather than a byte at a time.
+    @targetName("appendArray")
+    inline def append(source: Array[element]^{})(using ClassTag[element]): Unit =
+      val core = scribe.asInstanceOf[Core]
+      val count = source.readable.length
+      if core.growable then Scribe.reserve[element](core, count)
+      val target = core.buffer.asInstanceOf[scala.Array[element]^]
+      val room = count.min(target.length - core.mark)
+
+      if room > 0 then
+        System.arraycopy(source.asInstanceOf[scala.Array[element]], 0, target, core.mark, room)
+        core.mark += room
+
+    // A window of the source, for framing formats which append a slice of a larger block.
+    inline def append(source: Array[element]^{}, from: Int, count: Int)(using ClassTag[element])
+    :   Unit =
+
+      val core = scribe.asInstanceOf[Core]
+      if core.growable then Scribe.reserve[element](core, count)
+      val target = core.buffer.asInstanceOf[scala.Array[element]^]
+      val room = count.min(target.length - core.mark)
+
+      if room > 0 then
+        System.arraycopy(source.asInstanceOf[scala.Array[element]], from, target, core.mark, room)
+        core.mark += room
 
     // The number of elements appended so far.
     inline def mark: Int = scribe.asInstanceOf[Core].mark
 
     // Bulk copy of a whole frozen array into the scribe at `at`, clamped to the space that
     // remains: the confined form of `place`. Returns the count copied.
-    inline def place(source: Array[element]^{}, at: Ordinal in scribe.type): Int =
+    inline def place(source: Array[element]^{}, at: Ordinal in scribe.type)(using ClassTag[element])
+    :   Int =
+
       val ordinal: Ordinal = at
-      val target: scala.Array[element]^ =
-        scribe.asInstanceOf[Core].buffer.asInstanceOf[scala.Array[element]^]
+      val core = scribe.asInstanceOf[Core]
+
+      if core.growable
+      then Scribe.reserve[element](core, ordinal.n0 + source.readable.length - core.mark)
+
+      val target: scala.Array[element]^ = core.buffer.asInstanceOf[scala.Array[element]^]
       val count = source.readable.length.min(target.length - ordinal.n0)
 
       System.arraycopy
@@ -122,6 +184,37 @@ object Scribe:
       count
 
 extension (companion: Array.type)
+  // Allocate, lend, freeze — with no size given, so the scribe grows as it is written and the
+  // result is exactly what was written, not a capacity. This is what
+  // `java.io.ByteArrayOutputStream` was used for across a dozen libraries: never as a stream,
+  // always as a buffer whose total is not known in advance. Unlike that class, nothing here is
+  // synchronized (the buffer is owned by the block that builds it), nothing declares an
+  // `IOException` it cannot throw, and the terminal freeze does not copy when the buffer was
+  // filled exactly, where `toByteArray` copied on every call.
+  //
+  // The lambda receives no branded extent, because there is no fixed extent to brand: an
+  // unsized scribe is written through `append` and `place`, whose positions are its own.
+  // A plain `def`, not `inline`: inlining it reduces `Scribe[element]` to its representation in
+  // the expansion, so a caller's lambda is asked for `Scribe.Core` and does not conform. There
+  // is no dependent branded type here to justify inlining, as there is for `scribe`.
+  def collect[element: ClassTag](hint: Int = 16)(lambda: Scribe[element] => Unit)
+  :   Array[element]^{} =
+
+    val scribe = Scribe.growing[element](new scala.Array[element](hint.max(16)))
+    lambda(scribe)
+
+    val core = scribe.asInstanceOf[Scribe.Core]
+    val written = core.mark
+    val target = core.buffer.asInstanceOf[scala.Array[element]]
+
+    // No copy when the buffer was filled exactly.
+    if written == target.length then target.asInstanceOf[Array[element]^{}]
+    else
+      val exact: scala.Array[element]^ = new scala.Array[element](written)
+      System.arraycopy(target, 0, exact, 0, written)
+
+      exact.asInstanceOf[Array[element]^{}]
+
   // Allocate, lend, freeze: `lambda` receives the scribe and its branded extent, and the
   // frozen result is returned once the only writer has been retired.
   inline def scribe[element: ClassTag](size: Int)

--- a/lib/corpuscular/src/core/corpuscular.Digestion.scala
+++ b/lib/corpuscular/src/core/corpuscular.Digestion.scala
@@ -50,7 +50,7 @@ trait Digestion extends caps.Mutable:
   // providers that can consume a slice in place override it.
   update def append(array: Array[Byte]^{caps.any.rd}, start: Int, count: Int): Unit =
     val copy = Array.allocate[Byte](count)
-    copy.copyFrom(array, start, 0, count)
+    copy.place(array, start, 0, count)
     append(Array.freeze(copy))
 
   update def digest(): Data

--- a/lib/degustation/src/core/degustation.Atomizer.scala
+++ b/lib/degustation/src/core/degustation.Atomizer.scala
@@ -36,6 +36,7 @@ import scala.quoted.Quotes
 
 import anticipation.*
 import murmuration.map
+import rudiments.{Scribe, collect}
 
 // The atomization rules of `tasty/1`, applied over the compiler's reflection of unpickled
 // TASTy. The folding principle (LIRA §10.3) governs every decision here: declarations whose
@@ -61,21 +62,21 @@ object Atomizer:
 
     // --- canonical binary encoding -----------------------------------------------------------
 
-    def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+    def uvarint(out: Scribe[Byte], value0: Long): Unit =
       var value = value0
 
       while value >= 0x80L do
-        out.write(((value & 0x7f) | 0x80).toInt)
+        out.append(((value & 0x7f) | 0x80).toByte)
         value >>>= 7
 
-      out.write(value.toInt)
+      out.append(value.toByte)
 
-    def utf8(out: java.io.ByteArrayOutputStream, text: String): Unit =
-      val bytes = text.getBytes("UTF-8").nn
+    def utf8(out: Scribe[Byte], text: String): Unit =
+      val bytes = Array.unsafeFrozen(text.getBytes("UTF-8").nn)
       uvarint(out, bytes.length.toLong)
-      out.write(bytes)
+      out.append(bytes)
 
-    def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+    def tag(out: Scribe[Byte], char: Char): Unit = out.append(char.toByte)
 
     // The subset of modifier flags that consumers can depend on, in a fixed bit order. The
     // `exported` flag is deliberately absent (`tasty.md` §9): an `export` forwarder atomizes
@@ -96,7 +97,7 @@ object Atomizer:
     // Structural type encoding. `binders` tracks enclosing lambda-like binders outermost-last,
     // so parameter references encode as (de Bruijn depth, index) and binder names vanish.
     def encodeType
-      ( out: java.io.ByteArrayOutputStream, tpe: TypeRepr, binders: scala.List[Any] )
+      ( out: Scribe[Byte], tpe: TypeRepr, binders: scala.List[Any] )
     :   Unit =
 
       tpe match
@@ -273,12 +274,11 @@ object Atomizer:
     def record
       ( key:         String,
         replaceable: Boolean,
-        encoding:    java.io.ByteArrayOutputStream,
+        data:        Data,
         references:  scala.List[String] = scala.Nil )
     :   Unit =
 
       if atoms.contains(key) then throw Unencodable(s"duplicate key $key")
-      val data = Array.unsafeFrozen(encoding.toByteArray.nn)
 
       val listed =
         references.map: reference => ScalaReference.Own(Text(reference))
@@ -289,20 +289,21 @@ object Atomizer:
     // --- members ------------------------------------------------------------------------------
 
     def termAtom(ownerKey: String, symbol: Symbol): Unit =
-      val out = java.io.ByteArrayOutputStream()
-      tag(out, if symbol.isDefDef then 'd' else 'v')
-      uvarint(out, flagBits(symbol))
+      val encoded = Array.collect[Byte](): out =>
+        tag(out, if symbol.isDefDef then 'd' else 'v')
+        uvarint(out, flagBits(symbol))
 
-      // Parameter names are not part of the key, but they are named-argument surface, so they
-      // fold into the value; `HASDEFAULT` existence travels through the flag bits of the
-      // default getters, which are ordinary (synthetic) members.
-      symbol.paramSymss.foreach: clause =>
-        uvarint(out, clause.length.toLong)
-        clause.foreach: param => utf8(out, param.name)
+        // Parameter names are not part of the key, but they are named-argument surface, so they
+        // fold into the value; `HASDEFAULT` existence travels through the flag bits of the
+        // default getters, which are ordinary (synthetic) members.
+        symbol.paramSymss.foreach: clause =>
+          uvarint(out, clause.length.toLong)
+          clause.foreach: param => utf8(out, param.name)
 
-      encodeType(out, symbol.info, scala.Nil)
-      annotations(out, symbol)
-      record(keyOf(ownerKey, symbol), replaceable = false, out)
+        encodeType(out, symbol.info, scala.Nil)
+        annotations(out, symbol)
+
+      record(keyOf(ownerKey, symbol), replaceable = false, encoded)
 
       if symbol.flags.is(Flags.Inline) || symbol.flags.is(Flags.Macro) then inlineAtom(ownerKey,
           symbol)
@@ -313,250 +314,255 @@ object Atomizer:
       // canonical encoding of the body tree — local names alpha-normalized, every outward
       // reference fully qualified — and whose reference list names everything the body splices
       // into consumers, for used-set closure (LIRA §13.4).
-      val out = java.io.ByteArrayOutputStream()
-      tag(out, 'i')
-
-      val locals = scala.collection.mutable.HashMap[Symbol, Int]()
+      // Declared outside the lender: the reference set is read by the `record` call below, and
+      // the lender's lambda scope ends before it.
       val references = scala.collection.mutable.TreeSet[String]()
 
-      def local(member: Symbol): Boolean =
-        var current = member
-        var found = false
+      val encoded = Array.collect[Byte](): out =>
+        tag(out, 'i')
 
-        while !found && !current.isNoSymbol do
-          if current == symbol then found = true
-          current = if current.isNoSymbol then current else current.owner
+        val locals = scala.collection.mutable.HashMap[Symbol, Int]()
 
-        found
+        def local(member: Symbol): Boolean =
+          var current = member
+          var found = false
 
-      def reference(member: Symbol): Unit =
-        if !member.isNoSymbol && !member.isPackageDef && !member.owner.isNoSymbol
-        then
-          if member.isClassDef || member.isTypeDef then references += member.fullName else
-            references += keyOf(ownerKeyOf(member.owner), member)
+          while !found && !current.isNoSymbol do
+            if current == symbol then found = true
+            current = if current.isNoSymbol then current else current.owner
 
-            // Closure through nested inlining: using an inline member copies its body too.
-            if member.flags.is(Flags.Inline) || member.flags.is(Flags.Macro)
-            then references += keyOf(ownerKeyOf(member.owner), member) + "[inline]"
+          found
 
-      def name(member: Symbol): Unit =
-        if local(member) then
-          tag(out, 'l')
-          uvarint(out, locals.getOrElseUpdate(member, locals.size).toLong)
-        else
-          tag(out, 'g')
-          utf8(out, member.fullName + signatureText(member))
-          reference(member)
+        def reference(member: Symbol): Unit =
+          if !member.isNoSymbol && !member.isPackageDef && !member.owner.isNoSymbol
+          then
+            if member.isClassDef || member.isTypeDef then references += member.fullName else
+              references += keyOf(ownerKeyOf(member.owner), member)
 
-      def term(tree: Tree): Unit = tree match
-        case Inlined(_, bindings, body) =>
-          tag(out, 'I')
-          uvarint(out, bindings.length.toLong)
-          bindings.foreach(term)
-          term(body)
+              // Closure through nested inlining: using an inline member copies its body too.
+              if member.flags.is(Flags.Inline) || member.flags.is(Flags.Macro)
+              then references += keyOf(ownerKeyOf(member.owner), member) + "[inline]"
 
-        case Ident(_) =>
-          tag(out, 'x')
-          name(tree.symbol)
+        def name(member: Symbol): Unit =
+          if local(member) then
+            tag(out, 'l')
+            uvarint(out, locals.getOrElseUpdate(member, locals.size).toLong)
+          else
+            tag(out, 'g')
+            utf8(out, member.fullName + signatureText(member))
+            reference(member)
 
-        case Select(qualifier, _) =>
-          tag(out, '.')
-          term(qualifier)
-          name(tree.symbol)
+        def term(tree: Tree): Unit = tree match
+          case Inlined(_, bindings, body) =>
+            tag(out, 'I')
+            uvarint(out, bindings.length.toLong)
+            bindings.foreach(term)
+            term(body)
 
-        case Literal(constant) =>
-          tag(out, 'k')
-          utf8(out, constant.getClass.getName.nn + ":" + constant.show)
+          case Ident(_) =>
+            tag(out, 'x')
+            name(tree.symbol)
 
-        case This(_) =>
-          tag(out, 'z')
-          utf8(out, tree.symbol.fullName)
+          case Select(qualifier, _) =>
+            tag(out, '.')
+            term(qualifier)
+            name(tree.symbol)
 
-        case New(tpt) =>
-          tag(out, 'n')
-          encodeType(out, tpt.tpe, scala.Nil)
+          case Literal(constant) =>
+            tag(out, 'k')
+            utf8(out, constant.getClass.getName.nn + ":" + constant.show)
 
-        case Apply(fun, arguments) =>
-          tag(out, 'a')
-          term(fun)
-          uvarint(out, arguments.length.toLong)
-          arguments.foreach(term)
+          case This(_) =>
+            tag(out, 'z')
+            utf8(out, tree.symbol.fullName)
 
-        case TypeApply(fun, arguments) =>
-          tag(out, 'y')
-          term(fun)
-          uvarint(out, arguments.length.toLong)
-          arguments.foreach: argument => encodeType(out, argument.tpe, scala.Nil)
+          case New(tpt) =>
+            tag(out, 'n')
+            encodeType(out, tpt.tpe, scala.Nil)
 
-        case Typed(expression, tpt) =>
-          tag(out, ':')
-          term(expression)
-          encodeType(out, tpt.tpe, scala.Nil)
+          case Apply(fun, arguments) =>
+            tag(out, 'a')
+            term(fun)
+            uvarint(out, arguments.length.toLong)
+            arguments.foreach(term)
 
-        case Block(statements, expression) =>
-          tag(out, '{')
+          case TypeApply(fun, arguments) =>
+            tag(out, 'y')
+            term(fun)
+            uvarint(out, arguments.length.toLong)
+            arguments.foreach: argument => encodeType(out, argument.tpe, scala.Nil)
 
-          // Imports and exports among a body's statements are purely lexical: every
-          // reference this encoding emits is already fully-qualified, so they carry no
-          // semantic content and fold into nothing, like positions.
-          val retained = statements.filter:
-            case _: Import => false
-            case _: Export => false
-            case _         => true
+          case Typed(expression, tpt) =>
+            tag(out, ':')
+            term(expression)
+            encodeType(out, tpt.tpe, scala.Nil)
 
-          uvarint(out, retained.length.toLong)
-          retained.foreach(term)
-          term(expression)
+          case Block(statements, expression) =>
+            tag(out, '{')
 
-        case If(condition, positive, negative) =>
-          tag(out, '?')
-          term(condition)
-          term(positive)
-          term(negative)
+            // Imports and exports among a body's statements are purely lexical: every
+            // reference this encoding emits is already fully-qualified, so they carry no
+            // semantic content and fold into nothing, like positions.
+            val retained = statements.filter:
+              case _: Import => false
+              case _: Export => false
+              case _         => true
 
-        case matched @ Match(scrutinee, cases) =>
-          tag(out, if matched.isInline then 'M' else 'm')
-          term(scrutinee)
-          uvarint(out, cases.length.toLong)
-          cases.foreach(term)
+            uvarint(out, retained.length.toLong)
+            retained.foreach(term)
+            term(expression)
 
-        case SummonFrom(cases) =>
-          tag(out, 'f')
-          uvarint(out, cases.length.toLong)
-          cases.foreach(term)
+          case If(condition, positive, negative) =>
+            tag(out, '?')
+            term(condition)
+            term(positive)
+            term(negative)
 
-        case CaseDef(pattern, guard, rhs) =>
-          tag(out, 'e')
-          term(pattern)
+          case matched @ Match(scrutinee, cases) =>
+            tag(out, if matched.isInline then 'M' else 'm')
+            term(scrutinee)
+            uvarint(out, cases.length.toLong)
+            cases.foreach(term)
 
-          guard match
-            case scala.Some(condition) => term(condition)
-            case scala.None            => tag(out, '0')
+          case SummonFrom(cases) =>
+            tag(out, 'f')
+            uvarint(out, cases.length.toLong)
+            cases.foreach(term)
 
-          term(rhs)
+          case CaseDef(pattern, guard, rhs) =>
+            tag(out, 'e')
+            term(pattern)
 
-        case Bind(_, pattern) =>
-          tag(out, 'b')
-          uvarint(out, locals.getOrElseUpdate(tree.symbol, locals.size).toLong)
-          term(pattern)
+            guard match
+              case scala.Some(condition) => term(condition)
+              case scala.None            => tag(out, '0')
 
-        case Unapply(fun, implicits, patterns) =>
-          tag(out, 'u')
-          term(fun)
-          uvarint(out, implicits.length.toLong)
-          implicits.foreach(term)
-          uvarint(out, patterns.length.toLong)
-          patterns.foreach(term)
+            term(rhs)
 
-        case Alternatives(patterns) =>
-          tag(out, '/')
-          uvarint(out, patterns.length.toLong)
-          patterns.foreach(term)
+          case Bind(_, pattern) =>
+            tag(out, 'b')
+            uvarint(out, locals.getOrElseUpdate(tree.symbol, locals.size).toLong)
+            term(pattern)
 
-        case Wildcard() =>
-          tag(out, '_')
+          case Unapply(fun, implicits, patterns) =>
+            tag(out, 'u')
+            term(fun)
+            uvarint(out, implicits.length.toLong)
+            implicits.foreach(term)
+            uvarint(out, patterns.length.toLong)
+            patterns.foreach(term)
 
-        case TypedOrTest(inner, tpt) =>
-          tag(out, 'o')
-          term(inner)
-          encodeType(out, tpt.tpe, scala.Nil)
+          case Alternatives(patterns) =>
+            tag(out, '/')
+            uvarint(out, patterns.length.toLong)
+            patterns.foreach(term)
 
-        case While(condition, body) =>
-          tag(out, 'w')
-          term(condition)
-          term(body)
+          case Wildcard() =>
+            tag(out, '_')
 
-        case Assign(lhs, rhs) =>
-          tag(out, '=')
-          term(lhs)
-          term(rhs)
+          case TypedOrTest(inner, tpt) =>
+            tag(out, 'o')
+            term(inner)
+            encodeType(out, tpt.tpe, scala.Nil)
 
-        case Return(expression, _) =>
-          tag(out, 'j')
-          term(expression)
+          case While(condition, body) =>
+            tag(out, 'w')
+            term(condition)
+            term(body)
 
-        case Try(expression, cases, finalizer) =>
-          tag(out, 'q')
-          term(expression)
-          uvarint(out, cases.length.toLong)
-          cases.foreach(term)
+          case Assign(lhs, rhs) =>
+            tag(out, '=')
+            term(lhs)
+            term(rhs)
 
-          finalizer match
-            case scala.Some(effect) => term(effect)
-            case scala.None         => tag(out, '0')
+          case Return(expression, _) =>
+            tag(out, 'j')
+            term(expression)
 
-        case Repeated(elements, tpt) =>
-          tag(out, '*')
-          uvarint(out, elements.length.toLong)
-          elements.foreach(term)
-          encodeType(out, tpt.tpe, scala.Nil)
+          case Try(expression, cases, finalizer) =>
+            tag(out, 'q')
+            term(expression)
+            uvarint(out, cases.length.toLong)
+            cases.foreach(term)
 
-        case Closure(target, _) =>
-          tag(out, '\\')
-          term(target)
+            finalizer match
+              case scala.Some(effect) => term(effect)
+              case scala.None         => tag(out, '0')
 
-        case NamedArg(argName, argument) =>
-          tag(out, '$')
-          utf8(out, argName)
-          term(argument)
+          case Repeated(elements, tpt) =>
+            tag(out, '*')
+            uvarint(out, elements.length.toLong)
+            elements.foreach(term)
+            encodeType(out, tpt.tpe, scala.Nil)
 
-        case valDef: ValDef =>
-          tag(out, 'V')
-          uvarint(out, locals.getOrElseUpdate(valDef.symbol, locals.size).toLong)
-          encodeType(out, valDef.tpt.tpe, scala.Nil)
+          case Closure(target, _) =>
+            tag(out, '\\')
+            term(target)
 
-          valDef.rhs match
-            case scala.Some(rhs) => term(rhs)
-            case scala.None      => tag(out, '0')
+          case NamedArg(argName, argument) =>
+            tag(out, '$')
+            utf8(out, argName)
+            term(argument)
 
-        case defDef: DefDef =>
-          tag(out, 'D')
-          uvarint(out, locals.getOrElseUpdate(defDef.symbol, locals.size).toLong)
+          case valDef: ValDef =>
+            tag(out, 'V')
+            uvarint(out, locals.getOrElseUpdate(valDef.symbol, locals.size).toLong)
+            encodeType(out, valDef.tpt.tpe, scala.Nil)
 
-          defDef.termParamss.foreach: clause =>
-            clause.params.foreach: param =>
-              uvarint(out, locals.getOrElseUpdate(param.symbol, locals.size).toLong)
+            valDef.rhs match
+              case scala.Some(rhs) => term(rhs)
+              case scala.None      => tag(out, '0')
 
-          encodeType(out, defDef.returnTpt.tpe, scala.Nil)
+          case defDef: DefDef =>
+            tag(out, 'D')
+            uvarint(out, locals.getOrElseUpdate(defDef.symbol, locals.size).toLong)
 
-          defDef.rhs match
-            case scala.Some(rhs) => term(rhs)
-            case scala.None      => tag(out, '0')
+            defDef.termParamss.foreach: clause =>
+              clause.params.foreach: param =>
+                uvarint(out, locals.getOrElseUpdate(param.symbol, locals.size).toLong)
 
-        case tpt: TypeTree =>
-          tag(out, 'T')
-          encodeType(out, tpt.tpe, scala.Nil)
+            encodeType(out, defDef.returnTpt.tpe, scala.Nil)
 
-        case _ =>
-          throw Unencodable(s"term ${tree.getClass.getName}")
+            defDef.rhs match
+              case scala.Some(rhs) => term(rhs)
+              case scala.None      => tag(out, '0')
 
-      symbol.tree match
-        case defDef: DefDef =>
-          defDef.termParamss.foreach: clause =>
-            clause.params.foreach: param =>
-              uvarint(out, locals.getOrElseUpdate(param.symbol, locals.size).toLong)
+          case tpt: TypeTree =>
+            tag(out, 'T')
+            encodeType(out, tpt.tpe, scala.Nil)
 
-          defDef.rhs match
+          case _ =>
+            throw Unencodable(s"term ${tree.getClass.getName}")
+
+        symbol.tree match
+          case defDef: DefDef =>
+            defDef.termParamss.foreach: clause =>
+              clause.params.foreach: param =>
+                uvarint(out, locals.getOrElseUpdate(param.symbol, locals.size).toLong)
+
+            defDef.rhs match
+              case scala.Some(body) => term(body)
+              case scala.None       => tag(out, '0')
+
+          case valDef: ValDef => valDef.rhs match
             case scala.Some(body) => term(body)
             case scala.None       => tag(out, '0')
 
-        case valDef: ValDef => valDef.rhs match
-          case scala.Some(body) => term(body)
-          case scala.None       => tag(out, '0')
+          case _ => tag(out, '0')
 
-        case _ => tag(out, '0')
 
-      record(keyOf(ownerKey, symbol) + "[inline]", replaceable = true, out, references.toList)
+      record(keyOf(ownerKey, symbol) + "[inline]", replaceable = true, encoded, references.toList)
 
     def typeMemberAtom(ownerKey: String, symbol: Symbol): Unit =
-      val out = java.io.ByteArrayOutputStream()
-      tag(out, 't')
-      uvarint(out, flagBits(symbol))
-      encodeType(out, symbol.info, scala.Nil)
-      annotations(out, symbol)
-      record(s"$ownerKey.${symbol.name}", replaceable = false, out)
+      val encoded = Array.collect[Byte](): out =>
+        tag(out, 't')
+        uvarint(out, flagBits(symbol))
+        encodeType(out, symbol.info, scala.Nil)
+        annotations(out, symbol)
 
-    def annotations(out: java.io.ByteArrayOutputStream, symbol: Symbol): Unit =
+      record(s"$ownerKey.${symbol.name}", replaceable = false, encoded)
+
+    def annotations(out: Scribe[Byte], symbol: Symbol): Unit =
       val names = symbol.annotations
         . map(_.tpe.typeSymbol.fullName)
         . filter: name => !denylisted(name)
@@ -581,74 +587,75 @@ object Atomizer:
             else if member.isDefDef || member.isValDef then termAtom(ownerKey, member)
 
     def templateAtom(symbol: Symbol): Unit =
-      val out = java.io.ByteArrayOutputStream()
-      tag(out, 'c')
-      uvarint(out, flagBits(symbol))
+      val encoded = Array.collect[Byte](): out =>
+        tag(out, 'c')
+        uvarint(out, flagBits(symbol))
 
-      // Type parameters: positional, variance and bounds folded; names alpha-normalized away.
-      val typeParams = symbol.typeMembers.filter(_.isTypeParam)
-      uvarint(out, typeParams.length.toLong)
+        // Type parameters: positional, variance and bounds folded; names alpha-normalized away.
+        val typeParams = symbol.typeMembers.filter(_.isTypeParam)
+        uvarint(out, typeParams.length.toLong)
 
-      typeParams.foreach: param =>
-        val variance =
-          if param.flags.is(Flags.Covariant) then 1L
-          else if param.flags.is(Flags.Contravariant) then 2L else 0L
+        typeParams.foreach: param =>
+          val variance =
+            if param.flags.is(Flags.Covariant) then 1L
+            else if param.flags.is(Flags.Contravariant) then 2L else 0L
 
-        uvarint(out, variance)
-        encodeType(out, param.info, scala.Nil)
+          uvarint(out, variance)
+          encodeType(out, param.info, scala.Nil)
 
-      // Parents, in linearization-relevant declaration order.
-      val parents = symbol.typeRef.baseClasses match
-        case _ =>
-          symbol.tree match
-            case classDef: ClassDef =>
-              classDef.parents.map:
-                case tpt: TypeTree => tpt.tpe
-                case parent        => parent.asInstanceOf[Term].tpe
+        // Parents, in linearization-relevant declaration order.
+        val parents = symbol.typeRef.baseClasses match
+          case _ =>
+            symbol.tree match
+              case classDef: ClassDef =>
+                classDef.parents.map:
+                  case tpt: TypeTree => tpt.tpe
+                  case parent        => parent.asInstanceOf[Term].tpe
 
-            case _ => scala.Nil
+              case _ => scala.Nil
 
-      uvarint(out, parents.length.toLong)
-      parents.foreach: parent => encodeType(out, parent, scala.Nil)
+        uvarint(out, parents.length.toLong)
+        parents.foreach: parent => encodeType(out, parent, scala.Nil)
 
-      // The self type, when declared.
-      symbol.tree match
-        case classDef: ClassDef => classDef.self match
-          case scala.Some(self) =>
-            tag(out, 's')
-            encodeType(out, self.tpt.tpe, scala.Nil)
+        // The self type, when declared.
+        symbol.tree match
+          case classDef: ClassDef => classDef.self match
+            case scala.Some(self) =>
+              tag(out, 's')
+              encodeType(out, self.tpt.tpe, scala.Nil)
 
-          case scala.None => tag(out, '-')
+            case scala.None => tag(out, '-')
 
-        case _ => tag(out, '-')
+          case _ => tag(out, '-')
 
-      // Abstract members fold into an *open* template (adding one breaks external subclasses);
-      // on sealed or final templates they are pure additions and do not fold.
-      val open =
-        !symbol.flags.is(Flags.Final) && !symbol.flags.is(Flags.Sealed) &&
-          !symbol.flags.is(Flags.Module)
+        // Abstract members fold into an *open* template (adding one breaks external subclasses);
+        // on sealed or final templates they are pure additions and do not fold.
+        val open =
+          !symbol.flags.is(Flags.Final) && !symbol.flags.is(Flags.Sealed) &&
+            !symbol.flags.is(Flags.Module)
 
-      if open then
-        val deferred = symbol.declarations
-          . filter: member => member.flags.is(Flags.Deferred) && !excluded(member)
-          . map: member => keyOf(symbol.fullName, member)
-          . sorted
+        if open then
+          val deferred = symbol.declarations
+            . filter: member => member.flags.is(Flags.Deferred) && !excluded(member)
+            . map: member => keyOf(symbol.fullName, member)
+            . sorted
 
-        uvarint(out, deferred.length.toLong)
-        deferred.foreach: key => utf8(out, key)
-      else
-        uvarint(out, 0L)
+          uvarint(out, deferred.length.toLong)
+          deferred.foreach: key => utf8(out, key)
+        else
+          uvarint(out, 0L)
 
-      // The sealed/enum child list folds in declaration order: ordinals are behavior.
-      if symbol.flags.is(Flags.Sealed) || symbol.flags.is(Flags.Enum) then
-        val children = symbol.children.map(_.fullName)
-        uvarint(out, children.length.toLong)
-        children.foreach: child => utf8(out, child)
-      else
-        uvarint(out, 0L)
+        // The sealed/enum child list folds in declaration order: ordinals are behavior.
+        if symbol.flags.is(Flags.Sealed) || symbol.flags.is(Flags.Enum) then
+          val children = symbol.children.map(_.fullName)
+          uvarint(out, children.length.toLong)
+          children.foreach: child => utf8(out, child)
+        else
+          uvarint(out, 0L)
 
-      annotations(out, symbol)
-      record(symbol.fullName, replaceable = false, out)
+        annotations(out, symbol)
+
+      record(symbol.fullName, replaceable = false, encoded)
 
     // --- roots --------------------------------------------------------------------------------
 

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -477,7 +477,7 @@ object Tests extends Suite(m"Enigmatic tests"):
       test(m"Verification fails after tampering the wire bytes"):
         val wire = Cose(payload, key).bytes
         val tampered = Array.allocate[Byte](wire.length)
-        tampered.copyFrom(wire, 0, 0, wire.length)
+        tampered.place(wire)
         // Flip a bit in the MAC tag near the end of the envelope.
         val index = wire.length - 5
         tampered(index) = (tampered.readable(index) ^ 0xFF.toByte).toByte

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -375,9 +375,9 @@ case class Teletype
           // Add a new run starting at plain.length, with style = tail
           val newBoundaries = Array.allocate[Int](k + 1)
           val newStyles = Array.allocate[Long](k + 2)
-          newBoundaries.copyFrom(boundaries, 0, 0, k)
+          newBoundaries.place(boundaries, 0, 0, k)
           newBoundaries(k) = plain.length
-          newStyles.copyFrom(styles, 0, 0, k)
+          newStyles.place(styles, 0, 0, k)
           newStyles(k) = tail
           newStyles(k + 1) = tail
 
@@ -405,8 +405,8 @@ case class Teletype
         // Both dense — direct array copy
         val newLength = aN + that.plain.length + 1
         val arr = Array.allocate[Long](newLength)
-        arr.copyFrom(styles, 0, 0, aN)
-        arr.copyFrom(that.styles, 0, aN, that.styles.length)
+        arr.place(styles, 0, 0, aN)
+        arr.place(that.styles, 0, aN, that.styles.length)
 
         Teletype
           ( combinedPlain,
@@ -427,8 +427,8 @@ case class Teletype
         val newBoundariesArr = Array.allocate[Int](newK)
         val newStylesArr = Array.allocate[Long](newK + 1)
         // Copy A's runs
-        newBoundariesArr.copyFrom(aBoundaries, 0, 0, aK)
-        newStylesArr.copyFrom(aStyles, 0, 0, aK)
+        newBoundariesArr.place(aBoundaries, 0, 0, aK)
+        newStylesArr.place(aStyles, 0, 0, aK)
         // Copy B's runs (shifted by aN), optionally skipping the first if merging
         var bi = if merge then 1 else 0
         var ni = aK

--- a/lib/facsimile/src/core/facsimile.Cos.scala
+++ b/lib/facsimile/src/core/facsimile.Cos.scala
@@ -67,7 +67,7 @@ object Cos:
       val bytes = Array.allocate[Byte](body.length + 2)
       bytes(0) = 0xfe.toByte
       bytes(1) = 0xff.toByte
-      bytes.copyFrom(body, 0, 2, body.length)
+      bytes.place(body, 0, 2, body.length)
       Array.freeze(bytes)
 
   // A text string (ISO 32000-2 §7.9.2.2): UTF-16BE or UTF-8 by byte-order mark, otherwise

--- a/lib/facsimile/src/core/facsimile.Predictor.scala
+++ b/lib/facsimile/src/core/facsimile.Predictor.scala
@@ -57,7 +57,7 @@ private[facsimile] object Predictor:
       // The row decorrelation is undone in place, so the working copy is built exclusively
       // and frozen once at the end rather than thawed out of `data`.
       val out = Array.allocate[Byte](data.length)
-      out.copyFrom(data, 0, 0, data.length)
+      out.place(data)
       var row = 0
 
       while row*rowLength < data.length do

--- a/lib/gastronomy/src/test/gastronomy_test.scala
+++ b/lib/gastronomy/src/test/gastronomy_test.scala
@@ -198,7 +198,7 @@ object Tests extends Suite(m"Gastronomy tests"):
       // nonzero base offset, so block-boundary carry and offset arithmetic are exercised.
       def windowed(digestion: Digestion^): Text =
         val buffer = Array.allocate[Byte](payload.length + 13)
-        buffer.copyFrom(payload, 0, 13, payload.length)
+        buffer.place(payload, 0, 13, payload.length)
         val array = Array.freeze(buffer)
         var offset = 13
         var step = 1

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -485,7 +485,7 @@ package proximities:
           dist(j) = (old.readable(j - 1) + c).min(old.readable(j) + 1).min(dist.readable(j - 1) + 1)
           j += 1
 
-        old.copyFrom(dist, 0, 0, n + 1)
+        old.place(dist, 0, 0, n + 1)
         i += 1
 
       if m == 0 then n else dist.readable(n)

--- a/lib/hallucination/src/core-jvm/hallucination.ImageIo.scala
+++ b/lib/hallucination/src/core-jvm/hallucination.ImageIo.scala
@@ -73,6 +73,8 @@ private[hallucination] object ImageIo:
       argb(index) = opacity << 24 | raster.descriptor.chroma(word).underlying
 
     image.setRGB(0, 0, raster.width, raster.height, argb, 0, raster.width)
+    // A genuine `OutputStream` sink: `ImageIO.write` writes INTO the stream it is given, as
+    // `java.util.jar.Manifest.write` does. `Scribe` cannot stand in for either.
     val out = ji2.ByteArrayOutputStream()
     ji.ImageIO.write(image, format.name.s, out)
 

--- a/lib/hallucination/src/webp/hallucination.Vp8BoolEncoder.scala
+++ b/lib/hallucination/src/webp/hallucination.Vp8BoolEncoder.scala
@@ -44,6 +44,12 @@ import scala.caps
 // The VP8 boolean entropy encoder (RFC 6386 §7), ported from image-rs/image-webp
 // (`src/lossy/arithmetic_encoder.rs`, MIT/Apache-2.0) — the inverse of `Vp8Bool`.
 private[hallucination] final class Vp8BoolEncoder extends caps.Mutable:
+  // Field-held, and more strongly so than the other cases: `Vp8Encoder` keeps two of these in
+  // `var` fields, writing to separate buffers which are combined afterwards, so the buffer
+  // outlives any single expression. `Array.collect` lends a scribe and freezes it when the
+  // lender returns, and that confinement is what makes the freeze sound, so this cannot use it
+  // without either exposing growable construction outside a lender — which would give the
+  // soundness argument away — or restructuring the codec.
   private val out = ji.ByteArrayOutputStream()
 
   private val buffer: scala.collection.mutable.ArrayBuffer[Int] =

--- a/lib/hallucination/src/webp/hallucination.WebpBitWriter.scala
+++ b/lib/hallucination/src/webp/hallucination.WebpBitWriter.scala
@@ -42,6 +42,12 @@ import scala.caps
 // (`src/lossless/encoder/mod.rs`, MIT/Apache-2.0). Bits accumulate least-significant first into a
 // 64-bit buffer, flushed eight bytes at a time.
 private[hallucination] final class WebpBitWriter extends caps.Mutable:
+  // Field-held, and more strongly so than the other cases: `Vp8Encoder` keeps two of these in
+  // `var` fields, writing to separate buffers which are combined afterwards, so the buffer
+  // outlives any single expression. `Array.collect` lends a scribe and freezes it when the
+  // lender returns, and that confinement is what makes the freeze sound, so this cannot use it
+  // without either exposing growable construction outside a lender — which would give the
+  // soundness argument away — or restructuring the codec.
   private val out = ji.ByteArrayOutputStream()
   private var buffer: Long = 0L
   private var count: Int = 0

--- a/lib/hieroglyph/src/core/hieroglyph.GraphemeBreak.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.GraphemeBreak.scala
@@ -286,5 +286,5 @@ object GraphemeBreak:
       // conversion.
       val frozen = Array.freeze(breaks)
       val result = Array.allocate[Int](size)
-      result.copyFrom(frozen, 0, 0, size)
+      result.place(frozen, 0, 0, size)
       Array.freeze(result)

--- a/lib/honeycomb/src/core/honeycomb.internal.scala
+++ b/lib/honeycomb/src/core/honeycomb.internal.scala
@@ -878,8 +878,8 @@ object internal:
 
         if idx < 0 then attrs else
           val nu = Array.allocate[String | Null](n - 2)
-          if idx > 0 then nu.copyFrom(Array.frozen(attrs), 0, 0, idx)
-          if idx < n - 2 then nu.copyFrom(Array.frozen(attrs), idx + 2, idx, n - 2 - idx)
+          if idx > 0 then nu.place(Array.frozen(attrs), 0, 0, idx)
+          if idx < n - 2 then nu.place(Array.frozen(attrs), idx + 2, idx, n - 2 - idx)
           Array.freeze(nu).readable
 
       inline def `-`(key: Text): Attributes = removed(key)
@@ -907,12 +907,12 @@ object internal:
 
         if idx >= 0 then
           val nu = Array.allocate[String | Null](n)
-          nu.copyFrom(Array.frozen(attrs), 0, 0, n)
+          nu.place(Array.frozen(attrs), 0, 0, n)
           nu(idx + 1) = value.lay(null: String | Null)(_.s)
           Array.freeze(nu).readable
         else
           val nu = Array.allocate[String | Null](n + 2)
-          nu.copyFrom(Array.frozen(attrs), 0, 0, n)
+          nu.place(Array.frozen(attrs), 0, 0, n)
           nu(n) = keyStr
           nu(n + 1) = value.lay(null: String | Null)(_.s)
           Array.freeze(nu).readable
@@ -968,7 +968,7 @@ object internal:
 
           if written == total then frozen.readable else
             val tu = Array.allocate[String | Null](written)
-            tu.copyFrom(frozen, 0, 0, written)
+            tu.place(frozen, 0, 0, written)
             Array.freeze(tu).readable
 
       def `++`(other: Map[Text, Optional[Text]]): Attributes =

--- a/lib/hypotenuse/src/core/hypotenuse.Decimal.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Decimal.scala
@@ -212,7 +212,7 @@ object decimalInternal:
         val result = Array.allocate[Int](count + 2)
         result(0) = signum
         result(1) = scale
-        result.copyFrom(magnitude, 0, 2, count)
+        result.place(magnitude, 0, 2, count)
         Array.freeze(result).readable
 
     // In-place small division, returning the remainder; `divisor` is at most 10⁹.
@@ -541,7 +541,7 @@ object decimalInternal:
     def negation(value: Decimal): Decimal =
       if value(0) == 0 then value else
         val result = Array.allocate[Int](value.length)
-        result.copyFrom(Array.frozen(value), 0, 0, value.length)
+        result.place(Array.frozen(value), 0, 0, value.length)
         result(0) = -value(0)
         Array.freeze(result).readable
 

--- a/lib/inimitable/src/core/inimitable.Uuid.scala
+++ b/lib/inimitable/src/core/inimitable.Uuid.scala
@@ -86,8 +86,8 @@ case class Uuid(msb: Long, lsb: Long):
     val high = msb.bytestream
     val low = lsb.bytestream
     val buffer = Array.allocate[Byte](high.length + low.length)
-    buffer.copyFrom(high, 0, 0, high.length)
-    buffer.copyFrom(low, 0, high.length, low.length)
+    buffer.place(high)
+    buffer.place(low, 0, high.length, low.length)
     Array.freeze(buffer)
 
   @targetName("invert")

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -1641,7 +1641,7 @@ object Json extends Json2, Dynamic:
       if (n & 1) == 1 then elements
       else
         val padded = Array.allocate[Any](n + 1)
-        padded.copyFrom(elements, 0, 0, n)
+        padded.place(elements, 0, 0, n)
         padded(n) = arrayPad
         Array.freeze(padded)
 
@@ -2826,14 +2826,14 @@ extends Dynamic, Topical, Original derives CanEqual:
     root.objectIndexOf(field) match
       case -1 =>
         val out = Array.allocate[Any](len + 2)
-        out.copyFrom(arr, 0, 0, len)
+        out.place(arr, 0, 0, len)
         out(len) = field
         out(len + 1) = value.root
         Json.ast(Json.Ast(Array.freeze(out)))
 
       case index =>
         val out = Array.allocate[Any](len)
-        out.copyFrom(arr, 0, 0, len)
+        out.place(arr, 0, 0, len)
         out(index*2 + 1) = value.root
         Json.ast(Json.Ast(Array.freeze(out)))
 
@@ -2847,8 +2847,8 @@ extends Dynamic, Topical, Original derives CanEqual:
 
       case index =>
         val out = Array.allocate[Any](len - 2)
-        out.copyFrom(arr, 0, 0, index*2)
-        out.copyFrom(arr, index*2 + 2, index*2, len - index*2 - 2)
+        out.place(arr, 0, 0, index*2)
+        out.place(arr, index*2 + 2, index*2, len - index*2 - 2)
         Json.ast(Json.Ast(Array.freeze(out)))
 
   def apply(field: Text): Json raises Json.Error =

--- a/lib/mandible/src/lira/mandible.ClassfileAtomizer.scala
+++ b/lib/mandible/src/lira/mandible.ClassfileAtomizer.scala
@@ -94,23 +94,23 @@ object ClassfileAtomizer:
   // The same tag-length-value scheme `tasty/1` uses (`tasty.md` §7): unsigned LEB128 lengths,
   // length-prefixed UTF-8 strings, single-character constructor tags.
 
-  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+  private def uvarint(out: Scribe[Byte], value0: Long): Unit =
     var value = value0
 
     while value >= 0x80L do
-      out.write(((value & 0x7f) | 0x80).toInt)
+      out.append(((value & 0x7f) | 0x80).toByte)
       value >>>= 7
 
-    out.write(value.toInt)
+    out.append(value.toByte)
 
-  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
-    val bytes = text.s.getBytes("UTF-8").nn
+  private def utf8(out: Scribe[Byte], text: Text): Unit =
+    val bytes = Array.unsafeFrozen(text.s.getBytes("UTF-8").nn)
     uvarint(out, bytes.length.toLong)
-    out.write(bytes)
+    out.append(bytes)
 
-  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+  private def tag(out: Scribe[Byte], char: Char): Unit = out.append(char.toByte)
 
-  private def optional(out: java.io.ByteArrayOutputStream, value: Optional[Text]): Unit =
+  private def optional(out: Scribe[Byte], value: Optional[Text]): Unit =
     value.lay(tag(out, '0')):
       text =>
         tag(out, '1')
@@ -118,14 +118,12 @@ object ClassfileAtomizer:
 
   // The count is a length prefix, so it must precede the elements; the extra walk it costs is
   // the same order as the write that follows it.
-  private def texts(out: java.io.ByteArrayOutputStream, values: List[Text]): Unit =
+  private def texts(out: Scribe[Byte], values: List[Text]): Unit =
     uvarint(out, values.size.toLong)
     values.each(utf8(out, _))
 
-  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
-    val out = java.io.ByteArrayOutputStream()
-    encode(out)
-    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+  private def hash(encode: Scribe[Byte] => Unit): Data =
+    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.collect[Byte]()(encode))
 
   // --- the presented member set -----------------------------------------------------------------
 

--- a/lib/phoenicia/src/core/phoenicia.Sfnt.scala
+++ b/lib/phoenicia/src/core/phoenicia.Sfnt.scala
@@ -172,7 +172,7 @@ object Sfnt:
 
       (0 until 4).each: position => buffer(directory + position) = tagBytes(position)
 
-      buffer.copyFrom(table, 0, offset, table.length)
+      buffer.place(table, 0, offset, table.length)
       putU32(directory + 4, checksum(offset, table.length))
       putU32(directory + 8, offset.toLong)
       putU32(directory + 12, table.length.toLong)

--- a/lib/phoenicia/src/core/phoenicia.Truetype.scala
+++ b/lib/phoenicia/src/core/phoenicia.Truetype.scala
@@ -93,7 +93,7 @@ case class Truetype(data: Data) extends Sfnt:
     var written = 0
 
     parts.result().each: part =>
-      newGlyf.copyFrom(part, 0, written, part.length)
+      newGlyf.place(part, 0, written, part.length)
       written += part.length
 
     // The rebuilt loca always uses the long format, so head's format field must agree.
@@ -108,7 +108,7 @@ case class Truetype(data: Data) extends Sfnt:
     val headRef = tables(Sfnt.Table.Ttf.Head).lest(Font.Error(Font.Error.Reason.MissingTable(Sfnt.Table.Ttf.Head)))
     val headData = data.segment((headRef.offset).z till (headRef.offset + headRef.length).z)
     val newHead = Array.allocate[Byte](headData.length)
-    newHead.copyFrom(headData, 0, 0, headData.length)
+    newHead.place(headData)
     (8 to 11).each { index => newHead(index) = 0 } // adjustment is recomputed on assembly
     newHead(50) = 0
     newHead(51) = 1

--- a/lib/pneumatic/src/flate/pneumatic_flate.scala
+++ b/lib/pneumatic/src/flate/pneumatic_flate.scala
@@ -52,7 +52,7 @@ private def concatenate(stream: Chain[Data]): Data =
   var offset = 0
 
   chunks.each: chunk =>
-    result.copyFrom(chunk, 0, offset, chunk.length)
+    result.place(chunk, 0, offset, chunk.length)
     offset += chunk.length
 
   Array.freeze(result)

--- a/lib/pneumatic/src/test/pneumatic_test.scala
+++ b/lib/pneumatic/src/test/pneumatic_test.scala
@@ -405,7 +405,7 @@ object Tests extends Suite(m"Pneumatic tests"):
         // The tampered copy is built in an exclusive buffer and frozen once, so corrupting a
         // byte asserts nothing.
         val buffer = Array.allocate[Byte](source.length)
-        buffer.copyFrom(source, 0, 0, source.length)
+        buffer.place(source)
         buffer(36) = (source.readable(36) ^ 0x55).toByte
         val corrupted: Data = Array.freeze(buffer)
         try corrupted.decompress[Xz].to[List] != original.to[List]

--- a/lib/polysyllabic/src/core/polysyllabic.Hyphenation.scala
+++ b/lib/polysyllabic/src/core/polysyllabic.Hyphenation.scala
@@ -162,7 +162,7 @@ object Hyphenation:
   // The first `count` elements of `source`, as an immutable array.
   private def exactCopy(source: Array[Int]^, count: Int): Array[Int]^{} =
     val result = Array.allocate[Int](count)
-    result.copyFrom(source, 0, 0, count)
+    result.place(source, 0, 0, count)
     Array.freeze(result)
 
   private def walkCompact

--- a/lib/polysyllabic/src/core/polysyllabic.TexPatterns.scala
+++ b/lib/polysyllabic/src/core/polysyllabic.TexPatterns.scala
@@ -99,7 +99,7 @@ private[polysyllabic] object TexPatterns:
       i += 1
 
     val exact = Array.allocate[Int](count)
-    exact.copyFrom(breaks, 0, 0, count)
+    exact.place(breaks, 0, 0, count)
     (letters.toString.tt, Array.freeze(exact))
 
   // Strip `%`-to-end-of-line comments from a TeX file. Backslash-escaped

--- a/lib/proscenium/src/core/proscenium.Array.scala
+++ b/lib/proscenium/src/core/proscenium.Array.scala
@@ -150,9 +150,22 @@ object Array:
         buffer(index) = value
         index += 1
 
-    // One `copyFrom` for every readable source: frozen (`^{}`) and shared references both
-    // subsume into `^{caps.any.rd}`.
-    def copyFrom
+    // Copying a source INTO this array, which is what `place` means throughout the collection
+    // (`rudiments.place`, `concordance.Scribe.place`); `snapshot` is its counterpart, copying
+    // out into a fresh array. One overload set for every readable source: frozen (`^{}`) and
+    // shared references both subsume into `^{caps.any.rd}`.
+    //
+    // Indexed by `Int` rather than by `Ordinal`, unlike most of the collection: `denominative`
+    // sits above `proscenium`, so an ordinal cannot be named here. `Array`'s own `apply`,
+    // `update` and `readUnchecked` are `Int`-indexed for the same reason, and the ordinal-taking
+    // façade lives in `rudiments`.
+    def place(source: Array[element]^{caps.any.rd}): Unit =
+      place(source, 0, 0, source.length)
+
+    def place(source: Array[element]^{caps.any.rd}, at: Int): Unit =
+      place(source, 0, at, source.length)
+
+    def place
       ( source: Array[element]^{caps.any.rd},
         sourceStart: Int,
         targetStart: Int,

--- a/lib/proscenium/src/test/proscenium_test.scala
+++ b/lib/proscenium/src/test/proscenium_test.scala
@@ -165,9 +165,9 @@ object Tests extends Suite(m"Proscenium Tests"):
         Array(1, 2, 3).map(_.toString).readable.toList
       . assert(_ == scala.List("1", "2", "3"))
 
-      test(m"copyFrom transfers a window"):
+      test(m"place transfers a window"):
         val buffer = Array.allocate[Int](4)
-        buffer.copyFrom(Array(1, 2, 3, 4), 1, 0, 2)
+        buffer.place(Array(1, 2, 3, 4), 1, 0, 2)
         buffer.readable.toList
       . assert(_ == scala.List(2, 3, 0, 0))
 

--- a/lib/reliquary/src/core/reliquary.CapabilityDiscipline.scala
+++ b/lib/reliquary/src/core/reliquary.CapabilityDiscipline.scala
@@ -114,17 +114,13 @@ object CapabilityDiscipline extends Discipline:
       if left(0).s > right(0).s then abort(malformed(t"capability rows are not sorted by name"))
 
     val listing = entries.toList.map: (name, predicate) =>
-      val out = java.io.ByteArrayOutputStream()
-      out.write(name.s.getBytes("UTF-8").nn)
-      out.write(0)
+      val encoding = Array.collect[Byte](): out =>
+        out.append(Array.unsafeFrozen(name.s.getBytes("UTF-8").nn))
+        out.append(0)
 
-      predicate.let: text =>
-        out.write(1)
-        out.write(text.s.getBytes("UTF-8").nn)
-
-      . or(out.write(0))
-
-      val encoding = Array.unsafeFrozen(out.toByteArray.nn)
+        predicate.lay(out.append(0)): text =>
+          out.append(1)
+          out.append(Array.unsafeFrozen(text.s.getBytes("UTF-8").nn))
       Atom(name, Atom.Class.Rigid, Lira.Hash(Lira.Hash.Domain.Atom(id), encoding))
 
     // `entries` is the stdlib `Vector` the TEL reader hands back; the listing crosses to the

--- a/lib/reliquary/src/derive/reliquary.Derivative.scala
+++ b/lib/reliquary/src/derive/reliquary.Derivative.scala
@@ -80,15 +80,15 @@ object Derivative:
 
       Zip.Entry(ref, store.resolve(entry.blob))
 
-    val out = java.io.ByteArrayOutputStream()
+    Array.collect[Byte](): out =>
+      Zipfile(entries, Unset, Unset).serialize.drain: region =>
+        range =>
+          val interval: Interval = range
 
-    Zipfile(entries, Unset, Unset).serialize.drain: region =>
-      range =>
-        val interval: Interval = range
-        out.write(unsafely(region.raw.asInstanceOf[scala.Array[Byte]]), interval.start.n0,
-            interval.size)
-
-    Array.unsafeFrozen(out.toByteArray.nn)
+          out.append
+           ( Array.unsafeFrozen(unsafely(region.raw.asInstanceOf[scala.Array[Byte]])),
+             interval.start.n0,
+             interval.size )
 
   def hash(tree: Lira.Tree, store: Blobstore): Data raises Lira.Error =
     Lira.Hash(Lira.Hash.Domain.Derivative, jar(tree, store))

--- a/lib/revolution/src/core/revolution.Manifest.scala
+++ b/lib/revolution/src/core/revolution.Manifest.scala
@@ -101,6 +101,9 @@ case class Manifest(entries: Map[Text, Text]):
     entries.each: (key, value) =>
       manifest.getMainAttributes.nn.putValue(key.s, value.s)
 
+    // A genuine `OutputStream` sink, not a buffer: `java.util.jar.Manifest.write` writes INTO
+    // the stream it is given, so `Scribe` cannot stand in for it. One of the two places where
+    // `ByteArrayOutputStream` was doing what its name says.
     val out = ji.ByteArrayOutputStream()
     manifest.write(out)
     Array.unsafeFrozen(out.toByteArray().nn)

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -1709,3 +1709,154 @@ object Tests extends Suite(m"Rudiments Tests"):
       test(m"a long array reports its size"):
         Atomic.Longs(3).size
       . assert(_ == 3)
+
+    // `doc/philosophy/zero-cost.md` says the claim is tested rather than asserted, and this is
+    // that test for `Atomic`. Each probe below is read back out of the classfile and checked for
+    // the JDK instruction it should have become — so a dropped `inline`, a transition shape that
+    // stops being recognised, or a release store quietly promoted to a volatile one all fail
+    // here rather than silently costing something at every call site.
+    suite(m"Atomic bytecode shape"):
+      import classloaders.threadContextClassloader
+
+      def methodBytecode(method: Text)(using Classloader): Optional[Bytecode] =
+        Classfile[AtomicProbes.type]
+        . let(_.methods.seek(_.name == method))
+        . let(_.bytecode)
+
+      // The JDK atomic method a probe compiled down to, if it reached exactly one.
+      def atomicCalls(bytecode: Bytecode): Set[Text] =
+        bytecode.instructions.stdlib.collect:
+          case instruction => instruction.opcode
+        . collect:
+            case Bytecode.Opcode.Invokevirtual(owner, name, _)
+            if owner.s.startsWith("java.util.concurrent.atomic") =>
+              name
+        . to(Set)
+
+      def calls(method: Text, expected: Text)(using Classloader): Boolean =
+        methodBytecode(method).lay(false)(atomicCalls(_).has(expected))
+
+      // Any surviving dispatch to the wrapper's own vocabulary would mean an extension had not
+      // inlined, and every operation would pay a call it should not.
+      def callsWrapper(bytecode: Bytecode): Boolean =
+        val names = Set(t"ere", t"since", t"revise", t"publish", t"swap", t"replace", t"update")
+
+        bytecode.instructions.stdlib.exists: instruction =>
+          instruction.opcode match
+            case Bytecode.Opcode.Invokevirtual(_, name, _)      => names.has(name)
+            case Bytecode.Opcode.Invokeinterface(_, name, _, _) => names.has(name)
+            case _                                              => false
+
+      def hasBoxing(bytecode: Bytecode): Boolean =
+        bytecode.instructions.stdlib.exists: instruction =>
+          instruction.opcode match
+            case Bytecode.Opcode.Invokestatic(owner, method, _) =>
+              owner.s.contains("BoxesRunTime") && method.s.contains("box")
+
+            case _ =>
+              false
+
+      // A closure allocated per retry is exactly what the four hand-hoisted `UnaryOperator`
+      // values in `parasite.Promise` existed to avoid; the transition must beta-reduce instead.
+      def allocatesClosure(bytecode: Bytecode): Boolean =
+        bytecode.instructions.stdlib.exists: instruction =>
+          instruction.opcode match
+            case Bytecode.Opcode.Invokeinterface(owner, t"apply", _, _) =>
+              owner.s.startsWith("scala.Function")
+
+            case _ =>
+              false
+
+      test(m"since(_ + 1) becomes incrementAndGet"):
+        calls(t"intSince", t"incrementAndGet")
+      . assert(_ == true)
+
+      test(m"ere(_ + 1) becomes getAndIncrement"):
+        calls(t"intEre", t"getAndIncrement")
+      . assert(_ == true)
+
+      test(m"since(_ + n) becomes addAndGet"):
+        calls(t"intAdd", t"addAndGet")
+      . assert(_ == true)
+
+      test(m"ere(_ + n) becomes getAndAdd"):
+        calls(t"intClaim", t"getAndAdd")
+      . assert(_ == true)
+
+      test(m"since(_ - 1) becomes decrementAndGet"):
+        calls(t"intDecrement", t"decrementAndGet")
+      . assert(_ == true)
+
+      test(m"ere(value) becomes getAndSet"):
+        calls(t"intSet", t"getAndSet")
+      . assert(_ == true)
+
+      test(m"a long transition reaches AtomicLong's intrinsic"):
+        calls(t"longSince", t"incrementAndGet")
+      . assert(_ == true)
+
+      test(m"raising a flag becomes getAndSet"):
+        calls(t"boolRaise", t"getAndSet")
+      . assert(_ == true)
+
+      test(m"a read becomes get"):
+        calls(t"intRead", t"get")
+      . assert(_ == true)
+
+      // The release store must stay a release store: promoting it to `set` would silently
+      // strengthen the ordering that zephyrine's single-producer rings depend on.
+      test(m"publish on an int array becomes lazySet, not set"):
+        calls(t"intsPublish", t"lazySet")
+      . assert(_ == true)
+
+      test(m"publish on an int array does not become set"):
+        calls(t"intsPublish", t"set")
+      . assert(_ == false)
+
+      test(m"publish on a long array becomes lazySet"):
+        calls(t"longsPublish", t"lazySet")
+      . assert(_ == true)
+
+      test(m"an intrinsic transition leaves no dispatch to the wrapper"):
+        methodBytecode(t"intSince").lay(true)(callsWrapper)
+      . assert(_ == false)
+
+      test(m"a general transition leaves no dispatch to the wrapper"):
+        methodBytecode(t"intGeneral").lay(true)(callsWrapper)
+      . assert(_ == false)
+
+      test(m"a general transition compiles to a compare-and-set loop"):
+        calls(t"intGeneral", t"compareAndSet")
+      . assert(_ == true)
+
+      test(m"a general transition allocates no closure"):
+        methodBytecode(t"intGeneral").lay(true)(allocatesClosure)
+      . assert(_ == false)
+
+      test(m"an unboxed transition does not box"):
+        methodBytecode(t"intGeneral").lay(true)(hasBoxing)
+      . assert(_ == false)
+
+      test(m"a reference read does not call nnFail"):
+        methodBytecode(t"refRead").lay(true): bytecode =>
+          bytecode.instructions.stdlib.exists: instruction =>
+            instruction.opcode match
+              case Bytecode.Opcode.Invokestatic(_, t"nnFail", _) => true
+              case _                                             => false
+
+      . assert(_ == false)
+
+object AtomicProbes:
+  def intSince(a: Atomic[Int]): Int = a.since(_ + 1)
+  def intEre(a: Atomic[Int]): Int = a.ere(_ + 1)
+  def intAdd(a: Atomic[Int], n: Int): Int = a.since(_ + n)
+  def intClaim(a: Atomic[Int], n: Int): Int = a.ere(_ + n)
+  def intDecrement(a: Atomic[Int]): Int = a.since(_ - 1)
+  def intSet(a: Atomic[Int]): Int = a.ere(5)
+  def intRead(a: Atomic[Int]): Int = a()
+  def intGeneral(a: Atomic[Int]): Int = a.since(_*3)
+  def longSince(a: Atomic[Long]): Long = a.since(_ + 1L)
+  def boolRaise(a: Atomic[Boolean]): Boolean = a.ere(true)
+  def refRead(a: Atomic[Text]): Text = a()
+  def intsPublish(a: Atomic.Ints, index: Ordinal, value: Int): Unit = a.publish(index, value)
+  def longsPublish(a: Atomic.Longs, index: Ordinal, value: Long): Unit = a.publish(index, value)

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -1846,6 +1846,54 @@ object Tests extends Suite(m"Rudiments Tests"):
 
       . assert(_ == false)
 
+    suite(m"Array.collect tests"):
+      test(m"an unsized scribe yields only what was written"):
+        Array.collect[Int](): scribe =>
+          scribe.append(1)
+          scribe.append(2)
+          scribe.append(3)
+
+        . length
+      . assert(_ == 3)
+
+      // The point of the type: appending past the hint grows rather than clamping, which is
+      // what `Array.scribe`'s fixed lender does and why `ByteArrayOutputStream` was reached for.
+      test(m"an unsized scribe grows past its hint"):
+        Array.collect[Int](2): scribe =>
+          var i = 0
+
+          while i < 100 do
+            scribe.append(i)
+            i += 1
+
+        . length
+      . assert(_ == 100)
+
+      test(m"a grown scribe keeps every element in order"):
+        val grown = Array.collect[Int](2): scribe =>
+          var i = 0
+
+          while i < 100 do
+            scribe.append(i*2)
+            i += 1
+
+        grown.at(Ordinal.zerary(99))
+      . assert(_ == 198)
+
+      test(m"an unsized scribe with no writes is empty"):
+        Array.collect[Int]()(scribe => ()).length
+      . assert(_ == 0)
+
+      // The fixed lender must be unaffected: it still returns an array of exactly the size
+      // asked for, and its append still clamps rather than growing.
+      test(m"the sized lender still returns exactly its size"):
+        Array.scribe[Int](5): scribe =>
+          extent => scribe.append(1)
+
+        . length
+      . assert(_ == 5)
+
+
 object AtomicProbes:
   def intSince(a: Atomic[Int]): Int = a.since(_ + 1)
   def intEre(a: Atomic[Int]): Int = a.ere(_ + 1)

--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -32,7 +32,6 @@
                                                                                                   */
 package stratiform
 
-import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 
 import scala.language.unsafeNulls
@@ -102,9 +101,8 @@ object Bintel:
     ( using Tactic[Tel.Error], Tactic[Bintel.Error] )
   :   Data =
 
-    val out = new ByteArrayOutputStream
-    encodeRoot(out, element, schema, codecs)
-    out.toByteArray.asInstanceOf[Array[Byte]^{}]
+    Array.collect[Byte](): out =>
+      encodeRoot(out, element, schema, codecs)
 
   // Is `signature` a syntactically-valid palimpsest? Recovers the cadence
   // byte from the XOR-fold of every byte and checks the byte length is
@@ -131,20 +129,11 @@ object Bintel:
     if !validSignatureLength(signature)
     then abort(Bintel.Error(Bintel.Error.Reason.BadSignatureLength))
 
-    val out = new ByteArrayOutputStream(magic.length + 10 + signature.length + body.length)
-    out.write(magic.asInstanceOf[scala.Array[Byte]])
-    val sigLen = new ByteArrayOutputStream(10)
-    var n = signature.length.toLong
-
-    while n >= 0x80L do
-      sigLen.write(((n & 0x7fL) | 0x80L).toInt)
-      n >>>= 7
-
-    sigLen.write(n.toInt)
-    out.write(sigLen.toByteArray)
-    out.write(signature.asInstanceOf[scala.Array[Byte]])
-    out.write(body.asInstanceOf[scala.Array[Byte]])
-    out.toByteArray.asInstanceOf[Array[Byte]^{}]
+    Array.collect[Byte](magic.length + 10 + signature.length + body.length): out =>
+      out.append(magic)
+      writeVarint(out, signature.length.toLong)
+      out.append(signature)
+      out.append(body)
 
   // §6 unframing. Parse a complete BinTEL byte sequence into its
   // signature bytes and body bytes. Validates the magic number (B01),
@@ -213,16 +202,16 @@ object Bintel:
     if !validSignatureLength(signature)
     then abort(Bintel.Error(Bintel.Error.Reason.BadSignatureLength))
 
-    val out = new ByteArrayOutputStream(
-        magicSelfContained.length + 20 + signature.length + schemaBody.length + body.length)
+    val hint =
+      magicSelfContained.length + 20 + signature.length + schemaBody.length + body.length
 
-    out.write(magicSelfContained.asInstanceOf[scala.Array[Byte]])
-    writeVarint(out, signature.length.toLong)
-    out.write(signature.asInstanceOf[scala.Array[Byte]])
-    writeVarint(out, schemaBody.length.toLong)
-    out.write(schemaBody.asInstanceOf[scala.Array[Byte]])
-    out.write(body.asInstanceOf[scala.Array[Byte]])
-    out.toByteArray.asInstanceOf[Array[Byte]^{}]
+    Array.collect[Byte](hint): out =>
+      out.append(magicSelfContained)
+      writeVarint(out, signature.length.toLong)
+      out.append(signature)
+      writeVarint(out, schemaBody.length.toLong)
+      out.append(schemaBody)
+      out.append(body)
 
   // §6.2 self-contained encoding of the TEL document `tel`, whose schema is given
   // as the TEL document `schemaDoc` (parseable under the tels axiom). The
@@ -621,7 +610,7 @@ object Bintel:
   private final class Cursor(val data: Data, @scala.caps.unsafe.untrackedCaptures var offset: Int)
 
   private def encodeRoot
-    ( out: ByteArrayOutputStream, element: Tel.Element, schema: Tels,
+    ( out: Scribe[Byte], element: Tel.Element, schema: Tels,
       codecs: Optional[Tel.Codec.Resolver] )
     ( using Tactic[Tel.Error], Tactic[Bintel.Error] )
   :   Unit =
@@ -646,7 +635,7 @@ object Bintel:
         encodeElement(out, element, schema, codecs)
 
   private def encodeElement
-    ( out: ByteArrayOutputStream, element: Tel.Element, schema: Tels,
+    ( out: Scribe[Byte], element: Tel.Element, schema: Tels,
       codecs: Optional[Tel.Codec.Resolver] )
     ( using Tactic[Tel.Error], Tactic[Bintel.Error] )
   :   Unit =
@@ -656,7 +645,7 @@ object Bintel:
       case value: Tel.Element.Value => encodeValue(out, value, codecs)
 
   private def encodeNode
-    ( out: ByteArrayOutputStream, node: Tel.Element.Node, schema: Tels,
+    ( out: Scribe[Byte], node: Tel.Element.Node, schema: Tels,
       codecs: Optional[Tel.Codec.Resolver] )
     ( using Tactic[Tel.Error], Tactic[Bintel.Error] )
   :   Unit =
@@ -688,7 +677,7 @@ object Bintel:
   // scalar, the bound codec's bytes for an encoded one. The framing —
   // keyword index, byte length, bytes — is identical in both forms.
   private def encodeValue
-    ( out: ByteArrayOutputStream, value: Tel.Element.Value,
+    ( out: Scribe[Byte], value: Tel.Element.Value,
       codecs: Optional[Tel.Codec.Resolver] )
     ( using Tactic[Tel.Error], Tactic[Bintel.Error] )
   :   Unit =
@@ -710,16 +699,16 @@ object Bintel:
     . or(value.text.s.getBytes(StandardCharsets.UTF_8).nn)
 
     writeVarint(out, bytes.length.toLong)
-    out.write(bytes)
+    out.append(Array.unsafeFrozen(bytes))
 
-  private def writeVarint(out: ByteArrayOutputStream, value: Long): Unit =
+  private def writeVarint(out: Scribe[Byte], value: Long): Unit =
     var n = value
 
     while n >= 0x80L do
-      out.write(((n & 0x7fL) | 0x80L).toInt)
+      out.append(((n & 0x7fL) | 0x80L).toByte)
       n >>>= 7
 
-    out.write(n.toInt)
+    out.append(n.toByte)
 
   // §7.2 canonical child order: emit elements member by member, in member
   // declaration order, preserving source order within a single member.

--- a/lib/turbulence/src/core/turbulence.LineSeparation.scala
+++ b/lib/turbulence/src/core/turbulence.LineSeparation.scala
@@ -344,6 +344,10 @@ object LineSeparation:
       // The incomplete current line's bytes, carried across steps: the
       // counterpart of the char duct's `StringBuilder`, and free of its coder
       // trap, since bytes carry no encoding state to inflate.
+      // Not a `Scribe`: this is a long-lived field which is reset and reused across steps, and
+      // decoded through `toString(charset)`. `Array.collect` lends a scribe and freezes it when
+      // the lender returns — that confinement is exactly what makes the freeze sound — so a
+      // resettable buffer held as a field is a different shape, not a missing method.
       private val partial: ji.ByteArrayOutputStream = ji.ByteArrayOutputStream(64)
 
       // A separator's first byte at a window boundary (10 or 13; 0 = none).

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -349,15 +349,15 @@ extension (stream: Chain[Data])
           val free = destSize - destPos
 
           if ready < free then
-            dest.copyFrom(source, sourcePos, destPos, ready)
+            dest.place(source, sourcePos, destPos, ready)
             recur(more, 0, dest, destSize, destPos + ready)
           else if free < ready then
-            dest.copyFrom(source, sourcePos, destPos, free)
+            dest.place(source, sourcePos, destPos, free)
             val chunk = Array.freeze(dest)
             val size = newSize()
             chunk.asInstanceOf[Data] #:: recur(stream, sourcePos + free, newArray(size), size, 0)
           else // free == ready
-            dest.copyFrom(source, sourcePos, destPos, free)
+            dest.place(source, sourcePos, destPos, free)
             val chunk = Array.freeze(dest)
             val size = newSize()
             chunk.asInstanceOf[Data] #:: recur(more, 0, newArray(size), size, 0)
@@ -366,7 +366,7 @@ extension (stream: Chain[Data])
           if destPos == 0 then Chain()
           else
             val out = Array.allocate[Byte](destPos)
-            out.copyFrom(Array.freeze(dest), 0, 0, destPos)
+            out.place(Array.freeze(dest), 0, 0, destPos)
             Chain(Array.freeze(out).asInstanceOf[Data])
 
     val size = newSize()

--- a/lib/ulysses/src/core/ulysses.BloomFilter.scala
+++ b/lib/ulysses/src/core/ulysses.BloomFilter.scala
@@ -73,7 +73,7 @@ case class BloomFilter[element: Digestible, algorithm <: Algorithm]
 
         while rest.nonEmpty do
           val chunk = rest.head
-          whole.copyFrom(chunk, 0, offset, chunk.length)
+          whole.place(chunk, 0, offset, chunk.length)
           offset += chunk.length
           rest = rest.tail
 

--- a/lib/ulysses/src/core/ulysses.Palimpsest.scala
+++ b/lib/ulysses/src/core/ulysses.Palimpsest.scala
@@ -75,7 +75,7 @@ object Palimpsest:
       k += 1
 
     val out = Array.allocate[Byte](bodyLen + 1)
-    out.copyFrom(body, 0, 0, bodyLen)
+    out.place(body, 0, 0, bodyLen)
     out(bodyLen) = (xor ^ (cadence.byte & 0xff)).toByte
 
     Palimpsest(Array.freeze(out), n)

--- a/lib/vivisection/src/core/vivisection.Jdwp.scala
+++ b/lib/vivisection/src/core/vivisection.Jdwp.scala
@@ -48,7 +48,7 @@ import coaxial.*
 // caller's argument lists, of a handful of elements.
 import denominative.dysasymptotics.linearSize
 import denominative.size
-import rudiments.{Atomic, each}
+import rudiments.{Atomic, collect, each}
 import contingency.*
 import fulminate.*
 import gossamer.*
@@ -333,24 +333,25 @@ object Jdwp:
 
   private[vivisection] def encodeModifiedUtf8(text: Text): scala.Array[Byte] =
     val string = text.s
-    val buffer = ji.ByteArrayOutputStream()
-    var index = 0
 
-    while index < string.length do
-      val char = string.charAt(index).toInt
+    val encoded = Array.collect[Byte](string.length): buffer =>
+      var index = 0
 
-      if char >= 0x01 && char <= 0x7f then buffer.write(char)
-      else if char <= 0x7ff then
-        buffer.write(0xc0 | (char >> 6))
-        buffer.write(0x80 | (char & 0x3f))
-      else
-        buffer.write(0xe0 | (char >> 12))
-        buffer.write(0x80 | ((char >> 6) & 0x3f))
-        buffer.write(0x80 | (char & 0x3f))
+      while index < string.length do
+        val char = string.charAt(index).toInt
 
-      index += 1
+        if char >= 0x01 && char <= 0x7f then buffer.append(char.toByte)
+        else if char <= 0x7ff then
+          buffer.append((0xc0 | (char >> 6)).toByte)
+          buffer.append((0x80 | (char & 0x3f)).toByte)
+        else
+          buffer.append((0xe0 | (char >> 12)).toByte)
+          buffer.append((0x80 | ((char >> 6) & 0x3f)).toByte)
+          buffer.append((0x80 | (char & 0x3f)).toByte)
 
-    buffer.toByteArray.nn
+        index += 1
+
+    Array.unsafeJvm(encoded)
 
   // Decodes a JDWP packet payload. Big-endian throughout; identifier reads consult the negotiated
   // `sizes`. Stateful and single-threaded — one reader decodes one reply or one event, in order.

--- a/lib/vivisection/src/core/vivisection.Jdwp.scala
+++ b/lib/vivisection/src/core/vivisection.Jdwp.scala
@@ -435,6 +435,9 @@ object Jdwp:
   // Marshals a JDWP packet payload. Fluent: each write returns the writer. `data` snapshots the
   // accumulated bytes.
   class Writer(sizes: IdSizes):
+    // Field-held, like the reader's accumulator below and `turbulence.LineSeparation`'s partial
+    // line: `Array.collect` lends a scribe and freezes it when the lender returns, which is what
+    // makes the freeze sound, so a buffer that outlives a single expression cannot use it.
     private val out = ji.ByteArrayOutputStream()
 
     def byte(value: Byte): Writer = { out.write(value.toInt & 0xff); this }
@@ -753,6 +756,8 @@ object Jdwp:
       // thread off the channel's first (blocking) refill before the writer has started.
       val reader: Task[Unit] = async:
         val source = duplex.source
+        // Reset and refilled with the leftover of each partial packet, so field-held; see
+        // `Writer` above.
         val accumulator = ji.ByteArrayOutputStream()
         var handshaken = false
 

--- a/lib/xenophile/src/lira/xenophile.CHeaderAtomizer.scala
+++ b/lib/xenophile/src/lira/xenophile.CHeaderAtomizer.scala
@@ -51,31 +51,29 @@ import denominative.size
 object CHeaderAtomizer:
   val id: Text = t"cheader/1"
 
-  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+  private def uvarint(out: Scribe[Byte], value0: Long): Unit =
     var value = value0
 
     while value >= 0x80L do
-      out.write(((value & 0x7f) | 0x80).toInt)
+      out.append(((value & 0x7f) | 0x80).toByte)
       value >>>= 7
 
-    out.write(value.toInt)
+    out.append(value.toByte)
 
-  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
-    val bytes = text.s.getBytes("UTF-8").nn
+  private def utf8(out: Scribe[Byte], text: Text): Unit =
+    val bytes = Array.unsafeFrozen(text.s.getBytes("UTF-8").nn)
     uvarint(out, bytes.length.toLong)
-    out.write(bytes)
+    out.append(bytes)
 
-  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+  private def tag(out: Scribe[Byte], char: Char): Unit = out.append(char.toByte)
 
-  private def flag(out: java.io.ByteArrayOutputStream, value: Boolean): Unit =
-    out.write(if value then 1 else 0)
+  private def flag(out: Scribe[Byte], value: Boolean): Unit =
+    if value then out.append(1) else out.append(0)
 
-  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
-    val out = java.io.ByteArrayOutputStream()
-    encode(out)
-    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+  private def hash(encode: Scribe[Byte] => Unit): Data =
+    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.collect[Byte]()(encode))
 
-  private def encode(out: java.io.ByteArrayOutputStream, typed: Foreign.Type): Unit =
+  private def encode(out: Scribe[Byte], typed: Foreign.Type): Unit =
     typed match
       case Foreign.Type.Named(name) =>
         tag(out, 'N')

--- a/lib/xenophile/src/lira/xenophile.DtsAtomizer.scala
+++ b/lib/xenophile/src/lira/xenophile.DtsAtomizer.scala
@@ -64,29 +64,27 @@ object DtsAtomizer:
 
   // --- canonical binary encoding ---------------------------------------------------------------
 
-  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+  private def uvarint(out: Scribe[Byte], value0: Long): Unit =
     var value = value0
 
     while value >= 0x80L do
-      out.write(((value & 0x7f) | 0x80).toInt)
+      out.append(((value & 0x7f) | 0x80).toByte)
       value >>>= 7
 
-    out.write(value.toInt)
+    out.append(value.toByte)
 
-  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
-    val bytes = text.s.getBytes("UTF-8").nn
+  private def utf8(out: Scribe[Byte], text: Text): Unit =
+    val bytes = Array.unsafeFrozen(text.s.getBytes("UTF-8").nn)
     uvarint(out, bytes.length.toLong)
-    out.write(bytes)
+    out.append(bytes)
 
-  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+  private def tag(out: Scribe[Byte], char: Char): Unit = out.append(char.toByte)
 
-  private def flag(out: java.io.ByteArrayOutputStream, value: Boolean): Unit =
-    out.write(if value then 1 else 0)
+  private def flag(out: Scribe[Byte], value: Boolean): Unit =
+    if value then out.append(1) else out.append(0)
 
-  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
-    val out = java.io.ByteArrayOutputStream()
-    encode(out)
-    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+  private def hash(encode: Scribe[Byte] => Unit): Data =
+    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.collect[Byte]()(encode))
 
   // --- types -----------------------------------------------------------------------------------
 
@@ -94,7 +92,7 @@ object DtsAtomizer:
   // renaming `T` to `U` throughout a declaration changes nothing a consumer can observe, and
   // must therefore change no atom. `binders` holds the enclosing binder scopes, innermost last.
   private def encode
-    ( out:     java.io.ByteArrayOutputStream,
+    ( out:     Scribe[Byte],
       typed:   Typescript.Type,
       binders: List[List[Text]] )
   :   Unit =
@@ -208,7 +206,7 @@ object DtsAtomizer:
         encode(out, result, inner)
 
   private def sorted
-    ( out:     java.io.ByteArrayOutputStream,
+    ( out:     Scribe[Byte],
       members: List[Typescript.Type],
       binders: List[List[Text]] )
   :   Unit =
@@ -217,11 +215,11 @@ object DtsAtomizer:
     // fails capture checking here, because the vector's `prefix1` array carries a root
     // capability that cannot flow into the traversal evidence's empty capture set.
     val encodings = members.stdlib.map: member =>
-      val buffer = java.io.ByteArrayOutputStream()
-      encode(buffer, member, binders)
+      val buffer = Array.collect[Byte](): buffer =>
+        encode(buffer, member, binders)
       // An immutable view: the sort's comparator would otherwise capture the mutable arrays
       // exclusively, which capture checking rejects.
-      val bytes: scala.Array[Byte] = buffer.toByteArray().nn
+      val bytes: scala.Array[Byte] = Array.unsafeJvm(buffer)
       // An immutable, unsigned view: the comparator would otherwise capture the mutable arrays
       // exclusively, which capture checking rejects, and signed bytes would sort wrongly.
       scala.Vector.tabulate(bytes.length) { index => bytes(index) & 0xff }
@@ -230,7 +228,7 @@ object DtsAtomizer:
 
     encodings.sortWith { (left, right) => compare(left, right) < 0 }.foreach: encoding =>
       uvarint(out, encoding.length.toLong)
-      encoding.foreach { byte => out.write(byte) }
+      encoding.foreach { byte => out.append(byte.toByte) }
 
   // Sorting by encoded bytes, rather than by rendered text, keeps the order a property of the
   // structure: two types that encode identically must sort adjacently whatever they were called.
@@ -246,7 +244,7 @@ object DtsAtomizer:
     if result != 0 then result else left.length - right.length
 
   private def encodeMember
-    ( out:     java.io.ByteArrayOutputStream,
+    ( out:     Scribe[Byte],
       member:  Typescript.Member,
       binders: List[List[Text]] )
   :   Unit =
@@ -356,7 +354,7 @@ object DtsAtomizer:
     atoms.toList.to(List)
 
   private def parameters
-    ( out:     java.io.ByteArrayOutputStream,
+    ( out:     Scribe[Byte],
       typed:   List[Typescript.Type.Parameter],
       binders: List[List[Text]] )
   :   Unit =

--- a/lib/xenophile/src/lira/xenophile.KotlinMetadataAtomizer.scala
+++ b/lib/xenophile/src/lira/xenophile.KotlinMetadataAtomizer.scala
@@ -64,29 +64,27 @@ object KotlinMetadataAtomizer:
 
   // --- canonical binary encoding -------------------------------------------------------------
 
-  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+  private def uvarint(out: Scribe[Byte], value0: Long): Unit =
     var value = value0
 
     while value >= 0x80L do
-      out.write(((value & 0x7f) | 0x80).toInt)
+      out.append(((value & 0x7f) | 0x80).toByte)
       value >>>= 7
 
-    out.write(value.toInt)
+    out.append(value.toByte)
 
-  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
-    val bytes = text.s.getBytes("UTF-8").nn
+  private def utf8(out: Scribe[Byte], text: Text): Unit =
+    val bytes = Array.unsafeFrozen(text.s.getBytes("UTF-8").nn)
     uvarint(out, bytes.length.toLong)
-    out.write(bytes)
+    out.append(bytes)
 
-  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+  private def tag(out: Scribe[Byte], char: Char): Unit = out.append(char.toByte)
 
-  private def flag(out: java.io.ByteArrayOutputStream, value: Boolean): Unit =
-    out.write(if value then 1 else 0)
+  private def flag(out: Scribe[Byte], value: Boolean): Unit =
+    if value then out.append(1) else out.append(0)
 
-  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
-    val out = java.io.ByteArrayOutputStream()
-    encode(out)
-    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+  private def hash(encode: Scribe[Byte] => Unit): Data =
+    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.collect[Byte]()(encode))
 
   // --- type rendering -------------------------------------------------------------------------
 

--- a/lib/xenophile/src/lira/xenophile.WebIdlAtomizer.scala
+++ b/lib/xenophile/src/lira/xenophile.WebIdlAtomizer.scala
@@ -64,32 +64,30 @@ object WebIdlAtomizer:
 
   // --- canonical binary encoding -------------------------------------------------------------
 
-  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+  private def uvarint(out: Scribe[Byte], value0: Long): Unit =
     var value = value0
 
     while value >= 0x80L do
-      out.write(((value & 0x7f) | 0x80).toInt)
+      out.append(((value & 0x7f) | 0x80).toByte)
       value >>>= 7
 
-    out.write(value.toInt)
+    out.append(value.toByte)
 
-  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
-    val bytes = text.s.getBytes("UTF-8").nn
+  private def utf8(out: Scribe[Byte], text: Text): Unit =
+    val bytes = Array.unsafeFrozen(text.s.getBytes("UTF-8").nn)
     uvarint(out, bytes.length.toLong)
-    out.write(bytes)
+    out.append(bytes)
 
-  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+  private def tag(out: Scribe[Byte], char: Char): Unit = out.append(char.toByte)
 
-  private def flag(out: java.io.ByteArrayOutputStream, value: Boolean): Unit =
-    out.write(if value then 1 else 0)
+  private def flag(out: Scribe[Byte], value: Boolean): Unit =
+    if value then out.append(1) else out.append(0)
 
-  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
-    val out = java.io.ByteArrayOutputStream()
-    encode(out)
-    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+  private def hash(encode: Scribe[Byte] => Unit): Data =
+    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.collect[Byte]()(encode))
 
   // Union members sort by their encoded bytes (`webidl.md` §7): `(A or B)` is `(B or A)`.
-  private def encode(out: java.io.ByteArrayOutputStream, typed: Foreign.Type): Unit =
+  private def encode(out: Scribe[Byte], typed: Foreign.Type): Unit =
     typed match
       case Foreign.Type.Named(name) =>
         tag(out, 'N')
@@ -102,16 +100,17 @@ object WebIdlAtomizer:
         // fails capture checking here, because the vector's `prefix1` array carries a root
         // capability that cannot flow into the traversal evidence's empty capture set.
         val encodings = members.stdlib.map: member =>
-          val buffer = java.io.ByteArrayOutputStream()
-          encode(buffer, member)
-          val bytes: scala.Array[Byte] = buffer.toByteArray().nn
+          val collected = Array.collect[Byte](): buffer =>
+            encode(buffer, member)
+
+          val bytes: scala.Array[Byte] = Array.unsafeJvm(collected)
           scala.Vector.tabulate(bytes.length) { index => bytes(index) & 0xff }
 
         uvarint(out, encodings.length.toLong)
 
         encodings.sortWith { (left, right) => compare(left, right) < 0 }.foreach: encoding =>
           uvarint(out, encoding.length.toLong)
-          encoding.foreach { byte => out.write(byte) }
+          encoding.foreach { byte => out.append(byte.toByte) }
 
       case Foreign.Type.Applied(constructor, arguments) =>
         tag(out, 'A')
@@ -132,7 +131,7 @@ object WebIdlAtomizer:
 
   // Argument *names* are not folded — WebIDL calls are positional — while optionality,
   // variadicity and a default's existence decide which calls are legal, so all three are.
-  private def arguments(out: java.io.ByteArrayOutputStream, list: List[WebIdl.Argument]): Unit =
+  private def arguments(out: Scribe[Byte], list: List[WebIdl.Argument]): Unit =
     uvarint(out, list.size.toLong)
 
     list.each: argument =>
@@ -142,7 +141,7 @@ object WebIdlAtomizer:
       encode(out, argument.typed)
 
   private def encodeMember
-    ( out: java.io.ByteArrayOutputStream, container: Text, member: WebIdl.Member )
+    ( out: Scribe[Byte], container: Text, member: WebIdl.Member )
   :   Unit =
 
     // The container's key folds into the value, not merely the atom's key: the snapshot hashes

--- a/lib/xenophile/src/lira/xenophile.WitAtomizer.scala
+++ b/lib/xenophile/src/lira/xenophile.WitAtomizer.scala
@@ -68,29 +68,27 @@ object WitAtomizer:
 
   // --- canonical binary encoding -------------------------------------------------------------
 
-  private def uvarint(out: java.io.ByteArrayOutputStream, value0: Long): Unit =
+  private def uvarint(out: Scribe[Byte], value0: Long): Unit =
     var value = value0
 
     while value >= 0x80L do
-      out.write(((value & 0x7f) | 0x80).toInt)
+      out.append(((value & 0x7f) | 0x80).toByte)
       value >>>= 7
 
-    out.write(value.toInt)
+    out.append(value.toByte)
 
-  private def utf8(out: java.io.ByteArrayOutputStream, text: Text): Unit =
-    val bytes = text.s.getBytes("UTF-8").nn
+  private def utf8(out: Scribe[Byte], text: Text): Unit =
+    val bytes = Array.unsafeFrozen(text.s.getBytes("UTF-8").nn)
     uvarint(out, bytes.length.toLong)
-    out.write(bytes)
+    out.append(bytes)
 
-  private def tag(out: java.io.ByteArrayOutputStream, char: Char): Unit = out.write(char.toInt)
+  private def tag(out: Scribe[Byte], char: Char): Unit = out.append(char.toByte)
 
-  private def flag(out: java.io.ByteArrayOutputStream, value: Boolean): Unit =
-    out.write(if value then 1 else 0)
+  private def flag(out: Scribe[Byte], value: Boolean): Unit =
+    if value then out.append(1) else out.append(0)
 
-  private def hash(encode: java.io.ByteArrayOutputStream => Unit): Data =
-    val out = java.io.ByteArrayOutputStream()
-    encode(out)
-    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.unsafeFrozen(out.toByteArray.nn))
+  private def hash(encode: Scribe[Byte] => Unit): Data =
+    Lira.Hash(Lira.Hash.Domain.Atom(id), Array.collect[Byte]()(encode))
 
   private val primitives: Set[Text] =
     Set(t"bool", t"u8", t"u16", t"u32", t"u64", t"s8", t"s16", t"s32", t"s64", t"f32", t"f64",
@@ -103,7 +101,7 @@ object WitAtomizer:
   // declaring interface's id, `use`-imported names under the interface they came from. A name
   // that resolves to neither is a hard error, never a guess.
   private def encode
-    ( out:   java.io.ByteArrayOutputStream,
+    ( out:   Scribe[Byte],
       typed: Foreign.Type,
       scope: Map[Text, Text] )
   :   Unit raises Discipline.Error =

--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -1163,8 +1163,8 @@ object internal:
 
         if idx < 0 then attrs else
           val nu = Array.allocate[String](n - 2)
-          if idx > 0 then nu.copyFrom(Array.frozen(attrs), 0, 0, idx)
-          if idx < n - 2 then nu.copyFrom(Array.frozen(attrs), idx + 2, idx, n - 2 - idx)
+          if idx > 0 then nu.place(Array.frozen(attrs), 0, 0, idx)
+          if idx < n - 2 then nu.place(Array.frozen(attrs), idx + 2, idx, n - 2 - idx)
           Array.freeze(nu).readable
 
       inline def `-`(key: Text): Attributes = removed(key)
@@ -1188,12 +1188,12 @@ object internal:
 
         if idx >= 0 then
           val nu = Array.allocate[String](n)
-          nu.copyFrom(Array.frozen(attrs), 0, 0, n)
+          nu.place(Array.frozen(attrs), 0, 0, n)
           nu(idx + 1) = value.s
           Array.freeze(nu).readable
         else
           val nu = Array.allocate[String](n + 2)
-          nu.copyFrom(Array.frozen(attrs), 0, 0, n)
+          nu.place(Array.frozen(attrs), 0, 0, n)
           nu(n) = keyStr
           nu(n + 1) = value.s
           Array.freeze(nu).readable
@@ -1246,7 +1246,7 @@ object internal:
 
           if written == total then frozen.readable else
             val tu = Array.allocate[String](written)
-            tu.copyFrom(frozen, 0, 0, written)
+            tu.place(frozen, 0, 0, written)
             Array.freeze(tu).readable
 
       def `++`(other: Map[Text, Text]): Attributes =

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -801,7 +801,7 @@ object Yaml extends Yaml2, Dynamic:
       if (n & 1) == 1 then items.asInstanceOf[Yaml.Ast]
       else
         val padded = Array.allocate[Any](n + 1)
-        padded.copyFrom(items.asInstanceOf[Array[Any]^{}], 0, 0, n)
+        padded.place(items.asInstanceOf[Array[Any]^{}], 0, 0, n)
         padded(n) = arrayPad
         Array.freeze(padded).asInstanceOf[Yaml.Ast]
 
@@ -829,7 +829,7 @@ object Yaml extends Yaml2, Dynamic:
       if (n & 1) == 1 then items.asInstanceOf[Yaml.Ast]
       else
         val padded = Array.allocate[Any](n + 1)
-        padded.copyFrom(items, 0, 0, n)
+        padded.place(items, 0, 0, n)
         padded(n) = arrayPad
         Array.freeze(padded).asInstanceOf[Yaml.Ast]
 
@@ -911,7 +911,7 @@ object Yaml extends Yaml2, Dynamic:
 
           if n > 0 && (xs(n - 1).asInstanceOf[AnyRef] eq arrayPad) then
             val out = Array.allocate[Any](n - 1)
-            out.copyFrom(xs.asInstanceOf[Array[Any]^{}], 0, 0, n - 1)
+            out.place(xs.asInstanceOf[Array[Any]^{}], 0, 0, n - 1)
             Some(Array.freeze(out).asInstanceOf[Array[Yaml.Ast]^{}])
           else
             Some(xs.asInstanceOf[Array[Yaml.Ast]^{}])
@@ -1595,12 +1595,12 @@ object Yaml extends Yaml2, Dynamic:
             val out =
               if existing >= 0 then
                 val arr = Array.allocate[Any](xs.length)
-                arr.copyFrom(xs.asInstanceOf[Array[Any]^{}], 0, 0, xs.length)
+                arr.place(xs.asInstanceOf[Array[Any]^{}], 0, 0, xs.length)
                 arr(existing + 1) = Yaml.Ast.Str(kind).asInstanceOf[Any]
                 Array.freeze(arr)
               else
                 val arr = Array.allocate[Any](xs.length + 2)
-                arr.copyFrom(xs.asInstanceOf[Array[Any]^{}], 0, 0, xs.length)
+                arr.place(xs.asInstanceOf[Array[Any]^{}], 0, 0, xs.length)
                 arr(xs.length)     = Yaml.Ast.Str(label).asInstanceOf[Any]
                 arr(xs.length + 1) = Yaml.Ast.Str(kind).asInstanceOf[Any]
                 Array.freeze(arr)
@@ -1630,9 +1630,9 @@ object Yaml extends Yaml2, Dynamic:
             if existing < 0 then yaml
             else
               val arr = Array.allocate[Any](xs.length - 2)
-              arr.copyFrom(xs.asInstanceOf[Array[Any]^{}], 0, 0, existing)
+              arr.place(xs.asInstanceOf[Array[Any]^{}], 0, 0, existing)
 
-              arr.copyFrom
+              arr.place
                 ( xs.asInstanceOf[Array[Any]^{}],
                   existing + 2,
                   existing,
@@ -6140,14 +6140,14 @@ extends Dynamic derives CanEqual:
       root.objectIndexOf(field) match
         case -1 =>
           val out = Array.allocate[Any](len + 2)
-          out.copyFrom(arr, 0, 0, len)
+          out.place(arr, 0, 0, len)
           out(len)     = field
           out(len + 1) = value.root.asInstanceOf[Any]
           Yaml.ast(Yaml.Ast.mapFromAnyArray(Array.freeze(out)))
 
         case index =>
           val out = Array.allocate[Any](len)
-          out.copyFrom(arr, 0, 0, len)
+          out.place(arr, 0, 0, len)
           out(index*2 + 1) = value.root.asInstanceOf[Any]
           Yaml.ast(Yaml.Ast.mapFromAnyArray(Array.freeze(out)))
 
@@ -6164,8 +6164,8 @@ extends Dynamic derives CanEqual:
 
         case index =>
           val out = Array.allocate[Any](len - 2)
-          out.copyFrom(arr, 0, 0, index*2)
-          out.copyFrom(arr, index*2 + 2, index*2, len - index*2 - 2)
+          out.place(arr, 0, 0, index*2)
+          out.place(arr, index*2 + 2, index*2, len - index*2 - 2)
           Yaml.ast(Yaml.Ast.mapFromAnyArray(Array.freeze(out)))
 
   override def hashCode: Int = Yaml.Ast.deepHash(root)

--- a/lib/zeppelin/src/core/zeppelin.Zip.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zip.scala
@@ -273,10 +273,14 @@ object Zip:
     deflater.setInput(Array.unsafeJvm(data))
     deflater.finish()
     val buffer = new scala.Array[Byte](8192)
-    val out = ji.ByteArrayOutputStream()
-    while !deflater.finished() do out.write(buffer, 0, deflater.deflate(buffer))
+
+    val deflated = Array.collect[Byte](): out =>
+      while !deflater.finished()
+      do out.append(Array.unsafeFrozen(buffer), 0, deflater.deflate(buffer))
+
     deflater.end()
-    Array.unsafeFrozen(out.toByteArray.nn)
+
+    deflated
 
   // ZipError -> Zip.Error
   object Error:


### PR DESCRIPTION
Three follow-ups to the `Atomic` work, each reducing what Soundness reaches for from the Java standard library, or proving that what it already claims is true.

The zero-cost claim `Atomic` makes is now tested rather than asserted, `Array.copyFrom` takes the name the collection had already settled on, and `Scribe` grows — which is the one thing `java.io.ByteArrayOutputStream` was ever used for.

## The zero-cost claim is tested

`doc/philosophy/zero-cost.md` says a performance claim that is only stated tends to stop being true. `Atomic`'s was only stated. Eighteen probes are now read back out of the classfile through `mandible` and checked for the instruction they should have become — `since(_ + 1)` is `incrementAndGet`, `ere(_ + n)` is `getAndAdd`, `ere(value)` is `getAndSet`, a general transition is a compare-and-set loop with no closure and no boxing, and a reference read reaches no `nnFail`. The suite was itself checked against a deliberate regression: swapping a release store for a volatile one fails it.

`doc/philosophy/immutability.md` said three places in Soundness are deliberately mutable and each is confined, "never a property of a value that others can see". An atomic cell is the deliberate opposite, and the collection now holds one in eleven modules, so the document gains a fourth case saying what replaces confinement: the location is a single machine word and every operation on it is indivisible, so the type promises not that the mutation is invisible but that it cannot be caught half-done.

## `place`, not `copyFrom`

`place` already meant "copy a source into the receiver" in two places — `rudiments.place` and `concordance.Scribe#place` — so `copyFrom` was the odd one out, and two words where the vocabulary had settled on one. `snapshot` is its counterpart, copying out into a fresh array.

```scala
buffer.place(source)              // the whole source, at the start
buffer.place(source, at)          // the whole source, at a position
buffer.place(source, from, to, n) // a window
```

Indices stay `Int`, matching `Array`'s own `apply` and `update`: `denominative` sits above `proscenium`, so an ordinal cannot be named there.

## A `Scribe` can grow

Across a dozen libraries `ByteArrayOutputStream` was never used as a stream. It was a byte buffer that grows: 173 `write` calls, 47 `toByteArray`, and the `flush` and `close` calls only satisfying `OutputStream`. `Scribe` was already the collection's "write into a buffer through a cursor" concept, but fixed-size.

```scala
Array.scribe[Int](5): scribe => extent => …   // size known: an array of exactly that size
Array.collect[Byte](): scribe =>              // size unknown: grows, yields what was written
  scribe.append(0x1f)
  scribe.append(chunk)
  scribe.append(chunk, from, count)
```

Growth is opt-in, so `Array.scribe`'s promise of an exact size is untouched. `append` gains bulk overloads at the cursor, which `place` cannot serve — it takes an `Ordinal in scribe.type`, and an unsized scribe hands out no branded extent to draw one from.

Against the JDK class: `append` takes a `Byte`, so `append(300)` does not compile where `write(300)` silently stored 44, while an in-range literal still needs no `.toByte`; nothing is synchronized, because the buffer belongs to the block that built it; nothing declares an `IOException` it cannot throw; and the terminal freeze does not copy when the buffer filled exactly.

Fourteen of the twenty-five uses are migrated. Of the rest, two are genuine `OutputStream` sinks (`Manifest.write` and `ImageIO.write` write *into* the stream they are given), five hold the buffer in a field and reset or reuse it, and the remainder are tests and benchmarks, deferred as the `.stdlib` ratchet defers them. Each exception carries the reason beside it.
