### PR TITLE
Benchmark parasite against cats-effect and Kyo, and add a pooling supervisor

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -2638,6 +2638,18 @@ object parasite extends Library:
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
   object test extends Tests(core, jvm, quantitative.units)
+  // The effect-runtime rivals: the cats-effect/fs2 and Kyo constructions of
+  // github.com/stasimus/scala-effect-bench, each measured beside its direct-style Soundness
+  // idiom. `zephyrine.core` supplies `Handoff`, the bounded hand-off ring the queue rows use.
+  object bench extends Benchmarks(core, jvm, quantitative.units, zephyrine.core):
+    def mvnDeps = Seq(
+      mvn"org.typelevel::cats-effect:3.7.1",
+      mvn"co.fs2::fs2-core:3.13.0",
+      mvn"io.getkyo::kyo-core:1.0.0-RC6" )
+    // Kyo's `Safepoint`/`Frame` given machinery does not resolve under explicit-nulls and
+    // no-flexible-types; drop just those two for the benchmark sources, as `turbulence.bench` does.
+    override def scalacOptions = Task:
+      super.scalacOptions().filterNot(Set("-Yexplicit-nulls", "-Yno-flexible-types"))
 
 object perihelion extends Library:
   object core extends Component(telekinesis.core, coaxial.jvm, gastronomy.core, monotonous.core,

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -546,3 +546,12 @@ not yet been recorded here.
   offered before `finish()` is always delivered. Previously a consumer racing the producer's last
   `offer`/`finish` pair could lose that item (about one hand-off in 10⁵ with both sides on virtual
   threads). Behaviour in every other interleaving is unchanged.
+
+## parasite
+
+- New: `parasite.concurrently[result: ClassTag](count: Int, parallelism: Int)(job: Int => result)(using Monitor^, Probate^, Codepoint): IArray[result] raises Async.Error`
+  (also exported as `soundness.concurrently`): runs `job(0)` to `job(count - 1)` across at most
+  `parallelism` tasks pulling indices from a shared counter, and returns the results in index
+  order once all have joined. Prefer it over one `async` per element for a batch of cheap jobs:
+  a task is a virtual thread, so the spawn cost is paid `parallelism` times instead of `count`.
+  A job's exception fails its task and is rethrown at the join.

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -537,3 +537,12 @@ not yet been recorded here.
   `TestEvent.BenchmarkRecorded`. The harness's own boxing of each body result into its sink
   (one box per operation for a primitive result) is included, not subtracted. The staged
   measurement list returned by a cell has one more trailing element.
+
+## zephyrine
+
+- `zephyrine.Handoff#take()` and `Handoff#drain(into)` no longer report the ring drained (`null` /
+  `0`) when the producer's `finish()` was observed between the consumer's read of the tail index
+  and its check of the finished flag: the tail is re-read after `done` is seen, so the final item
+  offered before `finish()` is always delivered. Previously a consumer racing the producer's last
+  `offer`/`finish` pair could lose that item (about one hand-off in 10⁵ with both sides on virtual
+  threads). Behaviour in every other interleaving is unchanged.

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -555,3 +555,10 @@ not yet been recorded here.
   order once all have joined. Prefer it over one `async` per element for a batch of cheap jobs:
   a task is a virtual thread, so the spawn cost is paid `parallelism` times instead of `count`.
   A job's exception fails its task and is rethrown at the join.
+- New: `parasite.PoolingSupervisor` (abstract; `protected def spawn(runnable: Runnable): Thread`,
+  `protected def idleLimit: Int = 256`), a `ThreadSupervisor` that runs tasks on reusable carrier
+  threads, and `parasite.PooledSupervisor`, its instance over virtual threads on the JVM and
+  platform threads on Scala Native, selected by the new `parasite.threading.pooledThreading`
+  given (all three re-exported from `soundness`). Under it a task's `Thread.currentThread` is a
+  carrier reused across tasks, so thread-locals and thread names are not per-task; cancellation,
+  probates, `Promise` waiting and every other observable behaviour match `virtualThreading`.

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -513,3 +513,27 @@ not yet been recorded here.
   the path of a file the bootstrap keeps updated with one line, `<completed> <total> <bytes>`,
   while fetching, and deletes when done. Ethereal's launcher sets it; a plain `java -jar` run
   writes nothing. (#1938)
+## probably (allocation per operation)
+
+- `probably.TestEvent.BenchmarkRecorded` gains a field `allocation: Optional[Long]` (bytes
+  allocated per operation over the timed batches; `Unset` when the producer did not measure it)
+  between `operationRate` and `timestamp`. Its arity is now 14. The BinTEL schema fingerprint
+  `probably.Streamer.fingerprint` changes accordingly, so a host built against an earlier
+  `probably` reports the suite as incompatible: fume must be rebuilt against this version.
+- `probably.Benchmark` gains a trailing parameter `allocation: Optional[Long] = Unset`, and
+  `Benchmark.inclusion` records `Metric.Allocation` (bytes per operation) in the `Run` metrics
+  when it is present.
+
+## sedentary
+
+- `sedentary.Bench` constructor changed from `Bench()(using Classloader, Environment)(using BenchmarkDevice)`
+  to `Bench(heap: Optional[Text] = Unset, cpus: Optional[Int] = Unset, gc: Optional[Text] = Unset)(using Classloader, Environment)(using BenchmarkDevice)`,
+  with the same meaning as `Stress`'s parameters: the measurement JVM's fixed heap (`-Xms`/`-Xmx`,
+  default `1g`), its processor count, and its collector (`-XX:+Use<gc>GC`, default `Serial`).
+  `Bench()` is unchanged in behaviour.
+- `sedentary.Bench` now measures the bytes allocated across a cell's timed batches (via
+  `com.sun.management.ThreadMXBean#getTotalThreadAllocatedBytes`, so worker and virtual-thread
+  allocation is included) and reports it as `allocation` on `probably.Benchmark` and
+  `TestEvent.BenchmarkRecorded`. The harness's own boxing of each body result into its sink
+  (one box per operation for a primitive result) is included, not subtracted. The staged
+  measurement list returned by a cell has one more trailing element.

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -540,6 +540,14 @@ not yet been recorded here.
 
 ## zephyrine
 
+- New: `zephyrine.Addressable#assemble(pieces: scala.collection.immutable.Seq[Self], total: Int): Self`,
+  joining exact-size pieces into one value of length `total`. The trait supplies a default
+  through `allocate`/`copyChunk`/`materialize`; the `Data` and `Text` instances override it to
+  copy the pieces once. A custom `Addressable` needs no change.
+- `zephyrine.Stream#memoize` now copies each region once at its exact size and joins the pieces
+  with `assemble` (returning a single region's copy directly), instead of appending to a growing
+  builder: for a 4 MB result, about 8 MB allocated rather than 12 MB. The value returned is
+  unchanged.
 - `zephyrine.Handoff#take()` and `Handoff#drain(into)` no longer report the ring drained (`null` /
   `0`) when the producer's `finish()` was observed between the consumer's read of the tail index
   and its check of the finished flag: the tail is re-read after `done` is seen, so the final item

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -519,10 +519,10 @@ not yet been recorded here.
   allocated per operation over the timed batches; `Unset` when the producer did not measure it)
   between `operationRate` and `timestamp`. Its arity is now 14. The BinTEL schema fingerprint
   `probably.Streamer.fingerprint` changes accordingly, so a host built against an earlier
-  `probably` reports the suite as incompatible: fume must be rebuilt against this version.
+  `probably` reports the suite as incompatible: fume must be rebuilt against this version. (#1969)
 - `probably.Benchmark` gains a trailing parameter `allocation: Optional[Long] = Unset`, and
   `Benchmark.inclusion` records `Metric.Allocation` (bytes per operation) in the `Run` metrics
-  when it is present.
+  when it is present. (#1969)
 
 ## sedentary
 
@@ -530,30 +530,30 @@ not yet been recorded here.
   to `Bench(heap: Optional[Text] = Unset, cpus: Optional[Int] = Unset, gc: Optional[Text] = Unset)(using Classloader, Environment)(using BenchmarkDevice)`,
   with the same meaning as `Stress`'s parameters: the measurement JVM's fixed heap (`-Xms`/`-Xmx`,
   default `1g`), its processor count, and its collector (`-XX:+Use<gc>GC`, default `Serial`).
-  `Bench()` is unchanged in behaviour.
+  `Bench()` is unchanged in behaviour. (#1969)
 - `sedentary.Bench` now measures the bytes allocated across a cell's timed batches (via
   `com.sun.management.ThreadMXBean#getTotalThreadAllocatedBytes`, so worker and virtual-thread
   allocation is included) and reports it as `allocation` on `probably.Benchmark` and
   `TestEvent.BenchmarkRecorded`. The harness's own boxing of each body result into its sink
   (one box per operation for a primitive result) is included, not subtracted. The staged
-  measurement list returned by a cell has one more trailing element.
+  measurement list returned by a cell has one more trailing element. (#1969)
 
 ## zephyrine
 
 - New: `zephyrine.Addressable#assemble(pieces: scala.collection.immutable.Seq[Self], total: Int): Self`,
   joining exact-size pieces into one value of length `total`. The trait supplies a default
   through `allocate`/`copyChunk`/`materialize`; the `Data` and `Text` instances override it to
-  copy the pieces once. A custom `Addressable` needs no change.
+  copy the pieces once. A custom `Addressable` needs no change. (#1969)
 - `zephyrine.Stream#memoize` now copies each region once at its exact size and joins the pieces
   with `assemble` (returning a single region's copy directly), instead of appending to a growing
   builder: for a 4 MB result, about 8 MB allocated rather than 12 MB. The value returned is
-  unchanged.
+  unchanged. (#1969)
 - `zephyrine.Handoff#take()` and `Handoff#drain(into)` no longer report the ring drained (`null` /
   `0`) when the producer's `finish()` was observed between the consumer's read of the tail index
   and its check of the finished flag: the tail is re-read after `done` is seen, so the final item
   offered before `finish()` is always delivered. Previously a consumer racing the producer's last
   `offer`/`finish` pair could lose that item (about one hand-off in 10⁵ with both sides on virtual
-  threads). Behaviour in every other interleaving is unchanged.
+  threads). Behaviour in every other interleaving is unchanged. (#1969)
 
 ## parasite
 
@@ -562,11 +562,11 @@ not yet been recorded here.
   `parallelism` tasks pulling indices from a shared counter, and returns the results in index
   order once all have joined. Prefer it over one `async` per element for a batch of cheap jobs:
   a task is a virtual thread, so the spawn cost is paid `parallelism` times instead of `count`.
-  A job's exception fails its task and is rethrown at the join.
+  A job's exception fails its task and is rethrown at the join. (#1969)
 - New: `parasite.PoolingSupervisor` (abstract; `protected def spawn(runnable: Runnable): Thread`,
   `protected def idleLimit: Int = 256`), a `ThreadSupervisor` that runs tasks on reusable carrier
   threads, and `parasite.PooledSupervisor`, its instance over virtual threads on the JVM and
   platform threads on Scala Native, selected by the new `parasite.threading.pooledThreading`
   given (all three re-exported from `soundness`). Under it a task's `Thread.currentThread` is a
   carrier reused across tasks, so thread-locals and thread names are not per-task; cancellation,
-  probates, `Promise` waiting and every other observable behaviour match `virtualThreading`.
+  probates, `Promise` waiting and every other observable behaviour match `virtualThreading`. (#1969)

--- a/doc/modules/concurrency.md
+++ b/doc/modules/concurrency.md
@@ -105,6 +105,22 @@ supervise:
 results says nothing about the order in which they finished. `race` returns the first to finish
 and the rest are canceled, since their results were not wanted.
 
+### Bounded parallelism
+
+A task is a thread, and starting one costs a few microseconds, so a thousand cheap jobs should
+not become a thousand tasks. `concurrently` runs numbered jobs across a fixed number of tasks,
+each taking the next job from a shared counter, and returns the results in job order once every
+task has finished:
+
+```scala
+supervise:
+  concurrently(1000, 8)(i => i*i)   // the squares of 0 to 999, in order, from eight tasks
+```
+
+The spawn cost is paid eight times rather than a thousand, and no job runs before an earlier one
+has been claimed, so the load balances itself: a slow job simply holds its task while the others
+continue through the rest. A job's exception fails the task it ran on and is rethrown at the join.
+
 ### Naming tasks
 
 `task` is `async` with a name, checked as the code compiles against the rules for a task name — no

--- a/doc/modules/concurrency.md
+++ b/doc/modules/concurrency.md
@@ -295,6 +295,15 @@ threads at all, `javascriptThreading` schedules tasks on the event loop, and the
 `cancelProbate` cancels it, `awaitProbate` waits for it — so the policy for tidying up concurrent work
 is explicit rather than assumed.
 
+`pooledThreading` runs tasks on a pool of reusable carrier threads — virtual threads on the JVM,
+platform threads on Scala Native — handing each new task to an idle carrier where one is waiting
+and starting another only where none is. A hand-off costs a few hundred nanoseconds where a thread
+start and join cost a few microseconds, so it suits fine-grained fan-out: a task per element, or a
+spawn and join inside a loop. A task that blocks keeps its carrier and the pool grows, so it can
+never starve, and cancellation is delivered to the task rather than to the carrier. The price is
+that a task no longer has a thread of its own: thread-locals persist across the tasks a carrier
+runs, and a thread dump shows carriers where the monitor tree shows tasks.
+
 An `await` may also be given a duration, after which it raises `Async.Error` rather than waiting
 on, so a task that has taken too long is abandoned at a point the code chooses:
 

--- a/lib/parasite/src/bench/parasite.Benchmarks.scala
+++ b/lib/parasite/src/bench/parasite.Benchmarks.scala
@@ -80,6 +80,49 @@ import probates.panicProbate
 //     JMH ran three forks of five). Runner overhead is reported and never subtracted.
 //   * Allocation per operation is `getTotalThreadAllocatedBytes` over the timed batches, which
 //     includes every fiber's and worker's allocation, plus the harness's one box per result.
+//
+// Results, 2026-09-07, Mac16,11 (12 cores, 24 GB), JDK 25.0.2, Scala 3.9.0-p16; mean time per
+// operation (one operation = the whole construction), Soundness / cats-effect / Kyo. The blog's
+// machine was a 16-core Mac15,9 on JDK 25.0.3, so absolute numbers differ; the CE:Kyo ratios
+// (last column, this run → blog) reproduce closely, as do the rivals' bytes per operation
+// (e.g. permit 1.95 MB / 329 kB against the blog's 1,945,464 / 329,642).
+//
+//   Runner overhead                      0.031 µs    8.10 µs    7.40 µs   Kyo 1.09× → 1.20×
+//   Deep bind, depth 1000                0.044 µs    19.8 µs    20.2 µs   CE 1.02× → Kyo 1.01×
+//   Deep bind, depth 10000               0.044 µs     119 µs     137 µs   CE 1.15× → 1.14×
+//   Left bind, depth 1000                0.044 µs    24.6 µs    3.26 ms   CE 132× → 107×
+//   Left bind, depth 10000               0.044 µs     160 µs     340 ms   CE 2125× → 1895×
+//   Map chain, depth 1000                0.043 µs    18.5 µs    20.9 µs   CE 1.13× → 1.06×
+//   Map chain, depth 10000               0.043 µs     104 µs     134 µs   CE 1.29× → 1.20×
+//   CAS reference updates ×1000          1.84 µs     22.7 µs    25.2 µs   CE 1.11× → 1.00×
+//   Complete then read promise ×1000     5.44 µs     65.6 µs    70.1 µs   CE 1.07× → 1.10×
+//   Queue, 1 producer / 1 consumer       56.7 µs      110 µs    77.7 µs   Kyo 1.42× → 1.45×
+//   Uncontended permit ×1000             4.87 µs      340 µs    60.1 µs   Kyo 5.67× → 5.02×
+//   Sequential spawn/join ×1000          6.96 ms      456 µs     155 µs   Kyo 2.93× → 2.75×
+//   Bounded workers, work 0              0.193 ms    0.273 ms   0.199 ms  Kyo 1.37× → 1.13×
+//   Bounded workers, work 64             0.232 ms    0.336 ms   0.593 ms  CE 1.76× → 2.22×
+//   Collect successes, work 0            4.69 ms     1.02 ms    0.96 ms   Kyo 1.06× → CE 1.08×
+//   Collect successes, work 64           4.53 ms     0.99 ms    1.36 ms   CE 1.38× → 1.41×
+//   Sequential chunks, work 0            6.72 µs      528 µs     755 µs   fs2 1.43× → 1.24×
+//   Sequential chunks, work 64           0.626 ms    1.17 ms    1.63 ms   fs2 1.40× → 1.18×
+//   Parallel chunks, work 0              3.52 ms     1.51 ms    0.81 ms   Kyo 1.86× → 1.93×
+//   Parallel chunks, work 64             3.88 ms     1.84 ms    1.70 ms   Kyo 1.08× → 1.11×
+//   Queue-backed chunks, work 0          18.0 µs      571 µs     143 µs   Kyo 3.99× → 3.70×
+//   Queue-backed chunks, work 64         0.748 ms    1.25 ms    0.80 ms   Kyo 1.57× → 1.75×
+//
+// The Soundness column splits cleanly by whether the construction spawns tasks: every row that
+// does not (direct-style chains, `Atomic`, `Promise`, `Mutex`, `Handoff` hand-off, the sequential
+// and queue-backed streams) is between 1.4× and three orders of magnitude ahead, whereas the
+// rows dominated by spawning — one `async` per element or per batch — lose: a spawn/join costs
+// about 7 µs here (a virtual thread plus a `Worker`'s bookkeeping) against Kyo's 0.15 µs and
+// cats-effect's 0.46 µs. Where the spawned tasks do real work (bounded workers) that overhead is
+// amortised and Soundness leads again. Allocation tells the same story: 32 B for a thousand
+// `Atomic` updates or `Mutex` sections, 15 kB for a thousand queued ints, 0.95 MB for a thousand
+// spawns.
+//
+// Running the queue rows at ~10⁵ repetitions also exposed a real race in `Handoff`: a consumer
+// observing `finish()` between its read of the tail index and its check of the finished flag
+// dropped the final item. `take`/`drain` now re-read the tail after seeing `done`.
 object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs Kyo"):
   given decimalizer: Decimalizer     = Decimalizer(2)
   given device:      BenchmarkDevice = LocalhostDevice

--- a/lib/parasite/src/bench/parasite.Benchmarks.scala
+++ b/lib/parasite/src/bench/parasite.Benchmarks.scala
@@ -1,0 +1,505 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package parasite
+
+import scala.annotation.tailrec
+import scala.quoted.*
+
+import ambience.*, environments.javaBaseEnvironment, systems.javaBaseSystem
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import denominative.*, dysasymptotics.linearSize
+import fulminate.*, errorDiagnostics.emptyDiagnostics
+import gossamer.*
+import hellenism.*, classloaders.threadContextClassloader
+import probably.*
+import proscenium.*
+import quantitative.*
+import rudiments.*
+import sedentary.*
+import symbolism.*
+import temporaryDirectories.systemTemporaryDirectory
+import vacuous.*
+import zephyrine.*
+
+import threading.virtualThreading
+import probates.panicProbate
+
+// The effect-runtime comparison from github.com/stasimus/scala-effect-bench (the blog post
+// "Kyo vs Cats Effect: promising numbers", 2026-09), re-measured under Soundness's own harness,
+// with a third row per construction: the way the same job is written in Soundness. The rival
+// rows run that repository's benchmark bodies verbatim (`Rivals`); the Soundness rows are the
+// idiom a user of parasite, rudiments and zephyrine would reach for, written plainly.
+//
+// Read the comparison with these differences in mind:
+//   * Soundness has no suspension monad. The "core chain" rows (deep bind, left-associated bind,
+//     map chain) are, in Soundness, a loop or a tail-recursive function: there is no `IO`/`<`
+//     node per step, so those rows measure the effect wrapper's cost against direct style. (A
+//     `Task.bind` chain is not the analogue — every `bind` starts a worker, which is what the
+//     spawn/join row measures.)
+//   * The rivals' fibers are scheduled on their own thread pools; Soundness tasks are virtual
+//     threads under a `supervise` scope, so a spawn/join is a Loom mount/unmount and a scope's
+//     bookkeeping, not an interpreter step.
+//   * `Handoff` is the bounded single-producer/single-consumer ring behind `Conduit`; the queue
+//     rows box each `Int` into it, as the generic `Queue`/`Channel` do.
+//   * `Mutex` is a `ReentrantLock`, so the permit row compares a reentrant lock against the
+//     rivals' non-reentrant single permit; the rivals return the free permit count, which a
+//     `Mutex` does not expose, so the Soundness row returns the constant the rivals compute.
+//   * The measurement JVM is fixed at a 2 GB heap on G1, as the blog's JMH forks were, and each
+//     cell runs in a fresh JVM (sedentary forks one per cell, and reports five timed batches;
+//     JMH ran three forks of five). Runner overhead is reported and never subtracted.
+//   * Allocation per operation is `getTotalThreadAllocatedBytes` over the timed batches, which
+//     includes every fiber's and worker's allocation, plus the harness's one box per result.
+object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs Kyo"):
+  given decimalizer: Decimalizer     = Decimalizer(2)
+  given device:      BenchmarkDevice = LocalhostDevice
+
+  // The comparison axis; cats-effect is the baseline, since the blog reports Kyo relative to it.
+  enum Library:
+    case Soundness, CatsEffect, Kyo
+
+  // Every parameter is read from an array at measurement time, so no arm — direct-style code
+  // in particular — can see its loop bound as a compile-time constant.
+  val depths:      scala.Array[Int] = scala.Array(1000, 10000)
+  val rounds:      scala.Array[Int] = scala.Array(0, 64)
+  val ops:         Int = 1000
+  val capacity:    Int = 64
+  val size:        Int = 4096
+  val parallelism: Int = 8
+  val streamSize:  Int = 10000
+  val chunkSize:   Int = 64
+  val streamWorkers: Int = 4
+
+  // The rivals take stdlib `Vector`s, exactly as their benchmarks declared them; the Soundness
+  // arms take immutable arrays. Both are built once, here, and referenced from the staged
+  // bodies by fully-qualified name.
+  lazy val values: scala.Vector[Int] = scala.Vector.tabulate(size)(identity)
+  lazy val batches: scala.Vector[scala.Vector[Int]] =
+    scala.Vector.tabulate(streamSize)(identity).grouped(chunkSize).toVector
+
+  lazy val valuesArray: IArray[Int] = IArray.tabulate(size)(identity)
+  lazy val batchArrays: List[IArray[Int]] =
+    List.tabulate(batches.size) { index => IArray.from(batches(index)) }
+
+  // An error a task raises to stand for the rivals' `RuntimeException with NoStackTrace`;
+  // `emptyDiagnostics` likewise records no stack.
+  object Expected:
+    case class Error()(using Diagnostics) extends fulminate.Error(m"expected failure")
+
+  inline def work(value: Int, rounds: Int): Int = Rivals.work(value, rounds)
+
+  // ── The Soundness arms ──────────────────────────────────────────────────────────────────
+
+  object Direct:
+    def runner(): Int = supervise(1)
+
+    def deepBind(depth: Int): Int =
+      @tailrec
+      def loop(i: Int): Int = if i == depth then i else loop(i + 1)
+      loop(0)
+
+    def leftBind(depth: Int): Int =
+      var acc = 0
+      var i = 0
+      while i < depth do
+        acc += 1
+        i += 1
+      acc
+
+    def mapChain(depth: Int): Int =
+      var acc = 0
+      var i = 0
+      while i < depth do
+        acc += 1
+        i += 1
+      acc
+
+    def ref(ops: Int): Int =
+      val ref = Atomic(0)
+      var i = 0
+      while i < ops do
+        ref.since(_ + 1)
+        i += 1
+      ref()
+
+    def promise(ops: Int): Long = supervise:
+      var sum = 0L
+      var i = 0
+      while i < ops do
+        val promise: Promise[Int] = Promise()
+        promise.fulfill(i)
+        sum += promise.await()
+        i += 1
+      sum
+
+    // One producer task, the consumer on the calling strand, `Int`s boxed through the ring.
+    def queue(ops: Int, capacity: Int): Long = supervise:
+      val queue = Handoff(capacity)
+      val producer = async:
+        var i = 0
+        while i < ops do
+          queue.offer(Integer.valueOf(i))
+          i += 1
+        queue.finish()
+      var sum = 0L
+      var i = 0
+      while i < ops do
+        sum += queue.take().asInstanceOf[Integer].intValue
+        i += 1
+      producer.await()
+      sum
+
+    def permit(ops: Int): Int =
+      val mutex = Mutex()
+      var i = 0
+      while i < ops do
+        mutex(())
+        i += 1
+      1
+
+    def spawnJoin(ops: Int): Long = supervise:
+      var sum = 0L
+      var i = 0
+      while i < ops do
+        val value = i
+        sum += async(value).await()
+        i += 1
+      sum
+
+    // The same shape as the rivals' `Workers`: a shared index, an indexed output array,
+    // min(size, parallelism) tasks, joined together.
+    def workers(values: IArray[Int], parallelism: Int, rounds: Int): IArray[Int] = supervise:
+      val index = Atomic(0)
+      val output = new scala.Array[Int](values.length)
+      val tasks = List.fill(parallelism.min(values.length)):
+        async:
+          var running = true
+          while running do
+            val i = index.ere(_ + 1)
+            if i >= values.length then running = false else output(i) = work(values(i), rounds)
+      tasks.sequence.await()
+      IArray.unsafeFromArray(output)
+
+    // One task per element; a failing element aborts with a typed error, which `safely` turns
+    // into an absent result at the join, so the successes come back in order.
+    def collectSuccesses(values: IArray[Int], rounds: Int): IArray[Int] = supervise:
+      val tasks = List.tabulate(values.length): i =>
+        val value = values(i)
+        async:
+          if (value & 1023) == 0 then abort(Expected.Error()) else work(value, rounds)
+      val output = new scala.Array[Int](values.length)
+      var count = 0
+      tasks.each: task =>
+        safely(task.await()).let: value =>
+          output(count) = value
+          count += 1
+      IArray.unsafeFromArray(output.take(count))
+
+    // Each chunk is transformed whole, then folded: a nested loop, since a batch of ints needs
+    // no stream.
+    def evalChunks(batches: List[IArray[Int]], rounds: Int): Long =
+      var sum = 0L
+      batches.each: batch =>
+        val transformed = batch.map(work(_, rounds))
+        var i = 0
+        while i < transformed.length do
+          sum += transformed(i)
+          i += 1
+      sum
+
+    // Per batch, the bounded workers above; the batch is complete before the next starts.
+    def parallelChunks(batches: List[IArray[Int]], parallelism: Int, rounds: Int): Long =
+      var sum = 0L
+      batches.each: batch =>
+        val transformed = workers(batch, parallelism, rounds)
+        var i = 0
+        while i < transformed.length do
+          sum += transformed(i)
+          i += 1
+      sum
+
+    // A producer task hands each prebuilt chunk through a `Handoff` of `capacity` chunks; the
+    // consumer takes exactly `batches.size` of them and transforms each as it arrives.
+    def queueChunks(batches: List[IArray[Int]], capacity: Int, rounds: Int): Long = supervise:
+      val queue = Handoff(capacity)
+      val producer = async:
+        batches.each(batch => queue.offer(batch.asInstanceOf[AnyRef]))
+        queue.finish()
+      var sum = 0L
+      var taken = 0
+      val count = batches.size
+      while taken < count do
+        val batch = queue.take().asInstanceOf[IArray[Int]]
+        var i = 0
+        while i < batch.length do
+          sum += work(batch(i), rounds)
+          i += 1
+        taken += 1
+      producer.await()
+      sum
+
+  // ── Agreement checks and the plan ───────────────────────────────────────────────────────
+
+  private def agree[value](construction: Text)(soundness: value, catsEffect: value, kyo: value)
+  :   Unit =
+    assert(soundness == catsEffect, s"$construction: Soundness $soundness ≠ cats-effect $catsEffect")
+    assert(kyo == catsEffect, s"$construction: Kyo $kyo ≠ cats-effect $catsEffect")
+
+  private def check(): Unit =
+    agree(t"runner")(Direct.runner(), Rivals.Ce.runner(), Rivals.Ky.runner())
+
+    depths.foreach: depth =>
+      agree(t"deep bind $depth")(Direct.deepBind(depth), Rivals.Ce.deepBind(depth), Rivals.Ky.deepBind(depth))
+      agree(t"left bind $depth")(Direct.leftBind(depth), Rivals.Ce.leftBind(depth), Rivals.Ky.leftBind(depth))
+      agree(t"map chain $depth")(Direct.mapChain(depth), Rivals.Ce.mapChain(depth), Rivals.Ky.mapChain(depth))
+
+    agree(t"ref")(Direct.ref(ops), Rivals.Ce.ref(ops), Rivals.Ky.ref(ops))
+    agree(t"promise")(Direct.promise(ops), Rivals.Ce.deferred(ops), Rivals.Ky.promise(ops))
+    agree(t"queue")(Direct.queue(ops, capacity), Rivals.Ce.queue(ops, capacity), Rivals.Ky.queue(ops, capacity))
+    agree(t"permit")(Direct.permit(ops), Rivals.Ce.semaphore(ops), Rivals.Ky.semaphore(ops))
+    agree(t"spawn/join")(Direct.spawnJoin(ops), Rivals.Ce.spawnJoin(ops), Rivals.Ky.spawnJoin(ops))
+
+    rounds.foreach: work =>
+      agree(t"workers $work")
+        ( Direct.workers(valuesArray, parallelism, work).toVector,
+          Rivals.Ce.workers(values, parallelism, work),
+          Rivals.Ky.workers(values, parallelism, work) )
+
+      agree(t"collect successes $work")
+        ( Direct.collectSuccesses(valuesArray, work).toVector,
+          Rivals.Ce.collectSuccesses(values, work),
+          Rivals.Ky.collectSuccesses(values, work) )
+
+      agree(t"eval chunks $work")
+        ( Direct.evalChunks(batchArrays, work),
+          Rivals.Ce.evalChunks(batches, work),
+          Rivals.Ky.evalChunks(batches, work) )
+
+      agree(t"parallel chunks $work")
+        ( Direct.parallelChunks(batchArrays, streamWorkers, work),
+          Rivals.Ce.parallelChunks(batches, streamWorkers, work),
+          Rivals.Ky.parallelChunks(batches, streamWorkers, work) )
+
+      agree(t"queue chunks $work")
+        ( Direct.queueChunks(batchArrays, capacity, work),
+          Rivals.Ce.queueChunks(batches, capacity, work),
+          Rivals.Ky.queueChunks(batches, capacity, work) )
+
+  def run(): Unit =
+    check()
+
+    val bench = Bench(heap = t"2g", gc = t"G1")
+    val depthAxis: Axis[Int] = Axis(t"depth")(1000, 10000)
+    val workAxis: Axis[Int] = Axis(t"work")(0, 64)
+
+    suite(m"Runner baseline"):
+      bench(m"Runner overhead")(target = 1*Second, baseline = Library.CatsEffect).over(Library):
+        case Library.Soundness  => '{ parasite.Benchmarks.Direct.runner() }
+        case Library.CatsEffect => '{ parasite.Rivals.Ce.runner() }
+        case Library.Kyo        => '{ parasite.Rivals.Ky.runner() }
+
+    // The staged bodies receive an INDEX into `depths`/`rounds` (spliced as a literal) and load
+    // the parameter through the array at run time; see the note on the parameter arrays.
+    def depthAt(depth: Int)(using Quotes): Expr[Int] = Expr(depths.indexOf(depth))
+    def workAt(work: Int)(using Quotes): Expr[Int] = Expr(rounds.indexOf(work))
+
+    suite(m"Core chains"):
+      bench(m"Deep suspended bind")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library, depthAxis):
+          case (Library.Soundness, depth) =>
+            '{ parasite.Benchmarks.Direct.deepBind(parasite.Benchmarks.depths(${depthAt(depth)})) }
+          case (Library.CatsEffect, depth) =>
+            '{ parasite.Rivals.Ce.deepBind(parasite.Benchmarks.depths(${depthAt(depth)})) }
+          case (Library.Kyo, depth) =>
+            '{ parasite.Rivals.Ky.deepBind(parasite.Benchmarks.depths(${depthAt(depth)})) }
+
+      bench(m"Left-associated suspended bind")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library, depthAxis):
+          case (Library.Soundness, depth) =>
+            '{ parasite.Benchmarks.Direct.leftBind(parasite.Benchmarks.depths(${depthAt(depth)})) }
+          case (Library.CatsEffect, depth) =>
+            '{ parasite.Rivals.Ce.leftBind(parasite.Benchmarks.depths(${depthAt(depth)})) }
+          case (Library.Kyo, depth) =>
+            '{ parasite.Rivals.Ky.leftBind(parasite.Benchmarks.depths(${depthAt(depth)})) }
+
+      bench(m"Map chain from suspended zero")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library, depthAxis):
+          case (Library.Soundness, depth) =>
+            '{ parasite.Benchmarks.Direct.mapChain(parasite.Benchmarks.depths(${depthAt(depth)})) }
+          case (Library.CatsEffect, depth) =>
+            '{ parasite.Rivals.Ce.mapChain(parasite.Benchmarks.depths(${depthAt(depth)})) }
+          case (Library.Kyo, depth) =>
+            '{ parasite.Rivals.Ky.mapChain(parasite.Benchmarks.depths(${depthAt(depth)})) }
+
+    suite(m"Primitives (ops = 1000, queue capacity 64)"):
+      bench(m"CAS reference updates")(target = 1*Second, baseline = Library.CatsEffect).over(Library):
+        case Library.Soundness  => '{ parasite.Benchmarks.Direct.ref(parasite.Benchmarks.ops) }
+        case Library.CatsEffect => '{ parasite.Rivals.Ce.ref(parasite.Benchmarks.ops) }
+        case Library.Kyo        => '{ parasite.Rivals.Ky.ref(parasite.Benchmarks.ops) }
+
+      bench(m"Complete then read promise")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library):
+          case Library.Soundness  => '{ parasite.Benchmarks.Direct.promise(parasite.Benchmarks.ops) }
+          case Library.CatsEffect => '{ parasite.Rivals.Ce.deferred(parasite.Benchmarks.ops) }
+          case Library.Kyo        => '{ parasite.Rivals.Ky.promise(parasite.Benchmarks.ops) }
+
+      bench(m"Queue: one producer, one consumer")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library):
+          case Library.Soundness =>
+            '{ parasite.Benchmarks.Direct.queue(parasite.Benchmarks.ops, parasite.Benchmarks.capacity) }
+          case Library.CatsEffect =>
+            '{ parasite.Rivals.Ce.queue(parasite.Benchmarks.ops, parasite.Benchmarks.capacity) }
+          case Library.Kyo =>
+            '{ parasite.Rivals.Ky.queue(parasite.Benchmarks.ops, parasite.Benchmarks.capacity) }
+
+      bench(m"Uncontended non-reentrant permit")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library):
+          case Library.Soundness  => '{ parasite.Benchmarks.Direct.permit(parasite.Benchmarks.ops) }
+          case Library.CatsEffect => '{ parasite.Rivals.Ce.semaphore(parasite.Benchmarks.ops) }
+          case Library.Kyo        => '{ parasite.Rivals.Ky.semaphore(parasite.Benchmarks.ops) }
+
+      bench(m"Sequential child spawn and join")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library):
+          case Library.Soundness  => '{ parasite.Benchmarks.Direct.spawnJoin(parasite.Benchmarks.ops) }
+          case Library.CatsEffect => '{ parasite.Rivals.Ce.spawnJoin(parasite.Benchmarks.ops) }
+          case Library.Kyo        => '{ parasite.Rivals.Ky.spawnJoin(parasite.Benchmarks.ops) }
+
+    suite(m"Parallel constructions (size = 4096, parallelism = 8)"):
+      bench(m"Bounded workers")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library, workAxis):
+          case (Library.Soundness, work) =>
+            '{
+                parasite.Benchmarks.Direct.workers
+                  ( parasite.Benchmarks.valuesArray,
+                    parasite.Benchmarks.parallelism,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.CatsEffect, work) =>
+            '{
+                parasite.Rivals.Ce.workers
+                  ( parasite.Benchmarks.values,
+                    parasite.Benchmarks.parallelism,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.Kyo, work) =>
+            '{
+                parasite.Rivals.Ky.workers
+                  ( parasite.Benchmarks.values,
+                    parasite.Benchmarks.parallelism,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+
+      bench(m"Parallel attempt and collect successes")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library, workAxis):
+          case (Library.Soundness, work) =>
+            '{
+                parasite.Benchmarks.Direct.collectSuccesses
+                  ( parasite.Benchmarks.valuesArray, parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.CatsEffect, work) =>
+            '{
+                parasite.Rivals.Ce.collectSuccesses
+                  ( parasite.Benchmarks.values, parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.Kyo, work) =>
+            '{
+                parasite.Rivals.Ky.collectSuccesses
+                  ( parasite.Benchmarks.values, parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+
+    suite(m"Streaming constructions (10000 ints in chunks of 64, 4 workers, 64-chunk queue)"):
+      bench(m"Sequential chunk transformation")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library, workAxis):
+          case (Library.Soundness, work) =>
+            '{
+                parasite.Benchmarks.Direct.evalChunks
+                  ( parasite.Benchmarks.batchArrays, parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.CatsEffect, work) =>
+            '{
+                parasite.Rivals.Ce.evalChunks
+                  ( parasite.Benchmarks.batches, parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.Kyo, work) =>
+            '{
+                parasite.Rivals.Ky.evalChunks
+                  ( parasite.Benchmarks.batches, parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+
+      bench(m"Parallel chunk transformation")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library, workAxis):
+          case (Library.Soundness, work) =>
+            '{
+                parasite.Benchmarks.Direct.parallelChunks
+                  ( parasite.Benchmarks.batchArrays,
+                    parasite.Benchmarks.streamWorkers,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.CatsEffect, work) =>
+            '{
+                parasite.Rivals.Ce.parallelChunks
+                  ( parasite.Benchmarks.batches,
+                    parasite.Benchmarks.streamWorkers,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.Kyo, work) =>
+            '{
+                parasite.Rivals.Ky.parallelChunks
+                  ( parasite.Benchmarks.batches,
+                    parasite.Benchmarks.streamWorkers,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+
+      bench(m"Queue-backed chunk stream")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library, workAxis):
+          case (Library.Soundness, work) =>
+            '{
+                parasite.Benchmarks.Direct.queueChunks
+                  ( parasite.Benchmarks.batchArrays,
+                    parasite.Benchmarks.capacity,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.CatsEffect, work) =>
+            '{
+                parasite.Rivals.Ce.queueChunks
+                  ( parasite.Benchmarks.batches,
+                    parasite.Benchmarks.capacity,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.Kyo, work) =>
+            '{
+                parasite.Rivals.Ky.queueChunks
+                  ( parasite.Benchmarks.batches,
+                    parasite.Benchmarks.capacity,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }

