### PR TITLE
Write an empty inline atom as no atom at all

### DIFF
--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -44,6 +44,14 @@ format. Entries are grouped by module, most-recently-added last within a module.
 
 - `TelBlueprint.fieldsOf` returns `List[(Text, Member)]` in schema order, not `Map[Text,
   Member]`; `TelBlueprint.fields` likewise. (#1974)
+- `stratiform.Tel` serialization (`Tel.Document is Showable`, `Tel is Showable`): an empty
+  inline atom (a `Tel.Atom.Inline` whose text is empty, as `Tel.scalar(t"")` and the `Text`
+  encoder produce for an empty text) is now written as no atom at all, so a keyword-bearing
+  compound with an empty scalar serializes as the bare keyword (`text`) where it previously
+  wrote the keyword followed by the atom's preceding spaces (`text `). Reading is unchanged:
+  the bare keyword decodes as the empty string, where the previous output was refused as a
+  trailing space. Code comparing serialized documents textually must expect the bare keyword.
+  (#1977)
 
 ## spectacular
 

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -2710,10 +2710,14 @@ object Tel extends Tel2:
           case atom @ Tel.Atom.Source(_)     => trailingAtom = atom
           case atom @ Tel.Atom.Literal(_, _) => trailingAtom = atom
 
+          // An empty inline atom serializes as no atom at all (a keyword-bearing compound with
+          // no atom reads back as the empty string), so its spacing is not written either: a
+          // trailing space would make the line unparseable.
           case Tel.Atom.Inline(text, precedingSpaces) =>
-            var k = 0
-            while k < precedingSpaces do { line.append(' '); k += 1 }
-            line.append(text.s)
+            if !text.s.isEmpty then
+              var k = 0
+              while k < precedingSpaces do { line.append(' '); k += 1 }
+              line.append(text.s)
 
         compound.remark.let: remark =>
           // Two spaces before the sigil ensure correct re-parsing regardless of whether the


### PR DESCRIPTION
An empty text was serialized with the spaces preceding its empty atom, which stratiform's own parser refuses as a trailing space, so a TEL document holding an empty token, cell or phrase could never be read back. Found in Flame, where a compiler message with a blank line inside it made the client drop a whole reply.

A keyword-bearing compound with no atom already decodes as the empty string, so an empty atom now serializes as no atom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)