### PR TITLE
Add tasseomancy, an SVG charting module, and the savagery figures it draws with

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -905,7 +905,7 @@ object soundness extends Toolchain:
 
   object web extends Bundle(archimedes.core, cacophony.core, cataclysm.core, coaxial.core, coaxial.jvm, cosmopolite.core, gesticulate.core,
     honeycomb.core, urticose.core, urticose.url, urticose.ansi, hallucination.core, phoenicia.core,
-    punctuation.core, savagery.core, scintillate.server, scintillate.servlet,
+    punctuation.core, savagery.core, tasseomancy.core, scintillate.server, scintillate.servlet,
     telekinesis.jvm, plutocrat.core, eucalyptus.gcp, punctuation.html, perihelion.core,
     legerdemain.core, legerdemain.query, telekinesis.forms, jacinta.optics, caduceus.core,
     caduceus.resend,
@@ -3102,6 +3102,19 @@ object tarantula extends Library:
     override def scalacOptions = Task:
       settings.sep(super.scalacOptions())
 
+object tasseomancy extends Library:
+  // SVG charts in four layers — data shape, chart kind, fit and style — drawn through savagery;
+  // aviation and quantitative supply the time and unit axes, phoenicia measures text.
+  object core extends Component(savagery.core, hypotenuse.core, gossamer.core, quantitative.core,
+      quantitative.units, aviation.core, spectacular.core, phoenicia.core, distillate.core,
+      murmuration.core):
+    override def scalaNative = false // draws through savagery (cataclysm classpath resources, JVM/JS-only)
+    override def scalacOptions = Task:
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,proscenium"))
+  object test extends Tests(core, quantitative.units):
+    override def scalacOptions = Task:
+      settings.sep(super.scalacOptions())
+
 object telekinesis extends Library:
   object core extends Component(gesticulate.core, monotonous.core, legerdemain.query,
       turbulence.core, urticose.url):
@@ -3520,7 +3533,8 @@ val allLibraries: Seq[Library] = Seq(
   probably, profanity, prophesy,
   proscenium, punctuation, quantitative, querencia, reliquary, revolution, rudiments, savagery,
   scintillate, sedentary, serpentine, sibylline, spectacular, stenography, stratiform, superlunary,
-  surveillance, symbolism, synesthesia, tarantula, telekinesis, tessellate, turbulence, typonym,
+  surveillance, symbolism, synesthesia, tarantula, tasseomancy, telekinesis, tessellate, turbulence,
+  typonym,
   ultimatum, ulysses, umbrageous, urticose, vacuous, vexillology, vicarious, virility,
   vivisection,
   wisteria, xenophile, xylophone,

--- a/doc/compatibility.tsv
+++ b/doc/compatibility.tsv
@@ -138,6 +138,7 @@ surveillance	yes	no	no	no	file watching (`java.nio.file` WatchService)
 symbolism	yes	yes	yes	js	
 synesthesia	yes	no	no	no	transitively JVM-only (networking/crypto/fs/process)
 tarantula	yes	no	no	no	browser automation; depends on JVM-only `guillotine`/`telekinesis.jvm`
+tasseomancy	yes	yes	no	js	
 telekinesis	yes	core	no	wasi	backends: core+jvm+wasi; JVM-only submodule(s): jvm
 tessellate	yes	yes	yes	js	
 turbulence	yes	yes	yes	wasi	backends: core+wasi

--- a/doc/migration/0.65.0.md
+++ b/doc/migration/0.65.0.md
@@ -572,3 +572,17 @@ Entries are grouped by module, most-recently-added last within a module.
   given (all three re-exported from `soundness`). Under it a task's `Thread.currentThread` is a
   carrier reused across tasks, so thread-locals and thread names are not per-task; cancellation,
   probates, `Promise` waiting and every other observable behaviour match `virtualThreading`. (#1969)
+## savagery
+
+- `Rectangle` and `Ellipse` gained trailing `style: Optional[Css.Style] = Unset` and
+  `id: Optional[Svg.Id] = Unset` fields after `transforms`. Construction by name or by the first
+  three (or four) positional arguments is unchanged; extractor patterns must add two wildcards:
+  `case Rectangle(position, width, height, transforms, _, _)` and
+  `case Ellipse(center, xRadius, yRadius, angle, transforms, _, _)`. `Circle.apply` accepts the
+  same three optional arguments.
+- Parsing an SVG no longer flattens `<g>` elements into their children: each becomes a `Group`
+  figure. `<polyline>`, `<polygon>` and `<text>` elements, previously skipped, now parse as
+  `Polyline` (with `closed = true` for a polygon) and `Lettering`; `id`, `transform` and `style`
+  attributes are read on every figure rather than only on `<path>`.
+- New figures `Group`, `Polyline` and `Lettering` (with `Lettering.Anchor` and
+  `Lettering.Baseline`), all exported from `soundness`.

--- a/doc/modules/charts.md
+++ b/doc/modules/charts.md
@@ -49,7 +49,8 @@ which a chart draws as an error bar or a band:
 val timings = Series(t"sort")((1000, Estimate(2.1, 1.9, 2.4)), (10000, Estimate(24.0, 22.5, 26.1)))
 ```
 
-A series' name, like a sample set's or a `Category`, is any showable value — text, an enum
+A value may also carry a note — `Annotated(3.0, t"Paris")` — which a scatter plot or a line
+chart sets beside the point. A series' name, like a sample set's or a `Category`, is any showable value — text, an enum
 case, a number — rendered once when it is made. A series is immutable, and `add` appends a point
 in constant amortized time, which is what a chart
 fed one measurement at a time needs. Several series are any collection of them — a `List`, a
@@ -109,17 +110,50 @@ five for numbers, and at clock steps — seconds, half-minutes, hours — for du
 
 ### Style
 
-A `Chart.Style` holds everything about appearance that is not data: the size, stroke width and
-marker radius, the typeface, how densely axes are graduated, where the legend goes and the axis
-titles. Colors are a `ChartPalette`, named by role — the series ramp, the axes, the grid, the
-lettering — so that one chart renders under any palette. Both have no-import defaults; a palette
-is chosen by importing one, and a style by giving one:
+Everything about a chart's appearance that is not data is a *style*: a trait with a method for
+each component the chart draws — a tick, a tick label, a bar, a wedge, a legend swatch — taking
+the geometry the chart computed and returning the figures to draw. `Chart.Style` holds what every
+kind shares (the canvas, the typeface, the legend and how text is set), `Chart.Cartesian` adds
+axes, gradations, grid, titles, markers and error bars, and each kind adds its own: `Bars.Style`
+has `bar`, `Lines.Style` has `line` and `band`, `Pie.Style` has `wedge`. A chart asks for the
+style of its kind, so a bar chart compiles against `Bars.Style`.
+
+`Chart.Standard` implements all of them. It is a case class, so its parameters are named
+arguments, and any component is an override:
+
+```scala
+given Chart.Standard = new Chart.Standard(width = 800.0, ordinateTitle = t"units sold"):
+  override def bar(corner: Point, width: Double, height: Double, color: Color in Srgb, series: Int)
+  :   List[Figure] =
+    List(Rectangle(corner, width.toFloat, height.toFloat, style = Css.Style(fill = color.to[Srgb])))
+
+  override def arrowhead(tip: Point, axis: Chart.Axis, color: Color in Srgb): List[Figure] =
+    List(Polyline(List(tip, Point(tip.x - 6, tip.y - 3), Point(tip.x - 6, tip.y + 3)), closed = true))
+```
+
+The hooks cover the details a chart is usually judged on: where a label sits relative to its
+tick and whether it is rotated (`tickLabel`, with `labelRoom` telling the layout how much space
+that takes), the stroke of each axis (`axisLine`), a break mark where a linear axis starts away
+from zero (`axisBreak`), arrowheads (`arrowhead`), the thickness of series lines (`line`), the
+typeface (`font`, or `lettering` for every run of text), and the labelling of points that carry
+a note (`pointLabel`, for an `Annotated` value).
+
+Colors are a `ChartPalette`, named by role — the series ramp, the axes, the grid, the
+lettering — so that one style renders under any palette; a palette is chosen by importing one:
 
 ```scala
 import palettes.solarizedDarkChartPalette
-
-given Chart.Style = Chart.Style(width = 800, height = 300, ordinateTitle = t"units sold")
 ```
+
+Text is measured to lay out the axis labels and legend. Without a font in scope, an average width
+per character is assumed; with a [font](fonts.md) loaded, its own glyph advances are used, and
+the margins fit their labels exactly:
+
+```scala
+import fontMetrics.averageFontMetric
+```
+
+The face measured should be the one the page will render, since the SVG does not embed it.
 
 An axis over a [quantity](quantities.md) is titled by what it measures and its unit, taken from
 the type: a series of `Quantity[Metres[1]]` values has the ordinate title `distance / m`, and one

--- a/doc/modules/charts.md
+++ b/doc/modules/charts.md
@@ -1,0 +1,172 @@
+## Charts
+
+### About
+
+A chart turns a run of numbers into a picture: bars for categories, a line for a trend, wedges for
+the parts of a whole, a histogram for a distribution. Soundness draws charts as
+[SVG](svg.md) from typed data, in four separable layers — the shape of the data, the kind of
+chart, the fit of one to the other, and the style — so that each can be chosen without disturbing
+the rest, and a chart can be revised as new data arrives.
+
+### On charting
+
+Charting libraries usually take a bag of numbers and a bag of options, and discover at runtime
+that the two do not go together: a pie chart of three series, a line through category labels, a
+logarithmic axis over a range that includes zero. The decisions that ought to be separate — what
+the data is, how it is drawn, how its axes are chosen, what it looks like — arrive tangled in one
+call.
+
+Charts whose kind is chosen by the shape of the data, and whose axes and style are chosen apart from it, are [decoupling](../philosophy/decoupling.md) between meaning and rendering.
+
+Soundness keeps the four decisions apart. The *shape* of the data is in its types: a series over
+`Text` is categorical, a series over `Double` or a `Duration` is continuous. A chart *kind* is
+compatible with some shapes and not others, and the compiler checks the pairing. The *fit* of the
+data to the axes — linear or logarithmic, padded to round numbers or tight, anchored at zero —
+is a calibration chosen per axis type or passed explicitly. Everything about the *style* — size,
+colors, type, legend — is a separate value. Everything comes from the `soundness` package:
+
+```scala
+import soundness.*
+import strategies.throwUnsafely
+```
+
+### Series
+
+A `Series` is a named run of points, each an abscissa paired with an ordinate:
+
+```scala
+val north = Series(t"north")((t"jan", 3.0), (t"feb", 5.0), (t"mar", 4.0))
+val south = Series(t"south")((t"jan", 2.0), (t"feb", 1.0), (t"mar", 6.0))
+```
+
+The abscissa type decides the axis. A `Text` (or an enum, or a `Category`) is `Categorical`: its
+values are distinct labels in first-appearance order. A number, a `Duration`, an `Instant` or any
+`Quantity` is `Continuous`: its values have positions on a numeric axis. Either typeclass can be
+given for a type of your own. An `Estimate` is a continuous value with the interval it lies in,
+which a chart draws as an error bar or a band:
+
+```scala
+val timings = Series(t"sort")((1000, Estimate(2.1, 1.9, 2.4)), (10000, Estimate(24.0, 22.5, 26.1)))
+```
+
+A series is immutable, and `add` appends a point in constant amortized time, which is what a chart
+fed one measurement at a time needs. Several series are any collection of them — a `List`, a
+`Sequence`, a `Set` — since compatibility is stated for anything traversable by series.
+
+### Chart kinds
+
+A chart kind is a value: `Bars`, `StackedBars`, `Lines`, `Scatter`, `Pie`, `Histogram` or
+`Boxes`. The `chart` method pairs data with a kind, and compiles only where the kind can draw the
+data's shape:
+
+```scala
+val sales = List(north, south).chart(Bars())
+```
+
+Bars and pies want a categorical abscissa; lines and scatter plots want both axes continuous; a
+pie takes exactly one series; a histogram and a box plot take `Samples` — raw measurements —
+rather than points. A pairing that makes no sense is a compile error rather than a runtime
+surprise:
+
+```scala
+north.chart(Lines())       // does not compile: a categorical series has no numeric abscissa
+List(north, south).chart(Pie())  // does not compile: a pie is one series
+```
+
+The pairing is a `Plottable` instance, and a new kind of chart is a new value with instances for
+the shapes it can draw; nothing else has to change.
+
+### Fitting
+
+Fitting chooses each axis's range and gradations from the data. The chart kind decides what the
+axis must show — a bar chart's ordinate is anchored at zero, a line chart's is not — and a
+`Calibration` decides how: linear or logarithmic positions, padded outward to whole steps or tight
+to the data. The default is linear. A calibration is keyed on the type of the values on the axis,
+so a scoped given changes every axis of that type, and an import changes every axis:
+
+```scala
+val sizes = Series(t"sort")((100, 1.2), (1000, 14.0), (10000, 160.0), (100000, 1900.0))
+
+val logged =
+  given Int is Calibration = calibrations.logarithmicCalibration
+  sizes.chart(Lines())
+
+logged.fit.abscissa.transform   // Scale.Transform.Logarithmic
+```
+
+A calibration can also be passed to a chart kind for one axis, when both axes share a type:
+
+```scala
+val scaled = sizes.chart(Lines(ordinate = calibrations.adaptiveCalibration))
+```
+
+The adaptive calibration goes logarithmic when the range spans three orders of magnitude, which
+is what benchmark timings over input sizes usually want. The `Scale` a fit produces is plain
+data: its bounds, its transform and its gradations, which are spaced at multiples of one, two and
+five for numbers, and at clock steps — seconds, half-minutes, hours — for durations and instants.
+
+### Style
+
+A `Chart.Style` holds everything about appearance that is not data: the size, stroke width and
+marker radius, the typeface, how densely axes are graduated, where the legend goes and the axis
+titles. Colors are a `ChartPalette`, named by role — the series ramp, the axes, the grid, the
+lettering — so that one chart renders under any palette. Both have no-import defaults; a palette
+is chosen by importing one, and a style by giving one:
+
+```scala
+import palettes.solarizedDarkChartPalette
+
+given Chart.Style = Chart.Style(width = 800, height = 300, ordinateTitle = t"units sold")
+```
+
+Text is measured to lay out the axis labels and legend. Without a font in scope, an average width
+per character is assumed; with a [font](fonts.md) loaded, its own glyph advances are used, and
+the margins fit their labels exactly:
+
+```scala
+import fontMetrics.averageFontMetric
+```
+
+The face measured should be the one the page will render, since the SVG does not embed it.
+
+### Rendering
+
+A chart renders to a savagery `Svg`, which serializes to XML text like any other:
+
+```scala
+val drawing = sales.svg
+drawing.xml.show.keep(60)   // <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 300" …
+```
+
+Every part of the drawing is a group with a stable identifier — `grid`, `abscissa`, `ordinate`,
+`legend` and `series-0`, `series-1`, … — which is what makes the chart revisable.
+
+### Revision
+
+A chart is immutable. Given new data, `revise` yields the next chart and a list of what changed on
+the page. If the fit still accommodates the new data, the axes hold still and only the parts that
+differ are replaced; if a point falls outside them, the whole chart is redrawn:
+
+```scala
+val latency = Series(t"p99")((0.0, 12.0), (10.0, 14.0)).chart(Lines())
+val (next, revisions) = latency.revise(latency.data.add((5.0, 13.0)))
+revisions.length   // 1: a Chart.Revision.Replace of `series-0`
+```
+
+A page holding the SVG needs only two operations, replace an element by its identifier and
+replace the whole drawing, so a chart can be kept current over a WebSocket by sending each
+revision as it is produced.
+
+### Distributions
+
+Raw measurements are `Samples`. A `Histogram` cuts their range into equal bins — by Sturges' rule
+unless a bin count is given — and counts the samples in each; `Boxes` summarizes each set of
+samples as a box between its quartiles with whiskers to its extremes:
+
+```scala
+val runs = List(Samples(t"before")(21.0, 22.5, 23.1, 22.8, 24.0), Samples(t"after")(18.2, 18.9, 19.5, 18.1, 19.0))
+runs.chart(Histogram()).fit.edges.size
+runs.chart(Boxes()).fit.summaries.size   // 2
+```
+
+Both accept any collection of sample sets, as the other kinds accept collections of series.

--- a/doc/modules/charts.md
+++ b/doc/modules/charts.md
@@ -119,6 +119,19 @@ import palettes.solarizedDarkChartPalette
 given Chart.Style = Chart.Style(width = 800, height = 300, ordinateTitle = t"units sold")
 ```
 
+An axis over a [quantity](quantities.md) is titled by what it measures and its unit, taken from
+the type: a series of `Quantity[Metres[1]]` values has the ordinate title `distance / m`, and one
+of `Metre/Second` values `velocity / m·s¯¹`, with the units rendered as they are everywhere
+else in Soundness. A title given in the style replaces the name but keeps the unit:
+
+```scala
+val tides = Series(t"tide")((0.0, 1.2*Metre), (6.0, 4.6*Metre), (12.0, 1.1*Metre))
+tides.chart(Lines()).svg.xml.show.contains(t"distance / m")   // true
+```
+
+A `Duration` axis is titled `time`, and its gradations carry their own units — `250ms`,
+`1m30s` — since clock steps are not decimal.
+
 Text is measured to lay out the axis labels and legend. Without a font in scope, an average width
 per character is assumed; with a [font](fonts.md) loaded, its own glyph advances are used, and
 the margins fit their labels exactly:

--- a/doc/modules/charts.md
+++ b/doc/modules/charts.md
@@ -49,7 +49,9 @@ which a chart draws as an error bar or a band:
 val timings = Series(t"sort")((1000, Estimate(2.1, 1.9, 2.4)), (10000, Estimate(24.0, 22.5, 26.1)))
 ```
 
-A series is immutable, and `add` appends a point in constant amortized time, which is what a chart
+A series' name, like a sample set's or a `Category`, is any showable value — text, an enum
+case, a number — rendered once when it is made. A series is immutable, and `add` appends a point
+in constant amortized time, which is what a chart
 fed one measurement at a time needs. Several series are any collection of them — a `List`, a
 `Sequence`, a `Set` — since compatibility is stated for anything traversable by series.
 

--- a/doc/modules/svg.md
+++ b/doc/modules/svg.md
@@ -100,6 +100,40 @@ so a reference to a definition that does not exist is not silently rendered:
 Outline(id = Svg.Id(t"plus")).moveTo((0, 0)).closed
 ```
 
+### Groups, polylines and text
+
+A `Group` is a `<g>` element: figures that move, style and identify together. A chart's axes, or
+one series of it, is a group, so that the whole part can be found and replaced by its identifier
+when it changes:
+
+```scala
+val axes = Group(List(Rectangle((0, 0), 100, 60)), id = Svg.Id(t"axes"))
+```
+
+A `Polyline` joins absolute points with straight segments, and becomes a `<polygon>` when it is
+`closed`, so a plotted line and the filled area beneath it are the same figure with one flag
+different:
+
+```scala
+val line = Polyline(List(Point(0, 60), Point(50, 20), Point(100, 40)))
+val area = Polyline(List(Point(0, 60), Point(50, 20), Point(100, 40), Point(100, 60)), closed = true)
+```
+
+`Lettering` sets text at a position — named for what it is in a drawing, since `Text` is the
+string type. Its anchor says whether the position is the start, middle or end of the run, and its
+baseline which line of the glyphs lies on the position:
+
+```scala
+Lettering((50, 70), t"time", Lettering.Anchor.Middle, Lettering.Baseline.Hanging)
+```
+
+Every figure may carry an inline `style`, a typed [CSS](css.md) declaration set whose property
+names and values are checked as the code compiles, and an `id`:
+
+```scala
+Rectangle((0, 0), 10, 10, style = Css.Style(fill = Srgb(1, 0, 0)), id = Svg.Id(t"box"))
+```
+
 ### Gradients and color
 
 A linear gradient is a definition with typed stops, each an offset in `[0, 1]` — a

--- a/doc/tags.md
+++ b/doc/tags.md
@@ -120,6 +120,7 @@ surveillance: file-watcher filesystem file-events directory-monitoring nio
 symbolism: operators arithmetic typeclass operator-overloading algebra
 synesthesia: mcp model-context-protocol llm ai-protocol
 tarantula: webdriver browser-automation chrome firefox safari edge selenium headless
+tasseomancy: charts graphs plotting data-visualization svg benchmarks bar-chart line-chart pie-chart histogram
 telekinesis: http http-client cookies authentication rest-client web-requests
 tessellate: layout box-drawing reflow alignment flex text-layout
 turbulence: streams io stdio streaming reactive line-separation

--- a/lib/quantitative/src/core/quantitative.internal.scala
+++ b/lib/quantitative/src/core/quantitative.internal.scala
@@ -43,6 +43,7 @@ import prepositional.*
 import rudiments.*
 import spectacular.*
 import symbolism.*
+import vacuous.*
 
 object internal extends protointernal:
   opaque type Quantity[units <: Measure] = Double
@@ -102,6 +103,11 @@ object internal extends protointernal:
       ${quantitative.internal.collectUnits[units]}
 
     inline def units[units <: Measure]: Text = expressUnits(unitsMap[units])
+
+    // The name of the physical quantity some units measure — `distance`, `velocity` — or
+    // `Unset` for a combination of dimensions that has none.
+    inline def dimension[units <: Measure]: Optional[Text] =
+      ${quantitative.internal.describeOptional[units]}
 
     // Concrete inline-friendly operator instances. These are summoned via
     // `transparent inline given`s below so the static type at the use site

--- a/lib/quantitative/src/core/quantitative.protointernal.scala
+++ b/lib/quantitative/src/core/quantitative.protointernal.scala
@@ -47,6 +47,7 @@ import hypotenuse.*
 import prepositional.*
 import rudiments.*
 import symbolism.*
+import vacuous.*
 
 // `caps.Pure`: a stateless namespace of macro-support value classes; without the marker, the
 // nested classes' references to sibling members capture `protointernal.this`, which their pure
@@ -818,3 +819,9 @@ trait protointernal extends caps.Pure:
     UnitsMap[units].dimensionality.quantityName match
       case Some(name) => '{${Expr(name)}.tt}
       case None       => halt(m"there is no descriptive name for this physical quantity")
+
+  // The same name, or `Unset` where the dimension has none, for callers that can do without.
+  def describeOptional[units <: Measure: Type](using Quotes): Expr[Optional[Text]] =
+    UnitsMap[units].dimensionality.quantityName match
+      case Some(name) => '{${Expr(name)}.tt}
+      case None       => '{Unset}

--- a/lib/savagery/src/core/savagery.Circle.scala
+++ b/lib/savagery/src/core/savagery.Circle.scala
@@ -32,7 +32,17 @@
                                                                                                   */
 package savagery
 
+import cataclysm.Css
 import geodesy.*
+import vacuous.*
 
 object Circle:
-  def apply(center: Point, radius: Float): Ellipse = Ellipse(center, radius, radius, Angle(0.0))
+  def apply
+    ( center:     Point,
+      radius:     Float,
+      transforms: List[Transform]     = Nil,
+      style:      Optional[Css.Style] = Unset,
+      id:         Optional[Svg.Id]    = Unset )
+  :   Ellipse =
+
+    Ellipse(center, radius, radius, Angle(0.0), transforms, style, id)

--- a/lib/savagery/src/core/savagery.Figure.scala
+++ b/lib/savagery/src/core/savagery.Figure.scala
@@ -33,6 +33,7 @@
 package savagery
 
 import scala.collection.immutable.VectorMap
+import scala.collection.mutable.Builder
 
 import anticipation.*
 import cataclysm.Css
@@ -44,13 +45,26 @@ import spectacular.*
 import vacuous.*
 import xylophone.*
 
-
-sealed trait Figure:
-  def xml: Xml
-
 object Figure:
   private def fields(pairs: (Text, Text)*): Text =
     pairs.map { (label, value) => s"${label.s}:${value.s}" }.mkString(" ╱ ").tt
+
+  private def optional[value: Inspectable](value: Optional[value]): Text =
+    value.lay(t"○"): value => t"｢${value.inspect}｣"
+
+  // The attributes any figure may carry besides its geometry — identifier, transform list and
+  // inline style — appended in that order, and only when present, so a figure without them
+  // serializes exactly as it did before they existed.
+  private[savagery] def decorate
+    ( attrs:      Builder[(Text, Text), VectorMap[Text, Text]],
+      id:         Optional[Svg.Id],
+      transforms: List[Transform],
+      style:      Optional[Css.Style] )
+  :   Unit =
+
+    id.let: svgId => attrs += t"id" -> svgId.text
+    if !transforms.nil then attrs += t"transform" -> transforms.map(_.encode).join(t" ")
+    style.let: css => attrs += t"style" -> css.text
 
   // A figure's `xml` is its serialized form: multi-line, and (for an `Outline`) with every path
   // operation compressed into one `d` attribute. Inspection names the case and labels each field
@@ -58,14 +72,18 @@ object Figure:
   // from — stay individually legible. A `Css.Style` has no inspection of its own, so its property
   // text is rendered here rather than borrowed.
   given inspectable: [figure <: Figure] => figure is Inspectable = figure =>
+    given styleInspectable: Css.Style is Inspectable = _.text.inspect
+
     figure.absolve match
-      case Rectangle(position, width, height, transforms) =>
+      case Rectangle(position, width, height, transforms, style, id) =>
         val body =
           fields
             ( t"position"   -> position.inspect,
               t"width"      -> width.inspect,
               t"height"     -> height.inspect,
-              t"transforms" -> transforms.inspect )
+              t"transforms" -> transforms.inspect,
+              t"style"      -> optional(style),
+              t"id"         -> optional(id) )
 
         t"Rectangle($body)"
 
@@ -73,28 +91,69 @@ object Figure:
         val body =
           fields
             ( t"ops"        -> ops.inspect,
-              t"style"      -> style.lay(t"○") { css => t"｢${css.text.inspect}｣" },
-              t"id"         -> id.lay(t"○") { svgId => t"｢${svgId.inspect}｣" },
+              t"style"      -> optional(style),
+              t"id"         -> optional(id),
               t"transforms" -> transforms.inspect )
 
         t"Outline($body)"
 
-      case Ellipse(center, xRadius, yRadius, angle, transforms) =>
+      case Ellipse(center, xRadius, yRadius, angle, transforms, style, id) =>
         val body =
           fields
             ( t"center"     -> center.inspect,
               t"xRadius"    -> xRadius.inspect,
               t"yRadius"    -> yRadius.inspect,
               t"angle"      -> angle.inspect,
-              t"transforms" -> transforms.inspect )
+              t"transforms" -> transforms.inspect,
+              t"style"      -> optional(style),
+              t"id"         -> optional(id) )
 
         t"Ellipse($body)"
+
+      case Group(figures, id, style, transforms) =>
+        val body =
+          fields
+            ( t"figures"    -> figures.inspect,
+              t"id"         -> optional(id),
+              t"style"      -> optional(style),
+              t"transforms" -> transforms.inspect )
+
+        t"Group($body)"
+
+      case Polyline(points, closed, id, style, transforms) =>
+        val body =
+          fields
+            ( t"points"     -> points.inspect,
+              t"closed"     -> closed.inspect,
+              t"id"         -> optional(id),
+              t"style"      -> optional(style),
+              t"transforms" -> transforms.inspect )
+
+        t"Polyline($body)"
+
+      case Lettering(position, text, anchor, baseline, id, style, transforms) =>
+        val body =
+          fields
+            ( t"position"   -> position.inspect,
+              t"text"       -> text.inspect,
+              t"anchor"     -> anchor.inspect,
+              t"baseline"   -> optional(baseline),
+              t"id"         -> optional(id),
+              t"style"      -> optional(style),
+              t"transforms" -> transforms.inspect )
+
+        t"Lettering($body)"
+
+sealed trait Figure:
+  def xml: Xml
 
 case class Rectangle
   ( position:   Point,
     width:      Float,
     height:     Float,
-    transforms: List[Transform] = Nil )
+    transforms: List[Transform]     = Nil,
+    style:      Optional[Css.Style] = Unset,
+    id:         Optional[Svg.Id]    = Unset )
 extends Figure:
 
   def xml: Xml =
@@ -104,17 +163,15 @@ extends Figure:
     attrs += t"y" -> position.y.show
     attrs += t"width" -> width.show
     attrs += t"height" -> height.show
-
-    if !transforms.nil
-    then attrs += t"transform" -> transforms.map(_.encode).join(t" ")
+    Figure.decorate(attrs, id, transforms, style)
 
     Element(t"rect", Attributes.from(attrs.result().to(Map)), Array())
 
 case class Outline
-  ( ops:        List[Stroke]       = Nil,
+  ( ops:        List[Stroke]        = Nil,
     style:      Optional[Css.Style] = Unset,
     id:         Optional[Svg.Id]    = Unset,
-    transforms: List[Transform]    = Nil )
+    transforms: List[Transform]     = Nil )
 extends Figure:
 
   import Stroke.*
@@ -123,12 +180,8 @@ extends Figure:
     val d: Text = ops.reverse.map(_.encode).join(t" ")
     val attrs = VectorMap.newBuilder[Text, Text]
     attrs += t"d" -> d
-    id.let: svgId => attrs += t"id" -> svgId.text
+    Figure.decorate(attrs, id, transforms, style)
 
-    if !transforms.nil
-    then attrs += t"transform" -> transforms.map(_.encode).join(t" ")
-
-    style.let: css => attrs += t"style" -> css.text
     Element(t"path", Attributes.from(attrs.result().to(Map)), Array())
 
   def moveTo(point: Point): Outline = copy(ops = MoveTo(point) :: ops)
@@ -166,7 +219,9 @@ case class Ellipse
     xRadius:    Float,
     yRadius:    Float,
     angle:      Angle,
-    transforms: List[Transform] = Nil )
+    transforms: List[Transform]     = Nil,
+    style:      Optional[Css.Style] = Unset,
+    id:         Optional[Svg.Id]    = Unset )
 extends Figure:
 
   def circle: Boolean = xRadius == yRadius
@@ -182,7 +237,84 @@ extends Figure:
       attrs += t"rx" -> xRadius.show
       attrs += t"ry" -> yRadius.show
 
-    if !transforms.nil
-    then attrs += t"transform" -> transforms.map(_.encode).join(t" ")
+    Figure.decorate(attrs, id, transforms, style)
 
-    Element(if circle then t"circle" else t"ellipse", Attributes.from(attrs.result().to(Map)), Array())
+    val label = if circle then t"circle" else t"ellipse"
+    Element(label, Attributes.from(attrs.result().to(Map)), Array())
+
+// A `<g>` element: figures that move, style and identify together. A chart's axes or one of its
+// series is a group, so that the whole part can be replaced by its identifier when it changes.
+case class Group
+  ( figures:    List[Figure],
+    id:         Optional[Svg.Id]    = Unset,
+    style:      Optional[Css.Style] = Unset,
+    transforms: List[Transform]     = Nil )
+extends Figure:
+
+  def xml: Xml =
+    val attrs = VectorMap.newBuilder[Text, Text]
+    Figure.decorate(attrs, id, transforms, style)
+
+    Element(t"g", Attributes.from(attrs.result().to(Map)), figures.map(_.xml).nodes)
+
+// A `<polyline>` through absolute points, or a `<polygon>` when `closed`: the shape of a plotted
+// line, an area under it, or a bar's outline, without a path operation per vertex.
+case class Polyline
+  ( points:     List[Point],
+    closed:     Boolean             = false,
+    id:         Optional[Svg.Id]    = Unset,
+    style:      Optional[Css.Style] = Unset,
+    transforms: List[Transform]     = Nil )
+extends Figure:
+
+  def xml: Xml =
+    val attrs = VectorMap.newBuilder[Text, Text]
+    def pair(point: Point): Text = t"${point.x.toString},${point.y.toString}"
+    attrs += t"points" -> points.map(pair).join(t" ")
+    Figure.decorate(attrs, id, transforms, style)
+    val label = if closed then t"polygon" else t"polyline"
+
+    Element(label, Attributes.from(attrs.result().to(Map)), Array())
+
+object Lettering:
+  // Where the text sits relative to its position: `text-anchor`.
+  enum Anchor:
+    case Start, Middle, End
+
+    def text: Text = this match
+      case Start  => t"start"
+      case Middle => t"middle"
+      case End    => t"end"
+
+  // Which line of the text the position lies on: `dominant-baseline`. Unset leaves it to the
+  // renderer, which is the alphabetic baseline.
+  enum Baseline:
+    case Alphabetic, Middle, Hanging
+
+    def text: Text = this match
+      case Alphabetic => t"alphabetic"
+      case Middle     => t"middle"
+      case Hanging    => t"hanging"
+
+// A `<text>` element: a run of characters set at a position, anchored at its start, middle or end.
+// Named for what it is in a drawing — lettering — since `Text` is the string type.
+case class Lettering
+  ( position:   Point,
+    text:       Text,
+    anchor:     Lettering.Anchor             = Lettering.Anchor.Start,
+    baseline:   Optional[Lettering.Baseline] = Unset,
+    id:         Optional[Svg.Id]             = Unset,
+    style:      Optional[Css.Style]          = Unset,
+    transforms: List[Transform]              = Nil )
+extends Figure:
+
+  def xml: Xml =
+    given showable: Float is Showable = _.toString.tt
+    val attrs = VectorMap.newBuilder[Text, Text]
+    attrs += t"x" -> position.x.show
+    attrs += t"y" -> position.y.show
+    if anchor != Lettering.Anchor.Start then attrs += t"text-anchor" -> anchor.text
+    baseline.let: baseline => attrs += t"dominant-baseline" -> baseline.text
+    Figure.decorate(attrs, id, transforms, style)
+
+    Element(t"text", Attributes.from(attrs.result().to(Map)), List[Xml](TextNode(text)).nodes)

