### PR TITLE
Let a cold Burdock bootstrap outlive Ethereal's startup deadline (#1938)

### DIFF
--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -414,6 +414,15 @@ not yet been recorded here.
   signature).
 - `ethereal.core` now depends on `stratiform.binary` (and so on `stratiform.core`,
   `stratiform.base256` and `ulysses.core`).
+- The launcher's startup deadline is now an *idle* limit: the daemon must bind its socket
+  within 10 s of the last change to the `progress` file in its state directory, rather than
+  within 10 s of being spawned. The launcher passes `-Dburdock.progress=<state dir>/progress`
+  to the JVM; a Burdock bootstrap fetching a cold cache writes its position there, the
+  launcher shows `Fetching dependencies n/N (size)…` while it waits, and the failure report
+  names the download in flight (`it was still fetching dependency 35 of 128 … after 10s
+  without progress`). A second launcher waiting on another launcher's startup follows the
+  same rule (previously a fixed 4 s). This is a change to the Rust runner: rebuild stubs
+  (`make runners-build`) or use a `runners-<version>` release carrying it. (#1938)
 
 ## probably (fume takes over running and reporting)
 
@@ -489,3 +498,18 @@ not yet been recorded here.
   `hellenism.classloaders.systemClassloader`, and `superlunary.Rig#classpath` derives its entries
   from `Classloader[Rig]` rather than the thread-context classloader. Identical in a plain
   `java -cp` process; differs only when the rig is loaded by a non-system classloader. (#1963)
+
+## burdock
+
+- `burdock.Bootstrap` (the runtime class a repackaged JAR starts with) downloads its
+  `Burdock-Require` dependencies concurrently (up to eight at a time) instead of one after
+  another, applies connect/read timeouts to each download, and cleans up its temporary file
+  on failure; classpath order is unchanged. A malformed `Burdock-Require` item exits with
+  status 2 and a message instead of a stack trace. (#1938)
+- `burdock.Bootstrap` now honours `XDG_CACHE_HOME`: the cache is `$XDG_CACHE_HOME/burdock`
+  when the variable is set and non-empty, else `~/.cache/burdock`. Previously a set variable
+  made it use a `burdock` directory relative to the working directory. (#1938)
+- `burdock.Bootstrap` reads the optional `burdock.progress` system property: when set, it is
+  the path of a file the bootstrap keeps updated with one line, `<completed> <total> <bytes>`,
+  while fetching, and deletes when done. Ethereal's launcher sets it; a plain `java -jar` run
+  writes nothing. (#1938)

--- a/doc/modules/packaging.md
+++ b/doc/modules/packaging.md
@@ -92,9 +92,12 @@ def mytool(): Unit = externalize:
 
 Repackaging then splits the JAR: dependencies whose hashes resolve to published artifacts are
 replaced by URL-and-hash references, and only unpublished code stays inlined. The resulting thin
-JAR carries a small bootstrap that, on first run, downloads each requirement, verifies its hash,
-caches it, and launches — so the artifact that users download is the application, and the
-dependencies arrive once, verified, from where they already live.
+JAR carries a small bootstrap that, on first run, downloads the requirements (several at a
+time), verifies each hash, caches it in `~/.cache/burdock` (or under `$XDG_CACHE_HOME`), and
+launches — so the artifact that users download is the application, and the dependencies arrive
+once, verified, from where they already live. When the application is an Ethereal daemon, the
+bootstrap reports its progress to the launcher, which shows it and waits for as long as the
+downloads keep advancing.
 
 Hashes are resolved against Maven Central through deps.dev. There is no such global index for
 GitHub releases, but a repository's releases can be listed one at a time, so the repackager

--- a/lib/burdock/Makefile
+++ b/lib/burdock/Makefile
@@ -1,6 +1,6 @@
-SOURCES := $(wildcard src/java/**/*.java)
+SOURCES := $(wildcard src/boot/**/*.java)
 
 compile: $(SOURCES)
-	javac -d res -Xlint:deprecation src/java/burdock/*.java
+	javac -d res -Xlint:deprecation src/boot/burdock/*.java
 
 .PHONY: compile

--- a/lib/burdock/src/boot/burdock/Bootstrap.java
+++ b/lib/burdock/src/boot/burdock/Bootstrap.java
@@ -7,17 +7,221 @@ import java.lang.reflect.*;
 import java.security.*;
 import java.util.jar.*;
 import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
+// The runtime entry point of a repackaged JAR. The repackager force-includes exactly ONE class
+// file, `burdock/Bootstrap.class`, so everything here must compile into it: no nested or
+// anonymous classes and no records (lambdas are fine; they need no class file of their own).
 public class Bootstrap {
   static int verbosity = 1;
 
+  // Concurrent downloads. Bounded, because every requirement of a typical application
+  // lives on one or two hosts, and a hundred simultaneous connections to a release server
+  // invites throttling rather than throughput.
+  static final int PARALLELISM = 8;
+  static final int CONNECT_TIMEOUT_MS = 10_000;
+  static final int READ_TIMEOUT_MS = 30_000;
+  static final int BUFFER_SIZE = 65_536;
+
+  // Startup progress, reported to whatever launched this JVM through the file named by the
+  // `burdock.progress` system property (Ethereal's launcher sets it to a path in the daemon's
+  // state directory, and extends its startup deadline while the file keeps changing). With no
+  // property set, reporting is a no-op. The file holds one line, `<completed> <total> <bytes>`:
+  // requirements verified so far, requirements in total, and bytes downloaded so far. Writes go
+  // through a temporary sibling and an atomic rename so a reader never sees a partial line, and
+  // are throttled so a fast download does not turn into thousands of renames.
+  static final long PROGRESS_INTERVAL_MS = 200;
+  static Path progressPath = null;
+  static Path progressTemp = null;
+  static int progressTotal = 0;
+  static final AtomicInteger progressCompleted = new AtomicInteger();
+  static final AtomicLong progressBytes = new AtomicLong();
+  static long progressLastWrite = 0;
+
+  // Also the exit path from a worker thread, so the `finally` that would normally remove the
+  // progress file never runs: remove it here, or a later launch would read a stale position.
   static void quit(String message, int status) {
     if (verbosity != 0) System.err.println(message);
+    progressFinish();
     System.exit(status);
   }
 
   static void info(String message, int severity) {
     if (verbosity >= severity) System.err.println(message);
+  }
+
+  // Each `Burdock-Require` item is `<64 hex chars>:<url>`, as written by the repackager. Parsed
+  // into `{hash, url}` pairs.
+  static List<String[]> parseRequirements(String requirements) {
+    List<String[]> result = new ArrayList<>();
+    if (requirements == null) return result;
+    for (String item : requirements.split(" ")) {
+      if (item.isEmpty()) continue;
+      if (item.length() < 66 || item.charAt(64) != ':')
+        quit("The Burdock-Require entry \""+item+"\" is malformed.", 2);
+      result.add(new String[] { item.substring(0, 64), item.substring(65) });
+    }
+    return result;
+  }
+
+  static File cacheDir() {
+    String cacheEnv = System.getenv("XDG_CACHE_HOME");
+    File cache = (cacheEnv == null || cacheEnv.isEmpty())
+        ? new File(new File(System.getProperty("user.home")), ".cache")
+        : new File(cacheEnv);
+    return new File(cache, "burdock");
+  }
+
+  static String hex(byte[] bytes) {
+    StringBuilder builder = new StringBuilder();
+    for (byte b : bytes) builder.append(String.format("%02x", b));
+    return builder.toString();
+  }
+
+  static void progressStart(int total) {
+    String property = System.getProperty("burdock.progress");
+    if (property == null || property.isEmpty()) return;
+    progressPath = Paths.get(property);
+    progressTemp = progressPath.resolveSibling(progressPath.getFileName()+".tmp");
+    progressTotal = total;
+    progressReport(true);
+  }
+
+  static void progressDownloaded(int count) {
+    progressBytes.addAndGet(count);
+    progressReport(false);
+  }
+
+  static void progressCompleted() {
+    progressCompleted.incrementAndGet();
+    progressReport(true);
+  }
+
+  static synchronized void progressReport(boolean force) {
+    if (progressPath == null) return;
+    long now = System.currentTimeMillis();
+    if (!force && now - progressLastWrite < PROGRESS_INTERVAL_MS) return;
+    progressLastWrite = now;
+    String line = progressCompleted.get()+" "+progressTotal+" "+progressBytes.get()+"\n";
+    try {
+      Files.writeString(progressTemp, line);
+      try {
+        Files.move(progressTemp, progressPath, StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING);
+      } catch (AtomicMoveNotSupportedException e) {
+        Files.move(progressTemp, progressPath, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } catch (IOException e) {
+      // Progress is advisory: a launcher that cannot read it just falls back to its fixed
+      // deadline, so a failure to write it must not fail the application.
+    }
+  }
+
+  static synchronized void progressFinish() {
+    if (progressPath == null) return;
+    try { Files.deleteIfExists(progressPath); } catch (IOException e) {}
+    try { Files.deleteIfExists(progressTemp); } catch (IOException e) {}
+  }
+
+  // Returns the cached, verified JAR for one requirement, downloading it if necessary. Runs on
+  // a worker thread; a checksum mismatch quits the whole process, as it always has.
+  static File fetch(String requiredHash, String location, File dir) throws Exception {
+    URL url = new URI(location).toURL();
+    File file = new File(dir, requiredHash+".jar");
+    info("Application requires "+url+".", 3);
+
+    if (file.exists()) {
+      info("JAR file exists locally at "+file+".", 3);
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      try (InputStream in = new FileInputStream(file)) {
+        byte[] buffer = new byte[BUFFER_SIZE];
+        int n;
+        while ((n = in.read(buffer)) != -1) digest.update(buffer, 0, n);
+      }
+      String calculatedHash = hex(digest.digest());
+      if (!calculatedHash.equals(requiredHash))
+        quit("SHA-256 checksum of local dependency "+file+" does not match hash value ("+
+            requiredHash+").", 1);
+    } else {
+      info("File does not exist locally.", 3);
+      info("Downloading "+url, 2);
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      File temp = File.createTempFile("tempfiles", ".tmp", dir);
+      boolean moved = false;
+
+      try {
+        URLConnection connection = url.openConnection();
+        connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        connection.setReadTimeout(READ_TIMEOUT_MS);
+
+        try (InputStream in = connection.getInputStream();
+             OutputStream out = new FileOutputStream(temp)) {
+          byte[] buffer = new byte[BUFFER_SIZE];
+          int n;
+          while ((n = in.read(buffer)) != -1) {
+            out.write(buffer, 0, n);
+            digest.update(buffer, 0, n);
+            progressDownloaded(n);
+          }
+        }
+
+        String calculatedHash = hex(digest.digest());
+        info("Calculated hash of downloaded file as "+calculatedHash+".", 3);
+
+        if (!calculatedHash.equals(requiredHash)) {
+          temp.delete();
+          quit("SHA-256 checksum of dependency "+url+" does not match expected value ("+
+              requiredHash+").", 1);
+        }
+
+        // Another process (a retried launch, say) may have completed the same download
+        // meanwhile; both wrote identical, verified bytes, so replacing is harmless.
+        try {
+          Files.move(temp.toPath(), file.toPath(), StandardCopyOption.ATOMIC_MOVE,
+              StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+          Files.move(temp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+        moved = true;
+      } finally {
+        if (!moved) temp.delete();
+      }
+    }
+
+    progressCompleted();
+    return file;
+  }
+
+  // Fetches every requirement, in parallel, returning their files in manifest order so the
+  // classpath order is the one the repackager wrote.
+  static List<File> fetchAll(List<String[]> requirements) throws Exception {
+    List<File> files = new ArrayList<>();
+    if (requirements.isEmpty()) return files;
+    File dir = cacheDir();
+    dir.mkdirs();
+    progressStart(requirements.size());
+    ExecutorService executor =
+        Executors.newFixedThreadPool(Math.min(requirements.size(), PARALLELISM));
+
+    try {
+      List<Future<File>> futures = new ArrayList<>();
+      for (String[] requirement : requirements)
+        futures.add(executor.submit(() -> fetch(requirement[0], requirement[1], dir)));
+
+      for (Future<File> future : futures) {
+        try { files.add(future.get()); }
+        catch (ExecutionException e) {
+          Throwable cause = e.getCause();
+          throw (cause instanceof Exception exception) ? exception : e;
+        }
+      }
+    } finally {
+      executor.shutdownNow();
+      progressFinish();
+    }
+
+    return files;
   }
 
   public static void main(String[] args) throws Exception {
@@ -33,11 +237,6 @@ public class Bootstrap {
 
       CodeSource codeSource = Bootstrap.class.getProtectionDomain().getCodeSource();
       if (codeSource != null) jars.add(codeSource.getLocation().toURI().toURL());
-      String cacheEnv = System.getenv("XDG_CACHE_HOME");
-      File cache = null;
-
-      if (cacheEnv == null || cacheEnv.isEmpty())
-        cache = new File(new File(System.getProperty("user.home")), ".cache");
 
       String verbosityLevel = attributes.getValue("Burdock-Verbosity");
       mainClassname = attributes.getValue("Burdock-Main");
@@ -53,82 +252,12 @@ public class Bootstrap {
 
       if (verbosity < 0) quit("invalid verbosity level: "+verbosityLevel, 2);
 
-      String requirements = attributes.getValue("Burdock-Require");
-      if (requirements != null) {
-        for (String item : requirements.split(" ")) {
-          String requiredHash = item.substring(0, 64);
-          URL url = new URI(item.substring(65)).toURL();
-          info("Application requires "+url+".", 3);
-          File dir = new File(cache, "burdock");
-          dir.mkdirs();
-          File temp = File.createTempFile("tempfiles", ".tmp", dir);
-          File file = new File(dir, requiredHash+".jar");
-
-          if (!file.exists()) {
-            info("File does not exist locally.", 3);
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            String calculatedHash = null;
-
-            info("Downloading "+url, 2);
-
-            try (InputStream in = url.openStream();
-                 FileOutputStream out = new FileOutputStream(temp)) {
-
-              byte[] buffer = new byte[4096];
-              int n = 0;
-
-              while ((n = in.read(buffer)) != -1) {
-                out.write(buffer, 0, n);
-                digest.update(buffer, 0, n);
-              }
-
-              byte[] hashBytes = digest.digest();
-              StringBuilder builder = new StringBuilder();
-              for (byte b : hashBytes) builder.append(String.format("%02x", b));
-
-              calculatedHash = builder.toString();
-              out.close();
-            }
-
-            info("Calculated hash of downloaded file as "+calculatedHash+".", 3);
-
-            if (calculatedHash.equals(requiredHash))
-              Files.move(temp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            else {
-              Files.delete(temp.toPath());
-              quit("SHA-256 checksum of dependency "+url+" does not match expected value ("+
-                  requiredHash+").", 1);
-            }
-          } else {
-            info("JAR file exists locally at "+file+".", 3);
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            try (FileInputStream fis = new FileInputStream(file)) {
-              byte[] byteArray = new byte[4096];
-              int bytesRead;
-              while ((bytesRead = fis.read(byteArray)) != -1) {
-                digest.update(byteArray, 0, bytesRead);
-              }
-              byte[] hashBytes = digest.digest();
-              StringBuilder builder = new StringBuilder();
-              for (byte b : hashBytes) builder.append(String.format("%02x", b));
-              String calculatedHash = builder.toString();
-
-              if (!calculatedHash.equals(requiredHash)) {
-                quit("SHA-256 checksum of local dependency "+file+" does not match hash value ("+
-                    requiredHash+").", 1);
-              }
-            }
-          }
-
-          jars.add(file.toURI().toURL());
-        }
-      }
+      for (File file : fetchAll(parseRequirements(attributes.getValue("Burdock-Require"))))
+        jars.add(file.toURI().toURL());
 
       if (mainClassname == null) quit("The main method has not been specified.", 2);
 
-      URL[] jarfiles = new URL[jars.size()];
-
-      for (int i = 0; i < jarfiles.length; i++) jarfiles[i] = jars.get(i);
+      URL[] jarfiles = jars.toArray(new URL[0]);
 
       try (URLClassLoader classLoader = new URLClassLoader(jarfiles,
           Bootstrap.class.getClassLoader().getParent())) {

--- a/lib/burdock/src/test/burdock/Probe.java
+++ b/lib/burdock/src/test/burdock/Probe.java
@@ -1,0 +1,10 @@
+package burdock;
+
+// The application the bootstrap end-to-end tests launch: its class bytes are copied from the
+// test classpath into a JAR whose `Burdock-Main` names it. Plain Java, so the JAR needs no
+// Scala runtime.
+public class Probe {
+  public static void main(String[] args) {
+    System.out.println("probe");
+  }
+}

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -42,6 +42,10 @@ import errorDiagnostics.stackTracesDiagnostics
 import charEncoders.utf8Encoder
 import systems.javaBaseSystem
 import temporaryDirectories.systemTemporaryDirectory
+import workingDirectories.javaBaseWorkingDirectory
+import logging.silentLogging
+import threading.platformThreading
+import probates.awaitProbate
 
 object Tests extends Suite(m"Burdock Tests"):
   def run(): Unit =
@@ -468,3 +472,171 @@ object Tests extends Suite(m"Burdock Tests"):
       test(m"the decompressed Deflate payload is preserved"):
         entry(outputJar, t"pkg/Deflated.class").read[Data].utf8
       .assert(_ == t"a"*2000)
+
+    // The bootstrap itself, run as a real JVM against a loopback server: the JAR under test
+    // carries `burdock.Bootstrap`, a `Burdock-Main` probe class, and two requirements whose
+    // "jars" are arbitrary bytes (they are never class-loaded; only their hashes matter).
+    suite(m"Bootstrap (end-to-end)"):
+      import java.net.InetSocketAddress
+      import java.nio.file as jnf
+      import java.security as js
+      import java.util as ju
+      import java.util.jar as juj
+      import java.io as ji
+      import com.sun.net.httpserver as csnh
+
+      val javaBinary: Text = t"${_root_.java.lang.System.getProperty("java.home").nn}/bin/java"
+      val root: Path on Linux = temporaryDirectory[Path on Linux]/t"burdock-boot-${Uuid().show}"
+      jnf.Files.createDirectories(jnf.Paths.get(root.show.s))
+
+      def data(bytes: scala.Array[Byte]): Data = Data.fill(bytes.length)(bytes(_))
+
+      def resource(name: String): scala.Array[Byte] =
+        getClass.nn.getResourceAsStream(name).nn.readAllBytes().nn
+
+      def sha256(bytes: scala.Array[Byte]): Text =
+        ju.HexFormat.of().nn.formatHex(js.MessageDigest.getInstance("SHA-256").nn.digest(bytes).nn).nn.tt
+
+      def exists(path: Text): Boolean = jnf.Files.exists(jnf.Paths.get(path.s))
+
+      def leftovers(cache: Text): Int =
+        val dir = jnf.Paths.get(cache.s, "burdock")
+        if !jnf.Files.isDirectory(dir) then 0
+        else jnf.Files.list(dir).nn.filter(_.nn.getFileName.nn.toString.nn.endsWith(".tmp")).nn.count().toInt
+
+      // Requests are served on a pool (the default executor is one dispatcher thread, which would
+      // serialize them and hide the bootstrap's parallelism), each after a configurable delay,
+      // while counting the peak number in flight.
+      val server = csnh.HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).nn
+      server.setExecutor(juc.Executors.newCachedThreadPool())
+      val inFlight = juca.AtomicInteger()
+      val peak = juca.AtomicInteger()
+      val requests = juca.AtomicInteger()
+      val delayOne = juca.AtomicLong(300)
+      val delayTwo = juca.AtomicLong(300)
+
+      def serve(name: String, bytes: scala.Array[Byte], delay: juca.AtomicLong): Unit =
+        server.createContext("/"+name, { exchange =>
+          requests.incrementAndGet()
+          peak.accumulateAndGet(inFlight.incrementAndGet(), (a, b) => Math.max(a, b))
+          try
+            Thread.sleep(delay.get())
+            exchange.nn.sendResponseHeaders(200, bytes.length)
+            exchange.nn.getResponseBody.nn.write(bytes)
+            exchange.nn.close()
+          finally inFlight.decrementAndGet() })
+
+      val one: scala.Array[Byte] = "dependency one".getBytes("UTF-8").nn
+      val two: scala.Array[Byte] = "dependency two".getBytes("UTF-8").nn
+      serve("one.jar", one, delayOne)
+      serve("two.jar", two, delayTwo)
+      server.start()
+      val port: Int = server.getAddress.nn.getPort
+      val hashOne: Text = sha256(one)
+      val hashTwo: Text = sha256(two)
+
+      val requirements: Text =
+        t"$hashOne:http://127.0.0.1:$port/one.jar $hashTwo:http://127.0.0.1:$port/two.jar"
+
+      def appJar(name: Text, require: Text): Path on Linux =
+        val manifest = juj.Manifest()
+        val attributes = manifest.getMainAttributes.nn
+        attributes.put(juj.Attributes.Name.MANIFEST_VERSION, "1.0")
+        attributes.putValue("Main-Class", "burdock.Bootstrap")
+        attributes.putValue("Burdock-Main", "burdock.Probe")
+        attributes.putValue("Burdock-Verbosity", "error")
+        attributes.putValue("Burdock-Require", require.s)
+        val out = ji.ByteArrayOutputStream()
+        manifest.write(out)
+        val jar: Path on Linux = root/name
+
+        Zipfile.write(jar):
+          ( Zip.Entry(t"META-INF/MANIFEST.MF".as[Path on Zip], data(out.toByteArray.nn))
+            #:: Zip.Entry(t"burdock/Bootstrap.class".as[Path on Zip], data(resource("/burdock/Bootstrap.class")))
+            #:: Zip.Entry(t"burdock/Probe.class".as[Path on Zip], data(resource("/burdock/Probe.class")))
+            #:: Chain() ).to[List]
+
+        jar
+
+      val jar: Path on Linux = appJar(t"app.jar", requirements)
+      val cache: Text = t"${root.show}/cache"
+      val progress: Text = t"${root.show}/progress"
+
+      def launch(jar: Path on Linux, cache: Text): Text =
+        sh"env XDG_CACHE_HOME=$cache $javaBinary -Dburdock.progress=$progress -jar $jar".exec[Text]().trim
+
+      def status(jar: Path on Linux, cache: Text): Exit =
+        sh"env XDG_CACHE_HOME=$cache $javaBinary -Dburdock.progress=$progress -jar $jar".exec[Exit]()
+
+      val coldOutput: Text = launch(jar, cache)
+      val coldRequests: Int = requests.get()
+
+      test(m"the application's main class runs after a cold fetch"):
+        coldOutput
+      .assert(_ == t"probe")
+
+      test(m"both requirements are fetched once"):
+        coldRequests
+      .assert(_ == 2)
+
+      test(m"the requirements are cached under XDG_CACHE_HOME"):
+        (exists(t"$cache/burdock/$hashOne.jar"), exists(t"$cache/burdock/$hashTwo.jar"))
+      .assert(_ == (true, true))
+
+      test(m"the downloads overlap"):
+        peak.get()
+      .assert(_ >= 2)
+
+      test(m"no temporary file is left in the cache"):
+        leftovers(cache)
+      .assert(_ == 0)
+
+      test(m"the progress file is removed once fetching completes"):
+        exists(progress)
+      .assert(_ == false)
+
+      val warmOutput: Text = launch(jar, cache)
+
+      test(m"a warm cache makes no requests"):
+        (warmOutput, requests.get() - coldRequests)
+      .assert(_ == (t"probe", 0))
+
+      jnf.Files.write(jnf.Paths.get(t"$cache/burdock/$hashOne.jar".s), "corrupted".getBytes("UTF-8").nn)
+
+      test(m"a corrupted cached requirement is rejected with status 1"):
+        status(jar, cache)
+      .assert(_ == Exit.Fail(1))
+
+      test(m"a malformed requirement exits with status 2"):
+        status(appJar(t"malformed.jar", t"not-a-requirement"), cache)
+      .assert(_ == Exit.Fail(2))
+
+      // With the server slowed down, the progress file can be watched from outside while the
+      // bootstrap runs, which is exactly what Ethereal's launcher does. The two downloads are
+      // staggered so that the position after the first completes persists long enough to be seen.
+      val slowCache: Text = t"${root.show}/slow-cache"
+      delayOne.set(500)
+      delayTwo.set(2500)
+
+      val observed: List[Text] =
+        supervise:
+          val task = async(status(jar, slowCache))
+          var seen: List[Text] = Nil
+          while !task.ready do
+            if exists(progress) then
+              val line: Text = jnf.Files.readString(jnf.Paths.get(progress.s)).nn.tt.trim
+              if line != t"" && !seen.has(line) then seen = line :: seen
+            snooze(0.05*Second)
+          seen.reverse
+
+      test(m"the progress file reports the requirements before any download completes"):
+        observed match
+          case first :: _ => first
+          case _          => t""
+      .assert(_ == t"0 2 0")
+
+      test(m"the progress file reports the first requirement's completion"):
+        observed.exists(_.starts(t"1 2 "))
+      .assert(_ == true)
+
+      server.stop(0)

--- a/lib/ethereal/src/runner/src/launch.rs
+++ b/lib/ethereal/src/runner/src/launch.rs
@@ -1,12 +1,25 @@
 use std::path::Path;
-use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
 
 use crate::config::BuildConfig;
+use crate::progress::{self, Progress, Watch};
 
 const STARTUP_POLL: Duration = Duration::from_millis(50);
-const STARTUP_MAX_ATTEMPTS: u32 = 200;
+// How long the daemon may go without any sign of progress before it is presumed hung. A
+// Burdock-repackaged application reports its dependency downloads through the `progress` file
+// (see `progress.rs`), and every change to that file restarts this window, so a cold cache on a
+// slow link is not a hang (#1938). Without a progress file the window is simply the old fixed
+// deadline measured from the spawn.
+const STARTUP_IDLE_LIMIT: Duration = Duration::from_secs(10);
 const BUILD_FILE_GRACE_ATTEMPTS: u32 = 20;
+
+pub enum Outcome {
+    Bound,
+    Failed,
+    Exited,
+    Idle(Option<Progress>),
+}
 
 pub fn launch(
     script: &Path,
@@ -16,6 +29,7 @@ pub fn launch(
     pid_file: &Path,
     socket_file: &Path,
     fail_file: &Path,
+    progress_file: &Path,
     config: &BuildConfig,
     download: bool,
 ) {
@@ -36,7 +50,7 @@ pub fn launch(
     let executable = std::env::current_exe().unwrap_or_else(|_| script.to_path_buf());
     let mut command = Command::new(&executable);
     command.arg(crate::WRAP_SENTINEL).arg(&java);
-    for argument in build_java_arguments(script, name, config) { command.arg(argument); }
+    for argument in build_java_arguments(script, name, progress_file, config) { command.arg(argument); }
     // Capture the JVM invocation time as late as possible — after the slow
     // argument-building work (zsh probe, $fpath capture) — so `uptime` in the
     // daemon measures from the moment java is actually spawned, not from when
@@ -61,6 +75,9 @@ pub fn launch(
     // Mark them non-inheritable just before the spawn; the launcher continues
     // to use them normally afterwards.
     mark_stdio_non_inheritable();
+    // A progress file left by a bootstrap that died mid-download would otherwise
+    // count as this daemon's first sign of life.
+    let _ = std::fs::remove_file(progress_file);
     crate::debug!("launch: spawning daemon: {} (wrapper)", executable.display());
 
     let mut child = match command.spawn() {
@@ -76,43 +93,33 @@ pub fn launch(
 
     let _ = std::fs::write(pid_file, format!("{}\n", child.id()));
 
-    let mut attempts = 0;
-    let start = std::time::Instant::now();
-    let mut shown = false;
-    while !crate::state::socket_ready(socket_file)
-        && !fail_file.exists()
-        && attempts < STARTUP_MAX_ATTEMPTS
-    {
-        // If the daemon process exits before its socket appears, it failed during
-        // startup. Stop immediately and signal failure rather than polling out the
-        // full window — or, worse, falling through to connect to a socket that will
-        // never accept (which can block forever).
-        if matches!(child.try_wait(), Ok(Some(_))) && !crate::state::socket_ready(socket_file) {
+    let start = Instant::now();
+    let (outcome, shown) = await_startup(socket_file, fail_file, progress_file, name, Some(&mut child));
+    let _ = std::fs::remove_file(progress_file);
+    crate::debug!("launch: post-poll socket_ready={} fail_exists={}",
+        crate::state::socket_ready(socket_file), fail_file.exists());
+
+    match outcome {
+        Outcome::Bound => (),
+
+        // The daemon process exited before its socket appeared: it failed during startup.
+        Outcome::Exited => {
             crate::debug!("launch: daemon exited during startup, aborting");
             crate::state::abort(fail_file);
             crate::state::report_failure(base_dir, name, "it exited during startup");
             crate::state::backout(fail_file, pid_file, name);
             std::process::exit(1);
         }
-        if !shown && start.elapsed() >= Duration::from_secs(2) {
-            crate::xeq::step(name, "Starting…");
-            shown = true;
-        }
-        std::thread::sleep(STARTUP_POLL);
-        attempts += 1;
-    }
-    crate::debug!("launch: post-poll attempts={} socket_ready={} fail_exists={}",
-        attempts, crate::state::socket_ready(socket_file), fail_file.exists());
 
-    if !crate::state::socket_ready(socket_file) {
-        crate::debug!("launch: socket never appeared, aborting");
-        crate::state::abort(fail_file);
-        let seconds = STARTUP_POLL.as_millis()*u128::from(STARTUP_MAX_ATTEMPTS)/1000;
-        let reason = format!("it did not bind its socket within {seconds}s");
-        crate::state::report_failure(base_dir, name, &reason);
-        crate::state::backout(fail_file, pid_file, name);
-        std::process::exit(1);
+        Outcome::Failed | Outcome::Idle(_) => {
+            crate::debug!("launch: socket never appeared, aborting");
+            crate::state::abort(fail_file);
+            crate::state::report_failure(base_dir, name, &idle_reason(&outcome));
+            crate::state::backout(fail_file, pid_file, name);
+            std::process::exit(1);
+        }
     }
+
     if shown {
         let secs = start.elapsed().as_secs_f64();
         crate::xeq::done(name, &format!("Started in {secs:.1}s"));
@@ -128,7 +135,66 @@ pub fn launch(
     crate::debug!("launch: returning");
 }
 
-fn build_java_arguments(script: &Path, name: &str, config: &BuildConfig) -> Vec<String> {
+// Waits for the daemon to bind its socket, restarting the idle window on every change to the
+// progress file and echoing the bootstrap's position to the terminal. `child` is the daemon
+// process when this launcher spawned it (its exit is then detected immediately rather than at
+// the deadline); a launcher waiting on another launcher's daemon passes `None`. Returns the
+// outcome and whether a status line was shown (so the caller can close it).
+pub fn await_startup(
+    socket_file: &Path,
+    fail_file: &Path,
+    progress_file: &Path,
+    name: &str,
+    mut child: Option<&mut Child>,
+) -> (Outcome, bool) {
+    let start = Instant::now();
+    let mut watch = Watch::new(start);
+    let mut shown = false;
+
+    loop {
+        if crate::state::socket_ready(socket_file) { return (Outcome::Bound, shown); }
+        if fail_file.exists() { return (Outcome::Failed, shown); }
+
+        // If the daemon process exits before its socket appears, stop immediately rather
+        // than polling out the full window — or, worse, falling through to connect to a
+        // socket that will never accept (which can block forever).
+        if let Some(child) = child.as_deref_mut() {
+            if matches!(child.try_wait(), Ok(Some(_))) && !crate::state::socket_ready(socket_file) {
+                return (Outcome::Exited, shown);
+            }
+        }
+
+        let now = Instant::now();
+        let current = progress::read(progress_file);
+
+        if watch.observe(current, now) {
+            if let Some(progress) = current {
+                crate::xeq::step(name, &progress::message(&progress));
+                shown = true;
+            }
+        }
+
+        if watch.expired(now, STARTUP_IDLE_LIMIT) {
+            return (Outcome::Idle(watch.current()), shown);
+        }
+
+        if !shown && start.elapsed() >= Duration::from_secs(2) {
+            crate::xeq::step(name, "Starting…");
+            shown = true;
+        }
+
+        std::thread::sleep(STARTUP_POLL);
+    }
+}
+
+pub fn idle_reason(outcome: &Outcome) -> String {
+    match outcome {
+        Outcome::Idle(Some(progress)) => progress::reason(progress, STARTUP_IDLE_LIMIT),
+        _ => format!("it did not bind its socket within {}s", STARTUP_IDLE_LIMIT.as_secs()),
+    }
+}
+
+fn build_java_arguments(script: &Path, name: &str, progress_file: &Path, config: &BuildConfig) -> Vec<String> {
     let jar_size = std::fs::metadata(script).map(|metadata| metadata.len()).unwrap_or(0);
     let user_name = std::env::var("USER").or_else(|_| std::env::var("USERNAME")).unwrap_or_default();
     let uid: u32 = {
@@ -158,6 +224,8 @@ fn build_java_arguments(script: &Path, name: &str, config: &BuildConfig) -> Vec<
         format!("-Dethereal.jarSize={}", jar_size),
         format!("-Dethereal.command={}", command_path),
         format!("-Dethereal.fpath={}", fpath.trim_end()),
+        // Where a Burdock bootstrap reports its dependency downloads; see `progress.rs`.
+        format!("-Dburdock.progress={}", progress_file.display()),
     ]
 }
 

--- a/lib/ethereal/src/runner/src/main.rs
+++ b/lib/ethereal/src/runner/src/main.rs
@@ -11,6 +11,7 @@ mod config;
 mod state;
 mod java;
 mod launch;
+mod progress;
 mod protocol;
 mod signals;
 mod tty;
@@ -71,6 +72,7 @@ fn main() {
     let pid_file    = base_dir.join("pid");
     let socket_file = base_dir.join("socket");
     let fail_file   = base_dir.join("fail");
+    let progress_file = base_dir.join("progress");
     debug!("main: base_dir={}", base_dir.display());
 
     // Non-interactive invocations (completions, admin) must not touch the TTY,
@@ -91,18 +93,26 @@ fn main() {
                 debug!("main: acquired lock, launching daemon");
                 launch::launch(
                     &script, &name, &base_dir,
-                    &build_file, &pid_file, &socket_file, &fail_file,
+                    &build_file, &pid_file, &socket_file, &fail_file, &progress_file,
                     &build_config, download,
                 );
                 debug!("main: launch::launch returned");
             }
             None => {
+                // Wait by the same rule as the launcher doing the spawning: a cold
+                // Burdock cache being fetched by that daemon is progress here too.
                 debug!("main: another launcher holds the lock; awaiting socket");
-                if !state::await_socket(&socket_file, 40) {
+                let (outcome, shown) =
+                    launch::await_startup(&socket_file, &fail_file, &progress_file, &name, None);
+                if shown && matches!(outcome, launch::Outcome::Bound) { xeq::done(&name, "Started"); }
+                if !matches!(outcome, launch::Outcome::Bound) {
                     debug!("main: socket did not appear");
                     state::abort(&fail_file);
-                    let reason = "another launcher held the startup lock but bound no socket";
-                    state::report_failure(&base_dir, &name, reason);
+                    let reason = match outcome {
+                        launch::Outcome::Idle(Some(_)) => launch::idle_reason(&outcome),
+                        _ => "another launcher held the startup lock but bound no socket".to_string(),
+                    };
+                    state::report_failure(&base_dir, &name, &reason);
                     state::backout(&fail_file, &pid_file, &name);
                     std::process::exit(1);
                 }

--- a/lib/ethereal/src/runner/src/progress.rs
+++ b/lib/ethereal/src/runner/src/progress.rs
@@ -1,0 +1,146 @@
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+// While a Burdock-repackaged application is fetching its externalized dependencies, its
+// bootstrap reports where it has got to in a `progress` file in the daemon's state directory
+// (the launcher names it through the `burdock.progress` system property). One line:
+// `<completed> <total> <bytes>` — requirements verified so far, requirements in total, and bytes
+// downloaded so far. The launcher's startup deadline is measured from the last *change* to this
+// file rather than from the spawn, so a cold cache on a slow link takes as long as it takes,
+// while a daemon that is making no progress at all still dies after the fixed limit (#1938).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Progress {
+    pub completed: u64,
+    pub total: u64,
+    pub bytes: u64,
+}
+
+pub fn parse(text: &str) -> Option<Progress> {
+    let mut fields = text.split_whitespace();
+    let completed = fields.next()?.parse().ok()?;
+    let total = fields.next()?.parse().ok()?;
+    let bytes = fields.next()?.parse().ok()?;
+    if fields.next().is_some() { return None; }
+    Some(Progress { completed, total, bytes })
+}
+
+pub fn read(path: &Path) -> Option<Progress> {
+    std::fs::read_to_string(path).ok().and_then(|text| parse(&text))
+}
+
+pub fn message(progress: &Progress) -> String {
+    format!(
+        "Fetching dependencies {}/{} ({})…",
+        progress.completed, progress.total, size(progress.bytes),
+    )
+}
+
+pub fn reason(progress: &Progress, idle: Duration) -> String {
+    format!(
+        "it was still fetching dependency {} of {} ({} downloaded) after {}s without progress",
+        (progress.completed + 1).min(progress.total.max(1)), progress.total, size(progress.bytes),
+        idle.as_secs(),
+    )
+}
+
+fn size(bytes: u64) -> String {
+    if bytes >= 1_000_000 { format!("{:.1} MB", bytes as f64 / 1_000_000.0) }
+    else if bytes >= 1_000 { format!("{:.0} kB", bytes as f64 / 1_000.0) }
+    else { format!("{bytes} B") }
+}
+
+// Tracks the last observed progress and when it last changed. The file's absence is itself a
+// state: its disappearance after downloads complete counts as one change, so class loading gets
+// a fresh idle window of its own.
+pub struct Watch {
+    last_seen: Option<Progress>,
+    last_change: Instant,
+}
+
+impl Watch {
+    pub fn new(now: Instant) -> Watch { Watch { last_seen: None, last_change: now } }
+
+    pub fn observe(&mut self, current: Option<Progress>, now: Instant) -> bool {
+        if current == self.last_seen { return false; }
+        self.last_seen = current;
+        self.last_change = now;
+        true
+    }
+
+    pub fn current(&self) -> Option<Progress> { self.last_seen }
+
+    pub fn expired(&self, now: Instant, idle_limit: Duration) -> bool {
+        now.duration_since(self.last_change) >= idle_limit
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn progress(completed: u64, total: u64, bytes: u64) -> Progress {
+        Progress { completed, total, bytes }
+    }
+
+    #[test]
+    fn parses_a_full_line() {
+        assert_eq!(parse("34 128 12345678\n"), Some(progress(34, 128, 12345678)));
+    }
+
+    #[test]
+    fn rejects_blank_partial_garbage_and_extra_fields() {
+        assert_eq!(parse(""), None);
+        assert_eq!(parse("34 128"), None);
+        assert_eq!(parse("a b c"), None);
+        assert_eq!(parse("1 2 3 4"), None);
+    }
+
+    #[test]
+    fn a_fresh_watch_expires_at_the_idle_limit() {
+        let start = Instant::now();
+        let watch = Watch::new(start);
+        assert!(!watch.expired(start + Duration::from_secs(9), Duration::from_secs(10)));
+        assert!(watch.expired(start + Duration::from_secs(10), Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn a_change_resets_the_idle_clock() {
+        let start = Instant::now();
+        let mut watch = Watch::new(start);
+        assert!(watch.observe(Some(progress(0, 2, 0)), start + Duration::from_secs(1)));
+        assert!(watch.observe(Some(progress(0, 2, 500)), start + Duration::from_secs(9)));
+        assert!(!watch.expired(start + Duration::from_secs(18), Duration::from_secs(10)));
+        assert!(watch.expired(start + Duration::from_secs(19), Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn identical_content_does_not_reset_the_clock() {
+        let start = Instant::now();
+        let mut watch = Watch::new(start);
+        assert!(watch.observe(Some(progress(1, 2, 500)), start + Duration::from_secs(1)));
+        assert!(!watch.observe(Some(progress(1, 2, 500)), start + Duration::from_secs(9)));
+        assert!(watch.expired(start + Duration::from_secs(11), Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn disappearance_counts_as_one_change() {
+        let start = Instant::now();
+        let mut watch = Watch::new(start);
+        assert!(watch.observe(Some(progress(2, 2, 900)), start + Duration::from_secs(1)));
+        assert!(watch.observe(None, start + Duration::from_secs(5)));
+        assert!(!watch.observe(None, start + Duration::from_secs(6)));
+        assert!(!watch.expired(start + Duration::from_secs(14), Duration::from_secs(10)));
+        assert!(watch.expired(start + Duration::from_secs(15), Duration::from_secs(10)));
+        assert_eq!(watch.current(), None);
+    }
+
+    #[test]
+    fn messages_name_the_position_and_size() {
+        assert_eq!(message(&progress(34, 128, 12_345_678)), "Fetching dependencies 34/128 (12.3 MB)…");
+        assert_eq!(message(&progress(0, 2, 512)), "Fetching dependencies 0/2 (512 B)…");
+        assert_eq!(
+            reason(&progress(34, 128, 12_345_678), Duration::from_secs(10)),
+            "it was still fetching dependency 35 of 128 (12.3 MB downloaded) after 10s without progress",
+        );
+    }
+}

--- a/lib/ethereal/src/runner/src/state.rs
+++ b/lib/ethereal/src/runner/src/state.rs
@@ -83,10 +83,6 @@ pub fn await_file(path: &Path, max_attempts: u32) -> bool {
     poll_until(path, max_attempts, file_has_content)
 }
 
-pub fn await_socket(path: &Path, max_attempts: u32) -> bool {
-    poll_until(path, max_attempts, socket_ready)
-}
-
 pub fn abort(fail_file: &Path) {
     let _ = File::create(fail_file);
 }

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -1018,3 +1018,88 @@ object Tests extends Suite(m"Ethereal Tests"):
         . assert(_ == Exit.Ok)
 
       sh"rm -rf $brokenStateDir".exec[Unit]()
+
+      // A daemon that stands in for a Burdock bootstrap on a cold cache: before binding its
+      // socket it keeps the launcher's progress file advancing for longer than the launcher's
+      // 10s idle limit, so it may only start if that limit is measured from the last change
+      // to the file (#1938). The stalled control binds just as late but reports nothing, and
+      // must still be abandoned.
+      val progressStateDir: Path on Local =
+        Xdg.runtimeDir[Path on Local].or(Xdg.stateHome[Path on Local]) / t"prgrs"
+
+      val stalledStateDir: Path on Local =
+        Xdg.runtimeDir[Path on Local].or(Xdg.stateHome[Path on Local]) / t"stald"
+
+      val progressExe: Path on Linux = Enclave("prgrs").dispatch:
+        ' {
+            import executives.completionsExecutive
+            import interpreters.posixInterpreter
+
+            val progress: String | Null = jl.System.getProperty("burdock.progress")
+
+            if jl.System.getProperty("ethereal.name") != null && progress != null then
+              val path = _root_.java.nio.file.Paths.get(progress).nn
+              val deadline = jl.System.currentTimeMillis + 13000
+              var bytes: Long = 0
+
+              while jl.System.currentTimeMillis < deadline do
+                bytes += 4096
+                _root_.java.nio.file.Files.writeString(path, "0 1 "+bytes+"\n")
+                jl.Thread.sleep(500)
+
+              _root_.java.nio.file.Files.deleteIfExists(path)
+
+            cli:
+              arguments match
+                case _ => execute(Out.print(if progress == null then t"" else progress.tt) yet Exit.Ok)
+
+            t"finished"
+          }
+      . path
+
+      val stalledExe: Path on Linux = Enclave("stald").dispatch:
+        ' {
+            import executives.completionsExecutive
+            import interpreters.posixInterpreter
+
+            if jl.System.getProperty("ethereal.name") != null then jl.Thread.sleep(13000)
+
+            cli:
+              arguments match
+                case _ => execute(Out.print(t"stalled") yet Exit.Ok)
+
+            t"finished"
+          }
+      . path
+
+      // Staging a launcher runs it once, so each test below first kills whatever that left
+      // behind and wipes its state: the cold start under test must be the test's own.
+      def coldStart(name: Text, stateDir: Path on Local): Unit =
+        safely(sh"pkill $name".exec[Exit]())
+        snooze(0.3*Second)
+        sh"rm -rf $stateDir".exec[Unit]()
+
+      suite(m"Startup progress"):
+        test(m"a daemon reporting progress may take longer than the idle limit to bind"):
+          coldStart(t"prgrs", progressStateDir)
+          sh"$progressExe hello".exec[Text]()
+        . assert(_ == t"$progressStateDir/progress")
+
+        test(m"the progress file is gone once the daemon has started"):
+          sh"test -e $progressStateDir/progress".exec[Exit]()
+        . assert(_ != Exit.Ok)
+
+        test(m"a daemon binding late without reporting progress is abandoned"):
+          coldStart(t"stald", stalledStateDir)
+          safely(sh"$stalledExe hello".exec[Exit]()).or(Exit.Fail(1))
+        . assert(_ != Exit.Ok)
+
+        test(m"the abandoned daemon leaves a fail file"):
+          sh"test -f $stalledStateDir/fail".exec[Exit]()
+        . assert(_ == Exit.Ok)
+
+      safely(sh"$progressExe '{admin}' kill".exec[Exit]())
+      snooze(0.2*Second)
+      safely(sh"pkill prgrs".exec[Exit]())
+      safely(sh"pkill stald".exec[Exit]())
+      sh"rm -rf $progressStateDir $stalledStateDir".exec[Unit]()


### PR DESCRIPTION
A Burdock-repackaged Ethereal daemon downloaded its externalized dependencies one at a time before binding its socket, while the launcher killed it at a fixed 10 s, so the first run of a distributed binary on a machine with an empty cache failed until enough retries had filled it (#1938). The bootstrap now fetches on a bounded thread pool and reports its position in a progress file; the launcher measures its 10 s limit from the last change to that file, shows the position while it waits, and names the download in flight if it does give up. Fixes #1938.

### Burdock
- `Bootstrap` downloads `Burdock-Require` dependencies up to eight at a time, with connect and read timeouts, preserving classpath order.
- When the `burdock.progress` system property names a file, the bootstrap keeps it updated with `<completed> <total> <bytes>` while fetching and deletes it when done. A plain `java -jar` run writes nothing.
- `XDG_CACHE_HOME` is honoured. Previously a set value sent dependencies to a `burdock` directory under the working directory.
- No temp file is leaked on a cache hit, and a malformed requirement exits with status 2 and a message instead of a stack trace.

### Ethereal
- The launcher passes `-Dburdock.progress=<state dir>/progress` and treats its 10 s startup deadline as an idle limit, restarted by every change to that file. A cold cache on a slow link takes as long as it takes; a daemon making no progress is still abandoned after 10 s.
- While waiting it shows `Fetching dependencies 34/128 (12.3 MB)…`, and the failure report says `it was still fetching dependency 35 of 128 … after 10s without progress` rather than quoting an unrelated log tail.
- A second launcher waiting on another launcher's startup follows the same rule.

The runner change ships to users with the next `runners-<version>` release and pin bump; the bootstrap change reaches a repackaged application when it is repackaged against a Soundness release carrying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
