### PR TITLE
Recognise infix aliases reached through re-exports, and prefer them at render time

### DIFF
--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -68,3 +68,28 @@ format. Entries are grouped by module, most-recently-added last within a module.
   yields `t"(t\"Simon\" ╱ 72)"`, and `EmptyTuple.inspect` still yields `t"()"`). A value whose
   static type is a bare `Tuple`, whose element types cannot be walked, renders as its `toString` in
   the `“…”` marker, as before. (#1975)
+
+## stenography
+
+- `stenography.Imports` gained a third parameter, `aliases: scala.collection.immutable.Map[String,
+  Text] = Map()`, mapping a refined type member's name to the infix type alias which refines
+  it. `Imports.resolve(designators, direct)` now fills it from every wildcard scope in
+  `designators`; `Imports(designators, direct)` written directly leaves it empty. New:
+  `Imports.infixAliases(scope: Designator)(using Context): Map[String, Text]`, the harvest for
+  one scope. (#1979)
+- `stenography.Syntax#text(using Imports)` now writes `Syntax.Structural(base, members, defs)`
+  as nested `Infix` applications when `defs` is empty and every member of `members` is a plain
+  alias (not a `Syntax.Declaration`) whose name is in `imports.aliases`: `Foo { type Form =
+  Bar }` renders as `Foo in Bar` under an `Imports` resolved against a scope declaring `infix
+  type in [refined, form] = refined { type Form = form }`. Previously this preference applied
+  only to a `Syntax` built inside a macro (`Syntax.name`), and `text` always wrote the
+  refinement. (#1979)
+- `stenography.Syntax#text(using Imports)` now writes `Syntax.Application(Simple(Type(parent,
+  name)), List(a, b), infix = true)` as `a name b` when `imports.hasDirect(Type(parent, name))`,
+  in addition to when `imports.has(parent)`. Previously such an alias reached only through an
+  `export` rendered as `parent.name[a, b]`. (#1979)
+- `stenography.Imports.exports(scope)` (and so `resolve`) now includes the target of a
+  polymorphic exported type alias whose body applies a `TypeRef` to exactly the alias's own
+  parameters in order (an `export prepositional.on` forwarder), so that target renders by its
+  leaf name under a wildcard import of `scope`. Previously only monomorphic aliases counted.
+  (#1979)

--- a/doc/migration/pending.md
+++ b/doc/migration/pending.md
@@ -44,6 +44,14 @@ format. Entries are grouped by module, most-recently-added last within a module.
 
 - `TelBlueprint.fieldsOf` returns `List[(Text, Member)]` in schema order, not `Map[Text,
   Member]`; `TelBlueprint.fields` likewise. (#1974)
+- `stratiform.Tel` serialization (`Tel.Document is Showable`, `Tel is Showable`): an empty
+  inline atom (a `Tel.Atom.Inline` whose text is empty, as `Tel.scalar(t"")` and the `Text`
+  encoder produce for an empty text) is now written as no atom at all, so a keyword-bearing
+  compound with an empty scalar serializes as the bare keyword (`text`) where it previously
+  wrote the keyword followed by the atom's preceding spaces (`text `). Reading is unchanged:
+  the bare keyword decodes as the empty string, where the previous output was refused as a
+  trailing space. Code comparing serialized documents textually must expect the bare keyword.
+  (#1977)
 
 ## spectacular
 

--- a/lib/stenography/src/core/stenography.Imports.scala
+++ b/lib/stenography/src/core/stenography.Imports.scala
@@ -70,12 +70,46 @@ object Imports:
   // `Imports(designators, direct)`, with `direct` extended by the `exports` of every one of
   // `designators`, so that a type reached through a wildcard-imported prelude renders as the
   // user would write it.
+  // The infix type aliases declared in `scope` which each refine a single type member, by that
+  // member's name: what lets `Foo { type Form = Bar }` be written `Foo in Bar` where `scope`
+  // is wildcard-imported. Where two aliases claim a member, the one first by name wins, as in
+  // a macro's harvest.
+  def infixAliases(scope: Designator)(using context: dotty.tools.dotc.core.Contexts.Context)
+  :   sci.Map[String, Text] =
+
+    import dotty.tools.dotc.core.Denotations
+    import dotty.tools.dotc.core.Names.termName
+
+    def path(designator: Designator): String = designator.parent.lay(designator.name.s): parent =>
+      s"${path(parent)}.${designator.name}"
+
+    try
+      val denotation = Denotations.staticRef(termName(path(scope)), generateStubs = false)
+      if !denotation.exists then sci.Map() else
+        given quotes: scala.quoted.Quotes = scala.quoted.runtime.impl.QuotesImpl()
+        given Bindings = Bindings()
+        stenography.internal.scopeInfo(denotation.symbol)(1).groupBy(_(0)).view.mapValues: candidates =>
+          candidates.map(_(1).s).min.tt
+        . toMap
+    catch case NonFatal(_) => sci.Map()
+
   def resolve(designators: sci.Set[Designator], direct: sci.Set[Designator])
        (using dotty.tools.dotc.core.Contexts.Context)
   :   Imports =
 
-    Imports(designators, direct ++ designators.flatMap(exports))
+    val aliases: sci.Map[String, Text] =
+      designators.toList.flatMap(infixAliases(_).toList).groupBy(_(0)).view.mapValues: candidates =>
+        candidates.map(_(1).s).min.tt
+      . toMap
 
-case class Imports(designators: sci.Set[Designator], direct: sci.Set[Designator]):
+    Imports(designators, direct ++ designators.flatMap(exports), aliases)
+
+// `aliases` maps a refined member's name to the infix type alias in scope which refines it,
+// for `Syntax.text` to prefer; empty unless resolved against a compiler context.
+case class Imports
+  ( designators: sci.Set[Designator],
+    direct:      sci.Set[Designator],
+    aliases:     sci.Map[String, Text] = sci.Map() ):
+
   def has(designator: Designator): Boolean = designators.contains(designator)
   def hasDirect(designator: Designator): Boolean = direct.contains(designator)

--- a/lib/stenography/src/core/stenography.Syntax.scala
+++ b/lib/stenography/src/core/stenography.Syntax.scala
@@ -749,9 +749,12 @@ enum Syntax:
     case Declaration(method, syntaxes, result) =>
       s"${joined(syntaxes.map(_.text))}${if method then ": " else ""}${result.text}".tt
 
+    // An infix alias is written infix when it can be written unqualified: its parent is
+    // imported, or it is reachable by its leaf through an export.
     case Application(left, elements, infix) =>
       left match
-        case Simple(Designator.Type(parent, name)) if infix && imports.has(parent) =>
+        case Simple(Designator.Type(parent, name))
+        if infix && (imports.has(parent) || imports.hasDirect(Designator.Type(parent, name))) =>
           elements match
             case List(first, second) => Infix(first, name, second).text
             case _ => left.text+joined(elements.map(_.text), ", ", "[", "]").tt
@@ -759,10 +762,27 @@ enum Syntax:
         case _ =>
           left.text+joined(elements.map(_.text), ", ", "[", "]").tt
 
+    // A refinement of type members which are each aliased by an infix type alias in scope
+    // (`imports.aliases`, harvested by `Imports.resolve`) is written with those aliases:
+    // `Foo { type Form = Bar }` as `Foo in Bar`. A bounded member is not what an alias
+    // expands to, so any such member keeps the whole refinement in its written form. This is
+    // the render-time counterpart of the alias preference applied when a `Syntax` is built
+    // inside a macro, for a `Syntax` built elsewhere and rendered against a scope.
     case Structural(base, members, defs) =>
-      val members2: List[Text] = members.remap: (name, syntax) => s"type $name = ${syntax.text}".tt
-      val defs2: List[Text] = defs.remap: (name, syntax) => s"def $name${syntax.text}".tt
-      s"${base.text} { ${joined(members2 + defs2, "; ")} }".tt
+      val entries = members.stdlib.toList
+
+      val aliased: Boolean =
+        defs.stdlib.isEmpty && entries.nonEmpty && entries.forall: (name, syntax) =>
+          imports.aliases.contains(name.s) && (syntax match
+            case Declaration(_, _, _) => false
+            case _                    => true)
+
+      if aliased then
+        entries.foldLeft(base) { case (left, (name, syntax)) => Infix(left, imports.aliases(name.s), syntax) }.text
+      else
+        val members2: List[Text] = members.remap: (name, syntax) => s"type $name = ${syntax.text}".tt
+        val defs2: List[Text] = defs.remap: (name, syntax) => s"def $name${syntax.text}".tt
+        s"${base.text} { ${joined(members2 + defs2, "; ")} }".tt
 
     case Infix(left: Syntax, middle, right: Syntax) =>
       val left2 = if left.precedence < precedence then Sequence('(', List(left)) else left

--- a/lib/stenography/src/core/stenography.internal.scala
+++ b/lib/stenography/src/core/stenography.internal.scala
@@ -160,13 +160,29 @@ object internal:
     import dotty.tools.dotc.core.Types
     import quotes.reflect.TypeRepr
 
+    // A re-export's target, when the forwarder is a plain renaming of it: a simple alias of a
+    // `TypeRef`, or a polymorphic one whose body applies a `TypeRef` to exactly its own
+    // parameters in order (an exported `infix type on[a, b]`, say). Other polymorphic aliases
+    // (tuple types, `Some`, `<:<`, …) reshape their parameters, so their target is not
+    // reachable by the forwarder's leaf, and they are skipped.
+    def target(tpe: Types.Type): Option[Types.TypeRef] = tpe match
+      case ref: Types.TypeRef => Some(ref)
+
+      case lambda: Types.HKTypeLambda => lambda.resType match
+        case Types.AppliedType(ref: Types.TypeRef, arguments)
+        if arguments.length == lambda.paramNames.length
+           && arguments.zipWithIndex.forall:
+                case (param: Types.TypeParamRef, index) => param.binder == lambda && param.paramNum == index
+                case _                                  => false
+        => Some(ref)
+
+        case _ => None
+
+      case _ => None
+
     decl.info match
-      // Only simple (non-polymorphic) alias targets can shorten to a name. Polymorphic
-      // re-exports (tuple types, `Some`, `<:<`, …) carry `TypeParamRef`s that `Syntax`
-      // cannot render — matching only `TypeRef` skips them instead of crashing. This path
-      // is now exercised by proscenium's prelude re-exports of the primitives.
-      case alias: Types.TypeAlias => alias.alias match
-        case ref: Types.TypeRef =>
+      case alias: Types.TypeAlias => target(alias.alias) match
+        case Some(ref) =>
           Syntax(ref.asInstanceOf[TypeRepr]) match
             // Add both forms so the same import path can shorten references
             // to either the type itself or its companion (e.g. `Textual` and
@@ -174,7 +190,7 @@ object internal:
             case Syntax.Simple(designator) => List(designator, designator.companionObject)
             case _                         => Nil
 
-        case _ =>
+        case None =>
           Nil
 
       case _ =>

--- a/lib/stenography/src/test/stenography_probe_test.scala
+++ b/lib/stenography/src/test/stenography_probe_test.scala
@@ -40,3 +40,10 @@ import soundness.*
 object Probe:
   def exportedName: Text = Syntax.name[stenography.Syntax]
   def companionName: Text = Syntax.name[stenography.Syntax.type]
+
+  // `on` reaches this scope only through `soundness`'s re-export of `prepositional.on`, so
+  // its infix alias must be recognised through the forwarder, both when the alias is written
+  // (and kept by the compiler) and when the refinement it expands to is met.
+  trait Planar { type Plane }
+  def infixExportName: Text = Syntax.name[Planar on Int]
+  def refinedExportName: Text = Syntax.name[Planar { type Plane = Int }]

--- a/lib/stenography/src/test/stenography_test.scala
+++ b/lib/stenography/src/test/stenography_test.scala
@@ -173,6 +173,20 @@ object Tests extends Suite(m"Stenography Tests"):
       stenographyProbe.Probe.companionName
     . assert(_ == t"Syntax.type")
 
+    test(m"Write an infix alias reached through a re-export infix, by its leaf"):
+      stenographyProbe.Probe.infixExportName
+    . assert(_ == t"Probe.Planar on Int")
+
+    test(m"Prefer an infix alias reached through a re-export over the refinement"):
+      stenographyProbe.Probe.refinedExportName
+    . assert(_ == t"Probe.Planar on Int")
+
+    test(m"Prefer an infix alias at render time, from the imports' aliases"):
+      val refined: Syntax =
+        Syntax.Structural(Syntax.Simple(Designator("Addable")), Ledger((t"Operand", Syntax.Simple(Designator("Int")))), Ledger())
+      refined.text(using Imports(scala.collection.immutable.Set(), scala.collection.immutable.Set(), scala.collection.immutable.Map("Operand" -> t"by")))
+    . assert(_ == t"Addable by Int")
+
     test(m"Show typeclass type"):
       Syntax.name[Addable by Int to Double]
     . assert(_ == t"Addable by Int to Double")

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -2710,10 +2710,14 @@ object Tel extends Tel2:
           case atom @ Tel.Atom.Source(_)     => trailingAtom = atom
           case atom @ Tel.Atom.Literal(_, _) => trailingAtom = atom
 
+          // An empty inline atom serializes as no atom at all (a keyword-bearing compound with
+          // no atom reads back as the empty string), so its spacing is not written either: a
+          // trailing space would make the line unparseable.
           case Tel.Atom.Inline(text, precedingSpaces) =>
-            var k = 0
-            while k < precedingSpaces do { line.append(' '); k += 1 }
-            line.append(text.s)
+            if !text.s.isEmpty then
+              var k = 0
+              while k < precedingSpaces do { line.append(' '); k += 1 }
+              line.append(text.s)
 
         compound.remark.let: remark =>
           // Two spaces before the sigil ensure correct re-parsing regardless of whether the

--- a/lib/ultimatum/src/gauges/soundness_ultimatum_gauges.scala
+++ b/lib/ultimatum/src/gauges/soundness_ultimatum_gauges.scala
@@ -47,7 +47,7 @@ package spinners:
     ultimatum.spinners
     . { aestheticSpinner, arcSpinner, arrowDoubleSpinner, arrowSpinner, balloonSpinner,
         binarySpinner, bounceSpinner, bouncingBallSpinner, bouncingBarSpinner, boxSpinner,
-        brailleDotsSpinner, brailleGrowSpinner, brailleSnakeSpinner, brailleWaveSpinner,
+        brailleDotsSpinner, brailleGrowSpinner, brailleRingSpinner, brailleSnakeSpinner, brailleWaveSpinner,
         circleHalfSpinner, circlePulseSpinner, circleQuadrantSpinner, clockSpinner,
         crossStarSpinner, dotsScrollSpinner, dqpbSpinner, earthSpinner, growingBarSpinner,
         growingBlockSpinner, hamburgerSpinner, hourglassSpinner, hourglassThinSpinner, layerSpinner,

--- a/lib/ultimatum/src/gauges/ultimatum_gauges_spinners.scala
+++ b/lib/ultimatum/src/gauges/ultimatum_gauges_spinners.scala
@@ -79,6 +79,11 @@ package spinners:
   given brailleGrowSpinner: Gauging => Fraction is Gaugeable =
     Spinner.each(t"⠋⠙⠚⠞⠖⠦⠴⠲⠳⠓", 80, Unicode, line).gaugeable
 
+  // A ring of six dots with a two-dot gap chasing round it: eight frames, and a fuller cell than
+  // the dots.
+  given brailleRingSpinner: Gauging => Fraction is Gaugeable =
+    Spinner.each(t"⣸⢹⠻⠟⡏⣇⣦⣴", 80, Unicode, line).gaugeable
+
   // Circles, arcs and quadrants.
   given arcSpinner: Gauging => Fraction is Gaugeable = arc.gaugeable
   given circleQuadrantSpinner: Gauging => Fraction is Gaugeable = quadrant.gaugeable


### PR DESCRIPTION
Under `import soundness.*`, `prepositional.on[Path, Linux]` rendered fully qualified and prefix rather than as `Path on Linux`. Three gaps, all fixed here:

- Harvesting a scope's re-exports skipped polymorphic aliases, so `soundness`'s forwarder for `on` never made `prepositional.on` reachable by its leaf. A forwarder that applies its target to exactly its own parameters is now recognised.
- An infix alias was written infix only when its parent package was imported; now also when it is reachable by leaf through an export.
- The infix-alias preference for refinements applied only inside macros. `Imports` now carries the aliases harvested from its wildcard scopes, and `Syntax.text` applies them, so types rendered by delicious, harlequin and Flame's scope inspector benefit too.

Three tests added: the re-exported alias written and kept, the refinement it expands to, and the render-time preference from an `Imports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)