--- a/lib/savagery/src/core/savagery.Svg.scala
+++ b/lib/savagery/src/core/savagery.Svg.scala
@@ -47,6 +47,7 @@ import zephyrine.*
 import fulminate.*
 import scala.collection.mutable.ListBuffer
 import cardinality.*
+import cataclysm.Css
 import distillate.*
 import geodesy.*
 import iridescence.*
@@ -132,14 +133,11 @@ object Svg:
       val defs = ListBuffer[Def]()
       val figures = ListBuffer[Figure]()
 
-      def walk(parent: Element): Unit = parent.children.each:
+      elem.children.each:
         case child: Element => child.label match
           case t"defs" => child.children.each:
             case dd: Element => decodeSvgDef(dd).let: svgDef => defs += svgDef
             case _           => ()
-
-          case t"g" =>
-            walk(child)
 
           case _ =>
             decodeFigure(child).let: figure => figures += figure
@@ -147,42 +145,121 @@ object Svg:
         case _ =>
           ()
 
-      walk(elem)
       Svg(width, height, defs.toList.to(List), figures.toList.to(List))
 
     private def decodeFigure(elem: Element)(using Tactic[Svg.Error]): Optional[Figure] =
       elem.label match
-        case t"rect"    => decodeRectangle(elem)
-        case t"circle"  => decodeCircle(elem)
-        case t"ellipse" => decodeEllipse(elem)
-        case t"path"    => decodePath(elem)
-        case _          => Unset
+        case t"rect"     => decodeRectangle(elem)
+        case t"circle"   => decodeCircle(elem)
+        case t"ellipse"  => decodeEllipse(elem)
+        case t"path"     => decodePath(elem)
+        case t"g"        => decodeGroup(elem)
+        case t"polyline" => decodePolyline(elem, false)
+        case t"polygon"  => decodePolyline(elem, true)
+        case t"text"     => decodeLettering(elem)
+        case _           => Unset
+
+    // The attributes any figure may carry: read by every decoder, so that a figure's identifier,
+    // transform list and inline style survive a round trip whatever its shape.
+    private def idAttr(elem: Element): Optional[Id] = elem.attributes(t"id").let(Id(_))
+
+    private def transformsAttr(elem: Element): List[Transform] =
+      elem.attributes(t"transform").let(parseTransforms).or(Nil)
+
+    // An inline `style` attribute is `name: value` declarations separated by semicolons; each is
+    // split at its first colon, and a declaration without one is dropped.
+    private def styleAttr(elem: Element): Optional[Css.Style] =
+      elem.attributes(t"style").let: text =>
+        val declarations = ListBuffer[(Text, Text)]()
+
+        text.s.split(";").nn.iterator.map(_.nn).foreach: declaration =>
+          val colon = declaration.indexOf(':')
+
+          if colon > 0 then
+            val name = declaration.substring(0, colon).nn.trim.nn
+            val value = declaration.substring(colon + 1).nn.trim.nn
+            if !name.isEmpty then declarations += ((name.tt, value.tt))
+
+        if declarations.isEmpty then Unset else Css.Style.of(declarations.toList.to(List))
 
     private def decodeRectangle(elem: Element): Rectangle =
       Rectangle
         ( Point(numAttr(elem, t"x"), numAttr(elem, t"y")),
-         numAttr(elem, t"width"),
-         numAttr(elem, t"height") )
+          numAttr(elem, t"width"),
+          numAttr(elem, t"height"),
+          transformsAttr(elem),
+          styleAttr(elem),
+          idAttr(elem) )
 
     private def decodeCircle(elem: Element): Ellipse =
       val cx = numAttr(elem, t"cx")
       val cy = numAttr(elem, t"cy")
       val r = numAttr(elem, t"r")
-      Ellipse(Point(cx, cy), r, r, Angle(0))
+      Ellipse(Point(cx, cy), r, r, Angle(0), transformsAttr(elem), styleAttr(elem), idAttr(elem))
 
     private def decodeEllipse(elem: Element): Ellipse =
       val cx = numAttr(elem, t"cx")
       val cy = numAttr(elem, t"cy")
       val rx = numAttr(elem, t"rx")
       val ry = numAttr(elem, t"ry")
-      Ellipse(Point(cx, cy), rx, ry, Angle(0))
+      Ellipse
+        ( Point(cx, cy), rx, ry, Angle(0), transformsAttr(elem), styleAttr(elem), idAttr(elem) )
 
     private def decodePath(elem: Element)(using Tactic[Svg.Error]): Outline =
       val d = elem.attributes(t"d").or(t"")
       val ops = parsePathData(d)
-      val id = elem.attributes(t"id").let(Id(_))
-      val transforms = elem.attributes(t"transform").let(parseTransforms).or(Nil)
-      Outline(ops = ops.reverse, id = id, transforms = transforms)
+      Outline(ops.reverse, styleAttr(elem), idAttr(elem), transformsAttr(elem))
+
+    private def decodeGroup(elem: Element)(using Tactic[Svg.Error]): Group =
+      val figures = ListBuffer[Figure]()
+
+      elem.children.each:
+        case child: Element => decodeFigure(child).let: figure => figures += figure
+        case _              => ()
+
+      Group(figures.toList.to(List), idAttr(elem), styleAttr(elem), transformsAttr(elem))
+
+    // A `points` attribute is pairs of numbers, separated by whitespace or commas within and
+    // between pairs alike; an odd trailing number is dropped.
+    private def decodePolyline(elem: Element, closed: Boolean): Polyline =
+      val numbers = ListBuffer[Float]()
+
+      elem.attributes(t"points").or(t"").s.split("[\\s,]+").nn.iterator.map(_.nn).foreach: number =>
+        if !number.isEmpty then
+          try numbers += number.toFloat catch case _: NumberFormatException => ()
+
+      val points = ListBuffer[Point]()
+      var index = 0
+
+      while index + 1 < numbers.length do
+        points += Point(numbers(index), numbers(index + 1))
+        index += 2
+
+      Polyline(points.toList.to(List), closed, idAttr(elem), styleAttr(elem), transformsAttr(elem))
+
+    private def decodeLettering(elem: Element): Lettering =
+      val text: Text = elem.children.readable.toList.collect { case TextNode(text) => text }
+        . to(List).join
+
+      val anchor: Lettering.Anchor = elem.attributes(t"text-anchor") match
+        case t"middle" => Lettering.Anchor.Middle
+        case t"end"    => Lettering.Anchor.End
+        case _         => Lettering.Anchor.Start
+
+      val baseline: Optional[Lettering.Baseline] = elem.attributes(t"dominant-baseline") match
+        case t"alphabetic" => Lettering.Baseline.Alphabetic
+        case t"middle"     => Lettering.Baseline.Middle
+        case t"hanging"    => Lettering.Baseline.Hanging
+        case _             => Unset
+
+      Lettering
+        ( Point(numAttr(elem, t"x"), numAttr(elem, t"y")),
+          text,
+          anchor,
+          baseline,
+          idAttr(elem),
+          styleAttr(elem),
+          transformsAttr(elem) )
 
 
     private def decodeSvgDef(elem: Element)

--- a/lib/savagery/src/core/savagery.Transformable.scala
+++ b/lib/savagery/src/core/savagery.Transformable.scala
@@ -59,6 +59,15 @@ object Transformable:
   given svg: Svg is Transformable =
     Transformable(_.transforms, (figure, ts) => figure.copy(transforms = ts))
 
+  given group: Group is Transformable =
+    Transformable(_.transforms, (figure, ts) => figure.copy(transforms = ts))
+
+  given polyline: Polyline is Transformable =
+    Transformable(_.transforms, (figure, ts) => figure.copy(transforms = ts))
+
+  given lettering: Lettering is Transformable =
+    Transformable(_.transforms, (figure, ts) => figure.copy(transforms = ts))
+
 trait Transformable extends Typeclass:
   def transforms(self: Self): List[Transform]
   def withTransforms(self: Self, transforms: List[Transform]): Self

--- a/lib/savagery/src/core/soundness_savagery_core.scala
+++ b/lib/savagery/src/core/soundness_savagery_core.scala
@@ -34,6 +34,6 @@ package soundness
 
 export
   savagery
-  . { Circle, Delta, Down, Ellipse, Figure, Left, Orientation, Outline, Point, Rectangle,
-      Right, Segment, Stop, Stroke, Svg, Sweep, Transform, Transformable, Up, unary_+, transform,
-      translate, scale, rotate, skew }
+  . { Circle, Delta, Down, Ellipse, Figure, Group, Left, Lettering, Orientation, Outline, Point,
+      Polyline, Rectangle, Right, Segment, Stop, Stroke, Svg, Sweep, Transform, Transformable, Up,
+      unary_+, transform, translate, scale, rotate, skew }

--- a/lib/savagery/src/test/savagery_test.scala
+++ b/lib/savagery/src/test/savagery_test.scala
@@ -134,6 +134,47 @@ object Tests extends Suite(m"Savagery tests"):
         (Transform.Matrix(Affine(1.0f, 0.0f, 0.0f, 1.0f, 5.0f, 10.0f)): Transform).encode
       .assert(_ == t"matrix(1.0,0.0,0.0,1.0,5.0,10.0)")
 
+    suite(m"Groups, polylines and lettering"):
+      test(m"Group wraps its figures"):
+        Group(List(Rectangle((0, 0), 1, 1), Circle((0, 0), 1)), id = Svg.Id(t"pair")).xml.show
+      .assert(_ == t"""<g id="pair"><rect x="0.0" y="0.0" width="1.0" height="1.0"/><circle cx="0.0" cy="0.0" r="1.0"/></g>""")
+
+      test(m"Empty group"):
+        Group(Nil).xml.show
+      .assert(_ == t"""<g/>""")
+
+      test(m"Polyline lists its points"):
+        Polyline(List(Point(0, 0), Point(10, 5), Point(20, 0))).xml.show
+      .assert(_ == t"""<polyline points="0.0,0.0 10.0,5.0 20.0,0.0"/>""")
+
+      test(m"Closed polyline is a polygon"):
+        Polyline(List(Point(0, 0), Point(10, 5), Point(20, 0)), closed = true).xml.show
+      .assert(_ == t"""<polygon points="0.0,0.0 10.0,5.0 20.0,0.0"/>""")
+
+      test(m"Lettering at its start"):
+        Lettering((1, 2), t"Hello").xml.show
+      .assert(_ == t"""<text x="1.0" y="2.0">Hello</text>""")
+
+      test(m"Lettering anchored at its middle on the hanging baseline"):
+        Lettering((1, 2), t"Hi", Lettering.Anchor.Middle, Lettering.Baseline.Hanging).xml.show
+      .assert(_ == t"""<text x="1.0" y="2.0" text-anchor="middle" dominant-baseline="hanging">Hi</text>""")
+
+      test(m"Lettering escapes markup"):
+        Lettering((0, 0), t"a < b").xml.show
+      .assert(_ == t"""<text x="0.0" y="0.0">a &lt; b</text>""")
+
+      test(m"Rectangle with style and id"):
+        Rectangle((0, 0), 1, 1, style = Css.Style(fill = Srgb(1, 0, 0)), id = Svg.Id(t"box")).xml.show
+      .assert(_ == t"""<rect x="0.0" y="0.0" width="1.0" height="1.0" id="box" style="fill: #ff0000"/>""")
+
+      test(m"Ellipse with style"):
+        Circle((0, 0), 1, style = Css.Style(stroke = Srgb(0, 0, 1))).xml.show
+      .assert(_ == t"""<circle cx="0.0" cy="0.0" r="1.0" style="stroke: #0000ff"/>""")
+
+      test(m"Group translate method"):
+        Group(Nil).translate(Delta(1, 2)).xml.show
+      .assert(_ == t"""<g transform="translate(1.0,2.0)"/>""")
+
     suite(m"Outline with attributes"):
       test(m"Outline with id"):
         Outline(id = Svg.Id(t"plus")).moveTo((0, 0)).closed.xml.show
@@ -476,19 +517,59 @@ object Tests extends Suite(m"Savagery tests"):
 
       test(m"Skip unknown element"):
         val svg =
-          t"""<svg width="10" height="10"><text x="0" y="0">Hello</text><rect x="0" y="0" width="5" height="5"/></svg>"""
+          t"""<svg width="10" height="10"><image href="x.png"/><rect x="0" y="0" width="5" height="5"/></svg>"""
         . read[Svg]
 
         svg.figures.size
       .assert(_ == 1)
 
-      test(m"Flatten group"):
+      test(m"Parse group as a Group figure"):
         val svg =
-          t"""<svg width="10" height="10"><g><rect x="0" y="0" width="5" height="5"/><circle cx="0" cy="0" r="3"/></g></svg>"""
+          t"""<svg width="10" height="10"><g id="pair"><rect x="0" y="0" width="5" height="5"/><circle cx="0" cy="0" r="3"/></g></svg>"""
         . read[Svg]
 
-        svg.figures.size
-      .assert(_ == 2)
+        svg.figures.stdlib.head
+      .assert:
+          case Group(figures, id, _, _) =>
+            id == Svg.Id(t"pair") && figures == List(Rectangle((0, 0), 5, 5), Circle((0, 0), 3))
+          case _ => false
+
+      test(m"Parse polyline points"):
+        val svg =
+          t"""<svg width="10" height="10"><polyline points="0,0 10,5 20 0"/></svg>""".read[Svg]
+
+        svg.figures.stdlib.head
+      .assert(_ == Polyline(List(Point(0, 0), Point(10, 5), Point(20, 0))))
+
+      test(m"Parse polygon as closed polyline"):
+        val svg =
+          t"""<svg width="10" height="10"><polygon points="0,0 10,5 20,0"/></svg>""".read[Svg]
+
+        svg.figures.stdlib.head
+      .assert(_ == Polyline(List(Point(0, 0), Point(10, 5), Point(20, 0)), closed = true))
+
+      test(m"Parse text with anchor and baseline"):
+        val svg =
+          t"""<svg width="10" height="10"><text x="1" y="2" text-anchor="middle" dominant-baseline="hanging">Hi</text></svg>"""
+        . read[Svg]
+
+        svg.figures.stdlib.head
+      .assert:
+          case Lettering(position, text, anchor, baseline, _, _, _) =>
+            position == Point(1, 2) && text == t"Hi" && anchor == Lettering.Anchor.Middle
+            && baseline == Lettering.Baseline.Hanging
+          case _ => false
+
+      test(m"Parse rectangle style and id"):
+        val svg =
+          t"""<svg width="10" height="10"><rect x="0" y="0" width="5" height="5" id="r" style="fill: red; stroke-width: 2px"/></svg>"""
+        . read[Svg]
+
+        svg.figures.stdlib.head
+      .assert:
+          case Rectangle(_, _, _, _, style, id) =>
+            id == Svg.Id(t"r") && style.let(_.text) == t"fill: red; stroke-width: 2px"
+          case _ => false
 
       test(m"Ignore unknown attributes"):
         val svg = t"""<svg width="10" height="10"><rect x="0" y="0" width="5" height="5" foo="bar"/></svg>"""
@@ -538,6 +619,24 @@ object Tests extends Suite(m"Savagery tests"):
         encoded.read[Svg].xml.show == encoded
       .assert(_ == true)
 
+      test(m"Round-trip: group with nested figures and text"):
+        val encoded = Svg
+         (100,
+          100,
+          figures = List
+           (Group
+             (List
+               (Rectangle((0, 0), 10, 10, style = Css.Style(fill = Srgb(1, 0, 0)), id = Svg.Id(t"box")),
+                Polyline(List(Point(0, 0), Point(5, 5))),
+                Polyline(List(Point(0, 0), Point(5, 5), Point(0, 5)), closed = true),
+                Lettering((1, 2), t"label", Lettering.Anchor.End, Lettering.Baseline.Middle)),
+              id = Svg.Id(t"axes"),
+              transforms = List(Transform.Translate(Delta(5, 10))))))
+        . xml.show
+
+        encoded.read[Svg].xml.show == encoded
+      .assert(_ == true)
+
       test(m"Round-trip: SVG with multiple figures"):
         val encoded = Svg
          (100, 100, figures = List(Rectangle((0, 0), 10, 10), Circle((50, 50), 5)))
@@ -574,6 +673,9 @@ object Tests extends Suite(m"Savagery tests"):
            Rectangle((0, 0), 10, 5).inspect,
            Ellipse((1, 2), 3, 4, Angle(0)).inspect,
            Outline().moveTo((0, 0)).lineTo((3, 4)).inspect,
+           Group(List(Rectangle((0, 0), 1, 1)), id = Svg.Id(t"g")).inspect,
+           Polyline(List(Point(0, 0), Point(1, 1)), closed = true).inspect,
+           Lettering((0, 0), t"x", Lettering.Anchor.End, Lettering.Baseline.Middle).inspect,
            Transform.Rotate(Angle(0)).inspect,
            Transform.Matrix(Affine[Float](1, 0, 0, 1, 0, 0)).inspect,
            Stroke.MoveTo(Point(0, 0)).inspect )

--- a/lib/tasseomancy/src/core/soundness_tasseomancy_core.scala
+++ b/lib/tasseomancy/src/core/soundness_tasseomancy_core.scala
@@ -34,9 +34,9 @@ package soundness
 
 export
   tasseomancy
