### PR TITLE
Select tests by tag, exclude with not:, and list axes for completion

### DIFF
--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -124,6 +124,64 @@ not yet been recorded here.
 - `probably.harnesses.threadLocal` renamed to `threadLocalHarness`. (#1939)
 - `probably.autopsies.none` renamed to `noAutopsy`; `autopsies.contrastExpectations` renamed to
   `contrastAutopsy`. (#1939)
+- New `probably.Tag` (`into case class Tag(name: Name[Tagging])`, with `def text: Text`) and
+  naming plane `probably.Tagging` (`Tagging is Nominative under
+  MustMatch["[A-Za-z_][A-Za-z0-9_-]*"]`), whose given is exported at package level as
+  `probably.taggingNominative` (and `soundness.taggingNominative`) alongside the existing
+  `probably.nominative`. `Tag.conversion: Conversion[Name[Tagging], Tag]` lets an `n"…"` literal
+  stand as a `Tag`. `Tag` itself is not re-exported by `soundness` (`soundness.Tag` remains
+  `honeycomb.Tag`); name it as `probably.Tag`. `Tagging` is re-exported. Neither `nominative` given is brought into scope by `import probably.*` or
+  `import soundness.*`; a suite using `n"…"` literals must import them by name.
+- `probably.Test.Id` gained a fifth field `tags: List[Tag] = Nil` after `moniker`; case-class
+  equality, `unapply` and `copy` include it.
+- `probably.test(name: Message)(using Testable, Codepoint): Test.Id` is now
+  `test(name: Message, tags: Tag*)(using Testable, Codepoint): Test.Id`, and
+  `test(name: Name[Probing], description: Message)(using Testable, Codepoint): Test.Id` is now
+  `test(name: Name[Probing], description: Message, tags: Tag*)(using Testable, Codepoint): Test.Id`.
+  Calls without tags are unchanged; a `test(name)(body)` application still resolves.
+- `probably.Selection` gained fields, in order after `constraints`: `tags: List[Set[Text]]`,
+  `exclusions: List[Selection]`. The full constructor is now
+  `Selection(terms, kinds, constraints, tags, exclusions, listOnly, scale)`; positional
+  construction and `unapply` must change. `Selection.trivial` is true only when `tags` and
+  `exclusions` are also empty.
+- `probably.Selection#admits(id: Test.Id, kind: Entry.Kind, coordinates: List[(Axis.Spec, Value)]): Boolean`
+  is now `admits(id: Test.Id, kind: Entry.Kind, coordinates: List[(Axis.Spec, Value)], tags: List[Tag]): Boolean`.
+- `probably.Selection.parse` now recognises four more term forms: `tag:<t1>,<t2>` (admits a test
+  carrying any listed tag; repeated `tag:` terms intersect), `not:<term>` (parsed as a one-term
+  `Selection` appended to `exclusions`; a cell any exclusion would admit is rejected, where a
+  constraint on an axis the cell lacks matches nothing rather than everything), `<axis>=<lo>..`
+  (parsed as `Constraint.Least(axis, lo, inclusive = true)`) and `<axis>=..<hi>` (parsed as
+  `Constraint.Most(axis, hi, inclusive = true)`); an empty argument is ignored. Previously
+  `tag:x` and `not:x` parsed as name globs, `N=4..` as `Membership(N, {"4.."})`, and `""` as
+  a glob.
+- `probably.Runner#listed: List[(Test.Id, Entry.Kind, Optional[Long])]` is now
+  `listed: List[Runner.Scheduled]`, where new
+  `Runner.Scheduled(id: Test.Id, kind: Entry.Kind, expected: Optional[Long], axes: List[Axis.Schedule])`
+  has `def tags: List[Tag] = id.tags`.
+- New `probably.Axis.Schedule(spec: Axis.Spec, values: List[Value], least: Optional[Double] = Unset, most: Optional[Double] = Unset)`
+  and new `probably.Runner#declare(id: Test.Id, kind: Entry.Kind, axis: Axis.Spec, least: Optional[Double], most: Optional[Double]): Unit`
+  (a listing-mode announcement of an emergent axis's bounds; a no-op otherwise).
+- `probably.TestEvent.TestScheduled(test: Ref, kind: Text, expected: Optional[Long])` is now
+  `TestScheduled(test: Ref, kind: Text, expected: Optional[Long], tags: List[Text], axes: List[TestEvent.AxisSchedule])`,
+  with new `TestEvent.AxisSchedule(axis: Text, domain: Text, emergent: Boolean, values: List[Text], least: Optional[Double], most: Optional[Double])`
+  and `AxisSchedule.of(schedule: Axis.Schedule): AxisSchedule`. The derived BinTEL schema of
+  `TestEvent`, and so `probably.Streamer.fingerprint`, changes: a consumer built against the
+  previous layout reports the stream incompatible.
+
+## sedentary
+
+- `sedentary.Bench#apply(name: Message)(target, operationSize, iterations, warmups, confidence, baseline, comparison): Bench.Plan`
+  is now `apply(name: Message, tags: Tag*)(…same second list…): Bench.Plan`, and
+  `sedentary.Bench.Plan` gained a third field `tags: List[Tag]` between `name` and `target`
+  (positional construction and `unapply` must change).
+- `sedentary.Stress#apply(name: Message)(target, concurrency, sweep, threshold, compliance)(body)`
+  is now `apply(name: Message, tags: Tag*)(…)(body)`, and
+  `sedentary.Profile#apply(name: Message)(target, frames)(body)` is now
+  `apply(name: Message, tags: Tag*)(target, frames)(body)`. Each threads the tags into the
+  `Test.Id` it builds.
+- `sedentary.Stress#apply` now calls `Runner#declare` with an emergent integral `N` axis bounded
+  by `concurrency` (default 1) and the sweep limit before calling `Runner#skip`, so a `--list`
+  of a stress test reports an `N` axis with bounds.
 
 ## iridescence
 

--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -118,8 +118,14 @@ abstract class Suite(suiteName: Message) extends Testable(suiteName):
       try
         runner.suite(testableView, run())
 
-        runner.listed.each: (id, kind, expected) =>
-          sink(TestEvent.TestScheduled(TestEvent.Ref.of(id), TestEvent.kindName(kind), expected))
+        runner.listed.each: scheduled =>
+          sink:
+            TestEvent.TestScheduled
+              ( TestEvent.Ref.of(scheduled.id),
+                TestEvent.kindName(scheduled.kind),
+                scheduled.expected,
+                scheduled.tags.map(_.text),
+                scheduled.axes.map(TestEvent.AxisSchedule.of(_)) )
 
         0
       catch case error: Throwable => 2

--- a/lib/probably/src/core/probably.Axis.scala
+++ b/lib/probably/src/core/probably.Axis.scala
@@ -89,6 +89,17 @@ object Axis:
   // domain.
   case class Spec(label: Text, domain: Domain, emergent: Boolean = false)
 
+  // What a listing knows of one axis of a test before anything runs: its spec, the distinct
+  // values of the cells the selection admits in first-appearance order (none for an
+  // emergent axis, whose values the run produces), and — for an emergent axis whose
+  // producer declares them — the bounds its values will lie within, such as a stress
+  // sweep's starting and maximum concurrency. A host completes axis constraints from these.
+  case class Schedule
+    ( spec:   Spec,
+      values: List[Value],
+      least:  Optional[Double] = Unset,
+      most:   Optional[Double] = Unset )
+
   def apply[value: Axable](label: Text)(values: value*): Axis[value] =
     new Axis(label, values.to(List))
 

--- a/lib/probably/src/core/probably.Runner.scala
+++ b/lib/probably/src/core/probably.Runner.scala
@@ -34,6 +34,7 @@ package probably
 
 import anticipation.*
 import rudiments.*
+import symbolism.*
 import vacuous.*
 
 import beneficence.*
@@ -43,13 +44,25 @@ import denominative.dysasymptotics.linearSize
 object Runner:
   private[probably] val harnessThreadLocal: ThreadLocal[Option[Harness]] = ThreadLocal()
 
+  // One row of a listing: a test the selection admits, its kind, the expected measuring
+  // time summed over its admitted cells (absent for untimed kinds), and its axes with the
+  // values (or declared bounds) of those cells. The tags are the test's own.
+  case class Scheduled
+    ( id: Test.Id, kind: Entry.Kind, expected: Optional[Long], axes: List[Axis.Schedule] ):
+
+    def tags: List[Tag] = id.tags
+
 class Runner[report](selection: Selection = Selection.all)(using reporter: Reporter[report])
 extends Findable:
   private val mutex: Mutex = Mutex()
   @scala.caps.unsafe.untrackedCaptures
   private var active: List[Test.Id] = Nil
   @scala.caps.unsafe.untrackedCaptures
-  private var listed0: List[(Test.Id, Entry.Kind, Optional[Long])] = Nil
+  private var listed0: List[(Test.Id, Entry.Kind, Optional[Long], List[(Axis.Spec, Value)])] =
+    Nil
+  @scala.caps.unsafe.untrackedCaptures
+  private var declared0: List[(Test.Id, Entry.Kind, Axis.Spec, Optional[Double], Optional[Double])] =
+    Nil
   @scala.caps.unsafe.untrackedCaptures
   private var admitted0: Int = 0
 
@@ -76,29 +89,63 @@ extends Findable:
       expected:    Optional[Long] )
   :   Boolean =
 
-    if !selection.admits(id, kind, coordinates) then true
+    if !selection.admits(id, kind, coordinates, id.tags) then true
     else if selection.listOnly then
-      mutex { listed0 = (id, kind, expected) :: listed0 }
+      mutex { listed0 = (id, kind, expected, coordinates) :: listed0 }
       true
     else
       mutex { admitted0 += 1 }
       false
 
+  // Announces, for a listing, an EMERGENT axis of a test whose coordinates only the run will
+  // produce (a stress sweep's `N`), with the bounds the producer knows at declaration, so a
+  // host can offer a range of it without iterating cells that do not yet exist. A no-op
+  // outside listing mode; the declaration is reported only if the test itself is listed.
+  def declare
+    ( id:    Test.Id,
+      kind:  Entry.Kind,
+      axis:  Axis.Spec,
+      least: Optional[Double],
+      most:  Optional[Double] )
+  :   Unit =
+
+    if selection.listOnly then mutex { declared0 = (id, kind, axis, least, most) :: declared0 }
+
   // One schedule row per test, in first-appearance order — an axial spread's cells each call
   // `skip`, but they are one test with coordinates, not many tests — with the row's expected
   // time the SUM over its admitted cells: what the test will spend measuring is the total of
   // the cells the selection admits. Absent estimates stay absent rather than becoming zero.
-  def listed: List[(Test.Id, Entry.Kind, Optional[Long])] = mutex:
+  // The row's axes are those of its admitted cells, in first-appearance order, each with the
+  // distinct values seen, followed by any declared emergent axes not seen among the cells.
+  def listed: List[Runner.Scheduled] = mutex:
     val entries = listed0.reverse
+    val declarations = declared0.reverse
 
-    entries.map { (id, kind, _) => (id, kind) }.distinct.map: (id, kind) =>
+    entries.map { entry => (entry(0), entry(1)) }.distinct.map: (id, kind) =>
+      val cells = entries.filter { entry => entry(0) == id && entry(1) == kind }
+
       val expected: Optional[Long] =
-        entries.fold(Unset: Optional[Long]): (sum, entry) =>
-          if entry(0) == id && entry(1) == kind
-          then entry(2).lay(sum) { value => sum.lay(value)(_ + value) }
-          else sum
+        cells.fold(Unset: Optional[Long]): (sum, entry) =>
+          entry(2).lay(sum) { value => sum.lay(value)(_ + value) }
 
-      (id, kind, expected)
+      val declared = declarations.filter { entry => entry(0) == id && entry(1) == kind }
+
+      val specs: List[Axis.Spec] =
+        cells.flatMap { entry => entry(3).map(_(0)) }.distinct
+
+      val seen: List[Axis.Schedule] = specs.map: spec =>
+        val values: List[Value] =
+          cells.flatMap { entry => entry(3).filter(_(0) == spec).map(_(1)) }.distinct
+
+        val bounds = declared.seek(_(2) == spec)
+        Axis.Schedule(spec, values, bounds.let(_(3)), bounds.let(_(4)))
+
+      val emergent: List[Axis.Schedule] =
+        declared.filter { entry => !specs.has(entry(2)) }.map: entry =>
+          Axis.Schedule(entry(2), Nil, entry(3), entry(4))
+
+      Runner.Scheduled(id, kind, expected, seen + emergent)
+
   def admitted: Int = mutex(admitted0)
 
   val report: report = reporter.report()

--- a/lib/probably/src/core/probably.Selection.scala
+++ b/lib/probably/src/core/probably.Selection.scala
@@ -56,7 +56,7 @@ object Selection:
 
     def axis: Text
 
-  val all: Selection = Selection(Nil, Nil, Nil, false, 1.0)
+  val all: Selection = Selection(Nil, Nil, Nil, Nil, Nil, false, 1.0)
 
   private def hex(text: Text): Boolean =
     text.length == 6 && text.s.forall: char => char.isDigit || (char >= 'a' && char <= 'f')
@@ -69,11 +69,15 @@ object Selection:
     if text.s.matches("-?[0-9]+(\\.[0-9]+)?") then text.s.toDouble else Unset
 
   // Parses command-line selection terms. Identity terms (hashes, monikers, name globs) are
-  // unioned; `kind:` terms and axis constraints (`parser=jacinta`, `N<32`, `N=4..64`)
-  // intersect with that union. Unrecognized terms are treated as name globs.
+  // unioned; `kind:` terms, `tag:` terms and axis constraints (`parser=jacinta`, `N<32`,
+  // `N=4..64`, `N=4..`, `N=..64`) intersect with that union; and `not:<term>` terms are
+  // subtracted last, each removing whatever its term would admit. Unrecognized terms are
+  // treated as name globs.
   def parse(arguments: List[Text]): Selection =
     arguments.fold(all): (selection, argument) =>
-      if argument == t"--list" then selection.copy(listOnly = true)
+      // An empty argument selects nothing and is not a term (so a bare `not:` is ignored).
+      if argument == t"" then selection
+      else if argument == t"--list" then selection.copy(listOnly = true)
       // `--scale=<factor>` is not a selection at all — it changes how long the tests it
       // admits are given to run — but it arrives on the same command line, and a host like
       // fume has no other channel to a suite. A non-positive or unparseable factor is
@@ -90,6 +94,20 @@ object Selection:
           case _          => Nil
 
         selection.copy(kinds = selection.kinds + kinds)
+      // `tag:a,b` admits a test carrying ANY of the listed tags; a second `tag:` term
+      // intersects with the first, so `tag:slow tag:network` means slow AND network.
+      else if argument.starts(t"tag:") then
+        val tags: Set[Text] = argument.skip(4).cut(t",").filter(_ != t"").to[Set]
+        if tags.nil then selection else selection.copy(tags = selection.tags :+ tags)
+      // `not:<term>` subtracts: the inner term is parsed as a selection of its own, and any
+      // cell it would admit is excluded. Each `not:` is independent (they union), so
+      // `not:tag:slow not:kind:bench` excludes every slow test AND every benchmark. An inner
+      // term that selects nothing in particular (`not:` alone, or `not:--list`) is ignored,
+      // as excluding everything could never be what was meant.
+      else if argument.starts(t"not:") then
+        val exclusion = parse(List(argument.skip(4)))
+        if exclusion.trivial then selection
+        else selection.copy(exclusions = selection.exclusions :+ exclusion)
       else constraint(argument).lay(selection.copy(terms = selection.terms :+ term(argument))):
         constraint => selection.copy(constraints = selection.constraints :+ constraint)
 
@@ -112,10 +130,15 @@ object Selection:
         split(t"=").let: (axis, value) =>
           if value.contains(t"..") then
             val index = value.s.indexOf("..")
-            val least = number(value.keep(index))
-            val most = number(value.skip(index + 2))
+            val least: Text = value.keep(index)
+            val most: Text = value.skip(index + 2)
 
-            least.let { least => most.let(Constraint.Interval(axis, least, _)) }
+            // A range may be open at either end: `N=4..` means at least 4 and `N=..64` at
+            // most 64 (both inclusive), spellings which need no shell quoting, unlike `>=`.
+            if least == t"" && most == t"" then Unset
+            else if least == t"" then number(most).let(Constraint.Most(axis, _, true))
+            else if most == t"" then number(least).let(Constraint.Least(axis, _, true))
+            else number(least).let { least => number(most).let(Constraint.Interval(axis, least, _)) }
           else Constraint.Membership(axis, value.cut(t",").to[Set])
 
 
@@ -126,6 +149,10 @@ case class Selection
   ( terms:       List[Selection.Term],
     kinds:       List[Entry.Kind],
     constraints: List[Selection.Constraint],
+    // Each element is one `tag:` term — a set of alternatives — and the elements intersect.
+    tags:        List[Set[Text]],
+    // The `not:` terms, each a one-term selection, subtracted after admission.
+    exclusions:  List[Selection],
     listOnly:    Boolean,
     // The multiplier applied to every declared target DURATION — `Bench`'s, `Stress`'s and
     // `Profile`'s — so that a whole run can be made proportionally longer (a careful
@@ -134,12 +161,30 @@ case class Selection
     // Latency thresholds are NOT scaled: they are pass/fail criteria, not durations.
     scale:       Double ):
 
-  def trivial: Boolean = terms.nil && kinds.nil && constraints.nil
+  def trivial: Boolean =
+    terms.nil && kinds.nil && constraints.nil && tags.nil && exclusions.nil
 
-  def admits(id: Test.Id, kind: Entry.Kind, coordinates: List[(Axis.Spec, Value)]): Boolean =
-    admitted(kind) && admitted(id) && admitted(coordinates)
+  def admits
+    ( id: Test.Id, kind: Entry.Kind, coordinates: List[(Axis.Spec, Value)], tags: List[Tag] )
+  :   Boolean =
+
+    admitted(kind) && admitted(id) && admitted(coordinates, false) && admitted(tags)
+    && !exclusions.exists(_.excludes(id, kind, coordinates, tags))
+
+  // Whether this selection, as a `not:` term, removes the cell. Identical to admission but
+  // for one thing: a constraint on an axis the cell does not have matches NOTHING here,
+  // where for admission it admits everything — `not:N=4` must not remove tests without an
+  // `N` axis, just as `N=4` must not exclude them.
+  private def excludes
+    ( id: Test.Id, kind: Entry.Kind, coordinates: List[(Axis.Spec, Value)], tags: List[Tag] )
+  :   Boolean =
+
+    admitted(kind) && admitted(id) && admitted(coordinates, true) && admitted(tags)
 
   private def admitted(kind: Entry.Kind): Boolean = kinds.nil || kinds.has(kind)
+
+  private def admitted(tags: List[Tag]): Boolean =
+    this.tags.all { alternatives => tags.exists { tag => alternatives.has(tag.text) } }
 
   private def ancestry(id: Test.Id): List[Test.Id] =
     id :: id.suite.let { suite => ancestry(suite.id) }.or(Nil)
@@ -167,9 +212,11 @@ case class Selection
         || glob.matches(path)
         || glob.matches(monikerPath)
 
-  private def admitted(coordinates: List[(Axis.Spec, Value)]): Boolean =
+  // `strict`: whether a constraint on an axis absent from the coordinates fails (for an
+  // exclusion) rather than passes (for an admission).
+  private def admitted(coordinates: List[(Axis.Spec, Value)], strict: Boolean): Boolean =
     constraints.all: constraint =>
-      coordinates.seek(_(0).label == constraint.axis).lay(true): pair =>
+      coordinates.seek(_(0).label == constraint.axis).lay(!strict): pair =>
         val value = pair(1)
 
         constraint match

--- a/lib/probably/src/core/probably.Tag.scala
+++ b/lib/probably/src/core/probably.Tag.scala
@@ -33,81 +33,35 @@
 package probably
 
 import anticipation.*
-import chiaroscuro.*
-import digression.*
-import fulminate.*
 import gossamer.*
-import hypotenuse.*
 import nomenclature.*
 import prepositional.*
-import symbolism.*
-import vacuous.*
+import rudiments.*
+import spectacular.*
 
-// The default four-decimal-place rendering for numeric comparisons, imported
-// decisively rather than silently supplied by `import probably.*`.
-package decimalizers:
-  given fourDecimalPlaces: Decimalizer = Decimalizer(4)
+// The naming plane for tags: `Name[Tagging]`. A tag is constrained to identifier characters
+// and `-`, so it can be typed unquoted on a command line (`tag:slow`, `not:tag:network`)
+// and completed by a shell without escaping.
+object Tagging:
+  inline given nominative: Tagging is Nominative under MustMatch["[A-Za-z_][A-Za-z0-9_-]*"] = !!
 
-export Baseline.Compare.{Min, Mean, Max}
-export Baseline.Metric.{Cadential, Temporal}
-export Baseline.Mode.{Arithmetic, Geometric}
+sealed trait Tagging
 
-// Exported at package level so that `n"…"` moniker and tag literals work wherever probably is
-// imported, without a separate `import Probing.nominative` in every suite. Both planes are in
-// scope together, so a literal valid in both (`n"slow"`) infers to their intersection and is
-// usable as either; one with a `-` (`n"no-network"`) is a tag alone.
-export Probing.nominative
-export Tagging.{nominative as taggingNominative}
+object Tag:
+  given showable: Tag is Showable = _.text
+  given inspectable: Tag is Inspectable = tag => t"Tag(${tag.text})"
 
-// The checking vocabulary now lives in `anticipation.check`, so that modules which only need to
-// compare values (notably `quantitative`) do not depend on the test framework. It is re-exported
-// here so that `import probably.*` still provides it.
-export anticipation.{!==, +/-, ===, Checkable, Tolerance, ±}
+  // A validated name IS a tag wherever a tag is expected: `test(m"…", n"slow")` reads as it
+  // should, with the literal checked at compile time against the `Tagging` rule. (With
+  // `Probing`'s plane also in scope, a literal that is a valid Java identifier infers to the
+  // intersection of the two planes, which is a `Name[Tagging]` by covariance.)
+  given conversion: Conversion[Name[Tagging], Tag] = Tag(_)
 
-
-// Declares a test by its description, optionally with tags (`test(m"…", n"slow", n"network")`)
-// by which a selection can admit or exclude it.
-def test[report](name: Message, tags: Tag*)(using suite: Testable, codepoint: Codepoint)
-:   Test.Id =
-
-  Test.Id(name, suite, codepoint, Unset, tags.to(List))
-
-// Declares a test with a stable moniker (a compile-time-checked Java identifier) alongside
-// its description. The moniker addresses the test in selections and charts, independently
-// of edits to the description.
-def test[report](name: Name[Probing], description: Message, tags: Tag*)
-  ( using suite: Testable, codepoint: Codepoint )
-:   Test.Id =
-
-  Test.Id(description, suite, codepoint, name, tags.to(List))
-
-
-def suite[report](name: Message)(using suite: Testable, runner: Runner[report])
-  ( block: Testable ?=> Unit )
-:   Unit =
-
-  runner.suite(Testable(name, suite), block)
-
-
-def suite[report](name: Name[Probing], description: Message)
-  ( using suite: Testable, runner: Runner[report] )
-  ( block: Testable ?=> Unit )
-:   Unit =
-
-  runner.suite(Testable(description, suite, name), block)
-
-
-package harnesses:
-  given threadLocalHarness: Harness:
-    private val delegate: Option[Harness] =
-      Option(Runner.harnessThreadLocal.get()).map(_.nn).flatten
-
-    override def capture[value: Decomposable](name: Text, value: value): value =
-      delegate.map(_.capture[value](name, value)).getOrElse(value)
-
-package autopsies:
-  given contrastAutopsy: Autopsy:
-    type Analyse = true
-
-  given noAutopsy: Autopsy:
-    type Analyse = false
+// A label on a test, benchmark, stress test or profile, orthogonal to its name, moniker and
+// kind: `slow`, `network`, `nightly`. A selection admits by tag (`tag:slow,network`: any of)
+// and excludes by tag (`not:tag:slow`), and a host can enumerate the tags a classpath carries.
+// Its own type rather than a bare `Text`, so a declaration cannot mistake a description for a
+// tag, and validated at compile time through nomenclature, like a moniker. An `into` type, so
+// a `Name[Tagging]` literal is accepted directly (via `Tag.conversion`).
+into case class Tag(name: Name[Tagging]):
+  def text: Text = name

--- a/lib/probably/src/core/probably.Test.scala
+++ b/lib/probably/src/core/probably.Test.scala
@@ -84,7 +84,10 @@ object Test:
     ( name:      Message,
       suite:     Optional[Testable],
       codepoint: Codepoint,
-      moniker:   Optional[Name[Probing]] = Unset ):
+      moniker:   Optional[Name[Probing]] = Unset,
+      // The declaration's tags, in declaration order; a selection admits and excludes by
+      // them, and a listing reports them.
+      tags:      List[Tag] = Nil ):
     val timestamp: Long = System.currentTimeMillis
 
     import textMetrics.uniformMetric

--- a/lib/probably/src/core/probably.TestEvent.scala
+++ b/lib/probably/src/core/probably.TestEvent.scala
@@ -185,6 +185,33 @@ object TestEvent:
       metrics.to[List].map: (entry: (Metric, Double)) =>
         MetricValue(entry(0).toString.tt, entry(1))
 
+  // One axis of a scheduled test: the `Axis.Spec` fields, the labels of the values of the
+  // admitted cells (`Value#text`, in first-appearance order; none for an emergent axis) and,
+  // for an emergent axis with declared bounds, the least and greatest values the run will
+  // produce.
+  case class AxisSchedule
+    ( axis:     Text,
+      domain:   Text,
+      emergent: Boolean,
+      values:   List[Text],
+      least:    Optional[Double],
+      most:     Optional[Double] )
+
+  object AxisSchedule:
+    def of(schedule: Axis.Schedule): AxisSchedule =
+      val domain = schedule.spec.domain match
+        case Axis.Domain.Discrete => t"discrete"
+        case Axis.Domain.Integral => t"integral"
+        case Axis.Domain.Decimal  => t"decimal"
+
+      AxisSchedule
+        ( schedule.spec.label,
+          domain,
+          schedule.spec.emergent,
+          schedule.values.map(_.text),
+          schedule.least,
+          schedule.most )
+
   def kindName(kind: Entry.Kind): Text = kind match
     case Entry.Kind.Check   => t"check"
     case Entry.Kind.Bench   => t"bench"
@@ -196,8 +223,15 @@ enum TestEvent:
   // consumer can pre-render every expected row and fill it in as results arrive. For the
   // timed kinds, `expected` estimates (from declared metadata, in nanoseconds, under any
   // `--scale` in force) how long the test will spend measuring, so a host can budget a
-  // whole run before staging anything; plain checks carry no estimate.
-  case TestScheduled(test: TestEvent.Ref, kind: Text, expected: Optional[Long])
+  // whole run before staging anything; plain checks carry no estimate. `tags` are the
+  // test's declared tags and `axes` its axes with the values (or bounds) of the admitted
+  // cells, from which a host can complete `tag:` terms and axis constraints.
+  case TestScheduled
+    ( test:     TestEvent.Ref,
+      kind:     Text,
+      expected: Optional[Long],
+      tags:     List[Text],
+      axes:     List[TestEvent.AxisSchedule] )
 
   case SuiteStarted(suite: TestEvent.Ref, timestamp: Long)
   case SuiteEnded(suite: TestEvent.Ref, timestamp: Long)

--- a/lib/probably/src/core/soundness_probably_core.scala
+++ b/lib/probably/src/core/soundness_probably_core.scala
@@ -37,8 +37,12 @@ export
   . { Anchor, Arithmetic, Autopsy, Axable, Axis, Baseline, Benchmark, Cadential,
       Geometric, Harness, Hotspots, Inclusion,
       Max, Mean, Metric, Min, nominative, Probing, Report, Reporter, Run, Runner, Spread,
-      Spread2, Strain, suite, Tally, Temporal, Test, test, Testable,
-      Trial, Value, Verdict }
+      Spread2, Strain, suite, Tagging, taggingNominative, Tally, Temporal, Test, test,
+      Testable, Trial, Value, Verdict }
+
+// `probably.Tag` is deliberately NOT re-exported: `soundness.Tag` is honeycomb's HTML tag. A
+// suite rarely needs to name the type — tags are written as `n"…"` literals — and when it
+// does, `probably.Tag` is unambiguous.
 
 package harnesses:
   export probably.harnesses.threadLocalHarness

