### PR TITLE
Extend the track background under a bar's boundary cell

### DIFF
--- a/lib/ultimatum/src/gauges/ultimatum.Bar.scala
+++ b/lib/ultimatum/src/gauges/ultimatum.Bar.scala
@@ -229,15 +229,23 @@ enum Bar:
 
         . reduceLeft: (left, right) => e"$left$right"
 
-    val edge = boundary.lay(e""): glyph => gauging.tint(palette.leadingEdge)(Teletype(glyph))
+    // A track drawn with spaces is only visible as a background; one with its own glyph is drawn
+    // in the track colour instead, so both kinds of design read correctly on any terminal.
+    val washedTrack = glyphs.empty == t" "
+
+    // The boundary cell is only partly covered by its glyph, and whatever the glyph leaves
+    // uncovered is track, so it needs the same background as the cells to its right. Without
+    // this, that uncovered fraction falls through to the terminal's default background and shows
+    // as a sliver of the wrong colour along the leading edge. Where the track is drawn as a glyph
+    // there is no background to match, and the cell is left alone.
+    val edge = boundary.lay(e""): glyph =>
+      val tinted = gauging.tint(palette.leadingEdge)(Teletype(glyph))
+      if washedTrack then gauging.wash(palette.track)(tinted) else tinted
 
     val blank = Teletype(glyphs.empty*(inner - used).max(0))
 
-    // A track drawn with spaces is only visible as a background; one with its own glyph is drawn
-    // in the track colour instead, so both kinds of design read correctly on any terminal.
     val rest =
-      if glyphs.empty == t" " then gauging.wash(palette.track)(blank)
-      else gauging.tint(palette.track)(blank)
+      if washedTrack then gauging.wash(palette.track)(blank) else gauging.tint(palette.track)(blank)
 
     e"$filled$edge$rest"
 

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -1138,6 +1138,18 @@ object Tests extends Suite(m"Ultimatum Tests"):
         bar(bars.smoothBar)(Fraction(0.05), 10)
       . assert(_ == t"▌         ")
 
+      // The boundary cell's glyph covers only part of its cell, and the rest of it is track, so
+      // it must carry the track background exactly as the empty cells to its right do. One
+      // background is therefore set for the whole run — before the boundary glyph — and never
+      // changed again; anything else shows as a sliver of the wrong colour at the leading edge.
+      test(m"the boundary cell shares the track's background"):
+        val rendered =
+          bars.smoothBar.rows(Fraction(0.05), Tick.zero, 10).stdlib.head
+          . render(termcapDefinitions.xtermTrueColorTermcap)
+
+        (rendered.cut(t"48;2;").size - 1, rendered.cut(t"▌").stdlib.head.contains(t"48;2;"))
+      . assert(_ == (1, true))
+
       test(m"a full bar leaves no empty cells"):
         bar(bars.smoothBar)(Fraction(1.0), 8)
       . assert(_ == t"████████")


### PR DESCRIPTION
Ultimatum's progress bars draw their track as a background colour when the design's empty
glyph is a space, but the boundary cell — the partially-filled character that shows progress
in eighths — was only ever given a foreground colour, so the part of that cell its glyph did
not cover fell through to the terminal's default background and showed as a thin sliver of the
wrong colour at the leading edge. The boundary cell now carries the track background too, so
the unfilled remainder of the cell matches the empty cells beside it.

Progress bars whose track is drawn as a background colour — `smoothBar` (the default design
for `Fraction`), `shadedBar`, `risingBar`, `gradientBar`, `equalsBar` and `arrowheadBar` — now
extend that background under the boundary cell.

The boundary cell is the partially-filled character at the leading edge; for the eighth-block
designs it is one of `▏▎▍▌▋▊▉`, showing how much of that cell is filled. Its glyph covers only
part of the cell, and what it leaves uncovered is track — but it was previously tinted in the
leading-edge colour without ever being washed, so the uncovered fraction fell through to the
terminal's default background and appeared as a sliver of the wrong colour between the fill
and the track.

Designs whose track is a glyph of its own (`blockBar`, `capsuleBar`, `asciiBar`, `railBar`, …)
have no background to match and are unchanged, as are the filled cells and the end caps.

No action is required: this is an appearance fix, with no change to any API.