-  . { Bands, Bars, Boxes, Calibration, Categorical, Category, Chart, ChartPalette, Continuous,
-      Estimate, FontMetric, Gradation, Histogram, Lines, Pie, Plottable, Ruler, Samples, Scale,
-      Scatter, Series, StackedBars, chart }
+  . { Annotated, Bands, Bars, Boxes, Calibration, Categorical, Category, Chart, ChartPalette,
+      Continuous, Estimate, FontMetric, Gradation, Histogram, Lines, Pie, Plottable, Ruler,
+      Samples, Scale, Scatter, Series, StackedBars, chart }
 
 package calibrations:
   export tasseomancy.calibrations.{adaptiveCalibration, linearCalibration, logarithmicCalibration,

--- a/lib/tasseomancy/src/core/soundness_tasseomancy_core.scala
+++ b/lib/tasseomancy/src/core/soundness_tasseomancy_core.scala
@@ -1,0 +1,50 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export
+  tasseomancy
+  . { Bands, Bars, Boxes, Calibration, Categorical, Category, Chart, ChartPalette, Continuous,
+      Estimate, FontMetric, Gradation, Histogram, Lines, Pie, Plottable, Ruler, Samples, Scale,
+      Scatter, Series, StackedBars, chart }
+
+package calibrations:
+  export tasseomancy.calibrations.{adaptiveCalibration, linearCalibration, logarithmicCalibration,
+      tightCalibration}
+
+package palettes:
+  export tasseomancy.palettes.{slateChartPalette, solarizedDarkChartPalette,
+      solarizedLightChartPalette}
+
+package fontMetrics:
+  export tasseomancy.fontMetrics.{averageFontMetric, tabularFontMetric}

--- a/lib/tasseomancy/src/core/tasseomancy.Annotated.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Annotated.scala
@@ -32,73 +32,8 @@
                                                                                                   */
 package tasseomancy
 
-import gossamer.*
-import iridescence.*
-import prepositional.*
-import quantitative.*
-import symbolism.*
+import anticipation.*
 
-// The entry point: data and a chart kind, checked for compatibility as the code compiles, become
-// a chart fitted to the data.
-extension [data](data: data)
-  def chart[form, fit, style <: Chart.Style](form: form)
-    ( using plottable: data is Plottable in form to fit by style )
-  :   Chart[data, form, fit, style] =
-
-    Chart(data, form, plottable.fit(form, data))
-
-package calibrations:
-  given linearCalibration: [value] => value is Calibration = Calibration(Calibration.Policy.Linear)
-
-  given logarithmicCalibration: [value] => value is Calibration =
-    Calibration(Calibration.Policy.Logarithmic)
-
-  given adaptiveCalibration: [value] => value is Calibration =
-    Calibration(Calibration.Policy.Adaptive)
-
-  given tightCalibration: [value] => value is Calibration = Calibration(Calibration.Policy.Tight)
-
-package palettes:
-  private def rgb(red: Double, green: Double, blue: Double): Color in Srgb = Srgb(red, green, blue)
-
-  given slateChartPalette: ChartPalette = new ChartPalette:
-    val series: Sequence[Color in Srgb] =
-      Sequence
-        ( rgb(0.306, 0.475, 0.655), rgb(0.949, 0.557, 0.169), rgb(0.882, 0.341, 0.349),
-          rgb(0.463, 0.718, 0.698), rgb(0.349, 0.631, 0.310), rgb(0.929, 0.788, 0.282),
-          rgb(0.690, 0.478, 0.631), rgb(1.000, 0.616, 0.655) )
-
-    def background: Color in Srgb = rgb(1.0, 1.0, 1.0)
-    def foreground: Color in Srgb = rgb(0.2, 0.2, 0.2)
-    def axis: Color in Srgb = rgb(0.4, 0.4, 0.4)
-    def grid: Color in Srgb = rgb(0.87, 0.87, 0.87)
-    def text: Color in Srgb = rgb(0.2, 0.2, 0.2)
-
-  private val solarizedSeries: Sequence[Color in Srgb] =
-    Sequence
-      ( rgb(0.149, 0.545, 0.824), rgb(0.796, 0.294, 0.086), rgb(0.522, 0.600, 0.000),
-        rgb(0.827, 0.212, 0.510), rgb(0.165, 0.631, 0.596), rgb(0.710, 0.537, 0.000),
-        rgb(0.424, 0.443, 0.769), rgb(0.863, 0.196, 0.184) )
-
-  given solarizedDarkChartPalette: ChartPalette = new ChartPalette:
-    val series: Sequence[Color in Srgb] = solarizedSeries
-    def background: Color in Srgb = rgb(0.000, 0.169, 0.212)
-    def foreground: Color in Srgb = rgb(0.514, 0.580, 0.588)
-    def axis: Color in Srgb = rgb(0.345, 0.431, 0.459)
-    def grid: Color in Srgb = rgb(0.027, 0.212, 0.259)
-    def text: Color in Srgb = rgb(0.576, 0.631, 0.631)
-
-  given solarizedLightChartPalette: ChartPalette = new ChartPalette:
-    val series: Sequence[Color in Srgb] = solarizedSeries
-    def background: Color in Srgb = rgb(0.992, 0.965, 0.890)
-    def foreground: Color in Srgb = rgb(0.396, 0.482, 0.514)
-    def axis: Color in Srgb = rgb(0.576, 0.631, 0.631)
-    def grid: Color in Srgb = rgb(0.933, 0.910, 0.835)
-    def text: Color in Srgb = rgb(0.345, 0.431, 0.459)
-
-package fontMetrics:
-  // Six tenths of an em per character: the width of an average proportional face.
-  given averageFontMetric: FontMetric = text => 0.6*text.length*Em
-
-  // Half an em per character: a monospace face.
-  given tabularFontMetric: FontMetric = text => 0.5*text.length*Em
+// A value with a note attached — the name of the point it plots — which a scatter plot or a line
+// chart sets beside the marker.
+case class Annotated(value: Double, note: Text)

--- a/lib/tasseomancy/src/core/tasseomancy.Bands.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Bands.scala
@@ -1,0 +1,65 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import anticipation.*
+import denominative.*
+import rudiments.*
+import vacuous.*
+
+// The categorical counterpart of a `Scale`: the axis is divided into equal bands, one per
+// category in first-appearance order, and a value is placed at the centre of its band.
+case class Bands(categories: Sequence[Text]) extends Ruler:
+  def count: Int = categories.size
+  def width: Double = if count == 0 then 1.0 else 1.0/count
+  def centre(index: Int): Double = (index + 0.5)*width
+
+  def index(label: Text): Optional[Int] =
+    var found: Optional[Int] = Unset
+    var position: Int = 0
+
+    categories.foreach: category =>
+      if found.absent && category == label then found = position
+      position += 1
+
+    found
+
+  def gradations(budget: Int): Sequence[Gradation] =
+    var position: Int = 0
+    var marks: List[Gradation] = Nil
+
+    categories.foreach: category =>
+      marks = Gradation(centre(position), category) :: marks
+      position += 1
+
+    marks.reverse.to[Sequence]

--- a/lib/tasseomancy/src/core/tasseomancy.Bars.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Bars.scala
@@ -32,7 +32,8 @@
                                                                                                   */
 package tasseomancy
 
-import Cartesian.*
+import Framing.*
+import iridescence.*
 import murmuration.Traversable
 import prepositional.*
 import rudiments.*
@@ -43,8 +44,18 @@ import vacuous.*
 object Bars:
   case class Fit(bands: Bands, ordinate: Scale)
 
+  // The components of a bar chart beyond the axes: the bars themselves, and how wide a group of
+  // them may be within its category's band.
+  trait Style extends Chart.Cartesian:
+    def barGap: Double
+
+    def bar(corner: Point, width: Double, height: Double, color: Color in Srgb, series: Int)
+    :   List[Figure] =
+
+      List(Rectangle(corner, width.toFloat, height.toFloat, style = filled(color)))
+
   given series: [x: Categorical, y: {Continuous, Calibration}]
-  =>  Series[x, y] is Plottable in Bars to Bars.Fit =
+  =>  Series[x, y] is Plottable in Bars to Bars.Fit by Bars.Style =
     plottable[Series[x, y], y]: series => List(columnOf(series))
 
   // The traversal evidence comes first: it is what determines `x` and `y`, which the evidence
@@ -52,18 +63,19 @@ object Bars:
   given traversable: [collection, x, y]
   =>  ( traversable: collection is Traversable by Series[x, y] )
   =>  ( categorical: x is Categorical, continuous: y is Continuous, calibration: y is Calibration )
-  =>  collection is Plottable in Bars to Bars.Fit =
+  =>  collection is Plottable in Bars to Bars.Fit by Bars.Style =
     plottable[collection, y]: collection =>
       List.from(traversable.traverse(collection).map(columnOf(_)))
 
   private def plottable[data, y: {Continuous as continuous, Calibration as calibration}]
     ( columns: data -> List[Column] )
-  :   data is Plottable in Bars to Bars.Fit =
+  :   data is Plottable in Bars to Bars.Fit by Bars.Style =
 
     new Plottable:
       type Self = data
       type Form = Bars
       type Result = Bars.Fit
+      type Operand = Bars.Style
 
       def fit(form: Bars, data: data): Bars.Fit =
         val all = columns(data)
@@ -86,12 +98,12 @@ object Bars:
             fit.bands.index(mark.category).present && fit.ordinate.accommodates(mark.y) && within
 
       def draw(form: Bars, data: data, fit: Bars.Fit)
-        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+        ( using style: Bars.Style, palette: ChartPalette, metric: FontMetric )
       :   Chart.Drawing =
 
         val all = columns(data)
         val names = all.map(_.name)
-        val layout = Cartesian.layout(fit.bands, fit.ordinate, names)
+        val layout = Framing.layout(fit.bands, fit.ordinate, names)
         val frame = layout.frame
         val total = countOf(all).max(1)
         val groupWidth = frame.width*fit.bands.width*(1.0 - style.barGap)
@@ -100,28 +112,27 @@ object Bars:
         var index = 0
 
         val seriesParts = all.map: column =>
-          val color = filled(palette.color(index))
+          val color = palette.color(index)
 
           val figures = column.marks.fold(List[Figure]()): (acc, mark) =>
             fit.bands.index(mark.category).lay(acc): band =>
               val x0 = frame.x(fit.bands.centre(band)) - groupWidth/2.0 + index*barWidth
               val y = frame.y(fit.ordinate.unit(mark.y))
-              val corner = point(x0, y.min(zero))
-              val bar = Rectangle(corner, barWidth.toFloat, (y - zero).abs.toFloat, style = color)
+              val bar = style.bar(point(x0, y.min(zero)), barWidth, (y - zero).abs, color, index)
 
               val errors = mark.bounds.lay(Nil): (low, high) =>
                 val top = frame.y(fit.ordinate.unit(high))
                 val bottom = frame.y(fit.ordinate.unit(low))
-                errorBar(x0 + barWidth/2.0, top, bottom, barWidth/4.0)
+                style.errorBar(x0 + barWidth/2.0, top, bottom, barWidth/4.0, palette.axis)
 
-              errors.reverse + (bar :: acc)
+              errors.reverse + (bar.reverse + acc)
 
           val part = seriesId(index) -> Group(figures.reverse, id = seriesId(index))
           index += 1
           part
 
         val legend = legendPart(layout.legend, names)
-        Cartesian.drawing(axes(frame, fit.bands, fit.ordinate) + seriesParts + legend)
+        Framing.drawing(axes(frame, fit.bands, fit.ordinate) + seriesParts + legend)
 
 // Bars grouped by category: one bar per series within each category's band, from zero to the
 // value, with error bars where the value carries an interval. The ordinate is anchored at zero,

--- a/lib/tasseomancy/src/core/tasseomancy.Bars.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Bars.scala
@@ -73,7 +73,7 @@ object Bars:
 
         val scale =
           form.ordinate.or(calibration)
-          . scale(extent.lowerOr0, extent.upperOr1, true, continuous.spacing, continuous.labelling)
+          . scale(extent.lowerOr0, extent.upperOr1, true, continuous.notation)
 
         Bars.Fit(Bands(categories(all)), scale)
 
@@ -91,7 +91,7 @@ object Bars:
 
         val all = columns(data)
         val names = all.map(_.name)
-        val layout = Cartesian.layout(fit.ordinate, names)
+        val layout = Cartesian.layout(fit.bands, fit.ordinate, names)
         val frame = layout.frame
         val total = countOf(all).max(1)
         val groupWidth = frame.width*fit.bands.width*(1.0 - style.barGap)

--- a/lib/tasseomancy/src/core/tasseomancy.Bars.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Bars.scala
@@ -1,0 +1,129 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import Cartesian.*
+import murmuration.Traversable
+import prepositional.*
+import rudiments.*
+import savagery.*
+import symbolism.*
+import vacuous.*
+
+object Bars:
+  case class Fit(bands: Bands, ordinate: Scale)
+
+  given series: [x: Categorical, y: {Continuous, Calibration}]
+  =>  Series[x, y] is Plottable in Bars to Bars.Fit =
+    plottable[Series[x, y], y]: series => List(columnOf(series))
+
+  // The traversal evidence comes first: it is what determines `x` and `y`, which the evidence
+  // after it is then resolved for.
+  given traversable: [collection, x, y]
+  =>  ( traversable: collection is Traversable by Series[x, y] )
+  =>  ( categorical: x is Categorical, continuous: y is Continuous, calibration: y is Calibration )
+  =>  collection is Plottable in Bars to Bars.Fit =
+    plottable[collection, y]: collection =>
+      List.from(traversable.traverse(collection).map(columnOf(_)))
+
+  private def plottable[data, y: {Continuous as continuous, Calibration as calibration}]
+    ( columns: data -> List[Column] )
+  :   data is Plottable in Bars to Bars.Fit =
+
+    new Plottable:
+      type Self = data
+      type Form = Bars
+      type Result = Bars.Fit
+
+      def fit(form: Bars, data: data): Bars.Fit =
+        val all = columns(data)
+
+        val extent = all.fold(Extent.empty): (acc, column) =>
+          column.marks.fold(acc): (acc2, mark) => acc2.include(mark.y).include(mark.bounds)
+
+        val scale =
+          form.ordinate.or(calibration)
+          . scale(extent.lowerOr0, extent.upperOr1, true, continuous.spacing, continuous.labelling)
+
+        Bars.Fit(Bands(categories(all)), scale)
+
+      def accommodates(form: Bars, fit: Bars.Fit, data: data): Boolean =
+        columns(data).all: column =>
+          column.marks.all: mark =>
+            val within = mark.bounds.lay(true): (low, high) =>
+              fit.ordinate.accommodates(low) && fit.ordinate.accommodates(high)
+
+            fit.bands.index(mark.category).present && fit.ordinate.accommodates(mark.y) && within
+
+      def draw(form: Bars, data: data, fit: Bars.Fit)
+        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+      :   Chart.Drawing =
+
+        val all = columns(data)
+        val names = all.map(_.name)
+        val layout = Cartesian.layout(fit.ordinate, names)
+        val frame = layout.frame
+        val total = countOf(all).max(1)
+        val groupWidth = frame.width*fit.bands.width*(1.0 - style.barGap)
+        val barWidth = groupWidth/total
+        val zero = frame.y(fit.ordinate.unit(0.0))
+        var index = 0
+
+        val seriesParts = all.map: column =>
+          val color = filled(palette.color(index))
+
+          val figures = column.marks.fold(List[Figure]()): (acc, mark) =>
+            fit.bands.index(mark.category).lay(acc): band =>
+              val x0 = frame.x(fit.bands.centre(band)) - groupWidth/2.0 + index*barWidth
+              val y = frame.y(fit.ordinate.unit(mark.y))
+              val corner = point(x0, y.min(zero))
+              val bar = Rectangle(corner, barWidth.toFloat, (y - zero).abs.toFloat, style = color)
+
+              val errors = mark.bounds.lay(Nil): (low, high) =>
+                val top = frame.y(fit.ordinate.unit(high))
+                val bottom = frame.y(fit.ordinate.unit(low))
+                errorBar(x0 + barWidth/2.0, top, bottom, barWidth/4.0)
+
+              errors.reverse + (bar :: acc)
+
+          val part = seriesId(index) -> Group(figures.reverse, id = seriesId(index))
+          index += 1
+          part
+
+        val legend = legendPart(layout.legend, names)
+        Cartesian.drawing(axes(frame, fit.bands, fit.ordinate) + seriesParts + legend)
+
+// Bars grouped by category: one bar per series within each category's band, from zero to the
+// value, with error bars where the value carries an interval. The ordinate is anchored at zero,
+// since a bar's length is its meaning.
+case class Bars(ordinate: Optional[Calibration] = Unset)

--- a/lib/tasseomancy/src/core/tasseomancy.Boxes.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Boxes.scala
@@ -1,0 +1,167 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import Cartesian.*
+import anticipation.*
+import cataclysm.Css
+import denominative.*
+import hypotenuse.*
+import murmuration.Traversable
+import murmuration.sortingAlgorithms.timsort
+import prepositional.*
+import rudiments.*
+import savagery.*
+import symbolism.*
+import vacuous.*
+
+object Boxes:
+  object Summary:
+    // Quartiles by linear interpolation between the order statistics either side.
+    def of(values: Sequence[Double]): Summary =
+      val sorted: Sequence[Double] = values.sort
+      val size = sorted.size
+
+      def quantile(fraction: Double): Double =
+        if size == 0 then 0.0 else
+          val position = fraction*(size - 1)
+          val low = position.floor.toInt
+          val high = position.ceiling.toInt
+          val below = Sequence.at(sorted, low)
+          val above = Sequence.at(sorted, high)
+          below + (above - below)*(position - low)
+
+      Summary(quantile(0.0), quantile(0.25), quantile(0.5), quantile(0.75), quantile(1.0))
+
+  // The five-number summary of one set of samples.
+  case class Summary
+    ( minimum:       Double,
+      lowerQuartile: Double,
+      median:        Double,
+      upperQuartile: Double,
+      maximum:       Double )
+
+  case class Fit(bands: Bands, ordinate: Scale, summaries: Sequence[Summary])
+
+  given samples: [y: {Continuous, Calibration}] => Samples[y] is Plottable in Boxes to Boxes.Fit =
+    plottable[Samples[y], y]: samples => List(Histogram.positions(samples))
+
+  given traversable: [collection, y]
+  =>  ( traversable: collection is Traversable by Samples[y] )
+  =>  ( continuous: y is Continuous, calibration: y is Calibration )
+  =>  collection is Plottable in Boxes to Boxes.Fit =
+    plottable[collection, y]: collection =>
+      List.from(traversable.traverse(collection).map(Histogram.positions(_)))
+
+  private def plottable[data, y: {Continuous as continuous, Calibration as calibration}]
+    ( extract: data -> List[(Text, Sequence[Double])] )
+  :   data is Plottable in Boxes to Boxes.Fit =
+
+    new Plottable:
+      type Self = data
+      type Form = Boxes
+      type Result = Boxes.Fit
+
+      def fit(form: Boxes, data: data): Boxes.Fit =
+        val all = extract(data)
+        val names = all.map(_(0)).to[Sequence]
+        val summaries = all.map { entry => Summary.of(entry(1)) }.to[Sequence]
+
+        val extent = summaries.fold(Extent.empty): (acc, summary) =>
+          acc.include(summary.minimum).include(summary.maximum)
+
+        val scale =
+          form.ordinate.or(calibration)
+          . scale(extent.lowerOr0, extent.upperOr1, false, continuous.spacing, continuous.labelling)
+
+        Boxes.Fit(Bands(names), scale, summaries)
+
+      def accommodates(form: Boxes, fit: Boxes.Fit, data: data): Boolean =
+        val all = extract(data)
+
+        val known = all.all: entry =>
+          fit.bands.index(entry(0)).present && entry(1).all(fit.ordinate.accommodates(_))
+
+        countOf(all) == fit.bands.count && known
+
+      def draw(form: Boxes, data: data, fit: Boxes.Fit)
+        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+      :   Chart.Drawing =
+
+        val all = extract(data)
+        val names = all.map(_(0))
+        val layout = Cartesian.layout(fit.ordinate, names)
+        val frame = layout.frame
+        val boxWidth = frame.width*fit.bands.width*(1.0 - style.barGap)
+        val outline = stroked(palette.axis, 1.0)
+        val medianStroke = stroked(palette.axis, style.strokeWidth)
+        var index = 0
+
+        val seriesParts = all.map: entry =>
+          val summary = Summary.of(entry(1))
+          val color = palette.color(index)
+          val x = frame.x(fit.bands.centre(index))
+          val x0 = x - boxWidth/2.0
+          val x1 = x + boxWidth/2.0
+          val cap = boxWidth/4.0
+
+          def y(value: Double): Double = frame.y(fit.ordinate.unit(value))
+
+          def line(xa: Double, ya: Double, xb: Double, yb: Double, style: Css.Style): Figure =
+            Polyline(List(point(xa, ya), point(xb, yb)), style = style)
+
+          val box =
+            Rectangle
+              ( point(x0, y(summary.upperQuartile)), boxWidth.toFloat,
+                (y(summary.lowerQuartile) - y(summary.upperQuartile)).abs.toFloat,
+                style = filled(color) )
+
+          val figures: List[Figure] =
+            List
+              ( line(x, y(summary.maximum), x, y(summary.upperQuartile), outline),
+                line(x, y(summary.lowerQuartile), x, y(summary.minimum), outline),
+                line(x - cap, y(summary.maximum), x + cap, y(summary.maximum), outline),
+                line(x - cap, y(summary.minimum), x + cap, y(summary.minimum), outline),
+                box,
+                line(x0, y(summary.median), x1, y(summary.median), medianStroke) )
+
+          val part = seriesId(index) -> Group(figures, id = seriesId(index))
+          index += 1
+          part
+
+        val legend = legendPart(layout.legend, names)
+        Cartesian.drawing(axes(frame, fit.bands, fit.ordinate) + seriesParts + legend)
+
+// A box per set of samples: the box spans the quartiles with the median across it, and the
+// whiskers reach the least and greatest sample. Each set is a category on the abscissa.
+case class Boxes(ordinate: Optional[Calibration] = Unset)

--- a/lib/tasseomancy/src/core/tasseomancy.Boxes.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Boxes.scala
@@ -102,7 +102,7 @@ object Boxes:
 
         val scale =
           form.ordinate.or(calibration)
-          . scale(extent.lowerOr0, extent.upperOr1, false, continuous.spacing, continuous.labelling)
+          . scale(extent.lowerOr0, extent.upperOr1, false, continuous.notation)
 
         Boxes.Fit(Bands(names), scale, summaries)
 
@@ -120,7 +120,7 @@ object Boxes:
 
         val all = extract(data)
         val names = all.map(_(0))
-        val layout = Cartesian.layout(fit.ordinate, names)
+        val layout = Cartesian.layout(fit.bands, fit.ordinate, names)
         val frame = layout.frame
         val boxWidth = frame.width*fit.bands.width*(1.0 - style.barGap)
         val outline = stroked(palette.axis, 1.0)

--- a/lib/tasseomancy/src/core/tasseomancy.Boxes.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Boxes.scala
@@ -32,11 +32,11 @@
                                                                                                   */
 package tasseomancy
 
-import Cartesian.*
+import Framing.*
 import anticipation.*
-import cataclysm.Css
 import denominative.*
 import hypotenuse.*
+import iridescence.*
 import murmuration.Traversable
 import murmuration.sortingAlgorithms.timsort
 import prepositional.*
@@ -73,24 +73,45 @@ object Boxes:
 
   case class Fit(bands: Bands, ordinate: Scale, summaries: Sequence[Summary])
 
-  given samples: [y: {Continuous, Calibration}] => Samples[y] is Plottable in Boxes to Boxes.Fit =
+  // The components of a box plot beyond the axes: the box between the quartiles, the median
+  // across it, and the whiskers to the extremes with their caps.
+  trait Style extends Chart.Cartesian:
+    def boxGap: Double
+
+    def box(corner: Point, width: Double, height: Double, color: Color in Srgb, series: Int)
+    :   List[Figure] =
+
+      List(Rectangle(corner, width.toFloat, height.toFloat, style = filled(color)))
+
+    def whisker(from: Point, to: Point, color: Color in Srgb): List[Figure] =
+      List(Polyline(List(from, to), style = stroked(color, 1.0)))
+
+    def whiskerCap(from: Point, to: Point, color: Color in Srgb): List[Figure] =
+      List(Polyline(List(from, to), style = stroked(color, 1.0)))
+
+    def median(from: Point, to: Point, color: Color in Srgb): List[Figure] =
+      List(Polyline(List(from, to), style = stroked(color, strokeWidth)))
+
+  given samples: [y: {Continuous, Calibration}]
+  =>  Samples[y] is Plottable in Boxes to Boxes.Fit by Boxes.Style =
     plottable[Samples[y], y]: samples => List(Histogram.positions(samples))
 
   given traversable: [collection, y]
   =>  ( traversable: collection is Traversable by Samples[y] )
   =>  ( continuous: y is Continuous, calibration: y is Calibration )
-  =>  collection is Plottable in Boxes to Boxes.Fit =
+  =>  collection is Plottable in Boxes to Boxes.Fit by Boxes.Style =
     plottable[collection, y]: collection =>
       List.from(traversable.traverse(collection).map(Histogram.positions(_)))
 
   private def plottable[data, y: {Continuous as continuous, Calibration as calibration}]
     ( extract: data -> List[(Text, Sequence[Double])] )
-  :   data is Plottable in Boxes to Boxes.Fit =
+  :   data is Plottable in Boxes to Boxes.Fit by Boxes.Style =
 
     new Plottable:
       type Self = data
       type Form = Boxes
       type Result = Boxes.Fit
+      type Operand = Boxes.Style
 
       def fit(form: Boxes, data: data): Boxes.Fit =
         val all = extract(data)
@@ -115,16 +136,14 @@ object Boxes:
         countOf(all) == fit.bands.count && known
 
       def draw(form: Boxes, data: data, fit: Boxes.Fit)
-        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+        ( using style: Boxes.Style, palette: ChartPalette, metric: FontMetric )
       :   Chart.Drawing =
 
         val all = extract(data)
         val names = all.map(_(0))
-        val layout = Cartesian.layout(fit.bands, fit.ordinate, names)
+        val layout = Framing.layout(fit.bands, fit.ordinate, names)
         val frame = layout.frame
-        val boxWidth = frame.width*fit.bands.width*(1.0 - style.barGap)
-        val outline = stroked(palette.axis, 1.0)
-        val medianStroke = stroked(palette.axis, style.strokeWidth)
+        val boxWidth = frame.width*fit.bands.width*(1.0 - style.boxGap)
         var index = 0
 
         val seriesParts = all.map: entry =>
@@ -137,30 +156,32 @@ object Boxes:
 
           def y(value: Double): Double = frame.y(fit.ordinate.unit(value))
 
-          def line(xa: Double, ya: Double, xb: Double, yb: Double, style: Css.Style): Figure =
-            Polyline(List(point(xa, ya), point(xb, yb)), style = style)
-
           val box =
-            Rectangle
-              ( point(x0, y(summary.upperQuartile)), boxWidth.toFloat,
-                (y(summary.lowerQuartile) - y(summary.upperQuartile)).abs.toFloat,
-                style = filled(color) )
+            style.box
+              ( point(x0, y(summary.upperQuartile)), boxWidth,
+                (y(summary.lowerQuartile) - y(summary.upperQuartile)).abs, color, index )
 
-          val figures: List[Figure] =
+          val top = y(summary.maximum)
+          val bottom = y(summary.minimum)
+          val axis = palette.axis
+
+          val parts: List[List[Figure]] =
             List
-              ( line(x, y(summary.maximum), x, y(summary.upperQuartile), outline),
-                line(x, y(summary.lowerQuartile), x, y(summary.minimum), outline),
-                line(x - cap, y(summary.maximum), x + cap, y(summary.maximum), outline),
-                line(x - cap, y(summary.minimum), x + cap, y(summary.minimum), outline),
+              ( style.whisker(point(x, top), point(x, y(summary.upperQuartile)), axis),
+                style.whisker(point(x, y(summary.lowerQuartile)), point(x, bottom), axis),
+                style.whiskerCap(point(x - cap, top), point(x + cap, top), axis),
+                style.whiskerCap(point(x - cap, bottom), point(x + cap, bottom), axis),
                 box,
-                line(x0, y(summary.median), x1, y(summary.median), medianStroke) )
+                style.median(point(x0, y(summary.median)), point(x1, y(summary.median)), axis) )
+
+          val figures: List[Figure] = parts.fold(List[Figure]())(_ + _)
 
           val part = seriesId(index) -> Group(figures, id = seriesId(index))
           index += 1
           part
 
         val legend = legendPart(layout.legend, names)
-        Cartesian.drawing(axes(frame, fit.bands, fit.ordinate) + seriesParts + legend)
+        Framing.drawing(axes(frame, fit.bands, fit.ordinate) + seriesParts + legend)
 
 // A box per set of samples: the box spans the quartiles with the median across it, and the
 // whiskers reach the least and greatest sample. Each set is a category on the abscissa.

--- a/lib/tasseomancy/src/core/tasseomancy.Calibration.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Calibration.scala
@@ -51,67 +51,50 @@ object Calibration:
   def apply[value](policy: Policy): value is Calibration = new Calibration:
     type Self = value
 
-    def scale
-      ( lower:     Double,
-        upper:     Double,
-        anchored:  Boolean,
-        spacing:   Scale.Spacing,
-        labelling: Scale.Labelling )
-    :   Scale =
-
+    def scale(lower: Double, upper: Double, anchored: Boolean, notation: Scale.Notation): Scale =
       policy match
-        case Policy.Linear =>
-          Calibration.linear(lower, upper, anchored, spacing, labelling, false)
-
-        case Policy.Tight =>
-          Calibration.linear(lower, upper, anchored, spacing, labelling, true)
-
-        case Policy.Logarithmic =>
-          Calibration.logarithmic(lower, upper, anchored, spacing, labelling)
+        case Policy.Linear      => Calibration.linear(lower, upper, anchored, notation, false)
+        case Policy.Tight       => Calibration.linear(lower, upper, anchored, notation, true)
+        case Policy.Logarithmic => Calibration.logarithmic(lower, upper, anchored, notation)
 
         case Policy.Adaptive =>
           if lower > 0.0 && upper/lower >= 1000.0
-          then Calibration.logarithmic(lower, upper, anchored, spacing, labelling)
-          else Calibration.linear(lower, upper, anchored, spacing, labelling, false)
+          then Calibration.logarithmic(lower, upper, anchored, notation)
+          else Calibration.linear(lower, upper, anchored, notation, false)
 
   private[tasseomancy] def linear
-    ( lower0:    Double,
-      upper0:    Double,
-      anchored:  Boolean,
-      spacing:   Scale.Spacing,
-      labelling: Scale.Labelling,
-      tight:     Boolean )
+    ( lower0:   Double,
+      upper0:   Double,
+      anchored: Boolean,
+      notation: Scale.Notation,
+      tight:    Boolean )
   :   Scale =
 
     val lower1 = if anchored && lower0 > 0.0 then 0.0 else lower0
     val upper1 = if anchored && upper0 < 0.0 then 0.0 else upper0
 
-    if tight then Scale(lower1, upper1, Scale.Transform.Linear, spacing, labelling) else
+    if tight then Scale(lower1, upper1, Scale.Transform.Linear, notation) else
       val span0 = upper1 - lower1
       val span = if span0 > 0.0 then span0 else if upper1 != 0.0 then upper1.abs else 1.0
 
-      val step = spacing match
+      val step = notation.spacing match
         case Scale.Spacing.Decimal     => Scale.step(span/5.0)
         case Scale.Spacing.Sexagesimal => Scale.sexagesimalStep(span/5.0)
 
       val lower = (lower1/step + Scale.tolerance).floor*step
       val upper = (upper1/step - Scale.tolerance).ceiling*step
       val upper2 = if upper > lower then upper else lower + step
-      Scale(lower, upper2, Scale.Transform.Linear, spacing, labelling)
+      Scale(lower, upper2, Scale.Transform.Linear, notation)
 
   private[tasseomancy] def logarithmic
-    ( lower0:    Double,
-      upper0:    Double,
-      anchored:  Boolean,
-      spacing:   Scale.Spacing,
-      labelling: Scale.Labelling )
+    ( lower0: Double, upper0: Double, anchored: Boolean, notation: Scale.Notation )
   :   Scale =
 
-    if lower0 <= 0.0 then linear(lower0, upper0, anchored, spacing, labelling, false) else
+    if lower0 <= 0.0 then linear(lower0, upper0, anchored, notation, false) else
       val lower = 10.0 ** log10(lower0).double.floor
       val upper = 10.0 ** log10(upper0).double.ceiling
       val upper2 = if upper > lower then upper else lower*10.0
-      Scale(lower, upper2, Scale.Transform.Logarithmic, spacing, labelling)
+      Scale(lower, upper2, Scale.Transform.Logarithmic, notation)
 
 // How the extent of the data becomes the range of an axis: whether positions are linear or
 // logarithmic, whether the range is padded out to whole gradations, and whether it must include
@@ -119,10 +102,4 @@ object Calibration:
 // one axis; the methods are independent of `Self`, so a calibration can also be passed explicitly
 // to a chart kind for one of its axes.
 trait Calibration extends Typeclass.Pure:
-  def scale
-    ( lower:     Double,
-      upper:     Double,
-      anchored:  Boolean,
-      spacing:   Scale.Spacing,
-      labelling: Scale.Labelling )
-  :   Scale
+  def scale(lower: Double, upper: Double, anchored: Boolean, notation: Scale.Notation): Scale

--- a/lib/tasseomancy/src/core/tasseomancy.Calibration.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Calibration.scala
@@ -1,0 +1,128 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import hypotenuse.*
+import prepositional.*
+
+object Calibration:
+  // The no-import default for an axis of any type: a linear scale, padded outward to whole
+  // gradation steps, and anchored at zero when the chart kind asks for it. Any
+  // `import calibrations.…` outranks this, because a lexically-scoped given beats a companion
+  // one.
+  given linear: [value] => value is Calibration = Calibration(Policy.Linear)
+
+  // The choices a calibration makes: linear or logarithmic positions (falling back to linear
+  // where a logarithm is undefined), adaptive between the two by the range's ratio, or linear
+  // over exactly the data's own extent.
+  enum Policy:
+    case Linear, Logarithmic, Adaptive, Tight
+
+  def apply[value](policy: Policy): value is Calibration = new Calibration:
+    type Self = value
+
+    def scale
+      ( lower:     Double,
+        upper:     Double,
+        anchored:  Boolean,
+        spacing:   Scale.Spacing,
+        labelling: Scale.Labelling )
+    :   Scale =
+
+      policy match
+        case Policy.Linear =>
+          Calibration.linear(lower, upper, anchored, spacing, labelling, false)
+
+        case Policy.Tight =>
+          Calibration.linear(lower, upper, anchored, spacing, labelling, true)
+
+        case Policy.Logarithmic =>
+          Calibration.logarithmic(lower, upper, anchored, spacing, labelling)
+
+        case Policy.Adaptive =>
+          if lower > 0.0 && upper/lower >= 1000.0
+          then Calibration.logarithmic(lower, upper, anchored, spacing, labelling)
+          else Calibration.linear(lower, upper, anchored, spacing, labelling, false)
+
+  private[tasseomancy] def linear
+    ( lower0:    Double,
+      upper0:    Double,
+      anchored:  Boolean,
+      spacing:   Scale.Spacing,
+      labelling: Scale.Labelling,
+      tight:     Boolean )
+  :   Scale =
+
+    val lower1 = if anchored && lower0 > 0.0 then 0.0 else lower0
+    val upper1 = if anchored && upper0 < 0.0 then 0.0 else upper0
+
+    if tight then Scale(lower1, upper1, Scale.Transform.Linear, spacing, labelling) else
+      val span0 = upper1 - lower1
+      val span = if span0 > 0.0 then span0 else if upper1 != 0.0 then upper1.abs else 1.0
+
+      val step = spacing match
+        case Scale.Spacing.Decimal     => Scale.step(span/5.0)
+        case Scale.Spacing.Sexagesimal => Scale.sexagesimalStep(span/5.0)
+
+      val lower = (lower1/step + Scale.tolerance).floor*step
+      val upper = (upper1/step - Scale.tolerance).ceiling*step
+      val upper2 = if upper > lower then upper else lower + step
+      Scale(lower, upper2, Scale.Transform.Linear, spacing, labelling)
+
+  private[tasseomancy] def logarithmic
+    ( lower0:    Double,
+      upper0:    Double,
+      anchored:  Boolean,
+      spacing:   Scale.Spacing,
+      labelling: Scale.Labelling )
+  :   Scale =
+
+    if lower0 <= 0.0 then linear(lower0, upper0, anchored, spacing, labelling, false) else
+      val lower = 10.0 ** log10(lower0).double.floor
+      val upper = 10.0 ** log10(upper0).double.ceiling
+      val upper2 = if upper > lower then upper else lower*10.0
+      Scale(lower, upper2, Scale.Transform.Logarithmic, spacing, labelling)
+
+// How the extent of the data becomes the range of an axis: whether positions are linear or
+// logarithmic, whether the range is padded out to whole gradations, and whether it must include
+// zero. Keyed on the type of the values on the axis, so that a scoped given for one type changes
+// one axis; the methods are independent of `Self`, so a calibration can also be passed explicitly
+// to a chart kind for one of its axes.
+trait Calibration extends Typeclass.Pure:
+  def scale
+    ( lower:     Double,
+      upper:     Double,
+      anchored:  Boolean,
+      spacing:   Scale.Spacing,
+      labelling: Scale.Labelling )
+  :   Scale

--- a/lib/tasseomancy/src/core/tasseomancy.Cartesian.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Cartesian.scala
@@ -146,10 +146,16 @@ private[tasseomancy] object Cartesian:
   private def legendWidth(names: List[Text])(using Chart.Style, FontMetric): Double =
     names.fold(0.0) { (acc, name) => acc.max(textWidth(name)) } + swatch + gap
 
+  // An axis's title: the style's, if given, with the axis's unit appended; otherwise the name and
+  // unit the axis's type supplies; a categorical axis has neither.
+  def title(ruler: Ruler, supplied: Optional[Text]): Optional[Text] = ruler match
+    case scale: Scale => scale.notation.title(supplied)
+    case _            => supplied
+
   // The plot rectangle: the style's size less the insets, the ordinate's labels (measured from
   // the gradations the full height would allow), the abscissa's labels, any titles and the
   // legend. A chart without an ordinate (a pie) passes none.
-  def layout(ordinate: Optional[Ruler], names: List[Text])
+  def layout(abscissa: Optional[Ruler], ordinate: Optional[Ruler], names: List[Text])
     ( using style: Chart.Style, metric: FontMetric )
   :   Layout =
 
@@ -164,14 +170,16 @@ private[tasseomancy] object Cartesian:
       ruler.gradations(budget).fold(0.0): (acc, gradation) => acc.max(textWidth(gradation.label))
 
     val axisRoom = ordinate.lay(0.0) { _ => gap + style.tickLength }
-    val titleWidth = style.ordinateTitle.lay(0.0) { _ => titleRoom }
+    val ordinateTitle = ordinate.let(title(_, style.ordinateTitle)).or(style.ordinateTitle)
+    val abscissaTitle = abscissa.let(title(_, style.abscissaTitle)).or(style.abscissaTitle)
+    val titleWidth = ordinateTitle.lay(0.0) { _ => titleRoom }
     val left = style.inset + labelWidth + axisRoom + titleWidth
     val legendRoom = if rightLegend then legendWidth(names) + gap*2 else 0.0
     val right = style.inset + style.fontSize*0.6 + legendRoom
     val top = style.inset + style.fontSize*0.6
     val legendRow = if bottomLegend then lineHeight else 0.0
     val labelRow = ordinate.lay(0.0) { _ => style.fontSize + gap + style.tickLength }
-    val titleHeight = style.abscissaTitle.lay(0.0) { _ => titleRoom }
+    val titleHeight = abscissaTitle.lay(0.0) { _ => titleRoom }
     val bottom = style.inset + labelRow + titleHeight + legendRow
     val width = (style.width - left - right).max(1.0)
     val height = (style.height - top - bottom).max(1.0)
@@ -259,7 +267,7 @@ private[tasseomancy] object Cartesian:
 
           label :: tick :: acc
 
-      val title = style.abscissaTitle.lay(Nil): text =>
+      val title = Cartesian.title(abscissa, style.abscissaTitle).lay(Nil): text =>
         val y = frame.bottom + style.tickLength + gap + style.fontSize + gap
         val position = point(frame.left + frame.width/2.0, y)
 
@@ -287,7 +295,7 @@ private[tasseomancy] object Cartesian:
 
           label :: tick :: acc
 
-      val title = style.ordinateTitle.lay(Nil): text =>
+      val title = Cartesian.title(ordinate, style.ordinateTitle).lay(Nil): text =>
         val centre = Delta(style.inset.toFloat, (frame.top + frame.height/2.0).toFloat)
         val transforms = List(Transform.Translate(centre), Transform.Rotate(Angle.degrees(-90.0)))
 
@@ -349,5 +357,15 @@ private[tasseomancy] object Cartesian:
 
     frame.lay(Nil): frame => List(legend(frame, names))
 
-  def drawing(parts: List[(Svg.Id, Figure)])(using style: Chart.Style): Chart.Drawing =
-    Chart.Drawing(style.width, style.height, Nil, parts.to[Ledger])
+  // The parts behind a backdrop in the palette's background colour, so that a dark palette's
+  // lettering is not set on the page's white.
+  def drawing(parts: List[(Svg.Id, Figure)])(using style: Chart.Style, palette: ChartPalette)
+  :   Chart.Drawing =
+
+    val backdrop =
+      Rectangle
+        ( point(0.0, 0.0), style.width.toFloat, style.height.toFloat,
+          style = filled(palette.background), id = Svg.Id(t"backdrop") )
+
+    val all = (Svg.Id(t"backdrop") -> backdrop) :: parts
+    Chart.Drawing(style.width, style.height, Nil, all.to[Ledger])

--- a/lib/tasseomancy/src/core/tasseomancy.Cartesian.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Cartesian.scala
@@ -1,0 +1,353 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import anticipation.*
+import cataclysm.Css
+import denominative.*
+import geodesy.*
+import gossamer.*
+import hypotenuse.*
+import iridescence.*
+import prepositional.*
+import rudiments.*
+import savagery.*
+import symbolism.*
+import vacuous.*
+
+// The layout and axes shared by every chart kind with an abscissa and an ordinate: the plot
+// rectangle after room is taken for labels, titles and the legend; the grid, the two axes with
+// their gradations; the legend itself; and the normalized forms of series that the kinds fit
+// and draw from.
+private[tasseomancy] object Cartesian:
+  case class Frame(left: Double, top: Double, width: Double, height: Double):
+    def right: Double = left + width
+    def bottom: Double = top + height
+    def x(unit: Double): Double = left + unit*width
+    def y(unit: Double): Double = top + (1.0 - unit)*height
+
+  case class Layout(frame: Frame, legend: Optional[Frame])
+
+  // A series with numeric axes, and one with a categorical abscissa, reduced to positions.
+  case class Datum(x: Double, y: Double, bounds: Optional[(Double, Double)])
+  case class Trace(name: Text, data: Sequence[Datum])
+  case class Mark(category: Text, y: Double, bounds: Optional[(Double, Double)])
+  case class Column(name: Text, marks: Sequence[Mark])
+
+  def traceOf[x: Continuous as cx, y: Continuous as cy](series: Series[x, y]): Trace =
+    val data = series.points.map: (abscissa, ordinate) =>
+      Datum(cx.position(abscissa), cy.position(ordinate), cy.bounds(ordinate))
+
+    Trace(series.name, data)
+
+  def columnOf[x: Categorical as cx, y: Continuous as cy](series: Series[x, y]): Column =
+    val marks = series.points.map: (abscissa, ordinate) =>
+      Mark(cx.label(abscissa), cy.position(ordinate), cy.bounds(ordinate))
+
+    Column(series.name, marks)
+
+  // The categories of some columns, in first-appearance order.
+  def categories(columns: List[Column]): Sequence[Text] =
+    val labels = columns.fold(List[Text]()): (acc, column) =>
+      column.marks.fold(acc): (acc2, mark) =>
+        if acc2.exists(_ == mark.category) then acc2 else mark.category :: acc2
+
+    labels.reverse.to[Sequence]
+
+  object Extent:
+    val empty: Extent = Extent(0.0, 0.0, false)
+
+  // The least and greatest of some values, growing as values are included. An empty extent is
+  // reported as `[0, 1]`, so an axis over no data is still an axis.
+  case class Extent(lower: Double, upper: Double, populated: Boolean):
+    def include(value: Double): Extent =
+      if !populated then Extent(value, value, true)
+      else Extent(lower.min(value), upper.max(value), true)
+
+    def include(bounds: Optional[(Double, Double)]): Extent =
+      bounds.lay(this): (low, high) => include(low).include(high)
+
+    def lowerOr0: Double = if populated then lower else 0.0
+    def upperOr1: Double = if populated then upper else 1.0
+
+  def countOf[element](list: List[element]): Int = list.fold(0): (n, _) => n + 1
+
+  // Colour and style helpers: every figure's style is an inline declaration set, so an SVG is
+  // self-contained.
+  private val hexDigits: Text = t"0123456789abcdef"
+
+  def hexOf(color: Color in Srgb): Text =
+    val srgb = color.to[Srgb]
+
+    def channel(value: Double): Text =
+      val byte = (value*255.0).round.toInt.max(0).min(255)
+      t"${hexDigits.at((byte/16).z).or('0')}${hexDigits.at((byte%16).z).or('0')}"
+
+    t"#${channel(srgb.red)}${channel(srgb.green)}${channel(srgb.blue)}"
+
+  def px(value: Double): Text = t"${value.toString}px"
+  def css(pairs: (Text, Text)*): Css.Style = Css.Style.of(List.from(pairs))
+
+  def filled(color: Color in Srgb, opacity: Optional[Double] = Unset): Css.Style =
+    val base = List(t"fill" -> hexOf(color), t"stroke" -> t"none")
+    val alpha = opacity.lay(Nil): value => List(t"fill-opacity" -> value.toString.tt)
+    Css.Style.of(base + alpha)
+
+  def stroked(color: Color in Srgb, width: Double): Css.Style =
+    css
+      ( t"fill" -> t"none", t"stroke" -> hexOf(color), t"stroke-width" -> px(width),
+        t"stroke-linejoin" -> t"round", t"stroke-linecap" -> t"round" )
+
+  def font(using style: Chart.Style, palette: ChartPalette): Css.Style =
+    css
+      ( t"font-family" -> style.fontFamily, t"font-size" -> px(style.fontSize),
+        t"fill" -> hexOf(palette.text) )
+
+  def textWidth(text: Text)(using metric: FontMetric, style: Chart.Style): Double =
+    metric.width(text).value*style.fontSize
+
+  def point(x: Double, y: Double): Point = Point(x.toFloat, y.toFloat)
+  def seriesId(index: Int): Svg.Id = Svg.Id(t"series-$index")
+
+  private def gap(using style: Chart.Style): Double = style.fontSize*0.4
+  private def lineHeight(using style: Chart.Style): Double = style.fontSize*1.6
+  private def swatch(using style: Chart.Style): Double = style.fontSize
+
+  private def legendWidth(names: List[Text])(using Chart.Style, FontMetric): Double =
+    names.fold(0.0) { (acc, name) => acc.max(textWidth(name)) } + swatch + gap
+
+  // The plot rectangle: the style's size less the insets, the ordinate's labels (measured from
+  // the gradations the full height would allow), the abscissa's labels, any titles and the
+  // legend. A chart without an ordinate (a pie) passes none.
+  def layout(ordinate: Optional[Ruler], names: List[Text])
+    ( using style: Chart.Style, metric: FontMetric )
+  :   Layout =
+
+    val titleRoom = style.fontSize*1.6
+    val entries = countOf(names)
+    val showLegend = entries > 0 && style.legend != Chart.Legend.Hidden
+    val rightLegend = showLegend && style.legend == Chart.Legend.Right
+    val bottomLegend = showLegend && style.legend == Chart.Legend.Bottom
+
+    val labelWidth = ordinate.lay(0.0): ruler =>
+      val budget = (style.height/style.pitch).toInt.max(2)
+      ruler.gradations(budget).fold(0.0): (acc, gradation) => acc.max(textWidth(gradation.label))
+
+    val axisRoom = ordinate.lay(0.0) { _ => gap + style.tickLength }
+    val titleWidth = style.ordinateTitle.lay(0.0) { _ => titleRoom }
+    val left = style.inset + labelWidth + axisRoom + titleWidth
+    val legendRoom = if rightLegend then legendWidth(names) + gap*2 else 0.0
+    val right = style.inset + style.fontSize*0.6 + legendRoom
+    val top = style.inset + style.fontSize*0.6
+    val legendRow = if bottomLegend then lineHeight else 0.0
+    val labelRow = ordinate.lay(0.0) { _ => style.fontSize + gap + style.tickLength }
+    val titleHeight = style.abscissaTitle.lay(0.0) { _ => titleRoom }
+    val bottom = style.inset + labelRow + titleHeight + legendRow
+    val width = (style.width - left - right).max(1.0)
+    val height = (style.height - top - bottom).max(1.0)
+    val frame = Frame(left, top, width, height)
+
+    val legend: Optional[Frame] =
+      if !showLegend then Unset
+      else if rightLegend
+      then Frame(frame.right + gap*2, frame.top, legendWidth(names), entries*lineHeight)
+      else Frame(frame.left, style.height - style.inset - lineHeight, frame.width, lineHeight)
+
+    Layout(frame, legend)
+
+  // The abscissa's gradations: as many as the pitch allows on a numeric axis, reduced until their
+  // labels no longer overlap; every band of a categorical one.
+  def abscissaGradations(frame: Frame, ruler: Ruler)
+    ( using style: Chart.Style, metric: FontMetric )
+  :   Sequence[Gradation] =
+
+    ruler match
+      case bands: Bands => bands.gradations(0)
+
+      case scale: Scale =>
+        var budget = (frame.width/style.pitch).toInt.max(1)
+        var marks = scale.gradations(budget)
+
+        def crowded: Boolean =
+          val occupied = marks.fold(0.0): (acc, mark) =>
+            if mark.major then acc + textWidth(mark.label) + gap else acc
+
+          occupied > frame.width
+
+        while budget > 1 && crowded do
+          budget -= 1
+          marks = scale.gradations(budget)
+
+        marks
+
+      case other => other.gradations((frame.width/style.pitch).toInt.max(1))
+
+  // The grid and both axes, as identified groups.
+  def axes(frame: Frame, abscissa: Ruler, ordinate: Ruler)
+    ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+  :   List[(Svg.Id, Figure)] =
+
+    val xs = abscissaGradations(frame, abscissa)
+    val ys = ordinate.gradations((frame.height/style.pitch).toInt.max(2))
+    val lettering = font
+    val gridStroke = stroked(palette.grid, 1.0)
+    val axisStroke = stroked(palette.axis, 1.0)
+
+    def line(x0: Double, y0: Double, x1: Double, y1: Double, style: Css.Style): Figure =
+      Polyline(List(point(x0, y0), point(x1, y1)), style = style)
+
+    val gridLines: List[Figure] =
+      if !style.grid then Nil else
+        val horizontal = ys.fold(List[Figure]()): (acc, mark) =>
+          if !mark.major then acc else
+            val y = frame.y(mark.position)
+            line(frame.left, y, frame.right, y, gridStroke) :: acc
+
+        abscissa match
+          case scale: Scale =>
+            xs.fold(horizontal): (acc, mark) =>
+              if !mark.major then acc else
+                val x = frame.x(mark.position)
+                line(x, frame.top, x, frame.bottom, gridStroke) :: acc
+
+          case _ => horizontal
+
+    val abscissaFigures: List[Figure] =
+      val baseline = line(frame.left, frame.bottom, frame.right, frame.bottom, axisStroke)
+
+      val marks = xs.fold(List[Figure]()): (acc, mark) =>
+        val x = frame.x(mark.position)
+        val tick = line(x, frame.bottom, x, frame.bottom + style.tickLength, axisStroke)
+
+        if !mark.major then tick :: acc else
+          val position = point(x, frame.bottom + style.tickLength + gap)
+
+          val label =
+            Lettering
+              ( position, mark.label, Lettering.Anchor.Middle, Lettering.Baseline.Hanging,
+                style = lettering )
+
+          label :: tick :: acc
+
+      val title = style.abscissaTitle.lay(Nil): text =>
+        val y = frame.bottom + style.tickLength + gap + style.fontSize + gap
+        val position = point(frame.left + frame.width/2.0, y)
+
+        List
+          ( Lettering
+              ( position, text, Lettering.Anchor.Middle, Lettering.Baseline.Hanging,
+                style = lettering ) )
+
+      baseline :: (marks.reverse + title)
+
+    val ordinateFigures: List[Figure] =
+      val baseline = line(frame.left, frame.top, frame.left, frame.bottom, axisStroke)
+
+      val marks = ys.fold(List[Figure]()): (acc, mark) =>
+        val y = frame.y(mark.position)
+        val tick = line(frame.left - style.tickLength, y, frame.left, y, axisStroke)
+
+        if !mark.major then tick :: acc else
+          val position = point(frame.left - style.tickLength - gap, y)
+
+          val label =
+            Lettering
+              ( position, mark.label, Lettering.Anchor.End, Lettering.Baseline.Middle,
+                style = lettering )
+
+          label :: tick :: acc
+
+      val title = style.ordinateTitle.lay(Nil): text =>
+        val centre = Delta(style.inset.toFloat, (frame.top + frame.height/2.0).toFloat)
+        val transforms = List(Transform.Translate(centre), Transform.Rotate(Angle.degrees(-90.0)))
+
+        List
+          ( Lettering
+              ( point(0.0, 0.0), text, Lettering.Anchor.Middle, Lettering.Baseline.Hanging,
+                style = lettering, transforms = transforms ) )
+
+      baseline :: (marks.reverse + title)
+
+    List
+      ( Svg.Id(t"grid") -> Group(gridLines.reverse, id = Svg.Id(t"grid")),
+        Svg.Id(t"abscissa") -> Group(abscissaFigures, id = Svg.Id(t"abscissa")),
+        Svg.Id(t"ordinate") -> Group(ordinateFigures, id = Svg.Id(t"ordinate")) )
+
+  // The legend: a swatch and a name per series, stacked at the right or flowing along the bottom.
+  def legend(frame: Frame, names: List[Text])
+    ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+  :   (Svg.Id, Figure) =
+
+    val lettering = font
+    val vertical = style.legend == Chart.Legend.Right
+    var index = 0
+    var x = frame.left
+    var figures: List[Figure] = Nil
+
+    names.foreach: name =>
+      val y = if vertical then frame.top + index*lineHeight else frame.top
+      val corner = point(x, y + (lineHeight - swatch)/2.0)
+      val color = filled(palette.color(index))
+      val box = Rectangle(corner, swatch.toFloat, swatch.toFloat, style = color)
+      val position = point(x + swatch + gap, y + lineHeight/2.0)
+
+      val label =
+        Lettering
+          ( position, name, Lettering.Anchor.Start, Lettering.Baseline.Middle, style = lettering )
+
+      figures = label :: box :: figures
+      if !vertical then x += swatch + gap + textWidth(name) + gap*3
+      index += 1
+
+    Svg.Id(t"legend") -> Group(figures.reverse, id = Svg.Id(t"legend"))
+
+  // An error bar: a vertical line between two ordinate positions with a cap at each end.
+  def errorBar(x: Double, low: Double, high: Double, cap: Double)(using palette: ChartPalette)
+  :   List[Figure] =
+
+    val bar = stroked(palette.axis, 1.0)
+
+    List
+      ( Polyline(List(point(x, low), point(x, high)), style = bar),
+        Polyline(List(point(x - cap, low), point(x + cap, low)), style = bar),
+        Polyline(List(point(x - cap, high), point(x + cap, high)), style = bar) )
+
+  // The parts of a chart whose legend, if any, occupies the given frame.
+  def legendPart(frame: Optional[Frame], names: List[Text])
+    ( using Chart.Style, ChartPalette, FontMetric )
+  :   List[(Svg.Id, Figure)] =
+
+    frame.lay(Nil): frame => List(legend(frame, names))
+
+  def drawing(parts: List[(Svg.Id, Figure)])(using style: Chart.Style): Chart.Drawing =
+    Chart.Drawing(style.width, style.height, Nil, parts.to[Ledger])

--- a/lib/tasseomancy/src/core/tasseomancy.Categorical.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Categorical.scala
@@ -1,0 +1,50 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import anticipation.*
+import distillate.*
+import prepositional.*
+
+object Categorical:
+  given text: Text is Categorical = text => text
+  given category: Category is Categorical = _.label
+
+  given enumerable: [enumeration <: scala.reflect.Enum: Enumerable as evidence]
+  =>  enumeration is Categorical =
+    evidence.name(_)
+
+// A value that names a category on an axis: distinct labels in first-appearance order, with no
+// arithmetic between them. What a bar chart's or a pie chart's abscissa is made of.
+trait Categorical extends Typeclass.Pure:
+  def label(value: Self): Text

--- a/lib/tasseomancy/src/core/tasseomancy.Category.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Category.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import anticipation.*
+
+// A category with no type of its own: what `Series.categorical` produces from a numeric axis.
+case class Category(label: Text)

--- a/lib/tasseomancy/src/core/tasseomancy.Category.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Category.scala
@@ -33,6 +33,11 @@
 package tasseomancy
 
 import anticipation.*
+import spectacular.*
 
-// A category with no type of its own: what `Series.categorical` produces from a numeric axis.
+object Category:
+  def apply[label: Showable](label: label): Category = new Category(label.show)
+
+// A category with no type of its own: what `Series.categorical` produces from a numeric axis, or
+// any showable value wrapped by hand.
 case class Category(label: Text)

--- a/lib/tasseomancy/src/core/tasseomancy.Chart.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Chart.scala
@@ -1,0 +1,112 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import anticipation.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import savagery.*
+import spectacular.*
+import vacuous.*
+
+object Chart:
+  enum Legend:
+    case Hidden, Right, Bottom
+
+  object Style:
+    given standard: Style = Style()
+
+  // Everything about a chart's appearance that is not the data: its size, its lines and markers,
+  // its type, how densely its axes are graduated (`pitch` is the least spacing between
+  // gradations, in pixels), and where its legend goes. Colours are the `ChartPalette`'s.
+  case class Style
+    ( width:         Double         = 640.0,
+      height:        Double         = 400.0,
+      inset:         Double         = 12.0,
+      strokeWidth:   Double         = 2.0,
+      markerRadius:  Double         = 3.5,
+      markers:       Boolean        = false,
+      fontFamily:    Text           = t"sans-serif",
+      fontSize:      Double         = 12.0,
+      tickLength:    Double         = 5.0,
+      pitch:         Double         = 60.0,
+      grid:          Boolean        = true,
+      legend:        Legend         = Legend.Right,
+      barGap:        Double         = 0.25,
+      abscissaTitle: Optional[Text] = Unset,
+      ordinateTitle: Optional[Text] = Unset )
+
+  // A rendered chart as its parts, each under a stable identifier — `grid`, `abscissa`,
+  // `ordinate`, `legend`, `series-0`, `series-1`, … — in drawing order. The identifiers are what
+  // a revision names.
+  case class Drawing
+    ( width: Double, height: Double, defs: List[Svg.Def], parts: Ledger[Svg.Id, Figure] ):
+    def svg: Svg = Svg(width.toFloat, height.toFloat, defs, parts.values)
+
+  // What changed between one drawing of a chart and the next: either the whole chart, because
+  // the axes moved to fit the new data, or only the identified parts that differ. A page holding
+  // the SVG needs only to replace an element by its identifier, or the whole element.
+  enum Revision:
+    case Redraw(svg: Svg)
+    case Replace(id: Svg.Id, figure: Figure)
+
+// Data, a chart kind that can draw it, and the fit of the one to the other. Immutable: `revise`
+// yields a new chart for new data along with what has to change on the page, keeping the fit
+// whenever it still accommodates the data so that the axes hold still.
+class Chart[data, form, fit](val data: data, val form: form, val fit: fit)
+  ( using val plottable: data is Plottable in form to fit ):
+
+  def drawing(using Chart.Style, ChartPalette, FontMetric): Chart.Drawing =
+    plottable.draw(form, data, fit)
+
+  def svg(using Chart.Style, ChartPalette, FontMetric): Svg = drawing.svg
+
+  def revise(data2: data)(using Chart.Style, ChartPalette, FontMetric)
+  :   (Chart[data, form, fit], List[Chart.Revision]) =
+
+    if plottable.accommodates(form, fit, data2) then
+      val next = Chart(data2, form, fit)
+
+      val before: List[(Svg.Id, Text)] = drawing.parts.fold(List[(Svg.Id, Text)]()): (acc, pair) =>
+        (pair(0), pair(1).xml.show) :: acc
+
+      val revisions = next.drawing.parts.fold(List[Chart.Revision]()): (acc, pair) =>
+        val rendered = pair(1).xml.show
+        val unchanged = before.exists: (id, text) => id == pair(0) && text == rendered
+        if unchanged then acc else Chart.Revision.Replace(pair(0), pair(1)) :: acc
+
+      (next, revisions.reverse)
+    else
+      val next = Chart(data2, form, plottable.fit(form, data2))
+      (next, List(Chart.Revision.Redraw(next.svg)))

--- a/lib/tasseomancy/src/core/tasseomancy.Chart.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Chart.scala
@@ -32,8 +32,12 @@
                                                                                                   */
 package tasseomancy
 
+import Framing.*
 import anticipation.*
+import cataclysm.Css
+import geodesy.*
 import gossamer.*
+import iridescence.*
 import prepositional.*
 import rudiments.*
 import savagery.*
@@ -44,32 +48,171 @@ object Chart:
   enum Legend:
     case Hidden, Right, Bottom
 
-  object Style:
-    given standard: Style = Style()
+  enum Axis:
+    case Abscissa, Ordinate
 
-  // Everything about a chart's appearance that is not the data: its size, its lines and markers,
-  // its type, how densely its axes are graduated (`pitch` is the least spacing between
-  // gradations, in pixels), and where its legend goes. Colours are the `ChartPalette`'s.
-  case class Style
+  object Style:
+    given standard: Standard = Standard()
+
+  // What every kind of chart shares: the canvas, the typeface, the legend, and how the components
+  // common to all of them — a run of text, the backdrop, a legend entry — become figures. A chart
+  // kind computes the geometry (where a label sits, how tall a bar is) and calls one of these
+  // methods for each component; a style overrides the methods it wants drawn differently, and
+  // inherits the rest. `Standard` implements every kind's style with the defaults below.
+  trait Style:
+    def width: Double
+    def height: Double
+    def inset: Double
+    def fontFamily: Text
+    def fontSize: Double
+    def legend: Legend
+
+    // The unit of spacing between components, derived from the type size.
+    def gap: Double = fontSize*0.4
+
+    def font(color: Color in Srgb): Css.Style =
+      css(t"font-family" -> fontFamily, t"font-size" -> px(fontSize), t"fill" -> hexOf(color))
+
+    // Every label, title and legend entry is set through this, unless a more specific method is
+    // overridden.
+    def lettering
+      ( position:   Point,
+        text:       Text,
+        anchor:     Lettering.Anchor,
+        baseline:   Lettering.Baseline,
+        color:      Color in Srgb,
+        transforms: List[Transform] = Nil )
+    :   Figure =
+
+      Lettering(position, text, anchor, baseline, style = font(color), transforms = transforms)
+
+    def backdrop(width: Double, height: Double, color: Color in Srgb): List[Figure] =
+      List(Rectangle(point(0.0, 0.0), width.toFloat, height.toFloat, style = filled(color)))
+
+    def legendLineHeight: Double = fontSize*1.6
+    def swatchSize: Double = fontSize
+
+    def swatch(corner: Point, color: Color in Srgb, series: Int): List[Figure] =
+      List(Rectangle(corner, swatchSize.toFloat, swatchSize.toFloat, style = filled(color)))
+
+    def legendLabel(position: Point, name: Text, color: Color in Srgb): List[Figure] =
+      List(lettering(position, name, Lettering.Anchor.Start, Lettering.Baseline.Middle, color))
+
+  // What every chart with an abscissa and an ordinate shares: the axes and their gradations, the
+  // grid, the titles, and the markers, error bars and point labels that lines and scatter plots
+  // draw. Positions are given in the drawing's coordinates; the style decides the shape, the
+  // stroke and where a label sits relative to its tick.
+  trait Cartesian extends Style:
+    def pitch: Double
+    def tickLength: Double
+    def grid: Boolean
+    def abscissaTitle: Optional[Text]
+    def ordinateTitle: Optional[Text]
+    def strokeWidth: Double
+    def markerRadius: Double
+
+    def axisLine(from: Point, to: Point, axis: Axis, color: Color in Srgb): List[Figure] =
+      List(Polyline(List(from, to), style = stroked(color, 1.0)))
+
+    // Drawn at the far end of each axis; nothing by default.
+    def arrowhead(tip: Point, axis: Axis, color: Color in Srgb): List[Figure] = Nil
+
+    // Drawn at the origin end of a linear axis whose range does not include zero; nothing by
+    // default.
+    def axisBreak(at: Point, axis: Axis, color: Color in Srgb): List[Figure] = Nil
+
+    def gridLine(from: Point, to: Point, axis: Axis, color: Color in Srgb): List[Figure] =
+      if grid then List(Polyline(List(from, to), style = stroked(color, 1.0))) else Nil
+
+    def tick(at: Point, axis: Axis, major: Boolean, color: Color in Srgb): List[Figure] =
+      val far = axis match
+        case Axis.Abscissa => point(at.x, at.y + tickLength)
+        case Axis.Ordinate => point(at.x - tickLength, at.y)
+
+      List(Polyline(List(at, far), style = stroked(color, 1.0)))
+
+    def tickLabel(at: Point, text: Text, axis: Axis, color: Color in Srgb): List[Figure] =
+      axis match
+        case Axis.Abscissa =>
+          val position = point(at.x, at.y + tickLength + gap)
+          val anchor = Lettering.Anchor.Middle
+          List(lettering(position, text, anchor, Lettering.Baseline.Hanging, color))
+
+        case Axis.Ordinate =>
+          val position = point(at.x - tickLength - gap, at.y)
+          List(lettering(position, text, Lettering.Anchor.End, Lettering.Baseline.Middle, color))
+
+    // The room an axis's ticks and labels take beyond its line, which the layout reserves: a
+    // style that rotates or moves its labels overrides this to match.
+    def labelRoom(axis: Axis, labels: List[Text])(using metric: FontMetric): Double = axis match
+      case Axis.Abscissa => tickLength + gap + fontSize
+
+      case Axis.Ordinate =>
+        val widest = labels.fold(0.0): (acc, label) => acc.max(metric.width(label).value*fontSize)
+        tickLength + gap + widest
+
+    def titleRoom: Double = fontSize*1.6
+
+    // `at` is the title's anchor: below the middle of the abscissa, or beside the middle of the
+    // ordinate at the drawing's left edge, where the default turns the text upright.
+    def axisTitle(at: Point, text: Text, axis: Axis, color: Color in Srgb): List[Figure] =
+      axis match
+        case Axis.Abscissa =>
+          List(lettering(at, text, Lettering.Anchor.Middle, Lettering.Baseline.Hanging, color))
+
+        case Axis.Ordinate =>
+          val transforms =
+            List(Transform.Translate(Delta(at.x, at.y)), Transform.Rotate(Angle.degrees(-90.0)))
+
+          List
+            ( lettering
+                ( point(0.0, 0.0), text, Lettering.Anchor.Middle, Lettering.Baseline.Hanging,
+                  color, transforms ) )
+
+    def marker(at: Point, color: Color in Srgb, series: Int): List[Figure] =
+      List(Circle(at, markerRadius.toFloat, style = filled(color)))
+
+    def errorBar(x: Double, top: Double, bottom: Double, cap: Double, color: Color in Srgb)
+    :   List[Figure] =
+
+      val bar = stroked(color, 1.0)
+
+      List
+        ( Polyline(List(point(x, top), point(x, bottom)), style = bar),
+          Polyline(List(point(x - cap, top), point(x + cap, top)), style = bar),
+          Polyline(List(point(x - cap, bottom), point(x + cap, bottom)), style = bar) )
+
+    // The note an `Annotated` point carries, set beside its marker.
+    def pointLabel(at: Point, text: Text, color: Color in Srgb): List[Figure] =
+      val position = point(at.x + markerRadius + gap/2.0, at.y)
+      List(lettering(position, text, Lettering.Anchor.Start, Lettering.Baseline.Middle, color))
+
+  // The default style of every chart kind, as a case class: its parameters are named
+  // arguments, and any component's rendering is an override on an anonymous subclass.
+  case class Standard
     ( width:         Double         = 640.0,
       height:        Double         = 400.0,
       inset:         Double         = 12.0,
+      fontFamily:    Text           = t"sans-serif",
+      fontSize:      Double         = 12.0,
+      legend:        Legend         = Legend.Right,
+      pitch:         Double         = 60.0,
+      tickLength:    Double         = 5.0,
+      grid:          Boolean        = true,
+      abscissaTitle: Optional[Text] = Unset,
+      ordinateTitle: Optional[Text] = Unset,
       strokeWidth:   Double         = 2.0,
       markerRadius:  Double         = 3.5,
       markers:       Boolean        = false,
-      fontFamily:    Text           = t"sans-serif",
-      fontSize:      Double         = 12.0,
-      tickLength:    Double         = 5.0,
-      pitch:         Double         = 60.0,
-      grid:          Boolean        = true,
-      legend:        Legend         = Legend.Right,
       barGap:        Double         = 0.25,
-      abscissaTitle: Optional[Text] = Unset,
-      ordinateTitle: Optional[Text] = Unset )
+      boxGap:        Double         = 0.25,
+      hole:          Double         = 0.0 )
+  extends Bars.Style, StackedBars.Style, Histogram.Style, Lines.Style, Scatter.Style, Boxes.Style,
+    Pie.Style
 