--- a/lib/probably/src/test/probably_test.scala
+++ b/lib/probably/src/test/probably_test.scala
@@ -37,9 +37,20 @@ import soundness.*
 enum Codec:
   case Zip, Tar, Cpio
 
+// A runner in LISTING mode over the given terms: `skip` records rather than runs, and
+// nothing is ever reported, so a `Reporter[Unit]` suffices.
+def listing(terms: List[Text] = Nil): Runner[Unit] =
+  given reporter: Reporter[Unit] = new Reporter[Unit]:
+    def report(): Unit = ()
+    def fail(report: Unit, error: Throwable, active: Set[Test.Id]): Unit = ()
+    def declare(report: Unit, suite: Testable): Unit = ()
+    def complete(report: Unit): Unit = ()
+
+  Runner(Selection.parse(terms).copy(listOnly = true))
+
 object Tests extends Suite(m"Probably Tests"):
   def run(): Unit =
-    test(n"square", m"square a number")(3*3).assert(_ == 9)
+    test(n"square", m"square a number", n"quick")(3*3).assert(_ == 9)
 
     test(m"double every value").over(Axis(t"n")(1, 2, 3, 4)): n =>
       n*2
@@ -68,4 +79,131 @@ object Tests extends Suite(m"Probably Tests"):
     test(m"a non-positive or unparseable scale leaves the default"):
       List(t"--scale=0", t"--scale=-1", t"--scale=soon").map(term => Selection.parse(List(term)).scale)
     . assert(_ == List(1.0, 1.0, 1.0))