--- a/lib/parasite/src/bench/parasite.Benchmarks.scala
+++ b/lib/parasite/src/bench/parasite.Benchmarks.scala
@@ -52,7 +52,6 @@ import temporaryDirectories.systemTemporaryDirectory
 import vacuous.*
 import zephyrine.*
 
-import threading.virtualThreading
 import probates.panicProbate
 
 // The effect-runtime comparison from github.com/stasimus/scala-effect-bench (the blog post
@@ -82,45 +81,51 @@ import probates.panicProbate
 //     includes every fiber's and worker's allocation, plus the harness's one box per result.
 //
 // Results, 2026-09-07, Mac16,11 (12 cores, 24 GB), JDK 25.0.2, Scala 3.9.0-p16; mean time per
-// operation (one operation = the whole construction), Soundness / cats-effect / Kyo. The blog's
-// machine was a 16-core Mac15,9 on JDK 25.0.3, so absolute numbers differ; the CE:Kyo ratios
-// (last column, this run → blog) reproduce closely, as do the rivals' bytes per operation
-// (e.g. permit 1.95 MB / 329 kB against the blog's 1,945,464 / 329,642).
+// operation (one operation = the whole construction). Columns: Soundness on virtual threads,
+// Soundness on the pooled supervisor (`pooledThreading`, only where a construction spawns
+// tasks), cats-effect, Kyo. The blog's machine was a 16-core Mac15,9 on JDK 25.0.3, so absolute
+// numbers differ; the CE:Kyo ratios (last column, this run → blog) reproduce closely, as do the
+// rivals' bytes per operation (e.g. permit 1.95 MB / 329 kB against the blog's
+// 1,945,464 / 329,642).
 //