-  // A rendered chart as its parts, each under a stable identifier — `grid`, `abscissa`,
-  // `ordinate`, `legend`, `series-0`, `series-1`, … — in drawing order. The identifiers are what
-  // a revision names.
+  // A rendered chart as its parts, each under a stable identifier — `backdrop`, `grid`,
+  // `abscissa`, `ordinate`, `legend`, `series-0`, `series-1`, … — in drawing order. The
+  // identifiers are what a revision names.
   case class Drawing
     ( width: Double, height: Double, defs: List[Svg.Def], parts: Ledger[Svg.Id, Figure] ):
     def svg: Svg = Svg(width.toFloat, height.toFloat, defs, parts.values)
@@ -83,17 +226,18 @@ object Chart:
 
 // Data, a chart kind that can draw it, and the fit of the one to the other. Immutable: `revise`
 // yields a new chart for new data along with what has to change on the page, keeping the fit
-// whenever it still accommodates the data so that the axes hold still.
-class Chart[data, form, fit](val data: data, val form: form, val fit: fit)
-  ( using val plottable: data is Plottable in form to fit ):
+// whenever it still accommodates the data so that the axes hold still. The style type is the
+// kind's own (`Bars.Style` for bars), so a chart asks for exactly the components it draws.
+class Chart[data, form, fit, style <: Chart.Style](val data: data, val form: form, val fit: fit)
+  ( using val plottable: data is Plottable in form to fit by style ):
 
-  def drawing(using Chart.Style, ChartPalette, FontMetric): Chart.Drawing =
+  def drawing(using style, ChartPalette, FontMetric): Chart.Drawing =
     plottable.draw(form, data, fit)
 
-  def svg(using Chart.Style, ChartPalette, FontMetric): Svg = drawing.svg
+  def svg(using style, ChartPalette, FontMetric): Svg = drawing.svg
 
-  def revise(data2: data)(using Chart.Style, ChartPalette, FontMetric)
-  :   (Chart[data, form, fit], List[Chart.Revision]) =
+  def revise(data2: data)(using style, ChartPalette, FontMetric)
+  :   (Chart[data, form, fit, style], List[Chart.Revision]) =
 
     if plottable.accommodates(form, fit, data2) then
       val next = Chart(data2, form, fit)

--- a/lib/tasseomancy/src/core/tasseomancy.ChartPalette.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.ChartPalette.scala
@@ -1,0 +1,68 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import denominative.*
+import iridescence.*
+import prepositional.*
+import rudiments.*
+
+object ChartPalette:
+  // The no-import default: a light palette with a categorical ramp of eight distinguishable
+  // hues. Any `import palettes.…` outranks this, because a lexically-scoped given beats a
+  // companion one.
+  given slate: ChartPalette = tasseomancy.palettes.slateChartPalette
+
+  // A palette from a theme: its colours, in order, for the series; its foreground for the axes
+  // and text, and a blend of the two for the grid.
+  def of(theme: Theme { type Form = Srgb }): ChartPalette = new ChartPalette:
+    val series: Sequence[Color in Srgb] = theme.colors.to[Sequence]
+    def background: Color in Srgb = theme.background
+    def foreground: Color in Srgb = theme.foreground
+    def axis: Color in Srgb = mix(foreground, background, 0.3)
+    def grid: Color in Srgb = mix(foreground, background, 0.85)
+    def text: Color in Srgb = foreground
+
+// The colours a chart draws with, named by the role each plays rather than by hue: the series
+// ramp, cycled when there are more series than colours; the axes and their gradations; the grid;
+// the lettering. A real trait rather than a structural refinement of `Palette`, as `GaugePalette`
+// is, so that member selection is a virtual call rather than reflection.
+trait ChartPalette extends Palette:
+  type Form = Srgb
+  def series: Sequence[Color in Srgb]
+  def axis: Color in Srgb
+  def grid: Color in Srgb
+  def text: Color in Srgb
+
+  def color(index: Int): Color in Srgb =
+    if series.size == 0 then foreground else Sequence.at(series, index%series.size)

--- a/lib/tasseomancy/src/core/tasseomancy.Continuous.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Continuous.scala
@@ -1,0 +1,81 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import anticipation.*
+import aviation.*
+import gossamer.*
+import hypotenuse.*
+import prepositional.*
+import quantitative.*
+import vacuous.*
+
+object Continuous:
+  given int: Int is Continuous = _.toDouble
+  given long: Long is Continuous = _.toDouble
+  given double: Double is Continuous = double => double
+  given float: Float is Continuous = _.toDouble
+  given f64: F64 is Continuous = _.double
+
+  // Any quantity, by its magnitude in its own units. The more specific `duration` below takes
+  // precedence for seconds, where clock-time spacing reads better than decimal.
+  given quantity: [units <: Measure] => Quantity[units] is Continuous = _.value
+
+  given duration: Duration is Continuous:
+    def position(value: Duration): Double = value.value
+    override def spacing: Scale.Spacing = Scale.Spacing.Sexagesimal
+    override def labelling: Scale.Labelling = Scale.Labelling.Interval
+
+  // An instant is placed by its seconds since the epoch, whatever the resolution of its
+  // timeline, and labelled as a time of day.
+  given instant: [transport] => (resolution: transport is Resolution)
+  =>  (Instant over transport) is Continuous:
+    def position(value: Instant over transport): Double =
+      value.long.toDouble*resolution.nanos/1.0e9
+
+    override def spacing: Scale.Spacing = Scale.Spacing.Sexagesimal
+    override def labelling: Scale.Labelling = Scale.Labelling.Clock
+
+  given estimate: Estimate is Continuous:
+    def position(value: Estimate): Double = value.value
+    override def bounds(value: Estimate): Optional[(Double, Double)] = (value.lower, value.upper)
+
+// A value with a position on a numeric axis, and optionally an interval around it. Positions
+// are what a line, a scatter plot or a bar's height is drawn from; `spacing` and `labelling`
+// say how an axis of this type is graduated and how its gradations are written, since seconds
+// are read differently from counts.
+trait Continuous extends Typeclass.Pure:
+  def position(value: Self): Double
+  def bounds(value: Self): Optional[(Double, Double)] = Unset
+  def spacing: Scale.Spacing = Scale.Spacing.Decimal
+  def labelling: Scale.Labelling = Scale.Labelling.Number(t"")

--- a/lib/tasseomancy/src/core/tasseomancy.Continuous.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Continuous.scala
@@ -47,35 +47,47 @@ object Continuous:
   given float: Float is Continuous = _.toDouble
   given f64: F64 is Continuous = _.double
 
-  // Any quantity, by its magnitude in its own units. The more specific `duration` below takes
-  // precedence for seconds, where clock-time spacing reads better than decimal.
-  given quantity: [units <: Measure] => Quantity[units] is Continuous = _.value
+  // Any quantity, by its magnitude in its own units, which name the axis: `distance / m`. Inline,
+  // so that the units and the quantity's name are read from the type where the chart is made.
+  // The more specific `duration` below takes precedence for seconds, where clock-time spacing
+  // reads better than decimal.
+  inline given quantity: [units <: Measure] => Quantity[units] is Continuous =
+    val notation = Scale.Notation(name = Quantity.dimension[units], unit = Quantity.units[units])
+    QuantityContinuous[units](notation)
+
+  // A named class rather than an anonymous instance, which an inline given would duplicate at
+  // every expansion site.
+  class QuantityContinuous[units <: Measure](notation0: Scale.Notation)
+  extends Continuous:
+    type Self = Quantity[units]
+    def position(value: Quantity[units]): Double = value.value
+    override val notation: Scale.Notation = notation0
 
   given duration: Duration is Continuous:
     def position(value: Duration): Double = value.value
-    override def spacing: Scale.Spacing = Scale.Spacing.Sexagesimal
-    override def labelling: Scale.Labelling = Scale.Labelling.Interval
+
+    override val notation: Scale.Notation =
+      Scale.Notation(Scale.Spacing.Sexagesimal, Scale.Labelling.Interval, t"time")
 
   // An instant is placed by its seconds since the epoch, whatever the resolution of its
   // timeline, and labelled as a time of day.
   given instant: [transport] => (resolution: transport is Resolution)
   =>  (Instant over transport) is Continuous:
     def position(value: Instant over transport): Double =
-      value.long.toDouble*resolution.nanos/1.0e9
+      value.long.toDouble*resolution.nanos/1000000000.0
 
-    override def spacing: Scale.Spacing = Scale.Spacing.Sexagesimal
-    override def labelling: Scale.Labelling = Scale.Labelling.Clock
+    override val notation: Scale.Notation =
+      Scale.Notation(Scale.Spacing.Sexagesimal, Scale.Labelling.Clock, t"time")
 
   given estimate: Estimate is Continuous:
     def position(value: Estimate): Double = value.value
     override def bounds(value: Estimate): Optional[(Double, Double)] = (value.lower, value.upper)
 
 // A value with a position on a numeric axis, and optionally an interval around it. Positions