+
+    test(m"tag: terms parse as sets of alternatives which intersect"):
+      Selection.parse(List(t"tag:slow,network", t"tag:nightly")).tags
+    . assert(_ == List(Set(t"slow", t"network"), Set(t"nightly")))
+
+    test(m"not: terms parse as exclusions; an empty one is ignored"):
+      Selection.parse(List(t"not:tag:slow", t"not:kind:bench", t"not:")).exclusions.map(_.trivial)
+    . assert(_ == List(false, false))
+
+    test(m"an open-ended range is a one-sided inclusive bound"):
+      Selection.parse(List(t"N=4..", t"N=..64")).constraints
+    . assert:
+        _ == List
+          ( Selection.Constraint.Least(t"N", 4.0, true),
+            Selection.Constraint.Most(t"N", 64.0, true) )
+
+    test(m"a tag literal is a tag, and a test carries its tags in order"):
+      test(m"probe", n"slow", n"no-network").tags.map(_.text)
+    . assert(_ == List(t"slow", t"no-network"))
+
+    test(m"a tagged test is admitted by any of a tag: term's alternatives"):
+      val id = test(m"probe", n"slow", n"network")
+
+      List(t"tag:slow", t"tag:network,fast", t"tag:fast").map: term =>
+        Selection.parse(List(term)).admits(id, Entry.Kind.Check, Nil, id.tags)
+    . assert(_ == List(true, true, false))
+
+    test(m"repeated tag: terms intersect"):
+      val both = test(m"probe", n"slow", n"network")
+      val lone = test(m"lone", n"slow")
+      val selection = Selection.parse(List(t"tag:slow", t"tag:network"))
+
+      ( selection.admits(both, Entry.Kind.Check, Nil, both.tags),
+        selection.admits(lone, Entry.Kind.Check, Nil, lone.tags) )
+    . assert(_ == (true, false))
+
+    test(m"not:tag: excludes the tagged tests and keeps the rest"):
+      val slow = test(m"slow one", n"slow")
+      val quick = test(m"quick one")
+      val selection = Selection.parse(List(t"not:tag:slow"))
+
+      ( selection.admits(slow, Entry.Kind.Check, Nil, slow.tags),
+        selection.admits(quick, Entry.Kind.Check, Nil, quick.tags) )
+    . assert(_ == (false, true))
+
+    test(m"not: on an axis constraint removes only the matching cells"):
+      val id = test(m"probe")
+      val axis = Axis(t"N")(4, 8)
+      val selection = Selection.parse(List(t"not:N=4"))
+
+      ( selection.admits(id, Entry.Kind.Check, List(axis.coordinate(4)), Nil),
+        selection.admits(id, Entry.Kind.Check, List(axis.coordinate(8)), Nil),
+        selection.admits(id, Entry.Kind.Check, Nil, Nil) )
+    . assert(_ == (false, true, true))
+
+    test(m"not: on a kind removes that kind alone"):
+      val id = test(m"probe")
+      val selection = Selection.parse(List(t"not:kind:bench"))
+
+      ( selection.admits(id, Entry.Kind.Bench, Nil, Nil),
+        selection.admits(id, Entry.Kind.Check, Nil, Nil) )
+    . assert(_ == (false, true))
+
+    test(m"not: on an identity removes that test from a wider selection"):
+      val kept = test(n"kept", m"kept")
+      val dropped = test(n"dropped", m"dropped")
+      val selection = Selection.parse(List(t"**", t"not:dropped"))
+
+      ( selection.admits(kept, Entry.Kind.Check, Nil, Nil),
+        selection.admits(dropped, Entry.Kind.Check, Nil, Nil) )
+    . assert(_ == (true, false))
+
+    test(m"open ranges admit from, and up to, their bounds"):
+      val id = test(m"probe")
+      val axis = Axis(t"N")(2, 4, 8)
+      val least = Selection.parse(List(t"N=4.."))
+      val most = Selection.parse(List(t"N=..4"))
+
+      axis.values.map: n =>
+        ( least.admits(id, Entry.Kind.Check, List(axis.coordinate(n)), Nil),
+          most.admits(id, Entry.Kind.Check, List(axis.coordinate(n)), Nil) )
+    . assert(_ == List((false, true), (true, true), (true, false)))
+
+    test(m"a listing retains a spread's axis and its values, as one row"):
+      given runner: Runner[Unit] = listing()
+      given verdicts: Inclusion[Unit, Verdict] = (_, _, _, _) => ()
+      given details: Inclusion[Unit, Verdict.Detail] = (_, _, _, _) => ()
+
+      test(m"spread", n"axial").over(Axis(t"n")(1, 2, 3)) { n => n }.assert(_ > 0)
+
+      runner.listed.map: row =>
+        ( row.id.name.text,
+          row.kind,
+          row.tags.map(_.text),
+          row.axes.map { axis => (axis.spec.label, axis.values.map(_.text)) } )
+    . assert(_ == List((t"spread", Entry.Kind.Check, List(t"axial"), List((t"n", List(t"1", t"2", t"3"))))))
+
+    test(m"a listing keeps only the cells the selection admits"):
+      given runner: Runner[Unit] = listing(List(t"n=2.."))
+      given verdicts: Inclusion[Unit, Verdict] = (_, _, _, _) => ()
+      given details: Inclusion[Unit, Verdict.Detail] = (_, _, _, _) => ()
+
+      test(m"spread").over(Axis(t"n")(1, 2, 3)) { n => n }.assert(_ > 0)
+      runner.listed.map { row => row.axes.map { axis => axis.values.map(_.text) } }
+    . assert(_ == List(List(List(t"2", t"3"))))
+
+    test(m"a declared emergent axis is listed with its bounds and no values"):
+      val runner = listing()
+      val id = test(m"stress")
+      val spec = Axis.Spec(t"N", Axis.Domain.Integral, emergent = true)
+      runner.declare(id, Entry.Kind.Stress, spec, 1.0, 64.0)
+      runner.skip(id, Entry.Kind.Stress, Nil, 100L)
+
+      runner.listed.map: row =>
+        val axes = row.axes.map: axis =>
+          (axis.spec.label, axis.spec.emergent, axis.values, axis.least, axis.most)
+
+        (row.expected, axes)
+    . assert(_ == List((100L, List((t"N", true, Nil, 1.0, 64.0)))))
+
+    test(m"a declaration for an unlisted test is not reported"):
+      val runner = listing(List(t"kind:bench"))
+      val id = test(m"stress")
+      runner.declare(id, Entry.Kind.Stress, Axis.Spec(t"N", Axis.Domain.Integral, true), 1.0, 8.0)
+      runner.skip(id, Entry.Kind.Stress, Nil, 100L)
+      runner.listed
+    . assert(_ == Nil)
 

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -72,11 +72,12 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
   type Target = Path on Linux
   type Transport = Json
 