-//   Runner overhead                      7.70 µs     8.13 µs    7.39 µs   Kyo 1.10× → 1.20×
-//   Deep bind, depth 1000                0.044 µs    20.9 µs    21.5 µs   CE 1.03× → Kyo 1.01×
-//   Deep bind, depth 10000               0.043 µs     117 µs     137 µs   CE 1.17× → 1.14×
-//   Left bind, depth 1000                0.043 µs    26.5 µs    3.35 ms   CE 126× → 107×
-//   Left bind, depth 10000               0.043 µs     161 µs     344 ms   CE 2137× → 1895×
-//   Map chain, depth 1000                0.044 µs    19.8 µs    22.6 µs   CE 1.14× → 1.06×
-//   Map chain, depth 10000               0.044 µs     105 µs     136 µs   CE 1.30× → 1.20×
-//   CAS reference updates ×1000          1.83 µs     23.9 µs    26.6 µs   CE 1.11× → 1.00×
-//   Complete then read promise ×1000     14.7 µs     65.8 µs    70.3 µs   CE 1.07× → 1.10×
-//   Queue, 1 producer / 1 consumer       67.8 µs      110 µs    76.4 µs   Kyo 1.45× → 1.45×
-//   Uncontended permit ×1000             4.97 µs      340 µs    59.1 µs   Kyo 5.76× → 5.02×
-//   Sequential spawn/join ×1000          2.85 ms      412 µs     156 µs   Kyo 2.64× → 2.75×
-//   Bounded workers, work 0              0.218 ms    0.272 ms   0.205 ms  Kyo 1.33× → 1.13×
-//   Bounded workers, work 64             0.322 ms    0.338 ms   0.596 ms  CE 1.76× → 2.22×
-//   Collect successes, work 0            0.277 ms    0.892 ms   0.960 ms  CE 1.08× → CE 1.08×
-//   Collect successes, work 64           0.324 ms    1.01 ms    1.36 ms   CE 1.35× → 1.41×
-//   Sequential chunks, work 0            6.74 µs      522 µs     768 µs   fs2 1.47× → 1.24×
-//   Sequential chunks, work 64           0.630 ms    1.18 ms    1.58 ms   fs2 1.34× → 1.18×
-//   Parallel chunks, work 0              24.1 µs     1.36 ms    0.82 ms   Kyo 1.66× → 1.93×
-//   Parallel chunks, work 64             0.184 ms    1.85 ms    1.76 ms   Kyo 1.06× → 1.11×
-//   Queue-backed chunks, work 0          20.7 µs      562 µs     142 µs   Kyo 3.96× → 3.70×
-//   Queue-backed chunks, work 64         0.738 ms    1.29 ms    0.81 ms   Kyo 1.60× → 1.75×
+//   Runner overhead                      7.55 µs   8.47 µs    7.95 µs    7.53 µs   Kyo 1.06× → 1.20×
+//   Deep bind, depth 1000                0.045 µs      —      19.7 µs    20.2 µs   CE 1.02× → Kyo 1.01×
+//   Deep bind, depth 10000               0.043 µs      —       117 µs     137 µs   CE 1.17× → 1.14×
+//   Left bind, depth 1000                0.044 µs      —      24.8 µs    3.30 ms   CE 133× → 107×
+//   Left bind, depth 10000               0.044 µs      —       162 µs     342 ms   CE 2111× → 1895×
+//   Map chain, depth 1000                0.043 µs      —      18.3 µs    20.6 µs   CE 1.13× → 1.06×
+//   Map chain, depth 10000               0.043 µs      —       104 µs     130 µs   CE 1.25× → 1.20×
+//   CAS reference updates ×1000          1.81 µs       —      22.5 µs    24.9 µs   CE 1.10× → 1.00×
+//   Complete then read promise ×1000     13.4 µs   14.0 µs    65.7 µs    69.8 µs   CE 1.06× → 1.10×
+//   Queue, 1 producer / 1 consumer       66.4 µs   65.4 µs     118 µs    77.2 µs   Kyo 1.53× → 1.45×
+//   Uncontended permit ×1000             4.86 µs       —       335 µs    60.6 µs   Kyo 5.53× → 5.02×
+//   Sequential spawn/join ×1000          2.87 ms   0.575 ms    441 µs     153 µs   Kyo 2.87× → 2.75×
+//   Bounded workers, work 0              0.233 ms  0.248 ms   0.269 ms   0.201 ms  Kyo 1.34× → 1.13×
+//   Bounded workers, work 64             0.306 ms  0.323 ms   0.340 ms   0.589 ms  CE 1.73× → 2.22×
+//   Collect successes, work 0            0.272 ms  0.284 ms   1.02 ms    0.97 ms   Kyo 1.05× → CE 1.08×
+//   Collect successes, work 64           0.325 ms  0.327 ms   0.99 ms    1.35 ms   CE 1.37× → 1.41×
+//   Sequential chunks, work 0            6.73 µs       —       552 µs     722 µs   fs2 1.31× → 1.24×
+//   Sequential chunks, work 64           0.626 ms      —      1.17 ms    1.70 ms   fs2 1.46× → 1.18×
+//   Parallel chunks, work 0              24.2 µs   28.1 µs    1.51 ms    0.82 ms   Kyo 1.84× → 1.93×
+//   Parallel chunks, work 64             0.187 ms  0.192 ms   1.87 ms    1.72 ms   Kyo 1.09× → 1.11×
+//   Queue-backed chunks, work 0          20.8 µs   21.1 µs     592 µs     157 µs   Kyo 3.77× → 3.70×
+//   Queue-backed chunks, work 64         0.735 ms  0.737 ms   1.27 ms    0.81 ms   Kyo 1.58× → 1.75×
 //
 // Every Soundness construction runs on one task under `supervise`, joined once by the caller
 // (`Direct.running`), as the rivals' run inside their runtimes; that entry is the Soundness
 // runner-overhead row, and is included in every other row. The rows that spawn a task per
 // element or per batch in the rivals (collect successes, parallel chunks) use `concurrently`,
-// a fixed set of workers over numbered jobs, on the Soundness side: a task is a virtual thread,
-// costing about 2.5 µs to start and join from another virtual thread (and 7 µs from a platform
-// thread, whose park is a kernel call), against Kyo's 0.15 µs and cats-effect's 0.4 µs per
-// fiber, so the one row that spawns a thousand tasks by specification — sequential spawn/join —
-// is the one Soundness loses, and bounded fan-out is the idiom that wins the others.
-// Allocation tells the same story: 32 B for a thousand `Atomic` updates or `Mutex` sections,
-// 17 kB for a thousand queued ints, 1.1 MB for a thousand spawns.
+// a fixed set of workers over numbered jobs, on the Soundness side. A task on `virtualThreading`
+// is a virtual thread, costing about 2.5 µs to start and join from another virtual thread (and
+// 7 µs from a platform thread, whose park is a kernel call), against Kyo's 0.15 µs and
+// cats-effect's 0.4 µs per fiber; so the one row that spawns a thousand tasks by specification
+// — sequential spawn/join — is the one Soundness loses on virtual threads, and bounded fan-out
+// is the idiom that wins the others. The pooled supervisor hands a task to a waiting carrier
+// instead of starting a thread, which takes that row from 2.87 ms to 0.575 ms (Kyo 0.153 ms,
+// cats-effect 0.441 ms) and its allocation from 1.0 MB to 0.58 MB, while leaving every other
+// row within noise: the remaining gap to Kyo is that a Kyo fiber's parent and child share one
+// worker thread with no hand-off at all. Allocation tells the same story elsewhere: 32 B for a
+// thousand `Atomic` updates or `Mutex` sections, 17 kB for a thousand queued ints.
 //
 // An earlier form of these rows, spawning a task per element and joining from the harness's
 // platform thread, measured 4.7 ms for collect successes and 3.5 ms for parallel chunks (four
@@ -136,7 +141,7 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
 
   // The comparison axis; cats-effect is the baseline, since the blog reports Kyo relative to it.
   enum Library:
-    case Soundness, CatsEffect, Kyo
+    case Soundness, Pooled, CatsEffect, Kyo
 
   // Every parameter is read from an array at measurement time, so no arm — direct-style code
   // in particular — can see its loop bound as a compile-time constant.
@@ -177,10 +182,10 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
     // once. A join inside the construction is then a virtual-thread park, not a platform
     // thread's kernel park. This is also the runner-overhead row: entering a scope, starting
     // one task and joining it.
-    inline def running[result](inline body: Monitor ?=> result): result =
+    inline def running[result](inline body: Monitor ?=> result)(using Threading): result =
       supervise(async(body).await())
 
-    def runner(): Int = running(1)
+    def runner()(using Threading): Int = running(1)
 
     def deepBind(depth: Int): Int =
       @tailrec
@@ -211,7 +216,7 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
         i += 1
       ref()
 
-    def promise(ops: Int): Long = running:
+    def promise(ops: Int)(using Threading): Long = running:
       var sum = 0L
       var i = 0
       while i < ops do
@@ -222,7 +227,7 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
       sum
 
     // One producer task, the consumer on the calling strand, `Int`s boxed through the ring.
-    def queue(ops: Int, capacity: Int): Long = running:
+    def queue(ops: Int, capacity: Int)(using Threading): Long = running:
       val queue = Handoff(capacity)
       val producer = async:
         var i = 0
@@ -246,7 +251,7 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
         i += 1
       1
 
-    def spawnJoin(ops: Int): Long = running:
+    def spawnJoin(ops: Int)(using Threading): Long = running:
       var sum = 0L
       var i = 0
       while i < ops do
@@ -257,13 +262,16 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
 
     // `concurrently` is the rivals' `Workers` construction exactly: a shared index, an indexed
     // output array, min(size, parallelism) tasks, joined together.
-    def workers(values: IArray[Int], parallelism: Int, rounds: Int): IArray[Int] = running:
-      concurrently(values.length, parallelism)(i => work(values(i), rounds))
+    def workers(values: IArray[Int], parallelism: Int, rounds: Int)(using Threading)
+    :   IArray[Int] =
+      running:
+        concurrently(values.length, parallelism)(i => work(values(i), rounds))
 
-    // The rivals start one fiber per element; a Soundness task is a thread, so the bounded form
-    // is the idiom: eight workers over the elements, each element's failure caught where it
-    // happens (`safely` on the typed `abort`), and the absent results dropped in order.
-    def collectSuccesses(values: IArray[Int], parallelism: Int, rounds: Int): IArray[Int] =
+      // The rivals start one fiber per element; a Soundness task is a thread, so the bounded form
+      // is the idiom: eight workers over the elements, each element's failure caught where it
+      // happens (`safely` on the typed `abort`), and the absent results dropped in order.
+    def collectSuccesses(values: IArray[Int], parallelism: Int, rounds: Int)(using Threading)
+    :   IArray[Int] =
       running:
         val results: IArray[Optional[Int]] =
           concurrently(values.length, parallelism): i =>
@@ -298,7 +306,8 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
     // Soundness form keeps the same number of workers alive across the whole stream, each
     // transforming and folding whole batches in order of claim: the same bounded parallelism
     // and ordered result, without a spawn per batch or a barrier between batches.
-    def parallelChunks(batches: List[IArray[Int]], parallelism: Int, rounds: Int): Long =
+    def parallelChunks(batches: List[IArray[Int]], parallelism: Int, rounds: Int)(using Threading)
+    :   Long =
       running:
         val chunks: IArray[IArray[Int]] = IArray.from(batches.stdlib)
 
@@ -321,42 +330,51 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
 
     // A producer task hands each prebuilt chunk through a `Handoff` of `capacity` chunks; the
     // consumer takes exactly `batches.size` of them and transforms each as it arrives.
-    def queueChunks(batches: List[IArray[Int]], capacity: Int, rounds: Int): Long = running:
-      val queue = Handoff(capacity)
-      val producer = async:
-        batches.each(batch => queue.offer(batch.asInstanceOf[AnyRef]))
-        queue.finish()
-      var sum = 0L
-      var taken = 0
-      val count = batches.size
-      while taken < count do
-        val batch = queue.take().asInstanceOf[IArray[Int]]
-        var i = 0
-        while i < batch.length do
-          sum += work(batch(i), rounds)
-          i += 1
-        taken += 1
-      producer.await()
-      sum
+    def queueChunks(batches: List[IArray[Int]], capacity: Int, rounds: Int)(using Threading)
+    :   Long =
+      running:
+        val queue = Handoff(capacity)
+        val producer = async:
+          batches.each(batch => queue.offer(batch.asInstanceOf[AnyRef]))
+          queue.finish()
+        var sum = 0L
+        var taken = 0
+        val count = batches.size
+        while taken < count do
+          val batch = queue.take().asInstanceOf[IArray[Int]]
+          var i = 0
+          while i < batch.length do
+            sum += work(batch(i), rounds)
+            i += 1
+          taken += 1
+        producer.await()
+        sum
 
   // ── Agreement checks and the plan ───────────────────────────────────────────────────────
 
   private def agree[value](construction: Text)(soundness: value, catsEffect: value, kyo: value)
   :   Unit =
-    assert(soundness == catsEffect, s"$construction: Soundness $soundness ≠ cats-effect $catsEffect")
+    assert(soundness == catsEffect,
+           s"$construction: Soundness $soundness ≠ cats-effect $catsEffect")
     assert(kyo == catsEffect, s"$construction: Kyo $kyo ≠ cats-effect $catsEffect")
 
-  private def check(): Unit =
+  private def check()(using Threading): Unit =
     agree(t"runner")(Direct.runner(), Rivals.Ce.runner(), Rivals.Ky.runner())
 
     depths.foreach: depth =>
-      agree(t"deep bind $depth")(Direct.deepBind(depth), Rivals.Ce.deepBind(depth), Rivals.Ky.deepBind(depth))
-      agree(t"left bind $depth")(Direct.leftBind(depth), Rivals.Ce.leftBind(depth), Rivals.Ky.leftBind(depth))
-      agree(t"map chain $depth")(Direct.mapChain(depth), Rivals.Ce.mapChain(depth), Rivals.Ky.mapChain(depth))
+      agree(t"deep bind $depth")
+        ( Direct.deepBind(depth), Rivals.Ce.deepBind(depth), Rivals.Ky.deepBind(depth) )
+      agree(t"left bind $depth")
+        ( Direct.leftBind(depth), Rivals.Ce.leftBind(depth), Rivals.Ky.leftBind(depth) )
+      agree(t"map chain $depth")
+        ( Direct.mapChain(depth), Rivals.Ce.mapChain(depth), Rivals.Ky.mapChain(depth) )
 
     agree(t"ref")(Direct.ref(ops), Rivals.Ce.ref(ops), Rivals.Ky.ref(ops))
     agree(t"promise")(Direct.promise(ops), Rivals.Ce.deferred(ops), Rivals.Ky.promise(ops))