-// are what a line, a scatter plot or a bar's height is drawn from; `spacing` and `labelling`
-// say how an axis of this type is graduated and how its gradations are written, since seconds
-// are read differently from counts.
+// are what a line, a scatter plot or a bar's height is drawn from; the notation says how an
+// axis of this type is graduated, written and titled, since seconds are read differently from
+// counts and a quantity is measured in units.
 trait Continuous extends Typeclass.Pure:
   def position(value: Self): Double
   def bounds(value: Self): Optional[(Double, Double)] = Unset
-  def spacing: Scale.Spacing = Scale.Spacing.Decimal
-  def labelling: Scale.Labelling = Scale.Labelling.Number(t"")
+  def notation: Scale.Notation = Scale.Notation()

--- a/lib/tasseomancy/src/core/tasseomancy.Continuous.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Continuous.scala
@@ -83,6 +83,10 @@ object Continuous:
     def position(value: Estimate): Double = value.value
     override def bounds(value: Estimate): Optional[(Double, Double)] = (value.lower, value.upper)
 
+  given annotated: Annotated is Continuous:
+    def position(value: Annotated): Double = value.value
+    override def annotation(value: Annotated): Optional[Text] = value.note
+
 // A value with a position on a numeric axis, and optionally an interval around it. Positions
 // are what a line, a scatter plot or a bar's height is drawn from; the notation says how an
 // axis of this type is graduated, written and titled, since seconds are read differently from
@@ -90,4 +94,5 @@ object Continuous:
 trait Continuous extends Typeclass.Pure:
   def position(value: Self): Double
   def bounds(value: Self): Optional[(Double, Double)] = Unset
+  def annotation(value: Self): Optional[Text] = Unset
   def notation: Scale.Notation = Scale.Notation()

--- a/lib/tasseomancy/src/core/tasseomancy.Estimate.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Estimate.scala
@@ -1,0 +1,37 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+// A value with the interval it is believed to lie in — a mean with its confidence interval, a
+// median with its quartiles — drawn as a point with error bars, or a line with a band.
+case class Estimate(value: Double, lower: Double, upper: Double)

--- a/lib/tasseomancy/src/core/tasseomancy.FontMetric.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.FontMetric.scala
@@ -1,0 +1,55 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import anticipation.*
+import contingency.*
+import phoenicia.*
+import quantitative.*
+import vacuous.*
+
+object FontMetric:
+  // The no-import default: an average width per character, which lays out a chart acceptably in
+  // any proportional face. Any `import fontMetrics.…` outranks this.
+  given average: FontMetric = tasseomancy.fontMetrics.averageFontMetric
+
+  // Widths summed from a font's own glyph advances, for the face the chart will be shown in;
+  // margins and legends then fit their text exactly. A character the face lacks would raise, so
+  // the average width stands in for any text containing one.
+  def of(font: Sfnt): FontMetric = text =>
+    safely(font.width(text)).or(tasseomancy.fontMetrics.averageFontMetric.width(text))
+
+// The width of a run of text in ems, as the chart's typeface will set it. Multiplied by the
+// style's font size, this is what decides how much room an axis's labels and a legend need.
+trait FontMetric:
+  def width(text: Text): Quantity[Ems[1]]

--- a/lib/tasseomancy/src/core/tasseomancy.Framing.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Framing.scala
@@ -35,7 +35,6 @@ package tasseomancy
 import anticipation.*
 import cataclysm.Css
 import denominative.*
-import geodesy.*
 import gossamer.*
 import hypotenuse.*
 import iridescence.*
@@ -45,11 +44,12 @@ import savagery.*
 import symbolism.*
 import vacuous.*
 
-// The layout and axes shared by every chart kind with an abscissa and an ordinate: the plot
-// rectangle after room is taken for labels, titles and the legend; the grid, the two axes with
-// their gradations; the legend itself; and the normalized forms of series that the kinds fit
-// and draw from.
-private[tasseomancy] object Cartesian:
+// The layout shared by every chart kind with an abscissa and an ordinate: the plot rectangle
+// after room is taken for labels, titles and the legend; the grid, the two axes with their
+// gradations; the legend; and the normalized forms of series that the kinds fit and draw from.
+// Every figure is produced by a method of the style in scope, so this decides only where each
+// component goes.
+private[tasseomancy] object Framing:
   case class Frame(left: Double, top: Double, width: Double, height: Double):
     def right: Double = left + width
     def bottom: Double = top + height
@@ -59,14 +59,15 @@ private[tasseomancy] object Cartesian:
   case class Layout(frame: Frame, legend: Optional[Frame])
 
   // A series with numeric axes, and one with a categorical abscissa, reduced to positions.
-  case class Datum(x: Double, y: Double, bounds: Optional[(Double, Double)])
+  case class Datum(x: Double, y: Double, bounds: Optional[(Double, Double)], note: Optional[Text])
   case class Trace(name: Text, data: Sequence[Datum])
   case class Mark(category: Text, y: Double, bounds: Optional[(Double, Double)])
   case class Column(name: Text, marks: Sequence[Mark])
 
   def traceOf[x: Continuous as cx, y: Continuous as cy](series: Series[x, y]): Trace =
     val data = series.points.map: (abscissa, ordinate) =>
-      Datum(cx.position(abscissa), cy.position(ordinate), cy.bounds(ordinate))
+      val note = cx.annotation(abscissa).or(cy.annotation(ordinate))
+      Datum(cx.position(abscissa), cy.position(ordinate), cy.bounds(ordinate), note)
 
     Trace(series.name, data)
 
@@ -128,23 +129,11 @@ private[tasseomancy] object Cartesian:
       ( t"fill" -> t"none", t"stroke" -> hexOf(color), t"stroke-width" -> px(width),
         t"stroke-linejoin" -> t"round", t"stroke-linecap" -> t"round" )
 
-  def font(using style: Chart.Style, palette: ChartPalette): Css.Style =
-    css
-      ( t"font-family" -> style.fontFamily, t"font-size" -> px(style.fontSize),
-        t"fill" -> hexOf(palette.text) )
-
   def textWidth(text: Text)(using metric: FontMetric, style: Chart.Style): Double =
     metric.width(text).value*style.fontSize
 
   def point(x: Double, y: Double): Point = Point(x.toFloat, y.toFloat)
   def seriesId(index: Int): Svg.Id = Svg.Id(t"series-$index")
-
-  private def gap(using style: Chart.Style): Double = style.fontSize*0.4
-  private def lineHeight(using style: Chart.Style): Double = style.fontSize*1.6
-  private def swatch(using style: Chart.Style): Double = style.fontSize
-
-  private def legendWidth(names: List[Text])(using Chart.Style, FontMetric): Double =
-    names.fold(0.0) { (acc, name) => acc.max(textWidth(name)) } + swatch + gap
 
   // An axis's title: the style's, if given, with the axis's unit appended; otherwise the name and
   // unit the axis's type supplies; a categorical axis has neither.
@@ -152,43 +141,53 @@ private[tasseomancy] object Cartesian:
     case scale: Scale => scale.notation.title(supplied)
     case _            => supplied
 
-  // The plot rectangle: the style's size less the insets, the ordinate's labels (measured from
-  // the gradations the full height would allow), the abscissa's labels, any titles and the
-  // legend. A chart without an ordinate (a pie) passes none.
+  private def legendWidth(names: List[Text])(using style: Chart.Style, metric: FontMetric)
+  :   Double =
+
+    names.fold(0.0) { (acc, name) => acc.max(textWidth(name)) } + style.swatchSize + style.gap
+
+  // The plot rectangle: the style's size less the insets, the room each axis's labels need
+  // (which the style reports, from the gradations the full extent would allow), any titles and
+  // the legend. A chart without axes (a pie) passes none.
   def layout(abscissa: Optional[Ruler], ordinate: Optional[Ruler], names: List[Text])
-    ( using style: Chart.Style, metric: FontMetric )
+    ( using style: Chart.Cartesian, metric: FontMetric )
   :   Layout =
 
-    val titleRoom = style.fontSize*1.6
+    import Chart.Axis.*
+
     val entries = countOf(names)
     val showLegend = entries > 0 && style.legend != Chart.Legend.Hidden
     val rightLegend = showLegend && style.legend == Chart.Legend.Right
     val bottomLegend = showLegend && style.legend == Chart.Legend.Bottom
-
-    val labelWidth = ordinate.lay(0.0): ruler =>
-      val budget = (style.height/style.pitch).toInt.max(2)
-      ruler.gradations(budget).fold(0.0): (acc, gradation) => acc.max(textWidth(gradation.label))
-
-    val axisRoom = ordinate.lay(0.0) { _ => gap + style.tickLength }
     val ordinateTitle = ordinate.let(title(_, style.ordinateTitle)).or(style.ordinateTitle)
     val abscissaTitle = abscissa.let(title(_, style.abscissaTitle)).or(style.abscissaTitle)
-    val titleWidth = ordinateTitle.lay(0.0) { _ => titleRoom }
-    val left = style.inset + labelWidth + axisRoom + titleWidth
-    val legendRoom = if rightLegend then legendWidth(names) + gap*2 else 0.0
+
+    def labels(ruler: Ruler, length: Double): List[Text] =
+      ruler.gradations((length/style.pitch).toInt.max(2)).filter(_.major).map(_.label).to[List]
+
+    val ordinateRoom = ordinate.lay(0.0): ruler =>
+      style.labelRoom(Ordinate, labels(ruler, style.height))
+
+    val left = style.inset + ordinateRoom + ordinateTitle.lay(0.0) { _ => style.titleRoom }
+    val legendRoom = if rightLegend then legendWidth(names) + style.gap*2 else 0.0
     val right = style.inset + style.fontSize*0.6 + legendRoom
     val top = style.inset + style.fontSize*0.6
-    val legendRow = if bottomLegend then lineHeight else 0.0
-    val labelRow = ordinate.lay(0.0) { _ => style.fontSize + gap + style.tickLength }
-    val titleHeight = abscissaTitle.lay(0.0) { _ => titleRoom }
-    val bottom = style.inset + labelRow + titleHeight + legendRow
     val width = (style.width - left - right).max(1.0)
+
+    val abscissaRoom = abscissa.lay(0.0): ruler => style.labelRoom(Abscissa, labels(ruler, width))
+
+    val legendRow = if bottomLegend then style.legendLineHeight else 0.0
+    val titleHeight = abscissaTitle.lay(0.0) { _ => style.titleRoom }
+    val bottom = style.inset + abscissaRoom + titleHeight + legendRow
     val height = (style.height - top - bottom).max(1.0)
     val frame = Frame(left, top, width, height)
+
+    val lineHeight = style.legendLineHeight
 
     val legend: Optional[Frame] =
       if !showLegend then Unset
       else if rightLegend
-      then Frame(frame.right + gap*2, frame.top, legendWidth(names), entries*lineHeight)
+      then Frame(frame.right + style.gap*2, frame.top, legendWidth(names), entries*lineHeight)
       else Frame(frame.left, style.height - style.inset - lineHeight, frame.width, lineHeight)
 
     Layout(frame, legend)
@@ -196,7 +195,7 @@ private[tasseomancy] object Cartesian:
   // The abscissa's gradations: as many as the pitch allows on a numeric axis, reduced until their
   // labels no longer overlap; every band of a categorical one.
   def abscissaGradations(frame: Frame, ruler: Ruler)
-    ( using style: Chart.Style, metric: FontMetric )
+    ( using style: Chart.Cartesian, metric: FontMetric )
   :   Sequence[Gradation] =
 
     ruler match
@@ -208,7 +207,7 @@ private[tasseomancy] object Cartesian:
 
         def crowded: Boolean =
           val occupied = marks.fold(0.0): (acc, mark) =>
-            if mark.major then acc + textWidth(mark.label) + gap else acc
+            if mark.major then acc + textWidth(mark.label) + style.gap else acc
 
           occupied > frame.width
 
@@ -220,91 +219,81 @@ private[tasseomancy] object Cartesian:
 
       case other => other.gradations((frame.width/style.pitch).toInt.max(1))
 
+  // Whether a linear axis starts away from zero, which the style may mark with a break.
+  private def broken(ruler: Ruler): Boolean = ruler match
+    case scale: Scale =>
+      scale.transform == Scale.Transform.Linear && (scale.lower > 0.0 || scale.upper < 0.0)
+
+    case _ => false
+
   // The grid and both axes, as identified groups.
   def axes(frame: Frame, abscissa: Ruler, ordinate: Ruler)
-    ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+    ( using style: Chart.Cartesian, palette: ChartPalette, metric: FontMetric )
   :   List[(Svg.Id, Figure)] =
+
+    import Chart.Axis.*
 
     val xs = abscissaGradations(frame, abscissa)
     val ys = ordinate.gradations((frame.height/style.pitch).toInt.max(2))
-    val lettering = font
-    val gridStroke = stroked(palette.grid, 1.0)
-    val axisStroke = stroked(palette.axis, 1.0)
-
-    def line(x0: Double, y0: Double, x1: Double, y1: Double, style: Css.Style): Figure =
-      Polyline(List(point(x0, y0), point(x1, y1)), style = style)
+    val origin = point(frame.left, frame.bottom)
+    val axisColor = palette.axis
 
     val gridLines: List[Figure] =
-      if !style.grid then Nil else
-        val horizontal = ys.fold(List[Figure]()): (acc, mark) =>
-          if !mark.major then acc else
-            val y = frame.y(mark.position)
-            line(frame.left, y, frame.right, y, gridStroke) :: acc
+      val horizontal = ys.fold(List[Figure]()): (acc, mark) =>
+        if !mark.major then acc else
+          val y = frame.y(mark.position)
+          style.gridLine(point(frame.left, y), point(frame.right, y), Ordinate, palette.grid) + acc
 
-        abscissa match
-          case scale: Scale =>
-            xs.fold(horizontal): (acc, mark) =>
-              if !mark.major then acc else
-                val x = frame.x(mark.position)
-                line(x, frame.top, x, frame.bottom, gridStroke) :: acc
+      abscissa match
+        case scale: Scale =>
+          xs.fold(horizontal): (acc, mark) =>
+            if !mark.major then acc else
+              val x = frame.x(mark.position)
+              val top = point(x, frame.top)
+              style.gridLine(top, point(x, frame.bottom), Abscissa, palette.grid) + acc
 
-          case _ => horizontal
+        case _ => horizontal
+
+    // The gradations of one axis: each tick and, for a major gradation, its label.
+    def gradations(marks: Sequence[Gradation], axis: Chart.Axis, at: Gradation => Point)
+    :   List[Figure] =
+
+      val figures = marks.fold(List[Figure]()): (acc, mark) =>
+        val position = at(mark)
+        val tick = style.tick(position, axis, mark.major, axisColor)
+
+        val label =
+          if mark.major then style.tickLabel(position, mark.label, axis, palette.text) else Nil
+
+        label.reverse + (tick.reverse + acc)
+
+      figures.reverse
+
+    // The far-end arrowhead and the origin-end break mark of one axis, if the style draws them.
+    def ends(ruler: Ruler, axis: Chart.Axis, tip: Point): List[Figure] =
+      val break = if broken(ruler) then style.axisBreak(origin, axis, axisColor) else Nil
+      style.arrowhead(tip, axis, axisColor) + break
 
     val abscissaFigures: List[Figure] =
-      val baseline = line(frame.left, frame.bottom, frame.right, frame.bottom, axisStroke)
+      val line = style.axisLine(origin, point(frame.right, frame.bottom), Abscissa, axisColor)
+      val marks = gradations(xs, Abscissa, mark => point(frame.x(mark.position), frame.bottom))
 
-      val marks = xs.fold(List[Figure]()): (acc, mark) =>
-        val x = frame.x(mark.position)
-        val tick = line(x, frame.bottom, x, frame.bottom + style.tickLength, axisStroke)
+      val titleFigures = title(abscissa, style.abscissaTitle).lay(Nil): text =>
+        val room = style.labelRoom(Abscissa, xs.filter(_.major).map(_.label).to[List])
+        val at = point(frame.left + frame.width/2.0, frame.bottom + room + style.gap)
+        style.axisTitle(at, text, Abscissa, palette.text)
 
-        if !mark.major then tick :: acc else
-          val position = point(x, frame.bottom + style.tickLength + gap)
-
-          val label =
-            Lettering
-              ( position, mark.label, Lettering.Anchor.Middle, Lettering.Baseline.Hanging,
-                style = lettering )
-
-          label :: tick :: acc
-
-      val title = Cartesian.title(abscissa, style.abscissaTitle).lay(Nil): text =>
-        val y = frame.bottom + style.tickLength + gap + style.fontSize + gap
-        val position = point(frame.left + frame.width/2.0, y)
-
-        List
-          ( Lettering
-              ( position, text, Lettering.Anchor.Middle, Lettering.Baseline.Hanging,
-                style = lettering ) )
-
-      baseline :: (marks.reverse + title)
+      line + marks + titleFigures + ends(abscissa, Abscissa, point(frame.right, frame.bottom))
 
     val ordinateFigures: List[Figure] =
-      val baseline = line(frame.left, frame.top, frame.left, frame.bottom, axisStroke)
+      val line = style.axisLine(point(frame.left, frame.top), origin, Ordinate, axisColor)
+      val marks = gradations(ys, Ordinate, mark => point(frame.left, frame.y(mark.position)))
 
-      val marks = ys.fold(List[Figure]()): (acc, mark) =>
-        val y = frame.y(mark.position)
-        val tick = line(frame.left - style.tickLength, y, frame.left, y, axisStroke)
+      val titleFigures = title(ordinate, style.ordinateTitle).lay(Nil): text =>
+        val at = point(style.inset, frame.top + frame.height/2.0)
+        style.axisTitle(at, text, Ordinate, palette.text)
 