-  // Captures the benchmark's name and settings; the returned plan is applied to a quoted
-  // body directly (a single measurement) or spread `over` one or two axes, one measurement
-  // per defined combination. `baseline` names one axis value as the comparison anchor.
+  // Captures the benchmark's name, tags and settings; the returned plan is applied to a
+  // quoted body directly (a single measurement) or spread `over` one or two axes, one
+  // measurement per defined combination. `baseline` names one axis value as the comparison
+  // anchor. The tags label the benchmark for selection (`tag:slow`) and exclusion.
   def apply[duration: Abstractable across Durations to Long]
-    ( name: Message )
+    ( name: Message, tags: Tag* )
     ( target:        duration,
       operationSize: Optional[OperationSize]         = Unset,
       iterations:    Optional[Int]                   = Unset,
@@ -94,6 +95,7 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
     Bench.Plan
       ( this,
         name,
+        tags.to(List),
         target.generic,
         operationSize,
         iterations2,
@@ -257,6 +259,7 @@ object Bench:
   case class Plan
     ( bench:         Bench,
       name:          Message,
+      tags:          List[Tag],
       target:        Long,
       operationSize: Optional[OperationSize],
       iterations:    Int,
@@ -275,7 +278,7 @@ object Bench:
               codepoint: Codepoint )
     :   Unit raises Compiler.Error raises Rig.Error =
 
-      val testId = Test.Id(name, suite, codepoint)
+      val testId = Test.Id(name, suite, codepoint, Unset, tags)
       val target2: Long = Bench.scaled(target, runner.scale)
 
       val expected: Optional[Long] = Bench.expected(target2, iterations, warmups)
@@ -301,7 +304,7 @@ object Bench:
               codepoint: Codepoint )
     :   Unit raises Compiler.Error raises Rig.Error =
 
-      val testId = Test.Id(name, suite, codepoint)
+      val testId = Test.Id(name, suite, codepoint, Unset, tags)
       val target2: Long = Bench.scaled(target, runner.scale)
       val values = axis.values
 
@@ -364,7 +367,7 @@ object Bench:
               codepoint: Codepoint )
     :   Unit raises Compiler.Error raises Rig.Error =
 