-    agree(t"queue")(Direct.queue(ops, capacity), Rivals.Ce.queue(ops, capacity), Rivals.Ky.queue(ops, capacity))
+    agree(t"queue")
+      ( Direct.queue(ops, capacity),
+        Rivals.Ce.queue(ops, capacity),
+        Rivals.Ky.queue(ops, capacity) )
     agree(t"permit")(Direct.permit(ops), Rivals.Ce.semaphore(ops), Rivals.Ky.semaphore(ops))
     agree(t"spawn/join")(Direct.spawnJoin(ops), Rivals.Ce.spawnJoin(ops), Rivals.Ky.spawnJoin(ops))
 
@@ -387,7 +405,8 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
           Rivals.Ky.queueChunks(batches, capacity, work) )
 
   def run(): Unit =
-    check()
+    check()(using threading.virtualThreading)
+    check()(using threading.pooledThreading)
 
     val bench = Bench(heap = t"2g", gc = t"G1")
     val depthAxis: Axis[Int] = Axis(t"depth")(1000, 10000)
@@ -395,7 +414,16 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
 
     suite(m"Runner baseline"):
       bench(m"Runner overhead")(target = 1*Second, baseline = Library.CatsEffect).over(Library):
-        case Library.Soundness  => '{ parasite.Benchmarks.Direct.runner() }
+        case Library.Soundness  =>
+          '{
+              given Threading = parasite.threading.virtualThreading
+              parasite.Benchmarks.Direct.runner()
+          }
+        case Library.Pooled  =>
+          '{
+              given Threading = parasite.threading.pooledThreading
+              parasite.Benchmarks.Direct.runner()
+          }
         case Library.CatsEffect => '{ parasite.Rivals.Ce.runner() }
         case Library.Kyo        => '{ parasite.Rivals.Ky.runner() }
 
@@ -433,21 +461,41 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
             '{ parasite.Rivals.Ky.mapChain(parasite.Benchmarks.depths(${depthAt(depth)})) }
 
     suite(m"Primitives (ops = 1000, queue capacity 64)"):
-      bench(m"CAS reference updates")(target = 1*Second, baseline = Library.CatsEffect).over(Library):
+      bench(m"CAS reference updates")(target = 1*Second, baseline = Library.CatsEffect)
+      . over(Library):
         case Library.Soundness  => '{ parasite.Benchmarks.Direct.ref(parasite.Benchmarks.ops) }
         case Library.CatsEffect => '{ parasite.Rivals.Ce.ref(parasite.Benchmarks.ops) }
         case Library.Kyo        => '{ parasite.Rivals.Ky.ref(parasite.Benchmarks.ops) }
 
       bench(m"Complete then read promise")(target = 1*Second, baseline = Library.CatsEffect)
       . over(Library):
-          case Library.Soundness  => '{ parasite.Benchmarks.Direct.promise(parasite.Benchmarks.ops) }
+          case Library.Soundness  =>
+            '{
+                given Threading = parasite.threading.virtualThreading
+                parasite.Benchmarks.Direct.promise(parasite.Benchmarks.ops)
+            }
+          case Library.Pooled  =>
+            '{
+                given Threading = parasite.threading.pooledThreading
+                parasite.Benchmarks.Direct.promise(parasite.Benchmarks.ops)
+            }
           case Library.CatsEffect => '{ parasite.Rivals.Ce.deferred(parasite.Benchmarks.ops) }
           case Library.Kyo        => '{ parasite.Rivals.Ky.promise(parasite.Benchmarks.ops) }
 
       bench(m"Queue: one producer, one consumer")(target = 1*Second, baseline = Library.CatsEffect)
       . over(Library):
           case Library.Soundness =>
-            '{ parasite.Benchmarks.Direct.queue(parasite.Benchmarks.ops, parasite.Benchmarks.capacity) }
+            '{
+                given Threading = parasite.threading.virtualThreading
+                parasite.Benchmarks.Direct.queue
+                  ( parasite.Benchmarks.ops, parasite.Benchmarks.capacity )
+            }
+          case Library.Pooled =>
+            '{
+                given Threading = parasite.threading.pooledThreading
+                parasite.Benchmarks.Direct.queue
+                  ( parasite.Benchmarks.ops, parasite.Benchmarks.capacity )
+            }
           case Library.CatsEffect =>
             '{ parasite.Rivals.Ce.queue(parasite.Benchmarks.ops, parasite.Benchmarks.capacity) }
           case Library.Kyo =>
@@ -461,7 +509,16 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
 
       bench(m"Sequential child spawn and join")(target = 1*Second, baseline = Library.CatsEffect)
       . over(Library):
-          case Library.Soundness  => '{ parasite.Benchmarks.Direct.spawnJoin(parasite.Benchmarks.ops) }
+          case Library.Soundness  =>
+            '{
+                given Threading = parasite.threading.virtualThreading
+                parasite.Benchmarks.Direct.spawnJoin(parasite.Benchmarks.ops)
+            }
+          case Library.Pooled  =>
+            '{
+                given Threading = parasite.threading.pooledThreading
+                parasite.Benchmarks.Direct.spawnJoin(parasite.Benchmarks.ops)
+            }
           case Library.CatsEffect => '{ parasite.Rivals.Ce.spawnJoin(parasite.Benchmarks.ops) }
           case Library.Kyo        => '{ parasite.Rivals.Ky.spawnJoin(parasite.Benchmarks.ops) }
 
@@ -470,6 +527,15 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
       . over(Library, workAxis):
           case (Library.Soundness, work) =>
             '{
+                given Threading = parasite.threading.virtualThreading
+                parasite.Benchmarks.Direct.workers
+                  ( parasite.Benchmarks.valuesArray,
+                    parasite.Benchmarks.parallelism,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.Pooled, work) =>
+            '{
+                given Threading = parasite.threading.pooledThreading
                 parasite.Benchmarks.Direct.workers
                   ( parasite.Benchmarks.valuesArray,
                     parasite.Benchmarks.parallelism,
@@ -490,10 +556,20 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
                     parasite.Benchmarks.rounds(${workAt(work)}) )
             }
 
-      bench(m"Parallel attempt and collect successes")(target = 1*Second, baseline = Library.CatsEffect)
+      bench(m"Parallel attempt and collect successes")
+        ( target = 1*Second, baseline = Library.CatsEffect )
       . over(Library, workAxis):
           case (Library.Soundness, work) =>
             '{