-        if !mark.major then tick :: acc else
-          val position = point(frame.left - style.tickLength - gap, y)
-
-          val label =
-            Lettering
-              ( position, mark.label, Lettering.Anchor.End, Lettering.Baseline.Middle,
-                style = lettering )
-
-          label :: tick :: acc
-
-      val title = Cartesian.title(ordinate, style.ordinateTitle).lay(Nil): text =>
-        val centre = Delta(style.inset.toFloat, (frame.top + frame.height/2.0).toFloat)
-        val transforms = List(Transform.Translate(centre), Transform.Rotate(Angle.degrees(-90.0)))
-
-        List
-          ( Lettering
-              ( point(0.0, 0.0), text, Lettering.Anchor.Middle, Lettering.Baseline.Hanging,
-                style = lettering, transforms = transforms ) )
-
-      baseline :: (marks.reverse + title)
+      line + marks + titleFigures + ends(ordinate, Ordinate, point(frame.left, frame.top))
 
     List
       ( Svg.Id(t"grid") -> Group(gridLines.reverse, id = Svg.Id(t"grid")),
@@ -316,39 +305,23 @@ private[tasseomancy] object Cartesian:
     ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
   :   (Svg.Id, Figure) =
 
-    val lettering = font
     val vertical = style.legend == Chart.Legend.Right
+    val lineHeight = style.legendLineHeight
     var index = 0
     var x = frame.left
     var figures: List[Figure] = Nil
 
     names.foreach: name =>
       val y = if vertical then frame.top + index*lineHeight else frame.top
-      val corner = point(x, y + (lineHeight - swatch)/2.0)
-      val color = filled(palette.color(index))
-      val box = Rectangle(corner, swatch.toFloat, swatch.toFloat, style = color)
-      val position = point(x + swatch + gap, y + lineHeight/2.0)
-
-      val label =
-        Lettering
-          ( position, name, Lettering.Anchor.Start, Lettering.Baseline.Middle, style = lettering )
-
-      figures = label :: box :: figures
-      if !vertical then x += swatch + gap + textWidth(name) + gap*3
+      val corner = point(x, y + (lineHeight - style.swatchSize)/2.0)
+      val position = point(x + style.swatchSize + style.gap, y + lineHeight/2.0)
+      val swatch = style.swatch(corner, palette.color(index), index)
+      val entry = swatch + style.legendLabel(position, name, palette.text)
+      figures = entry.reverse + figures
+      if !vertical then x += style.swatchSize + style.gap + textWidth(name) + style.gap*3
       index += 1
 
     Svg.Id(t"legend") -> Group(figures.reverse, id = Svg.Id(t"legend"))
-
-  // An error bar: a vertical line between two ordinate positions with a cap at each end.
-  def errorBar(x: Double, low: Double, high: Double, cap: Double)(using palette: ChartPalette)
-  :   List[Figure] =
-
-    val bar = stroked(palette.axis, 1.0)
-
-    List
-      ( Polyline(List(point(x, low), point(x, high)), style = bar),
-        Polyline(List(point(x - cap, low), point(x + cap, low)), style = bar),
-        Polyline(List(point(x - cap, high), point(x + cap, high)), style = bar) )
 
   // The parts of a chart whose legend, if any, occupies the given frame.
   def legendPart(frame: Optional[Frame], names: List[Text])
@@ -362,10 +335,7 @@ private[tasseomancy] object Cartesian:
   def drawing(parts: List[(Svg.Id, Figure)])(using style: Chart.Style, palette: ChartPalette)
   :   Chart.Drawing =
 
-    val backdrop =
-      Rectangle
-        ( point(0.0, 0.0), style.width.toFloat, style.height.toFloat,
-          style = filled(palette.background), id = Svg.Id(t"backdrop") )
-
+    val figures = style.backdrop(style.width, style.height, palette.background)
+    val backdrop = Group(figures, id = Svg.Id(t"backdrop"))
     val all = (Svg.Id(t"backdrop") -> backdrop) :: parts
     Chart.Drawing(style.width, style.height, Nil, all.to[Ledger])

--- a/lib/tasseomancy/src/core/tasseomancy.Gradation.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Gradation.scala
@@ -1,0 +1,39 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import anticipation.*
+
+// One mark on an axis: where it lies, as a fraction of the axis's length, and how it is
+// labelled. A minor gradation is drawn without a label.
+case class Gradation(position: Double, label: Text, major: Boolean = true)

--- a/lib/tasseomancy/src/core/tasseomancy.Histogram.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Histogram.scala
@@ -107,7 +107,7 @@ object Histogram:
         val span0 = extent.upperOr1 - extent.lowerOr0
         val span = if span0 > 0.0 then span0 else extent.upperOr1.abs.max(1.0)
 
-        val width = continuous.spacing match
+        val width = continuous.notation.spacing match
           case Scale.Spacing.Decimal     => Scale.step(span/bins)
           case Scale.Spacing.Sexagesimal => Scale.sexagesimalStep(span/bins)
 
@@ -121,16 +121,14 @@ object Histogram:
           edges = edge :: edges
           count += 1
 
-        val abscissa =
-          Scale(first, edge, Scale.Transform.Linear, continuous.spacing, continuous.labelling)
-
+        val abscissa = Scale(first, edge, Scale.Transform.Linear, continuous.notation)
         val provisional = Histogram.Fit(edges.reverse.to[Sequence], abscissa, abscissa)
         val most = mostCounted(provisional, all)
-        val number = Scale.Labelling.Number(t"")
+        val counting = Scale.Notation(name = t"count")
 
         val ordinate =
           form.ordinate.or(Calibration[Int](Calibration.Policy.Linear))
-          . scale(0.0, most.toDouble, true, Scale.Spacing.Decimal, number)
+          . scale(0.0, most.toDouble, true, counting)
 
         Histogram.Fit(provisional.edges, abscissa, ordinate)
 
@@ -145,7 +143,7 @@ object Histogram:
 
         val all = extract(data)
         val names = all.map(_(0))
-        val layout = Cartesian.layout(fit.ordinate, names)
+        val layout = Cartesian.layout(fit.abscissa, fit.ordinate, names)
         val frame = layout.frame
         val total = countOf(all).max(1)
         val bins = fit.edges.size - 1

--- a/lib/tasseomancy/src/core/tasseomancy.Histogram.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Histogram.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package tasseomancy
 
-import Cartesian.*
+import Framing.*
 import anticipation.*
 import denominative.*
 import gossamer.*
@@ -47,14 +47,17 @@ import vacuous.*
 object Histogram:
   case class Fit(edges: Sequence[Double], abscissa: Scale, ordinate: Scale)
 
+  // A histogram draws the same components as a bar chart.
+  trait Style extends Bars.Style
+
   given samples: [y: {Continuous, Calibration}]
-  =>  Samples[y] is Plottable in Histogram to Histogram.Fit =
+  =>  Samples[y] is Plottable in Histogram to Histogram.Fit by Histogram.Style =
     plottable[Samples[y], y]: samples => List(positions(samples))
 
   given traversable: [collection, y]
   =>  ( traversable: collection is Traversable by Samples[y] )
   =>  ( continuous: y is Continuous, calibration: y is Calibration )
-  =>  collection is Plottable in Histogram to Histogram.Fit =
+  =>  collection is Plottable in Histogram to Histogram.Fit by Histogram.Style =
     plottable[collection, y]: collection =>
       List.from(traversable.traverse(collection).map(positions(_)))
 
@@ -87,12 +90,13 @@ object Histogram:
 
   private def plottable[data, y: {Continuous as continuous, Calibration as calibration}]
     ( extract: data -> List[(Text, Sequence[Double])] )
-  :   data is Plottable in Histogram to Histogram.Fit =
+  :   data is Plottable in Histogram to Histogram.Fit by Histogram.Style =
 
     new Plottable:
       type Self = data
       type Form = Histogram
       type Result = Histogram.Fit
+      type Operand = Histogram.Style
 
       def fit(form: Histogram, data: data): Histogram.Fit =
         val all = extract(data)
@@ -138,12 +142,12 @@ object Histogram:
         within && mostCounted(fit, all).toDouble <= fit.ordinate.upper
 
       def draw(form: Histogram, data: data, fit: Histogram.Fit)
-        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+        ( using style: Histogram.Style, palette: ChartPalette, metric: FontMetric )
       :   Chart.Drawing =
 
         val all = extract(data)
         val names = all.map(_(0))
-        val layout = Cartesian.layout(fit.abscissa, fit.ordinate, names)
+        val layout = Framing.layout(fit.abscissa, fit.ordinate, names)
         val frame = layout.frame
         val total = countOf(all).max(1)
         val bins = fit.edges.size - 1
@@ -155,7 +159,7 @@ object Histogram:
 
         val seriesParts = all.map: entry =>
           val tally = counts(fit, entry(1))
-          val color = filled(palette.color(index))
+          val color = palette.color(index)
           var bin = 0
           var figures: List[Figure] = Nil
 
@@ -165,8 +169,7 @@ object Histogram:
             if height > 0 then
               val x0 = frame.left + bin*binWidth + (binWidth - groupWidth)/2.0 + index*barWidth
               val y = frame.y(fit.ordinate.unit(height.toDouble))
-              val bar = Rectangle(point(x0, y), barWidth.toFloat, (zero - y).toFloat, style = color)
-              figures = bar :: figures
+              figures = style.bar(point(x0, y), barWidth, zero - y, color, index).reverse + figures
 
             bin += 1
 
@@ -175,7 +178,7 @@ object Histogram:
           part
 
         val legend = legendPart(layout.legend, names)
-        Cartesian.drawing(axes(frame, fit.abscissa, fit.ordinate) + seriesParts + legend)
+        Framing.drawing(axes(frame, fit.abscissa, fit.ordinate) + seriesParts + legend)
 
 // The distribution of samples: the range is cut into equal bins, and a bar per series in each
 // bin counts the samples that fall in it. Without a bin count, Sturges' rule chooses one.

--- a/lib/tasseomancy/src/core/tasseomancy.Histogram.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Histogram.scala
@@ -1,0 +1,184 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import Cartesian.*
+import anticipation.*
+import denominative.*
+import gossamer.*
+import hypotenuse.*
+import murmuration.Traversable
+import prepositional.*
+import rudiments.*
+import savagery.*
+import symbolism.*
+import vacuous.*
+
+object Histogram:
+  case class Fit(edges: Sequence[Double], abscissa: Scale, ordinate: Scale)
+
+  given samples: [y: {Continuous, Calibration}]
+  =>  Samples[y] is Plottable in Histogram to Histogram.Fit =
+    plottable[Samples[y], y]: samples => List(positions(samples))
+
+  given traversable: [collection, y]
+  =>  ( traversable: collection is Traversable by Samples[y] )
+  =>  ( continuous: y is Continuous, calibration: y is Calibration )
+  =>  collection is Plottable in Histogram to Histogram.Fit =
+    plottable[collection, y]: collection =>
+      List.from(traversable.traverse(collection).map(positions(_)))
+
+  private[tasseomancy] def positions[y: Continuous as continuous](samples: Samples[y])
+  :   (Text, Sequence[Double]) =
+
+    (samples.name, samples.values.map(continuous.position(_)))
+
+  private def bin(fit: Histogram.Fit, value: Double): Int =
+    val bins = fit.edges.size - 1
+    val width = (fit.abscissa.upper - fit.abscissa.lower)/bins
+    ((value - fit.abscissa.lower)/width).floor.toInt.max(0).min(bins - 1)
+
+  private def counts(fit: Histogram.Fit, values: Sequence[Double]): Sequence[Int] =
+    var tally: Sequence[Int] = Sequence.empty
+    var index = 0
+
+    while index < fit.edges.size - 1 do
+      tally = Sequence.append(tally, 0)
+      index += 1
+
+    values.foreach: value =>
+      val slot = bin(fit, value)
+      tally = Sequence.define(tally, slot, Sequence.at(tally, slot) + 1)
+
+    tally
+
+  private def mostCounted(fit: Histogram.Fit, all: List[(Text, Sequence[Double])]): Int =
+    all.fold(0): (acc, entry) => counts(fit, entry(1)).fold(acc)(_.max(_))
+
+  private def plottable[data, y: {Continuous as continuous, Calibration as calibration}]
+    ( extract: data -> List[(Text, Sequence[Double])] )
+  :   data is Plottable in Histogram to Histogram.Fit =
+
+    new Plottable:
+      type Self = data
+      type Form = Histogram
+      type Result = Histogram.Fit
+
+      def fit(form: Histogram, data: data): Histogram.Fit =
+        val all = extract(data)
+
+        val (extent, total) = all.fold((Extent.empty, 0)): (acc, entry) =>
+          entry(1).fold(acc): (acc2, value) => (acc2(0).include(value), acc2(1) + 1)
+
+        // Sturges' rule where no bin count is given: one more than the base-two logarithm of the
+        // sample count.
+        val sturges = (ln(total.max(1).toDouble).double/ln(2.0).double).ceiling.toInt + 1
+        val bins = form.bins.or(sturges).max(1)
+        val span0 = extent.upperOr1 - extent.lowerOr0
+        val span = if span0 > 0.0 then span0 else extent.upperOr1.abs.max(1.0)
+
+        val width = continuous.spacing match
+          case Scale.Spacing.Decimal     => Scale.step(span/bins)
+          case Scale.Spacing.Sexagesimal => Scale.sexagesimalStep(span/bins)
+
+        val first = (extent.lowerOr0/width + Scale.tolerance).floor*width
+        var edges: List[Double] = List(first)
+        var edge = first
+        var count = 1
+
+        while edge < extent.upperOr1 - width*Scale.tolerance || count < 2 do
+          edge += width
+          edges = edge :: edges
+          count += 1
+
+        val abscissa =
+          Scale(first, edge, Scale.Transform.Linear, continuous.spacing, continuous.labelling)
+
+        val provisional = Histogram.Fit(edges.reverse.to[Sequence], abscissa, abscissa)
+        val most = mostCounted(provisional, all)
+        val number = Scale.Labelling.Number(t"")
+
+        val ordinate =
+          form.ordinate.or(Calibration[Int](Calibration.Policy.Linear))
+          . scale(0.0, most.toDouble, true, Scale.Spacing.Decimal, number)
+
+        Histogram.Fit(provisional.edges, abscissa, ordinate)
+
+      def accommodates(form: Histogram, fit: Histogram.Fit, data: data): Boolean =
+        val all = extract(data)
+        val within = all.all: entry => entry(1).all(fit.abscissa.accommodates(_))
+        within && mostCounted(fit, all).toDouble <= fit.ordinate.upper
+
+      def draw(form: Histogram, data: data, fit: Histogram.Fit)
+        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+      :   Chart.Drawing =
+
+        val all = extract(data)
+        val names = all.map(_(0))
+        val layout = Cartesian.layout(fit.ordinate, names)
+        val frame = layout.frame
+        val total = countOf(all).max(1)
+        val bins = fit.edges.size - 1
+        val binWidth = frame.width/bins.max(1)
+        val groupWidth = binWidth*(1.0 - style.barGap)
+        val barWidth = groupWidth/total
+        val zero = frame.y(fit.ordinate.unit(0.0))
+        var index = 0
+
+        val seriesParts = all.map: entry =>
+          val tally = counts(fit, entry(1))
+          val color = filled(palette.color(index))
+          var bin = 0
+          var figures: List[Figure] = Nil
+
+          while bin < bins do
+            val height = Sequence.at(tally, bin)
+
+            if height > 0 then
+              val x0 = frame.left + bin*binWidth + (binWidth - groupWidth)/2.0 + index*barWidth
+              val y = frame.y(fit.ordinate.unit(height.toDouble))
+              val bar = Rectangle(point(x0, y), barWidth.toFloat, (zero - y).toFloat, style = color)
+              figures = bar :: figures
+
+            bin += 1
+
+          val part = seriesId(index) -> Group(figures.reverse, id = seriesId(index))
+          index += 1
+          part
+
+        val legend = legendPart(layout.legend, names)
+        Cartesian.drawing(axes(frame, fit.abscissa, fit.ordinate) + seriesParts + legend)
+
+// The distribution of samples: the range is cut into equal bins, and a bar per series in each
+// bin counts the samples that fall in it. Without a bin count, Sturges' rule chooses one.
+case class Histogram(bins: Optional[Int] = Unset, ordinate: Optional[Calibration] = Unset)

--- a/lib/tasseomancy/src/core/tasseomancy.Lines.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Lines.scala
@@ -68,8 +68,8 @@ object Lines:
       trace.data.fold(acc): (acc2, datum) =>
         (acc2(0).include(datum.x), acc2(1).include(datum.y).include(datum.bounds))
 
-    val xScale = abscissa.or(kx).scale(xs.lowerOr0, xs.upperOr1, false, cx.spacing, cx.labelling)
-    val yScale = ordinate.or(ky).scale(ys.lowerOr0, ys.upperOr1, false, cy.spacing, cy.labelling)
+    val xScale = abscissa.or(kx).scale(xs.lowerOr0, xs.upperOr1, false, cx.notation)
+    val yScale = ordinate.or(ky).scale(ys.lowerOr0, ys.upperOr1, false, cy.notation)
     (xScale, yScale)
 
   private[tasseomancy] def accommodatesTraces
@@ -105,7 +105,7 @@ object Lines:
 
         val all = traces(data)
         val names = all.map(_.name)
-        val layout = Cartesian.layout(fit.ordinate, names)
+        val layout = Cartesian.layout(fit.abscissa, fit.ordinate, names)
         val frame = layout.frame
         var index = 0
 

--- a/lib/tasseomancy/src/core/tasseomancy.Lines.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Lines.scala
@@ -1,0 +1,148 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import Cartesian.*
+import denominative.*
+import murmuration.Traversable
+import murmuration.sortingAlgorithms.timsort
+import prepositional.*
+import rudiments.*
+import savagery.*
+import symbolism.*
+import vacuous.*
+
+object Lines:
+  case class Fit(abscissa: Scale, ordinate: Scale)
+
+  given series: [x: {Continuous, Calibration}, y: {Continuous, Calibration}]
+  =>  Series[x, y] is Plottable in Lines to Lines.Fit =
+    plottable[Series[x, y], x, y]: series => List(traceOf(series))
+
+  given traversable: [collection, x, y]
+  =>  ( traversable: collection is Traversable by Series[x, y] )
+  =>  ( continuousX: x is Continuous, calibrationX: x is Calibration )
+  =>  ( continuousY: y is Continuous, calibrationY: y is Calibration )
+  =>  collection is Plottable in Lines to Lines.Fit =
+    plottable[collection, x, y]: collection =>
+      List.from(traversable.traverse(collection).map(traceOf(_)))
+
+  // The fit shared with a scatter plot: each axis over the extent of its positions (and, on the
+  // ordinate, of their intervals), neither anchored at zero.
+  private[tasseomancy] def fitTraces
+    [ x: {Continuous as cx, Calibration as kx}, y: {Continuous as cy, Calibration as ky} ]
+    ( traces: List[Trace], abscissa: Optional[Calibration], ordinate: Optional[Calibration] )
+  :   (Scale, Scale) =
+
+    val (xs, ys) = traces.fold((Extent.empty, Extent.empty)): (acc, trace) =>
+      trace.data.fold(acc): (acc2, datum) =>
+        (acc2(0).include(datum.x), acc2(1).include(datum.y).include(datum.bounds))
+
+    val xScale = abscissa.or(kx).scale(xs.lowerOr0, xs.upperOr1, false, cx.spacing, cx.labelling)
+    val yScale = ordinate.or(ky).scale(ys.lowerOr0, ys.upperOr1, false, cy.spacing, cy.labelling)
+    (xScale, yScale)
+
+  private[tasseomancy] def accommodatesTraces
+    ( traces: List[Trace], abscissa: Scale, ordinate: Scale )
+  :   Boolean =
+
+    traces.all: trace =>
+      trace.data.all: datum =>
+        val within = datum.bounds.lay(true): (low, high) =>
+          ordinate.accommodates(low) && ordinate.accommodates(high)
+
+        abscissa.accommodates(datum.x) && ordinate.accommodates(datum.y) && within
+
+  private def plottable[data, x: {Continuous, Calibration}, y: {Continuous, Calibration}]
+    ( traces: data -> List[Trace] )
+  :   data is Plottable in Lines to Lines.Fit =
+
+    new Plottable:
+      type Self = data
+      type Form = Lines
+      type Result = Lines.Fit
+
+      def fit(form: Lines, data: data): Lines.Fit =
+        val (abscissa, ordinate) = fitTraces[x, y](traces(data), form.abscissa, form.ordinate)
+        Lines.Fit(abscissa, ordinate)
+
+      def accommodates(form: Lines, fit: Lines.Fit, data: data): Boolean =
+        accommodatesTraces(traces(data), fit.abscissa, fit.ordinate)
+
+      def draw(form: Lines, data: data, fit: Lines.Fit)
+        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+      :   Chart.Drawing =
+
+        val all = traces(data)
+        val names = all.map(_.name)
+        val layout = Cartesian.layout(fit.ordinate, names)
+        val frame = layout.frame
+        var index = 0
+
+        def at(datum: Datum, value: Double): Point =
+          point(frame.x(fit.abscissa.unit(datum.x)), frame.y(fit.ordinate.unit(value)))
+
+        val seriesParts = all.map: trace =>
+          val sorted: Sequence[Datum] = trace.data.order(_.x)
+          val color = palette.color(index)
+
+          val points: List[Point] =
+            sorted.fold(List[Point]()) { (acc, datum) => at(datum, datum.y) :: acc }.reverse
+
+          val (highs, lows) = sorted.fold((List[Point](), List[Point]())): (acc, datum) =>
+            datum.bounds.lay(acc): (low, high) =>
+              (at(datum, high) :: acc(0), at(datum, low) :: acc(1))
+
+          val band: List[Figure] =
+            if highs.nil then Nil
+            else List(Polyline(highs.reverse + lows, closed = true, style = filled(color, 0.2)))
+
+          val line = Polyline(points, style = stroked(color, style.strokeWidth))
+
+          val radius = style.markerRadius.toFloat
+
+          val markers: List[Figure] =
+            if !style.markers then Nil
+            else points.map: point => Circle(point, radius, style = filled(color))
+
+          val part = seriesId(index) -> Group(band + (line :: markers), id = seriesId(index))
+          index += 1
+          part
+
+        val legend = legendPart(layout.legend, names)
+        Cartesian.drawing(axes(frame, fit.abscissa, fit.ordinate) + seriesParts + legend)
+
+// A line per series through its points in abscissa order, with a translucent band where the
+// values carry intervals, and markers at the points if the style asks for them. Neither axis is
+// anchored at zero: a line shows change, not magnitude.
+case class Lines(abscissa: Optional[Calibration] = Unset, ordinate: Optional[Calibration] = Unset)

--- a/lib/tasseomancy/src/core/tasseomancy.Lines.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Lines.scala
@@ -32,8 +32,9 @@
                                                                                                   */
 package tasseomancy
 
-import Cartesian.*
+import Framing.*
 import denominative.*
+import iridescence.*
 import murmuration.Traversable
 import murmuration.sortingAlgorithms.timsort
 import prepositional.*
@@ -45,15 +46,29 @@ import vacuous.*
 object Lines:
   case class Fit(abscissa: Scale, ordinate: Scale)
 
+  // The components of a line chart beyond the axes: the line through a series' points, the band
+  // between their bounds, and a marker at each point if `markers` asks for one.
+  trait Style extends Chart.Cartesian:
+    def markers: Boolean
+
+    def line(points: List[Point], color: Color in Srgb, series: Int): List[Figure] =
+      List(Polyline(points, style = stroked(color, strokeWidth)))
+
+    def band(points: List[Point], color: Color in Srgb, series: Int): List[Figure] =
+      List(Polyline(points, closed = true, style = filled(color, 0.2)))
+
+    def lineMarker(at: Point, color: Color in Srgb, series: Int): List[Figure] =
+      if markers then marker(at, color, series) else Nil
+
   given series: [x: {Continuous, Calibration}, y: {Continuous, Calibration}]
-  =>  Series[x, y] is Plottable in Lines to Lines.Fit =
+  =>  Series[x, y] is Plottable in Lines to Lines.Fit by Lines.Style =
     plottable[Series[x, y], x, y]: series => List(traceOf(series))
 
   given traversable: [collection, x, y]
   =>  ( traversable: collection is Traversable by Series[x, y] )
   =>  ( continuousX: x is Continuous, calibrationX: x is Calibration )
   =>  ( continuousY: y is Continuous, calibrationY: y is Calibration )
-  =>  collection is Plottable in Lines to Lines.Fit =
+  =>  collection is Plottable in Lines to Lines.Fit by Lines.Style =
     plottable[collection, x, y]: collection =>
       List.from(traversable.traverse(collection).map(traceOf(_)))
 
@@ -85,12 +100,13 @@ object Lines:
 
   private def plottable[data, x: {Continuous, Calibration}, y: {Continuous, Calibration}]
     ( traces: data -> List[Trace] )
-  :   data is Plottable in Lines to Lines.Fit =
+  :   data is Plottable in Lines to Lines.Fit by Lines.Style =
 
     new Plottable:
       type Self = data
       type Form = Lines
       type Result = Lines.Fit
+      type Operand = Lines.Style
 
       def fit(form: Lines, data: data): Lines.Fit =
         val (abscissa, ordinate) = fitTraces[x, y](traces(data), form.abscissa, form.ordinate)
@@ -100,12 +116,12 @@ object Lines:
         accommodatesTraces(traces(data), fit.abscissa, fit.ordinate)
 
       def draw(form: Lines, data: data, fit: Lines.Fit)
-        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+        ( using style: Lines.Style, palette: ChartPalette, metric: FontMetric )
       :   Chart.Drawing =
 
         val all = traces(data)
         val names = all.map(_.name)
-        val layout = Cartesian.layout(fit.abscissa, fit.ordinate, names)
+        val layout = Framing.layout(fit.abscissa, fit.ordinate, names)
         val frame = layout.frame
         var index = 0
 
@@ -124,23 +140,23 @@ object Lines:
               (at(datum, high) :: acc(0), at(datum, low) :: acc(1))
 
           val band: List[Figure] =
-            if highs.nil then Nil
-            else List(Polyline(highs.reverse + lows, closed = true, style = filled(color, 0.2)))
+            if highs.nil then Nil else style.band(highs.reverse + lows, color, index)
 
-          val line = Polyline(points, style = stroked(color, style.strokeWidth))
+          val line = style.line(points, color, index)
 
-          val radius = style.markerRadius.toFloat
+          val decorations: List[Figure] = sorted.fold(List[Figure]()): (acc, datum) =>
+            val position = at(datum, datum.y)
+            val marker = style.lineMarker(position, color, index)
+            val note = datum.note.lay(Nil): text => style.pointLabel(position, text, palette.text)
+            note.reverse + (marker.reverse + acc)
 
-          val markers: List[Figure] =
-            if !style.markers then Nil
-            else points.map: point => Circle(point, radius, style = filled(color))
-
-          val part = seriesId(index) -> Group(band + (line :: markers), id = seriesId(index))
+          val figures = band + line + decorations.reverse
+          val part = seriesId(index) -> Group(figures, id = seriesId(index))
           index += 1
           part
 
         val legend = legendPart(layout.legend, names)
-        Cartesian.drawing(axes(frame, fit.abscissa, fit.ordinate) + seriesParts + legend)
+        Framing.drawing(axes(frame, fit.abscissa, fit.ordinate) + seriesParts + legend)
 
 // A line per series through its points in abscissa order, with a translucent band where the
 // values carry intervals, and markers at the points if the style asks for them. Neither axis is

--- a/lib/tasseomancy/src/core/tasseomancy.Pie.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Pie.scala
@@ -77,7 +77,7 @@ object Pie:
 
         val marks = columnOf(data).marks
         val names = fit.labels.to[List]
-        val layout = Cartesian.layout(Unset, names)
+        val layout = Cartesian.layout(Unset, Unset, names)
         val frame = layout.frame
         val radius = (frame.width.min(frame.height)/2.0 - style.fontSize).max(1.0)
         val hole = radius*form.hole.max(0.0).min(0.95)

--- a/lib/tasseomancy/src/core/tasseomancy.Pie.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Pie.scala
@@ -32,12 +32,14 @@
                                                                                                   */
 package tasseomancy
 
-import Cartesian.*
+import Framing.*
 import anticipation.*
+import cataclysm.Css
 import denominative.*
 import geodesy.*
 import gossamer.*
 import hypotenuse.*
+import iridescence.*
 import prepositional.*
 import rudiments.*
 import savagery.*
@@ -47,13 +49,27 @@ import vacuous.*
 object Pie:
   case class Fit(labels: Sequence[Text], total: Double)
 
+  // The components of a pie: its wedges, given as the path operations of their outlines, and the
+  // percentage set on any wedge at least `labelThreshold` of the whole. `hole` hollows the
+  // centre to that fraction of the radius.
+  trait Style extends Chart.Style:
+    def hole: Double
+    def labelThreshold: Double = 0.04
+
+    def wedge(ops: List[Stroke], color: Color in Srgb, index: Int): List[Figure] =
+      List(Outline(ops, style = filled(color) + Css.Style.of(List(t"fill-rule" -> t"evenodd"))))
+
+    def wedgeLabel(at: Point, text: Text, color: Color in Srgb): List[Figure] =
+      List(lettering(at, text, Lettering.Anchor.Middle, Lettering.Baseline.Middle, color))
+
   given series: [x: Categorical, y: Continuous as continuous]
-  =>  Series[x, y] is Plottable in Pie to Pie.Fit =
+  =>  Series[x, y] is Plottable in Pie to Pie.Fit by Pie.Style =
 
     new Plottable:
       type Self = Series[x, y]
       type Form = Pie
       type Result = Pie.Fit
+      type Operand = Pie.Style
 
       def fit(form: Pie, data: Series[x, y]): Pie.Fit =
         val marks = columnOf(data).marks
@@ -72,18 +88,16 @@ object Pie:
         same
 
       def draw(form: Pie, data: Series[x, y], fit: Pie.Fit)
-        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+        ( using style: Pie.Style, palette: ChartPalette, metric: FontMetric )
       :   Chart.Drawing =
 
         val marks = columnOf(data).marks
         val names = fit.labels.to[List]
-        val layout = Cartesian.layout(Unset, Unset, names)
-        val frame = layout.frame
+        val frame = pieFrame(names)
         val radius = (frame.width.min(frame.height)/2.0 - style.fontSize).max(1.0)
-        val hole = radius*form.hole.max(0.0).min(0.95)
+        val hole = radius*style.hole.max(0.0).min(0.95)
         val cx = frame.left + frame.width/2.0
         val cy = frame.top + frame.height/2.0
-        val lettering = font
 
         def rim(angle: Double, distance: Double): Point =
           point(cx + distance*sin(angle).double, cy - distance*cos(angle).double)
@@ -128,7 +142,6 @@ object Pie:
 
             inner + outer
 
-        val ring = css(t"fill-rule" -> t"evenodd")
         var start = 0.0
         var index = 0
 
@@ -139,26 +152,60 @@ object Pie:
           val end = start + sweep
           val complete = fraction >= 1.0 - Scale.tolerance
           val ops = if complete then whole else wedge(start, end, sweep > π)
-          val shape = Outline(ops, style = if complete then filled(color) + ring else filled(color))
+          val shape = style.wedge(ops, color, index)
 
           val label: List[Figure] =
-            if fraction < 0.04 then Nil else
+            if fraction < style.labelThreshold then Nil else
               val middle = (start + end)/2.0
               val distance = if hole <= 0.0 then radius*0.65 else (radius + hole)/2.0
               val text = t"${Scale.format(fraction*100.0, 0)}%"
-
-              List
-                ( Lettering
-                    ( rim(middle, distance), text, Lettering.Anchor.Middle,
-                      Lettering.Baseline.Middle, style = lettering ) )
+              style.wedgeLabel(rim(middle, distance), text, palette.text)
 
           start = end
           index += 1
-          label.reverse + (shape :: acc)
+          label.reverse + (shape.reverse + acc)
 
         val wedges = Svg.Id(t"wedges") -> Group(figures.reverse, id = Svg.Id(t"wedges"))
-        Cartesian.drawing(wedges :: legendPart(layout.legend, names))
+        Framing.drawing(wedges :: legendPart(legendFrame(names), names))
+
+      // A pie has no axes, so its frame is the canvas less the insets and the legend.
+      private def pieFrame(names: List[Text])
+        ( using style: Pie.Style, metric: FontMetric )
+      :   Frame =
+
+        val entries = countOf(names)
+        val showLegend = entries > 0 && style.legend != Chart.Legend.Hidden
+        val widest = names.fold(0.0): (acc, name) => acc.max(textWidth(name))
+        val legendWidth = widest + style.swatchSize + style.gap
+
+        val right =
+          if showLegend && style.legend == Chart.Legend.Right then legendWidth + style.gap*2
+          else 0.0
+
+        val bottom =
+          if showLegend && style.legend == Chart.Legend.Bottom then style.legendLineHeight else 0.0
+
+        val width = (style.width - style.inset*2 - right).max(1.0)
+        val height = (style.height - style.inset*2 - bottom).max(1.0)
+        Frame(style.inset, style.inset, width, height)
+
+      private def legendFrame(names: List[Text])
+        ( using style: Pie.Style, metric: FontMetric )
+      :   Optional[Frame] =
+
+        val entries = countOf(names)
+        val frame = pieFrame(names)
+        val widest = names.fold(0.0): (acc, name) => acc.max(textWidth(name))
+        val legendWidth = widest + style.swatchSize + style.gap
+        val lineHeight = style.legendLineHeight
+
+        if entries == 0 || style.legend == Chart.Legend.Hidden then Unset
+        else if style.legend == Chart.Legend.Right
+        then Frame(frame.right + style.gap*2, frame.top, legendWidth, entries*lineHeight)
+        else
+          val row = style.height - style.inset - style.legendLineHeight
+          Frame(frame.left, row, frame.width, style.legendLineHeight)
 
 // Parts of a whole: one series, each category a wedge proportional to its value, clockwise from
-// the top. A `hole` between 0 and 1 hollows the centre to that fraction of the radius.
-case class Pie(hole: Double = 0.0)
+// the top.
+case class Pie()

--- a/lib/tasseomancy/src/core/tasseomancy.Pie.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Pie.scala
@@ -1,0 +1,164 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import Cartesian.*
+import anticipation.*
+import denominative.*
+import geodesy.*
+import gossamer.*
+import hypotenuse.*
+import prepositional.*
+import rudiments.*
+import savagery.*
+import symbolism.*
+import vacuous.*
+
+object Pie:
+  case class Fit(labels: Sequence[Text], total: Double)
+
+  given series: [x: Categorical, y: Continuous as continuous]
+  =>  Series[x, y] is Plottable in Pie to Pie.Fit =
+
+    new Plottable:
+      type Self = Series[x, y]
+      type Form = Pie
+      type Result = Pie.Fit
+
+      def fit(form: Pie, data: Series[x, y]): Pie.Fit =
+        val marks = columnOf(data).marks
+        val total = marks.fold(0.0): (acc, mark) => acc + mark.y.max(0.0)
+        Pie.Fit(marks.map(_.category), total)
+
+      // A pie has no axes to hold still: any change in a value moves every wedge, so a fit only
+      // survives while the labels are the same, and then it is the one `wedges` part that
+      // changes.
+      def accommodates(form: Pie, fit: Pie.Fit, data: Series[x, y]): Boolean =
+        val labels = columnOf(data).marks.map(_.category)
+
+        val (same, _) = labels.fold((labels.size == fit.labels.size, 0)): (acc, label) =>
+          (acc(0) && Sequence.at(fit.labels, acc(1)) == label, acc(1) + 1)
+
+        same
+
+      def draw(form: Pie, data: Series[x, y], fit: Pie.Fit)
+        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+      :   Chart.Drawing =
+
+        val marks = columnOf(data).marks
+        val names = fit.labels.to[List]
+        val layout = Cartesian.layout(Unset, names)
+        val frame = layout.frame
+        val radius = (frame.width.min(frame.height)/2.0 - style.fontSize).max(1.0)
+        val hole = radius*form.hole.max(0.0).min(0.95)
+        val cx = frame.left + frame.width/2.0
+        val cy = frame.top + frame.height/2.0
+        val lettering = font
+
+        def rim(angle: Double, distance: Double): Point =
+          point(cx + distance*sin(angle).double, cy - distance*cos(angle).double)
+
+        def arc(distance: Double, large: Boolean, sweep: Sweep, angle: Double): Stroke =
+          val size = distance.toFloat
+          Stroke.ArcTo(size, size, Angle(0.0), large, sweep, rim(angle, distance))
+
+        // A wedge's path operations, listed last to first as an `Outline` holds them.
+        def wedge(start: Double, end: Double, large: Boolean): List[Stroke] =
+          if hole <= 0.0 then
+            List
+              ( Stroke.Close,
+                arc(radius, large, Sweep.Clockwise, end),
+                Stroke.DrawTo(rim(start, radius)),
+                Stroke.MoveTo(point(cx, cy)) )
+          else
+            List
+              ( Stroke.Close,
+                arc(hole, large, Sweep.Counterclockwise, start),
+                Stroke.DrawTo(rim(end, hole)),
+                arc(radius, large, Sweep.Clockwise, end),
+                Stroke.MoveTo(rim(start, radius)) )
+
+        // A whole circle cannot be one arc, whose ends would coincide: it is two half-turns,
+        // and a ring is a circle with a hole cut by the even-odd rule.
+        def whole: List[Stroke] =
+          val outer =
+            List
+              ( Stroke.Close,
+                arc(radius, true, Sweep.Clockwise, 0.0),
+                arc(radius, true, Sweep.Clockwise, π),
+                Stroke.MoveTo(rim(0.0, radius)) )
+
+          if hole <= 0.0 then outer else
+            val inner =
+              List
+                ( Stroke.Close,
+                  arc(hole, true, Sweep.Counterclockwise, π),
+                  arc(hole, true, Sweep.Counterclockwise, 0.0),
+                  Stroke.MoveTo(rim(π, hole)) )
+
+            inner + outer
+
+        val ring = css(t"fill-rule" -> t"evenodd")
+        var start = 0.0
+        var index = 0
+
+        val figures = marks.fold(List[Figure]()): (acc, mark) =>
+          val fraction = if fit.total <= 0.0 then 0.0 else mark.y.max(0.0)/fit.total
+          val sweep = fraction*2.0*π
+          val color = palette.color(index)
+          val end = start + sweep
+          val complete = fraction >= 1.0 - Scale.tolerance
+          val ops = if complete then whole else wedge(start, end, sweep > π)
+          val shape = Outline(ops, style = if complete then filled(color) + ring else filled(color))
+
+          val label: List[Figure] =
+            if fraction < 0.04 then Nil else
+              val middle = (start + end)/2.0
+              val distance = if hole <= 0.0 then radius*0.65 else (radius + hole)/2.0
+              val text = t"${Scale.format(fraction*100.0, 0)}%"
+
+              List
+                ( Lettering
+                    ( rim(middle, distance), text, Lettering.Anchor.Middle,
+                      Lettering.Baseline.Middle, style = lettering ) )
+
+          start = end
+          index += 1
+          label.reverse + (shape :: acc)
+
+        val wedges = Svg.Id(t"wedges") -> Group(figures.reverse, id = Svg.Id(t"wedges"))
+        Cartesian.drawing(wedges :: legendPart(layout.legend, names))
+
+// Parts of a whole: one series, each category a wedge proportional to its value, clockwise from
+// the top. A `hole` between 0 and 1 hollows the centre to that fraction of the radius.
+case class Pie(hole: Double = 0.0)

--- a/lib/tasseomancy/src/core/tasseomancy.Plottable.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Plottable.scala
@@ -39,11 +39,13 @@ import prepositional.*
 // line needs numeric axes — so an unsuitable pairing does not compile. `fit` chooses the axes
 // from the data, `draw` renders against a fit, and `accommodates` says whether a fit still holds
 // new data, which is what lets a live chart replace one part rather than everything. The fit's
-// type is the instance's `Result`, bound with `to` — `Series[x, y] is Plottable in Lines to
-// Lines.Fit` — so a chart's fit is the kind's own, with its axes visible.
-trait Plottable extends Typeclass.Pure, Formal, Resultant:
+// type is the instance's `Result`, bound with `to`, and the style it draws with is its
+// `Operand`, bound with `by` — `Series[x, y] is Plottable in Lines to Lines.Fit by Lines.Style` —
+// so a chart's fit is the kind's own, with its axes visible, and its style is the kind's own too.
+trait Plottable extends Typeclass.Pure, Formal, Resultant, Operable:
+  type Operand <: Chart.Style
   def fit(form: Form, data: Self): Result
   def accommodates(form: Form, fit: Result, data: Self): Boolean
 
-  def draw(form: Form, data: Self, fit: Result)(using Chart.Style, ChartPalette, FontMetric)
+  def draw(form: Form, data: Self, fit: Result)(using Operand, ChartPalette, FontMetric)
   :   Chart.Drawing

--- a/lib/tasseomancy/src/core/tasseomancy.Plottable.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Plottable.scala
@@ -1,0 +1,49 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import prepositional.*
+
+// The compatibility of a shape of data with a kind of chart, and what it takes to draw it. An
+// instance exists only where the kind can draw the data — a pie needs one categorical series, a
+// line needs numeric axes — so an unsuitable pairing does not compile. `fit` chooses the axes
+// from the data, `draw` renders against a fit, and `accommodates` says whether a fit still holds
+// new data, which is what lets a live chart replace one part rather than everything. The fit's
+// type is the instance's `Result`, bound with `to` — `Series[x, y] is Plottable in Lines to
+// Lines.Fit` — so a chart's fit is the kind's own, with its axes visible.
+trait Plottable extends Typeclass.Pure, Formal, Resultant:
+  def fit(form: Form, data: Self): Result
+  def accommodates(form: Form, fit: Result, data: Self): Boolean
+
+  def draw(form: Form, data: Self, fit: Result)(using Chart.Style, ChartPalette, FontMetric)
+  :   Chart.Drawing

--- a/lib/tasseomancy/src/core/tasseomancy.Ruler.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Ruler.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+// The mapping of an axis: either a `Scale` over a numeric range or the `Bands` of a categorical
+// one. A ruler says where its gradations fall, given how many the axis has room for.
+trait Ruler:
+  def gradations(budget: Int): Sequence[Gradation]

--- a/lib/tasseomancy/src/core/tasseomancy.Samples.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Samples.scala
@@ -1,0 +1,43 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import anticipation.*
+
+object Samples:
+  def apply[y](name: Text)(values: y*): Samples[y] = Samples(name, Sequence.from(values))
+
+// Raw measurements under one name, before any summary: what a histogram bins and a box plot
+// summarizes.
+case class Samples[y](name: Text, values: Sequence[y]):
+  def add(value: y): Samples[y] = Samples(name, Sequence.append(values, value))

--- a/lib/tasseomancy/src/core/tasseomancy.Samples.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Samples.scala
@@ -33,9 +33,11 @@
 package tasseomancy
 
 import anticipation.*
+import spectacular.*
 
 object Samples:
-  def apply[y](name: Text)(values: y*): Samples[y] = Samples(name, Sequence.from(values))
+  def apply[name: Showable, y](name: name)(values: y*): Samples[y] =
+    Samples(name.show, Sequence.from(values))
 
 // Raw measurements under one name, before any summary: what a histogram bins and a box plot
 // summarizes.

--- a/lib/tasseomancy/src/core/tasseomancy.Scale.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Scale.scala
@@ -55,6 +55,19 @@ object Scale:
     case Interval
     case Clock
 
+  // How an axis of some type is read: how its gradations are spaced and written, what the
+  // quantity is called (`distance`, `time`), and the unit its values are in (`m`, `kg·s⁻²`).
+  // The name and unit make the axis title — `distance / m` — unless the style gives a title, in
+  // which case the unit is appended to it.
+  case class Notation
+    ( spacing:   Spacing        = Spacing.Decimal,
+      labelling: Labelling      = Labelling.Number(t""),
+      name:      Optional[Text] = Unset,
+      unit:      Optional[Text] = Unset ):
+
+    def title(supplied: Optional[Text]): Optional[Text] =
+      supplied.or(name).let { text => unit.lay(text) { unit => t"$text / $unit" } }.or(unit)
+
   // The slack allowed when a value is compared against a bound it was computed from, so that a
   // gradation at the end of a scale is not lost to a rounding error.
   private[tasseomancy] val tolerance: Double = 0.000000001
@@ -160,15 +173,13 @@ object Scale:
 // A fitted numeric axis: the range it shows, whether positions are linear or logarithmic in
 // value, and how it is graduated and labelled. A scale is plain data, so a chart can tell whether
 // a new point still fits the axis it was drawn with.
-case class Scale
-  ( lower:     Double,
-    upper:     Double,
-    transform: Scale.Transform,
-    spacing:   Scale.Spacing,
-    labelling: Scale.Labelling )
+case class Scale(lower: Double, upper: Double, transform: Scale.Transform, notation: Scale.Notation)
 extends Ruler:
 
   import Scale.*
+
+  def spacing: Spacing = notation.spacing
+  def labelling: Labelling = notation.labelling
 
   // Where a value lies along the axis, as a fraction of its length. On a logarithmic scale a
   // value at or below zero has no position, and is clipped to the axis's start.

--- a/lib/tasseomancy/src/core/tasseomancy.Scale.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Scale.scala
@@ -1,0 +1,240 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import anticipation.*
+import denominative.*
+import gossamer.*
+import hypotenuse.*
+import rudiments.*
+import vacuous.*
+
+object Scale:
+  enum Transform:
+    case Linear, Logarithmic
+
+  // How gradations are spaced along a linear scale: at multiples of 1, 2 and 5 across the
+  // decades, as numbers are read, or at the sexagesimal steps of clock time.
+  enum Spacing:
+    case Decimal, Sexagesimal
+
+  // How a gradation's value is written: as a number with a suffix, as an interval (`250ms`,
+  // `2m30s`), or as a time of day.
+  enum Labelling:
+    case Number(suffix: Text)
+    case Interval
+    case Clock
+
+  // The slack allowed when a value is compared against a bound it was computed from, so that a
+  // gradation at the end of a scale is not lost to a rounding error.
+  private[tasseomancy] val tolerance: Double = 0.000000001
+
+  // The steps of clock time that gradations may take, in seconds, from a millisecond up to a
+  // day; beyond a day, days are counted decimally.
+  private val sexagesimal: Sequence[Double] =
+    Sequence
+      ( 0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0, 30.0,
+        60.0, 120.0, 300.0, 600.0, 900.0, 1800.0, 3600.0, 7200.0, 10800.0, 21600.0, 43200.0,
+        86400.0 )
+
+  // The smallest of 1, 2 and 5 times a power of ten that is no less than `raw`.
+  def step(raw: Double): Double =
+    if raw <= 0.0 then 1.0 else
+      val magnitude = 10.0 ** log10(raw).double.floor
+      val ratio = raw/magnitude
+
+      val factor =
+        if ratio <= 1.0 then 1.0
+        else if ratio <= 2.0 then 2.0
+        else if ratio <= 5.0 then 5.0
+        else 10.0
+
+      factor*magnitude
+
+  def sexagesimalStep(raw: Double): Double =
+    if raw < 0.001 then step(raw) else sexagesimal.seek(_ >= raw).or(step(raw/86400.0)*86400.0)
+
+  // The decimal places needed to write multiples of `step` exactly.
+  def decimals(step: Double): Int =
+    if step >= 1.0 then 0 else (-(log10(step).double + tolerance).floor).toInt
+
+  // A number to a fixed count of decimal places, without a decimal converter: gradation labels
+  // are multiples of a known step, so the places are known rather than chosen.
+  def format(value: Double, decimals: Int): Text =
+    val factor = 10.0 ** decimals.toDouble
+    val scaled: Long = (value*factor).round
+
+    if scaled == 0L then t"0" else
+      val negative = scaled < 0L
+      var digits: Text = (if negative then -scaled else scaled).toString.tt
+      while digits.length < decimals + 1 do digits = t"0$digits"
+
+      val body =
+        if decimals == 0 then digits
+        else t"${digits.keep(digits.length - decimals)}.${digits.skip(digits.length - decimals)}"
+
+      if negative then t"-$body" else body
+
+  // The shortest exact rendering of a value to at most three decimal places.
+  private def trim(value: Double): Text =
+    val thousandths = (value*1000.0).round
+
+    val places =
+      if thousandths%1000L == 0L then 0
+      else if thousandths%100L == 0L then 1
+      else if thousandths%10L == 0L then 2
+      else 3
+
+    format(value, places)
+
+  // An interval in the unit that keeps it short: `250ms`, `41s`, `2m30s`, `1h05m`, `3d02h`.
+  def interval(seconds: Double): Text =
+    val sign = if seconds < 0.0 then t"-" else t""
+    val abs = seconds.abs
+
+    def pair(major: Double, majorUnit: Text, minor: Double, minorUnit: Text): Text =
+      val minorText = format(minor, 0)
+      val padded = if minorText.length < 2 then t"0$minorText" else minorText
+
+      if minor < 0.5 then t"$sign${format(major, 0)}$majorUnit"
+      else t"$sign${format(major, 0)}$majorUnit$padded$minorUnit"
+
+    if abs == 0.0 then t"0s"
+    else if abs < 0.000001 then t"$sign${trim(abs*1000000000.0)}ns"
+    else if abs < 0.001 then t"$sign${trim(abs*1000000.0)}µs"
+    else if abs < 1.0 then t"$sign${trim(abs*1000.0)}ms"
+    else if abs < 60.0 then t"$sign${trim(abs)}s"
+    else if abs < 3600.0 then
+      val minutes = (abs/60.0).floor
+      pair(minutes, t"m", abs - minutes*60.0, t"s")
+    else if abs < 86400.0 then
+      val hours = (abs/3600.0).floor
+      pair(hours, t"h", (abs - hours*3600.0)/60.0, t"m")
+    else
+      val days = (abs/86400.0).floor
+      pair(days, t"d", (abs - days*86400.0)/3600.0, t"h")
+
+  // A time of day, from seconds since the epoch, as `HH:MM:SS` in UTC.
+  def clock(seconds: Double): Text =
+    val day = seconds - (seconds/86400.0).floor*86400.0
+    val hours = (day/3600.0).floor
+    val minutes = ((day - hours*3600.0)/60.0).floor
+    val rest = (day - hours*3600.0 - minutes*60.0).floor
+
+    def pad(value: Double): Text =
+      val text = format(value, 0)
+      if text.length < 2 then t"0$text" else text
+
+    t"${pad(hours)}:${pad(minutes)}:${pad(rest)}"
+
+// A fitted numeric axis: the range it shows, whether positions are linear or logarithmic in
+// value, and how it is graduated and labelled. A scale is plain data, so a chart can tell whether
+// a new point still fits the axis it was drawn with.
+case class Scale
+  ( lower:     Double,
+    upper:     Double,
+    transform: Scale.Transform,
+    spacing:   Scale.Spacing,
+    labelling: Scale.Labelling )
+extends Ruler:
+
+  import Scale.*
+
+  // Where a value lies along the axis, as a fraction of its length. On a logarithmic scale a
+  // value at or below zero has no position, and is clipped to the axis's start.
+  def unit(value: Double): Double = transform match
+    case Transform.Linear =>
+      if upper == lower then 0.5 else (value - lower)/(upper - lower)
+
+    case Transform.Logarithmic =>
+      if value <= 0.0 || lower <= 0.0 || upper <= lower then 0.0
+      else (log10(value).double - log10(lower).double)/(log10(upper).double - log10(lower).double)
+
+  def accommodates(value: Double): Boolean = value >= lower && value <= upper
+
+  def label(value: Double, step: Double): Text = labelling match
+    case Labelling.Number(suffix) => t"${format(value, decimals(step))}$suffix"
+    case Labelling.Interval       => interval(value)
+    case Labelling.Clock          => clock(value)
+
+  def gradations(budget: Int): Sequence[Gradation] = transform match
+    case Transform.Linear                     => linear(budget.max(1))
+    case Transform.Logarithmic if lower > 0.0 => logarithmic(budget.max(1))
+    case Transform.Logarithmic                => linear(budget.max(1))
+
+  private def linear(budget: Int): Sequence[Gradation] =
+    val span = upper - lower
+
+    if span <= 0.0 then Sequence(Gradation(0.5, label(lower, 1.0))) else
+      val raw = span/budget
+
+      val step = spacing match
+        case Spacing.Decimal     => Scale.step(raw)
+        case Spacing.Sexagesimal => sexagesimalStep(raw)
+
+      val first = (lower/step - tolerance).ceiling
+      var index = 0L
+      var marks: List[Gradation] = Nil
+
+      while (first + index)*step <= upper + step*tolerance*1000.0 do
+        val value = (first + index)*step
+        marks = Gradation(unit(value), label(value, step)) :: marks
+        index += 1
+
+      marks.reverse.to[Sequence]
+
+  private def logarithmic(budget: Int): Sequence[Gradation] =
+    val low = log10(lower).double.floor.toInt
+    val high = log10(upper).double.ceiling.toInt
+    val decades = high - low + 1
+    val stride = (decades + budget - 1)/budget
+    var marks: List[Gradation] = Nil
+    var decade = low
+
+    while decade <= high do
+      val value = 10.0 ** decade.toDouble
+
+      if value >= lower*(1.0 - tolerance) && value <= upper*(1.0 + tolerance)
+      then marks = Gradation(unit(value), label(value, value)) :: marks
+
+      if stride == 1 && decades*2 <= budget then
+        var multiple = 2
+
+        while multiple <= 9 do
+          val minor = multiple*value
+          if minor > lower && minor < upper then marks = Gradation(unit(minor), t"", false) :: marks
+          multiple += 1
+
+      decade += stride
+
+    marks.reverse.to[Sequence]

--- a/lib/tasseomancy/src/core/tasseomancy.Scatter.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Scatter.scala
@@ -1,0 +1,111 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import Cartesian.*
+import murmuration.Traversable
+import prepositional.*
+import rudiments.*
+import savagery.*
+import symbolism.*
+import vacuous.*
+
+object Scatter:
+  case class Fit(abscissa: Scale, ordinate: Scale)
+
+  given series: [x: {Continuous, Calibration}, y: {Continuous, Calibration}]
+  =>  Series[x, y] is Plottable in Scatter to Scatter.Fit =
+    plottable[Series[x, y], x, y]: series => List(traceOf(series))
+
+  given traversable: [collection, x, y]
+  =>  ( traversable: collection is Traversable by Series[x, y] )
+  =>  ( continuousX: x is Continuous, calibrationX: x is Calibration )
+  =>  ( continuousY: y is Continuous, calibrationY: y is Calibration )
+  =>  collection is Plottable in Scatter to Scatter.Fit =
+    plottable[collection, x, y]: collection =>
+      List.from(traversable.traverse(collection).map(traceOf(_)))
+
+  private def plottable[data, x: {Continuous, Calibration}, y: {Continuous, Calibration}]
+    ( traces: data -> List[Trace] )
+  :   data is Plottable in Scatter to Scatter.Fit =
+
+    new Plottable:
+      type Self = data
+      type Form = Scatter
+      type Result = Scatter.Fit
+
+      def fit(form: Scatter, data: data): Scatter.Fit =
+        val (abscissa, ordinate) =
+          Lines.fitTraces[x, y](traces(data), form.abscissa, form.ordinate)
+
+        Scatter.Fit(abscissa, ordinate)
+
+      def accommodates(form: Scatter, fit: Scatter.Fit, data: data): Boolean =
+        Lines.accommodatesTraces(traces(data), fit.abscissa, fit.ordinate)
+
+      def draw(form: Scatter, data: data, fit: Scatter.Fit)
+        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+      :   Chart.Drawing =
+
+        val all = traces(data)
+        val names = all.map(_.name)
+        val layout = Cartesian.layout(fit.ordinate, names)
+        val frame = layout.frame
+        var index = 0
+
+        val seriesParts = all.map: trace =>
+          val color = palette.color(index)
+
+          val figures = trace.data.fold(List[Figure]()): (acc, datum) =>
+            val x = frame.x(fit.abscissa.unit(datum.x))
+            val y = frame.y(fit.ordinate.unit(datum.y))
+            val marker = Circle(point(x, y), style.markerRadius.toFloat, style = filled(color))
+
+            val errors = datum.bounds.lay(Nil): (low, high) =>
+              val top = frame.y(fit.ordinate.unit(high))
+              val bottom = frame.y(fit.ordinate.unit(low))
+              errorBar(x, top, bottom, style.markerRadius)
+
+            errors.reverse + (marker :: acc)
+
+          val part = seriesId(index) -> Group(figures.reverse, id = seriesId(index))
+          index += 1
+          part
+
+        val legend = legendPart(layout.legend, names)
+        Cartesian.drawing(axes(frame, fit.abscissa, fit.ordinate) + seriesParts + legend)
+
+// A marker per point, in no particular order, with error bars where the values carry intervals.
+// The same fit as a line chart; only the drawing differs.
+case class Scatter
+  ( abscissa: Optional[Calibration] = Unset, ordinate: Optional[Calibration] = Unset )

--- a/lib/tasseomancy/src/core/tasseomancy.Scatter.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Scatter.scala
@@ -79,7 +79,7 @@ object Scatter:
 
         val all = traces(data)
         val names = all.map(_.name)
-        val layout = Cartesian.layout(fit.ordinate, names)
+        val layout = Cartesian.layout(fit.abscissa, fit.ordinate, names)
         val frame = layout.frame
         var index = 0
 

--- a/lib/tasseomancy/src/core/tasseomancy.Scatter.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Scatter.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package tasseomancy
 
-import Cartesian.*
+import Framing.*
 import murmuration.Traversable
 import prepositional.*
 import rudiments.*
@@ -43,26 +43,31 @@ import vacuous.*
 object Scatter:
   case class Fit(abscissa: Scale, ordinate: Scale)
 
+  // A scatter plot's components — markers, error bars and point labels — are the ones every
+  // cartesian chart shares.
+  trait Style extends Chart.Cartesian
+
   given series: [x: {Continuous, Calibration}, y: {Continuous, Calibration}]
-  =>  Series[x, y] is Plottable in Scatter to Scatter.Fit =
+  =>  Series[x, y] is Plottable in Scatter to Scatter.Fit by Scatter.Style =
     plottable[Series[x, y], x, y]: series => List(traceOf(series))
 
   given traversable: [collection, x, y]
   =>  ( traversable: collection is Traversable by Series[x, y] )
   =>  ( continuousX: x is Continuous, calibrationX: x is Calibration )
   =>  ( continuousY: y is Continuous, calibrationY: y is Calibration )
-  =>  collection is Plottable in Scatter to Scatter.Fit =
+  =>  collection is Plottable in Scatter to Scatter.Fit by Scatter.Style =
     plottable[collection, x, y]: collection =>
       List.from(traversable.traverse(collection).map(traceOf(_)))
 
   private def plottable[data, x: {Continuous, Calibration}, y: {Continuous, Calibration}]
     ( traces: data -> List[Trace] )
-  :   data is Plottable in Scatter to Scatter.Fit =
+  :   data is Plottable in Scatter to Scatter.Fit by Scatter.Style =
 
     new Plottable:
       type Self = data
       type Form = Scatter
       type Result = Scatter.Fit
+      type Operand = Scatter.Style
 
       def fit(form: Scatter, data: data): Scatter.Fit =
         val (abscissa, ordinate) =
@@ -74,12 +79,12 @@ object Scatter:
         Lines.accommodatesTraces(traces(data), fit.abscissa, fit.ordinate)
 
       def draw(form: Scatter, data: data, fit: Scatter.Fit)
-        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+        ( using style: Scatter.Style, palette: ChartPalette, metric: FontMetric )
       :   Chart.Drawing =
 
         val all = traces(data)
         val names = all.map(_.name)
-        val layout = Cartesian.layout(fit.abscissa, fit.ordinate, names)
+        val layout = Framing.layout(fit.abscissa, fit.ordinate, names)
         val frame = layout.frame
         var index = 0
 
@@ -89,23 +94,26 @@ object Scatter:
           val figures = trace.data.fold(List[Figure]()): (acc, datum) =>
             val x = frame.x(fit.abscissa.unit(datum.x))
             val y = frame.y(fit.ordinate.unit(datum.y))
-            val marker = Circle(point(x, y), style.markerRadius.toFloat, style = filled(color))
+            val marker = style.marker(point(x, y), color, index)
 
             val errors = datum.bounds.lay(Nil): (low, high) =>
               val top = frame.y(fit.ordinate.unit(high))
               val bottom = frame.y(fit.ordinate.unit(low))
-              errorBar(x, top, bottom, style.markerRadius)
+              style.errorBar(x, top, bottom, style.markerRadius, palette.axis)
 
-            errors.reverse + (marker :: acc)
+            val at = point(x, y)
+            val note = datum.note.lay(Nil): text => style.pointLabel(at, text, palette.text)
+            note.reverse + (errors.reverse + (marker.reverse + acc))
 
           val part = seriesId(index) -> Group(figures.reverse, id = seriesId(index))
           index += 1
           part
 
         val legend = legendPart(layout.legend, names)
-        Cartesian.drawing(axes(frame, fit.abscissa, fit.ordinate) + seriesParts + legend)
+        Framing.drawing(axes(frame, fit.abscissa, fit.ordinate) + seriesParts + legend)
 
-// A marker per point, in no particular order, with error bars where the values carry intervals.
-// The same fit as a line chart; only the drawing differs.
+// A marker per point, in no particular order, with error bars where the values carry intervals
+// and a label where a point carries a note. The same fit as a line chart; only the drawing
+// differs.
 case class Scatter
   ( abscissa: Optional[Calibration] = Unset, ordinate: Optional[Calibration] = Unset )

--- a/lib/tasseomancy/src/core/tasseomancy.Series.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Series.scala
@@ -37,7 +37,10 @@ import rudiments.*
 import spectacular.*
 
 object Series:
-  def apply[x, y](name: Text)(points: (x, y)*): Series[x, y] = Series(name, Sequence.from(points))
+  // A name is anything showable — a `Text`, an enum case, a number — shown once, at
+  // construction.
+  def apply[name: Showable, x, y](name: name)(points: (x, y)*): Series[x, y] =
+    Series(name.show, Sequence.from(points))
 
 // One named run of points: the unit of data a chart kind is compatible with. A series is
 // immutable; `add` appends in amortized constant time, which is what a chart fed one point at a

--- a/lib/tasseomancy/src/core/tasseomancy.Series.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.Series.scala
@@ -1,0 +1,51 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import anticipation.*
+import rudiments.*
+import spectacular.*
+
+object Series:
+  def apply[x, y](name: Text)(points: (x, y)*): Series[x, y] = Series(name, Sequence.from(points))
+
+// One named run of points: the unit of data a chart kind is compatible with. A series is
+// immutable; `add` appends in amortized constant time, which is what a chart fed one point at a
+// time needs.
+case class Series[x, y](name: Text, points: Sequence[(x, y)]):
+  def add(point: (x, y)): Series[x, y] = Series(name, Sequence.append(points, point))
+
+  // The same points with each abscissa value as a category, for a bar chart over what would
+  // otherwise be a numeric axis: a bar per input size, rather than a line over sizes.
+  def categorical(using showable: x is Showable): Series[Category, y] =
+    Series(name, points.map { (abscissa, ordinate) => (Category(abscissa.show), ordinate) })

--- a/lib/tasseomancy/src/core/tasseomancy.StackedBars.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.StackedBars.scala
@@ -1,0 +1,156 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import Cartesian.*
+import murmuration.Traversable
+import prepositional.*
+import rudiments.*
+import savagery.*
+import symbolism.*
+import vacuous.*
+
+object StackedBars:
+  case class Fit(bands: Bands, ordinate: Scale)
+
+  // The running totals of a category's positive and negative values, stacked apart.
+  private case class Stack(positive: Double, negative: Double)
+
+  given traversable: [collection, x, y]
+  =>  ( traversable: collection is Traversable by Series[x, y] )
+  =>  ( categorical: x is Categorical, continuous: y is Continuous, calibration: y is Calibration )
+  =>  collection is Plottable in StackedBars to StackedBars.Fit =
+    plottable[collection, y]: collection =>
+      List.from(traversable.traverse(collection).map(columnOf(_)))
+
+  private def empty(count: Int): Sequence[Stack] =
+    var stacks: Sequence[Stack] = Sequence.empty
+    var index = 0
+
+    while index < count do
+      stacks = Sequence.append(stacks, Stack(0.0, 0.0))
+      index += 1
+
+    stacks
+
+  private def totals(all: List[Column], bands: Bands): Sequence[Stack] =
+    var stacks = empty(bands.count)
+
+    all.foreach: column =>
+      column.marks.foreach: mark =>
+        bands.index(mark.category).let: band =>
+          val stack = Sequence.at(stacks, band)
+
+          val updated =
+            if mark.y >= 0.0 then Stack(stack.positive + mark.y, stack.negative)
+            else Stack(stack.positive, stack.negative + mark.y)
+
+          stacks = Sequence.define(stacks, band, updated)
+
+    stacks
+
+  private def plottable[data, y: {Continuous as continuous, Calibration as calibration}]
+    ( columns: data -> List[Column] )
+  :   data is Plottable in StackedBars to StackedBars.Fit =
+
+    new Plottable:
+      type Self = data
+      type Form = StackedBars
+      type Result = StackedBars.Fit
+
+      def fit(form: StackedBars, data: data): StackedBars.Fit =
+        val all = columns(data)
+        val bands = Bands(categories(all))
+
+        val extent = totals(all, bands).fold(Extent.empty): (acc, stack) =>
+          acc.include(stack.positive).include(stack.negative)
+
+        val scale =
+          form.ordinate.or(calibration)
+          . scale(extent.lowerOr0, extent.upperOr1, true, continuous.spacing, continuous.labelling)
+
+        StackedBars.Fit(bands, scale)
+
+      def accommodates(form: StackedBars, fit: StackedBars.Fit, data: data): Boolean =
+        val all = columns(data)
+
+        val known = all.all: column =>
+          column.marks.all: mark => fit.bands.index(mark.category).present
+
+        val within = totals(all, fit.bands).all: stack =>
+          fit.ordinate.accommodates(stack.positive) && fit.ordinate.accommodates(stack.negative)
+
+        known && within
+
+      def draw(form: StackedBars, data: data, fit: StackedBars.Fit)
+        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+      :   Chart.Drawing =
+
+        val all = columns(data)
+        val names = all.map(_.name)
+        val layout = Cartesian.layout(fit.ordinate, names)
+        val frame = layout.frame
+        val barWidth = frame.width*fit.bands.width*(1.0 - style.barGap)
+        var stacks = empty(fit.bands.count)
+        var index = 0
+
+        val seriesParts = all.map: column =>
+          val color = filled(palette.color(index))
+
+          val figures = column.marks.fold(List[Figure]()): (acc, mark) =>
+            fit.bands.index(mark.category).lay(acc): band =>
+              val stack = Sequence.at(stacks, band)
+              val from = if mark.y >= 0.0 then stack.positive else stack.negative
+              val to = from + mark.y
+
+              val updated =
+                if mark.y >= 0.0 then Stack(to, stack.negative) else Stack(stack.positive, to)
+
+              stacks = Sequence.define(stacks, band, updated)
+              val x0 = frame.x(fit.bands.centre(band)) - barWidth/2.0
+              val y0 = frame.y(fit.ordinate.unit(from))
+              val y1 = frame.y(fit.ordinate.unit(to))
+              val corner = point(x0, y0.min(y1))
+              Rectangle(corner, barWidth.toFloat, (y1 - y0).abs.toFloat, style = color) :: acc
+
+          val part = seriesId(index) -> Group(figures.reverse, id = seriesId(index))
+          index += 1
+          part
+
+        val legend = legendPart(layout.legend, names)
+        Cartesian.drawing(axes(frame, fit.bands, fit.ordinate) + seriesParts + legend)
+
+// Bars stacked by category: each series' value sits on the total of those before it, so that a
+// bar's full height is the category's total. Positive and negative values stack apart, in
+// opposite directions from zero.
+case class StackedBars(ordinate: Optional[Calibration] = Unset)

--- a/lib/tasseomancy/src/core/tasseomancy.StackedBars.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.StackedBars.scala
@@ -97,7 +97,7 @@ object StackedBars:
 
         val scale =
           form.ordinate.or(calibration)
-          . scale(extent.lowerOr0, extent.upperOr1, true, continuous.spacing, continuous.labelling)
+          . scale(extent.lowerOr0, extent.upperOr1, true, continuous.notation)
 
         StackedBars.Fit(bands, scale)
 
@@ -118,7 +118,7 @@ object StackedBars:
 
         val all = columns(data)
         val names = all.map(_.name)
-        val layout = Cartesian.layout(fit.ordinate, names)
+        val layout = Cartesian.layout(fit.bands, fit.ordinate, names)
         val frame = layout.frame
         val barWidth = frame.width*fit.bands.width*(1.0 - style.barGap)
         var stacks = empty(fit.bands.count)

--- a/lib/tasseomancy/src/core/tasseomancy.StackedBars.scala
+++ b/lib/tasseomancy/src/core/tasseomancy.StackedBars.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package tasseomancy
 
-import Cartesian.*
+import Framing.*
 import murmuration.Traversable
 import prepositional.*
 import rudiments.*
@@ -43,13 +43,16 @@ import vacuous.*
 object StackedBars:
   case class Fit(bands: Bands, ordinate: Scale)
 
+  // A stacked chart draws the same components as a grouped one.
+  trait Style extends Bars.Style
+
   // The running totals of a category's positive and negative values, stacked apart.
   private case class Stack(positive: Double, negative: Double)
 
   given traversable: [collection, x, y]
   =>  ( traversable: collection is Traversable by Series[x, y] )
   =>  ( categorical: x is Categorical, continuous: y is Continuous, calibration: y is Calibration )
-  =>  collection is Plottable in StackedBars to StackedBars.Fit =
+  =>  collection is Plottable in StackedBars to StackedBars.Fit by StackedBars.Style =
     plottable[collection, y]: collection =>
       List.from(traversable.traverse(collection).map(columnOf(_)))
 
@@ -81,12 +84,13 @@ object StackedBars:
 
   private def plottable[data, y: {Continuous as continuous, Calibration as calibration}]
     ( columns: data -> List[Column] )
-  :   data is Plottable in StackedBars to StackedBars.Fit =
+  :   data is Plottable in StackedBars to StackedBars.Fit by StackedBars.Style =
 
     new Plottable:
       type Self = data
       type Form = StackedBars
       type Result = StackedBars.Fit
+      type Operand = StackedBars.Style
 
       def fit(form: StackedBars, data: data): StackedBars.Fit =
         val all = columns(data)
@@ -113,19 +117,19 @@ object StackedBars:
         known && within
 
       def draw(form: StackedBars, data: data, fit: StackedBars.Fit)
-        ( using style: Chart.Style, palette: ChartPalette, metric: FontMetric )
+        ( using style: StackedBars.Style, palette: ChartPalette, metric: FontMetric )
       :   Chart.Drawing =
 
         val all = columns(data)
         val names = all.map(_.name)
-        val layout = Cartesian.layout(fit.bands, fit.ordinate, names)
+        val layout = Framing.layout(fit.bands, fit.ordinate, names)
         val frame = layout.frame
         val barWidth = frame.width*fit.bands.width*(1.0 - style.barGap)
         var stacks = empty(fit.bands.count)
         var index = 0
 
         val seriesParts = all.map: column =>
-          val color = filled(palette.color(index))
+          val color = palette.color(index)
 
           val figures = column.marks.fold(List[Figure]()): (acc, mark) =>
             fit.bands.index(mark.category).lay(acc): band =>
@@ -140,15 +144,14 @@ object StackedBars:
               val x0 = frame.x(fit.bands.centre(band)) - barWidth/2.0
               val y0 = frame.y(fit.ordinate.unit(from))
               val y1 = frame.y(fit.ordinate.unit(to))
-              val corner = point(x0, y0.min(y1))
-              Rectangle(corner, barWidth.toFloat, (y1 - y0).abs.toFloat, style = color) :: acc
+              style.bar(point(x0, y0.min(y1)), barWidth, (y1 - y0).abs, color, index).reverse + acc
 
           val part = seriesId(index) -> Group(figures.reverse, id = seriesId(index))
           index += 1
           part
 
         val legend = legendPart(layout.legend, names)
-        Cartesian.drawing(axes(frame, fit.bands, fit.ordinate) + seriesParts + legend)
+        Framing.drawing(axes(frame, fit.bands, fit.ordinate) + seriesParts + legend)
 
 // Bars stacked by category: each series' value sits on the total of those before it, so that a
 // bar's full height is the category's total. Positive and negative values stack apart, in

--- a/lib/tasseomancy/src/core/tasseomancy_core.scala
+++ b/lib/tasseomancy/src/core/tasseomancy_core.scala
@@ -1,0 +1,103 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import gossamer.*
+import iridescence.*
+import prepositional.*
+import quantitative.*
+import symbolism.*
+
+// The entry point: data and a chart kind, checked for compatibility as the code compiles, become
+// a chart fitted to the data.
+extension [data](data: data)
+  def chart[form, fit](form: form)(using plottable: data is Plottable in form to fit)
+  :   Chart[data, form, fit] =
+
+    Chart(data, form, plottable.fit(form, data))
+
+package calibrations:
+  given linearCalibration: [value] => value is Calibration = Calibration(Calibration.Policy.Linear)
+
+  given logarithmicCalibration: [value] => value is Calibration =
+    Calibration(Calibration.Policy.Logarithmic)
+
+  given adaptiveCalibration: [value] => value is Calibration =
+    Calibration(Calibration.Policy.Adaptive)
+
+  given tightCalibration: [value] => value is Calibration = Calibration(Calibration.Policy.Tight)
+
+package palettes:
+  private def rgb(red: Double, green: Double, blue: Double): Color in Srgb = Srgb(red, green, blue)
+
+  given slateChartPalette: ChartPalette = new ChartPalette:
+    val series: Sequence[Color in Srgb] =
+      Sequence
+        ( rgb(0.306, 0.475, 0.655), rgb(0.949, 0.557, 0.169), rgb(0.882, 0.341, 0.349),
+          rgb(0.463, 0.718, 0.698), rgb(0.349, 0.631, 0.310), rgb(0.929, 0.788, 0.282),
+          rgb(0.690, 0.478, 0.631), rgb(1.000, 0.616, 0.655) )
+
+    def background: Color in Srgb = rgb(1.0, 1.0, 1.0)
+    def foreground: Color in Srgb = rgb(0.2, 0.2, 0.2)
+    def axis: Color in Srgb = rgb(0.4, 0.4, 0.4)
+    def grid: Color in Srgb = rgb(0.87, 0.87, 0.87)
+    def text: Color in Srgb = rgb(0.2, 0.2, 0.2)
+
+  private val solarizedSeries: Sequence[Color in Srgb] =
+    Sequence
+      ( rgb(0.149, 0.545, 0.824), rgb(0.796, 0.294, 0.086), rgb(0.522, 0.600, 0.000),
+        rgb(0.827, 0.212, 0.510), rgb(0.165, 0.631, 0.596), rgb(0.710, 0.537, 0.000),
+        rgb(0.424, 0.443, 0.769), rgb(0.863, 0.196, 0.184) )
+
+  given solarizedDarkChartPalette: ChartPalette = new ChartPalette:
+    val series: Sequence[Color in Srgb] = solarizedSeries
+    def background: Color in Srgb = rgb(0.000, 0.169, 0.212)
+    def foreground: Color in Srgb = rgb(0.514, 0.580, 0.588)
+    def axis: Color in Srgb = rgb(0.345, 0.431, 0.459)
+    def grid: Color in Srgb = rgb(0.027, 0.212, 0.259)
+    def text: Color in Srgb = rgb(0.576, 0.631, 0.631)
+
+  given solarizedLightChartPalette: ChartPalette = new ChartPalette:
+    val series: Sequence[Color in Srgb] = solarizedSeries
+    def background: Color in Srgb = rgb(0.992, 0.965, 0.890)
+    def foreground: Color in Srgb = rgb(0.396, 0.482, 0.514)
+    def axis: Color in Srgb = rgb(0.576, 0.631, 0.631)
+    def grid: Color in Srgb = rgb(0.933, 0.910, 0.835)
+    def text: Color in Srgb = rgb(0.345, 0.431, 0.459)
+
+package fontMetrics:
+  // Six tenths of an em per character: the width of an average proportional face.
+  given averageFontMetric: FontMetric = text => 0.6*text.length*Em
+
+  // Half an em per character: a monospace face.
+  given tabularFontMetric: FontMetric = text => 0.5*text.length*Em

--- a/lib/tasseomancy/src/test/tasseomancy_test.scala
+++ b/lib/tasseomancy/src/test/tasseomancy_test.scala
@@ -372,6 +372,19 @@ object Tests extends Suite(m"Tasseomancy tests"):
         (next.fit.abscissa.upper, next.fit.ordinate.upper)
       . assert(_ == (10.0, 10.0))
 
+    suite(m"Names"):
+      test(m"a series may be named by any showable value"):
+        Series(2024)((t"jan", 1.0)).name
+      . assert(_ == t"2024")
+
+      test(m"samples may be named by an enum case"):
+        Samples(Chart.Legend.Right)(1.0, 2.0).name
+      . assert(_ == t"Right")
+
+      test(m"a category may be made from any showable value"):
+        Category(42).label
+      . assert(_ == t"42")
+
     suite(m"Compatibility"):
       test(m"a categorical series cannot be a line chart"):
         demilitarize:

--- a/lib/tasseomancy/src/test/tasseomancy_test.scala
+++ b/lib/tasseomancy/src/test/tasseomancy_test.scala
@@ -99,8 +99,8 @@ object Tests extends Suite(m"Tasseomancy tests"):
   def labels(scale: Scale, budget: Int): List[Text] =
     scale.gradations(budget).filter(_.major).map(_.label).to[List]
 
-  def rendered[data, form, fit](chart: Chart[data, form, fit])
-    ( using Chart.Style, ChartPalette, FontMetric )
+  def rendered[data, form, fit, style <: Chart.Style](chart: Chart[data, form, fit, style])
+    ( using style, ChartPalette, FontMetric )
   :   Text =
     chart.svg.xml.show
 
@@ -267,7 +267,7 @@ object Tests extends Suite(m"Tasseomancy tests"):
       . assert(_ == 1 + 6 + 2)
 
       test(m"a hidden legend draws no swatches"):
-        given Chart.Style = Chart.Style(legend = Chart.Legend.Hidden)
+        given Chart.Standard = Chart.Standard(legend = Chart.Legend.Hidden)
         occurrences(rendered(sales.chart(Bars())), t"<rect")
       . assert(_ == 1 + 6)
 
@@ -277,7 +277,7 @@ object Tests extends Suite(m"Tasseomancy tests"):
       . assert(_ >= 2)
 
       test(m"a scatter plot draws one marker per point"):
-        given Chart.Style = Chart.Style(grid = false, legend = Chart.Legend.Hidden)
+        given Chart.Standard = Chart.Standard(grid = false, legend = Chart.Legend.Hidden)
         occurrences(rendered(growth.chart(Scatter())), t"<circle")
       . assert(_ == 2)
 
@@ -301,7 +301,7 @@ object Tests extends Suite(m"Tasseomancy tests"):
       . assert(_ == 1 + 2 + 2)
 
       test(m"an error bar is drawn for an estimate"):
-        given Chart.Style = Chart.Style(grid = false, legend = Chart.Legend.Hidden)
+        given Chart.Standard = Chart.Standard(grid = false, legend = Chart.Legend.Hidden)
         val data = Series(t"a")((t"x", Estimate(5.0, 4.0, 6.0)))
         val text = rendered(data.chart(Bars())).s
         val start = text.indexOf("id=\"series-0\"")
@@ -315,7 +315,7 @@ object Tests extends Suite(m"Tasseomancy tests"):
       . assert(_ == true)
 
       test(m"a style's title takes the unit from the quantity"):
-        given Chart.Style = Chart.Style(ordinateTitle = t"tide height")
+        given Chart.Standard = Chart.Standard(ordinateTitle = t"tide height")
         val heights = Series(t"tide")((0.0, 1.2*Metre), (6.0, 4.6*Metre), (12.0, 1.1*Metre))
         rendered(heights.chart(Lines())).contains(t">tide height / m<")
       . assert(_ == true)
@@ -332,7 +332,7 @@ object Tests extends Suite(m"Tasseomancy tests"):
       . assert(_ == (true, true))
 
       test(m"axis titles are lettered"):
-        given Chart.Style = Chart.Style(abscissaTitle = t"month", ordinateTitle = t"sales")
+        given Chart.Standard = Chart.Standard(abscissaTitle = t"month", ordinateTitle = t"sales")
         val text = rendered(sales.chart(Bars()))
         (text.contains(t">month<"), text.contains(t">sales<"))
       . assert(_ == (true, true))
@@ -347,9 +347,8 @@ object Tests extends Suite(m"Tasseomancy tests"):
       . assert(_ == 0.9)
 
       test(m"a measured legend is narrower for a narrow face"):
-        given Chart.Style = Chart.Style()
-        val average = Cartesian.layout(Unset, Unset, List(t"ABC"))(using summon[Chart.Style], summon[FontMetric])
-        val measured = Cartesian.layout(Unset, Unset, List(t"ABC"))(using summon[Chart.Style], FontMetric.of(TestFont.font))
+        val average = Framing.layout(Unset, Unset, List(t"ABC"))(using summon[Chart.Standard], summon[FontMetric])
+        val measured = Framing.layout(Unset, Unset, List(t"ABC"))(using summon[Chart.Standard], FontMetric.of(TestFont.font))
         val width = measured.legend.let(_.width).or(0.0)
         (average.frame.width < measured.frame.width, (width - 32.4).abs < 0.000001)
       . assert(_ == (true, true))
@@ -371,6 +370,36 @@ object Tests extends Suite(m"Tasseomancy tests"):
         val (next, _) = growth.chart(Lines()).revise(growth.add((5.0, 5.0)))
         (next.fit.abscissa.upper, next.fit.ordinate.upper)
       . assert(_ == (10.0, 10.0))
+
+    suite(m"Styling"):
+      test(m"a component's rendering is an override on the standard style"):
+        given Chart.Standard = new Chart.Standard(legend = Chart.Legend.Hidden):
+          override def bar(corner: Point, width: Double, height: Double, color: Color in Srgb, series: Int)
+          :   List[Figure] =
+            List(Circle(corner, (width/2.0).toFloat))
+
+        val text = rendered(sales.chart(Bars()))
+        (occurrences(text, t"<circle"), occurrences(text, t"<rect"))
+      . assert(_ == (6, 1))
+
+      test(m"an axis gains an arrowhead through its hook"):
+        given Chart.Standard = new Chart.Standard():
+          override def arrowhead(tip: Point, axis: Chart.Axis, color: Color in Srgb): List[Figure] =
+            List(Polyline(List(tip, Point(tip.x - 6, tip.y - 3), Point(tip.x - 6, tip.y + 3)), closed = true))
+
+        occurrences(rendered(growth.chart(Lines())), t"<polygon")
+      . assert(_ == 2)
+
+      test(m"a style shared by every kind still resolves for each"):
+        given Chart.Standard = Chart.Standard(width = 320.0, height = 200.0)
+        rendered(Series(t"share")((t"a", 1.0), (t"b", 3.0)).chart(Pie())).contains(t"viewBox=\"0 0 320.0 200.0\"")
+      . assert(_ == true)
+
+      test(m"an annotated point is labelled beside its marker"):
+        val named = Series(t"cities")((1.0, Annotated(3.0, t"Paris")), (2.0, Annotated(5.0, t"Rome")))
+        val text = rendered(named.chart(Scatter()))
+        (text.contains(t">Paris<"), text.contains(t">Rome<"))
+      . assert(_ == (true, true))
 
     suite(m"Names"):
       test(m"a series may be named by any showable value"):

--- a/lib/tasseomancy/src/test/tasseomancy_test.scala
+++ b/lib/tasseomancy/src/test/tasseomancy_test.scala
@@ -94,8 +94,7 @@ object TestFont:
         t"maxp" -> maxpTable)
 
 object Tests extends Suite(m"Tasseomancy tests"):