-      val testId = Test.Id(name, suite, codepoint)
+      val testId = Test.Id(name, suite, codepoint, Unset, tags)
       val target2: Long = Bench.scaled(target, runner.scale)
       val lefts = first.values
       val rights = second.values

--- a/lib/sedentary/src/core/sedentary.Profile.scala
+++ b/lib/sedentary/src/core/sedentary.Profile.scala
@@ -84,7 +84,7 @@ extends Rig:
 
 
   inline def apply[duration: Abstractable across Durations to Long, report]
-    ( name: Message )
+    ( name: Message, tags: Tag* )
     ( target: duration, frames: Optional[Int] = Unset )
     ( body0: (References over Transport) ?=> Quotes ?=> Expr[Any] )
     ( using System, TemporaryDirectory, Stageable over Transport in Form )
@@ -94,7 +94,7 @@ extends Rig:
             codepoint: Codepoint )
   :   Unit raises Compiler.Error raises Rig.Error =
 
-    val testId = Test.Id(name, suite, codepoint)
+    val testId = Test.Id(name, suite, codepoint, Unset, tags.to(List))
     val frames0: Optional[Int] = frames
     val frames2: Int = frames0.or(25)
 

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -108,7 +108,7 @@ extends Rig:
 
 
   inline def apply[duration: Abstractable across Durations to Long, report]