+                given Threading = parasite.threading.virtualThreading
+                parasite.Benchmarks.Direct.collectSuccesses
+                  ( parasite.Benchmarks.valuesArray,
+                    parasite.Benchmarks.parallelism,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.Pooled, work) =>
+            '{
+                given Threading = parasite.threading.pooledThreading
                 parasite.Benchmarks.Direct.collectSuccesses
                   ( parasite.Benchmarks.valuesArray,
                     parasite.Benchmarks.parallelism,
@@ -533,6 +609,15 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
       . over(Library, workAxis):
           case (Library.Soundness, work) =>
             '{
+                given Threading = parasite.threading.virtualThreading
+                parasite.Benchmarks.Direct.parallelChunks
+                  ( parasite.Benchmarks.batchArrays,
+                    parasite.Benchmarks.streamWorkers,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.Pooled, work) =>
+            '{
+                given Threading = parasite.threading.pooledThreading
                 parasite.Benchmarks.Direct.parallelChunks
                   ( parasite.Benchmarks.batchArrays,
                     parasite.Benchmarks.streamWorkers,
@@ -557,6 +642,15 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
       . over(Library, workAxis):
           case (Library.Soundness, work) =>
             '{
+                given Threading = parasite.threading.virtualThreading
+                parasite.Benchmarks.Direct.queueChunks
+                  ( parasite.Benchmarks.batchArrays,
+                    parasite.Benchmarks.capacity,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
+            }
+          case (Library.Pooled, work) =>
+            '{
+                given Threading = parasite.threading.pooledThreading
                 parasite.Benchmarks.Direct.queueChunks
                   ( parasite.Benchmarks.batchArrays,
                     parasite.Benchmarks.capacity,

--- a/lib/parasite/src/bench/parasite.Benchmarks.scala
+++ b/lib/parasite/src/bench/parasite.Benchmarks.scala
@@ -87,38 +87,45 @@ import probates.panicProbate
 // (last column, this run → blog) reproduce closely, as do the rivals' bytes per operation
 // (e.g. permit 1.95 MB / 329 kB against the blog's 1,945,464 / 329,642).
 //
-//   Runner overhead                      0.031 µs    8.10 µs    7.40 µs   Kyo 1.09× → 1.20×
-//   Deep bind, depth 1000                0.044 µs    19.8 µs    20.2 µs   CE 1.02× → Kyo 1.01×
-//   Deep bind, depth 10000               0.044 µs     119 µs     137 µs   CE 1.15× → 1.14×
-//   Left bind, depth 1000                0.044 µs    24.6 µs    3.26 ms   CE 132× → 107×
-//   Left bind, depth 10000               0.044 µs     160 µs     340 ms   CE 2125× → 1895×
-//   Map chain, depth 1000                0.043 µs    18.5 µs    20.9 µs   CE 1.13× → 1.06×
-//   Map chain, depth 10000               0.043 µs     104 µs     134 µs   CE 1.29× → 1.20×
-//   CAS reference updates ×1000          1.84 µs     22.7 µs    25.2 µs   CE 1.11× → 1.00×
-//   Complete then read promise ×1000     5.44 µs     65.6 µs    70.1 µs   CE 1.07× → 1.10×
-//   Queue, 1 producer / 1 consumer       56.7 µs      110 µs    77.7 µs   Kyo 1.42× → 1.45×
-//   Uncontended permit ×1000             4.87 µs      340 µs    60.1 µs   Kyo 5.67× → 5.02×
-//   Sequential spawn/join ×1000          6.96 ms      456 µs     155 µs   Kyo 2.93× → 2.75×
-//   Bounded workers, work 0              0.193 ms    0.273 ms   0.199 ms  Kyo 1.37× → 1.13×
-//   Bounded workers, work 64             0.232 ms    0.336 ms   0.593 ms  CE 1.76× → 2.22×
-//   Collect successes, work 0            4.69 ms     1.02 ms    0.96 ms   Kyo 1.06× → CE 1.08×
-//   Collect successes, work 64           4.53 ms     0.99 ms    1.36 ms   CE 1.38× → 1.41×
-//   Sequential chunks, work 0            6.72 µs      528 µs     755 µs   fs2 1.43× → 1.24×
-//   Sequential chunks, work 64           0.626 ms    1.17 ms    1.63 ms   fs2 1.40× → 1.18×
-//   Parallel chunks, work 0              3.52 ms     1.51 ms    0.81 ms   Kyo 1.86× → 1.93×
-//   Parallel chunks, work 64             3.88 ms     1.84 ms    1.70 ms   Kyo 1.08× → 1.11×
-//   Queue-backed chunks, work 0          18.0 µs      571 µs     143 µs   Kyo 3.99× → 3.70×
-//   Queue-backed chunks, work 64         0.748 ms    1.25 ms    0.80 ms   Kyo 1.57× → 1.75×
+//   Runner overhead                      7.70 µs     8.13 µs    7.39 µs   Kyo 1.10× → 1.20×
+//   Deep bind, depth 1000                0.044 µs    20.9 µs    21.5 µs   CE 1.03× → Kyo 1.01×
+//   Deep bind, depth 10000               0.043 µs     117 µs     137 µs   CE 1.17× → 1.14×
+//   Left bind, depth 1000                0.043 µs    26.5 µs    3.35 ms   CE 126× → 107×
+//   Left bind, depth 10000               0.043 µs     161 µs     344 ms   CE 2137× → 1895×
+//   Map chain, depth 1000                0.044 µs    19.8 µs    22.6 µs   CE 1.14× → 1.06×
+//   Map chain, depth 10000               0.044 µs     105 µs     136 µs   CE 1.30× → 1.20×
+//   CAS reference updates ×1000          1.83 µs     23.9 µs    26.6 µs   CE 1.11× → 1.00×
+//   Complete then read promise ×1000     14.7 µs     65.8 µs    70.3 µs   CE 1.07× → 1.10×
+//   Queue, 1 producer / 1 consumer       67.8 µs      110 µs    76.4 µs   Kyo 1.45× → 1.45×
+//   Uncontended permit ×1000             4.97 µs      340 µs    59.1 µs   Kyo 5.76× → 5.02×
+//   Sequential spawn/join ×1000          2.85 ms      412 µs     156 µs   Kyo 2.64× → 2.75×
+//   Bounded workers, work 0              0.218 ms    0.272 ms   0.205 ms  Kyo 1.33× → 1.13×
+//   Bounded workers, work 64             0.322 ms    0.338 ms   0.596 ms  CE 1.76× → 2.22×
+//   Collect successes, work 0            0.277 ms    0.892 ms   0.960 ms  CE 1.08× → CE 1.08×
+//   Collect successes, work 64           0.324 ms    1.01 ms    1.36 ms   CE 1.35× → 1.41×
+//   Sequential chunks, work 0            6.74 µs      522 µs     768 µs   fs2 1.47× → 1.24×
+//   Sequential chunks, work 64           0.630 ms    1.18 ms    1.58 ms   fs2 1.34× → 1.18×
+//   Parallel chunks, work 0              24.1 µs     1.36 ms    0.82 ms   Kyo 1.66× → 1.93×
+//   Parallel chunks, work 64             0.184 ms    1.85 ms    1.76 ms   Kyo 1.06× → 1.11×
+//   Queue-backed chunks, work 0          20.7 µs      562 µs     142 µs   Kyo 3.96× → 3.70×
+//   Queue-backed chunks, work 64         0.738 ms    1.29 ms    0.81 ms   Kyo 1.60× → 1.75×
 //
-// The Soundness column splits cleanly by whether the construction spawns tasks: every row that
-// does not (direct-style chains, `Atomic`, `Promise`, `Mutex`, `Handoff` hand-off, the sequential
-// and queue-backed streams) is between 1.4× and three orders of magnitude ahead, whereas the
-// rows dominated by spawning — one `async` per element or per batch — lose: a spawn/join costs
-// about 7 µs here (a virtual thread plus a `Worker`'s bookkeeping) against Kyo's 0.15 µs and
-// cats-effect's 0.46 µs. Where the spawned tasks do real work (bounded workers) that overhead is
-// amortised and Soundness leads again. Allocation tells the same story: 32 B for a thousand
-// `Atomic` updates or `Mutex` sections, 15 kB for a thousand queued ints, 0.95 MB for a thousand
-// spawns.
+// Every Soundness construction runs on one task under `supervise`, joined once by the caller
+// (`Direct.running`), as the rivals' run inside their runtimes; that entry is the Soundness
+// runner-overhead row, and is included in every other row. The rows that spawn a task per
+// element or per batch in the rivals (collect successes, parallel chunks) use `concurrently`,
+// a fixed set of workers over numbered jobs, on the Soundness side: a task is a virtual thread,
+// costing about 2.5 µs to start and join from another virtual thread (and 7 µs from a platform
+// thread, whose park is a kernel call), against Kyo's 0.15 µs and cats-effect's 0.4 µs per
+// fiber, so the one row that spawns a thousand tasks by specification — sequential spawn/join —
+// is the one Soundness loses, and bounded fan-out is the idiom that wins the others.
+// Allocation tells the same story: 32 B for a thousand `Atomic` updates or `Mutex` sections,
+// 17 kB for a thousand queued ints, 1.1 MB for a thousand spawns.
+//
+// An earlier form of these rows, spawning a task per element and joining from the harness's
+// platform thread, measured 4.7 ms for collect successes and 3.5 ms for parallel chunks (four
+// to five times slower than the rivals) and 6.96 ms for spawn/join; a probe attributed almost
+// all of it to Loom itself — parasite adds about 0.1 µs to a bare virtual-thread start and join.
 //
 // Running the queue rows at ~10⁵ repetitions also exposed a real race in `Handoff`: a consumer
 // observing `finish()` between its read of the tail index and its check of the finished flag
@@ -164,7 +171,16 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
   // ── The Soundness arms ──────────────────────────────────────────────────────────────────
 
   object Direct:
-    def runner(): Int = supervise(1)
+    // Where a construction runs: the rivals execute theirs inside their runtime (a fiber on
+    // the runtime's pool, the caller blocked once), so the Soundness constructions likewise run
+    // on one task — a virtual thread, where a request handler lives — with the caller blocked
+    // once. A join inside the construction is then a virtual-thread park, not a platform
+    // thread's kernel park. This is also the runner-overhead row: entering a scope, starting
+    // one task and joining it.
+    inline def running[result](inline body: Monitor ?=> result): result =
+      supervise(async(body).await())
+
+    def runner(): Int = running(1)
 
     def deepBind(depth: Int): Int =
       @tailrec
@@ -195,7 +211,7 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
         i += 1
       ref()
 
-    def promise(ops: Int): Long = supervise:
+    def promise(ops: Int): Long = running:
       var sum = 0L
       var i = 0
       while i < ops do
@@ -206,7 +222,7 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
       sum
 
     // One producer task, the consumer on the calling strand, `Int`s boxed through the ring.
-    def queue(ops: Int, capacity: Int): Long = supervise:
+    def queue(ops: Int, capacity: Int): Long = running:
       val queue = Handoff(capacity)
       val producer = async:
         var i = 0
@@ -230,7 +246,7 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
         i += 1
       1
 
-    def spawnJoin(ops: Int): Long = supervise:
+    def spawnJoin(ops: Int): Long = running:
       var sum = 0L
       var i = 0
       while i < ops do
@@ -239,34 +255,32 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
         i += 1
       sum
 
-    // The same shape as the rivals' `Workers`: a shared index, an indexed output array,
-    // min(size, parallelism) tasks, joined together.
-    def workers(values: IArray[Int], parallelism: Int, rounds: Int): IArray[Int] = supervise:
-      val index = Atomic(0)
-      val output = new scala.Array[Int](values.length)
-      val tasks = List.fill(parallelism.min(values.length)):
-        async:
-          var running = true
-          while running do
-            val i = index.ere(_ + 1)
-            if i >= values.length then running = false else output(i) = work(values(i), rounds)
-      tasks.sequence.await()
-      IArray.unsafeFromArray(output)
+    // `concurrently` is the rivals' `Workers` construction exactly: a shared index, an indexed
+    // output array, min(size, parallelism) tasks, joined together.
+    def workers(values: IArray[Int], parallelism: Int, rounds: Int): IArray[Int] = running:
+      concurrently(values.length, parallelism)(i => work(values(i), rounds))
 
-    // One task per element; a failing element aborts with a typed error, which `safely` turns
-    // into an absent result at the join, so the successes come back in order.
-    def collectSuccesses(values: IArray[Int], rounds: Int): IArray[Int] = supervise:
-      val tasks = List.tabulate(values.length): i =>
-        val value = values(i)
-        async:
-          if (value & 1023) == 0 then abort(Expected.Error()) else work(value, rounds)
-      val output = new scala.Array[Int](values.length)
-      var count = 0
-      tasks.each: task =>
-        safely(task.await()).let: value =>
-          output(count) = value
-          count += 1
-      IArray.unsafeFromArray(output.take(count))
+    // The rivals start one fiber per element; a Soundness task is a thread, so the bounded form
+    // is the idiom: eight workers over the elements, each element's failure caught where it
+    // happens (`safely` on the typed `abort`), and the absent results dropped in order.
+    def collectSuccesses(values: IArray[Int], parallelism: Int, rounds: Int): IArray[Int] =
+      running:
+        val results: IArray[Optional[Int]] =
+          concurrently(values.length, parallelism): i =>
+            val value = values(i)
+            safely(if (value & 1023) == 0 then abort(Expected.Error()) else work(value, rounds))
+
+        val output = new scala.Array[Int](values.length)
+        var count = 0
+        var i = 0
+
+        while i < results.length do
+          results(i).let: value =>
+            output(count) = value
+            count += 1
+          i += 1
+
+        IArray.unsafeFromArray(output.take(count))
 
     // Each chunk is transformed whole, then folded: a nested loop, since a batch of ints needs
     // no stream.
@@ -280,20 +294,34 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
           i += 1
       sum
 
-    // Per batch, the bounded workers above; the batch is complete before the next starts.
+    // The rivals start fresh workers per batch and finish a batch before the next begins. The
+    // Soundness form keeps the same number of workers alive across the whole stream, each
+    // transforming and folding whole batches in order of claim: the same bounded parallelism
+    // and ordered result, without a spawn per batch or a barrier between batches.
     def parallelChunks(batches: List[IArray[Int]], parallelism: Int, rounds: Int): Long =
-      var sum = 0L
-      batches.each: batch =>
-        val transformed = workers(batch, parallelism, rounds)
+      running:
+        val chunks: IArray[IArray[Int]] = IArray.from(batches.stdlib)
+
+        val sums: IArray[Long] =
+          concurrently(chunks.length, parallelism): index =>
+            val batch = chunks(index)
+            var sum = 0L
+            var i = 0
+            while i < batch.length do
+              sum += work(batch(i), rounds)
+              i += 1
+            sum
+
+        var total = 0L
         var i = 0
-        while i < transformed.length do
-          sum += transformed(i)
+        while i < sums.length do
+          total += sums(i)
           i += 1
-      sum
+        total
 
     // A producer task hands each prebuilt chunk through a `Handoff` of `capacity` chunks; the
     // consumer takes exactly `batches.size` of them and transforms each as it arrives.
-    def queueChunks(batches: List[IArray[Int]], capacity: Int, rounds: Int): Long = supervise:
+    def queueChunks(batches: List[IArray[Int]], capacity: Int, rounds: Int): Long = running:
       val queue = Handoff(capacity)
       val producer = async:
         batches.each(batch => queue.offer(batch.asInstanceOf[AnyRef]))
@@ -339,7 +367,7 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
           Rivals.Ky.workers(values, parallelism, work) )
 
       agree(t"collect successes $work")
-        ( Direct.collectSuccesses(valuesArray, work).toVector,
+        ( Direct.collectSuccesses(valuesArray, parallelism, work).toVector,
           Rivals.Ce.collectSuccesses(values, work),
           Rivals.Ky.collectSuccesses(values, work) )
 
@@ -467,7 +495,9 @@ object Benchmarks extends Suite(m"Effect runtimes: Soundness vs cats-effect vs K
           case (Library.Soundness, work) =>
             '{
                 parasite.Benchmarks.Direct.collectSuccesses
-                  ( parasite.Benchmarks.valuesArray, parasite.Benchmarks.rounds(${workAt(work)}) )
+                  ( parasite.Benchmarks.valuesArray,
+                    parasite.Benchmarks.parallelism,
+                    parasite.Benchmarks.rounds(${workAt(work)}) )
             }
           case (Library.CatsEffect, work) =>
             '{

--- a/lib/parasite/src/bench/parasite.Rivals.scala
+++ b/lib/parasite/src/bench/parasite.Rivals.scala
@@ -1,0 +1,337 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package parasite
+
+import cats.effect.{Deferred, IO, Ref}
+import cats.effect.std.{Queue, Semaphore}
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all.*
+import fs2.{Chunk as FChunk, Stream as FStream}
+import kyo.*
+import kyo.AllowUnsafe.embrace.danger
+
+import java.util.concurrent.atomic.AtomicInteger
+
+// The rival constructions, ported from github.com/stasimus/scala-effect-bench (the `matched`
+// suite, at its 2026-09-05 state) with the benchmark bodies, worker helper, runners and `Work`
+// arithmetic kept exactly as that repository wrote them, so that the cats-effect and Kyo rows
+// here measure the same programs the blog post measured. Each construction is a method taking
+// its parameters, so the staged benchmark bodies are one call each and `Benchmarks.run()` can
+// check every arm agrees before anything is timed.
+//
+// This file is the rivals' world: stdlib `Vector`, their own `flatMap`/`map`, and a wildcard
+// `kyo.*` (which takes precedence over parasite's own `Async`, `Promise` and `Task`, in this
+// compilation unit only). Nothing of Soundness is used here except the package clause.
+object Rivals:
+  // Same non-allocating CPU work on both sides; zero rounds is one increment.
+  def work(value: Int, rounds: Int): Int =
+    var result = value + 1
+    var i = 0
+    while i < rounds do
+      result = java.lang.Integer.rotateLeft(result*1664525 + 1013904223, 7)
+      i += 1
+    result
+
+  private val boom = new RuntimeException("expected") with scala.util.control.NoStackTrace
+
+  // Program construction and execution both begin on the corresponding runtime worker.
+  def runCe[A](body: => IO[A]): A = IO.defer(body).unsafeRunSync()
+
+  def runKyo[A](body: => A < (Async & Abort[Throwable]))(using Frame): A =
+    Sync.Unsafe.evalOrThrow(Fiber.initUnscoped(Sync.defer(body)).flatMap(_.block(Duration.Infinity)))
+    . getOrThrow
+
+  // Benchmark-local, successful-work worker pools with identical indexing and result storage.
+  // Each starts min(size, parallelism) workers sequentially and joins them sequentially.
+  object Workers:
+    def ce(values: Vector[Int], parallelism: Int)(f: Int => IO[Int]): IO[Vector[Int]] = IO.defer {
+      require(parallelism > 0)
+      val index = new AtomicInteger(0)
+      val output = new Array[Int](values.size)
+      def worker: IO[Unit] =
+        IO(index.getAndIncrement()).flatMap { i =>
+          if i >= values.size then IO.unit
+          else f(values(i)).flatMap(v => IO(output(i) = v)) *> worker
+        }
+      Vector.fill(math.min(values.size, parallelism))(worker).traverse(_.start).flatMap { fibers =>
+        fibers.traverse_(_.joinWithNever) *> IO(output.toVector)
+      }
+    }
+
+    def ky(values: Vector[Int], parallelism: Int)(f: Int => Int < (Async & Abort[Throwable]))(using Frame)
+        : Vector[Int] < (Async & Abort[Throwable]) = Sync.defer {
+      require(parallelism > 0)
+      val index = new AtomicInteger(0)
+      val output = new Array[Int](values.size)
+      def worker: Unit < (Async & Abort[Throwable]) =
+        Sync.defer(index.getAndIncrement()).map { i =>
+          if i >= values.size then ()
+          else f(values(i)).map(v => Sync.defer(output(i) = v)).andThen(worker)
+        }
+      Kyo.foreach(0 until math.min(values.size, parallelism))(_ => Fiber.initUnscoped(worker)).map { fibers =>
+        Kyo.foreachDiscard(fibers)(_.get).andThen(Sync.defer(output.toVector))
+      }
+    }
+
+  object Ce:
+    def runner(): Int = runCe(IO(1))
+
+    def deepBind(depth: Int): Int = runCe {
+      def loop(i: Int): IO[Int] =
+        if i == depth then IO.pure(i) else IO(i + 1).flatMap(loop)
+      loop(0)
+    }
+
+    def leftBind(depth: Int): Int = runCe {
+      var acc = IO(0)
+      var i = 0
+      while i < depth do
+        acc = acc.flatMap(v => IO(v + 1))
+        i += 1
+      acc
+    }
+
+    def mapChain(depth: Int): Int = runCe {
+      var acc = IO(0)
+      var i = 0
+      while i < depth do
+        acc = acc.map(_ + 1)
+        i += 1
+      acc
+    }
+
+    def ref(ops: Int): Int = runCe {
+      Ref.of[IO, Int](0).flatMap { ref =>
+        def loop(i: Int): IO[Int] =
+          if i == ops then ref.get else ref.update(_ + 1).flatMap(_ => loop(i + 1))
+        loop(0)
+      }
+    }
+
+    def deferred(ops: Int): Long = runCe {
+      def loop(i: Int, sum: Long): IO[Long] =
+        if i == ops then IO.pure(sum)
+        else Deferred[IO, Int].flatMap(d => d.complete(i).flatMap(_ => d.get).flatMap(v => loop(i + 1, sum + v)))
+      loop(0, 0L)
+    }
+
+    // A single producer and consumer, Int entries, fixed count, no close/sentinel or batch draining.
+    def queue(ops: Int, capacity: Int): Long = runCe {
+      Queue.bounded[IO, Int](capacity).flatMap { q =>
+        def produce(i: Int): IO[Unit] =
+          if i == ops then IO.unit else q.offer(i).flatMap(_ => produce(i + 1))
+        def consume(i: Int, sum: Long): IO[Long] =
+          if i == ops then IO.pure(sum) else q.take.flatMap(v => consume(i + 1, sum + v))
+        produce(0).start.flatMap(f => consume(0, 0L).flatMap(sum => f.joinWithNever.map(_ => sum)))
+      }
+    }
+
+    def semaphore(ops: Int): Int = runCe {
+      Semaphore[IO](1).flatMap { sem =>
+        def loop(i: Int): IO[Int] =
+          if i == ops then sem.available.map(_.toInt)
+          else sem.permit.use(_ => IO.unit).flatMap(_ => loop(i + 1))
+        loop(0)
+      }
+    }
+
+    // Exactly one child at a time, with a successful join before the next spawn.
+    def spawnJoin(ops: Int): Long = runCe {
+      def loop(i: Int, sum: Long): IO[Long] =
+        if i == ops then IO.pure(sum)
+        else IO(i).start.flatMap(_.joinWithNever).flatMap(v => loop(i + 1, sum + v))
+      loop(0, 0L)
+    }
+
+    def workers(values: Vector[Int], parallelism: Int, rounds: Int): Vector[Int] =
+      runCe(Workers.ce(values, parallelism)(i => IO(work(i, rounds))))
+
+    // One fiber per element, sequential spawn and join, then the same ordered Option filtering.
+    // Failure selection is suspended on both sides; all-failure input returns an empty Vector.
+    def collectSuccesses(input: Vector[Int], rounds: Int): Vector[Int] = runCe {
+      input.traverse { i =>
+        IO.defer(if (i & 1023) == 0 then IO.raiseError[Int](boom) else IO(work(i, rounds)))
+          .attempt.map(_.toOption).start
+      }.flatMap(_.traverse(_.joinWithNever)).map(_.flatten)
+    }
+
+    private def source(batches: Vector[Vector[Int]]): FStream[IO, Int] =
+      FStream.emits(batches).covary[IO].flatMap(batch => FStream.chunk(FChunk.from(batch)))
+
+    // Both evaluate one whole chunk sequentially, then emit it before processing the next.
+    def evalChunks(batches: Vector[Vector[Int]], rounds: Int): Long = runCe {
+      source(batches).chunks.evalMap(_.toVector.traverse(i => IO(work(i, rounds)))).flatMap(FStream.emits)
+      . compile.fold(0L)(_ + _.toLong)
+    }
+
+    // Same fixed workers per batch, indexed result array, ordered output and batch barrier.
+    def parallelChunks(batches: Vector[Vector[Int]], parallelism: Int, rounds: Int): Long = runCe {
+      source(batches).chunks
+      . evalMap(batch => Workers.ce(batch.toVector, parallelism)(i => IO(work(i, rounds))))
+      . flatMap(FStream.emits)
+      . compile.fold(0L)(_ + _.toLong)
+    }
+
+    // Same prebuilt Vector chunks and capacity in chunks. The producer loop is direct on both
+    // sides. Consumers take exactly batches.size entries, emit each as a chunk and transform it.
+    def queueChunks(batches: Vector[Vector[Int]], capacity: Int, rounds: Int): Long = runCe {
+      Queue.bounded[IO, Vector[Int]](capacity).flatMap { q =>
+        def produce(i: Int): IO[Unit] =
+          if i == batches.size then IO.unit else q.offer(batches(i)).flatMap(_ => produce(i + 1))
+        val consume = FStream.unfoldEval(0) { i =>
+          if i == batches.size then IO.pure(None)
+          else q.take.map(batch => Some((batch, i + 1)))
+        }.flatMap(batch => FStream.chunk(FChunk.from(batch)))
+          .map(i => work(i, rounds)).compile.fold(0L)(_ + _.toLong)
+        produce(0).start.flatMap(f => consume.flatMap(sum => f.joinWithNever.map(_ => sum)))
+      }
+    }
+
+  object Ky:
+    def runner(): Int = runKyo(Sync.defer(1))
+
+    def deepBind(depth: Int): Int = runKyo {
+      def loop(i: Int): Int < Sync =
+        if i == depth then i else Sync.defer(i + 1).map(loop)
+      loop(0)
+    }
+
+    def leftBind(depth: Int): Int = runKyo {
+      var acc: Int < Sync = Sync.defer(0)
+      var i = 0
+      while i < depth do
+        acc = acc.map(v => Sync.defer(v + 1))
+        i += 1
+      acc
+    }
+
+    // Both chains begin with a suspended value, so Kyo cannot eagerly evaluate pure inputs.
+    def mapChain(depth: Int): Int = runKyo {
+      var acc: Int < Sync = Sync.defer(0)
+      var i = 0
+      while i < depth do
+        acc = acc.map(_ + 1)
+        i += 1
+      acc
+    }
+
+    def ref(ops: Int): Int = runKyo {
+      AtomicRef.init(0).map { ref =>
+        def loop(i: Int): Int < Sync =
+          if i == ops then ref.get else ref.updateAndGet(_ + 1).map(_ => loop(i + 1))
+        loop(0)
+      }
+    }
+
+    def promise(ops: Int): Long = runKyo {
+      def loop(i: Int, sum: Long): Long < (Async & Abort[Throwable]) =
+        if i == ops then sum
+        else Promise.init[Int, Any].map(p => p.completeDiscard(Result.succeed(i)).andThen(p.get).map(v => loop(i + 1, sum + v)))
+      loop(0, 0L)
+    }
+
+    def queue(ops: Int, capacity: Int): Long = runKyo {
+      Abort.run[Closed] {
+        Channel.initUnscoped[Int](capacity).map { q =>
+          def produce(i: Int): Unit < (Async & Abort[Closed]) =
+            if i == ops then () else q.put(i).andThen(produce(i + 1))
+          def consume(i: Int, sum: Long): Long < (Async & Abort[Closed]) =
+            if i == ops then sum else q.take.map(v => consume(i + 1, sum + v))
+          Fiber.initUnscoped(produce(0)).map(f => consume(0, 0L).map(sum => f.get.andThen(sum)))
+        }
+      }.map(_.getOrThrow)
+    }
+
+    def semaphore(ops: Int): Int = runKyo {
+      Abort.run[Closed] {
+        Meter.initSemaphoreUnscoped(1, reentrant = false).map { sem =>
+          def loop(i: Int): Int < (Async & Abort[Closed]) =
+            if i == ops then sem.availablePermits
+            else sem.run(()).andThen(loop(i + 1))
+          loop(0)
+        }
+      }.map(_.getOrThrow)
+    }
+
+    def spawnJoin(ops: Int): Long = runKyo {
+      def loop(i: Int, sum: Long): Long < (Async & Abort[Throwable]) =
+        if i == ops then sum
+        else Fiber.initUnscoped(Sync.defer(i)).map(_.get).map(v => loop(i + 1, sum + v))
+      loop(0, 0L)
+    }
+
+    def workers(values: Vector[Int], parallelism: Int, rounds: Int): Vector[Int] =
+      runKyo(Workers.ky(values, parallelism)(i => Sync.defer(work(i, rounds))))
+
+    def collectSuccesses(input: Vector[Int], rounds: Int): Vector[Int] = runKyo {
+      Kyo.foreach(input) { i =>
+        Fiber.initUnscoped {
+          Abort.run[Throwable](Sync.defer {
+            if (i & 1023) == 0 then Abort.fail(boom) else Sync.defer(work(i, rounds))
+          }).map {
+            case Result.Success(v) => Some(v): Option[Int]
+            case Result.Failure(_) => None: Option[Int]
+            case Result.Panic(_)   => None: Option[Int]
+          }
+        }
+      }.map(fibers => Kyo.foreach(fibers)(_.get).map(_.toVector.flatten))
+    }
+
+    private def source(batches: Vector[Vector[Int]]): Stream[Int, Any] =
+      Stream.init(batches, chunkSize = 1).mapChunkPure(_.flatten)
+
+    def evalChunks(batches: Vector[Vector[Int]], rounds: Int): Long = runKyo {
+      source(batches)
+      . mapChunk(batch => Kyo.foreach(batch.toVector)(i => Sync.defer(work(i, rounds))).map(_.toVector))
+      . foldPure(0L)(_ + _.toLong)
+    }
+
+    def parallelChunks(batches: Vector[Vector[Int]], parallelism: Int, rounds: Int): Long = runKyo {
+      source(batches)
+      . mapChunk(batch => Workers.ky(batch.toVector, parallelism)(i => Sync.defer(work(i, rounds))))
+      . foldPure(0L)(_ + _.toLong)
+    }
+
+    def queueChunks(batches: Vector[Vector[Int]], capacity: Int, rounds: Int): Long = runKyo {
+      Abort.run[Closed] {
+        Channel.initUnscoped[Vector[Int]](capacity).map { q =>
+          def produce(i: Int): Unit < (Async & Abort[Closed]) =
+            if i == batches.size then () else q.put(batches(i)).andThen(produce(i + 1))
+          val consume = Stream.unfold(0, chunkSize = 1) { i =>
+            if i == batches.size then Maybe.empty[(Vector[Int], Int)]
+            else q.take.map(batch => Maybe((batch, i + 1)))
+          }.mapChunkPure(_.flatten).mapPure(i => work(i, rounds)).foldPure(0L)(_ + _.toLong)
+          Fiber.initUnscoped(produce(0)).map(f => consume.map(sum => f.get.andThen(sum)))
+        }
+      }.map(_.getOrThrow)
+    }

--- a/lib/parasite/src/core-jvm/parasite.PooledSupervisor.scala
+++ b/lib/parasite/src/core-jvm/parasite.PooledSupervisor.scala
@@ -32,36 +32,13 @@
                                                                                                   */
 package parasite
 
-import anticipation.*
 import nomenclature.*
-import vacuous.*
 
 import Async.nominative
 
-// The Scala Native twins of the JVM virtual-thread supervisors. Scala Native has no Loom, so
-// both fork platform threads — keeping `supervisors.virtual`/`supervisors.adaptive` (and the
-// `Threading` givens) source-compatible: `adaptive` degrades exactly as it does on a pre-Loom
-// JVM, and `virtual` is a request for cheap concurrency, honoured with the cheapest available.
-
-object VirtualSupervisor extends ThreadSupervisor:
-  def name: Name[Async] = n"virtual"
-
-  def fork(name: () => Optional[Text])(block: => Unit): Strand =
-    PlatformSupervisor.fork(name)(block)
-
-object AdaptiveSupervisor extends ThreadSupervisor:
-  def name: Name[Async] = n"adaptive"
-
-  def fork(name: () => Optional[Text])(block: => Unit): Strand =
-    PlatformSupervisor.fork(name)(block)
-
-// The pooling supervisor over platform threads: with no Loom, reusing a thread across tasks
-// is the only way a task can cost less than a thread start, so this is where the pool matters
-// most. A task which blocks holds a platform thread until it continues.
+// The JVM pooling supervisor: its carriers are virtual threads, so a task which blocks its
+// carrier costs nothing more than a parked virtual thread, and a burst of blocked tasks grows
+// the pool without occupying platform threads.
 object PooledSupervisor extends PoolingSupervisor:
   def name: Name[Async] = n"pooled"
-
-  protected def spawn(runnable: Runnable): Thread =
-    val thread = new Thread(runnable)
-    thread.start()
-    thread
+  protected def spawn(runnable: Runnable): Thread = Thread.ofVirtual().nn.start(runnable).nn

--- a/lib/parasite/src/core/parasite.PoolingSupervisor.scala
+++ b/lib/parasite/src/core/parasite.PoolingSupervisor.scala
@@ -1,0 +1,285 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package parasite
+
+import scala.caps
+import scala.compiletime.asMatchable
+
+import java.lang as jl
+import java.util.concurrent as juc
+import java.util.concurrent.atomic as juca
+import java.util.concurrent.locks as jucl
+
+import anticipation.*
+import vacuous.*
+
+// A supervisor which runs tasks on a pool of reusable carrier threads instead of starting a
+// thread per task. `fork` hands the task to an idle carrier when one is waiting, and starts a
+// fresh carrier only when none is; a carrier that finishes a task parks itself on the idle
+// list for the next. The hand-off to a waiting carrier costs a few hundred nanoseconds where
+// a thread start and join cost a few microseconds, which is the whole point: fine-grained
+// fan-out — one task per element, a spawn-and-join in a loop — stops being dominated by thread
+// creation. The carriers are whatever `spawn` produces: virtual threads on the JVM, platform
+// threads on Scala Native, where there is no Loom and a thread start costs tens of
+// microseconds, so the saving is larger still.
+//
+// THE POOL NEVER STARVES. A task that blocks — through `park` or any other way, including
+// JDK I/O, `Thread.sleep`, a `synchronized` block or `Handoff`'s own spin-then-park — simply
+// keeps its carrier, and the next `fork` finding no idle carrier starts another. So the worst
+// case is exactly the cost of a thread per task, and there is no fixed size, no queue that
+// tasks wait in, and no compensation logic to get wrong: a task is running from the moment it
+// is forked, as with every other supervisor. Idle carriers above `idleLimit` retire instead of
+// waiting, which bounds the pool's memory after a burst.
+//
+// CANCELLATION IS A HANDSHAKE. `Worker.cancel` interrupts a task's strand; on a dedicated
+// thread that is the thread's own interrupt status, but a carrier's status must belong only to
+// the task mounted on it. Each task entry runs a small state machine — queued, running,
+// interrupting, finished — and an interrupter that finds the task running takes the
+// `interrupting` state before touching the carrier, while a carrier finishing a task waits
+// out any interrupter in flight before clearing the status. So an interrupt aimed at a task
+// can neither be lost (it lands while the task is mounted, or is deferred to its mount) nor
+// leak to the task that runs next on the same carrier. An entry's `join` waits for the
+// finished state, not for the carrier, which lives on.
+//
+// THE COSTS. A task no longer has a thread of its own: thread-locals persist across the tasks
+// a carrier runs (parasite sets none, but a library that keys on the thread may), and a
+// thread dump shows carriers rather than tasks — `Worker.stack` and the monitor tree are the
+// task-level view. A task's `Thread.currentThread` is stable for its duration, which is all
+// the parking and waiter identity below rely on.
+//
+// A waiting carrier, and a task waiting in `park`, spin briefly before parking: a hand-off to
+// a carrier in lockstep, or a join of a task that has all but finished, then completes without
+// a park/unpark round trip, as in `Handoff`. The budget is small enough that an idle carrier
+// stops burning its core within a microsecond or two.
+//
+// The pool's state and the classes over it live in the companion, so that none of them closes
+// over the supervisor instance: the supervisor is a plain value, not a capability, and its
+// inner workings are kept that way.
+abstract class PoolingSupervisor extends ThreadSupervisor:
+  // Starts a carrier thread running `runnable` and returns it started.
+  protected def spawn(runnable: Runnable): Thread
+
+  // The number of idle carriers kept for reuse; one arriving above it retires instead.
+  protected def idleLimit: Int = 256
+
+  import PoolingSupervisor.{Carrier, Entry, spins}
+
+  // The idle carriers, most recently idle first: a warm carrier is the better one to reuse.
+  // A linked deque (not a hand-rolled stack) so that reused carrier nodes cannot ABA.
+  private[parasite] val idle: juc.ConcurrentLinkedDeque[Carrier] = juc.ConcurrentLinkedDeque()
+  private[parasite] val idleCount: juca.AtomicInteger = juca.AtomicInteger(0)
+
+  // The carrier the calling thread is, if it is one; the JVM offers no cheaper way to ask.
+  private[parasite] val carriers: ThreadLocal[Carrier | Null] = ThreadLocal()
+
+  private[parasite] def limit: Int = idleLimit
+  private[parasite] val running: juca.AtomicInteger = juca.AtomicInteger(0)
+
+  // Diagnostics: the carriers running a task, and those waiting for one. A pool at rest has
+  // no active carriers; one that does not return to that state has a task that never finished.
+  def active: Int = running.get()
+  def idling: Int = idleCount.get()
+
+  def fork(name: () => Optional[Text])(block: => Unit): Strand =
+    // The entry closes over the task's body, as a dedicated thread's `Runnable` would; it is
+    // stored boxed as pure, the same laundering the supervision registry applies to workers.
+    val entry: Entry = caps.unsafe.unsafeAssumePure(Entry(() => block))
+    val carrier = idle.pollFirst()
+
+    if carrier == null then
+      // A supervisor is a plain value, not a capability (see `Supervisor`); capture checking
+      // cannot see that from inside its own body, so the reference is laundered here.
+      val fresh = Carrier(caps.unsafe.unsafeAssumePure(this))
+      fresh.task = entry
+      spawn(fresh)
+    else
+      idleCount.decrementAndGet()
+      carrier.task = entry
+      val thread = carrier.thread
+      if thread != null then jucl.LockSupport.unpark(thread)
+
+    entry
+
+  override def strand(): Strand = carriers.get() match
+    case null    => Strand.Threaded(Thread.currentThread.nn)
+    case carrier => carrier.strand
+
+  override def park(blocker: AnyRef): Unit = carriers.get() match
+    case null => jucl.LockSupport.park(blocker)
+    case carrier =>
+      var spun = 0
+      while !carrier.permit && spun < spins do
+        spun += 1
+        Thread.onSpinWait()
+
+      if !carrier.permit then jucl.LockSupport.park(blocker)
+      carrier.permit = false
+
+  override def park(blocker: AnyRef, deadline: Long): Unit = carriers.get() match
+    case null => jucl.LockSupport.parkNanos(blocker, deadline - jl.System.nanoTime())
+    case carrier =>
+      if !carrier.permit then jucl.LockSupport.parkNanos(blocker, deadline - jl.System.nanoTime())
+      carrier.permit = false
+
+object PoolingSupervisor:
+  // Spin budget before parking, for a carrier awaiting a task and for a task's `park`: long
+  // enough to bridge a counterpart's wake-up latency, short enough not to hold a core.
+  private inline val spins = 2048
+
+  private object State:
+    inline val Queued = 0
+    inline val Running = 1
+    inline val Interrupting = 2
+    inline val Finished = 3
+
+  // A forked task: its strand handle, and the record a carrier runs. Its mutable fields are
+  // published by volatile write, as `Handoff`'s are, so their captures are untracked.
+  private[parasite] final class Entry(block: () => Unit) extends Strand:
+    private val state: juca.AtomicInteger = juca.AtomicInteger(State.Queued)
+    @caps.unsafe.untrackedCaptures @volatile private var carrier: Thread | Null = null
+    @caps.unsafe.untrackedCaptures @volatile private var interruptRequested: Boolean = false
+    @caps.unsafe.untrackedCaptures @volatile private var joiner: Thread | Null = null
+
+    // Requests cancellation of the task. Queued: remembered, and delivered when it mounts.
+    // Running: delivered to the carrier under the `Interrupting` state, so the carrier cannot
+    // finish and clear it, nor move on to another task, while it is in flight. Finished: nothing.
+    def interrupt(): Unit =
+      interruptRequested = true
+
+      if state.compareAndSet(State.Running, State.Interrupting) then
+        try
+          val thread = carrier
+          if thread != null then thread.interrupt()
+        finally state.set(State.Running)
+
+    // Blocks until the task has finished; the carrier is not joined, since it lives on. As
+    // `Thread.join`, an interrupted joiner throws rather than waiting: a task that cancels
+    // itself interrupts its own carrier and then joins its own entry, which can never finish —
+    // and `park` returns at once on an interrupted thread, so without this check the join
+    // would spin for ever, on a carrier that never returns to the pool.
+    def join(): Unit =
+      import unsafeExceptions.canThrowAny
+
+      while state.get() != State.Finished do
+        if Thread.interrupted() then throw InterruptedException()
+        joiner = Thread.currentThread.nn
+        if state.get() != State.Finished then jucl.LockSupport.park(this)
+        joiner = null
+
+    // A task waiting in `park` is woken through its carrier's strand, not this handle, so this
+    // is only reached by a waiter set which recorded the entry itself; wake the carrier anyway.
+    def unpark(): Unit =
+      val thread = carrier
+      if thread != null then jucl.LockSupport.unpark(thread)
+
+    // Runs the task on the calling carrier thread.
+    def run(thread: Thread, pool: PoolingSupervisor): Unit =
+      pool.running.incrementAndGet()
+      state.set(State.Running)
+      carrier = thread
+      if interruptRequested then thread.interrupt()
+
+      try block()
+      catch case error: Throwable =>
+        // A worker's body settles its own state and promise; only an escalation reaches here,
+        // which goes where an uncaught exception on a dedicated thread would have gone. The
+        // carrier itself survives.
+        val handler = thread.getUncaughtExceptionHandler
+        if handler != null then handler.uncaughtException(thread, error)
+      finally
+        // The handshake: an interrupter holding `Interrupting` is about to interrupt this
+        // thread, so wait for it, then clear the status so nothing leaks to the next task.
+        while !state.compareAndSet(State.Running, State.Finished) do Thread.onSpinWait()
+        Thread.interrupted()
+        carrier = null
+        pool.running.decrementAndGet()
+        val waiting = joiner
+        if waiting != null then jucl.LockSupport.unpark(waiting)
+
+  // A carrier: the loop a pooled thread runs, and the strand identity of whatever task is
+  // mounted on it, for waiter sets and parking.
+  private[parasite] final class Carrier(pool: PoolingSupervisor) extends Runnable:
+    @caps.unsafe.untrackedCaptures @volatile var task: Entry | Null = null
+    @caps.unsafe.untrackedCaptures @volatile var thread: Thread | Null = null
+    // The park permit `CarrierStrand.unpark` grants, checked by the spinning phase of `park`.
+    @caps.unsafe.untrackedCaptures @volatile var permit: Boolean = false
+
+    val strand: Strand = CarrierStrand(this)
+
+    def run(): Unit =
+      val self = Thread.currentThread.nn
+      thread = self
+      pool.carriers.set(this)
+      var current: Entry | Null = task
+
+      while current != null do
+        current.run(self, pool)
+        task = null
+        current = next()
+
+    // Parks on the idle list until a task is handed over, or retires when the list is full.
+    private def next(): Entry | Null =
+      if pool.idleCount.incrementAndGet() > pool.limit then
+        pool.idleCount.decrementAndGet()
+        null
+      else
+        pool.idle.addFirst(this)
+        var spun = 0
+
+        while task == null do
+          if spun < spins then
+            spun += 1
+            Thread.onSpinWait()
+          else jucl.LockSupport.park(this)
+
+        // A hand-off leaves the carrier's own park permit possibly set; nothing else is
+        // waiting on it, so a stale permit only makes a later `park` spurious, which is allowed.
+        task
+
+  private[parasite] final class CarrierStrand(val carrier: Carrier) extends Strand:
+    def interrupt(): Unit =
+      val thread = carrier.thread
+      if thread != null then thread.interrupt()
+
+    def join(): Unit = ()
+
+    def unpark(): Unit =
+      carrier.permit = true
+      val thread = carrier.thread
+      if thread != null then jucl.LockSupport.unpark(thread)
+
+    override def equals(that: Any): Boolean = that.asMatchable match
+      case that: CarrierStrand => that.carrier.eq(carrier)
+      case _                   => false
+
+    override def hashCode: Int = carrier.hashCode

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -36,6 +36,7 @@ import scala.language.experimental.into
 import scala.language.experimental.pureFunctions
 
 import scala.caps
+import scala.reflect.ClassTag
 
 import java.lang as jl
 
@@ -46,6 +47,7 @@ import digression.*
 import fulminate.*
 import nomenclature.*
 import prepositional.*
+import rudiments.Atomic
 import symbolism.*
 import vacuous.*
 
@@ -210,6 +212,46 @@ def supervise[result](block: Monitor ?=> result)(using threading: Threading, cod
 :   (Tactic[Async.Error]^) ?->{block} result =
 
   block(using Root(threading.supervisor()))
+
+
+// Runs the numbered jobs `job(0)` to `job(count - 1)` across at most `parallelism` tasks, each
+// taking the next index from a shared counter, and returns every result in index order once all
+// have completed. This is the bounded fan-out for a batch of small jobs: a task is a virtual
+// thread, whose start and join cost a few microseconds, so the spawn cost here is paid
+// `parallelism` times rather than `count` times — the form to prefer over one `async` per element
+// whenever the elements outnumber the cores and each is cheap. Results are kept in a plain array
+// indexed by job number, so the output is ordered by job, not by completion. A job's exception
+// fails its task and surfaces here at that task's join, as it would from an `await`.
+def concurrently[result: ClassTag](count: Int, parallelism: Int)(job: Int => result)
+  ( using monitor: Monitor^, probate: Probate^, codepoint: Codepoint )
+:   (Tactic[Async.Error]^) ?->{job, monitor, probate} scala.IArray[result] =
+
+  val index: Atomic[Int] = Atomic(0)
+  val output: scala.Array[result] = new scala.Array[result](count)
+
+  // Sealed to pure handles as the `sequence` façade does: the workers are started and joined
+  // inside this one call, so their captures (the output array, the job, the scope) never escape.
+  val tasks: List[Task[Unit]] =
+    List.fill(parallelism.min(count).max(0)):
+      caps.unsafe.unsafeAssumePure:
+       async:
+         // The write view of the shared output: each worker writes only the slots it has
+         // claimed through the counter, and the array is read only after every worker has
+         // joined — the discipline separation checking cannot see through the closure (cf.
+         // `Handoff#drain`).
+         val slots = output.asInstanceOf[scala.Array[result]^]
+         var running = true
+
+         while running do
+           // `ere` yields the counter's prior value: the index this worker has claimed.
+           val i = index.ere(_ + 1)
+           if i >= count then running = false else slots(i) = job(i)
+
+  // Joined here rather than through `sequence`, which would start one more task for the join;
+  // through the stdlib bridge because a `Task` join inside an `each` lambda trips the compiler.
+  tasks.stdlib.foreach { (task: Task[Unit]) => task.join() }
+
+  scala.IArray.unsafeFromArray(output)
 
 
 def retry[value](evaluate: (surrender: () => Nothing, persevere: () => Nothing) ?=> value)

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -58,6 +58,9 @@ package threading:
   given platformThreading: Threading = () => PlatformSupervisor
   given virtualThreading: Threading = () => VirtualSupervisor
   given adaptiveThreading: Threading = () => AdaptiveSupervisor
+  // Tasks on reusable carrier threads (see `PoolingSupervisor`): for fine-grained fan-out,
+  // where a thread start per task would dominate.
+  given pooledThreading: Threading = () => PooledSupervisor
 
   // The model for Scala.js (issue #1450): tasks run eagerly at `fork`, so structured
   // gather-style concurrency works on the event loop, with the limitations documented on

--- a/lib/parasite/src/core/soundness_parasite_core.scala
+++ b/lib/parasite/src/core/soundness_parasite_core.scala
@@ -37,14 +37,14 @@ export
   . { AdaptiveSupervisor, async, Async, cancel, Probate, Daemon, daemon, delay,
       Destruction, Fault, Fulfillment, hibernate, Hook, intercept,
       Interceptable, JavascriptSupervisor, Monitor, monitor, Observation, Os, Perseverance,
-      PlatformSupervisor, Promise,
+      PlatformSupervisor, PooledSupervisor, PoolingSupervisor, Promise,
       relent, retry, Shutdown, sleep, snooze, Strand, supervise, Supervisor, Task, task,
       Tenacity, Threading, Timeout, Transgression, contain, Containment, VirtualSupervisor, Worker,
       AsyncTactic, Remedy, concurrent, concurrently }
 
 package threading:
   export parasite.threading.{adaptiveThreading, javascriptThreading, platformThreading,
-      virtualThreading}
+      pooledThreading, virtualThreading}
 
 package probates:
   export parasite.probates.{awaitProbate, cancelProbate, failProbate, panicProbate}

--- a/lib/parasite/src/core/soundness_parasite_core.scala
+++ b/lib/parasite/src/core/soundness_parasite_core.scala
@@ -40,7 +40,7 @@ export
       PlatformSupervisor, Promise,
       relent, retry, Shutdown, sleep, snooze, Strand, supervise, Supervisor, Task, task,
       Tenacity, Threading, Timeout, Transgression, contain, Containment, VirtualSupervisor, Worker,
-      AsyncTactic, Remedy, concurrent }
+      AsyncTactic, Remedy, concurrent, concurrently }
 
 package threading:
   export parasite.threading.{adaptiveThreading, javascriptThreading, platformThreading,

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -623,6 +623,46 @@ object Tests extends Suite(m"Parasite tests"):
           Chain[Int]().concurrent.stdlib.to(List)
         . assert(_ == List())
 
+      suite(m"Bounded concurrency"):
+        test(m"Results come back in job order"):
+          concurrently(100, 4)(i => i*i).toList
+        . assert(_ == scala.List.tabulate(100)(i => i*i))
+
+        test(m"No more than `parallelism` jobs run at once"):
+          val running = juca.AtomicInteger(0)
+          val peak = juca.AtomicInteger(0)
+
+          concurrently(64, 3): i =>
+            val now = running.incrementAndGet()
+            peak.accumulateAndGet(now, (a, b) => Math.max(a, b))
+            Thread.sleep(2)
+            running.decrementAndGet()
+            i
+
+          peak.get()
+        . assert(_ == 3)
+
+        test(m"Every job runs exactly once"):
+          val counts = juca.AtomicIntegerArray(200)
+          concurrently(200, 8) { i => counts.incrementAndGet(i) }
+          (0 until 200).forall(counts.get(_) == 1)
+        . assert(_ == true)
+
+        test(m"Zero jobs yields an empty result and starts nothing"):
+          concurrently(0, 8)(i => i).length
+        . assert(_ == 0)
+
+        test(m"Fewer jobs than workers starts only as many tasks as jobs"):
+          concurrently(2, 8)(i => i + 1).toList
+        . assert(_ == scala.List(1, 2))
+
+        test(m"A failing job surfaces its exception at the join"):
+          try
+            concurrently(10, 2) { i => if i == 5 then throw RuntimeException("job 5") else i }
+            "no failure"
+          catch case error: RuntimeException => error.getMessage
+        . assert(_ == "job 5")
+
       suite(m"High contention"):
         test(m"Many concurrent fulfill attempts result in one success"):
           val promise = Promise[Int]()

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -43,7 +43,6 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.emptyDiagnostics
 
-import threading.virtualThreading
 import probates.cancelProbate
 import Async.nominative
 
@@ -52,7 +51,193 @@ case class BarError(label: Text)(using Diagnostics) extends Error(m"bar failed: 
 
 object Tests extends Suite(m"Parasite tests"):
 
+  // Every behavioural suite runs twice: under the thread-per-task supervisor and under the
+  // pooling one, since the pool must be indistinguishable from a thread per task in every
+  // respect but cost. The pool-specific suites cover what only a pool can get wrong.
   def run(): Unit =
+    suite(m"Virtual threads"):
+      exercise()(using threading.virtualThreading)
+
+    suite(m"Pooled supervisor"):
+      exercise()(using threading.pooledThreading)
+      pooled()(using threading.pooledThreading)
+
+  def pooled()(using Threading, Testable): Unit =
+    supervise:
+      suite(m"Carrier reuse"):
+        test(m"Sequential tasks share a small number of carriers"):
+          val threads = juc.ConcurrentHashMap.newKeySet[Thread]().nn
+          var i = 0
+          while i < 2000 do
+            async(threads.add(Thread.currentThread.nn)).await()
+            i += 1
+          threads.size
+        . assert(_ <= 4)
+
+        test(m"A burst of blocked tasks all complete"):
+          import probates.awaitProbate
+          val gate = Promise[Unit]()
+          val started = juc.CountDownLatch(500)
+          val tasks = (1 to 500).map: i =>
+            async:
+              started.countDown()
+              gate.await()
+              i
+          started.await()
+          gate.fulfill(())
+          tasks.map(_.await()).sum
+        . assert(_ == (1 to 500).sum)
+
+      suite(m"No starvation"):
+        test(m"Deeply nested awaits complete however many carriers are blocked"):
+          def nest(depth: Int): Int = if depth == 0 then 1 else async(nest(depth - 1) + 1).await()
+          nest(300)
+        . assert(_ == 301)
+
+        test(m"Tasks blocked outside park do not stall the pool"):
+          val latch = juc.CountDownLatch(1)
+          val blocked = (1 to 100).map: i =>
+            async:
+              latch.await()
+              i
+          val meanwhile = async(7).await()
+          latch.countDown()
+          meanwhile + blocked.map(_.await()).sum
+        . assert(_ == 7 + (1 to 100).sum)
+
+        test(m"Tasks sleeping on the JDK clock do not stall the pool"):
+          val sleepers = (1 to 50).map: i =>
+            async:
+              Thread.sleep(20)
+              i
+          val meanwhile = async(7).await()
+          meanwhile + sleepers.map(_.await()).sum
+        . assert(_ == 7 + (1 to 50).sum)
+
+      suite(m"Interrupt hygiene"):
+        test(m"A cancelled task's interrupt does not reach the next task on its carrier"):
+          var leaked = 0
+          var round = 0
+          while round < 500 do
+            val gate = Promise[Unit]()
+            val victim = async:
+              gate.await()
+            victim.cancel()
+            safely(victim.await())
+            // The next task very likely lands on the carrier the victim just released.
+            if async(Thread.currentThread.nn.isInterrupted).await() then leaked += 1
+            round += 1
+          leaked
+        . assert(_ == 0)
+
+        test(m"Cancelling a task racing its own completion leaves no stale interrupt"):
+          var leaked = 0
+          var round = 0
+          while round < 2000 do
+            val victim = async(round)
+            victim.cancel()
+            safely(victim.await())
+            if async(Thread.currentThread.nn.isInterrupted).await() then leaked += 1
+            round += 1
+          leaked
+        . assert(_ == 0)
+
+        test(m"A task cancelled before it mounts still settles"):
+          var settled = 0
+          var round = 0
+          while round < 500 do
+            val task = async(round)
+            task.cancel()
+            safely(task.await()).let(_ => ())
+            if task.ready then settled += 1
+            round += 1
+          settled
+        . assert(_ == 500)
+
+        test(m"Cancelling one of two tasks leaves the other running"):
+          val gate = Promise[Unit]()
+          val survivorStarted = Promise[Unit]()
+          val victim = async(gate.await())
+          val survivor = async:
+            survivorStarted.fulfill(())
+            gate.await()
+            42
+          survivorStarted.await()
+          victim.cancel()
+          safely(victim.await())
+          gate.fulfill(())
+          survivor.await()
+        . assert(_ == 42)
+
+      suite(m"Self-cancellation"):
+        test(m"A task cancelling itself releases its carrier"):
+          // Tasks from earlier suites may still be sleeping on carriers, so the invariant is
+          // that this test leaves no more carriers active than it found.
+          val before = PooledSupervisor.active
+          var round = 0
+          while round < 100 do
+            val task: Task[Int] = async:
+              monitor.cancel()
+              42
+            safely(task.await())
+            round += 1
+
+          // Every carrier returns to the idle list once its task has finished; a task stuck in
+          // its own cancellation would hold one for ever.
+          var waited = 0
+          while PooledSupervisor.active > before && waited < 100 do
+            Thread.sleep(10)
+            waited += 1
+          PooledSupervisor.active <= before
+        . assert(_ == true)
+
+        test(m"A task cancelled from outside and inside at once settles and releases"):
+          val before = PooledSupervisor.active
+          var round = 0
+          while round < 100 do
+            val task: Task[Int] = async:
+              monitor.cancel()
+              42
+            task.cancel()
+            safely(task.await())
+            round += 1
+          var waited = 0
+          while PooledSupervisor.active > before && waited < 100 do
+            Thread.sleep(10)
+            waited += 1
+          PooledSupervisor.active <= before
+        . assert(_ == true)
+
+      suite(m"Waking"):
+        test(m"A pooled task wakes a joiner on a platform thread"):
+          val result = juca.AtomicInteger(0)
+          val gate = Promise[Unit]()
+          val task = async:
+            gate.await()
+            5
+          val scope: Monitor = monitor
+          val runnable: Runnable = () => result.set(task.await()(using scope))
+          val joiner = Thread(runnable)
+          joiner.start()
+          Thread.sleep(20)
+          gate.fulfill(())
+          joiner.join()
+          result.get()
+        . assert(_ == 5)
+
+        test(m"Promise waiters on carriers are woken exactly as on threads"):
+          val promise = Promise[Int]()
+          val started = juc.CountDownLatch(50)
+          val tasks = (1 to 50).map: _ =>
+            async:
+              started.countDown()
+              promise.await()
+          started.await()
+          promise.fulfill(9)
+          tasks.map(_.await()).sum
+        . assert(_ == 450)
+
+  def exercise()(using Threading, Testable): Unit =
     supervise:
 
       suite(m"Promise basic state"):
@@ -1281,7 +1466,8 @@ object Tests extends Suite(m"Parasite tests"):
             captured.set(monitor.stack)
           task.await()
           val current: Optional[Text] = captured.get().nn
-          current.lay(false)(_.contains(t"virtual"))
+          val expected: Text = summon[Threading].supervisor().name
+          current.lay(false)(_.contains(expected))
         . assert(_ == true)
 
         test(m"Nested workers' stack reflects nesting"):

--- a/lib/probably/src/core/probably.Benchmark.scala
+++ b/lib/probably/src/core/probably.Benchmark.scala
@@ -35,6 +35,8 @@ package probably
 import scala.math
 
 import anticipation.*
+import rudiments.*
+import symbolism.*
 import vacuous.*
 
 object Benchmark:
@@ -46,8 +48,8 @@ object Benchmark:
         benchmark:   Benchmark )
     :   Report =
 
-      val metrics =
-        Ledger
+      val timings: List[(Metric, Double)] =
+        List
           ( Metric.Iterations -> benchmark.iterations.toDouble,
             Metric.Mean       -> benchmark.mean,
             Metric.Least      -> benchmark.min,
@@ -57,6 +59,14 @@ object Benchmark:
             Metric.Confidence -> (if benchmark.mean == 0.0 then 0.0
                                   else benchmark.confidenceInterval/benchmark.mean),
             Metric.Throughput -> benchmark.throughput.toDouble )
+
+      // The `Optional` is bound to a typed local before the combinator, as in `Strain`.
+      val allocation: Optional[Long] = benchmark.allocation
+
+      val memory: List[(Metric, Double)] =
+        allocation.lay(List[(Metric, Double)]()): bytes => List(Metric.Allocation -> bytes.toDouble)
+
+      val metrics = (timings + memory).to[Ledger]
 
       val payload: Optional[Run.Payload] =
         if benchmark.operationSize.absent && benchmark.operationRate.absent then Unset
@@ -78,6 +88,7 @@ object Benchmark:
             benchmark.confidence,
             benchmark.operationSize,
             benchmark.operationRate,
+            benchmark.allocation,
             java.lang.System.currentTimeMillis )
 
       report.record
@@ -99,7 +110,8 @@ case class Benchmark
     sd:             Double,
     confidence:     Benchmark.Percentiles,
     operationSize:  Optional[Text] = Unset,
-    operationRate:  Optional[Text] = Unset ):
+    operationRate:  Optional[Text] = Unset,
+    allocation:     Optional[Long] = Unset ):
 
   // One-sided quantiles of Student's t-distribution, used for CI half-widths
   // computed from `runs` independent measurement-run means with df = runs - 1.