-  val number = Scale.Labelling.Number(t"")
-  val decimal = Scale.Spacing.Decimal
+  val decimal = Scale.Notation()
 
   def labels(scale: Scale, budget: Int): List[Text] =
     scale.gradations(budget).filter(_.major).map(_.label).to[List]
@@ -162,47 +161,47 @@ object Tests extends Suite(m"Tasseomancy tests"):
 
     suite(m"Calibration"):
       test(m"a linear scale pads outward to whole steps"):
-        val scale = Calibration.linear(0.0, 97.0, false, decimal, number, false)
+        val scale = Calibration.linear(0.0, 97.0, false, decimal, false)
         (scale.lower, scale.upper)
       . assert(_ == (0.0, 100.0))
 
       test(m"linear gradations fall on multiples of 1, 2 and 5"):
-        labels(Calibration.linear(0.0, 97.0, false, decimal, number, false), 5)
+        labels(Calibration.linear(0.0, 97.0, false, decimal, false), 5)
       . assert(_ == List(t"0", t"20", t"40", t"60", t"80", t"100"))
 
       test(m"a logarithmic scale spans whole decades"):
-        val scale = Calibration.logarithmic(3.0, 4200.0, false, decimal, number)
+        val scale = Calibration.logarithmic(3.0, 4200.0, false, decimal)
         (scale.transform, scale.lower, scale.upper)
       . assert(_ == (Scale.Transform.Logarithmic, 1.0, 10000.0))
 
       test(m"logarithmic gradations are powers of ten"):
