### PR TITLE
Finalise the migration notes for 0.65.0

### DIFF
--- a/doc/migration/0.65.0.md
+++ b/doc/migration/0.65.0.md
@@ -1,11 +1,8 @@
-# Changes since 0.64.0 (pending release)
+# Changes in 0.65.0
 
-This file is read by an LLM agent to upgrade code that consumes Soundness libraries. Each
-entry states precisely what changed; see `AGENTS.md` for the format. Entries are grouped
-by module, most-recently-added last within a module.
-
-Entries for changes merged between the 0.64.0 release and the introduction of this file have
-not yet been recorded here.
+This file is read by an LLM agent to upgrade code that consumes Soundness libraries from
+0.64.0 to 0.65.0. Each entry states precisely what changed; see `AGENTS.md` for the format.
+Entries are grouped by module, most-recently-added last within a module.
 
 ## ambience
 


### PR DESCRIPTION
The migration notes for the next release are finalised: `doc/migration/pending.md` becomes `doc/migration/0.65.0.md`, which the release script requires before it will tag, and its header drops the sentence saying that changes merged before the file existed are unrecorded, since the four commits in that window changed CI and documentation only.

## Release notes

No library changes. `doc/migration/0.65.0.md` describes every consumer-visible change between 0.64.0 and 0.65.0, for an LLM agent upgrading downstream code as `doc/migration.md` explains. The first change merged after the 0.65.0 tag starts a fresh `pending.md`.