--- a/lib/probably/src/core/probably.TestEvent.scala
+++ b/lib/probably/src/core/probably.TestEvent.scala
@@ -267,6 +267,8 @@ enum TestEvent:
       confidence:    Int,
       operationSize: Optional[Text],
       operationRate: Optional[Text],
+      // Bytes allocated per operation across the timed batches, when the harness measured it.
+      allocation:    Optional[Long],
       timestamp:     Long )
 
   case StrainRecorded

--- a/lib/sedentary/src/core/sedentary.Bench.scala
+++ b/lib/sedentary/src/core/sedentary.Bench.scala
@@ -66,7 +66,15 @@ import workingDirectories.javaBaseWorkingDirectory
 import denominative.*
 import denominative.dysasymptotics.linearSize
 
-case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice) extends Rig:
+// `heap`, `cpus` and `gc` size and pin the measurement JVM exactly as for `Stress` (see the
+// notes on `BenchmarkDevice#invoke`): the defaults are a fixed 1 GB heap and the Serial collector,
+// which suit single-threaded microbenchmarks; a body that runs a fiber runtime or many virtual
+// threads should ask for `gc = t"G1"` and a heap sized to what the rival's own harness used.
+case class Bench
+  ( heap: Optional[Text] = Unset, cpus: Optional[Int] = Unset, gc: Optional[Text] = Unset )
+  ( using Classloader, Environment )
+  ( using device: BenchmarkDevice )
+extends Rig:
   type Result[output] = output
   type Form = Text
   type Target = Path on Linux