-        labels(Calibration.logarithmic(3.0, 4200.0, false, decimal, number), 5)
+        labels(Calibration.logarithmic(3.0, 4200.0, false, decimal), 5)
       . assert(_ == List(t"1", t"10", t"100", t"1000", t"10000"))
 
       test(m"a logarithmic scale over non-positive values falls back to linear"):
-        Calibration.logarithmic(-1.0, 10.0, false, decimal, number).transform
+        Calibration.logarithmic(-1.0, 10.0, false, decimal).transform
       . assert(_ == Scale.Transform.Linear)
 
       test(m"adaptive calibration goes logarithmic at a thousandfold range"):
-        Calibration[Double](Calibration.Policy.Adaptive).scale(1.0, 5000.0, false, decimal, number).transform
+        Calibration[Double](Calibration.Policy.Adaptive).scale(1.0, 5000.0, false, decimal).transform
       . assert(_ == Scale.Transform.Logarithmic)
 
       test(m"adaptive calibration stays linear over a narrow range"):
-        Calibration[Double](Calibration.Policy.Adaptive).scale(1.0, 500.0, false, decimal, number).transform
+        Calibration[Double](Calibration.Policy.Adaptive).scale(1.0, 500.0, false, decimal).transform
       . assert(_ == Scale.Transform.Linear)
 
       test(m"an anchored scale includes zero"):
-        Calibration.linear(5.0, 9.0, true, decimal, number, false).lower
+        Calibration.linear(5.0, 9.0, true, decimal, false).lower
       . assert(_ == 0.0)
 
       test(m"a tight scale is exactly the data's extent"):
-        val scale = Calibration.linear(5.0, 9.0, false, decimal, number, true)
+        val scale = Calibration.linear(5.0, 9.0, false, decimal, true)
         (scale.lower, scale.upper)
       . assert(_ == (5.0, 9.0))
 
       test(m"sexagesimal gradations land on clock steps"):
-        val interval = Scale.Labelling.Interval
-        val scale = Calibration.linear(0.0, 100.0, false, Scale.Spacing.Sexagesimal, interval, false)
+        val clock = Scale.Notation(Scale.Spacing.Sexagesimal, Scale.Labelling.Interval)
+        val scale = Calibration.linear(0.0, 100.0, false, clock, false)
         labels(scale, 5)
       . assert(_ == List(t"0s", t"30s", t"1m", t"1m30s", t"2m"))
 
@@ -259,18 +258,18 @@ object Tests extends Suite(m"Tasseomancy tests"):
     suite(m"Drawing"):
       test(m"a chart's parts have stable identifiers"):
         val text = rendered(sales.chart(Bars()))
-        List(t"grid", t"abscissa", t"ordinate", t"series-0", t"series-1", t"legend").all: id =>
+        List(t"backdrop", t"grid", t"abscissa", t"ordinate", t"series-0", t"series-1", t"legend").all: id =>
           text.contains(t"""id="$id"""")
       . assert(_ == true)
 
       test(m"grouped bars draw one rectangle per value, plus the legend's swatches"):
         occurrences(rendered(sales.chart(Bars())), t"<rect")
-      . assert(_ == 8)
+      . assert(_ == 1 + 6 + 2)
 
       test(m"a hidden legend draws no swatches"):
         given Chart.Style = Chart.Style(legend = Chart.Legend.Hidden)
         occurrences(rendered(sales.chart(Bars())), t"<rect")
-      . assert(_ == 6)
+      . assert(_ == 1 + 6)
 
       test(m"a line chart draws one polyline per series"):
         val text = rendered(List(growth, Series(t"decay")((0.0, 10.0), (10.0, 0.0))).chart(Lines()))
@@ -290,16 +289,16 @@ object Tests extends Suite(m"Tasseomancy tests"):
       test(m"a set of series plots the same as a list"):
         val fromSet = rendered(sales.to[Set].chart(Bars()))
         occurrences(fromSet, t"<rect")
-      . assert(_ == 8)
+      . assert(_ == 9)
 
       test(m"a sequence of series plots the same as a list"):
         occurrences(rendered(sales.to[Sequence].chart(Bars())), t"<rect")
-      . assert(_ == 8)
+      . assert(_ == 9)
 
       test(m"a box plot draws a box and whiskers per sample set"):
         val data = List(Samples(t"a")(1.0, 2.0, 3.0), Samples(t"b")(2.0, 4.0, 8.0))
         occurrences(rendered(data.chart(Boxes())), t"<rect")
-      . assert(_ == 4)
+      . assert(_ == 1 + 2 + 2)
 
       test(m"an error bar is drawn for an estimate"):
         given Chart.Style = Chart.Style(grid = false, legend = Chart.Legend.Hidden)
@@ -309,6 +308,28 @@ object Tests extends Suite(m"Tasseomancy tests"):
         val end = text.indexOf("</g>", start)
         occurrences(text.substring(start, end).nn.tt, t"<polyline")
       . assert(_ == 3)
+
+      test(m"a quantity's axis is titled with its dimension and unit"):
+        val heights = Series(t"tide")((0.0, 1.2*Metre), (6.0, 4.6*Metre), (12.0, 1.1*Metre))
+        rendered(heights.chart(Lines())).contains(t">distance / m<")
+      . assert(_ == true)
+
+      test(m"a style's title takes the unit from the quantity"):
+        given Chart.Style = Chart.Style(ordinateTitle = t"tide height")
+        val heights = Series(t"tide")((0.0, 1.2*Metre), (6.0, 4.6*Metre), (12.0, 1.1*Metre))
+        rendered(heights.chart(Lines())).contains(t">tide height / m<")
+      . assert(_ == true)
+
+      test(m"a compound unit is rendered with its powers"):
+        val speeds = Series(t"gust")((0.0, 3.0*Metre/Second), (1.0, 7.5*Metre/Second))
+        rendered(speeds.chart(Lines())).contains(t">velocity / m·s¯¹<")
+      . assert(_ == true)
+
+      test(m"a duration axis is titled time, with units in its labels"):
+        val latency = Series(t"p99")((0.0*Second, 0.012*Second), (30.0*Second, 0.019*Second))
+        val text = rendered(latency.chart(Lines()))
+        (text.contains(t">time<"), text.contains(t">12ms<"))
+      . assert(_ == (true, true))
 
       test(m"axis titles are lettered"):
         given Chart.Style = Chart.Style(abscissaTitle = t"month", ordinateTitle = t"sales")
@@ -327,8 +348,8 @@ object Tests extends Suite(m"Tasseomancy tests"):
 
       test(m"a measured legend is narrower for a narrow face"):
         given Chart.Style = Chart.Style()
-        val average = Cartesian.layout(Unset, List(t"ABC"))(using summon[Chart.Style], summon[FontMetric])
-        val measured = Cartesian.layout(Unset, List(t"ABC"))(using summon[Chart.Style], FontMetric.of(TestFont.font))
+        val average = Cartesian.layout(Unset, Unset, List(t"ABC"))(using summon[Chart.Style], summon[FontMetric])
+        val measured = Cartesian.layout(Unset, Unset, List(t"ABC"))(using summon[Chart.Style], FontMetric.of(TestFont.font))
         val width = measured.legend.let(_.width).or(0.0)
         (average.frame.width < measured.frame.width, (width - 32.4).abs < 0.000001)
       . assert(_ == (true, true))

--- a/lib/tasseomancy/src/test/tasseomancy_test.scala
+++ b/lib/tasseomancy/src/test/tasseomancy_test.scala
@@ -1,0 +1,371 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.64.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package tasseomancy
+
+import soundness.*
+
+import strategies.throwUnsafely
+
+// A minimal TrueType font, assembled the way phoenicia's own fixtures are: enough tables for the
+// character map and the horizontal metrics, which is all a width measurement reads.
+object TestFont:
+  extension (left: Data)
+    @targetName("concatData")
+    def ++ (right: Data): Data = Array.frozen(left.readable ++ right.readable)
+
+  def u16(values: Int*): Data =
+    Array.from(values.flatMap { value => scala.Seq((value >> 8).toByte, value.toByte) })
+
+  def u32(values: Long*): Data =
+    Array.from:
+      values.flatMap: value =>
+        scala.Seq((value >> 24).toByte, (value >> 16).toByte, (value >> 8).toByte, value.toByte)
+
+  def sfnt(tables: (Text, Data)*): Truetype =
+    val count = tables.length
+    val entrySelector = 31 - Integer.numberOfLeadingZeros(count)
+    val searchRange = (1 << entrySelector)*16
+    val header = u32(0x00010000L) ++ u16(count, searchRange, entrySelector, count*16 - searchRange)
+
+    var offset = 12 + count*16
+    val directory = scala.collection.immutable.List.newBuilder[Data]
+    val body = scala.collection.immutable.List.newBuilder[Data]
+
+    tables.each: (tag, table) =>
+      val padding = if table.length%4 == 0 then 0 else 4 - table.length%4
+      val tagBytes = Array.unsafeFrozen(tag.s.getBytes("US-ASCII").nn)
+      directory += tagBytes ++ u32(0L, offset.toLong, table.length.toLong)
+      body += table ++ Array.fill[Byte](padding)(0)
+      offset += table.length + padding
+
+    Truetype(header ++ directory.result().reduce(_ ++ _) ++ body.result().reduce(_ ++ _))
+
+  val headTable: Data =
+    u16(1, 0, 1, 0) ++ u32(0L, 0x5f0f3cf5L) ++ u16(0, 1000) ++ u32(0L, 0L, 0L, 0L)
+    ++ u16(-50, -200, 1000, 800) ++ u16(0, 8) ++ u16(2, 0, 0)
+
+  val hheaTable: Data =
+    u16(1, 0) ++ u16(800, -200, 90) ++ u16(600) ++ u16(10, 10, 1000) ++ u16(1, 0, 0)
+    ++ u16(0, 0, 0, 0) ++ u16(0, 3)
+
+  // Glyph 0 (missing) advances 600, glyph 1 advances 500, glyph 2 advances 400, and every later
+  // glyph shares the last advance.
+  val hmtxTable: Data = u16(600, 10, 500, 20, 400, 30) ++ u16(25)
+  val maxpTable: Data = u32(0x00010000L) ++ u16(4)
+
+  // A–C map to glyphs 1–3 by delta.
+  val cmapTable: Data =
+    u16(0, 1) ++ u16(3, 1) ++ u32(12L)
+    ++ u16(4, 46, 0) ++ u16(6, 4, 1, 2) ++ u16(0x43, 0x63, 0xffff) ++ u16(0)
+    ++ u16(0x41, 0x61, 0xffff) ++ u16(-64, 0, 1) ++ u16(0, 4, 0) ++ u16(2, 3, 1)
+
+  lazy val font: Truetype =
+    sfnt(t"cmap" -> cmapTable, t"head" -> headTable, t"hhea" -> hheaTable, t"hmtx" -> hmtxTable,
+        t"maxp" -> maxpTable)
+
+object Tests extends Suite(m"Tasseomancy tests"):
+  val number = Scale.Labelling.Number(t"")
+  val decimal = Scale.Spacing.Decimal
+
+  def labels(scale: Scale, budget: Int): List[Text] =
+    scale.gradations(budget).filter(_.major).map(_.label).to[List]
+
+  def rendered[data, form, fit](chart: Chart[data, form, fit])
+    ( using Chart.Style, ChartPalette, FontMetric )
+  :   Text =
+    chart.svg.xml.show
+
+  def describe(revision: Chart.Revision): Text = revision match
+    case Chart.Revision.Redraw(_)      => t"redraw"
+    case Chart.Revision.Replace(id, _) => t"replace ${id.text}"
+
+  def occurrences(text: Text, needle: Text): Int =
+    var count = 0
+    var index = 0
+    while index >= 0 do
+      index = text.s.indexOf(needle.s, index)
+      if index >= 0 then
+        count += 1
+        index += needle.length
+    count
+
+  val sales: List[Series[Text, Double]] =
+    List
+      ( Series(t"north")((t"jan", 3.0), (t"feb", 5.0), (t"mar", 4.0)),
+        Series(t"south")((t"jan", 2.0), (t"feb", 1.0), (t"mar", 6.0)) )
+
+  val growth: Series[Double, Double] = Series(t"growth")((0.0, 0.0), (10.0, 10.0))
+
+  def run(): Unit =
+    suite(m"Number formatting"):
+      test(m"a whole number has no decimal point"):
+        Scale.format(1000.0, 0)
+      . assert(_ == t"1000")
+
+      test(m"decimal places are fixed"):
+        Scale.format(2.5, 1)
+      . assert(_ == t"2.5")
+
+      test(m"a small negative keeps its leading zero"):
+        Scale.format(-0.05, 2)
+      . assert(_ == t"-0.05")
+
+      test(m"an interval below a second is in milliseconds"):
+        Scale.interval(0.25)
+      . assert(_ == t"250ms")
+
+      test(m"an interval in microseconds trims trailing zeros"):
+        Scale.interval(0.0000015)
+      . assert(_ == t"1.5µs")
+
+      test(m"an interval over a minute pairs minutes and seconds"):
+        Scale.interval(90.0)
+      . assert(_ == t"1m30s")
+
+      test(m"an interval over an hour pads the minutes"):
+        Scale.interval(3660.0)
+      . assert(_ == t"1h01m")
+
+      test(m"a clock time is hours, minutes and seconds"):
+        Scale.clock(3661.0)
+      . assert(_ == t"01:01:01")
+
+    suite(m"Calibration"):
+      test(m"a linear scale pads outward to whole steps"):
+        val scale = Calibration.linear(0.0, 97.0, false, decimal, number, false)
+        (scale.lower, scale.upper)
+      . assert(_ == (0.0, 100.0))
+
+      test(m"linear gradations fall on multiples of 1, 2 and 5"):
+        labels(Calibration.linear(0.0, 97.0, false, decimal, number, false), 5)
+      . assert(_ == List(t"0", t"20", t"40", t"60", t"80", t"100"))
+
+      test(m"a logarithmic scale spans whole decades"):
+        val scale = Calibration.logarithmic(3.0, 4200.0, false, decimal, number)
+        (scale.transform, scale.lower, scale.upper)
+      . assert(_ == (Scale.Transform.Logarithmic, 1.0, 10000.0))
+
+      test(m"logarithmic gradations are powers of ten"):
+        labels(Calibration.logarithmic(3.0, 4200.0, false, decimal, number), 5)
+      . assert(_ == List(t"1", t"10", t"100", t"1000", t"10000"))
+
+      test(m"a logarithmic scale over non-positive values falls back to linear"):
+        Calibration.logarithmic(-1.0, 10.0, false, decimal, number).transform
+      . assert(_ == Scale.Transform.Linear)
+
+      test(m"adaptive calibration goes logarithmic at a thousandfold range"):
+        Calibration[Double](Calibration.Policy.Adaptive).scale(1.0, 5000.0, false, decimal, number).transform
+      . assert(_ == Scale.Transform.Logarithmic)
+
+      test(m"adaptive calibration stays linear over a narrow range"):
+        Calibration[Double](Calibration.Policy.Adaptive).scale(1.0, 500.0, false, decimal, number).transform
+      . assert(_ == Scale.Transform.Linear)
+
+      test(m"an anchored scale includes zero"):
+        Calibration.linear(5.0, 9.0, true, decimal, number, false).lower
+      . assert(_ == 0.0)
+
+      test(m"a tight scale is exactly the data's extent"):
+        val scale = Calibration.linear(5.0, 9.0, false, decimal, number, true)
+        (scale.lower, scale.upper)
+      . assert(_ == (5.0, 9.0))
+
+      test(m"sexagesimal gradations land on clock steps"):
+        val interval = Scale.Labelling.Interval
+        val scale = Calibration.linear(0.0, 100.0, false, Scale.Spacing.Sexagesimal, interval, false)
+        labels(scale, 5)
+      . assert(_ == List(t"0s", t"30s", t"1m", t"1m30s", t"2m"))
+
+      test(m"the type-keyed default is linear"):
+        growth.chart(Lines()).fit.ordinate.transform
+      . assert(_ == Scale.Transform.Linear)
+
+      test(m"an explicit calibration overrides one axis"):
+        val chart = Series(t"a")((1.0, 10.0), (2.0, 1000.0)).chart(Lines(ordinate = calibrations.logarithmicCalibration))
+        (chart.fit.abscissa.transform, chart.fit.ordinate.transform)
+      . assert(_ == (Scale.Transform.Linear, Scale.Transform.Logarithmic))
+
+      test(m"a scoped given overrides every axis of its type"):
+        given Double is Calibration = calibrations.logarithmicCalibration
+        Series(t"a")((1.0, 10.0), (2.0, 1000.0)).chart(Lines()).fit.abscissa.transform
+      . assert(_ == Scale.Transform.Logarithmic)
+
+      test(m"an imported calibration overrides every axis"):
+        import calibrations.tightCalibration
+        val fit = growth.chart(Lines()).fit
+        (fit.abscissa.lower, fit.abscissa.upper, fit.ordinate.upper)
+      . assert(_ == (0.0, 10.0, 10.0))
+
+    suite(m"Fitting"):
+      test(m"bands are the union of categories in first-appearance order"):
+        val data = List(Series(t"a")((t"x", 1.0), (t"y", 2.0)), Series(t"b")((t"y", 3.0), (t"z", 4.0)))
+        data.chart(Bars()).fit.bands.categories
+      . assert(_ == Sequence(t"x", t"y", t"z"))
+
+      test(m"a bar chart's ordinate is anchored at zero"):
+        sales.chart(Bars()).fit.ordinate.lower
+      . assert(_ == 0.0)
+
+      test(m"a stacked chart's ordinate spans the largest total"):
+        sales.chart(StackedBars()).fit.ordinate.upper
+      . assert(_ == 10.0)
+
+      test(m"Sturges' rule bins eight samples four ways"):
+        Samples(t"s")(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0).chart(Histogram()).fit.edges.size
+      . assert(_ == 5)
+
+      test(m"the box summary of five values is the values"):
+        Boxes.Summary.of(Sequence(5.0, 1.0, 4.0, 2.0, 3.0))
+      . assert(_ == Boxes.Summary(1.0, 2.0, 3.0, 4.0, 5.0))
+
+      test(m"quartiles interpolate between order statistics"):
+        Boxes.Summary.of(Sequence(1.0, 2.0, 3.0, 4.0)).lowerQuartile
+      . assert(_ == 1.75)
+
+      test(m"a pie's total is the sum of its values"):
+        Series(t"share")((t"a", 25.0), (t"b", 75.0)).chart(Pie()).fit.total
+      . assert(_ == 100.0)
+
+    suite(m"Drawing"):
+      test(m"a chart's parts have stable identifiers"):
+        val text = rendered(sales.chart(Bars()))
+        List(t"grid", t"abscissa", t"ordinate", t"series-0", t"series-1", t"legend").all: id =>
+          text.contains(t"""id="$id"""")
+      . assert(_ == true)
+
+      test(m"grouped bars draw one rectangle per value, plus the legend's swatches"):
+        occurrences(rendered(sales.chart(Bars())), t"<rect")
+      . assert(_ == 8)
+
+      test(m"a hidden legend draws no swatches"):
+        given Chart.Style = Chart.Style(legend = Chart.Legend.Hidden)
+        occurrences(rendered(sales.chart(Bars())), t"<rect")
+      . assert(_ == 6)
+
+      test(m"a line chart draws one polyline per series"):
+        val text = rendered(List(growth, Series(t"decay")((0.0, 10.0), (10.0, 0.0))).chart(Lines()))
+        occurrences(text, t"<polyline points=\"")
+      . assert(_ >= 2)
+
+      test(m"a scatter plot draws one marker per point"):
+        given Chart.Style = Chart.Style(grid = false, legend = Chart.Legend.Hidden)
+        occurrences(rendered(growth.chart(Scatter())), t"<circle")
+      . assert(_ == 2)
+
+      test(m"a pie draws a wedge and a percentage per category"):
+        val text = rendered(Series(t"share")((t"a", 25.0), (t"b", 75.0)).chart(Pie()))
+        (occurrences(text, t"<path"), text.contains(t"25%"), text.contains(t"75%"))
+      . assert(_ == (2, true, true))
+
+      test(m"a set of series plots the same as a list"):
+        val fromSet = rendered(sales.to[Set].chart(Bars()))
+        occurrences(fromSet, t"<rect")
+      . assert(_ == 8)
+
+      test(m"a sequence of series plots the same as a list"):
+        occurrences(rendered(sales.to[Sequence].chart(Bars())), t"<rect")
+      . assert(_ == 8)
+
+      test(m"a box plot draws a box and whiskers per sample set"):
+        val data = List(Samples(t"a")(1.0, 2.0, 3.0), Samples(t"b")(2.0, 4.0, 8.0))
+        occurrences(rendered(data.chart(Boxes())), t"<rect")
+      . assert(_ == 4)
+
+      test(m"an error bar is drawn for an estimate"):
+        given Chart.Style = Chart.Style(grid = false, legend = Chart.Legend.Hidden)
+        val data = Series(t"a")((t"x", Estimate(5.0, 4.0, 6.0)))
+        val text = rendered(data.chart(Bars())).s
+        val start = text.indexOf("id=\"series-0\"")
+        val end = text.indexOf("</g>", start)
+        occurrences(text.substring(start, end).nn.tt, t"<polyline")
+      . assert(_ == 3)
+
+      test(m"axis titles are lettered"):
+        given Chart.Style = Chart.Style(abscissaTitle = t"month", ordinateTitle = t"sales")
+        val text = rendered(sales.chart(Bars()))
+        (text.contains(t">month<"), text.contains(t">sales<"))
+      . assert(_ == (true, true))
+
+    suite(m"Font metrics"):
+      test(m"the average metric is six tenths of an em per character"):
+        summon[FontMetric].width(t"abcde").value
+      . assert(_ == 3.0)
+
+      test(m"a font metric sums the glyph advances"):
+        FontMetric.of(TestFont.font).width(t"AB").value
+      . assert(_ == 0.9)
+
+      test(m"a measured legend is narrower for a narrow face"):
+        given Chart.Style = Chart.Style()
+        val average = Cartesian.layout(Unset, List(t"ABC"))(using summon[Chart.Style], summon[FontMetric])
+        val measured = Cartesian.layout(Unset, List(t"ABC"))(using summon[Chart.Style], FontMetric.of(TestFont.font))
+        val width = measured.legend.let(_.width).or(0.0)
+        (average.frame.width < measured.frame.width, (width - 32.4).abs < 0.000001)
+      . assert(_ == (true, true))
+
+    suite(m"Revision"):
+      test(m"unchanged data revises nothing"):
+        growth.chart(Lines()).revise(growth)(1)
+      . assert(_ == Nil)
+
+      test(m"a point within the axes replaces only its series"):
+        growth.chart(Lines()).revise(growth.add((5.0, 5.0)))(1).map(describe)
+      . assert(_ == List(t"replace series-0"))
+
+      test(m"a point beyond the axes redraws the chart"):
+        growth.chart(Lines()).revise(growth.add((20.0, 20.0)))(1).map(describe)
+      . assert(_ == List(t"redraw"))
+
+      test(m"a revised chart keeps its fit when the data still fits"):
+        val (next, _) = growth.chart(Lines()).revise(growth.add((5.0, 5.0)))
+        (next.fit.abscissa.upper, next.fit.ordinate.upper)
+      . assert(_ == (10.0, 10.0))
+
+    suite(m"Compatibility"):
+      test(m"a categorical series cannot be a line chart"):
+        demilitarize:
+          Series(t"a")((t"x", 1.0)).chart(Lines())
+        . exists(_.error)
+      . assert(_ == true)
+
+      test(m"several series cannot be a pie"):
+        demilitarize:
+          sales.chart(Pie())
+        . exists(_.error)
+      . assert(_ == true)
+
+      test(m"samples cannot be bars"):
+        demilitarize:
+          Samples(t"s")(1.0, 2.0).chart(Bars())
+        . exists(_.error)
+      . assert(_ == true)


### PR DESCRIPTION
Tasseomancy draws charts as SVG from typed data in four separable layers: the shape of the data (in its types), the kind of chart (checked against the shape at compiletime), the fit of data to axes (a `Calibration` per axis type), and the style (a trait of rendering hooks per kind, with one standard implementation). Charts are immutable and revisable: given new data, `revise` keeps the axes still while they still fit and names the parts that changed, which is what a page fed over a WebSocket needs. Savagery gains the figures a chart is made of — groups, polylines and text — and `id`/`style` on every figure.

### Release notes

**tasseomancy** (new)

- `Series(name)((x, y)*)` and `Samples(name)(values*)` hold data; names are any `Showable` value. `Categorical` (text, enums, `Category`) and `Continuous` (numbers, `Quantity`, `Duration`, `Instant`, `Estimate`, `Annotated`) give the axes their kind.
- Chart kinds `Bars`, `StackedBars`, `Lines`, `Scatter`, `Pie`, `Histogram` and `Boxes`; `data.chart(kind)` compiles only for a compatible shape, and accepts any collection traversable by series.
- `Calibration` chooses linear, logarithmic, adaptive or tight axes; select by `import calibrations.…`, a scoped given for one type, or an argument on the kind.
- Style is a trait per kind (`Bars.Style`, `Lines.Style`, …) over `Chart.Cartesian` and `Chart.Style`, each method rendering one component; `Chart.Standard` implements them all as a case class, so parameters are named arguments and any component is an override. Hooks cover tick placement and rotation, per-axis strokes, arrowheads, axis breaks, line thickness, typeface and point labels.
- Colours come from a `ChartPalette` by role (`palettes.slateChartPalette`, Solarized dark and light, or `ChartPalette.of(theme)`); text is measured by a `FontMetric` (average widths, or a phoenicia font's glyph advances).
- Axes over quantities are titled by dimension and unit (`distance / m`); a style title keeps the unit.

**savagery**

- New figures `Group` (`<g>`), `Polyline` (`<polyline>`, or `<polygon>` when closed) and `Lettering` (`<text>` with anchor and baseline). `Rectangle`, `Ellipse` and `Circle` accept `style` and `id`; extractor patterns on `Rectangle` and `Ellipse` gain two trailing fields. The parser decodes the new elements and reads `id`, `transform` and `style` on every figure, and no longer flattens groups.

**quantitative**

- `Quantity.dimension[units]: Optional[Text]`, the non-halting form of the dimension name.

```scala
val sales = List(Series(t"north")((t"jan", 3.0), (t"feb", 5.0)), Series(t"south")((t"jan", 2.0), (t"feb", 1.0)))
given Chart.Standard = new Chart.Standard(ordinateTitle = t"units sold"):
  override def arrowhead(tip: Point, axis: Chart.Axis, color: Color in Srgb): List[Figure] =
    List(Polyline(List(tip, Point(tip.x - 6, tip.y - 3), Point(tip.x - 6, tip.y + 3)), closed = true))

val chart = sales.chart(Bars())
val (next, revisions) = chart.revise(sales.map(_.add((t"mar", 4.0))))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
