### PR TITLE
Show the labels when a named tuple is inspected

### DIFF
--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -44,3 +44,19 @@ format. Entries are grouped by module, most-recently-added last within a module.
 
 - `TelBlueprint.fieldsOf` returns `List[(Text, Member)]` in schema order, not `Map[Text,
   Member]`; `TelBlueprint.fields` likewise. (#1974)
+
+## spectacular
+
+- A `scala.NamedTuple` now has a native `Inspectable` instance, `spectacular.Inspectable.namedTuple`,
+  and renders as its labelled elements in the product notation without a type name: `(name =
+  t"Simon", age = 72).inspect` yields `t"(name:t\"Simon\" ╱ age:72)"`. Each element is rendered by
+  the `Inspectable` summoned at that element's static type. Previously no instance matched a named
+  tuple, so it fell through to `Inspectable.derived`'s `toString` case and rendered
+  `t"“(Simon,72)”"`, with the labels lost and the elements' own instances bypassed. Code asserting
+  on the old rendering, or filtering it out of `Inspectable.fallbacks`, must be updated. (#1975)
+- `scala.Tuple` now has an explicit instance, `spectacular.Inspectable.tuple`, in place of the
+  wisteria derivation a tuple previously reached through `Inspectable.derived`. The rendering of a
+  tuple whose element types are statically known is unchanged (`(t"Simon", 72).inspect` still
+  yields `t"(t\"Simon\" ╱ 72)"`, and `EmptyTuple.inspect` still yields `t"()"`). A value whose
+  static type is a bare `Tuple`, whose element types cannot be walked, renders as its `toString` in
+  the `“…”` marker, as before. (#1975)

--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -80,6 +80,7 @@ import wisteria.*
 //                    ⟨ a b ⟩ sequence  ⟦k → v⟧ ledger    ⦋…⦌ array   ⁅…⁆ frozen array
 //                    a ⋰ b ⋰ ..? lazy  ∿∿∿ unforced      ⯁ end
 //     products       Name(field:value ╱ field2:value)    (a ╱ b) tuple
+//                    (name:value ╱ age:value) named tuple
 //     optionality    ｢value｣ present   ○ absent
 //     text           t"…" with escapes                   'x' char
 //     numbers        3 int   3L long   3.1F float   3.toByte byte   BigInt(42)
@@ -88,14 +89,17 @@ import wisteria.*
 //
 object Inspectable extends Inspectable2:
   object Derivation extends Derivable[Inspectable]:
+    // `this.tuple` is wisteria's compile-time predicate, inherited here; the prefix is what
+    // distinguishes it from the enclosing object's `tuple` *instance*, which is otherwise
+    // equally in scope and makes a bare reference ambiguous.
     inline def conjunction[derivation <: Product: ProductReflection]: derivation is Inspectable =
       value =>
         val rendered = fields(value): [field] => field =>
           val text = contextual.text(field)
-          if tuple then text else s"$label:$text"
+          if this.tuple then text else s"$label:$text"
 
-        if rendered.readable.isEmpty && !tuple then typeName
-        else rendered.readable.mkString(if tuple then "(" else s"$typeName(", " ╱ ", ")").tt
+        if rendered.readable.isEmpty && !this.tuple then typeName
+        else rendered.readable.mkString(if this.tuple then "(" else s"$typeName(", " ╱ ", ")").tt
 
     inline def disjunction[derivation: SumReflection]: derivation is Inspectable = value =>
       variant(value):
@@ -157,6 +161,80 @@ object Inspectable extends Inspectable2:
   inline given enumeration: [enumeration <: reflect.Enum: Reflection]
   =>  enumeration is Inspectable =
     Derivation.derived[enumeration]
+
+  // A tuple shows its elements, and a named tuple its labels as well, in the product notation
+  // with the type name omitted — `(a ╱ b)` and `(name:a ╱ age:b)`. Neither can be confused
+  // with a case class, whose rendering always carries its type name. Each element is rendered
+  // by the `Inspectable` summoned at that element's *static* type, so an element with no
+  // native instance degrades on its own, and its marker still shows through `fallbacks`.
+  //
+  // A named tuple is an opaque alias for its value tuple, so here it is neither `<: Tuple` nor
+  // `<: Product`, and the two instances below cannot be ambiguous with one another. That
+  // opacity is also why a named tuple cannot be derived: `Derivation` reaches its fields
+  // through `derivation & Product` and the type symbol's `caseFields`, and an alias has
+  // neither, so without the instance below a named tuple renders as its `toString`.
+  //
+  // Both instances delegate to a method, as `enumeration` does, rather than naming a function
+  // value directly: an `inline` given whose right-hand side is a closure is reported as one
+  // which will be duplicated at every summon site. `inline` itself is not optional, though —
+  // the recursion below can only walk element types which are known at the summon site.
+  inline given tuple: [tuple <: Tuple] => tuple is Inspectable = tupleInspectable[tuple]
+
+  inline given namedTuple: [named <: scala.NamedTuple.AnyNamedTuple] => named is Inspectable =
+    namedTupleInspectable[named]
+
+  private transparent inline def tupleInspectable[tuple <: Tuple]: tuple is Inspectable = value =>
+    elements[scala.EmptyTuple, tuple](value.asInstanceOf[Product], 0, "")
+    . or(unrenderable(value))
+
+  private transparent inline def namedTupleInspectable[named <: scala.NamedTuple.AnyNamedTuple]
+  :   named is Inspectable =
+
+    value =>
+      val product = value.asInstanceOf[Product]
+
+      elements[scala.NamedTuple.Names[named], scala.NamedTuple.DropNames[named]](product, 0, "")
+      . or(unrenderable(value))
+
+  // Renders the elements of the value tuple `tuple`, labelling the nth with the nth member of
+  // `names` where there is one, joining them with the product separator, and enclosing the
+  // result in parentheses. `Unset` when the element types are not statically known — a value
+  // typed as a bare `Tuple`, or a named tuple with abstract names — which the two instances
+  // above turn into the `“…”` marker, so an unwalkable tuple is reported by `fallbacks`
+  // instead of failing to compile.
+  //
+  // The terminator must be spelt `scala.EmptyTuple.type`. This file compiles under
+  // `-Yimports:java.lang,proscenium`, where a bare `EmptyTuple` names proscenium's export
+  // forwarder — a nullary *method*, whose singleton type is a `TermRef` to the method and not
+  // to the module — and the match would then never see the end of the tuple.
+  //
+  // Elements are read positionally with `productElement`, as wisteria's field macro does,
+  // rather than by destructuring `*:`: that costs a cast, but works at every arity, including
+  // the `TupleXXL` representation used beyond twenty-two elements.
+  private inline def elements[names <: Tuple, tuple <: Tuple]
+    ( product: Product, index: Int, done: String )
+  :   Optional[Text] =
+
+    inline compiletime.erasedValue[tuple] match
+      case _: (head *: tail) =>
+        val inspectable = compiletime.summonInline[head is Inspectable]
+        val text = inspectable.text(product.productElement(index).asInstanceOf[head]).s
+        val separator = if index == 0 then "" else " ╱ "
+
+        inline compiletime.erasedValue[names] match
+          case _: (name *: names2) =>
+            val label = compiletime.constValue[name].toString
+            elements[names2, tail](product, index + 1, done+separator+label+":"+text)
+
+          case _ =>
+            elements[scala.EmptyTuple, tail](product, index + 1, done+separator+text)
+
+      case _: scala.EmptyTuple.type => ("("+done+")").tt
+      case _                        => Unset
+
+  // The same marker `derived` uses for a value with no instance at all, so a tuple which
+  // cannot be walked is reported by `fallbacks` exactly as any other uncovered type is.
+  private def unrenderable(value: Any): Text = ("“"+value+"”").tt
 
   // The sized numeric types all erase to a primitive, so a rendering which showed only the
   // number would be indistinguishable from an `Int` or a `Long` — and, for the unsigned types,

--- a/lib/spectacular/src/test/spectacular_test.scala
+++ b/lib/spectacular/src/test/spectacular_test.scala
@@ -192,6 +192,43 @@ object Tests extends Suite(m"Spectacular Tests"):
         (t"Simon", 72).inspect
       . assert(_ == t"(t\"Simon\" ╱ 72)")
 
+      test(m"serialize named tuple"):
+        (name = t"Simon", age = 72).inspect
+      . assert(_ == t"(name:t\"Simon\" ╱ age:72)")
+
+      test(m"serialize empty tuple"):
+        EmptyTuple.inspect
+      . assert(_ == t"()")
+
+      test(m"serialize one-element tuple"):
+        Tuple1(72).inspect
+      . assert(_ == t"(72)")
+
+      test(m"serialize named tuple nested in a tuple"):
+        (t"Simon", (width = 3, height = 4)).inspect
+      . assert(_ == t"(t\"Simon\" ╱ (width:3 ╱ height:4))")
+
+      test(m"serialize tuple nested in a named tuple"):
+        (name = t"Simon", size = (3, 4)).inspect
+      . assert(_ == t"(name:t\"Simon\" ╱ size:(3 ╱ 4))")
+
+      // Only the *element* carries the marker: the surrounding named tuple still renders, and
+      // every other element still reaches its own instance.
+      test(m"a named tuple's underivable element falls back on its own"):
+        (item = Underived(7), count = 3).inspect
+      . assert(_ == t"(item:“Underived(7)” ╱ count:3)")
+
+      test(m"a fully-covered named tuple inspects natively"):
+        Inspectable.fallbacks((name = t"Simon", age = 72).inspect)
+      . assert(_ == Nil)
+
+      // The element types of a value typed as a bare `Tuple` cannot be walked, so the whole
+      // value falls back to its `toString`, marked as such.
+      test(m"a tuple of unknown shape falls back to toString"):
+        val opaqueTuple: Tuple = (t"Simon", 72)
+        Inspectable.fallbacks(opaqueTuple.inspect)
+      . assert(_ == List(t"“(Simon,72)”"))
+
       test(m"serialize list of strings"):
         (List(t"one", t"two", t"three"): List[Text]).inspect
       . assert(_ == t"""[t"one", t"two", t"three"]""")


### PR DESCRIPTION
Inspecting a named tuple showed neither its labels nor its elements' own renderings: because a
named tuple is an opaque alias for its value tuple, no `Inspectable` instance matched one, and it
fell through to the `toString` fallback as `“(Simon,72)”`. Named tuples and plain tuples now both
have explicit instances which walk their element types at the point of use and render each element
through the `Inspectable` for that element's static type. A plain tuple's rendering is unchanged.

## Named tuples inspect structurally

A named tuple now renders its labels alongside its elements, in the same `field:value` notation as
a case class but without a type name:

```scala
(name = t"Simon", age = 72).inspect  // (name:t"Simon" ╱ age:72)
```

Previously this produced `“(Simon,72)”` — the `“…”` marker meaning no instance was found at all,
with the labels lost and each element rendered by `toString` rather than by its own `Inspectable`.
The change matters most for the named tuples that polyvinyl specifications now produce.

## Elements are rendered by their own instances

Both `Inspectable.tuple` and `Inspectable.namedTuple` summon an `Inspectable` per element, at that
element's static type, so an element with no native rendering degrades on its own and the rest of
the tuple is unaffected:

```scala
(item = Underived(7), count = 3).inspect  // (item:“Underived(7)” ╱ count:3)
```

The marker on that one element is still reported by `Inspectable.fallbacks`, so a coverage
regression in an element type remains visible.

## Tuples of unknown shape

A value whose static type is a bare `Tuple` has no element types to walk, and renders as its
`toString` inside the `“…”` marker rather than failing to compile — as it did before.
`EmptyTuple.inspect` is still `()`, and `(t"Simon", 72).inspect` is still `(t"Simon" ╱ 72)`.