@@ -123,7 +131,7 @@ case class Bench()(using Classloader, Environment)(using device: BenchmarkDevice
   protected val scalac: Scalac[3.7, Universe.Classfile] = Scalac(List(scalacOptions.experimental))
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
-    stage.remote: input => unsafely(device.invoke(stage.target, input))
+    stage.remote: input => unsafely(device.invoke(stage.target, input, heap, cpus, gc))
 
 object Bench:
   // The staged measurement harness, shared by every cell of every plan: warmup, doubling
@@ -186,7 +194,10 @@ object Bench:
 
         var rate: Double = d.toDouble/count
         count = math.max(1L, (${Expr(batch)}/rate).toLong)
-        val result = new scala.Array[Long](${Expr(iterations)} + 1)
+
+        // `count`, then `iterations` batch timings, then the bytes allocated across the timed
+        // batches (see below).
+        val result = new scala.Array[Long](${Expr(iterations)} + 2)
 
         // Warmup / calibration: run `warmups` full-count batches, adjusting
         // count run-by-run so it converges on the batch target, then pick the
@@ -209,6 +220,19 @@ object Bench:
 
         result(0) = count
 
+        // Allocation over the timed batches, from `getTotalThreadAllocatedBytes` (JDK 21+, as
+        // `Stress` uses it): it accumulates over terminated threads too, and a virtual thread's
+        // allocation is attributed to its carrier, so a body which forks its own workers or
+        // fibers is still fully accounted. The harness's own contribution is the boxing of each
+        // body result into the sink (a primitive result costs one box per operation); it is
+        // deliberately not subtracted, so the figure is a measurement and not an estimate.
+        val threadMx =
+          java.lang.management.ManagementFactory.getThreadMXBean.nn
+          . asInstanceOf[com.sun.management.ThreadMXBean]
+
+        jl.System.gc()
+        val allocated0 = threadMx.getTotalThreadAllocatedBytes
+
         var m = 1
         while m <= ${Expr(iterations)} do
           // Trigger a young-gen collection between runs so a GC pause is less
@@ -221,6 +245,8 @@ object Bench:
           val t1 = jl.System.nanoTime - t0
           result(m) = t1
           m += 1
+
+        result(${Expr(iterations)} + 1) = threadMx.getTotalThreadAllocatedBytes - allocated0
 
         if jl.System.nanoTime < 0L then jl.System.err.nn.println(sink.get)
 
@@ -236,9 +262,12 @@ object Bench:
   :   Benchmark =
 
     val sample: Long = results0.stdlib(0)
-    val results = results0.stdlib.drop(1)
+    val results = results0.stdlib.drop(1).take(runs)
+    val allocated: Long = results0.stdlib(runs + 1)
     val total = results.sum
     val count = sample*runs
+    // Bytes per operation, rounded to the nearest byte; a body allocating nothing reports 0.
+    val allocation: Long = math.round(allocated.toDouble/count.toDouble)
     val sampleMean0 = results.map(_.toDouble/sample).mean
     val sampleMean = sampleMean0.or(0.0)
     val sum = results.map(_.toDouble/sample - sampleMean).bi.map(_*_).sum
@@ -254,7 +283,7 @@ object Bench:
 
     Benchmark
       ( total, count, runs, total.toDouble/count, min, max, sd, confidence,
-        operationSizeText, operationRateText )
+        operationSizeText, operationRateText, allocation )
 
   case class Plan
     ( bench:         Bench,

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -248,6 +248,14 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
   // ── Shared run helpers (referenced from the staged bodies) ──────────────────
 
   // ZIO's unsafe-run entry point, wrapping each ZIO benchmark's effect.
+  // The counting terminal the rival rows end in (`compile.count`, `runCount`, a read loop): the
+  // stream is pulled to its end and its length summed, never materialised. `memoize` would
+  // concatenate the whole output — about three times its size in allocation for a 4 MB result,
+  // through a doubling builder and a final copy — which no rival row does, so a row that ended
+  // in `memoize.length` was charged for a materialisation its rivals were not asked for.
+  def count[medium](stream: Stream[medium] over Credit)(using Buffering): Long =
+    stream.gather(0L)(_ => (total, range) => total + (range: Interval).size)
+
   def runZio[A](effect: zio.ZIO[Any, Throwable, A]): A =
     zio.Unsafe.unsafe: (unsafe: zio.Unsafe) ?=>
       zio.Runtime.default.unsafe.run(effect).getOrThrow()
@@ -306,7 +314,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
     suite(m"Gzip compression (4 MB)"):
       bench(m"Soundness  Stream.compress[Gzip]")
         ( target = 1*Second, operationSize = size ):
-        '{ turbulence.Benchmarks.input.stream.compress[Gzip].memoize.length }
+        '{ turbulence.Benchmarks.count(turbulence.Benchmarks.input.stream.compress[Gzip]) }
 
       bench(m"FS2  Compression[IO].gzip")(target = 1*Second, operationSize = size):
         '{
@@ -331,7 +339,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
     suite(m"Gzip decompression (4 MB)"):
       bench(m"Soundness  Stream.decompress[Gzip]")
         ( target = 1*Second, operationSize = size ):
-        '{ turbulence.Benchmarks.gzippedInput.stream.decompress[Gzip].memoize.length }
+        '{ turbulence.Benchmarks.count(turbulence.Benchmarks.gzippedInput.stream.decompress[Gzip]) }
 
       bench(m"FS2  Compression[IO].gunzip")(target = 1*Second, operationSize = size):
         '{
@@ -373,10 +381,10 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
     suite(m"Brotli compression (4 MB)"):
       bench(m"Soundness  Stream.compress[Brotli]")
         ( target = 1*Second, operationSize = size ):
-        '{ turbulence.Benchmarks.input.stream.compress[Brotli].memoize.length }
+        '{ turbulence.Benchmarks.count(turbulence.Benchmarks.input.stream.compress[Brotli]) }
 
       bench(m"Soundness  Stream.compress[Gzip]")(target = 1*Second, operationSize = size):
-        '{ turbulence.Benchmarks.input.stream.compress[Gzip].memoize.length }
+        '{ turbulence.Benchmarks.count(turbulence.Benchmarks.input.stream.compress[Gzip]) }
 
     // Example 1d: Brotli decompression alone, on the pre-Brotli'd corpus. The reference pure-Java
     // decoder `org.brotli.dec.BrotliInputStream` is the "competitive-with-Java" baseline — our port
@@ -384,7 +392,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
     suite(m"Brotli decompression (4 MB)"):
       bench(m"Soundness  Stream.decompress[Brotli]")
         ( target = 1*Second, operationSize = size ):
-        '{ turbulence.Benchmarks.brotliInput.stream.decompress[Brotli].memoize.length }
+        '{ turbulence.Benchmarks.count(turbulence.Benchmarks.brotliInput.stream.decompress[Brotli]) }
 
       bench(m"Java  org.brotli.dec.BrotliInputStream")(target = 1*Second, operationSize = size):
         '{
@@ -502,7 +510,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
     suite(m"Chained: gzip -> gunzip roundtrip (4 MB)"):
       bench(m"Soundness  compress[Gzip].decompress[Gzip]")
         ( target = 1*Second, operationSize = size ):
-        '{ turbulence.Benchmarks.input.stream.compress[Gzip].decompress[Gzip].memoize.length }
+        '{ turbulence.Benchmarks.count(turbulence.Benchmarks.input.stream.compress[Gzip].decompress[Gzip]) }
 
       bench(m"FS2  gzip.gunzip")(target = 1*Second, operationSize = size):
         '{
@@ -526,8 +534,9 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
       bench(m"Soundness  via(dec).via(enc)")
         ( target = 1*Second, operationSize = textSize ):
         '{
-            turbulence.Benchmarks.textData.stream
-            . via(summon[CharDecoder]).via(summon[CharEncoder]).memoize.length
+            turbulence.Benchmarks.count:
+              turbulence.Benchmarks.textData.stream
+              . via(summon[CharDecoder]).via(summon[CharEncoder])
         }
 
       bench(m"FS2  utf8.decode.encode")(target = 1*Second, operationSize = textSize):