-    ( name: Message )
+    ( name: Message, tags: Tag* )
     ( target:      duration,
       concurrency: Optional[Int]      = Unset,
       sweep:       Optional[Int]      = Unset,
@@ -434,7 +434,17 @@ extends Rig:
     // Every step lands under the SAME test id: the probed concurrency is a coordinate on
     // the test's emergent `N` axis (supplied by `Strain`'s inclusion), so a sweep's steps
     // accumulate as cells of one entry rather than as separately-named tests.
-    val testId = Test.Id(name, suite, codepoint)
+    val testId = Test.Id(name, suite, codepoint, Unset, tags.to(List))
+
+    // For a listing: the emergent `N` axis, bounded by the starting and maximum worker
+    // counts, so a host can offer `N=<lo>..<hi>` constraints before any cell exists. (The
+    // same spec `Strain`'s inclusion attaches to each measurement.)
+    runner.declare
+      ( testId,
+        Entry.Kind.Stress,
+        Axis.Spec(t"N", Axis.Domain.Integral, emergent = true),
+        start.toDouble,
+        limit.toDouble )
 
     // The expected measuring time: one window per concurrency step, so a plain stress is a
     // single (scaled) target and a sweep or capacity search is bounded by a doubling ascent

--- a/lib/sedentary/src/test/sedentary_test.scala
+++ b/lib/sedentary/src/test/sedentary_test.scala
@@ -34,21 +34,69 @@ package sedentary
 
 import soundness.*
 
+// A wildcard import brings no givens: the `n"…"` literal's plane inference needs the
+// moniker and tag planes' `Nominative`s in lexical scope, by name.
+import soundness.{nominative, taggingNominative}
+
 import classloaders.threadContextClassloader
 import environments.javaBaseEnvironment
 import strategies.throwUnsafely
 import superlunary.embeddings.automaticEmbedding
 import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
+import threading.platformThreading
 
 given BenchmarkDevice = LocalhostDevice
 
 enum Summation:
   case Loop, Formula
 
+// A runner in LISTING mode: `skip` records rather than runs, so no measurement JVM is ever
+// staged, and nothing is reported.
+def listing(): Runner[Unit] =
+  given reporter: Reporter[Unit] = new Reporter[Unit]:
+    def report(): Unit = ()
+    def fail(report: Unit, error: Throwable, active: Set[Test.Id]): Unit = ()
+    def declare(report: Unit, suite: Testable): Unit = ()
+    def complete(report: Unit): Unit = ()
+
+  Runner(probably.Selection.parse(List(t"--list")))
+
 object Tests extends Suite(m"Sedentary Tests"):
   def run(): Unit =
     val bench = Bench()
+
+    test(m"a listing reports a biaxial benchmark's tags and axis values"):
+      given runner: Runner[Unit] = listing()
+      given benchmarks: Inclusion[Unit, Benchmark] = (_, _, _, _) => ()
+      given anchors: Inclusion[Unit, Anchor] = (_, _, _, _) => ()
+
+      bench(m"grid", n"slow")(target = 50*Milli(Second))
+      . over(Axis(t"x")(1, 2), Axis(t"y")(10, 20)):
+          case (x, y) => '{$x + $y}
+
+      runner.listed.map: row =>
+        ( row.kind,
+          row.tags.map(_.text),
+          row.axes.map { axis => (axis.spec.label, axis.values.map(_.text)) } )
+    . assert:
+        _ == List
+          ( ( probably.Entry.Kind.Bench,
+              List(t"slow"),
+              List((t"x", List(t"1", t"2")), (t"y", List(t"10", t"20"))) ) )
+
+    test(m"a listing reports a stress sweep's emergent axis with its bounds"):
+      given runner: Runner[Unit] = listing()
+      given strains: Inclusion[Unit, Strain] = (_, _, _, _) => ()
+
+      Stress()(m"sweep", n"heavy")(target = 50*Milli(Second), concurrency = 2, sweep = 16):
+        '{1 + 1}
+
+      runner.listed.map: row =>
+        ( row.kind,
+          row.tags.map(_.text),
+          row.axes.map { axis => (axis.spec.label, axis.spec.emergent, axis.least, axis.most) } )
+    . assert(_ == List((probably.Entry.Kind.Stress, List(t"heavy"), List((t"N", true, 2.0, 16.0)))))
 
     // The run-length multiplier a host passes as `--scale=<factor>`, applied to a declared
     // target. Checked directly rather than through a measurement: what a scaled benchmark


### PR DESCRIPTION
Probably tests, benchmarks, stress tests and profiles can now carry tags, written as `n"…"` literals after the name, and a selection can pick them out with `tag:`, subtract anything with `not:`, and bound an axis on one side with `N=4..` or `N=..64`. A listing retains every admitted cell's coordinates, so `TestScheduled` reports each test's tags and axes — the values the selection admits, or a stress sweep's declared bounds — which lets a host such as fume complete axis values and tags on the command line.

### Tags

A tag is a `probably.Tag`: a compile-time-validated name (`[A-Za-z_][A-Za-z0-9_-]*`), given as varargs after a declaration's name. The `n"…"` literal needs the naming planes' givens in lexical scope, since a wildcard import brings none:

```scala
import soundness.{nominative, taggingNominative}

test(m"parses a large document", n"slow", n"network"):
  parse(document)
. assert(_.valid)

bench(m"grid", n"slow")(target = 50*Milli(Second))
. over(Axis(t"x")(1, 2), Axis(t"y")(10, 20)):
  case (x, y) => '{ work(${Expr(x)}, ${Expr(y)}) }
```

### Selection terms

- `tag:slow,network` admits a test carrying any listed tag; repeated `tag:` terms intersect.
- `not:<term>` subtracts whatever the term would admit: `not:tag:slow`, `not:kind:stress`, `not:N=64`.
- `N=4..` and `N=..64` are inclusive one-sided ranges, needing no shell quoting where `N>=4` does.

### Listing

`Runner#listed` now yields `Runner.Scheduled` rows carrying each test's tags and `Axis.Schedule`s (the distinct values seen on each axis, in order). A producer of an emergent axis announces its bounds with `Runner#declare`, as `Stress` does for its concurrency sweep, so the axis is listed with `least..most` and no values. `TestEvent.TestScheduled` gains `tags` and `axes`, so the event layout's fingerprint changes: a consumer built against the previous layout reports the stream as incompatible.

See `doc/migration/pending.md` for the full list of signature changes.