@@ -551,8 +560,9 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
       bench(m"Soundness  decompress.via(summon[CharDecoder])")
         ( target = 1*Second, operationSize = textSize ):
         '{
-            turbulence.Benchmarks.gzippedText.stream.decompress[Gzip]
-            . via(summon[CharDecoder]).memoize.s.length
+            turbulence.Benchmarks.count:
+              turbulence.Benchmarks.gzippedText.stream.decompress[Gzip]
+              . via(summon[CharDecoder])
         }
 
       bench(m"FS2  gunzip.utf8.decode")(target = 1*Second, operationSize = textSize):
@@ -580,10 +590,11 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
       bench(m"Soundness  compress.b64.b64.decompress")
         ( target = 1*Second, operationSize = size ):
         '{
-            turbulence.Benchmarks.input.stream.compress[Gzip]
-            . serialize[Base64]
-            . deserialize[Base64]
-            . decompress[Gzip].memoize.length
+            turbulence.Benchmarks.count:
+              turbulence.Benchmarks.input.stream.compress[Gzip]
+              . serialize[Base64]
+              . deserialize[Base64]
+              . decompress[Gzip]
         }
 
       bench(m"FS2  gzip.base64.base64.gunzip")(target = 1*Second, operationSize = size):
@@ -639,7 +650,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
                 . memoize
 
               val decrypted: Data = recovered.decrypt[Data, Aes[256] over Cbc against Pkcs7]
-              decrypted.stream.decompress[Gzip].memoize.length
+              turbulence.Benchmarks.count(decrypted.stream.decompress[Gzip])
         }
 
       bench(m"JDK  GZIP/Cipher/Base64 composition")(target = 1*Second, operationSize = size):
@@ -687,10 +698,11 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
       bench(m"Soundness  dec.enc.dec.enc.dec")
         ( target = 1*Second, operationSize = textSize ):
         '{
-            turbulence.Benchmarks.textData.stream
-            . via(summon[CharDecoder]).via(summon[CharEncoder])
-            . via(summon[CharDecoder]).via(summon[CharEncoder])
-            . via(summon[CharDecoder]).memoize.s.length
+            turbulence.Benchmarks.count:
+              turbulence.Benchmarks.textData.stream
+              . via(summon[CharDecoder]).via(summon[CharEncoder])
+              . via(summon[CharDecoder]).via(summon[CharEncoder])
+              . via(summon[CharDecoder])
         }
 
       bench(m"FS2  utf8 decode/encode x2.5")(target = 1*Second, operationSize = textSize):
@@ -720,10 +732,11 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
       bench(m"Soundness  dec.enc.b64.b64.dec")
         ( target = 1*Second, operationSize = textSize ):
         '{
-            turbulence.Benchmarks.textData.stream
-            . via(summon[CharDecoder]).via(summon[CharEncoder])
-            . serialize[Base64].deserialize[Base64]
-            . via(summon[CharDecoder]).memoize.s.length
+            turbulence.Benchmarks.count:
+              turbulence.Benchmarks.textData.stream
+              . via(summon[CharDecoder]).via(summon[CharEncoder])
+              . serialize[Base64].deserialize[Base64]
+              . via(summon[CharDecoder])
         }
 
       bench(m"FS2  utf8/base64 chain")(target = 1*Second, operationSize = textSize):
@@ -794,8 +807,9 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
       bench(m"Soundness  serialize.deserialize")
         ( target = 1*Second, operationSize = size ):
         '{
-            turbulence.Benchmarks.input.stream
-            . serialize[Base64].deserialize[Base64].memoize.length
+            turbulence.Benchmarks.count:
+              turbulence.Benchmarks.input.stream
+              . serialize[Base64].deserialize[Base64]
         }
 
       bench(m"FS2  base64.encode.decode")(target = 1*Second, operationSize = size):

--- a/lib/zephyrine/src/core/zephyrine.Addressable.scala
+++ b/lib/zephyrine/src/core/zephyrine.Addressable.scala
@@ -37,6 +37,7 @@ import scala.caps
 import java.io as ji
 import java.lang as jl
 
+import scala.collection.immutable as sci
 import scala.collection.mutable as scm
 import scala.reflect.ClassTag
 
@@ -100,6 +101,17 @@ object Addressable:
 
     inline def materialize(storage: scala.Array[Byte], off: Int, len: Int): Data =
       Array.unsafeFrozen(java.util.Arrays.copyOfRange(storage, off, off + len).nn)
+
+    // The pieces are copied once, straight into the array that becomes the value.
+    override def assemble(pieces: sci.Seq[Data], total: Int): Data =
+      val array = new scala.Array[Byte](total)
+      var offset: Int = 0
+
+      pieces.foreach: piece =>
+        System.arraycopy(Array.unsafeJvm(piece), 0, array, offset, piece.length)
+        offset += piece.length
+
+      Array.unsafeFrozen(array)
 
     override inline def backing(value: Data): Optional[scala.Array[Byte]] =
       value.asInstanceOf[scala.Array[Byte]]
@@ -422,6 +434,13 @@ object Addressable:
     inline def materialize(storage: scala.Array[Char], off: Int, len: Int): Text =
       String(storage, off, len).tt
 
+    // `String.join` sizes its result exactly and copies each piece once; a `StringBuilder`
+    // would copy twice (into itself, then out of `toString`), and a `char[]` likewise.
+    override def assemble(pieces: sci.Seq[Text], total: Int): Text =
+      val list = java.util.ArrayList[CharSequence]()
+      pieces.foreach { piece => list.add(piece.s) }
+      String.join("", list).nn.tt
+
     inline def cloneStorage
       (storage: scala.Array[Char], off: Int, len: Int)(target: jl.StringBuilder)
     :   Unit =
@@ -476,6 +495,23 @@ trait Addressable extends Typeclass.Pure, Operable, Targetable:
 
   def materialize(storage: Storage^{caps.any.rd}, off: Int, len: Int): Self
   def cloneStorage(storage: Storage^{caps.any.rd}, off: Int, len: Int)(target: Target): Unit
+
+  // Joins exact-size pieces, in order, into one value of their total length: the terminal of
+  // `memoize`, which prefers this to a growing builder because a builder's doublings sum to
+  // twice the output before `build` copies it out a third time. This default assembles through
+  // fresh storage and `materialize`, copying the pieces twice over; a medium whose value can be
+  // built from its storage in a single copy overrides it.
+  def assemble(pieces: sci.Seq[Self], total: Int): Self =
+    val storage: Storage^ = allocate(total)
+    var offset: Int = 0
+
+    pieces.foreach: piece =>
+      val size = length(piece)
+      copyChunk(piece, 0, storage, offset, size)
+      offset += size
+
+    // Read back through the read-only view once every write is done (cf. `Region`'s casts).
+    materialize(storage.asInstanceOf[Storage], 0, total)
 
   // The value's backing storage, when the medium is immutable and its erased
   // representation *is* its `Storage` type, so a whole chunk can be exposed as

--- a/lib/zephyrine/src/core/zephyrine.Handoff.scala
+++ b/lib/zephyrine/src/core/zephyrine.Handoff.scala
@@ -168,7 +168,13 @@ final class Handoff(depth: Int) extends caps.SharedCapability:
         val waiting = producer
         if waiting != null then LockSupport.unpark(waiting)
         return count
-      else if done then return 0
+      // `finish` is published AFTER the final `offer`'s `tail` write, so a `done` observed
+      // here may postdate a `tail` read that missed that last item: re-read `tail` before
+      // concluding the ring is drained, and move the item on the next pass if it is there.
+      // Without the re-read, a consumer racing the producer's last `offer`/`finish` pair
+      // dropped the final item (found by the parasite queue benchmarks: one loss in ~10⁵).
+      else if done then
+        if position == tail() then return 0
       else if spun < spins then
         spun += 1
         Thread.onSpinWait()
@@ -199,7 +205,9 @@ final class Handoff(depth: Int) extends caps.SharedCapability:
         val waiting = producer
         if waiting != null then LockSupport.unpark(waiting)
         return item
-      else if done then return null
+      // See `drain`: re-read `tail` after observing `done`.
+      else if done then
+        if position == tail() then return null
       else if spun < spins then
         spun += 1
         Thread.onSpinWait()

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -219,14 +219,26 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
 
   // Drain the stream into a single immutable value: the explicit, bounded replacement
   // for a Chain's implicit memoization. The result is frozen and freely shareable.
+  //
+  // Each region is copied once, at its exact size, as it passes, and the pieces are joined
+  // once at the end (`Addressable#assemble`): two copies of the output in all, and one when the
+  // stream delivered it in a single region. The growing builder this replaces cost about three
+  // — its doublings sum to twice the output before `build` copies it out — which for a 4 MB
+  // result was 12 MB allocated against the 0.1 MB of the pipeline feeding it.
   def memoize(using buffering: Buffering): medium =
     given stream.addressable.type = stream.addressable
-    val target = stream.addressable.blank(buffering.capacity(stream.addressable.substrate))
+    val pieces = scala.collection.mutable.ArrayBuffer[medium]()
+    var total: Int = 0
 
     drain: region =>
-      range => region.cloneTo(range)(target)
+      range =>
+        pieces += region.materialize(range)
+        total += (range: Interval).size
 
-    stream.addressable.build(target)
+    pieces.length match
+      case 0 => stream.addressable.empty
+      case 1 => pieces(0)
+      case _ => stream.addressable.assemble(pieces.toSeq, total)
 
   // Drain the stream, threading an accumulator through each region: `sweep`'s
   // accumulating counterpart, the terminal end of a pull chain. The operation

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -987,6 +987,20 @@ object Tests extends Suite(m"Zephyrine tests"):
           small.stream.viaDuct(Doubler()).memoize.to[List]
         . assert(_ == (small.to[List]: List[Byte]).flatMap { byte => proscenium.List(byte, byte) })
 
+        test(m"memoize of a single-region stream returns that region's copy"):
+          Stream(Iterator(Array[Byte](7, 8, 9))).memoize.to[List]
+        . assert(_ == List(7.toByte, 8.toByte, 9.toByte))
+
+        test(m"memoize assembles many regions in order at their total length"):
+          val pieces = Iterator.tabulate(50) { i => Array.fill[Byte](1000 + i)(i.toByte) }
+          val value = Stream(pieces).memoize
+          (value.length, value.readUnchecked(0), value.readUnchecked(value.length - 1))
+        . assert(_ == (50*1000 + 49*50/2, 0.toByte, 49.toByte))
+
+        test(m"memoize of a boxed stream assembles through the default path"):
+          Stream(Iterator(Array[Text](t"a", t"b"), Array[Text](t"c"))).memoize.to[List]
+        . assert(_ == List(t"a", t"b", t"c"))
+
         test(m"memoize drains a text stream into a single text value"):
           Stream(Iterator(t"ab", t"cd", t"e")).memoize.s
         . assert(_ == "abcde")


### PR DESCRIPTION
Soundness now measures its concurrency primitives against cats-effect and Kyo using the constructions of a widely shared effect-runtime benchmark, and the comparison drove three improvements: `concurrently`, a bounded fan-out over numbered jobs; `pooledThreading`, a supervisor that runs tasks on reusable carrier threads so a spawn costs a hand-off rather than a thread start; and a fix to `Handoff`, whose consumer could lose the final item when it raced the producer's `finish`. The `Bench` harness gained JVM sizing parameters and reports allocation per operation.

## Benchmarks against cats-effect and Kyo

`lib/parasite/src/bench` ports the `matched` suite of [scala-effect-bench](https://github.com/stasimus/scala-effect-bench) — the constructions behind the "Kyo vs Cats Effect" comparison — with the cats-effect/fs2 and Kyo arms verbatim, and a Soundness arm per construction written the way a Soundness user writes the same job. The header of `parasite.Benchmarks.scala` records the results. In brief: the rivals' numbers reproduce under sedentary, Soundness leads every construction that does not spawn a task per element (by between 1.4× and three orders of magnitude), and the one row it loses — a thousand sequential spawn-and-joins — is where the pooling supervisor below takes it from 2.9 ms to 0.58 ms against cats-effect's 0.44 ms and Kyo's 0.15 ms. Run it with `make bench.parasite`.

## `concurrently`: bounded fan-out

A task is a thread, so a thousand cheap jobs should not become a thousand tasks. `concurrently` runs numbered jobs across a fixed number of tasks, each taking the next job from a shared counter, and returns the results in job order:

```scala
supervise:
  concurrently(1000, 8)(i => i*i)   // IArray of the squares, in order, from eight tasks
```

A job's exception fails the task it ran on and is rethrown at the join.

## `pooledThreading`: tasks on reusable carriers

```scala
import threading.pooledThreading
```

`PooledSupervisor` hands each forked task to an idle carrier thread when one is waiting and starts a fresh carrier only when none is; carriers are virtual threads on the JVM and platform threads on Scala Native. A task that blocks keeps its carrier, so the pool grows rather than starving, and cancellation is delivered to the task rather than to the carrier. The trade-off is that a task no longer has a thread of its own: thread-locals persist across the tasks a carrier runs, and a thread dump shows carriers where the monitor tree shows tasks. `PoolingSupervisor#active` and `#idling` report the pool's occupancy. `virtualThreading` remains the default.

## `Bench`: JVM sizing and allocation per operation

`Bench(heap = t"2g", cpus = 4, gc = t"G1")` sizes and pins the measurement JVM exactly as `Stress` already could (defaults unchanged: a 1 GB heap on the Serial collector). Every cell also measures the bytes allocated across its timed batches and reports them per operation as `Benchmark#allocation` and on `TestEvent.BenchmarkRecorded`, which fume renders as an `Alloc·op¯¹` column. The new event field changes the event schema's fingerprint, so a fume built against an earlier Soundness must be rebuilt to read this one's suites.

## `Handoff`: the final item is always delivered

A consumer which read `Handoff`'s tail index just before the producer's last `offer`, and then saw `finish()`, concluded the ring was drained and dropped the final item — about once in 10⁵ hand-offs with both ends on virtual threads. `take` and `drain` now re-read the tail after observing `done`.
